### PR TITLE
test(libmlx): group conversion tables into scenarios

### DIFF
--- a/crates/libmlx/src/device/cmd/device/args.rs
+++ b/crates/libmlx/src/device/cmd/device/args.rs
@@ -214,7 +214,7 @@ mod tests {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -235,103 +235,83 @@ mod coverage_tests {
     // case-insensitively, and any unknown token is rejected.
     #[test]
     fn parse_device_field_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "device_type canonical",
-                    input: "device_type",
-                    expect: Yields(DeviceField::DeviceType),
-                },
-                Case {
-                    scenario: "type alias",
-                    input: "type",
-                    expect: Yields(DeviceField::DeviceType),
-                },
-                Case {
-                    scenario: "device_type uppercased (lowercased internally)",
-                    input: "DEVICE_TYPE",
-                    expect: Yields(DeviceField::DeviceType),
-                },
-                Case {
-                    scenario: "part_number canonical",
-                    input: "part_number",
-                    expect: Yields(DeviceField::PartNumber),
-                },
-                Case {
-                    scenario: "part alias",
-                    input: "part",
-                    expect: Yields(DeviceField::PartNumber),
-                },
-                Case {
-                    scenario: "firmware_version canonical",
-                    input: "firmware_version",
-                    expect: Yields(DeviceField::FirmwareVersion),
-                },
-                Case {
-                    scenario: "firmware alias",
-                    input: "firmware",
-                    expect: Yields(DeviceField::FirmwareVersion),
-                },
-                Case {
-                    scenario: "fw alias",
-                    input: "fw",
-                    expect: Yields(DeviceField::FirmwareVersion),
-                },
-                Case {
-                    scenario: "mac_address canonical",
-                    input: "mac_address",
-                    expect: Yields(DeviceField::MacAddress),
-                },
-                Case {
-                    scenario: "mac alias",
-                    input: "mac",
-                    expect: Yields(DeviceField::MacAddress),
-                },
-                Case {
-                    scenario: "description canonical",
-                    input: "description",
-                    expect: Yields(DeviceField::Description),
-                },
-                Case {
-                    scenario: "desc alias",
-                    input: "desc",
-                    expect: Yields(DeviceField::Description),
-                },
-                Case {
-                    scenario: "pci_name canonical",
-                    input: "pci_name",
-                    expect: Yields(DeviceField::PciName),
-                },
-                Case {
-                    scenario: "pci alias",
-                    input: "pci",
-                    expect: Yields(DeviceField::PciName),
-                },
-                Case {
-                    scenario: "status canonical",
-                    input: "status",
-                    expect: Yields(DeviceField::Status),
-                },
-                Case {
-                    scenario: "unknown field rejected",
-                    input: "bogus",
-                    expect: FailsWith(
-                        "Unknown field 'bogus'. Valid fields: device_type, part_number, \
-                         firmware_version, mac_address, description, pci_name, status"
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "empty field rejected",
-                    input: "",
-                    expect: FailsWith(
-                        "Unknown field ''. Valid fields: device_type, part_number, \
-                         firmware_version, mac_address, description, pci_name, status"
-                            .to_string(),
-                    ),
-                },
-            ],
-            parse_device_field,
+        scenarios!(
+            run = parse_device_field;
+            "device_type canonical" {
+                "device_type" => Yields(DeviceField::DeviceType),
+            }
+
+            "type alias" {
+                "type" => Yields(DeviceField::DeviceType),
+            }
+
+            "device_type uppercased (lowercased internally)" {
+                "DEVICE_TYPE" => Yields(DeviceField::DeviceType),
+            }
+
+            "part_number canonical" {
+                "part_number" => Yields(DeviceField::PartNumber),
+            }
+
+            "part alias" {
+                "part" => Yields(DeviceField::PartNumber),
+            }
+
+            "firmware_version canonical" {
+                "firmware_version" => Yields(DeviceField::FirmwareVersion),
+            }
+
+            "firmware alias" {
+                "firmware" => Yields(DeviceField::FirmwareVersion),
+            }
+
+            "fw alias" {
+                "fw" => Yields(DeviceField::FirmwareVersion),
+            }
+
+            "mac_address canonical" {
+                "mac_address" => Yields(DeviceField::MacAddress),
+            }
+
+            "mac alias" {
+                "mac" => Yields(DeviceField::MacAddress),
+            }
+
+            "description canonical" {
+                "description" => Yields(DeviceField::Description),
+            }
+
+            "desc alias" {
+                "desc" => Yields(DeviceField::Description),
+            }
+
+            "pci_name canonical" {
+                "pci_name" => Yields(DeviceField::PciName),
+            }
+
+            "pci alias" {
+                "pci" => Yields(DeviceField::PciName),
+            }
+
+            "status canonical" {
+                "status" => Yields(DeviceField::Status),
+            }
+
+            "unknown field rejected" {
+                "bogus" => FailsWith(
+                    "Unknown field 'bogus'. Valid fields: device_type, part_number, \
+                     firmware_version, mac_address, description, pci_name, status"
+                        .to_string(),
+                ),
+            }
+
+            "empty field rejected" {
+                "" => FailsWith(
+                    "Unknown field ''. Valid fields: device_type, part_number, \
+                     firmware_version, mac_address, description, pci_name, status"
+                        .to_string(),
+                ),
+            }
         );
     }
 
@@ -339,44 +319,35 @@ mod coverage_tests {
     // MatchMode arm; anything else is rejected with the canonical message.
     #[test]
     fn parse_match_mode_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "regex",
-                    input: "regex",
-                    expect: Yields(MatchMode::Regex),
-                },
-                Case {
-                    scenario: "exact",
-                    input: "exact",
-                    expect: Yields(MatchMode::Exact),
-                },
-                Case {
-                    scenario: "prefix",
-                    input: "prefix",
-                    expect: Yields(MatchMode::Prefix),
-                },
-                Case {
-                    scenario: "uppercased prefix (lowercased internally)",
-                    input: "PREFIX",
-                    expect: Yields(MatchMode::Prefix),
-                },
-                Case {
-                    scenario: "unknown mode rejected",
-                    input: "fuzzy",
-                    expect: FailsWith(
-                        "Unknown match mode 'fuzzy'. Valid modes: regex, exact, prefix".to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "empty mode rejected",
-                    input: "",
-                    expect: FailsWith(
-                        "Unknown match mode ''. Valid modes: regex, exact, prefix".to_string(),
-                    ),
-                },
-            ],
-            parse_match_mode,
+        scenarios!(
+            run = parse_match_mode;
+            "regex" {
+                "regex" => Yields(MatchMode::Regex),
+            }
+
+            "exact" {
+                "exact" => Yields(MatchMode::Exact),
+            }
+
+            "prefix" {
+                "prefix" => Yields(MatchMode::Prefix),
+            }
+
+            "uppercased prefix (lowercased internally)" {
+                "PREFIX" => Yields(MatchMode::Prefix),
+            }
+
+            "unknown mode rejected" {
+                "fuzzy" => FailsWith(
+                    "Unknown match mode 'fuzzy'. Valid modes: regex, exact, prefix".to_string(),
+                ),
+            }
+
+            "empty mode rejected" {
+                "" => FailsWith(
+                    "Unknown match mode ''. Valid modes: regex, exact, prefix".to_string(),
+                ),
+            }
         );
     }
 
@@ -436,54 +407,46 @@ mod coverage_tests {
     // that collapses to empty after trimming.
     #[test]
     fn parse_filter_expression_err_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "single part (no colon) rejected",
-                    input: "device_type",
-                    expect: FailsWith(
-                        "Invalid filter expression 'device_type'. Expected format: \
-                         field:value[,value2,value3] or \
-                         field:value[,value2,value3]:match_mode"
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "four parts rejected",
-                    input: "a:b:c:d",
-                    expect: FailsWith(
-                        "Invalid filter expression 'a:b:c:d'. Expected format: \
-                         field:value[,value2,value3] or \
-                         field:value[,value2,value3]:match_mode"
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "unknown field propagated",
-                    input: "nope:value",
-                    expect: FailsWith(
-                        "Unknown field 'nope'. Valid fields: device_type, part_number, \
-                         firmware_version, mac_address, description, pci_name, status"
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "unknown mode propagated",
-                    input: "device_type:val:bogus",
-                    expect: FailsWith(
-                        "Unknown match mode 'bogus'. Valid modes: regex, exact, prefix".to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "values empty after trim/drop",
-                    input: "device_type: , :exact",
-                    expect: FailsWith(
-                        "No valid values found in filter expression 'device_type: , :exact'"
-                            .to_string(),
-                    ),
-                },
-            ],
-            |expr| parse_filter_expression(expr).map(|f| parts(&f)),
+        scenarios!(
+            run = |expr| parse_filter_expression(expr).map(|f| parts(&f));
+            "single part (no colon) rejected" {
+                "device_type" => FailsWith(
+                    "Invalid filter expression 'device_type'. Expected format: \
+                     field:value[,value2,value3] or \
+                     field:value[,value2,value3]:match_mode"
+                        .to_string(),
+                ),
+            }
+
+            "four parts rejected" {
+                "a:b:c:d" => FailsWith(
+                    "Invalid filter expression 'a:b:c:d'. Expected format: \
+                     field:value[,value2,value3] or \
+                     field:value[,value2,value3]:match_mode"
+                        .to_string(),
+                ),
+            }
+
+            "unknown field propagated" {
+                "nope:value" => FailsWith(
+                    "Unknown field 'nope'. Valid fields: device_type, part_number, \
+                     firmware_version, mac_address, description, pci_name, status"
+                        .to_string(),
+                ),
+            }
+
+            "unknown mode propagated" {
+                "device_type:val:bogus" => FailsWith(
+                    "Unknown match mode 'bogus'. Valid modes: regex, exact, prefix".to_string(),
+                ),
+            }
+
+            "values empty after trim/drop" {
+                "device_type: , :exact" => FailsWith(
+                    "No valid values found in filter expression 'device_type: , :exact'"
+                        .to_string(),
+                ),
+            }
         );
     }
 
@@ -492,35 +455,29 @@ mod coverage_tests {
     // expression aborts the whole build.
     #[test]
     fn build_filter_set_ok_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "empty input -> empty set",
-                    input: vec![],
-                    expect: Yields(vec![]),
-                },
-                Case {
-                    scenario: "single valid expression",
-                    input: vec!["device_type:ConnectX:exact".to_string()],
-                    expect: Yields(vec![(
-                        DeviceField::DeviceType,
-                        owned(&["ConnectX"]),
-                        MatchMode::Exact,
-                    )]),
-                },
-                Case {
-                    scenario: "multiple expressions accumulate in order",
-                    input: vec!["part:MCX:prefix".to_string(), "status:ok".to_string()],
-                    expect: Yields(vec![
-                        (DeviceField::PartNumber, owned(&["MCX"]), MatchMode::Prefix),
-                        (DeviceField::Status, owned(&["ok"]), MatchMode::Regex),
-                    ]),
-                },
-            ],
-            |exprs| {
+        scenarios!(
+            run = |exprs| {
                 build_filter_set_from_filter_args(exprs)
                     .map(|set| set.filters.iter().map(parts).collect::<Vec<_>>())
-            },
+            };
+            "empty input -> empty set" {
+                vec![] => Yields(vec![]),
+            }
+
+            "single valid expression" {
+                vec!["device_type:ConnectX:exact".to_string()] => Yields(vec![(
+                    DeviceField::DeviceType,
+                    owned(&["ConnectX"]),
+                    MatchMode::Exact,
+                )]),
+            }
+
+            "multiple expressions accumulate in order" {
+                vec!["part:MCX:prefix".to_string(), "status:ok".to_string()] => Yields(vec![
+                    (DeviceField::PartNumber, owned(&["MCX"]), MatchMode::Prefix),
+                    (DeviceField::Status, owned(&["ok"]), MatchMode::Regex),
+                ]),
+            }
         );
     }
 
@@ -528,32 +485,27 @@ mod coverage_tests {
     // surfaces that expression's error verbatim.
     #[test]
     fn build_filter_set_propagates_first_error() {
-        check_cases(
-            [
-                Case {
-                    scenario: "invalid field aborts the build",
-                    input: vec!["device_type:ok".to_string(), "nope:value".to_string()],
-                    expect: FailsWith(
-                        "Unknown field 'nope'. Valid fields: device_type, part_number, \
-                         firmware_version, mac_address, description, pci_name, status"
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "malformed expression aborts the build",
-                    input: vec!["justonepart".to_string()],
-                    expect: FailsWith(
-                        "Invalid filter expression 'justonepart'. Expected format: \
-                         field:value[,value2,value3] or \
-                         field:value[,value2,value3]:match_mode"
-                            .to_string(),
-                    ),
-                },
-            ],
-            |exprs| {
+        scenarios!(
+            run = |exprs| {
                 build_filter_set_from_filter_args(exprs)
                     .map(|set| set.filters.iter().map(parts).collect::<Vec<_>>())
-            },
+            };
+            "invalid field aborts the build" {
+                vec!["device_type:ok".to_string(), "nope:value".to_string()] => FailsWith(
+                    "Unknown field 'nope'. Valid fields: device_type, part_number, \
+                     firmware_version, mac_address, description, pci_name, status"
+                        .to_string(),
+                ),
+            }
+
+            "malformed expression aborts the build" {
+                vec!["justonepart".to_string()] => FailsWith(
+                    "Invalid filter expression 'justonepart'. Expected format: \
+                     field:value[,value2,value3] or \
+                     field:value[,value2,value3]:match_mode"
+                        .to_string(),
+                ),
+            }
         );
     }
 
@@ -561,30 +513,23 @@ mod coverage_tests {
     // every variant's kebab-cased name.
     #[test]
     fn output_format_value_enum_round_trip() {
-        check_values(
-            [
-                Check {
-                    scenario: "ascii-table",
-                    input: "ascii-table",
-                    expect: true,
-                },
-                Check {
-                    scenario: "json",
-                    input: "json",
-                    expect: true,
-                },
-                Check {
-                    scenario: "yaml",
-                    input: "yaml",
-                    expect: true,
-                },
-                Check {
-                    scenario: "unknown format not accepted",
-                    input: "xml",
-                    expect: false,
-                },
-            ],
-            |name| OutputFormat::from_str(name, true).is_ok(),
+        value_scenarios!(
+            run = |name| OutputFormat::from_str(name, true).is_ok();
+            "ascii-table" {
+                "ascii-table" => true,
+            }
+
+            "json" {
+                "json" => true,
+            }
+
+            "yaml" {
+                "yaml" => true,
+            }
+
+            "unknown format not accepted" {
+                "xml" => false,
+            }
         );
     }
 }

--- a/crates/libmlx/src/embedded/cmd/cmds.rs
+++ b/crates/libmlx/src/embedded/cmd/cmds.rs
@@ -1174,7 +1174,7 @@ fn build_credentials(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -1185,46 +1185,37 @@ mod tests {
         fn run(args: &[&str]) -> Result<Vec<(String, String)>, String> {
             parse_assignments(&args.iter().map(|s| s.to_string()).collect::<Vec<_>>())
         }
-        check_cases(
-            [
-                Case {
-                    scenario: "single assignment",
-                    input: &["SRIOV_EN=1"][..],
-                    expect: Yields(vec![("SRIOV_EN".to_string(), "1".to_string())]),
-                },
-                Case {
-                    scenario: "value with '=' splits on the first only",
-                    input: &["KEY=a=b"][..],
-                    expect: Yields(vec![("KEY".to_string(), "a=b".to_string())]),
-                },
-                Case {
-                    scenario: "whitespace trimmed and blank entries skipped",
-                    input: &["  X=1  ", "", "   ", "Y=2"][..],
-                    expect: Yields(vec![
-                        ("X".to_string(), "1".to_string()),
-                        ("Y".to_string(), "2".to_string()),
-                    ]),
-                },
-                Case {
-                    scenario: "missing '=' is rejected",
-                    input: &["NOEQUALS"][..],
-                    expect: FailsWith(
-                        "Invalid assignment format: 'NOEQUALS'. Expected 'variable=value'"
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "empty variable name is rejected",
-                    input: &["=value"][..],
-                    expect: FailsWith("Variable name cannot be empty".to_string()),
-                },
-                Case {
-                    scenario: "all-blank input yields no assignments",
-                    input: &["", "   "][..],
-                    expect: FailsWith("No valid assignments found".to_string()),
-                },
-            ],
-            run,
+        scenarios!(
+            run = run;
+            "single assignment" {
+                &["SRIOV_EN=1"][..] => Yields(vec![("SRIOV_EN".to_string(), "1".to_string())]),
+            }
+
+            "value with '=' splits on the first only" {
+                &["KEY=a=b"][..] => Yields(vec![("KEY".to_string(), "a=b".to_string())]),
+            }
+
+            "whitespace trimmed and blank entries skipped" {
+                &["  X=1  ", "", "   ", "Y=2"][..] => Yields(vec![
+                    ("X".to_string(), "1".to_string()),
+                    ("Y".to_string(), "2".to_string()),
+                ]),
+            }
+
+            "missing '=' is rejected" {
+                &["NOEQUALS"][..] => FailsWith(
+                    "Invalid assignment format: 'NOEQUALS'. Expected 'variable=value'"
+                        .to_string(),
+                ),
+            }
+
+            "empty variable name is rejected" {
+                &["=value"][..] => FailsWith("Variable name cannot be empty".to_string()),
+            }
+
+            "all-blank input yields no assignments" {
+                &["", "   "][..] => FailsWith("No valid assignments found".to_string()),
+            }
         );
     }
 
@@ -1232,26 +1223,21 @@ mod tests {
     // show-confs text, skipping the header and section lines.
     #[test]
     fn parse_mlx_show_confs_extracts_variable_names() {
-        check_values(
-            [
-                Check {
-                    scenario: "two variables under a section",
-                    input: "List of configurations:\n   POWER SETTINGS:\n       SRIOV_EN=<BOOLEAN> Enable SR-IOV\n       NUM_OF_VFS=<INTEGER> Number of virtual functions\n",
-                    expect: vec!["SRIOV_EN".to_string(), "NUM_OF_VFS".to_string()],
-                },
-                Check {
-                    scenario: "header only yields no variables",
-                    input: "List of configurations:\n",
-                    expect: Vec::<String>::new(),
-                },
-            ],
-            |content| {
+        value_scenarios!(
+            run = |content| {
                 parse_mlx_show_confs(content)
                     .variable_names()
                     .iter()
                     .map(|s| s.to_string())
                     .collect::<Vec<String>>()
-            },
+            };
+            "two variables under a section" {
+                "List of configurations:\n   POWER SETTINGS:\n       SRIOV_EN=<BOOLEAN> Enable SR-IOV\n       NUM_OF_VFS=<INTEGER> Number of virtual functions\n" => vec!["SRIOV_EN".to_string(), "NUM_OF_VFS".to_string()],
+            }
+
+            "header only yields no variables" {
+                "List of configurations:\n" => Vec::<String>::new(),
+            }
         );
     }
 }

--- a/crates/libmlx/src/firmware/source.rs
+++ b/crates/libmlx/src/firmware/source.rs
@@ -484,7 +484,7 @@ mod tests {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, Check, scenarios, value_scenarios};
 
     use super::*;
 
@@ -495,69 +495,55 @@ mod coverage_tests {
     // that yields uses an explicit user so the description is whoami-independent.
     #[test]
     fn from_url_routes_to_the_right_variant() {
-        check_cases(
-            [
-                Case {
-                    scenario: "https URL becomes an Http source",
-                    input: "https://example.com/fw.bin",
-                    expect: Yields("http:https://example.com/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "http URL becomes an Http source",
-                    input: "http://example.com/fw.bin",
-                    expect: Yields("http:http://example.com/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "file:// prefix is stripped to a Local path",
-                    input: "file:///abs/path/fw.bin",
-                    expect: Yields("local:/abs/path/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "file:// with a relative remainder",
-                    input: "file://relative/fw.bin",
-                    expect: Yields("local:relative/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "bare absolute path is a Local source",
-                    input: "/plain/path/fw.bin",
-                    expect: Yields("local:/plain/path/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "bare relative path is a Local source",
-                    input: "relative/fw.bin",
-                    expect: Yields("local:relative/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "ssh with explicit user and absolute path",
-                    input: "ssh://deploy@host.example:/abs/fw.bin",
-                    expect: Yields("ssh://deploy@host.example:22:/abs/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "ssh with explicit user and relative path",
-                    input: "ssh://deploy@host.example:rel/fw.bin",
-                    expect: Yields("ssh://deploy@host.example:22:rel/fw.bin".to_string()),
-                },
-                Case {
-                    scenario: "ssh URL with no colon separator is rejected",
-                    input: "ssh://hostonly",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ssh URL with an empty remote path is rejected",
-                    input: "ssh://deploy@host.example:",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ssh URL with an empty host is rejected",
-                    input: "ssh://:/abs/fw.bin",
-                    expect: Fails,
-                },
-            ],
-            |url| {
+        scenarios!(
+            run = |url| {
                 FirmwareSource::from_url(url)
                     .map(|s| s.description())
                     .map_err(drop)
-            },
+            };
+            "https URL becomes an Http source" {
+                "https://example.com/fw.bin" => Yields("http:https://example.com/fw.bin".to_string()),
+            }
+
+            "http URL becomes an Http source" {
+                "http://example.com/fw.bin" => Yields("http:http://example.com/fw.bin".to_string()),
+            }
+
+            "file:// prefix is stripped to a Local path" {
+                "file:///abs/path/fw.bin" => Yields("local:/abs/path/fw.bin".to_string()),
+            }
+
+            "file:// with a relative remainder" {
+                "file://relative/fw.bin" => Yields("local:relative/fw.bin".to_string()),
+            }
+
+            "bare absolute path is a Local source" {
+                "/plain/path/fw.bin" => Yields("local:/plain/path/fw.bin".to_string()),
+            }
+
+            "bare relative path is a Local source" {
+                "relative/fw.bin" => Yields("local:relative/fw.bin".to_string()),
+            }
+
+            "ssh with explicit user and absolute path" {
+                "ssh://deploy@host.example:/abs/fw.bin" => Yields("ssh://deploy@host.example:22:/abs/fw.bin".to_string()),
+            }
+
+            "ssh with explicit user and relative path" {
+                "ssh://deploy@host.example:rel/fw.bin" => Yields("ssh://deploy@host.example:22:rel/fw.bin".to_string()),
+            }
+
+            "ssh URL with no colon separator is rejected" {
+                "ssh://hostonly" => Fails,
+            }
+
+            "ssh URL with an empty remote path is rejected" {
+                "ssh://deploy@host.example:" => Fails,
+            }
+
+            "ssh URL with an empty host is rejected" {
+                "ssh://:/abs/fw.bin" => Fails,
+            }
         );
     }
 
@@ -580,59 +566,47 @@ mod coverage_tests {
     // (ConfigError is not PartialEq).
     #[test]
     fn parse_ssh_url_splits_components() {
-        check_cases(
-            [
-                Case {
-                    scenario: "user, host, absolute path",
-                    input: "ssh://deploy@host.example:/abs/fw.bin",
-                    expect: Yields(("host.example".to_string(), "/abs/fw.bin".to_string())),
-                },
-                Case {
-                    scenario: "user, host, relative path",
-                    input: "ssh://deploy@host.example:rel/fw.bin",
-                    expect: Yields(("host.example".to_string(), "rel/fw.bin".to_string())),
-                },
-                Case {
-                    scenario: "no user, host, absolute path",
-                    input: "ssh://host.example:/abs/fw.bin",
-                    expect: Yields(("host.example".to_string(), "/abs/fw.bin".to_string())),
-                },
-                Case {
-                    scenario: "path containing a colon keeps the rest after the first colon",
-                    input: "ssh://host.example:/abs:with:colons",
-                    expect: Yields(("host.example".to_string(), "/abs:with:colons".to_string())),
-                },
-                Case {
-                    scenario: "not an ssh URL (missing prefix)",
-                    input: "https://host.example/fw.bin",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing the colon separator",
-                    input: "ssh://hostonly",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty remote path",
-                    input: "ssh://deploy@host.example:",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty host with a user",
-                    input: "ssh://deploy@:/abs/fw.bin",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty host without a user",
-                    input: "ssh://:/abs/fw.bin",
-                    expect: Fails,
-                },
-            ],
-            |url| {
+        scenarios!(
+            run = |url| {
                 parse_ssh_url(url)
                     .map(|(host, _user, path)| (host, path))
                     .map_err(drop)
-            },
+            };
+            "user, host, absolute path" {
+                "ssh://deploy@host.example:/abs/fw.bin" => Yields(("host.example".to_string(), "/abs/fw.bin".to_string())),
+            }
+
+            "user, host, relative path" {
+                "ssh://deploy@host.example:rel/fw.bin" => Yields(("host.example".to_string(), "rel/fw.bin".to_string())),
+            }
+
+            "no user, host, absolute path" {
+                "ssh://host.example:/abs/fw.bin" => Yields(("host.example".to_string(), "/abs/fw.bin".to_string())),
+            }
+
+            "path containing a colon keeps the rest after the first colon" {
+                "ssh://host.example:/abs:with:colons" => Yields(("host.example".to_string(), "/abs:with:colons".to_string())),
+            }
+
+            "not an ssh URL (missing prefix)" {
+                "https://host.example/fw.bin" => Fails,
+            }
+
+            "missing the colon separator" {
+                "ssh://hostonly" => Fails,
+            }
+
+            "empty remote path" {
+                "ssh://deploy@host.example:" => Fails,
+            }
+
+            "empty host with a user" {
+                "ssh://deploy@:/abs/fw.bin" => Fails,
+            }
+
+            "empty host without a user" {
+                "ssh://:/abs/fw.bin" => Fails,
+            }
         );
     }
 
@@ -640,27 +614,21 @@ mod coverage_tests {
     // ssh rows are whoami-independent. Local/Http carry their raw field verbatim.
     #[test]
     fn description_formats_each_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "local path",
-                    input: FirmwareSource::local("/tmp/fw.bin"),
-                    expect: "local:/tmp/fw.bin".to_string(),
-                },
-                Check {
-                    scenario: "http url",
-                    input: FirmwareSource::http("https://example.com/fw.bin"),
-                    expect: "http:https://example.com/fw.bin".to_string(),
-                },
-                Check {
-                    scenario: "ssh with explicit user, port, host, path",
-                    input: FirmwareSource::ssh("host.example", "/abs/fw.bin")
-                        .with_username("deploy")
-                        .with_port(2222),
-                    expect: "ssh://deploy@host.example:2222:/abs/fw.bin".to_string(),
-                },
-            ],
-            |src| src.description(),
+        value_scenarios!(
+            run = |src| src.description();
+            "local path" {
+                FirmwareSource::local("/tmp/fw.bin") => "local:/tmp/fw.bin".to_string(),
+            }
+
+            "http url" {
+                FirmwareSource::http("https://example.com/fw.bin") => "http:https://example.com/fw.bin".to_string(),
+            }
+
+            "ssh with explicit user, port, host, path" {
+                FirmwareSource::ssh("host.example", "/abs/fw.bin")
+                .with_username("deploy")
+                .with_port(2222) => "ssh://deploy@host.example:2222:/abs/fw.bin".to_string(),
+            }
         );
     }
 
@@ -678,20 +646,15 @@ mod coverage_tests {
 
         // with_port and with_username are no-ops on non-ssh sources, so the
         // description is unchanged.
-        check_values(
-            [
-                Check {
-                    scenario: "with_port is a no-op on Local",
-                    input: FirmwareSource::local("/tmp/fw.bin").with_port(9999),
-                    expect: "local:/tmp/fw.bin".to_string(),
-                },
-                Check {
-                    scenario: "with_username is a no-op on Http",
-                    input: FirmwareSource::http("https://x/fw").with_username("ignored"),
-                    expect: "http:https://x/fw".to_string(),
-                },
-            ],
-            |src| src.description(),
+        value_scenarios!(
+            run = |src| src.description();
+            "with_port is a no-op on Local" {
+                FirmwareSource::local("/tmp/fw.bin").with_port(9999) => "local:/tmp/fw.bin".to_string(),
+            }
+
+            "with_username is a no-op on Http" {
+                FirmwareSource::http("https://x/fw").with_username("ignored") => "http:https://x/fw".to_string(),
+            }
         );
     }
 
@@ -700,32 +663,26 @@ mod coverage_tests {
     // pins the variant-specific behavior without exposing secrets.
     #[test]
     fn with_credentials_targets_http_and_ssh_only() {
-        check_values(
-            [
-                Check {
-                    scenario: "Http source stores the credential",
-                    input: FirmwareSource::http("https://x/fw")
-                        .with_credentials(Credentials::bearer_token("t")),
-                    expect: true,
-                },
-                Check {
-                    scenario: "Ssh source stores the credential",
-                    input: FirmwareSource::ssh("h", "/p")
-                        .with_credentials(Credentials::ssh_agent()),
-                    expect: true,
-                },
-                Check {
-                    scenario: "Local source ignores the credential",
-                    input: FirmwareSource::local("/tmp/fw.bin")
-                        .with_credentials(Credentials::bearer_token("t")),
-                    expect: false,
-                },
-            ],
-            |src| match src {
+        value_scenarios!(
+            run = |src| match src {
                 FirmwareSource::Http { credentials, .. } => credentials.is_some(),
                 FirmwareSource::Ssh(SshSource { credentials, .. }) => credentials.is_some(),
                 FirmwareSource::Local { .. } => false,
-            },
+            };
+            "Http source stores the credential" {
+                FirmwareSource::http("https://x/fw")
+                .with_credentials(Credentials::bearer_token("t")) => true,
+            }
+
+            "Ssh source stores the credential" {
+                FirmwareSource::ssh("h", "/p")
+                .with_credentials(Credentials::ssh_agent()) => true,
+            }
+
+            "Local source ignores the credential" {
+                FirmwareSource::local("/tmp/fw.bin")
+                .with_credentials(Credentials::bearer_token("t")) => false,
+            }
         );
     }
 
@@ -733,35 +690,27 @@ mod coverage_tests {
     // label. One row per variant.
     #[test]
     fn credential_type_name_covers_every_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "bearer token",
-                    input: Credentials::bearer_token("t"),
-                    expect: "bearer_token",
-                },
-                Check {
-                    scenario: "basic auth",
-                    input: Credentials::basic_auth("u", "p"),
-                    expect: "basic_auth",
-                },
-                Check {
-                    scenario: "header",
-                    input: Credentials::header("X-Key", "v"),
-                    expect: "header",
-                },
-                Check {
-                    scenario: "ssh key",
-                    input: Credentials::ssh_key("/k"),
-                    expect: "ssh_key",
-                },
-                Check {
-                    scenario: "ssh agent",
-                    input: Credentials::ssh_agent(),
-                    expect: "ssh_agent",
-                },
-            ],
-            |cred| credential_type_name(&cred),
+        value_scenarios!(
+            run = |cred| credential_type_name(&cred);
+            "bearer token" {
+                Credentials::bearer_token("t") => "bearer_token",
+            }
+
+            "basic auth" {
+                Credentials::basic_auth("u", "p") => "basic_auth",
+            }
+
+            "header" {
+                Credentials::header("X-Key", "v") => "header",
+            }
+
+            "ssh key" {
+                Credentials::ssh_key("/k") => "ssh_key",
+            }
+
+            "ssh agent" {
+                Credentials::ssh_agent() => "ssh_agent",
+            }
         );
     }
 
@@ -770,35 +719,27 @@ mod coverage_tests {
     // no-special-chars, single-quote, leading-quote, and empty cases.
     #[test]
     fn shell_escape_quotes_and_escapes() {
-        check_values(
-            [
-                Check {
-                    scenario: "plain path is wrapped in single quotes",
-                    input: "/firmware/fw.bin",
-                    expect: "'/firmware/fw.bin'".to_string(),
-                },
-                Check {
-                    scenario: "empty string",
-                    input: "",
-                    expect: "''".to_string(),
-                },
-                Check {
-                    scenario: "single embedded quote",
-                    input: "a'b",
-                    expect: "'a'\\''b'".to_string(),
-                },
-                Check {
-                    scenario: "leading quote",
-                    input: "'x",
-                    expect: "''\\''x'".to_string(),
-                },
-                Check {
-                    scenario: "two embedded quotes",
-                    input: "a'b'c",
-                    expect: "'a'\\''b'\\''c'".to_string(),
-                },
-            ],
-            shell_escape,
+        value_scenarios!(
+            run = shell_escape;
+            "plain path is wrapped in single quotes" {
+                "/firmware/fw.bin" => "'/firmware/fw.bin'".to_string(),
+            }
+
+            "empty string" {
+                "" => "''".to_string(),
+            }
+
+            "single embedded quote" {
+                "a'b" => "'a'\\''b'".to_string(),
+            }
+
+            "leading quote" {
+                "'x" => "''\\''x'".to_string(),
+            }
+
+            "two embedded quotes" {
+                "a'b'c" => "'a'\\''b'\\''c'".to_string(),
+            }
         );
     }
 }

--- a/crates/libmlx/src/lockdown/lockdown.rs
+++ b/crates/libmlx/src/lockdown/lockdown.rs
@@ -235,7 +235,7 @@ impl From<StatusReportPb> for StatusReport {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -244,28 +244,22 @@ mod coverage_tests {
     // arms of the `rename_all = "lowercase"` encoding via a stable equality.
     #[test]
     fn lock_status_round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "locked",
-                    input: LockStatus::Locked,
-                    expect: Yields(LockStatus::Locked),
-                },
-                Case {
-                    scenario: "unlocked",
-                    input: LockStatus::Unlocked,
-                    expect: Yields(LockStatus::Unlocked),
-                },
-                Case {
-                    scenario: "unknown",
-                    input: LockStatus::Unknown,
-                    expect: Yields(LockStatus::Unknown),
-                },
-            ],
-            |status: LockStatus| {
+        scenarios!(
+            run = |status: LockStatus| {
                 let json = serde_json::to_string(&status).map_err(drop)?;
                 serde_json::from_str(&json).map_err(drop)
-            },
+            };
+            "locked" {
+                LockStatus::Locked => Yields(LockStatus::Locked),
+            }
+
+            "unlocked" {
+                LockStatus::Unlocked => Yields(LockStatus::Unlocked),
+            }
+
+            "unknown" {
+                LockStatus::Unknown => Yields(LockStatus::Unknown),
+            }
         );
     }
 
@@ -274,25 +268,19 @@ mod coverage_tests {
     // the right assertion.
     #[test]
     fn lock_status_serializes_to_lowercase_token() {
-        check_cases(
-            [
-                Case {
-                    scenario: "locked",
-                    input: LockStatus::Locked,
-                    expect: Yields("\"locked\"".to_string()),
-                },
-                Case {
-                    scenario: "unlocked",
-                    input: LockStatus::Unlocked,
-                    expect: Yields("\"unlocked\"".to_string()),
-                },
-                Case {
-                    scenario: "unknown",
-                    input: LockStatus::Unknown,
-                    expect: Yields("\"unknown\"".to_string()),
-                },
-            ],
-            |status: LockStatus| serde_json::to_string(&status).map_err(drop),
+        scenarios!(
+            run = |status: LockStatus| serde_json::to_string(&status).map_err(drop);
+            "locked" {
+                LockStatus::Locked => Yields("\"locked\"".to_string()),
+            }
+
+            "unlocked" {
+                LockStatus::Unlocked => Yields("\"unlocked\"".to_string()),
+            }
+
+            "unknown" {
+                LockStatus::Unknown => Yields("\"unknown\"".to_string()),
+            }
         );
     }
 
@@ -301,30 +289,23 @@ mod coverage_tests {
     // rejection path.
     #[test]
     fn lock_status_deserializes_each_token() {
-        check_cases(
-            [
-                Case {
-                    scenario: "locked",
-                    input: "\"locked\"",
-                    expect: Yields(LockStatus::Locked),
-                },
-                Case {
-                    scenario: "unlocked",
-                    input: "\"unlocked\"",
-                    expect: Yields(LockStatus::Unlocked),
-                },
-                Case {
-                    scenario: "unknown",
-                    input: "\"unknown\"",
-                    expect: Yields(LockStatus::Unknown),
-                },
-                Case {
-                    scenario: "an unrecognized token is rejected",
-                    input: "\"bogus\"",
-                    expect: Fails,
-                },
-            ],
-            |raw: &str| serde_json::from_str::<LockStatus>(raw).map_err(drop),
+        scenarios!(
+            run = |raw: &str| serde_json::from_str::<LockStatus>(raw).map_err(drop);
+            "locked" {
+                "\"locked\"" => Yields(LockStatus::Locked),
+            }
+
+            "unlocked" {
+                "\"unlocked\"" => Yields(LockStatus::Unlocked),
+            }
+
+            "unknown" {
+                "\"unknown\"" => Yields(LockStatus::Unknown),
+            }
+
+            "an unrecognized token is rejected" {
+                "\"bogus\"" => Fails,
+            }
         );
     }
 
@@ -333,50 +314,38 @@ mod coverage_tests {
     // numbers (UNKNOWN=0, LOCKED=1, UNLOCKED=2) without relying on Pb being PartialEq.
     #[test]
     fn lock_status_into_pb_discriminant() {
-        check_values(
-            [
-                Check {
-                    scenario: "locked -> 1",
-                    input: LockStatus::Locked,
-                    expect: 1,
-                },
-                Check {
-                    scenario: "unlocked -> 2",
-                    input: LockStatus::Unlocked,
-                    expect: 2,
-                },
-                Check {
-                    scenario: "unknown -> 0",
-                    input: LockStatus::Unknown,
-                    expect: 0,
-                },
-            ],
-            |status: LockStatus| LockStatusPb::from(status) as i32,
+        value_scenarios!(
+            run = |status: LockStatus| LockStatusPb::from(status) as i32;
+            "locked -> 1" {
+                LockStatus::Locked => 1,
+            }
+
+            "unlocked -> 2" {
+                LockStatus::Unlocked => 2,
+            }
+
+            "unknown -> 0" {
+                LockStatus::Unknown => 0,
+            }
         );
     }
 
     // LockStatusPb -> LockStatus covers every match arm of the reverse conversion.
     #[test]
     fn lock_status_from_pb() {
-        check_values(
-            [
-                Check {
-                    scenario: "Locked",
-                    input: LockStatusPb::Locked,
-                    expect: LockStatus::Locked,
-                },
-                Check {
-                    scenario: "Unlocked",
-                    input: LockStatusPb::Unlocked,
-                    expect: LockStatus::Unlocked,
-                },
-                Check {
-                    scenario: "Unknown",
-                    input: LockStatusPb::Unknown,
-                    expect: LockStatus::Unknown,
-                },
-            ],
-            LockStatus::from,
+        value_scenarios!(
+            run = LockStatus::from;
+            "Locked" {
+                LockStatusPb::Locked => LockStatus::Locked,
+            }
+
+            "Unlocked" {
+                LockStatusPb::Unlocked => LockStatus::Unlocked,
+            }
+
+            "Unknown" {
+                LockStatusPb::Unknown => LockStatus::Unknown,
+            }
         );
     }
 
@@ -385,25 +354,19 @@ mod coverage_tests {
     // inverses without depending on the pb type being PartialEq.
     #[test]
     fn lock_status_round_trips_through_pb() {
-        check_values(
-            [
-                Check {
-                    scenario: "locked",
-                    input: LockStatus::Locked,
-                    expect: LockStatus::Locked,
-                },
-                Check {
-                    scenario: "unlocked",
-                    input: LockStatus::Unlocked,
-                    expect: LockStatus::Unlocked,
-                },
-                Check {
-                    scenario: "unknown",
-                    input: LockStatus::Unknown,
-                    expect: LockStatus::Unknown,
-                },
-            ],
-            |status: LockStatus| LockStatus::from(LockStatusPb::from(status)),
+        value_scenarios!(
+            run = |status: LockStatus| LockStatus::from(LockStatusPb::from(status));
+            "locked" {
+                LockStatus::Locked => LockStatus::Locked,
+            }
+
+            "unlocked" {
+                LockStatus::Unlocked => LockStatus::Unlocked,
+            }
+
+            "unknown" {
+                LockStatus::Unknown => LockStatus::Unknown,
+            }
         );
     }
 
@@ -412,37 +375,8 @@ mod coverage_tests {
     // of the fields we are sure about, keyed by status variant.
     #[test]
     fn status_report_into_pb_preserves_fields() {
-        check_values(
-            [
-                Check {
-                    scenario: "locked",
-                    input: LockStatus::Locked,
-                    expect: (
-                        "dev-a".to_string(),
-                        1,
-                        "2026-01-01T00:00:00+00:00".to_string(),
-                    ),
-                },
-                Check {
-                    scenario: "unlocked",
-                    input: LockStatus::Unlocked,
-                    expect: (
-                        "dev-a".to_string(),
-                        2,
-                        "2026-01-01T00:00:00+00:00".to_string(),
-                    ),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: LockStatus::Unknown,
-                    expect: (
-                        "dev-a".to_string(),
-                        0,
-                        "2026-01-01T00:00:00+00:00".to_string(),
-                    ),
-                },
-            ],
-            |status: LockStatus| {
+        value_scenarios!(
+            run = |status: LockStatus| {
                 let report = StatusReport {
                     device_id: "dev-a".to_string(),
                     status,
@@ -450,7 +384,30 @@ mod coverage_tests {
                 };
                 let pb = StatusReportPb::from(report);
                 (pb.device_id, pb.status, pb.timestamp)
-            },
+            };
+            "locked" {
+                LockStatus::Locked => (
+                    "dev-a".to_string(),
+                    1,
+                    "2026-01-01T00:00:00+00:00".to_string(),
+                ),
+            }
+
+            "unlocked" {
+                LockStatus::Unlocked => (
+                    "dev-a".to_string(),
+                    2,
+                    "2026-01-01T00:00:00+00:00".to_string(),
+                ),
+            }
+
+            "unknown" {
+                LockStatus::Unknown => (
+                    "dev-a".to_string(),
+                    0,
+                    "2026-01-01T00:00:00+00:00".to_string(),
+                ),
+            }
         );
     }
 
@@ -460,35 +417,8 @@ mod coverage_tests {
     // timestamp pass through unchanged; we project (device_id, status, timestamp).
     #[test]
     fn status_report_from_pb_maps_status_and_coerces_invalid() {
-        check_values(
-            [
-                Check {
-                    scenario: "0 -> Unknown",
-                    input: 0,
-                    expect: ("dev-b".to_string(), LockStatus::Unknown, "ts".to_string()),
-                },
-                Check {
-                    scenario: "1 -> Locked",
-                    input: 1,
-                    expect: ("dev-b".to_string(), LockStatus::Locked, "ts".to_string()),
-                },
-                Check {
-                    scenario: "2 -> Unlocked",
-                    input: 2,
-                    expect: ("dev-b".to_string(), LockStatus::Unlocked, "ts".to_string()),
-                },
-                Check {
-                    scenario: "out-of-range discriminant coerces to Unknown",
-                    input: 99,
-                    expect: ("dev-b".to_string(), LockStatus::Unknown, "ts".to_string()),
-                },
-                Check {
-                    scenario: "negative discriminant coerces to Unknown",
-                    input: -1,
-                    expect: ("dev-b".to_string(), LockStatus::Unknown, "ts".to_string()),
-                },
-            ],
-            |status_i32: i32| {
+        value_scenarios!(
+            run = |status_i32: i32| {
                 let pb = StatusReportPb {
                     device_id: "dev-b".to_string(),
                     status: status_i32,
@@ -496,7 +426,26 @@ mod coverage_tests {
                 };
                 let report = StatusReport::from(pb);
                 (report.device_id, report.status, report.timestamp)
-            },
+            };
+            "0 -> Unknown" {
+                0 => ("dev-b".to_string(), LockStatus::Unknown, "ts".to_string()),
+            }
+
+            "1 -> Locked" {
+                1 => ("dev-b".to_string(), LockStatus::Locked, "ts".to_string()),
+            }
+
+            "2 -> Unlocked" {
+                2 => ("dev-b".to_string(), LockStatus::Unlocked, "ts".to_string()),
+            }
+
+            "out-of-range discriminant coerces to Unknown" {
+                99 => ("dev-b".to_string(), LockStatus::Unknown, "ts".to_string()),
+            }
+
+            "negative discriminant coerces to Unknown" {
+                -1 => ("dev-b".to_string(), LockStatus::Unknown, "ts".to_string()),
+            }
         );
     }
 
@@ -505,25 +454,8 @@ mod coverage_tests {
     // From impls as inverses.
     #[test]
     fn status_report_round_trips_through_pb() {
-        check_values(
-            [
-                Check {
-                    scenario: "locked",
-                    input: LockStatus::Locked,
-                    expect: ("d".to_string(), LockStatus::Locked, "t".to_string()),
-                },
-                Check {
-                    scenario: "unlocked",
-                    input: LockStatus::Unlocked,
-                    expect: ("d".to_string(), LockStatus::Unlocked, "t".to_string()),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: LockStatus::Unknown,
-                    expect: ("d".to_string(), LockStatus::Unknown, "t".to_string()),
-                },
-            ],
-            |status: LockStatus| {
+        value_scenarios!(
+            run = |status: LockStatus| {
                 let report = StatusReport {
                     device_id: "d".to_string(),
                     status,
@@ -531,7 +463,18 @@ mod coverage_tests {
                 };
                 let back = StatusReport::from(StatusReportPb::from(report));
                 (back.device_id, back.status, back.timestamp)
-            },
+            };
+            "locked" {
+                LockStatus::Locked => ("d".to_string(), LockStatus::Locked, "t".to_string()),
+            }
+
+            "unlocked" {
+                LockStatus::Unlocked => ("d".to_string(), LockStatus::Unlocked, "t".to_string()),
+            }
+
+            "unknown" {
+                LockStatus::Unknown => ("d".to_string(), LockStatus::Unknown, "t".to_string()),
+            }
         );
     }
 
@@ -552,30 +495,24 @@ mod coverage_tests {
     // project) and proves the JSON is well-formed for every status variant.
     #[test]
     fn status_report_to_json_round_trips() {
-        check_cases(
-            [
-                Case {
-                    scenario: "locked",
-                    input: LockStatus::Locked,
-                    expect: Yields(("dev-j".to_string(), LockStatus::Locked)),
-                },
-                Case {
-                    scenario: "unlocked",
-                    input: LockStatus::Unlocked,
-                    expect: Yields(("dev-j".to_string(), LockStatus::Unlocked)),
-                },
-                Case {
-                    scenario: "unknown",
-                    input: LockStatus::Unknown,
-                    expect: Yields(("dev-j".to_string(), LockStatus::Unknown)),
-                },
-            ],
-            |status: LockStatus| {
+        scenarios!(
+            run = |status: LockStatus| {
                 let report = StatusReport::new("dev-j".to_string(), status);
                 let json = report.to_json().map_err(drop)?;
                 let back: StatusReport = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>((back.device_id, back.status))
-            },
+            };
+            "locked" {
+                LockStatus::Locked => Yields(("dev-j".to_string(), LockStatus::Locked)),
+            }
+
+            "unlocked" {
+                LockStatus::Unlocked => Yields(("dev-j".to_string(), LockStatus::Unlocked)),
+            }
+
+            "unknown" {
+                LockStatus::Unknown => Yields(("dev-j".to_string(), LockStatus::Unknown)),
+            }
         );
     }
 
@@ -632,25 +569,19 @@ mod coverage_tests {
         let manager = LockdownManager::with_runner(runner);
 
         // lock_device validates first, then would dry-run.
-        check_values(
-            [
-                Check {
-                    scenario: "empty id is rejected before the runner",
-                    input: "",
-                    expect: "InvalidDeviceId",
-                },
-                Check {
-                    scenario: "id with a space is rejected before the runner",
-                    input: "dev 0",
-                    expect: "InvalidDeviceId",
-                },
-                Check {
-                    scenario: "a valid id passes validation and reaches the dry-run",
-                    input: "0000:01:00.0",
-                    expect: "DryRun",
-                },
-            ],
-            |device_id: &str| kind(manager.lock_device(device_id, "12345678")),
+        value_scenarios!(
+            run = |device_id: &str| kind(manager.lock_device(device_id, "12345678"));
+            "empty id is rejected before the runner" {
+                "" => "InvalidDeviceId",
+            }
+
+            "id with a space is rejected before the runner" {
+                "dev 0" => "InvalidDeviceId",
+            }
+
+            "a valid id passes validation and reaches the dry-run" {
+                "0000:01:00.0" => "DryRun",
+            }
         );
     }
 
@@ -671,25 +602,19 @@ mod coverage_tests {
         let runner = FlintRunner::with_path("flint").with_dry_run(true);
         let manager = LockdownManager::with_runner(runner);
 
-        check_values(
-            [
-                Check {
-                    scenario: "empty id",
-                    input: "",
-                    expect: "InvalidDeviceId",
-                },
-                Check {
-                    scenario: "id with a space",
-                    input: "bad id",
-                    expect: "InvalidDeviceId",
-                },
-                Check {
-                    scenario: "valid id reaches the dry-run query",
-                    input: "mlx5_0",
-                    expect: "DryRun",
-                },
-            ],
-            |device_id: &str| kind(manager.get_status(device_id)),
+        value_scenarios!(
+            run = |device_id: &str| kind(manager.get_status(device_id));
+            "empty id" {
+                "" => "InvalidDeviceId",
+            }
+
+            "id with a space" {
+                "bad id" => "InvalidDeviceId",
+            }
+
+            "valid id reaches the dry-run query" {
+                "mlx5_0" => "DryRun",
+            }
         );
     }
 }

--- a/crates/libmlx/src/lockdown/runner.rs
+++ b/crates/libmlx/src/lockdown/runner.rs
@@ -338,7 +338,7 @@ impl Default for FlintRunner {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -368,55 +368,43 @@ mod coverage_tests {
     // chars, empty, and embedded whitespace.
     #[test]
     fn is_valid_key_requires_eight_hex_digits() {
-        check_values(
-            [
-                Check {
-                    scenario: "eight lowercase hex digits",
-                    input: "0a1b2c3d",
-                    expect: true,
-                },
-                Check {
-                    scenario: "eight uppercase hex digits",
-                    input: "ABCDEF01",
-                    expect: true,
-                },
-                Check {
-                    scenario: "eight digits, all numeric",
-                    input: "12345678",
-                    expect: true,
-                },
-                Check {
-                    scenario: "seven digits is too short",
-                    input: "1234567",
-                    expect: false,
-                },
-                Check {
-                    scenario: "nine digits is too long",
-                    input: "123456789",
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty string",
-                    input: "",
-                    expect: false,
-                },
-                Check {
-                    scenario: "right length but non-hex char 'g'",
-                    input: "1234567g",
-                    expect: false,
-                },
-                Check {
-                    scenario: "right length but contains a space",
-                    input: "1234 678",
-                    expect: false,
-                },
-                Check {
-                    scenario: "0x-prefixed is not bare hex of length 8",
-                    input: "0x123456",
-                    expect: false,
-                },
-            ],
-            FlintRunner::is_valid_key,
+        value_scenarios!(
+            run = FlintRunner::is_valid_key;
+            "eight lowercase hex digits" {
+                "0a1b2c3d" => true,
+            }
+
+            "eight uppercase hex digits" {
+                "ABCDEF01" => true,
+            }
+
+            "eight digits, all numeric" {
+                "12345678" => true,
+            }
+
+            "seven digits is too short" {
+                "1234567" => false,
+            }
+
+            "nine digits is too long" {
+                "123456789" => false,
+            }
+
+            "empty string" {
+                "" => false,
+            }
+
+            "right length but non-hex char 'g'" {
+                "1234567g" => false,
+            }
+
+            "right length but contains a space" {
+                "1234 678" => false,
+            }
+
+            "0x-prefixed is not bare hex of length 8" {
+                "0x123456" => false,
+            }
         );
     }
 
@@ -424,40 +412,31 @@ mod coverage_tests {
     // Errors aren't PartialEq, so the rejection rows use Fails + map_err(drop).
     #[test]
     fn validate_device_id_rejects_empty_and_spaces() {
-        check_cases(
-            [
-                Case {
-                    scenario: "a PCI-style address is accepted",
-                    input: "0000:01:00.0",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "a simple device name is accepted",
-                    input: "mlx5_0",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "a device path is accepted",
-                    input: "/dev/mst/mt4119_pciconf0",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "empty is rejected",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a leading space is rejected",
-                    input: " 01:00.0",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "an interior space is rejected",
-                    input: "01:00 .0",
-                    expect: Fails,
-                },
-            ],
-            |id| FlintRunner::validate_device_id(id).map_err(drop),
+        scenarios!(
+            run = |id| FlintRunner::validate_device_id(id).map_err(drop);
+            "a PCI-style address is accepted" {
+                "0000:01:00.0" => Yields(()),
+            }
+
+            "a simple device name is accepted" {
+                "mlx5_0" => Yields(()),
+            }
+
+            "a device path is accepted" {
+                "/dev/mst/mt4119_pciconf0" => Yields(()),
+            }
+
+            "empty is rejected" {
+                "" => Fails,
+            }
+
+            "a leading space is rejected" {
+                " 01:00.0" => Fails,
+            }
+
+            "an interior space is rejected" {
+                "01:00 .0" => Fails,
+            }
         );
     }
 
@@ -485,25 +464,19 @@ mod coverage_tests {
     #[test]
     fn build_command_formats_path_and_args() {
         let runner = FlintRunner::with_path("/opt/mellanox/mft/bin/flint");
-        check_values(
-            [
-                Check {
-                    scenario: "typical query args",
-                    input: &["-d", "dev0", "q"][..],
-                    expect: "/opt/mellanox/mft/bin/flint -d dev0 q".to_string(),
-                },
-                Check {
-                    scenario: "empty args leaves a trailing space",
-                    input: &[][..],
-                    expect: "/opt/mellanox/mft/bin/flint ".to_string(),
-                },
-                Check {
-                    scenario: "a single arg",
-                    input: &["burn"][..],
-                    expect: "/opt/mellanox/mft/bin/flint burn".to_string(),
-                },
-            ],
-            |args| runner.build_command(args),
+        value_scenarios!(
+            run = |args| runner.build_command(args);
+            "typical query args" {
+                &["-d", "dev0", "q"][..] => "/opt/mellanox/mft/bin/flint -d dev0 q".to_string(),
+            }
+
+            "empty args leaves a trailing space" {
+                &[][..] => "/opt/mellanox/mft/bin/flint ".to_string(),
+            }
+
+            "a single arg" {
+                &["burn"][..] => "/opt/mellanox/mft/bin/flint burn".to_string(),
+            }
         );
     }
 
@@ -572,25 +545,8 @@ mod coverage_tests {
         let runner = FlintRunner::with_path("flint").with_dry_run(true);
 
         // Each key-taking method, fed a too-short key, must report InvalidKey.
-        check_values(
-            [
-                Check {
-                    scenario: "enable_hw_access rejects a bad key",
-                    input: "enable",
-                    expect: "InvalidKey",
-                },
-                Check {
-                    scenario: "disable_hw_access rejects a bad key",
-                    input: "disable",
-                    expect: "InvalidKey",
-                },
-                Check {
-                    scenario: "set_key rejects a bad key",
-                    input: "set_key",
-                    expect: "InvalidKey",
-                },
-            ],
-            |which| {
+        value_scenarios!(
+            run = |which| {
                 let bad = "xyz"; // not 8 hex digits
                 let e = match which {
                     "enable" => runner.enable_hw_access("dev0", bad).unwrap_err(),
@@ -599,7 +555,18 @@ mod coverage_tests {
                     _ => unreachable!(),
                 };
                 err_kind(&e)
-            },
+            };
+            "enable_hw_access rejects a bad key" {
+                "enable" => "InvalidKey",
+            }
+
+            "disable_hw_access rejects a bad key" {
+                "disable" => "InvalidKey",
+            }
+
+            "set_key rejects a bad key" {
+                "set_key" => "InvalidKey",
+            }
         );
     }
 

--- a/crates/libmlx/src/profile/error.rs
+++ b/crates/libmlx/src/profile/error.rs
@@ -171,7 +171,7 @@ impl From<std::io::Error> for MlxProfileError {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Check, scenarios, value_scenarios};
 
     use super::*;
 
@@ -198,41 +198,33 @@ mod coverage_tests {
     // independent of the (non-PartialEq) payloads.
     #[test]
     fn constructors_select_the_right_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "registry_not_found -> RegistryNotFound",
-                    input: MlxProfileError::registry_not_found("reg"),
-                    expect: "RegistryNotFound",
-                },
-                Check {
-                    scenario: "variable_not_found -> VariableNotFound",
-                    input: MlxProfileError::variable_not_found("var", "reg"),
-                    expect: "VariableNotFound",
-                },
-                Check {
-                    scenario: "value_validation -> ValueValidation",
-                    input: MlxProfileError::value_validation(
-                        "var",
-                        MlxValueError::TypeMismatch {
-                            expected: "Integer".to_string(),
-                            got: "bool".to_string(),
-                        },
-                    ),
-                    expect: "ValueValidation",
-                },
-                Check {
-                    scenario: "profile_validation -> ProfileValidation",
-                    input: MlxProfileError::profile_validation("bad"),
-                    expect: "ProfileValidation",
-                },
-                Check {
-                    scenario: "serialization -> Serialization",
-                    input: MlxProfileError::serialization("boom"),
-                    expect: "Serialization",
-                },
-            ],
-            |error| discriminant(&error),
+        value_scenarios!(
+            run = |error| discriminant(&error);
+            "registry_not_found -> RegistryNotFound" {
+                MlxProfileError::registry_not_found("reg") => "RegistryNotFound",
+            }
+
+            "variable_not_found -> VariableNotFound" {
+                MlxProfileError::variable_not_found("var", "reg") => "VariableNotFound",
+            }
+
+            "value_validation -> ValueValidation" {
+                MlxProfileError::value_validation(
+                    "var",
+                    MlxValueError::TypeMismatch {
+                        expected: "Integer".to_string(),
+                        got: "bool".to_string(),
+                    },
+                ) => "ValueValidation",
+            }
+
+            "profile_validation -> ProfileValidation" {
+                MlxProfileError::profile_validation("bad") => "ProfileValidation",
+            }
+
+            "serialization -> Serialization" {
+                MlxProfileError::serialization("boom") => "Serialization",
+            }
         );
     }
 
@@ -241,43 +233,35 @@ mod coverage_tests {
     // exercises the nested MlxValueError Display ("Type mismatch: ...").
     #[test]
     fn constructors_render_their_display_strings() {
-        check_values(
-            [
-                Check {
-                    scenario: "RegistryNotFound Display",
-                    input: MlxProfileError::registry_not_found("my_registry"),
-                    expect: "Registry 'my_registry' not found in available registries".to_string(),
-                },
-                Check {
-                    scenario: "VariableNotFound Display",
-                    input: MlxProfileError::variable_not_found("my_var", "my_registry"),
-                    expect: "Variable 'my_var' not found in registry 'my_registry'".to_string(),
-                },
-                Check {
-                    scenario: "ValueValidation Display nests the MlxValueError",
-                    input: MlxProfileError::value_validation(
-                        "my_var",
-                        MlxValueError::TypeMismatch {
-                            expected: "Integer".to_string(),
-                            got: "bool".to_string(),
-                        },
-                    ),
-                    expect: "Value validation failed for variable 'my_var': \
-                             Type mismatch: expected Integer, got bool"
-                        .to_string(),
-                },
-                Check {
-                    scenario: "ProfileValidation Display",
-                    input: MlxProfileError::profile_validation("something went wrong"),
-                    expect: "Profile validation failed: something went wrong".to_string(),
-                },
-                Check {
-                    scenario: "Serialization Display",
-                    input: MlxProfileError::serialization("could not serialize"),
-                    expect: "Serialization error: could not serialize".to_string(),
-                },
-            ],
-            |error| error.to_string(),
+        value_scenarios!(
+            run = |error| error.to_string();
+            "RegistryNotFound Display" {
+                MlxProfileError::registry_not_found("my_registry") => "Registry 'my_registry' not found in available registries".to_string(),
+            }
+
+            "VariableNotFound Display" {
+                MlxProfileError::variable_not_found("my_var", "my_registry") => "Variable 'my_var' not found in registry 'my_registry'".to_string(),
+            }
+
+            "ValueValidation Display nests the MlxValueError" {
+                MlxProfileError::value_validation(
+                    "my_var",
+                    MlxValueError::TypeMismatch {
+                        expected: "Integer".to_string(),
+                        got: "bool".to_string(),
+                    },
+                ) => "Value validation failed for variable 'my_var': \
+                     Type mismatch: expected Integer, got bool"
+                .to_string(),
+            }
+
+            "ProfileValidation Display" {
+                MlxProfileError::profile_validation("something went wrong") => "Profile validation failed: something went wrong".to_string(),
+            }
+
+            "Serialization Display" {
+                MlxProfileError::serialization("could not serialize") => "Serialization error: could not serialize".to_string(),
+            }
         );
     }
 
@@ -285,25 +269,19 @@ mod coverage_tests {
     // both flavors flow through the constructors and land in Display.
     #[test]
     fn constructors_accept_str_and_string() {
-        check_values(
-            [
-                Check {
-                    scenario: "registry_not_found from &str",
-                    input: MlxProfileError::registry_not_found("a"),
-                    expect: "Registry 'a' not found in available registries".to_string(),
-                },
-                Check {
-                    scenario: "registry_not_found from String",
-                    input: MlxProfileError::registry_not_found("b".to_string()),
-                    expect: "Registry 'b' not found in available registries".to_string(),
-                },
-                Check {
-                    scenario: "profile_validation from String",
-                    input: MlxProfileError::profile_validation("msg".to_string()),
-                    expect: "Profile validation failed: msg".to_string(),
-                },
-            ],
-            |error| error.to_string(),
+        value_scenarios!(
+            run = |error| error.to_string();
+            "registry_not_found from &str" {
+                MlxProfileError::registry_not_found("a") => "Registry 'a' not found in available registries".to_string(),
+            }
+
+            "registry_not_found from String" {
+                MlxProfileError::registry_not_found("b".to_string()) => "Registry 'b' not found in available registries".to_string(),
+            }
+
+            "profile_validation from String" {
+                MlxProfileError::profile_validation("msg".to_string()) => "Profile validation failed: msg".to_string(),
+            }
         );
     }
 
@@ -312,48 +290,39 @@ mod coverage_tests {
     // resulting discriminant (the wrapped payloads are not PartialEq).
     #[test]
     fn from_impls_select_the_right_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "MlxValueError -> ValueValidation",
-                    input: MlxProfileError::from(MlxValueError::ReadOnlyVariable {
-                        variable_name: "ro".to_string(),
-                    }),
-                    expect: "ValueValidation",
-                },
-                Check {
-                    scenario: "MlxRunnerError -> Runner",
-                    input: MlxProfileError::from(MlxRunnerError::NoDeviceFound),
-                    expect: "Runner",
-                },
-                Check {
-                    scenario: "std::io::Error -> Io",
-                    input: MlxProfileError::from(std::io::Error::other("disk gone")),
-                    expect: "Io",
-                },
-                Check {
-                    scenario: "serde_json::Error -> JsonParsing",
-                    input: MlxProfileError::from(
-                        serde_json::from_str::<i32>("not json").unwrap_err(),
-                    ),
-                    expect: "JsonParsing",
-                },
-                Check {
-                    scenario: "serde_yaml::Error -> YamlParsing",
-                    input: MlxProfileError::from(
-                        serde_yaml::from_str::<i32>("{ : : invalid").unwrap_err(),
-                    ),
-                    expect: "YamlParsing",
-                },
-                Check {
-                    scenario: "toml::de::Error -> TomlParsing",
-                    input: MlxProfileError::from(
-                        toml::from_str::<toml::Value>("= broken").unwrap_err(),
-                    ),
-                    expect: "TomlParsing",
-                },
-            ],
-            |error| discriminant(&error),
+        value_scenarios!(
+            run = |error| discriminant(&error);
+            "MlxValueError -> ValueValidation" {
+                MlxProfileError::from(MlxValueError::ReadOnlyVariable {
+                    variable_name: "ro".to_string(),
+                }) => "ValueValidation",
+            }
+
+            "MlxRunnerError -> Runner" {
+                MlxProfileError::from(MlxRunnerError::NoDeviceFound) => "Runner",
+            }
+
+            "std::io::Error -> Io" {
+                MlxProfileError::from(std::io::Error::other("disk gone")) => "Io",
+            }
+
+            "serde_json::Error -> JsonParsing" {
+                MlxProfileError::from(
+                    serde_json::from_str::<i32>("not json").unwrap_err(),
+                ) => "JsonParsing",
+            }
+
+            "serde_yaml::Error -> YamlParsing" {
+                MlxProfileError::from(
+                    serde_yaml::from_str::<i32>("{ : : invalid").unwrap_err(),
+                ) => "YamlParsing",
+            }
+
+            "toml::de::Error -> TomlParsing" {
+                MlxProfileError::from(
+                    toml::from_str::<toml::Value>("= broken").unwrap_err(),
+                ) => "TomlParsing",
+            }
         );
     }
 
@@ -390,44 +359,34 @@ mod coverage_tests {
             Ok(value)
         }
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid toml yields",
-                    input: "key = 1",
-                    expect: Yields("TomlParsing-or-ok"),
-                },
-                Case {
-                    scenario: "invalid toml fails as TomlParsing",
-                    input: "= nope",
-                    expect: FailsWith("TomlParsing"),
-                },
-            ],
-            |raw| {
+        scenarios!(
+            run = |raw| {
                 parse_toml(raw)
                     .map(|_| "TomlParsing-or-ok")
                     .map_err(|error| discriminant(&error))
-            },
+            };
+            "valid toml yields" {
+                "key = 1" => Yields("TomlParsing-or-ok"),
+            }
+
+            "invalid toml fails as TomlParsing" {
+                "= nope" => FailsWith("TomlParsing"),
+            }
         );
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid json yields",
-                    input: "{}",
-                    expect: Yields("JsonParsing-or-ok"),
-                },
-                Case {
-                    scenario: "invalid json fails as JsonParsing",
-                    input: "not json",
-                    expect: FailsWith("JsonParsing"),
-                },
-            ],
-            |raw| {
+        scenarios!(
+            run = |raw| {
                 parse_json(raw)
                     .map(|_| "JsonParsing-or-ok")
                     .map_err(|error| discriminant(&error))
-            },
+            };
+            "valid json yields" {
+                "{}" => Yields("JsonParsing-or-ok"),
+            }
+
+            "invalid json fails as JsonParsing" {
+                "not json" => FailsWith("JsonParsing"),
+            }
         );
     }
 }

--- a/crates/libmlx/src/profile/profile.rs
+++ b/crates/libmlx/src/profile/profile.rs
@@ -288,7 +288,7 @@ impl MlxConfigProfile {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
     use crate::variables::spec::MlxVariableSpec;
@@ -350,30 +350,24 @@ mod coverage_tests {
     // success we project to the configured value name.
     #[test]
     fn with_validates_name_and_value() {
-        check_cases(
-            [
-                Case {
-                    scenario: "known boolean variable, valid value",
-                    input: ("BOOL_VAR", "true"),
-                    expect: Yields("BOOL_VAR".to_string()),
-                },
-                Case {
-                    scenario: "unknown variable name is rejected",
-                    input: ("NOPE", "true"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "known boolean variable, unparseable value fails validation",
-                    input: ("BOOL_VAR", "maybe"),
-                    expect: Fails,
-                },
-            ],
-            |(name, value)| {
+        scenarios!(
+            run = |(name, value)| {
                 MlxConfigProfile::new("p", test_registry())
                     .with(name, value)
                     .map(|p| p.get_variable(name).unwrap().name().to_string())
                     .map_err(drop)
-            },
+            };
+            "known boolean variable, valid value" {
+                ("BOOL_VAR", "true") => Yields("BOOL_VAR".to_string()),
+            }
+
+            "unknown variable name is rejected" {
+                ("NOPE", "true") => Fails,
+            }
+
+            "known boolean variable, unparseable value fails validation" {
+                ("BOOL_VAR", "maybe") => Fails,
+            }
         );
     }
 
@@ -383,25 +377,20 @@ mod coverage_tests {
     // variables tests.
     #[test]
     fn with_enum_validation_path() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid enum option",
-                    input: "high",
-                    expect: Yields(MlxValueType::Enum("high".to_string())),
-                },
-                Case {
-                    scenario: "invalid enum option fails value validation",
-                    input: "middle",
-                    expect: Fails,
-                },
-            ],
-            |opt| {
+        scenarios!(
+            run = |opt| {
                 MlxConfigProfile::new("p", test_registry())
                     .with("ENUM_VAR", opt)
                     .map(|p| p.get_variable("ENUM_VAR").unwrap().value.clone())
                     .map_err(drop)
-            },
+            };
+            "valid enum option" {
+                "high" => Yields(MlxValueType::Enum("high".to_string())),
+            }
+
+            "invalid enum option fails value validation" {
+                "middle" => Fails,
+            }
         );
     }
 
@@ -425,26 +414,21 @@ mod coverage_tests {
             other.get_variable("FOREIGN").unwrap().with(1i64).unwrap()
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "value for a known variable is accepted",
-                    input: known_value,
-                    expect: Yields("INT_VAR".to_string()),
-                },
-                Case {
-                    scenario: "value for a foreign variable is rejected",
-                    input: foreign_value,
-                    expect: Fails,
-                },
-            ],
-            |value| {
+        scenarios!(
+            run = |value| {
                 let name = value.name().to_string();
                 MlxConfigProfile::new("p", test_registry())
                     .with_value(value)
                     .map(|p| p.get_variable(&name).unwrap().name().to_string())
                     .map_err(drop)
-            },
+            };
+            "value for a known variable is accepted" {
+                known_value => Yields("INT_VAR".to_string()),
+            }
+
+            "value for a foreign variable is rejected" {
+                foreign_value => Fails,
+            }
         );
     }
 
@@ -454,25 +438,8 @@ mod coverage_tests {
     // does append. Each row reports (variable_count, INT_VAR value).
     #[test]
     fn adding_same_variable_replaces_in_place() {
-        check_values(
-            [
-                Check {
-                    scenario: "single write",
-                    input: vec![("INT_VAR", 1i64)],
-                    expect: (1usize, Some(MlxValueType::Integer(1))),
-                },
-                Check {
-                    scenario: "re-write same variable replaces, count stays 1",
-                    input: vec![("INT_VAR", 1i64), ("INT_VAR", 2i64)],
-                    expect: (1usize, Some(MlxValueType::Integer(2))),
-                },
-                Check {
-                    scenario: "distinct second variable appends",
-                    input: vec![("INT_VAR", 5i64), ("INT_VAR", 9i64)],
-                    expect: (1usize, Some(MlxValueType::Integer(9))),
-                },
-            ],
-            |writes| {
+        value_scenarios!(
+            run = |writes| {
                 let mut profile = MlxConfigProfile::new("p", test_registry());
                 for (name, value) in writes {
                     profile = profile.with(name, value).unwrap();
@@ -481,7 +448,18 @@ mod coverage_tests {
                     profile.variable_count(),
                     profile.get_variable("INT_VAR").map(|cv| cv.value.clone()),
                 )
-            },
+            };
+            "single write" {
+                vec![("INT_VAR", 1i64)] => (1usize, Some(MlxValueType::Integer(1))),
+            }
+
+            "re-write same variable replaces, count stays 1" {
+                vec![("INT_VAR", 1i64), ("INT_VAR", 2i64)] => (1usize, Some(MlxValueType::Integer(2))),
+            }
+
+            "distinct second variable appends" {
+                vec![("INT_VAR", 5i64), ("INT_VAR", 9i64)] => (1usize, Some(MlxValueType::Integer(9))),
+            }
         );
     }
 
@@ -505,25 +483,19 @@ mod coverage_tests {
         let profile = MlxConfigProfile::new("p", test_registry())
             .with("BOOL_VAR", true)
             .unwrap();
-        check_values(
-            [
-                Check {
-                    scenario: "configured variable is found",
-                    input: "BOOL_VAR",
-                    expect: true,
-                },
-                Check {
-                    scenario: "known-but-unconfigured variable is absent",
-                    input: "INT_VAR",
-                    expect: false,
-                },
-                Check {
-                    scenario: "nonexistent variable is absent",
-                    input: "MISSING",
-                    expect: false,
-                },
-            ],
-            |name| profile.get_variable(name).is_some(),
+        value_scenarios!(
+            run = |name| profile.get_variable(name).is_some();
+            "configured variable is found" {
+                "BOOL_VAR" => true,
+            }
+
+            "known-but-unconfigured variable is absent" {
+                "INT_VAR" => false,
+            }
+
+            "nonexistent variable is absent" {
+                "MISSING" => false,
+            }
         );
     }
 
@@ -531,26 +503,21 @@ mod coverage_tests {
     // whose values were all built through `with` (each validates against its spec).
     #[test]
     fn validate_empty_vs_populated() {
-        check_cases(
-            [
-                Case {
-                    scenario: "empty profile is rejected",
-                    input: false,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "populated profile validates",
-                    input: true,
-                    expect: Yields(()),
-                },
-            ],
-            |populate| {
+        scenarios!(
+            run = |populate| {
                 let mut profile = MlxConfigProfile::new("p", test_registry());
                 if populate {
                     profile = profile.with("BOOL_VAR", true).unwrap();
                 }
                 profile.validate().map_err(drop)
-            },
+            };
+            "empty profile is rejected" {
+                false => Fails,
+            }
+
+            "populated profile validates" {
+                true => Yields(()),
+            }
         );
     }
 
@@ -568,27 +535,22 @@ mod coverage_tests {
     // Both exact strings are derived from the format! literals in `summary`.
     #[test]
     fn summary_formats_with_and_without_description() {
-        check_values(
-            [
-                Check {
-                    scenario: "no description",
-                    input: None,
-                    expect: "Profile 'p': 1 variables for registry 'test_reg'".to_string(),
-                },
-                Check {
-                    scenario: "with description",
-                    input: Some("desc"),
-                    expect: "Profile 'p': desc - 1 variables for registry 'test_reg'".to_string(),
-                },
-            ],
-            |desc: Option<&str>| {
+        value_scenarios!(
+            run = |desc: Option<&str>| {
                 let mut profile = MlxConfigProfile::new("p", test_registry());
                 if let Some(d) = desc {
                     profile = profile.with_description(d);
                 }
                 profile = profile.with("BOOL_VAR", true).unwrap();
                 profile.summary()
-            },
+            };
+            "no description" {
+                None => "Profile 'p': 1 variables for registry 'test_reg'".to_string(),
+            }
+
+            "with description" {
+                Some("desc") => "Profile 'p': desc - 1 variables for registry 'test_reg'".to_string(),
+            }
         );
     }
 
@@ -598,35 +560,25 @@ mod coverage_tests {
     // input fails, since the wrapped parser error isn't PartialEq.
     #[test]
     fn from_yaml_and_json_reject_bad_input() {
-        check_cases(
-            [
-                Case {
-                    scenario: "yaml: unknown registry",
-                    input: "name: p\nregistry_name: does_not_exist\nconfig: {}\n",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "yaml: malformed document",
-                    input: "name: [unterminated",
-                    expect: Fails,
-                },
-            ],
-            |yaml| MlxConfigProfile::from_yaml(yaml).map(|_| ()).map_err(drop),
+        scenarios!(
+            run = |yaml| MlxConfigProfile::from_yaml(yaml).map(|_| ()).map_err(drop);
+            "yaml: unknown registry" {
+                "name: p\nregistry_name: does_not_exist\nconfig: {}\n" => Fails,
+            }
+
+            "yaml: malformed document" {
+                "name: [unterminated" => Fails,
+            }
         );
-        check_cases(
-            [
-                Case {
-                    scenario: "json: unknown registry",
-                    input: r#"{"name":"p","registry_name":"does_not_exist","config":{}}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "json: malformed document",
-                    input: "{not json",
-                    expect: Fails,
-                },
-            ],
-            |json| MlxConfigProfile::from_json(json).map(|_| ()).map_err(drop),
+        scenarios!(
+            run = |json| MlxConfigProfile::from_json(json).map(|_| ()).map_err(drop);
+            "json: unknown registry" {
+                r#"{"name":"p","registry_name":"does_not_exist","config":{}}"# => Fails,
+            }
+
+            "json: malformed document" {
+                "{not json" => Fails,
+            }
         );
     }
 

--- a/crates/libmlx/src/runner/json_parser.rs
+++ b/crates/libmlx/src/runner/json_parser.rs
@@ -593,7 +593,7 @@ impl<'a> JsonResponseParser<'a> {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, scenarios, value_scenarios};
     use serde_json::json;
 
     use super::*;
@@ -659,50 +659,39 @@ mod coverage_tests {
             options: &ExecOptions::default(),
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "TRUE(1) strips the parenthetical",
-                    input: json!("TRUE(1)"),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "FALSE(0) strips the parenthetical",
-                    input: json!("FALSE(0)"),
-                    expect: Yields(false),
-                },
-                Case {
-                    scenario: "bare true",
-                    input: json!("true"),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "bare false",
-                    input: json!("false"),
-                    expect: Yields(false),
-                },
-                Case {
-                    scenario: "mixed case True",
-                    input: json!("True"),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "unrecognized string is rejected",
-                    input: json!("maybe"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a number is not a boolean string",
-                    input: json!(1),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a JSON bool is still rejected (must be a string)",
-                    input: json!(true),
-                    expect: Fails,
-                },
-            ],
-            |value| parser.parse_bool_from_json(&value).map_err(drop),
+        scenarios!(
+            run = |value| parser.parse_bool_from_json(&value).map_err(drop);
+            "TRUE(1) strips the parenthetical" {
+                json!("TRUE(1)") => Yields(true),
+            }
+
+            "FALSE(0) strips the parenthetical" {
+                json!("FALSE(0)") => Yields(false),
+            }
+
+            "bare true" {
+                json!("true") => Yields(true),
+            }
+
+            "bare false" {
+                json!("false") => Yields(false),
+            }
+
+            "mixed case True" {
+                json!("True") => Yields(true),
+            }
+
+            "unrecognized string is rejected" {
+                json!("maybe") => Fails,
+            }
+
+            "a number is not a boolean string" {
+                json!(1) => Fails,
+            }
+
+            "a JSON bool is still rejected (must be a string)" {
+                json!(true) => Fails,
+            }
         );
     }
 
@@ -715,35 +704,27 @@ mod coverage_tests {
             options: &ExecOptions::default(),
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "positive integer",
-                    input: json!(42),
-                    expect: Yields(42),
-                },
-                Case {
-                    scenario: "negative integer",
-                    input: json!(-7),
-                    expect: Yields(-7),
-                },
-                Case {
-                    scenario: "zero",
-                    input: json!(0),
-                    expect: Yields(0),
-                },
-                Case {
-                    scenario: "a float has no i64 representation",
-                    input: json!(1.5),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a numeric string is not a JSON number",
-                    input: json!("42"),
-                    expect: Fails,
-                },
-            ],
-            |value| parser.parse_int_from_json(&value).map_err(drop),
+        scenarios!(
+            run = |value| parser.parse_int_from_json(&value).map_err(drop);
+            "positive integer" {
+                json!(42) => Yields(42),
+            }
+
+            "negative integer" {
+                json!(-7) => Yields(-7),
+            }
+
+            "zero" {
+                json!(0) => Yields(0),
+            }
+
+            "a float has no i64 representation" {
+                json!(1.5) => Fails,
+            }
+
+            "a numeric string is not a JSON number" {
+                json!("42") => Fails,
+            }
         );
     }
 
@@ -757,35 +738,27 @@ mod coverage_tests {
             options: &ExecOptions::default(),
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "parenthetical is stripped",
-                    input: json!("ENUM_VALUE(1)"),
-                    expect: Yields("ENUM_VALUE".to_string()),
-                },
-                Case {
-                    scenario: "plain string is unchanged",
-                    input: json!("plain"),
-                    expect: Yields("plain".to_string()),
-                },
-                Case {
-                    scenario: "only the first '(' splits",
-                    input: json!("a(b(c"),
-                    expect: Yields("a".to_string()),
-                },
-                Case {
-                    scenario: "surrounding whitespace is NOT trimmed here",
-                    input: json!("  spaced  "),
-                    expect: Yields("  spaced  ".to_string()),
-                },
-                Case {
-                    scenario: "a number is rejected",
-                    input: json!(5),
-                    expect: Fails,
-                },
-            ],
-            |value| parser.parse_string_from_json(&value).map_err(drop),
+        scenarios!(
+            run = |value| parser.parse_string_from_json(&value).map_err(drop);
+            "parenthetical is stripped" {
+                json!("ENUM_VALUE(1)") => Yields("ENUM_VALUE".to_string()),
+            }
+
+            "plain string is unchanged" {
+                json!("plain") => Yields("plain".to_string()),
+            }
+
+            "only the first '(' splits" {
+                json!("a(b(c") => Yields("a".to_string()),
+            }
+
+            "surrounding whitespace is NOT trimmed here" {
+                json!("  spaced  ") => Yields("  spaced  ".to_string()),
+            }
+
+            "a number is rejected" {
+                json!(5) => Fails,
+            }
         );
     }
 
@@ -798,45 +771,35 @@ mod coverage_tests {
             options: &ExecOptions::default(),
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "0x prefix",
-                    input: json!("0x1a2b3c"),
-                    expect: Yields(vec![0x1a, 0x2b, 0x3c]),
-                },
-                Case {
-                    scenario: "0X prefix",
-                    input: json!("0X1A2B"),
-                    expect: Yields(vec![0x1a, 0x2b]),
-                },
-                Case {
-                    scenario: "bare hex",
-                    input: json!("1a2b"),
-                    expect: Yields(vec![0x1a, 0x2b]),
-                },
-                Case {
-                    scenario: "empty string decodes to empty bytes",
-                    input: json!(""),
-                    expect: Yields(vec![]),
-                },
-                Case {
-                    scenario: "non-hex characters are rejected",
-                    input: json!("not_hex"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "odd length is rejected",
-                    input: json!("1a2"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a number is rejected",
-                    input: json!(123),
-                    expect: Fails,
-                },
-            ],
-            |value| parser.parse_hex_from_json(&value).map_err(drop),
+        scenarios!(
+            run = |value| parser.parse_hex_from_json(&value).map_err(drop);
+            "0x prefix" {
+                json!("0x1a2b3c") => Yields(vec![0x1a, 0x2b, 0x3c]),
+            }
+
+            "0X prefix" {
+                json!("0X1A2B") => Yields(vec![0x1a, 0x2b]),
+            }
+
+            "bare hex" {
+                json!("1a2b") => Yields(vec![0x1a, 0x2b]),
+            }
+
+            "empty string decodes to empty bytes" {
+                json!("") => Yields(vec![]),
+            }
+
+            "non-hex characters are rejected" {
+                json!("not_hex") => Fails,
+            }
+
+            "odd length is rejected" {
+                json!("1a2") => Fails,
+            }
+
+            "a number is rejected" {
+                json!(123) => Fails,
+            }
         );
     }
 
@@ -851,30 +814,24 @@ mod coverage_tests {
         };
         let jv = json_var_full(json!("cur"), json!("def"), json!("nxt"), false, false);
 
-        check_cases(
-            [
-                Case {
-                    scenario: "Current",
-                    input: JsonValueField::Current,
-                    expect: Yields(json!("cur")),
-                },
-                Case {
-                    scenario: "Default",
-                    input: JsonValueField::Default,
-                    expect: Yields(json!("def")),
-                },
-                Case {
-                    scenario: "Next",
-                    input: JsonValueField::Next,
-                    expect: Yields(json!("nxt")),
-                },
-            ],
-            |field| {
+        scenarios!(
+            run = |field| {
                 parser
                     .get_json_field_value(&jv, field)
                     .cloned()
                     .map_err(drop)
-            },
+            };
+            "Current" {
+                JsonValueField::Current => Yields(json!("cur")),
+            }
+
+            "Default" {
+                JsonValueField::Default => Yields(json!("def")),
+            }
+
+            "Next" {
+                JsonValueField::Next => Yields(json!("nxt")),
+            }
         );
     }
 
@@ -887,43 +844,34 @@ mod coverage_tests {
             options: &ExecOptions::default(),
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "boolean array",
-                    input: MlxVariableSpec::BooleanArray { size: 4 },
-                    expect: Yields(4),
-                },
-                Case {
-                    scenario: "integer array",
-                    input: MlxVariableSpec::IntegerArray { size: 2 },
-                    expect: Yields(2),
-                },
-                Case {
-                    scenario: "binary array",
-                    input: MlxVariableSpec::BinaryArray { size: 7 },
-                    expect: Yields(7),
-                },
-                Case {
-                    scenario: "enum array",
-                    input: MlxVariableSpec::EnumArray {
-                        options: vec!["a".to_string()],
-                        size: 3,
-                    },
-                    expect: Yields(3),
-                },
-                Case {
-                    scenario: "scalar boolean has no size",
-                    input: MlxVariableSpec::Boolean,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "untyped array has no size",
-                    input: MlxVariableSpec::Array,
-                    expect: Fails,
-                },
-            ],
-            |spec| parser.get_array_size(&spec).map_err(drop),
+        scenarios!(
+            run = |spec| parser.get_array_size(&spec).map_err(drop);
+            "boolean array" {
+                MlxVariableSpec::BooleanArray { size: 4 } => Yields(4),
+            }
+
+            "integer array" {
+                MlxVariableSpec::IntegerArray { size: 2 } => Yields(2),
+            }
+
+            "binary array" {
+                MlxVariableSpec::BinaryArray { size: 7 } => Yields(7),
+            }
+
+            "enum array" {
+                MlxVariableSpec::EnumArray {
+                    options: vec!["a".to_string()],
+                    size: 3,
+                } => Yields(3),
+            }
+
+            "scalar boolean has no size" {
+                MlxVariableSpec::Boolean => Fails,
+            }
+
+            "untyped array has no size" {
+                MlxVariableSpec::Array => Fails,
+            }
         );
     }
 
@@ -947,40 +895,32 @@ mod coverage_tests {
         );
 
         // String spec: parse_string keeps the raw text, then `with` trims it.
-        check_cases(
-            [
-                Case {
-                    scenario: "plain string stored (trimmed by `with`)",
-                    input: json!("  hi  "),
-                    expect: Yields(MlxValueType::String("hi".to_string())),
-                },
-                Case {
-                    scenario: "parenthetical stripped before `with`",
-                    input: json!("FOO(2)"),
-                    expect: Yields(MlxValueType::String("FOO".to_string())),
-                },
-                Case {
-                    scenario: "a JSON bool is neither string nor number",
-                    input: json!(true),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "JSON null is rejected",
-                    input: json!(null),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a JSON array is rejected",
-                    input: json!(["a", "b"]),
-                    expect: Fails,
-                },
-            ],
-            |value| {
+        scenarios!(
+            run = |value| {
                 parser
                     .json_value_to_config_value(&str_var, &value)
                     .map(|v| v.value)
                     .map_err(drop)
-            },
+            };
+            "plain string stored (trimmed by `with`)" {
+                json!("  hi  ") => Yields(MlxValueType::String("hi".to_string())),
+            }
+
+            "parenthetical stripped before `with`" {
+                json!("FOO(2)") => Yields(MlxValueType::String("FOO".to_string())),
+            }
+
+            "a JSON bool is neither string nor number" {
+                json!(true) => Fails,
+            }
+
+            "JSON null is rejected" {
+                json!(null) => Fails,
+            }
+
+            "a JSON array is rejected" {
+                json!(["a", "b"]) => Fails,
+            }
         );
 
         // Number spec: routes through parse_int + with(i64).
@@ -1273,13 +1213,11 @@ mod coverage_tests {
         let mut json_vars = HashMap::new();
         json_vars.insert("FOO".to_string(), json_var(json!(7)));
 
-        check_values(
-            [Check {
-                scenario: "no registered variables -> empty result",
-                input: json_vars,
-                expect: 0usize,
-            }],
-            |jv| parser.parse_variables(&jv).expect("parses").len(),
+        value_scenarios!(
+            run = |jv| parser.parse_variables(&jv).expect("parses").len();
+            "no registered variables -> empty result" {
+                json_vars => 0usize,
+            }
         );
     }
 

--- a/crates/libmlx/src/runner/result_types.rs
+++ b/crates/libmlx/src/runner/result_types.rs
@@ -525,7 +525,7 @@ impl TryFrom<SyncResultPb> for SyncResult {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, scenarios, value_scenarios};
 
     use super::*;
     use crate::variables::spec::MlxVariableSpec;
@@ -567,54 +567,41 @@ mod coverage_tests {
     // name and description are thin wrappers over the backing variable.
     #[test]
     fn queried_variable_name_and_description() {
-        check_values(
-            [
-                Check {
-                    scenario: "name returns the variable name",
-                    input: queried("ALPHA", 1, 1),
-                    expect: "ALPHA".to_string(),
-                },
-                Check {
-                    scenario: "empty name passes through",
-                    input: queried("", 1, 1),
-                    expect: "".to_string(),
-                },
-            ],
-            |q| q.name().to_string(),
+        value_scenarios!(
+            run = |q| q.name().to_string();
+            "name returns the variable name" {
+                queried("ALPHA", 1, 1) => "ALPHA".to_string(),
+            }
+
+            "empty name passes through" {
+                queried("", 1, 1) => "".to_string(),
+            }
         );
 
-        check_values(
-            [Check {
-                scenario: "description mirrors the backing variable",
-                input: queried("BETA", 1, 1),
-                expect: "desc of BETA".to_string(),
-            }],
-            |q| q.description().to_string(),
+        value_scenarios!(
+            run = |q| q.description().to_string();
+            "description mirrors the backing variable" {
+                queried("BETA", 1, 1) => "desc of BETA".to_string(),
+            }
         );
     }
 
     // is_pending_change is true exactly when current_value != next_value.
     #[test]
     fn queried_variable_is_pending_change() {
-        check_values(
-            [
-                Check {
-                    scenario: "current == next -> no pending change",
-                    input: queried("X", 5, 5),
-                    expect: false,
-                },
-                Check {
-                    scenario: "current != next -> pending change",
-                    input: queried("X", 5, 9),
-                    expect: true,
-                },
-                Check {
-                    scenario: "current == next at zero -> no pending change",
-                    input: queried("X", 0, 0),
-                    expect: false,
-                },
-            ],
-            |q| q.is_pending_change(),
+        value_scenarios!(
+            run = |q| q.is_pending_change();
+            "current == next -> no pending change" {
+                queried("X", 5, 5) => false,
+            }
+
+            "current != next -> pending change" {
+                queried("X", 5, 9) => true,
+            }
+
+            "current == next at zero -> no pending change" {
+                queried("X", 0, 0) => false,
+            }
         );
     }
 
@@ -630,25 +617,19 @@ mod coverage_tests {
     // variable_count is just the length of the variables vec, including 0.
     #[test]
     fn query_result_variable_count() {
-        check_values(
-            [
-                Check {
-                    scenario: "empty",
-                    input: query_result(&[]),
-                    expect: 0usize,
-                },
-                Check {
-                    scenario: "single",
-                    input: query_result(&["a"]),
-                    expect: 1usize,
-                },
-                Check {
-                    scenario: "several",
-                    input: query_result(&["a", "b", "c"]),
-                    expect: 3usize,
-                },
-            ],
-            |qr| qr.variable_count(),
+        value_scenarios!(
+            run = |qr| qr.variable_count();
+            "empty" {
+                query_result(&[]) => 0usize,
+            }
+
+            "single" {
+                query_result(&["a"]) => 1usize,
+            }
+
+            "several" {
+                query_result(&["a", "b", "c"]) => 3usize,
+            }
         );
     }
 
@@ -656,59 +637,47 @@ mod coverage_tests {
     // found name (or "<none>") so the row's expectation is a value we are sure of.
     #[test]
     fn query_result_get_variable() {
-        check_values(
-            [
-                Check {
-                    scenario: "present in the middle",
-                    input: ("b", query_result(&["a", "b", "c"])),
-                    expect: "b".to_string(),
-                },
-                Check {
-                    scenario: "present at the front",
-                    input: ("a", query_result(&["a", "b", "c"])),
-                    expect: "a".to_string(),
-                },
-                Check {
-                    scenario: "absent yields None",
-                    input: ("missing", query_result(&["a", "b", "c"])),
-                    expect: "<none>".to_string(),
-                },
-                Check {
-                    scenario: "absent in empty result",
-                    input: ("a", query_result(&[])),
-                    expect: "<none>".to_string(),
-                },
-            ],
-            |(name, qr)| {
+        value_scenarios!(
+            run = |(name, qr)| {
                 qr.get_variable(name)
                     .map(|v| v.name().to_string())
                     .unwrap_or_else(|| "<none>".to_string())
-            },
+            };
+            "present in the middle" {
+                ("b", query_result(&["a", "b", "c"])) => "b".to_string(),
+            }
+
+            "present at the front" {
+                ("a", query_result(&["a", "b", "c"])) => "a".to_string(),
+            }
+
+            "absent yields None" {
+                ("missing", query_result(&["a", "b", "c"])) => "<none>".to_string(),
+            }
+
+            "absent in empty result" {
+                ("a", query_result(&[])) => "<none>".to_string(),
+            }
         );
     }
 
     // variable_names collects every variable's name, preserving order.
     #[test]
     fn query_result_variable_names() {
-        check_values(
-            [
-                Check {
-                    scenario: "empty",
-                    input: query_result(&[]),
-                    expect: Vec::<String>::new(),
-                },
-                Check {
-                    scenario: "preserves order",
-                    input: query_result(&["c", "a", "b"]),
-                    expect: vec!["c".to_string(), "a".to_string(), "b".to_string()],
-                },
-            ],
-            |qr| {
+        value_scenarios!(
+            run = |qr| {
                 qr.variable_names()
                     .into_iter()
                     .map(String::from)
                     .collect::<Vec<String>>()
-            },
+            };
+            "empty" {
+                query_result(&[]) => Vec::<String>::new(),
+            }
+
+            "preserves order" {
+                query_result(&["c", "a", "b"]) => vec!["c".to_string(), "a".to_string(), "b".to_string()],
+            }
         );
     }
 
@@ -728,20 +697,15 @@ mod coverage_tests {
             }
         }
 
-        check_values(
-            [
-                Check {
-                    scenario: "none changed",
-                    input: sync(3, 0),
-                    expect: "Sync complete: 0/3 variables changed in 0ns".to_string(),
-                },
-                Check {
-                    scenario: "all changed",
-                    input: sync(2, 2),
-                    expect: "Sync complete: 2/2 variables changed in 0ns".to_string(),
-                },
-            ],
-            |s| s.summary(),
+        value_scenarios!(
+            run = |s| s.summary();
+            "none changed" {
+                sync(3, 0) => "Sync complete: 0/3 variables changed in 0ns".to_string(),
+            }
+
+            "all changed" {
+                sync(2, 2) => "Sync complete: 2/2 variables changed in 0ns".to_string(),
+            }
         );
     }
 
@@ -757,20 +721,15 @@ mod coverage_tests {
             }
         }
 
-        check_values(
-            [
-                Check {
-                    scenario: "none needing change",
-                    input: cmp(5, 0),
-                    expect: "Comparison complete: 0/5 variables would change".to_string(),
-                },
-                Check {
-                    scenario: "some needing change",
-                    input: cmp(5, 2),
-                    expect: "Comparison complete: 2/5 variables would change".to_string(),
-                },
-            ],
-            |c| c.summary(),
+        value_scenarios!(
+            run = |c| c.summary();
+            "none needing change" {
+                cmp(5, 0) => "Comparison complete: 0/5 variables would change".to_string(),
+            }
+
+            "some needing change" {
+                cmp(5, 2) => "Comparison complete: 2/5 variables would change".to_string(),
+            }
         );
     }
 
@@ -778,34 +737,30 @@ mod coverage_tests {
     // values render bare via to_display_string, so the arrow tail is exact.
     #[test]
     fn planned_change_description() {
-        check_values(
-            [Check {
-                scenario: "integer current and desired",
-                input: PlannedChange {
+        value_scenarios!(
+            run = |c| c.description();
+            "integer current and desired" {
+                PlannedChange {
                     variable_name: "VAR".to_string(),
                     current_value: int_value("VAR", 1),
                     desired_value: int_value("VAR", 2),
-                },
-                expect: "VAR: 1 → 2".to_string(),
-            }],
-            |c| c.description(),
+                } => "VAR: 1 → 2".to_string(),
+            }
         );
     }
 
     // VariableChange::description formats "name: old → new".
     #[test]
     fn variable_change_description() {
-        check_values(
-            [Check {
-                scenario: "integer old and new",
-                input: VariableChange {
+        value_scenarios!(
+            run = |c| c.description();
+            "integer old and new" {
+                VariableChange {
                     variable_name: "VAR".to_string(),
                     old_value: int_value("VAR", 7),
                     new_value: int_value("VAR", 8),
-                },
-                expect: "VAR: 7 → 8".to_string(),
-            }],
-            |c| c.description(),
+                } => "VAR: 7 → 8".to_string(),
+            }
         );
     }
 
@@ -830,49 +785,40 @@ mod coverage_tests {
             )
         }
 
-        check_values(
-            [
-                Check {
-                    scenario: "new is all None",
-                    input: QueriedDeviceInfo::new(),
-                    expect: (None, None, None, None),
-                },
-                Check {
-                    scenario: "with_device_id fills only device_id",
-                    input: QueriedDeviceInfo::new().with_device_id("dev-1"),
-                    expect: (Some("dev-1".to_string()), None, None, None),
-                },
-                Check {
-                    scenario: "with_device_type fills only device_type",
-                    input: QueriedDeviceInfo::new().with_device_type("ConnectX"),
-                    expect: (None, Some("ConnectX".to_string()), None, None),
-                },
-                Check {
-                    scenario: "with_part_number fills only part_number",
-                    input: QueriedDeviceInfo::new().with_part_number("MCX-1"),
-                    expect: (None, None, Some("MCX-1".to_string()), None),
-                },
-                Check {
-                    scenario: "with_description fills only description",
-                    input: QueriedDeviceInfo::new().with_description("a nic"),
-                    expect: (None, None, None, Some("a nic".to_string())),
-                },
-                Check {
-                    scenario: "all setters chain",
-                    input: QueriedDeviceInfo::new()
-                        .with_device_id("dev-1")
-                        .with_device_type("ConnectX")
-                        .with_part_number("MCX-1")
-                        .with_description("a nic"),
-                    expect: (
-                        Some("dev-1".to_string()),
-                        Some("ConnectX".to_string()),
-                        Some("MCX-1".to_string()),
-                        Some("a nic".to_string()),
-                    ),
-                },
-            ],
-            |i| fields(&i),
+        value_scenarios!(
+            run = |i| fields(&i);
+            "new is all None" {
+                QueriedDeviceInfo::new() => (None, None, None, None),
+            }
+
+            "with_device_id fills only device_id" {
+                QueriedDeviceInfo::new().with_device_id("dev-1") => (Some("dev-1".to_string()), None, None, None),
+            }
+
+            "with_device_type fills only device_type" {
+                QueriedDeviceInfo::new().with_device_type("ConnectX") => (None, Some("ConnectX".to_string()), None, None),
+            }
+
+            "with_part_number fills only part_number" {
+                QueriedDeviceInfo::new().with_part_number("MCX-1") => (None, None, Some("MCX-1".to_string()), None),
+            }
+
+            "with_description fills only description" {
+                QueriedDeviceInfo::new().with_description("a nic") => (None, None, None, Some("a nic".to_string())),
+            }
+
+            "all setters chain" {
+                QueriedDeviceInfo::new()
+                .with_device_id("dev-1")
+                .with_device_type("ConnectX")
+                .with_part_number("MCX-1")
+                .with_description("a nic") => (
+                    Some("dev-1".to_string()),
+                    Some("ConnectX".to_string()),
+                    Some("MCX-1".to_string()),
+                    Some("a nic".to_string()),
+                ),
+            }
         );
     }
 
@@ -897,33 +843,28 @@ mod coverage_tests {
             )
         }
 
-        check_values(
-            [
-                Check {
-                    scenario: "all None survives the round-trip",
-                    input: QueriedDeviceInfo::new(),
-                    expect: (None, None, None, None),
-                },
-                Check {
-                    scenario: "all Some survives the round-trip",
-                    input: QueriedDeviceInfo::new()
-                        .with_device_id("d")
-                        .with_device_type("t")
-                        .with_part_number("p")
-                        .with_description("x"),
-                    expect: (
-                        Some("d".to_string()),
-                        Some("t".to_string()),
-                        Some("p".to_string()),
-                        Some("x".to_string()),
-                    ),
-                },
-            ],
-            |info| {
+        value_scenarios!(
+            run = |info| {
                 let pb: QueriedDeviceInfoPb = info.into();
                 let back: QueriedDeviceInfo = pb.into();
                 fields(&back)
-            },
+            };
+            "all None survives the round-trip" {
+                QueriedDeviceInfo::new() => (None, None, None, None),
+            }
+
+            "all Some survives the round-trip" {
+                QueriedDeviceInfo::new()
+                .with_device_id("d")
+                .with_device_type("t")
+                .with_part_number("p")
+                .with_description("x") => (
+                    Some("d".to_string()),
+                    Some("t".to_string()),
+                    Some("p".to_string()),
+                    Some("x".to_string()),
+                ),
+            }
         );
     }
 
@@ -952,46 +893,39 @@ mod coverage_tests {
             q.try_into().expect("complete QueriedVariable converts")
         }
 
-        check_cases(
-            [
-                Case {
-                    scenario: "missing variable",
-                    input: QueriedVariablePb {
-                        variable: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing current_value",
-                    input: QueriedVariablePb {
-                        current_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing default_value",
-                    input: QueriedVariablePb {
-                        default_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing next_value",
-                    input: QueriedVariablePb {
-                        next_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-            ],
-            |pb| {
+        scenarios!(
+            run = |pb| {
                 QueriedVariable::try_from(pb)
                     .map(|q| q.name().to_string())
                     .map_err(drop)
-            },
+            };
+            "missing variable" {
+                QueriedVariablePb {
+                    variable: None,
+                    ..full_pb()
+                } => Fails,
+            }
+
+            "missing current_value" {
+                QueriedVariablePb {
+                    current_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
+
+            "missing default_value" {
+                QueriedVariablePb {
+                    default_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
+
+            "missing next_value" {
+                QueriedVariablePb {
+                    next_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
         );
     }
 
@@ -1056,30 +990,25 @@ mod coverage_tests {
                 .expect("complete PlannedChange converts")
         }
 
-        check_cases(
-            [
-                Case {
-                    scenario: "missing current_value",
-                    input: PlannedChangePb {
-                        current_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing desired_value",
-                    input: PlannedChangePb {
-                        desired_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-            ],
-            |pb| {
+        scenarios!(
+            run = |pb| {
                 PlannedChange::try_from(pb)
                     .map(|c| c.variable_name)
                     .map_err(drop)
-            },
+            };
+            "missing current_value" {
+                PlannedChangePb {
+                    current_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
+
+            "missing desired_value" {
+                PlannedChangePb {
+                    desired_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
         );
     }
 
@@ -1112,30 +1041,25 @@ mod coverage_tests {
                 .expect("complete VariableChange converts")
         }
 
-        check_cases(
-            [
-                Case {
-                    scenario: "missing old_value",
-                    input: VariableChangePb {
-                        old_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing new_value",
-                    input: VariableChangePb {
-                        new_value: None,
-                        ..full_pb()
-                    },
-                    expect: Fails,
-                },
-            ],
-            |pb| {
+        scenarios!(
+            run = |pb| {
                 VariableChange::try_from(pb)
                     .map(|c| c.variable_name)
                     .map_err(drop)
-            },
+            };
+            "missing old_value" {
+                VariableChangePb {
+                    old_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
+
+            "missing new_value" {
+                VariableChangePb {
+                    new_value: None,
+                    ..full_pb()
+                } => Fails,
+            }
         );
     }
 

--- a/crates/libmlx/src/variables/registry.rs
+++ b/crates/libmlx/src/variables/registry.rs
@@ -170,7 +170,7 @@ mod coverage_tests {
     };
     use carbide_libmlx_model::device::info::MlxDeviceInfo;
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
     use crate::device::filters::{DeviceField, MatchMode};
@@ -215,46 +215,36 @@ mod coverage_tests {
     // single field the setter touches so the non-PartialEq registry stays usable.
     #[test]
     fn builder_name_overwrites() {
-        check_values(
-            [
-                Check {
-                    scenario: "name() replaces the constructor name",
-                    input: "renamed",
-                    expect: "renamed".to_string(),
-                },
-                Check {
-                    scenario: "name() accepts an empty string",
-                    input: "",
-                    expect: String::new(),
-                },
-            ],
-            |new_name| MlxVariableRegistry::new("orig").name(new_name).name,
+        value_scenarios!(
+            run = |new_name| MlxVariableRegistry::new("orig").name(new_name).name;
+            "name() replaces the constructor name" {
+                "renamed" => "renamed".to_string(),
+            }
+
+            "name() accepts an empty string" {
+                "" => String::new(),
+            }
         );
     }
 
     // variables() replaces the whole list; the projected length proves the swap.
     #[test]
     fn builder_variables_replaces_list() {
-        check_values(
-            [
-                Check {
-                    scenario: "empty replacement",
-                    input: vec![],
-                    expect: 0usize,
-                },
-                Check {
-                    scenario: "two-element replacement",
-                    input: vec![var("a"), var("b")],
-                    expect: 2usize,
-                },
-            ],
-            |vars| {
+        value_scenarios!(
+            run = |vars| {
                 MlxVariableRegistry::new("r")
                     .add_variable(var("preexisting"))
                     .variables(vars)
                     .variables
                     .len()
-            },
+            };
+            "empty replacement" {
+                vec![] => 0usize,
+            }
+
+            "two-element replacement" {
+                vec![var("a"), var("b")] => 2usize,
+            }
         );
     }
 
@@ -278,34 +268,27 @@ mod coverage_tests {
             .add_variable(var("alpha"))
             .add_variable(var("beta"));
 
-        check_values(
-            [
-                Check {
-                    scenario: "first variable",
-                    input: "alpha",
-                    expect: "alpha".to_string(),
-                },
-                Check {
-                    scenario: "later variable",
-                    input: "beta",
-                    expect: "beta".to_string(),
-                },
-                Check {
-                    scenario: "missing variable yields None",
-                    input: "gamma",
-                    expect: "<none>".to_string(),
-                },
-                Check {
-                    scenario: "name match is case-sensitive",
-                    input: "ALPHA",
-                    expect: "<none>".to_string(),
-                },
-            ],
-            |name| {
+        value_scenarios!(
+            run = |name| {
                 reg.get_variable(name)
                     .map(|v| v.name.clone())
                     .unwrap_or_else(|| "<none>".to_string())
-            },
+            };
+            "first variable" {
+                "alpha" => "alpha".to_string(),
+            }
+
+            "later variable" {
+                "beta" => "beta".to_string(),
+            }
+
+            "missing variable yields None" {
+                "gamma" => "<none>".to_string(),
+            }
+
+            "name match is case-sensitive" {
+                "ALPHA" => "<none>".to_string(),
+            }
         );
     }
 
@@ -331,26 +314,20 @@ mod coverage_tests {
     // true only once a set holds at least one filter.
     #[test]
     fn has_filters_distinguishes_none_empty_and_nonempty() {
-        check_values(
-            [
-                Check {
-                    scenario: "no filter set",
-                    input: MlxVariableRegistry::new("r"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "present but empty filter set",
-                    input: MlxVariableRegistry::new("r").with_filters(DeviceFilterSet::new()),
-                    expect: false,
-                },
-                Check {
-                    scenario: "non-empty filter set",
-                    input: MlxVariableRegistry::new("r")
-                        .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX-6 Dx")),
-                    expect: true,
-                },
-            ],
-            |reg| reg.has_filters(),
+        value_scenarios!(
+            run = |reg| reg.has_filters();
+            "no filter set" {
+                MlxVariableRegistry::new("r") => false,
+            }
+
+            "present but empty filter set" {
+                MlxVariableRegistry::new("r").with_filters(DeviceFilterSet::new()) => false,
+            }
+
+            "non-empty filter set" {
+                MlxVariableRegistry::new("r")
+                .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX-6 Dx")) => true,
+            }
         );
     }
 
@@ -361,26 +338,21 @@ mod coverage_tests {
     // filter count distinguishes the two arms.
     #[test]
     fn with_filter_creates_then_extends() {
-        check_values(
-            [
-                Check {
-                    scenario: "first filter creates the set (None arm)",
-                    input: 1usize,
-                    expect: 1usize,
-                },
-                Check {
-                    scenario: "second filter extends the set (Some arm)",
-                    input: 2usize,
-                    expect: 2usize,
-                },
-            ],
-            |count| {
+        value_scenarios!(
+            run = |count| {
                 let mut reg = MlxVariableRegistry::new("r");
                 for i in 0..count {
                     reg = reg.with_filter(exact_filter(DeviceField::DeviceType, &format!("v{i}")));
                 }
                 reg.filters.map(|f| f.filters.len()).unwrap_or(0)
-            },
+            };
+            "first filter creates the set (None arm)" {
+                1usize => 1usize,
+            }
+
+            "second filter extends the set (Some arm)" {
+                2usize => 2usize,
+            }
         );
     }
 
@@ -399,26 +371,20 @@ mod coverage_tests {
     // the DeviceFilterSet Display. An empty set also Displays as "No filters".
     #[test]
     fn filter_summary_reports_none_and_delegates() {
-        check_values(
-            [
-                Check {
-                    scenario: "no filter set",
-                    input: MlxVariableRegistry::new("r"),
-                    expect: "No filters".to_string(),
-                },
-                Check {
-                    scenario: "empty set Displays as No filters",
-                    input: MlxVariableRegistry::new("r").with_filters(DeviceFilterSet::new()),
-                    expect: "No filters".to_string(),
-                },
-                Check {
-                    scenario: "one exact filter renders field:value:mode",
-                    input: MlxVariableRegistry::new("r")
-                        .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX")),
-                    expect: "device_type:ConnectX:exact".to_string(),
-                },
-            ],
-            |reg| reg.filter_summary(),
+        value_scenarios!(
+            run = |reg| reg.filter_summary();
+            "no filter set" {
+                MlxVariableRegistry::new("r") => "No filters".to_string(),
+            }
+
+            "empty set Displays as No filters" {
+                MlxVariableRegistry::new("r").with_filters(DeviceFilterSet::new()) => "No filters".to_string(),
+            }
+
+            "one exact filter renders field:value:mode" {
+                MlxVariableRegistry::new("r")
+                .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX")) => "device_type:ConnectX:exact".to_string(),
+            }
         );
     }
 
@@ -432,45 +398,36 @@ mod coverage_tests {
     fn matches_device_respects_filters() {
         let device = MlxDeviceInfo::create_test_device();
 
-        check_values(
-            [
-                Check {
-                    scenario: "no filters allows all",
-                    input: MlxVariableRegistry::new("r"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "empty filter set allows all",
-                    input: MlxVariableRegistry::new("r").with_filters(DeviceFilterSet::new()),
-                    expect: true,
-                },
-                Check {
-                    scenario: "matching exact device_type filter",
-                    input: MlxVariableRegistry::new("r")
-                        .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX-6 Dx")),
-                    expect: true,
-                },
-                Check {
-                    scenario: "exact filter is case-insensitive",
-                    input: MlxVariableRegistry::new("r")
-                        .with_filter(exact_filter(DeviceField::DeviceType, "connectx-6 dx")),
-                    expect: true,
-                },
-                Check {
-                    scenario: "non-matching device_type filter",
-                    input: MlxVariableRegistry::new("r")
-                        .with_filter(exact_filter(DeviceField::DeviceType, "BlueField3")),
-                    expect: false,
-                },
-                Check {
-                    scenario: "all filters must match (one fails)",
-                    input: MlxVariableRegistry::new("r")
-                        .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX-6 Dx"))
-                        .with_filter(exact_filter(DeviceField::PartNumber, "WRONG-PART")),
-                    expect: false,
-                },
-            ],
-            |reg| reg.matches_device(&device),
+        value_scenarios!(
+            run = |reg| reg.matches_device(&device);
+            "no filters allows all" {
+                MlxVariableRegistry::new("r") => true,
+            }
+
+            "empty filter set allows all" {
+                MlxVariableRegistry::new("r").with_filters(DeviceFilterSet::new()) => true,
+            }
+
+            "matching exact device_type filter" {
+                MlxVariableRegistry::new("r")
+                .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX-6 Dx")) => true,
+            }
+
+            "exact filter is case-insensitive" {
+                MlxVariableRegistry::new("r")
+                .with_filter(exact_filter(DeviceField::DeviceType, "connectx-6 dx")) => true,
+            }
+
+            "non-matching device_type filter" {
+                MlxVariableRegistry::new("r")
+                .with_filter(exact_filter(DeviceField::DeviceType, "BlueField3")) => false,
+            }
+
+            "all filters must match (one fails)" {
+                MlxVariableRegistry::new("r")
+                .with_filter(exact_filter(DeviceField::DeviceType, "ConnectX-6 Dx"))
+                .with_filter(exact_filter(DeviceField::PartNumber, "WRONG-PART")) => false,
+            }
         );
     }
 
@@ -503,33 +460,8 @@ mod coverage_tests {
     // the projected pieces instead of the whole value.
     #[test]
     fn registry_round_trips_through_pb() {
-        check_cases(
-            [
-                Case {
-                    scenario: "no filters, no variables",
-                    input: MlxVariableRegistry::new("empty"),
-                    expect: Yields(("empty".to_string(), Vec::<String>::new(), false)),
-                },
-                Case {
-                    scenario: "variables only",
-                    input: MlxVariableRegistry::new("vars")
-                        .add_variable(var("a"))
-                        .add_variable(var("b")),
-                    expect: Yields((
-                        "vars".to_string(),
-                        vec!["a".to_string(), "b".to_string()],
-                        false,
-                    )),
-                },
-                Case {
-                    scenario: "variables and a filter",
-                    input: MlxVariableRegistry::new("full")
-                        .add_variable(var("only"))
-                        .with_filter(exact_filter(DeviceField::PartNumber, "MCX")),
-                    expect: Yields(("full".to_string(), vec!["only".to_string()], true)),
-                },
-            ],
-            |reg: MlxVariableRegistry| {
+        scenarios!(
+            run = |reg: MlxVariableRegistry| {
                 let pb: MlxVariableRegistryPb = reg.into();
                 let back: MlxVariableRegistry = pb.try_into().map_err(drop)?;
                 let names: Vec<String> = back
@@ -539,7 +471,26 @@ mod coverage_tests {
                     .collect();
                 let has_filters = back.has_filters();
                 Ok::<_, ()>((back.name, names, has_filters))
-            },
+            };
+            "no filters, no variables" {
+                MlxVariableRegistry::new("empty") => Yields(("empty".to_string(), Vec::<String>::new(), false)),
+            }
+
+            "variables only" {
+                MlxVariableRegistry::new("vars")
+                .add_variable(var("a"))
+                .add_variable(var("b")) => Yields((
+                    "vars".to_string(),
+                    vec!["a".to_string(), "b".to_string()],
+                    false,
+                )),
+            }
+
+            "variables and a filter" {
+                MlxVariableRegistry::new("full")
+                .add_variable(var("only"))
+                .with_filter(exact_filter(DeviceField::PartNumber, "MCX")) => Yields(("full".to_string(), vec!["only".to_string()], true)),
+            }
         );
     }
 
@@ -557,86 +508,78 @@ mod coverage_tests {
             }
         }
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid filter converts",
-                    input: MlxVariableRegistryPb {
-                        name: "ok".to_string(),
-                        variables: vec![],
-                        filters: Some(DeviceFilterSetPb {
-                            filters: vec![DeviceFilterPb {
-                                // 1 == DEVICE_FIELD_DEVICE_TYPE
-                                field: 1,
-                                values: vec!["x".to_string()],
-                                // 2 == MATCH_MODE_EXACT
-                                match_mode: 2,
-                            }],
-                        }),
-                    },
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "unspecified device field rejected",
-                    input: MlxVariableRegistryPb {
-                        name: "bad-field".to_string(),
-                        variables: vec![],
-                        filters: Some(DeviceFilterSetPb {
-                            filters: vec![DeviceFilterPb {
-                                // 0 == DEVICE_FIELD_UNSPECIFIED -> conversion error
-                                field: 0,
-                                values: vec!["x".to_string()],
-                                match_mode: 2,
-                            }],
-                        }),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "out-of-range device field rejected",
-                    input: MlxVariableRegistryPb {
-                        name: "bad-field-range".to_string(),
-                        variables: vec![],
-                        filters: Some(DeviceFilterSetPb {
-                            filters: vec![DeviceFilterPb {
-                                field: 999,
-                                values: vec!["x".to_string()],
-                                match_mode: 2,
-                            }],
-                        }),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "variable missing its spec rejected",
-                    input: MlxVariableRegistryPb {
-                        name: "bad-var".to_string(),
-                        variables: vec![MlxConfigVariablePb {
-                            name: "v".to_string(),
-                            description: "d".to_string(),
-                            read_only: false,
-                            spec: None,
+        scenarios!(
+            run = |pb: MlxVariableRegistryPb| MlxVariableRegistry::try_from(pb).map(drop).map_err(drop);
+            "valid filter converts" {
+                MlxVariableRegistryPb {
+                    name: "ok".to_string(),
+                    variables: vec![],
+                    filters: Some(DeviceFilterSetPb {
+                        filters: vec![DeviceFilterPb {
+                            // 1 == DEVICE_FIELD_DEVICE_TYPE
+                            field: 1,
+                            values: vec!["x".to_string()],
+                            // 2 == MATCH_MODE_EXACT
+                            match_mode: 2,
                         }],
-                        filters: None,
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "no filters, valid variable converts",
-                    input: MlxVariableRegistryPb {
-                        name: "plain".to_string(),
-                        variables: vec![MlxConfigVariablePb {
-                            name: "v".to_string(),
-                            description: "d".to_string(),
-                            read_only: true,
-                            spec: Some(bool_spec_pb()),
+                    }),
+                } => Yields(()),
+            }
+
+            "unspecified device field rejected" {
+                MlxVariableRegistryPb {
+                    name: "bad-field".to_string(),
+                    variables: vec![],
+                    filters: Some(DeviceFilterSetPb {
+                        filters: vec![DeviceFilterPb {
+                            // 0 == DEVICE_FIELD_UNSPECIFIED -> conversion error
+                            field: 0,
+                            values: vec!["x".to_string()],
+                            match_mode: 2,
                         }],
-                        filters: None,
-                    },
-                    expect: Yields(()),
-                },
-            ],
-            |pb: MlxVariableRegistryPb| MlxVariableRegistry::try_from(pb).map(drop).map_err(drop),
+                    }),
+                } => Fails,
+            }
+
+            "out-of-range device field rejected" {
+                MlxVariableRegistryPb {
+                    name: "bad-field-range".to_string(),
+                    variables: vec![],
+                    filters: Some(DeviceFilterSetPb {
+                        filters: vec![DeviceFilterPb {
+                            field: 999,
+                            values: vec!["x".to_string()],
+                            match_mode: 2,
+                        }],
+                    }),
+                } => Fails,
+            }
+
+            "variable missing its spec rejected" {
+                MlxVariableRegistryPb {
+                    name: "bad-var".to_string(),
+                    variables: vec![MlxConfigVariablePb {
+                        name: "v".to_string(),
+                        description: "d".to_string(),
+                        read_only: false,
+                        spec: None,
+                    }],
+                    filters: None,
+                } => Fails,
+            }
+
+            "no filters, valid variable converts" {
+                MlxVariableRegistryPb {
+                    name: "plain".to_string(),
+                    variables: vec![MlxConfigVariablePb {
+                        name: "v".to_string(),
+                        description: "d".to_string(),
+                        read_only: true,
+                        spec: Some(bool_spec_pb()),
+                    }],
+                    filters: None,
+                } => Yields(()),
+            }
         );
     }
 }

--- a/crates/libmlx/src/variables/spec.rs
+++ b/crates/libmlx/src/variables/spec.rs
@@ -401,7 +401,7 @@ impl TryFrom<MlxVariableSpecPb> for MlxVariableSpec {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, value_scenarios};
 
     use super::*;
 
@@ -411,93 +411,75 @@ mod coverage_tests {
     // details (comma-space joins, bracketed sizes, "max:" / "[size]" layouts).
     #[test]
     fn display_renders_each_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "boolean",
-                    input: MlxVariableSpec::Boolean,
-                    expect: "Boolean",
-                },
-                Check {
-                    scenario: "integer",
-                    input: MlxVariableSpec::Integer,
-                    expect: "Integer",
-                },
-                Check {
-                    scenario: "string",
-                    input: MlxVariableSpec::String,
-                    expect: "String",
-                },
-                Check {
-                    scenario: "binary",
-                    input: MlxVariableSpec::Binary,
-                    expect: "Binary",
-                },
-                Check {
-                    scenario: "bytes",
-                    input: MlxVariableSpec::Bytes,
-                    expect: "Bytes",
-                },
-                Check {
-                    scenario: "array",
-                    input: MlxVariableSpec::Array,
-                    expect: "Array",
-                },
-                Check {
-                    scenario: "opaque",
-                    input: MlxVariableSpec::Opaque,
-                    expect: "Opaque",
-                },
-                Check {
-                    scenario: "enum with options",
-                    input: MlxVariableSpec::Enum {
-                        options: vec!["low".to_string(), "high".to_string()],
-                    },
-                    expect: "Enum [low, high]",
-                },
-                Check {
-                    scenario: "enum with no options",
-                    input: MlxVariableSpec::Enum { options: vec![] },
-                    expect: "Enum []",
-                },
-                Check {
-                    scenario: "preset",
-                    input: MlxVariableSpec::Preset { max_preset: 7 },
-                    expect: "Preset (max: 7)",
-                },
-                Check {
-                    scenario: "boolean array",
-                    input: MlxVariableSpec::BooleanArray { size: 3 },
-                    expect: "BooleanArray[3]",
-                },
-                Check {
-                    scenario: "integer array",
-                    input: MlxVariableSpec::IntegerArray { size: 5 },
-                    expect: "IntegerArray[5]",
-                },
-                Check {
-                    scenario: "enum array",
-                    input: MlxVariableSpec::EnumArray {
-                        options: vec!["a".to_string(), "b".to_string()],
-                        size: 2,
-                    },
-                    expect: "EnumArray[2] [a, b]",
-                },
-                Check {
-                    scenario: "enum array with no options",
-                    input: MlxVariableSpec::EnumArray {
-                        options: vec![],
-                        size: 4,
-                    },
-                    expect: "EnumArray[4] []",
-                },
-                Check {
-                    scenario: "binary array",
-                    input: MlxVariableSpec::BinaryArray { size: 8 },
-                    expect: "BinaryArray[8]",
-                },
-            ],
-            |spec| &*spec.to_string().leak(),
+        value_scenarios!(
+            run = |spec| &*spec.to_string().leak();
+            "boolean" {
+                MlxVariableSpec::Boolean => "Boolean",
+            }
+
+            "integer" {
+                MlxVariableSpec::Integer => "Integer",
+            }
+
+            "string" {
+                MlxVariableSpec::String => "String",
+            }
+
+            "binary" {
+                MlxVariableSpec::Binary => "Binary",
+            }
+
+            "bytes" {
+                MlxVariableSpec::Bytes => "Bytes",
+            }
+
+            "array" {
+                MlxVariableSpec::Array => "Array",
+            }
+
+            "opaque" {
+                MlxVariableSpec::Opaque => "Opaque",
+            }
+
+            "enum with options" {
+                MlxVariableSpec::Enum {
+                    options: vec!["low".to_string(), "high".to_string()],
+                } => "Enum [low, high]",
+            }
+
+            "enum with no options" {
+                MlxVariableSpec::Enum { options: vec![] } => "Enum []",
+            }
+
+            "preset" {
+                MlxVariableSpec::Preset { max_preset: 7 } => "Preset (max: 7)",
+            }
+
+            "boolean array" {
+                MlxVariableSpec::BooleanArray { size: 3 } => "BooleanArray[3]",
+            }
+
+            "integer array" {
+                MlxVariableSpec::IntegerArray { size: 5 } => "IntegerArray[5]",
+            }
+
+            "enum array" {
+                MlxVariableSpec::EnumArray {
+                    options: vec!["a".to_string(), "b".to_string()],
+                    size: 2,
+                } => "EnumArray[2] [a, b]",
+            }
+
+            "enum array with no options" {
+                MlxVariableSpec::EnumArray {
+                    options: vec![],
+                    size: 4,
+                } => "EnumArray[4] []",
+            }
+
+            "binary array" {
+                MlxVariableSpec::BinaryArray { size: 8 } => "BinaryArray[8]",
+            }
         );
     }
 
@@ -506,45 +488,35 @@ mod coverage_tests {
     // through one table exercises every simple builder method.
     #[test]
     fn simple_builders_yield_their_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "boolean",
-                    input: MlxVariableSpec::builder().boolean().build(),
-                    expect: MlxVariableSpec::Boolean,
-                },
-                Check {
-                    scenario: "integer",
-                    input: MlxVariableSpec::builder().integer().build(),
-                    expect: MlxVariableSpec::Integer,
-                },
-                Check {
-                    scenario: "string",
-                    input: MlxVariableSpec::builder().string().build(),
-                    expect: MlxVariableSpec::String,
-                },
-                Check {
-                    scenario: "binary",
-                    input: MlxVariableSpec::builder().binary().build(),
-                    expect: MlxVariableSpec::Binary,
-                },
-                Check {
-                    scenario: "bytes",
-                    input: MlxVariableSpec::builder().bytes().build(),
-                    expect: MlxVariableSpec::Bytes,
-                },
-                Check {
-                    scenario: "array",
-                    input: MlxVariableSpec::builder().array().build(),
-                    expect: MlxVariableSpec::Array,
-                },
-                Check {
-                    scenario: "opaque",
-                    input: MlxVariableSpec::builder().opaque().build(),
-                    expect: MlxVariableSpec::Opaque,
-                },
-            ],
-            |built| built,
+        value_scenarios!(
+            run = |built| built;
+            "boolean" {
+                MlxVariableSpec::builder().boolean().build() => MlxVariableSpec::Boolean,
+            }
+
+            "integer" {
+                MlxVariableSpec::builder().integer().build() => MlxVariableSpec::Integer,
+            }
+
+            "string" {
+                MlxVariableSpec::builder().string().build() => MlxVariableSpec::String,
+            }
+
+            "binary" {
+                MlxVariableSpec::builder().binary().build() => MlxVariableSpec::Binary,
+            }
+
+            "bytes" {
+                MlxVariableSpec::builder().bytes().build() => MlxVariableSpec::Bytes,
+            }
+
+            "array" {
+                MlxVariableSpec::builder().array().build() => MlxVariableSpec::Array,
+            }
+
+            "opaque" {
+                MlxVariableSpec::builder().opaque().build() => MlxVariableSpec::Opaque,
+            }
         );
     }
 
@@ -553,97 +525,82 @@ mod coverage_tests {
     // and the sized arrays default to size 1; the configured rows pin the set value.
     #[test]
     fn configured_builders_apply_values_and_defaults() {
-        check_values(
-            [
-                Check {
-                    scenario: "enum with options set",
-                    input: MlxVariableSpec::builder()
-                        .enum_type()
-                        .with_options(vec!["x".to_string(), "y".to_string()])
-                        .build(),
-                    expect: MlxVariableSpec::Enum {
-                        options: vec!["x".to_string(), "y".to_string()],
-                    },
+        value_scenarios!(
+            run = |built| built;
+            "enum with options set" {
+                MlxVariableSpec::builder()
+                .enum_type()
+                .with_options(vec!["x".to_string(), "y".to_string()])
+                .build() => MlxVariableSpec::Enum {
+                    options: vec!["x".to_string(), "y".to_string()],
                 },
-                Check {
-                    scenario: "enum default options is empty",
-                    input: MlxVariableSpec::builder().enum_type().build(),
-                    expect: MlxVariableSpec::Enum { options: vec![] },
+            }
+
+            "enum default options is empty" {
+                MlxVariableSpec::builder().enum_type().build() => MlxVariableSpec::Enum { options: vec![] },
+            }
+
+            "preset with max set" {
+                MlxVariableSpec::builder()
+                .preset()
+                .with_max_preset(9)
+                .build() => MlxVariableSpec::Preset { max_preset: 9 },
+            }
+
+            "preset default max is 0" {
+                MlxVariableSpec::builder().preset().build() => MlxVariableSpec::Preset { max_preset: 0 },
+            }
+
+            "boolean array with size set" {
+                MlxVariableSpec::builder()
+                .boolean_array()
+                .with_size(6)
+                .build() => MlxVariableSpec::BooleanArray { size: 6 },
+            }
+
+            "boolean array default size is 1" {
+                MlxVariableSpec::builder().boolean_array().build() => MlxVariableSpec::BooleanArray { size: 1 },
+            }
+
+            "integer array with size set" {
+                MlxVariableSpec::builder()
+                .integer_array()
+                .with_size(4)
+                .build() => MlxVariableSpec::IntegerArray { size: 4 },
+            }
+
+            "integer array default size is 1" {
+                MlxVariableSpec::builder().integer_array().build() => MlxVariableSpec::IntegerArray { size: 1 },
+            }
+
+            "binary array with size set" {
+                MlxVariableSpec::builder()
+                .binary_array()
+                .with_size(2)
+                .build() => MlxVariableSpec::BinaryArray { size: 2 },
+            }
+
+            "binary array default size is 1" {
+                MlxVariableSpec::builder().binary_array().build() => MlxVariableSpec::BinaryArray { size: 1 },
+            }
+
+            "enum array with options and size set" {
+                MlxVariableSpec::builder()
+                .enum_array()
+                .with_options(vec!["a".to_string()])
+                .with_size(3)
+                .build() => MlxVariableSpec::EnumArray {
+                    options: vec!["a".to_string()],
+                    size: 3,
                 },
-                Check {
-                    scenario: "preset with max set",
-                    input: MlxVariableSpec::builder()
-                        .preset()
-                        .with_max_preset(9)
-                        .build(),
-                    expect: MlxVariableSpec::Preset { max_preset: 9 },
+            }
+
+            "enum array defaults: empty options, size 1" {
+                MlxVariableSpec::builder().enum_array().build() => MlxVariableSpec::EnumArray {
+                    options: vec![],
+                    size: 1,
                 },
-                Check {
-                    scenario: "preset default max is 0",
-                    input: MlxVariableSpec::builder().preset().build(),
-                    expect: MlxVariableSpec::Preset { max_preset: 0 },
-                },
-                Check {
-                    scenario: "boolean array with size set",
-                    input: MlxVariableSpec::builder()
-                        .boolean_array()
-                        .with_size(6)
-                        .build(),
-                    expect: MlxVariableSpec::BooleanArray { size: 6 },
-                },
-                Check {
-                    scenario: "boolean array default size is 1",
-                    input: MlxVariableSpec::builder().boolean_array().build(),
-                    expect: MlxVariableSpec::BooleanArray { size: 1 },
-                },
-                Check {
-                    scenario: "integer array with size set",
-                    input: MlxVariableSpec::builder()
-                        .integer_array()
-                        .with_size(4)
-                        .build(),
-                    expect: MlxVariableSpec::IntegerArray { size: 4 },
-                },
-                Check {
-                    scenario: "integer array default size is 1",
-                    input: MlxVariableSpec::builder().integer_array().build(),
-                    expect: MlxVariableSpec::IntegerArray { size: 1 },
-                },
-                Check {
-                    scenario: "binary array with size set",
-                    input: MlxVariableSpec::builder()
-                        .binary_array()
-                        .with_size(2)
-                        .build(),
-                    expect: MlxVariableSpec::BinaryArray { size: 2 },
-                },
-                Check {
-                    scenario: "binary array default size is 1",
-                    input: MlxVariableSpec::builder().binary_array().build(),
-                    expect: MlxVariableSpec::BinaryArray { size: 1 },
-                },
-                Check {
-                    scenario: "enum array with options and size set",
-                    input: MlxVariableSpec::builder()
-                        .enum_array()
-                        .with_options(vec!["a".to_string()])
-                        .with_size(3)
-                        .build(),
-                    expect: MlxVariableSpec::EnumArray {
-                        options: vec!["a".to_string()],
-                        size: 3,
-                    },
-                },
-                Check {
-                    scenario: "enum array defaults: empty options, size 1",
-                    input: MlxVariableSpec::builder().enum_array().build(),
-                    expect: MlxVariableSpec::EnumArray {
-                        options: vec![],
-                        size: 1,
-                    },
-                },
-            ],
-            |built| built,
+            }
         );
     }
 

--- a/crates/libmlx/src/variables/value.rs
+++ b/crates/libmlx/src/variables/value.rs
@@ -1353,7 +1353,7 @@ impl TryFrom<MlxValueTypePb> for MlxValueType {
 #[cfg(test)]
 mod coverage_tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, Check, check_values, scenarios, value_scenarios};
     use serde_yaml::Value as Yaml;
 
     use super::*;
@@ -1477,58 +1477,49 @@ mod coverage_tests {
     // ----- MlxValueError Display strings (the contract for each variant) -----
     #[test]
     fn error_display_strings() {
-        check_values(
-            [
-                Check {
-                    scenario: "type mismatch",
-                    input: MlxValueError::TypeMismatch {
-                        expected: "A".to_string(),
-                        got: "B".to_string(),
-                    },
-                    expect: "Type mismatch: expected A, got B".to_string(),
-                },
-                Check {
-                    scenario: "invalid enum option",
-                    input: MlxValueError::InvalidEnumOption {
-                        value: "x".to_string(),
-                        allowed: vec!["a".to_string(), "b".to_string()],
-                    },
-                    expect: "Invalid enum option 'x', allowed: [a, b]".to_string(),
-                },
-                Check {
-                    scenario: "preset out of range",
-                    input: MlxValueError::PresetOutOfRange {
-                        value: 9,
-                        max_allowed: 5,
-                    },
-                    expect: "Preset value 9 exceeds maximum 5".to_string(),
-                },
-                Check {
-                    scenario: "array size mismatch",
-                    input: MlxValueError::ArraySizeMismatch {
-                        expected: 4,
-                        got: 2,
-                    },
-                    expect: "Array size mismatch: expected 4, got 2".to_string(),
-                },
-                Check {
-                    scenario: "invalid enum array option",
-                    input: MlxValueError::InvalidEnumArrayOption {
-                        position: 1,
-                        value: "z".to_string(),
-                        allowed: vec!["a".to_string()],
-                    },
-                    expect: "Invalid enum option 'z' at position 1, allowed: [a]".to_string(),
-                },
-                Check {
-                    scenario: "read only variable",
-                    input: MlxValueError::ReadOnlyVariable {
-                        variable_name: "RO".to_string(),
-                    },
-                    expect: "Variable 'RO' is read-only".to_string(),
-                },
-            ],
-            |err| err.to_string(),
+        value_scenarios!(
+            run = |err| err.to_string();
+            "type mismatch" {
+                MlxValueError::TypeMismatch {
+                    expected: "A".to_string(),
+                    got: "B".to_string(),
+                } => "Type mismatch: expected A, got B".to_string(),
+            }
+
+            "invalid enum option" {
+                MlxValueError::InvalidEnumOption {
+                    value: "x".to_string(),
+                    allowed: vec!["a".to_string(), "b".to_string()],
+                } => "Invalid enum option 'x', allowed: [a, b]".to_string(),
+            }
+
+            "preset out of range" {
+                MlxValueError::PresetOutOfRange {
+                    value: 9,
+                    max_allowed: 5,
+                } => "Preset value 9 exceeds maximum 5".to_string(),
+            }
+
+            "array size mismatch" {
+                MlxValueError::ArraySizeMismatch {
+                    expected: 4,
+                    got: 2,
+                } => "Array size mismatch: expected 4, got 2".to_string(),
+            }
+
+            "invalid enum array option" {
+                MlxValueError::InvalidEnumArrayOption {
+                    position: 1,
+                    value: "z".to_string(),
+                    allowed: vec!["a".to_string()],
+                } => "Invalid enum option 'z' at position 1, allowed: [a]".to_string(),
+            }
+
+            "read only variable" {
+                MlxValueError::ReadOnlyVariable {
+                    variable_name: "RO".to_string(),
+                } => "Variable 'RO' is read-only".to_string(),
+            }
         );
     }
 
@@ -1537,145 +1528,128 @@ mod coverage_tests {
     // failures that map spec<->value. The exact errors are pinned where derivable.
     #[test]
     fn new_validates_spec_against_value() {
-        check_cases(
-            [
-                Case {
-                    scenario: "matching boolean",
-                    input: (MlxVariableSpec::Boolean, MlxValueType::Boolean(true)),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "matching opaque",
-                    input: (MlxVariableSpec::Opaque, MlxValueType::Opaque(vec![1, 2])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "matching untyped array",
-                    input: (
-                        MlxVariableSpec::Array,
-                        MlxValueType::Array(vec!["a".to_string()]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "spec/value type mismatch",
-                    input: (MlxVariableSpec::Boolean, MlxValueType::Integer(1)),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "enum value not in options",
-                    input: (
-                        MlxVariableSpec::Enum {
-                            options: vec!["a".to_string()],
-                        },
-                        MlxValueType::Enum("nope".to_string()),
-                    ),
-                    expect: FailsWith(MlxValueError::InvalidEnumOption {
-                        value: "nope".to_string(),
-                        allowed: vec!["a".to_string()],
-                    }),
-                },
-                Case {
-                    scenario: "enum value in options",
-                    input: (
-                        MlxVariableSpec::Enum {
-                            options: vec!["a".to_string()],
-                        },
-                        MlxValueType::Enum("a".to_string()),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "preset over max",
-                    input: (
-                        MlxVariableSpec::Preset { max_preset: 3 },
-                        MlxValueType::Preset(4),
-                    ),
-                    expect: FailsWith(MlxValueError::PresetOutOfRange {
-                        value: 4,
-                        max_allowed: 3,
-                    }),
-                },
-                Case {
-                    scenario: "preset at max",
-                    input: (
-                        MlxVariableSpec::Preset { max_preset: 3 },
-                        MlxValueType::Preset(3),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "boolean array wrong size",
-                    input: (
-                        MlxVariableSpec::BooleanArray { size: 2 },
-                        MlxValueType::BooleanArray(vec![Some(true)]),
-                    ),
-                    expect: FailsWith(MlxValueError::ArraySizeMismatch {
-                        expected: 2,
-                        got: 1,
-                    }),
-                },
-                Case {
-                    scenario: "integer array right size",
-                    input: (
-                        MlxVariableSpec::IntegerArray { size: 2 },
-                        MlxValueType::IntegerArray(vec![Some(1), None]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "binary array wrong size",
-                    input: (
-                        MlxVariableSpec::BinaryArray { size: 1 },
-                        MlxValueType::BinaryArray(vec![None, None]),
-                    ),
-                    expect: FailsWith(MlxValueError::ArraySizeMismatch {
-                        expected: 1,
-                        got: 2,
-                    }),
-                },
-                Case {
-                    scenario: "enum array wrong size",
-                    input: (
-                        MlxVariableSpec::EnumArray {
-                            options: vec!["a".to_string()],
-                            size: 2,
-                        },
-                        MlxValueType::EnumArray(vec![Some("a".to_string())]),
-                    ),
-                    expect: FailsWith(MlxValueError::ArraySizeMismatch {
-                        expected: 2,
-                        got: 1,
-                    }),
-                },
-                Case {
-                    scenario: "enum array invalid element",
-                    input: (
-                        MlxVariableSpec::EnumArray {
-                            options: vec!["a".to_string()],
-                            size: 2,
-                        },
-                        MlxValueType::EnumArray(vec![Some("a".to_string()), Some("b".to_string())]),
-                    ),
-                    expect: FailsWith(MlxValueError::InvalidEnumArrayOption {
-                        position: 1,
-                        value: "b".to_string(),
-                        allowed: vec!["a".to_string()],
-                    }),
-                },
-                Case {
-                    scenario: "enum array None elements skipped in validation",
-                    input: (
-                        MlxVariableSpec::EnumArray {
-                            options: vec!["a".to_string()],
-                            size: 2,
-                        },
-                        MlxValueType::EnumArray(vec![Some("a".to_string()), None]),
-                    ),
-                    expect: Yields(()),
-                },
-            ],
-            |(spec, value)| MlxConfigValue::new(var("v", spec), value).map(|_| ()),
+        scenarios!(
+            run = |(spec, value)| MlxConfigValue::new(var("v", spec), value).map(|_| ());
+            "matching boolean" {
+                (MlxVariableSpec::Boolean, MlxValueType::Boolean(true)) => Yields(()),
+            }
+
+            "matching opaque" {
+                (MlxVariableSpec::Opaque, MlxValueType::Opaque(vec![1, 2])) => Yields(()),
+            }
+
+            "matching untyped array" {
+                (
+                    MlxVariableSpec::Array,
+                    MlxValueType::Array(vec!["a".to_string()]),
+                ) => Yields(()),
+            }
+
+            "spec/value type mismatch" {
+                (MlxVariableSpec::Boolean, MlxValueType::Integer(1)) => Fails,
+            }
+
+            "enum value not in options" {
+                (
+                    MlxVariableSpec::Enum {
+                        options: vec!["a".to_string()],
+                    },
+                    MlxValueType::Enum("nope".to_string()),
+                ) => FailsWith(MlxValueError::InvalidEnumOption {
+                    value: "nope".to_string(),
+                    allowed: vec!["a".to_string()],
+                }),
+            }
+
+            "enum value in options" {
+                (
+                    MlxVariableSpec::Enum {
+                        options: vec!["a".to_string()],
+                    },
+                    MlxValueType::Enum("a".to_string()),
+                ) => Yields(()),
+            }
+
+            "preset over max" {
+                (
+                    MlxVariableSpec::Preset { max_preset: 3 },
+                    MlxValueType::Preset(4),
+                ) => FailsWith(MlxValueError::PresetOutOfRange {
+                    value: 4,
+                    max_allowed: 3,
+                }),
+            }
+
+            "preset at max" {
+                (
+                    MlxVariableSpec::Preset { max_preset: 3 },
+                    MlxValueType::Preset(3),
+                ) => Yields(()),
+            }
+
+            "boolean array wrong size" {
+                (
+                    MlxVariableSpec::BooleanArray { size: 2 },
+                    MlxValueType::BooleanArray(vec![Some(true)]),
+                ) => FailsWith(MlxValueError::ArraySizeMismatch {
+                    expected: 2,
+                    got: 1,
+                }),
+            }
+
+            "integer array right size" {
+                (
+                    MlxVariableSpec::IntegerArray { size: 2 },
+                    MlxValueType::IntegerArray(vec![Some(1), None]),
+                ) => Yields(()),
+            }
+
+            "binary array wrong size" {
+                (
+                    MlxVariableSpec::BinaryArray { size: 1 },
+                    MlxValueType::BinaryArray(vec![None, None]),
+                ) => FailsWith(MlxValueError::ArraySizeMismatch {
+                    expected: 1,
+                    got: 2,
+                }),
+            }
+
+            "enum array wrong size" {
+                (
+                    MlxVariableSpec::EnumArray {
+                        options: vec!["a".to_string()],
+                        size: 2,
+                    },
+                    MlxValueType::EnumArray(vec![Some("a".to_string())]),
+                ) => FailsWith(MlxValueError::ArraySizeMismatch {
+                    expected: 2,
+                    got: 1,
+                }),
+            }
+
+            "enum array invalid element" {
+                (
+                    MlxVariableSpec::EnumArray {
+                        options: vec!["a".to_string()],
+                        size: 2,
+                    },
+                    MlxValueType::EnumArray(vec![Some("a".to_string()), Some("b".to_string())]),
+                ) => FailsWith(MlxValueError::InvalidEnumArrayOption {
+                    position: 1,
+                    value: "b".to_string(),
+                    allowed: vec!["a".to_string()],
+                }),
+            }
+
+            "enum array None elements skipped in validation" {
+                (
+                    MlxVariableSpec::EnumArray {
+                        options: vec!["a".to_string()],
+                        size: 2,
+                    },
+                    MlxValueType::EnumArray(vec![Some("a".to_string()), None]),
+                ) => Yields(()),
+            }
         );
     }
 
@@ -1683,43 +1657,34 @@ mod coverage_tests {
     #[test]
     fn i64_into_value_for_spec() {
         let preset = MlxVariableSpec::Preset { max_preset: 5 };
-        check_cases(
-            [
-                Case {
-                    scenario: "integer spec",
-                    input: (MlxVariableSpec::Integer, 42i64),
-                    expect: Yields(MlxValueType::Integer(42)),
-                },
-                Case {
-                    scenario: "preset in range",
-                    input: (preset.clone(), 3i64),
-                    expect: Yields(MlxValueType::Preset(3)),
-                },
-                Case {
-                    scenario: "preset negative rejected",
-                    input: (preset.clone(), -1i64),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "preset above u8::MAX rejected",
-                    input: (preset.clone(), 300i64),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "preset over max rejected",
-                    input: (preset.clone(), 10i64),
-                    expect: FailsWith(MlxValueError::PresetOutOfRange {
-                        value: 10,
-                        max_allowed: 5,
-                    }),
-                },
-                Case {
-                    scenario: "mismatched spec",
-                    input: (MlxVariableSpec::Boolean, 1i64),
-                    expect: Fails,
-                },
-            ],
-            |(spec, n)| n.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, n)| n.into_mlx_value_for_spec(&spec);
+            "integer spec" {
+                (MlxVariableSpec::Integer, 42i64) => Yields(MlxValueType::Integer(42)),
+            }
+
+            "preset in range" {
+                (preset.clone(), 3i64) => Yields(MlxValueType::Preset(3)),
+            }
+
+            "preset negative rejected" {
+                (preset.clone(), -1i64) => Fails,
+            }
+
+            "preset above u8::MAX rejected" {
+                (preset.clone(), 300i64) => Fails,
+            }
+
+            "preset over max rejected" {
+                (preset.clone(), 10i64) => FailsWith(MlxValueError::PresetOutOfRange {
+                    value: 10,
+                    max_allowed: 5,
+                }),
+            }
+
+            "mismatched spec" {
+                (MlxVariableSpec::Boolean, 1i64) => Fails,
+            }
         );
     }
 
@@ -1738,83 +1703,64 @@ mod coverage_tests {
     #[test]
     fn u8_into_value_for_spec() {
         let preset = MlxVariableSpec::Preset { max_preset: 5 };
-        check_cases(
-            [
-                Case {
-                    scenario: "preset in range",
-                    input: (preset.clone(), 5u8),
-                    expect: Yields(MlxValueType::Preset(5)),
-                },
-                Case {
-                    scenario: "preset over max",
-                    input: (preset.clone(), 6u8),
-                    expect: FailsWith(MlxValueError::PresetOutOfRange {
-                        value: 6,
-                        max_allowed: 5,
-                    }),
-                },
-                Case {
-                    scenario: "integer spec widens to i64",
-                    input: (MlxVariableSpec::Integer, 200u8),
-                    expect: Yields(MlxValueType::Integer(200)),
-                },
-                Case {
-                    scenario: "mismatched spec",
-                    input: (MlxVariableSpec::String, 1u8),
-                    expect: Fails,
-                },
-            ],
-            |(spec, n)| n.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, n)| n.into_mlx_value_for_spec(&spec);
+            "preset in range" {
+                (preset.clone(), 5u8) => Yields(MlxValueType::Preset(5)),
+            }
+
+            "preset over max" {
+                (preset.clone(), 6u8) => FailsWith(MlxValueError::PresetOutOfRange {
+                    value: 6,
+                    max_allowed: 5,
+                }),
+            }
+
+            "integer spec widens to i64" {
+                (MlxVariableSpec::Integer, 200u8) => Yields(MlxValueType::Integer(200)),
+            }
+
+            "mismatched spec" {
+                (MlxVariableSpec::String, 1u8) => Fails,
+            }
         );
     }
 
     // ----- IntoMlxValue for bool: only Boolean spec, else mismatch -----
     #[test]
     fn bool_into_value_for_spec() {
-        check_cases(
-            [
-                Case {
-                    scenario: "boolean spec",
-                    input: (MlxVariableSpec::Boolean, true),
-                    expect: Yields(MlxValueType::Boolean(true)),
-                },
-                Case {
-                    scenario: "mismatched spec",
-                    input: (MlxVariableSpec::Integer, false),
-                    expect: Fails,
-                },
-            ],
-            |(spec, b)| b.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, b)| b.into_mlx_value_for_spec(&spec);
+            "boolean spec" {
+                (MlxVariableSpec::Boolean, true) => Yields(MlxValueType::Boolean(true)),
+            }
+
+            "mismatched spec" {
+                (MlxVariableSpec::Integer, false) => Fails,
+            }
         );
     }
 
     // ----- IntoMlxValue for Vec<u8>: Binary / Bytes / Opaque / mismatch -----
     #[test]
     fn vec_u8_into_value_for_spec() {
-        check_cases(
-            [
-                Case {
-                    scenario: "binary spec",
-                    input: (MlxVariableSpec::Binary, vec![1u8, 2, 3]),
-                    expect: Yields(MlxValueType::Binary(vec![1, 2, 3])),
-                },
-                Case {
-                    scenario: "bytes spec",
-                    input: (MlxVariableSpec::Bytes, vec![1u8, 2, 3]),
-                    expect: Yields(MlxValueType::Bytes(vec![1, 2, 3])),
-                },
-                Case {
-                    scenario: "opaque spec",
-                    input: (MlxVariableSpec::Opaque, vec![1u8, 2, 3]),
-                    expect: Yields(MlxValueType::Opaque(vec![1, 2, 3])),
-                },
-                Case {
-                    scenario: "mismatched spec",
-                    input: (MlxVariableSpec::Boolean, vec![1u8]),
-                    expect: Fails,
-                },
-            ],
-            |(spec, bytes)| bytes.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, bytes)| bytes.into_mlx_value_for_spec(&spec);
+            "binary spec" {
+                (MlxVariableSpec::Binary, vec![1u8, 2, 3]) => Yields(MlxValueType::Binary(vec![1, 2, 3])),
+            }
+
+            "bytes spec" {
+                (MlxVariableSpec::Bytes, vec![1u8, 2, 3]) => Yields(MlxValueType::Bytes(vec![1, 2, 3])),
+            }
+
+            "opaque spec" {
+                (MlxVariableSpec::Opaque, vec![1u8, 2, 3]) => Yields(MlxValueType::Opaque(vec![1, 2, 3])),
+            }
+
+            "mismatched spec" {
+                (MlxVariableSpec::Boolean, vec![1u8]) => Fails,
+            }
         );
     }
 
@@ -1823,30 +1769,23 @@ mod coverage_tests {
     // rejection.
     #[test]
     fn string_into_value_hex_and_array_rejection() {
-        check_cases(
-            [
-                Case {
-                    scenario: "binary bare hex",
-                    input: (MlxVariableSpec::Binary, "1a2b".to_string()),
-                    expect: Yields(MlxValueType::Binary(vec![0x1a, 0x2b])),
-                },
-                Case {
-                    scenario: "bytes 0X prefix",
-                    input: (MlxVariableSpec::Bytes, "0XFF00".to_string()),
-                    expect: Yields(MlxValueType::Bytes(vec![0xff, 0x00])),
-                },
-                Case {
-                    scenario: "opaque bad hex rejected",
-                    input: (MlxVariableSpec::Opaque, "zz".to_string()),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "integer-array spec rejects single string",
-                    input: (MlxVariableSpec::IntegerArray { size: 2 }, "5".to_string()),
-                    expect: Fails,
-                },
-            ],
-            |(spec, s)| s.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, s)| s.into_mlx_value_for_spec(&spec);
+            "binary bare hex" {
+                (MlxVariableSpec::Binary, "1a2b".to_string()) => Yields(MlxValueType::Binary(vec![0x1a, 0x2b])),
+            }
+
+            "bytes 0X prefix" {
+                (MlxVariableSpec::Bytes, "0XFF00".to_string()) => Yields(MlxValueType::Bytes(vec![0xff, 0x00])),
+            }
+
+            "opaque bad hex rejected" {
+                (MlxVariableSpec::Opaque, "zz".to_string()) => Fails,
+            }
+
+            "integer-array spec rejects single string" {
+                (MlxVariableSpec::IntegerArray { size: 2 }, "5".to_string()) => Fails,
+            }
         );
     }
 
@@ -1872,78 +1811,60 @@ mod coverage_tests {
     #[test]
     fn sparse_vec_inputs_validate_size_and_spec() {
         // Vec<Option<bool>>
-        check_cases(
-            [
-                Case {
-                    scenario: "bool sparse right size",
-                    input: (
-                        MlxVariableSpec::BooleanArray { size: 2 },
-                        vec![Some(true), None],
-                    ),
-                    expect: Yields(MlxValueType::BooleanArray(vec![Some(true), None])),
-                },
-                Case {
-                    scenario: "bool sparse wrong size",
-                    input: (MlxVariableSpec::BooleanArray { size: 3 }, vec![Some(true)]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "bool sparse wrong spec",
-                    input: (MlxVariableSpec::Boolean, vec![Some(true)]),
-                    expect: Fails,
-                },
-            ],
-            |(spec, v)| v.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, v)| v.into_mlx_value_for_spec(&spec);
+            "bool sparse right size" {
+                (
+                    MlxVariableSpec::BooleanArray { size: 2 },
+                    vec![Some(true), None],
+                ) => Yields(MlxValueType::BooleanArray(vec![Some(true), None])),
+            }
+
+            "bool sparse wrong size" {
+                (MlxVariableSpec::BooleanArray { size: 3 }, vec![Some(true)]) => Fails,
+            }
+
+            "bool sparse wrong spec" {
+                (MlxVariableSpec::Boolean, vec![Some(true)]) => Fails,
+            }
         );
 
         // Vec<Option<i64>>
-        check_cases(
-            [
-                Case {
-                    scenario: "int sparse right size",
-                    input: (
-                        MlxVariableSpec::IntegerArray { size: 2 },
-                        vec![Some(1i64), None],
-                    ),
-                    expect: Yields(MlxValueType::IntegerArray(vec![Some(1), None])),
-                },
-                Case {
-                    scenario: "int sparse wrong size",
-                    input: (MlxVariableSpec::IntegerArray { size: 1 }, vec![None, None]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "int sparse wrong spec",
-                    input: (MlxVariableSpec::Integer, vec![Some(1i64)]),
-                    expect: Fails,
-                },
-            ],
-            |(spec, v)| v.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, v)| v.into_mlx_value_for_spec(&spec);
+            "int sparse right size" {
+                (
+                    MlxVariableSpec::IntegerArray { size: 2 },
+                    vec![Some(1i64), None],
+                ) => Yields(MlxValueType::IntegerArray(vec![Some(1), None])),
+            }
+
+            "int sparse wrong size" {
+                (MlxVariableSpec::IntegerArray { size: 1 }, vec![None, None]) => Fails,
+            }
+
+            "int sparse wrong spec" {
+                (MlxVariableSpec::Integer, vec![Some(1i64)]) => Fails,
+            }
         );
 
         // Vec<Option<Vec<u8>>>
-        check_cases(
-            [
-                Case {
-                    scenario: "binary sparse right size",
-                    input: (
-                        MlxVariableSpec::BinaryArray { size: 2 },
-                        vec![Some(vec![1u8]), None],
-                    ),
-                    expect: Yields(MlxValueType::BinaryArray(vec![Some(vec![1]), None])),
-                },
-                Case {
-                    scenario: "binary sparse wrong size",
-                    input: (MlxVariableSpec::BinaryArray { size: 3 }, vec![None]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "binary sparse wrong spec",
-                    input: (MlxVariableSpec::Bytes, vec![Some(vec![1u8])]),
-                    expect: Fails,
-                },
-            ],
-            |(spec, v)| v.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, v)| v.into_mlx_value_for_spec(&spec);
+            "binary sparse right size" {
+                (
+                    MlxVariableSpec::BinaryArray { size: 2 },
+                    vec![Some(vec![1u8]), None],
+                ) => Yields(MlxValueType::BinaryArray(vec![Some(vec![1]), None])),
+            }
+
+            "binary sparse wrong size" {
+                (MlxVariableSpec::BinaryArray { size: 3 }, vec![None]) => Fails,
+            }
+
+            "binary sparse wrong spec" {
+                (MlxVariableSpec::Bytes, vec![Some(vec![1u8])]) => Fails,
+            }
         );
 
         // Vec<Option<String>> for enum arrays: size, invalid option, wrong spec.
@@ -1951,37 +1872,30 @@ mod coverage_tests {
             options: vec!["a".to_string(), "b".to_string()],
             size: 2,
         };
-        check_cases(
-            [
-                Case {
-                    scenario: "enum sparse valid",
-                    input: (enum_spec.clone(), vec![Some("a".to_string()), None]),
-                    expect: Yields(MlxValueType::EnumArray(vec![Some("a".to_string()), None])),
-                },
-                Case {
-                    scenario: "enum sparse wrong size",
-                    input: (enum_spec.clone(), vec![Some("a".to_string())]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "enum sparse invalid option pins position",
-                    input: (
-                        enum_spec.clone(),
-                        vec![Some("a".to_string()), Some("zzz".to_string())],
-                    ),
-                    expect: FailsWith(MlxValueError::InvalidEnumArrayOption {
-                        position: 1,
-                        value: "zzz".to_string(),
-                        allowed: vec!["a".to_string(), "b".to_string()],
-                    }),
-                },
-                Case {
-                    scenario: "enum sparse wrong spec",
-                    input: (MlxVariableSpec::String, vec![Some("a".to_string())]),
-                    expect: Fails,
-                },
-            ],
-            |(spec, v)| v.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, v)| v.into_mlx_value_for_spec(&spec);
+            "enum sparse valid" {
+                (enum_spec.clone(), vec![Some("a".to_string()), None]) => Yields(MlxValueType::EnumArray(vec![Some("a".to_string()), None])),
+            }
+
+            "enum sparse wrong size" {
+                (enum_spec.clone(), vec![Some("a".to_string())]) => Fails,
+            }
+
+            "enum sparse invalid option pins position" {
+                (
+                    enum_spec.clone(),
+                    vec![Some("a".to_string()), Some("zzz".to_string())],
+                ) => FailsWith(MlxValueError::InvalidEnumArrayOption {
+                    position: 1,
+                    value: "zzz".to_string(),
+                    allowed: vec!["a".to_string(), "b".to_string()],
+                }),
+            }
+
+            "enum sparse wrong spec" {
+                (MlxVariableSpec::String, vec![Some("a".to_string())]) => Fails,
+            }
         );
     }
 
@@ -2032,75 +1946,64 @@ mod coverage_tests {
     // ----- IntoMlxValue for serde_yaml::Value -----
     #[test]
     fn yaml_value_into_value_for_spec() {
-        check_cases(
-            [
-                Case {
-                    scenario: "bool",
-                    input: (MlxVariableSpec::Boolean, Yaml::Bool(true)),
-                    expect: Yields(MlxValueType::Boolean(true)),
-                },
-                Case {
-                    scenario: "number to integer",
-                    input: (MlxVariableSpec::Integer, Yaml::Number(42.into())),
-                    expect: Yields(MlxValueType::Integer(42)),
-                },
-                Case {
-                    scenario: "number to preset in range",
-                    input: (
-                        MlxVariableSpec::Preset { max_preset: 5 },
-                        Yaml::Number(3.into()),
-                    ),
-                    expect: Yields(MlxValueType::Preset(3)),
-                },
-                Case {
-                    scenario: "negative number for preset rejected",
-                    input: (
-                        MlxVariableSpec::Preset { max_preset: 5 },
-                        Yaml::Number((-1).into()),
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "string to enum",
-                    input: (
-                        MlxVariableSpec::Enum {
-                            options: vec!["a".to_string()],
-                        },
-                        Yaml::String("a".to_string()),
-                    ),
-                    expect: Yields(MlxValueType::Enum("a".to_string())),
-                },
-                Case {
-                    scenario: "sequence to untyped array",
-                    input: (
-                        MlxVariableSpec::Array,
-                        Yaml::Sequence(vec![
-                            Yaml::String("x".to_string()),
-                            Yaml::Number(2.into()),
-                            Yaml::Bool(true),
-                        ]),
-                    ),
-                    expect: Yields(MlxValueType::Array(vec![
-                        "x".to_string(),
-                        "2".to_string(),
-                        "true".to_string(),
-                    ])),
-                },
-                Case {
-                    scenario: "unsupported yaml type rejected",
-                    input: (MlxVariableSpec::String, Yaml::Null),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "sequence with complex element rejected",
-                    input: (
-                        MlxVariableSpec::Array,
-                        Yaml::Sequence(vec![Yaml::Sequence(vec![])]),
-                    ),
-                    expect: Fails,
-                },
-            ],
-            |(spec, y)| y.into_mlx_value_for_spec(&spec),
+        scenarios!(
+            run = |(spec, y)| y.into_mlx_value_for_spec(&spec);
+            "bool" {
+                (MlxVariableSpec::Boolean, Yaml::Bool(true)) => Yields(MlxValueType::Boolean(true)),
+            }
+
+            "number to integer" {
+                (MlxVariableSpec::Integer, Yaml::Number(42.into())) => Yields(MlxValueType::Integer(42)),
+            }
+
+            "number to preset in range" {
+                (
+                    MlxVariableSpec::Preset { max_preset: 5 },
+                    Yaml::Number(3.into()),
+                ) => Yields(MlxValueType::Preset(3)),
+            }
+
+            "negative number for preset rejected" {
+                (
+                    MlxVariableSpec::Preset { max_preset: 5 },
+                    Yaml::Number((-1).into()),
+                ) => Fails,
+            }
+
+            "string to enum" {
+                (
+                    MlxVariableSpec::Enum {
+                        options: vec!["a".to_string()],
+                    },
+                    Yaml::String("a".to_string()),
+                ) => Yields(MlxValueType::Enum("a".to_string())),
+            }
+
+            "sequence to untyped array" {
+                (
+                    MlxVariableSpec::Array,
+                    Yaml::Sequence(vec![
+                        Yaml::String("x".to_string()),
+                        Yaml::Number(2.into()),
+                        Yaml::Bool(true),
+                    ]),
+                ) => Yields(MlxValueType::Array(vec![
+                    "x".to_string(),
+                    "2".to_string(),
+                    "true".to_string(),
+                ])),
+            }
+
+            "unsupported yaml type rejected" {
+                (MlxVariableSpec::String, Yaml::Null) => Fails,
+            }
+
+            "sequence with complex element rejected" {
+                (
+                    MlxVariableSpec::Array,
+                    Yaml::Sequence(vec![Yaml::Sequence(vec![])]),
+                ) => Fails,
+            }
         );
     }
 
@@ -2122,87 +2025,71 @@ mod coverage_tests {
     // ----- MlxValueType::to_yaml_value: every arm -----
     #[test]
     fn to_yaml_value_for_each_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "boolean",
-                    input: MlxValueType::Boolean(true),
-                    expect: Yaml::Bool(true),
-                },
-                Check {
-                    scenario: "integer",
-                    input: MlxValueType::Integer(7),
-                    expect: Yaml::Number(7.into()),
-                },
-                Check {
-                    scenario: "string",
-                    input: MlxValueType::String("s".to_string()),
-                    expect: Yaml::String("s".to_string()),
-                },
-                Check {
-                    scenario: "enum",
-                    input: MlxValueType::Enum("e".to_string()),
-                    expect: Yaml::String("e".to_string()),
-                },
-                Check {
-                    scenario: "preset as number",
-                    input: MlxValueType::Preset(3),
-                    expect: Yaml::Number(3.into()),
-                },
-                Check {
-                    scenario: "binary as hex string",
-                    input: MlxValueType::Binary(vec![0x1a, 0x2b]),
-                    expect: Yaml::String("0x1a2b".to_string()),
-                },
-                Check {
-                    scenario: "bytes as hex string",
-                    input: MlxValueType::Bytes(vec![0xff]),
-                    expect: Yaml::String("0xff".to_string()),
-                },
-                Check {
-                    scenario: "opaque as hex string",
-                    input: MlxValueType::Opaque(vec![0x00]),
-                    expect: Yaml::String("0x00".to_string()),
-                },
-                Check {
-                    scenario: "untyped array as sequence",
-                    input: MlxValueType::Array(vec!["a".to_string(), "b".to_string()]),
-                    expect: Yaml::Sequence(vec![
-                        Yaml::String("a".to_string()),
-                        Yaml::String("b".to_string()),
-                    ]),
-                },
-                Check {
-                    scenario: "boolean array with None as dash",
-                    input: MlxValueType::BooleanArray(vec![Some(true), None]),
-                    expect: Yaml::Sequence(vec![Yaml::Bool(true), Yaml::String("-".to_string())]),
-                },
-                Check {
-                    scenario: "integer array with None as dash",
-                    input: MlxValueType::IntegerArray(vec![Some(5), None]),
-                    expect: Yaml::Sequence(vec![
-                        Yaml::Number(5.into()),
-                        Yaml::String("-".to_string()),
-                    ]),
-                },
-                Check {
-                    scenario: "enum array with None as dash",
-                    input: MlxValueType::EnumArray(vec![Some("x".to_string()), None]),
-                    expect: Yaml::Sequence(vec![
-                        Yaml::String("x".to_string()),
-                        Yaml::String("-".to_string()),
-                    ]),
-                },
-                Check {
-                    scenario: "binary array with None as dash",
-                    input: MlxValueType::BinaryArray(vec![Some(vec![0x1a]), None]),
-                    expect: Yaml::Sequence(vec![
-                        Yaml::String("0x1a".to_string()),
-                        Yaml::String("-".to_string()),
-                    ]),
-                },
-            ],
-            |value| value.to_yaml_value(),
+        value_scenarios!(
+            run = |value| value.to_yaml_value();
+            "boolean" {
+                MlxValueType::Boolean(true) => Yaml::Bool(true),
+            }
+
+            "integer" {
+                MlxValueType::Integer(7) => Yaml::Number(7.into()),
+            }
+
+            "string" {
+                MlxValueType::String("s".to_string()) => Yaml::String("s".to_string()),
+            }
+
+            "enum" {
+                MlxValueType::Enum("e".to_string()) => Yaml::String("e".to_string()),
+            }
+
+            "preset as number" {
+                MlxValueType::Preset(3) => Yaml::Number(3.into()),
+            }
+
+            "binary as hex string" {
+                MlxValueType::Binary(vec![0x1a, 0x2b]) => Yaml::String("0x1a2b".to_string()),
+            }
+
+            "bytes as hex string" {
+                MlxValueType::Bytes(vec![0xff]) => Yaml::String("0xff".to_string()),
+            }
+
+            "opaque as hex string" {
+                MlxValueType::Opaque(vec![0x00]) => Yaml::String("0x00".to_string()),
+            }
+
+            "untyped array as sequence" {
+                MlxValueType::Array(vec!["a".to_string(), "b".to_string()]) => Yaml::Sequence(vec![
+                    Yaml::String("a".to_string()),
+                    Yaml::String("b".to_string()),
+                ]),
+            }
+
+            "boolean array with None as dash" {
+                MlxValueType::BooleanArray(vec![Some(true), None]) => Yaml::Sequence(vec![Yaml::Bool(true), Yaml::String("-".to_string())]),
+            }
+
+            "integer array with None as dash" {
+                MlxValueType::IntegerArray(vec![Some(5), None]) => Yaml::Sequence(vec![
+                    Yaml::Number(5.into()),
+                    Yaml::String("-".to_string()),
+                ]),
+            }
+
+            "enum array with None as dash" {
+                MlxValueType::EnumArray(vec![Some("x".to_string()), None]) => Yaml::Sequence(vec![
+                    Yaml::String("x".to_string()),
+                    Yaml::String("-".to_string()),
+                ]),
+            }
+
+            "binary array with None as dash" {
+                MlxValueType::BinaryArray(vec![Some(vec![0x1a]), None]) => Yaml::Sequence(vec![
+                    Yaml::String("0x1a".to_string()),
+                    Yaml::String("-".to_string()),
+                ]),
+            }
         );
     }
 
@@ -2211,82 +2098,66 @@ mod coverage_tests {
     // the proto bridge collapses to None) should survive the trip unchanged.
     #[test]
     fn value_type_proto_round_trips() {
-        check_cases(
-            [
-                Case {
-                    scenario: "boolean",
-                    input: MlxValueType::Boolean(true),
-                    expect: Yields(MlxValueType::Boolean(true)),
-                },
-                Case {
-                    scenario: "integer",
-                    input: MlxValueType::Integer(-9),
-                    expect: Yields(MlxValueType::Integer(-9)),
-                },
-                Case {
-                    scenario: "string",
-                    input: MlxValueType::String("s".to_string()),
-                    expect: Yields(MlxValueType::String("s".to_string())),
-                },
-                Case {
-                    scenario: "binary",
-                    input: MlxValueType::Binary(vec![1, 2]),
-                    expect: Yields(MlxValueType::Binary(vec![1, 2])),
-                },
-                Case {
-                    scenario: "bytes",
-                    input: MlxValueType::Bytes(vec![3, 4]),
-                    expect: Yields(MlxValueType::Bytes(vec![3, 4])),
-                },
-                Case {
-                    scenario: "untyped array",
-                    input: MlxValueType::Array(vec!["a".to_string()]),
-                    expect: Yields(MlxValueType::Array(vec!["a".to_string()])),
-                },
-                Case {
-                    scenario: "enum",
-                    input: MlxValueType::Enum("e".to_string()),
-                    expect: Yields(MlxValueType::Enum("e".to_string())),
-                },
-                Case {
-                    scenario: "preset",
-                    input: MlxValueType::Preset(7),
-                    expect: Yields(MlxValueType::Preset(7)),
-                },
-                Case {
-                    scenario: "boolean array sparse",
-                    input: MlxValueType::BooleanArray(vec![Some(true), None, Some(false)]),
-                    expect: Yields(MlxValueType::BooleanArray(vec![
-                        Some(true),
-                        None,
-                        Some(false),
-                    ])),
-                },
-                Case {
-                    scenario: "integer array sparse",
-                    input: MlxValueType::IntegerArray(vec![Some(1), None]),
-                    expect: Yields(MlxValueType::IntegerArray(vec![Some(1), None])),
-                },
-                Case {
-                    scenario: "enum array sparse (None survives empty-string bridge)",
-                    input: MlxValueType::EnumArray(vec![Some("x".to_string()), None]),
-                    expect: Yields(MlxValueType::EnumArray(vec![Some("x".to_string()), None])),
-                },
-                Case {
-                    scenario: "binary array sparse",
-                    input: MlxValueType::BinaryArray(vec![Some(vec![9]), None]),
-                    expect: Yields(MlxValueType::BinaryArray(vec![Some(vec![9]), None])),
-                },
-                Case {
-                    scenario: "opaque",
-                    input: MlxValueType::Opaque(vec![5, 6]),
-                    expect: Yields(MlxValueType::Opaque(vec![5, 6])),
-                },
-            ],
-            |value| {
+        scenarios!(
+            run = |value| {
                 let pb: MlxValueTypePb = value.into();
                 MlxValueType::try_from(pb).map_err(drop)
-            },
+            };
+            "boolean" {
+                MlxValueType::Boolean(true) => Yields(MlxValueType::Boolean(true)),
+            }
+
+            "integer" {
+                MlxValueType::Integer(-9) => Yields(MlxValueType::Integer(-9)),
+            }
+
+            "string" {
+                MlxValueType::String("s".to_string()) => Yields(MlxValueType::String("s".to_string())),
+            }
+
+            "binary" {
+                MlxValueType::Binary(vec![1, 2]) => Yields(MlxValueType::Binary(vec![1, 2])),
+            }
+
+            "bytes" {
+                MlxValueType::Bytes(vec![3, 4]) => Yields(MlxValueType::Bytes(vec![3, 4])),
+            }
+
+            "untyped array" {
+                MlxValueType::Array(vec!["a".to_string()]) => Yields(MlxValueType::Array(vec!["a".to_string()])),
+            }
+
+            "enum" {
+                MlxValueType::Enum("e".to_string()) => Yields(MlxValueType::Enum("e".to_string())),
+            }
+
+            "preset" {
+                MlxValueType::Preset(7) => Yields(MlxValueType::Preset(7)),
+            }
+
+            "boolean array sparse" {
+                MlxValueType::BooleanArray(vec![Some(true), None, Some(false)]) => Yields(MlxValueType::BooleanArray(vec![
+                    Some(true),
+                    None,
+                    Some(false),
+                ])),
+            }
+
+            "integer array sparse" {
+                MlxValueType::IntegerArray(vec![Some(1), None]) => Yields(MlxValueType::IntegerArray(vec![Some(1), None])),
+            }
+
+            "enum array sparse (None survives empty-string bridge)" {
+                MlxValueType::EnumArray(vec![Some("x".to_string()), None]) => Yields(MlxValueType::EnumArray(vec![Some("x".to_string()), None])),
+            }
+
+            "binary array sparse" {
+                MlxValueType::BinaryArray(vec![Some(vec![9]), None]) => Yields(MlxValueType::BinaryArray(vec![Some(vec![9]), None])),
+            }
+
+            "opaque" {
+                MlxValueType::Opaque(vec![5, 6]) => Yields(MlxValueType::Opaque(vec![5, 6])),
+            }
         );
     }
 

--- a/crates/libmlx/tests/device/test_discovery.rs
+++ b/crates/libmlx/tests/device/test_discovery.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{scenarios, value_scenarios};
 use libmlx::device::discovery::{convert_pci_name_to_address, parse_mlxfwmanager_xml};
 
 // Test XML to use for a single DPU with failed access due to lockdown.
@@ -189,40 +189,31 @@ fn test_parse_mixed_devices() {
 // strings) through untouched.
 #[test]
 fn test_convert_pci_name_to_address() {
-    check_cases(
-        [
-            Case {
-                scenario: "removes domain prefix",
-                input: "0000:01:00.0",
-                expect: Yields("01:00.0".to_string()),
-            },
-            Case {
-                scenario: "passes through a clean address",
-                input: "01:00.0",
-                expect: Yields("01:00.0".to_string()),
-            },
-            Case {
-                scenario: "passes through an mst path",
-                input: "/dev/mst/mt41692_pciconf0",
-                expect: Yields("/dev/mst/mt41692_pciconf0".to_string()),
-            },
-            Case {
-                scenario: "passes through an unrelated format",
-                input: "custom_device_path",
-                expect: Yields("custom_device_path".to_string()),
-            },
-            Case {
-                scenario: "removes only the first of multiple domain prefixes",
-                input: "0000:0000:01:00.0",
-                expect: Yields("0000:01:00.0".to_string()),
-            },
-            Case {
-                scenario: "passes through an empty string",
-                input: "",
-                expect: Yields("".to_string()),
-            },
-        ],
-        convert_pci_name_to_address,
+    scenarios!(
+        run = convert_pci_name_to_address;
+        "removes domain prefix" {
+            "0000:01:00.0" => Yields("01:00.0".to_string()),
+        }
+
+        "passes through a clean address" {
+            "01:00.0" => Yields("01:00.0".to_string()),
+        }
+
+        "passes through an mst path" {
+            "/dev/mst/mt41692_pciconf0" => Yields("/dev/mst/mt41692_pciconf0".to_string()),
+        }
+
+        "passes through an unrelated format" {
+            "custom_device_path" => Yields("custom_device_path".to_string()),
+        }
+
+        "removes only the first of multiple domain prefixes" {
+            "0000:0000:01:00.0" => Yields("0000:01:00.0".to_string()),
+        }
+
+        "passes through an empty string" {
+            "" => Yields("".to_string()),
+        }
     );
 }
 
@@ -248,44 +239,34 @@ fn test_optional_field_handling() {
     let devices = parse_mlxfwmanager_xml(DPU_FAILED_XML).unwrap();
     let device = &devices[0];
 
-    check_values(
-        [
-            Check {
-                scenario: "None psid renders as --",
-                input: "psid",
-                expect: "--".to_string(),
-            },
-            Check {
-                scenario: "None part_number renders as --",
-                input: "part_number",
-                expect: "--".to_string(),
-            },
-            Check {
-                scenario: "None base_mac renders as --",
-                input: "base_mac",
-                expect: "--".to_string(),
-            },
-            Check {
-                scenario: "None fw_version_current renders as --",
-                input: "fw_version_current",
-                expect: "--".to_string(),
-            },
-            Check {
-                scenario: "present pci_name",
-                input: "pci_name",
-                expect: "b4:00.0".to_string(),
-            },
-            Check {
-                scenario: "present device_type",
-                input: "device_type",
-                expect: "BlueField3".to_string(),
-            },
-            Check {
-                scenario: "present status",
-                input: "status",
-                expect: "Failed to open device".to_string(),
-            },
-        ],
-        |field| device.get_field_value(field),
+    value_scenarios!(
+        run = |field| device.get_field_value(field);
+        "None psid renders as --" {
+            "psid" => "--".to_string(),
+        }
+
+        "None part_number renders as --" {
+            "part_number" => "--".to_string(),
+        }
+
+        "None base_mac renders as --" {
+            "base_mac" => "--".to_string(),
+        }
+
+        "None fw_version_current renders as --" {
+            "fw_version_current" => "--".to_string(),
+        }
+
+        "present pci_name" {
+            "pci_name" => "b4:00.0".to_string(),
+        }
+
+        "present device_type" {
+            "device_type" => "BlueField3".to_string(),
+        }
+
+        "present status" {
+            "status" => "Failed to open device".to_string(),
+        }
     );
 }

--- a/crates/libmlx/tests/device/test_filters.rs
+++ b/crates/libmlx/tests/device/test_filters.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{scenarios, value_scenarios};
 use libmlx::device::filters::{DeviceField, DeviceFilter, DeviceFilterSet, MatchMode};
 
 // A single filter against the fully-populated test device should match across
@@ -29,66 +29,53 @@ use libmlx::device::filters::{DeviceField, DeviceFilter, DeviceFilterSet, MatchM
 fn filter_matches_complete_device() {
     let device = MlxDeviceInfo::create_test_device();
 
-    check_values(
-        [
-            Check {
-                scenario: "device_type exact \"ConnectX-6 Dx\"",
-                input: DeviceFilter::device_type(
-                    vec!["ConnectX-6 Dx".to_string()],
-                    MatchMode::Exact,
-                ),
-                expect: true,
-            },
-            Check {
-                scenario: "device_type prefix \"ConnectX\"",
-                input: DeviceFilter::device_type(vec!["ConnectX".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "device_type regex \"Connect.*\"",
-                input: DeviceFilter::device_type(vec!["Connect.*".to_string()], MatchMode::Regex),
-                expect: true,
-            },
-            Check {
-                scenario: "device_type complex regex \".*X-6.*\"",
-                input: DeviceFilter::device_type(vec![".*X-6.*".to_string()], MatchMode::Regex),
-                expect: true,
-            },
-            Check {
-                scenario: "part_number prefix \"MCX623\"",
-                input: DeviceFilter::part_number(vec!["MCX623".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "firmware_version prefix \"22.32\"",
-                input: DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "mac_address prefix \"b8:3f:d2\"",
-                input: DeviceFilter::mac_address(vec!["b8:3f:d2".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "description regex substring \".*100GbE.*\"",
-                input: DeviceFilter::description(vec![".*100GbE.*".to_string()], MatchMode::Regex),
-                expect: true,
-            },
-            Check {
-                scenario: "description case-insensitive prefix \"mellanox\"",
-                input: DeviceFilter::description(vec!["mellanox".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "multiple values, OR logic (one value matches)",
-                input: DeviceFilter::device_type(
-                    vec!["ConnectX-7".to_string(), "ConnectX-6 Dx".to_string()],
-                    MatchMode::Exact,
-                ),
-                expect: true,
-            },
-        ],
-        |filter| filter.matches(&device),
+    value_scenarios!(
+        run = |filter| filter.matches(&device);
+        "device_type exact \"ConnectX-6 Dx\"" {
+            DeviceFilter::device_type(
+                vec!["ConnectX-6 Dx".to_string()],
+                MatchMode::Exact,
+            ) => true,
+        }
+
+        "device_type prefix \"ConnectX\"" {
+            DeviceFilter::device_type(vec!["ConnectX".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "device_type regex \"Connect.*\"" {
+            DeviceFilter::device_type(vec!["Connect.*".to_string()], MatchMode::Regex) => true,
+        }
+
+        "device_type complex regex \".*X-6.*\"" {
+            DeviceFilter::device_type(vec![".*X-6.*".to_string()], MatchMode::Regex) => true,
+        }
+
+        "part_number prefix \"MCX623\"" {
+            DeviceFilter::part_number(vec!["MCX623".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "firmware_version prefix \"22.32\"" {
+            DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "mac_address prefix \"b8:3f:d2\"" {
+            DeviceFilter::mac_address(vec!["b8:3f:d2".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "description regex substring \".*100GbE.*\"" {
+            DeviceFilter::description(vec![".*100GbE.*".to_string()], MatchMode::Regex) => true,
+        }
+
+        "description case-insensitive prefix \"mellanox\"" {
+            DeviceFilter::description(vec!["mellanox".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "multiple values, OR logic (one value matches)" {
+            DeviceFilter::device_type(
+                vec!["ConnectX-7".to_string(), "ConnectX-6 Dx".to_string()],
+                MatchMode::Exact,
+            ) => true,
+        }
     );
 }
 
@@ -99,43 +86,34 @@ fn filter_matches_complete_device() {
 fn filter_matches_device_with_missing_data() {
     let device = MlxDeviceInfo::create_test_device_with_missing_data();
 
-    check_values(
-        [
-            Check {
-                scenario: "status exact \"Failed to open device\" present",
-                input: DeviceFilter::status(
-                    vec!["Failed to open device".to_string()],
-                    MatchMode::Exact,
-                ),
-                expect: true,
-            },
-            Check {
-                scenario: "status prefix \"Failed\" present",
-                input: DeviceFilter::status(vec!["Failed".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "device_type prefix \"BlueField\" present",
-                input: DeviceFilter::device_type(vec!["BlueField".to_string()], MatchMode::Prefix),
-                expect: true,
-            },
-            Check {
-                scenario: "part_number prefix \"MCX\" absent",
-                input: DeviceFilter::part_number(vec!["MCX".to_string()], MatchMode::Prefix),
-                expect: false,
-            },
-            Check {
-                scenario: "firmware_version prefix \"22.32\" absent",
-                input: DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix),
-                expect: false,
-            },
-            Check {
-                scenario: "mac_address prefix \"b8:3f\" absent",
-                input: DeviceFilter::mac_address(vec!["b8:3f".to_string()], MatchMode::Prefix),
-                expect: false,
-            },
-        ],
-        |filter| filter.matches(&device),
+    value_scenarios!(
+        run = |filter| filter.matches(&device);
+        "status exact \"Failed to open device\" present" {
+            DeviceFilter::status(
+                vec!["Failed to open device".to_string()],
+                MatchMode::Exact,
+            ) => true,
+        }
+
+        "status prefix \"Failed\" present" {
+            DeviceFilter::status(vec!["Failed".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "device_type prefix \"BlueField\" present" {
+            DeviceFilter::device_type(vec!["BlueField".to_string()], MatchMode::Prefix) => true,
+        }
+
+        "part_number prefix \"MCX\" absent" {
+            DeviceFilter::part_number(vec!["MCX".to_string()], MatchMode::Prefix) => false,
+        }
+
+        "firmware_version prefix \"22.32\" absent" {
+            DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix) => false,
+        }
+
+        "mac_address prefix \"b8:3f\" absent" {
+            DeviceFilter::mac_address(vec!["b8:3f".to_string()], MatchMode::Prefix) => false,
+        }
     );
 }
 
@@ -220,41 +198,35 @@ fn test_device_filter_set_summary_with_filters() {
 // Each row pins the full parsed triple (field, values, match_mode).
 #[test]
 fn device_filter_from_str_parses_field_values_and_mode() {
-    check_cases(
-        [
-            Case {
-                scenario: "\"device_type:ConnectX\" defaults to regex",
-                input: "device_type:ConnectX",
-                expect: Yields((
-                    DeviceField::DeviceType,
-                    vec!["ConnectX".to_string()],
-                    MatchMode::Regex,
-                )),
-            },
-            Case {
-                scenario: "\"part_number:MCX623:exact\" with explicit mode",
-                input: "part_number:MCX623:exact",
-                expect: Yields((
-                    DeviceField::PartNumber,
-                    vec!["MCX623".to_string()],
-                    MatchMode::Exact,
-                )),
-            },
-            Case {
-                scenario: "\"device_type:ConnectX-6,ConnectX-7:prefix\" splits values",
-                input: "device_type:ConnectX-6,ConnectX-7:prefix",
-                expect: Yields((
-                    DeviceField::DeviceType,
-                    vec!["ConnectX-6".to_string(), "ConnectX-7".to_string()],
-                    MatchMode::Prefix,
-                )),
-            },
-        ],
-        |s| {
+    scenarios!(
+        run = |s| {
             DeviceFilter::from_str(s)
                 .map(|f| (f.field, f.values, f.match_mode))
                 .map_err(drop)
-        },
+        };
+        "\"device_type:ConnectX\" defaults to regex" {
+            "device_type:ConnectX" => Yields((
+                DeviceField::DeviceType,
+                vec!["ConnectX".to_string()],
+                MatchMode::Regex,
+            )),
+        }
+
+        "\"part_number:MCX623:exact\" with explicit mode" {
+            "part_number:MCX623:exact" => Yields((
+                DeviceField::PartNumber,
+                vec!["MCX623".to_string()],
+                MatchMode::Exact,
+            )),
+        }
+
+        "\"device_type:ConnectX-6,ConnectX-7:prefix\" splits values" {
+            "device_type:ConnectX-6,ConnectX-7:prefix" => Yields((
+                DeviceField::DeviceType,
+                vec!["ConnectX-6".to_string(), "ConnectX-7".to_string()],
+                MatchMode::Prefix,
+            )),
+        }
     );
 }
 
@@ -262,35 +234,27 @@ fn device_filter_from_str_parses_field_values_and_mode() {
 // rejects anything else.
 #[test]
 fn match_mode_from_str_parses_known_modes() {
-    check_cases(
-        [
-            Case {
-                scenario: "\"regex\"",
-                input: "regex",
-                expect: Yields(MatchMode::Regex),
-            },
-            Case {
-                scenario: "\"exact\"",
-                input: "exact",
-                expect: Yields(MatchMode::Exact),
-            },
-            Case {
-                scenario: "\"prefix\"",
-                input: "prefix",
-                expect: Yields(MatchMode::Prefix),
-            },
-            Case {
-                scenario: "\"REGEX\" is case-insensitive",
-                input: "REGEX",
-                expect: Yields(MatchMode::Regex),
-            },
-            Case {
-                scenario: "\"invalid\" is rejected",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| MatchMode::from_str(s).map_err(drop),
+    scenarios!(
+        run = |s| MatchMode::from_str(s).map_err(drop);
+        "\"regex\"" {
+            "regex" => Yields(MatchMode::Regex),
+        }
+
+        "\"exact\"" {
+            "exact" => Yields(MatchMode::Exact),
+        }
+
+        "\"prefix\"" {
+            "prefix" => Yields(MatchMode::Prefix),
+        }
+
+        "\"REGEX\" is case-insensitive" {
+            "REGEX" => Yields(MatchMode::Regex),
+        }
+
+        "\"invalid\" is rejected" {
+            "invalid" => Fails,
+        }
     );
 }
 
@@ -298,50 +262,39 @@ fn match_mode_from_str_parses_known_modes() {
 // rejects anything else.
 #[test]
 fn device_field_from_str_parses_names_and_aliases() {
-    check_cases(
-        [
-            Case {
-                scenario: "\"device_type\"",
-                input: "device_type",
-                expect: Yields(DeviceField::DeviceType),
-            },
-            Case {
-                scenario: "\"type\" alias",
-                input: "type",
-                expect: Yields(DeviceField::DeviceType),
-            },
-            Case {
-                scenario: "\"part_number\"",
-                input: "part_number",
-                expect: Yields(DeviceField::PartNumber),
-            },
-            Case {
-                scenario: "\"part\" alias",
-                input: "part",
-                expect: Yields(DeviceField::PartNumber),
-            },
-            Case {
-                scenario: "\"firmware_version\"",
-                input: "firmware_version",
-                expect: Yields(DeviceField::FirmwareVersion),
-            },
-            Case {
-                scenario: "\"fw\" alias",
-                input: "fw",
-                expect: Yields(DeviceField::FirmwareVersion),
-            },
-            Case {
-                scenario: "\"status\"",
-                input: "status",
-                expect: Yields(DeviceField::Status),
-            },
-            Case {
-                scenario: "\"invalid\" is rejected",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| DeviceField::from_str(s).map_err(drop),
+    scenarios!(
+        run = |s| DeviceField::from_str(s).map_err(drop);
+        "\"device_type\"" {
+            "device_type" => Yields(DeviceField::DeviceType),
+        }
+
+        "\"type\" alias" {
+            "type" => Yields(DeviceField::DeviceType),
+        }
+
+        "\"part_number\"" {
+            "part_number" => Yields(DeviceField::PartNumber),
+        }
+
+        "\"part\" alias" {
+            "part" => Yields(DeviceField::PartNumber),
+        }
+
+        "\"firmware_version\"" {
+            "firmware_version" => Yields(DeviceField::FirmwareVersion),
+        }
+
+        "\"fw\" alias" {
+            "fw" => Yields(DeviceField::FirmwareVersion),
+        }
+
+        "\"status\"" {
+            "status" => Yields(DeviceField::Status),
+        }
+
+        "\"invalid\" is rejected" {
+            "invalid" => Fails,
+        }
     );
 }
 

--- a/crates/libmlx/tests/firmware/test_config.rs
+++ b/crates/libmlx/tests/firmware/test_config.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{scenarios, value_scenarios};
 use libmlx::firmware::config::FirmwareFlasherProfile;
 
 // Parse `toml` into a profile, panicking with the scenario label if it doesn't.
@@ -70,71 +70,64 @@ verify_version = true
 // of auth scheme (bearer token, basic auth, SSH key, SSH agent).
 #[test]
 fn credentials_block_populates_firmware_credentials() {
-    check_values(
-        [
-            Check {
-                scenario: "bearer token",
-                input: r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
-
-[firmware_credentials]
-type = "bearer_token"
-token = "my-secret-token"
-"#,
-                expect: true,
-            },
-            Check {
-                scenario: "basic auth",
-                input: r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-firmware_url = "https://internal.example.com/fw/prod.signed.bin"
-
-[firmware_credentials]
-type = "basic_auth"
-username = "deploy"
-password = "s3cret"
-"#,
-                expect: true,
-            },
-            Check {
-                scenario: "ssh key",
-                input: r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
-
-[firmware_credentials]
-type = "ssh_key"
-path = "/home/deploy/.ssh/id_ed25519"
-"#,
-                expect: true,
-            },
-            Check {
-                scenario: "ssh agent",
-                input: r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
-
-[firmware_credentials]
-type = "ssh_agent"
-"#,
-                expect: true,
-            },
-        ],
-        |toml| {
+    value_scenarios!(
+        run = |toml| {
             profile("credentials", toml)
                 .flash_spec
                 .firmware_credentials
                 .is_some()
-        },
+        };
+        "bearer token" {
+            r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
+
+                [firmware_credentials]
+                type = "bearer_token"
+                token = "my-secret-token"
+                "# => true,
+        }
+
+        "basic auth" {
+            r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                firmware_url = "https://internal.example.com/fw/prod.signed.bin"
+
+                [firmware_credentials]
+                type = "basic_auth"
+                username = "deploy"
+                password = "s3cret"
+                "# => true,
+        }
+
+        "ssh key" {
+            r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
+
+                [firmware_credentials]
+                type = "ssh_key"
+                path = "/home/deploy/.ssh/id_ed25519"
+                "# => true,
+        }
+
+        "ssh agent" {
+            r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
+
+                [firmware_credentials]
+                type = "ssh_agent"
+                "# => true,
+        }
     );
 }
 
@@ -143,51 +136,46 @@ type = "ssh_agent"
 // config with the scheme its source description must contain.
 #[test]
 fn firmware_source_describes_its_transport_scheme() {
-    check_values(
-        [
-            Check {
-                scenario: "https url -> http source",
-                input: (
-                    r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
-
-[firmware_credentials]
-type = "bearer_token"
-token = "my-secret-token"
-"#,
-                    "http:",
-                ),
-                expect: true,
-            },
-            Check {
-                scenario: "ssh url -> ssh source",
-                input: (
-                    r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
-
-[firmware_credentials]
-type = "ssh_key"
-path = "/home/deploy/.ssh/id_ed25519"
-"#,
-                    "ssh://",
-                ),
-                expect: true,
-            },
-        ],
-        |(toml, scheme)| {
+    value_scenarios!(
+        run = |(toml, scheme)| {
             profile("transport scheme", toml)
                 .flash_spec
                 .build_firmware_source()
                 .unwrap()
                 .description()
                 .contains(scheme)
-        },
+        };
+        "https url -> http source" {
+            (
+                                r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
+
+                [firmware_credentials]
+                type = "bearer_token"
+                token = "my-secret-token"
+                "#,
+                                "http:",
+                            ) => true,
+        }
+
+        "ssh url -> ssh source" {
+            (
+                                r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
+
+                [firmware_credentials]
+                type = "ssh_key"
+                path = "/home/deploy/.ssh/id_ed25519"
+                "#,
+                                "ssh://",
+                            ) => true,
+        }
     );
 }
 
@@ -241,29 +229,24 @@ firmware_url = "/opt/firmware/prod.signed.bin"
 // Malformed or incomplete TOML is rejected by `from_toml`.
 #[test]
 fn from_toml_rejects_malformed_or_incomplete_input() {
-    check_cases(
-        [
-            Case {
-                scenario: "unterminated string literal",
-                input: r#"
-firmware_url = "missing closing quote
-"#,
-                expect: Fails,
-            },
-            Case {
-                scenario: "missing required firmware_url",
-                input: r#"
-part_number = "900-9D3B4-00CV-TA0"
-psid = "MT_0000000884"
-version = "32.43.1014"
-"#,
-                expect: Fails,
-            },
-        ],
-        |toml| {
+    scenarios!(
+        run = |toml| {
             FirmwareFlasherProfile::from_toml(toml)
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "unterminated string literal" {
+            r#"
+                firmware_url = "missing closing quote
+                "# => Fails,
+        }
+
+        "missing required firmware_url" {
+            r#"
+                part_number = "900-9D3B4-00CV-TA0"
+                psid = "MT_0000000884"
+                version = "32.43.1014"
+                "# => Fails,
+        }
     );
 }

--- a/crates/libmlx/tests/firmware/test_credentials.rs
+++ b/crates/libmlx/tests/firmware/test_credentials.rs
@@ -16,42 +16,34 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use libmlx::firmware::credentials::Credentials;
 
 // -- validate_http --
 
 #[test]
 fn validate_http_accepts_http_creds_and_rejects_ssh_creds() {
-    check_cases(
-        [
-            Case {
-                scenario: "bearer token is valid for http",
-                input: Credentials::bearer_token("my-token"),
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "basic auth is valid for http",
-                input: Credentials::basic_auth("user", "pass"),
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "header is valid for http",
-                input: Credentials::header("X-API-Key", "abc123"),
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "ssh key is invalid for http",
-                input: Credentials::ssh_key("/home/user/.ssh/id_rsa"),
-                expect: Fails,
-            },
-            Case {
-                scenario: "ssh agent is invalid for http",
-                input: Credentials::ssh_agent(),
-                expect: Fails,
-            },
-        ],
-        |cred| cred.validate_http().map_err(drop),
+    scenarios!(
+        run = |cred| cred.validate_http().map_err(drop);
+        "bearer token is valid for http" {
+            Credentials::bearer_token("my-token") => Yields(()),
+        }
+
+        "basic auth is valid for http" {
+            Credentials::basic_auth("user", "pass") => Yields(()),
+        }
+
+        "header is valid for http" {
+            Credentials::header("X-API-Key", "abc123") => Yields(()),
+        }
+
+        "ssh key is invalid for http" {
+            Credentials::ssh_key("/home/user/.ssh/id_rsa") => Fails,
+        }
+
+        "ssh agent is invalid for http" {
+            Credentials::ssh_agent() => Fails,
+        }
     );
 }
 
@@ -59,38 +51,30 @@ fn validate_http_accepts_http_creds_and_rejects_ssh_creds() {
 
 #[test]
 fn validate_ssh_accepts_ssh_creds_and_rejects_http_creds() {
-    check_cases(
-        [
-            Case {
-                scenario: "ssh key is valid for ssh",
-                input: Credentials::ssh_key("/home/user/.ssh/id_rsa"),
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "ssh key with passphrase is valid for ssh",
-                input: Credentials::ssh_key_with_passphrase(
-                    "/home/user/.ssh/id_rsa",
-                    "my-passphrase",
-                ),
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "ssh agent is valid for ssh",
-                input: Credentials::ssh_agent(),
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "bearer token is invalid for ssh",
-                input: Credentials::bearer_token("my-token"),
-                expect: Fails,
-            },
-            Case {
-                scenario: "basic auth is invalid for ssh",
-                input: Credentials::basic_auth("user", "pass"),
-                expect: Fails,
-            },
-        ],
-        |cred| cred.validate_ssh().map_err(drop),
+    scenarios!(
+        run = |cred| cred.validate_ssh().map_err(drop);
+        "ssh key is valid for ssh" {
+            Credentials::ssh_key("/home/user/.ssh/id_rsa") => Yields(()),
+        }
+
+        "ssh key with passphrase is valid for ssh" {
+            Credentials::ssh_key_with_passphrase(
+                "/home/user/.ssh/id_rsa",
+                "my-passphrase",
+            ) => Yields(()),
+        }
+
+        "ssh agent is valid for ssh" {
+            Credentials::ssh_agent() => Yields(()),
+        }
+
+        "bearer token is invalid for ssh" {
+            Credentials::bearer_token("my-token") => Fails,
+        }
+
+        "basic auth is invalid for ssh" {
+            Credentials::basic_auth("user", "pass") => Fails,
+        }
     );
 }
 

--- a/crates/libmlx/tests/firmware/test_source.rs
+++ b/crates/libmlx/tests/firmware/test_source.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use libmlx::firmware::source::FirmwareSource;
 
 // from_url classifies a URL into a FirmwareSource whose `description()` records the
@@ -28,74 +28,60 @@ use libmlx::firmware::source::FirmwareSource;
 // standalone below.)
 #[test]
 fn from_url_classifies_by_scheme() {
-    check_cases(
-        [
-            Case {
-                scenario: "absolute local path",
-                input: "/opt/firmware/prod.signed.bin",
-                expect: Yields("local:/opt/firmware/prod.signed.bin".to_string()),
-            },
-            Case {
-                scenario: "relative local path",
-                input: "firmware/prod.signed.bin",
-                expect: Yields("local:firmware/prod.signed.bin".to_string()),
-            },
-            Case {
-                scenario: "file:// absolute path",
-                input: "file:///opt/firmware/prod.signed.bin",
-                expect: Yields("local:/opt/firmware/prod.signed.bin".to_string()),
-            },
-            Case {
-                scenario: "file:// relative path",
-                input: "file://firmware/prod.signed.bin",
-                expect: Yields("local:firmware/prod.signed.bin".to_string()),
-            },
-            Case {
-                scenario: "https URL",
-                input: "https://artifacts.example.com/fw/prod.signed.bin",
-                expect: Yields("http:https://artifacts.example.com/fw/prod.signed.bin".to_string()),
-            },
-            Case {
-                scenario: "http URL",
-                input: "http://internal.example.com/fw/prod.signed.bin",
-                expect: Yields("http:http://internal.example.com/fw/prod.signed.bin".to_string()),
-            },
-            Case {
-                scenario: "ssh with user and relative path",
-                input: "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin",
-                expect: Yields(
-                    "ssh://deploy@build-server.example.com:22:builds/fw/prod.signed.bin"
-                        .to_string(),
-                ),
-            },
-            Case {
-                scenario: "ssh with user and absolute path",
-                input: "ssh://deploy@build-server.example.com:/opt/fw/prod.signed.bin",
-                expect: Yields(
-                    "ssh://deploy@build-server.example.com:22:/opt/fw/prod.signed.bin".to_string(),
-                ),
-            },
-            Case {
-                scenario: "ssh missing path is rejected",
-                input: "ssh://deploy@build-server.example.com",
-                expect: Fails,
-            },
-            Case {
-                scenario: "ssh empty path is rejected",
-                input: "ssh://deploy@build-server.example.com:",
-                expect: Fails,
-            },
-            Case {
-                scenario: "ssh missing host is rejected",
-                input: "ssh://:path/to/file",
-                expect: Fails,
-            },
-        ],
-        |url| {
+    scenarios!(
+        run = |url| {
             FirmwareSource::from_url(url)
                 .map(|s| s.description())
                 .map_err(drop)
-        },
+        };
+        "absolute local path" {
+            "/opt/firmware/prod.signed.bin" => Yields("local:/opt/firmware/prod.signed.bin".to_string()),
+        }
+
+        "relative local path" {
+            "firmware/prod.signed.bin" => Yields("local:firmware/prod.signed.bin".to_string()),
+        }
+
+        "file:// absolute path" {
+            "file:///opt/firmware/prod.signed.bin" => Yields("local:/opt/firmware/prod.signed.bin".to_string()),
+        }
+
+        "file:// relative path" {
+            "file://firmware/prod.signed.bin" => Yields("local:firmware/prod.signed.bin".to_string()),
+        }
+
+        "https URL" {
+            "https://artifacts.example.com/fw/prod.signed.bin" => Yields("http:https://artifacts.example.com/fw/prod.signed.bin".to_string()),
+        }
+
+        "http URL" {
+            "http://internal.example.com/fw/prod.signed.bin" => Yields("http:http://internal.example.com/fw/prod.signed.bin".to_string()),
+        }
+
+        "ssh with user and relative path" {
+            "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin" => Yields(
+                "ssh://deploy@build-server.example.com:22:builds/fw/prod.signed.bin"
+                    .to_string(),
+            ),
+        }
+
+        "ssh with user and absolute path" {
+            "ssh://deploy@build-server.example.com:/opt/fw/prod.signed.bin" => Yields(
+                "ssh://deploy@build-server.example.com:22:/opt/fw/prod.signed.bin".to_string(),
+            ),
+        }
+
+        "ssh missing path is rejected" {
+            "ssh://deploy@build-server.example.com" => Fails,
+        }
+
+        "ssh empty path is rejected" {
+            "ssh://deploy@build-server.example.com:" => Fails,
+        }
+
+        "ssh missing host is rejected" {
+            "ssh://:path/to/file" => Fails,
+        }
     );
 }
 

--- a/crates/libmlx/tests/lockdown/test_cmd.rs
+++ b/crates/libmlx/tests/lockdown/test_cmd.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{scenarios, value_scenarios};
 use clap::Parser;
 use libmlx::lockdown::cmd::args::{Cli, Commands, LockdownAction, OutputFormat};
 use libmlx::lockdown::cmd::cmds::run_cli;
@@ -61,48 +61,41 @@ fn test_cli_help() {
 // per-subcommand parse-and-`matches!` blocks into one table over `action_kind`.
 #[test]
 fn lockdown_subcommands_parse_to_their_action_variant() {
-    check_values(
-        [
-            Check {
-                scenario: "lock",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "lock",
-                    "04:00.0",
-                    "12345678",
-                ],
-                expect: "lock",
-            },
-            Check {
-                scenario: "unlock",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "unlock",
-                    "04:00.0",
-                    "12345678",
-                ],
-                expect: "unlock",
-            },
-            Check {
-                scenario: "set-key",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "set-key",
-                    "04:00.0",
-                    "12345678",
-                ],
-                expect: "set-key",
-            },
-            Check {
-                scenario: "status",
-                input: vec!["mlxconfig-lockdown", "lockdown", "status", "04:00.0"],
-                expect: "status",
-            },
-        ],
-        |args| action_kind(&action_of(&args)),
+    value_scenarios!(
+        run = |args| action_kind(&action_of(&args));
+        "lock" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "lock",
+                "04:00.0",
+                "12345678",
+            ] => "lock",
+        }
+
+        "unlock" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "unlock",
+                "04:00.0",
+                "12345678",
+            ] => "unlock",
+        }
+
+        "set-key" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "set-key",
+                "04:00.0",
+                "12345678",
+            ] => "set-key",
+        }
+
+        "status" {
+            vec!["mlxconfig-lockdown", "lockdown", "status", "04:00.0"] => "status",
+        }
     );
 }
 
@@ -136,34 +129,29 @@ fn output_format_flag_parses_to_the_named_format() {
         }
     }
 
-    check_values(
-        [
-            Check {
-                scenario: "--format json",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "status",
-                    "04:00.0",
-                    "--format",
-                    "json",
-                ],
-                expect: "json",
-            },
-            Check {
-                scenario: "--format yaml",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "status",
-                    "04:00.0",
-                    "--format",
-                    "yaml",
-                ],
-                expect: "yaml",
-            },
-        ],
-        |args| status_format(&args),
+    value_scenarios!(
+        run = |args| status_format(&args);
+        "--format json" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "status",
+                "04:00.0",
+                "--format",
+                "json",
+            ] => "json",
+        }
+
+        "--format yaml" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "status",
+                "04:00.0",
+                "--format",
+                "yaml",
+            ] => "yaml",
+        }
     );
 }
 
@@ -180,32 +168,27 @@ fn positional_arguments_become_device_id_and_key() {
         }
     }
 
-    check_values(
-        [
-            Check {
-                scenario: "lock keeps an mst-style device id",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "lock",
-                    "test:device:id",
-                    "12345678",
-                ],
-                expect: ("test:device:id".to_string(), "12345678".to_string()),
-            },
-            Check {
-                scenario: "unlock keeps a PCI device id",
-                input: vec![
-                    "mlxconfig-lockdown",
-                    "lockdown",
-                    "unlock",
-                    "04:00.0",
-                    "abcdef01",
-                ],
-                expect: ("04:00.0".to_string(), "abcdef01".to_string()),
-            },
-        ],
-        |args| device_and_key(&args),
+    value_scenarios!(
+        run = |args| device_and_key(&args);
+        "lock keeps an mst-style device id" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "lock",
+                "test:device:id",
+                "12345678",
+            ] => ("test:device:id".to_string(), "12345678".to_string()),
+        }
+
+        "unlock keeps a PCI device id" {
+            vec![
+                "mlxconfig-lockdown",
+                "lockdown",
+                "unlock",
+                "04:00.0",
+                "abcdef01",
+            ] => ("04:00.0".to_string(), "abcdef01".to_string()),
+        }
     );
 }
 
@@ -225,62 +208,54 @@ mod integration_tests {
     // into one outcome table.
     #[test]
     fn run_cli_dry_runs_succeed_and_real_lookups_fail() {
-        check_cases(
-            [
-                Case {
-                    scenario: "status dry-run prints and succeeds",
-                    input: vec![
-                        "mlxconfig-lockdown",
-                        "lockdown",
-                        "status",
-                        "fake_device",
-                        "--dry-run",
-                    ],
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "lock dry-run prints and succeeds",
-                    input: vec![
-                        "mlxconfig-lockdown",
-                        "lockdown",
-                        "lock",
-                        "fake_device",
-                        "12345678",
-                        "--dry-run",
-                    ],
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "unlock dry-run prints and succeeds",
-                    input: vec![
-                        "mlxconfig-lockdown",
-                        "lockdown",
-                        "unlock",
-                        "fake_device",
-                        "12345678",
-                        "--dry-run",
-                    ],
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "set-key dry-run prints and succeeds",
-                    input: vec![
-                        "mlxconfig-lockdown",
-                        "lockdown",
-                        "set-key",
-                        "fake_device",
-                        "12345678",
-                        "--dry-run",
-                    ],
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "real status against a fake device fails (no flint)",
-                    input: vec!["mlxconfig-lockdown", "lockdown", "status", "fake_device"],
-                    expect: Fails,
-                },
-            ],
-            |args| run(&args),
+        scenarios!(
+            run = |args| run(&args);
+            "status dry-run prints and succeeds" {
+                vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "status",
+                    "fake_device",
+                    "--dry-run",
+                ] => Yields(()),
+            }
+
+            "lock dry-run prints and succeeds" {
+                vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "lock",
+                    "fake_device",
+                    "12345678",
+                    "--dry-run",
+                ] => Yields(()),
+            }
+
+            "unlock dry-run prints and succeeds" {
+                vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "unlock",
+                    "fake_device",
+                    "12345678",
+                    "--dry-run",
+                ] => Yields(()),
+            }
+
+            "set-key dry-run prints and succeeds" {
+                vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "set-key",
+                    "fake_device",
+                    "12345678",
+                    "--dry-run",
+                ] => Yields(()),
+            }
+
+            "real status against a fake device fails (no flint)" {
+                vec!["mlxconfig-lockdown", "lockdown", "status", "fake_device"] => Fails,
+            }
         );
     }
 }

--- a/crates/libmlx/tests/lockdown/test_error.rs
+++ b/crates/libmlx/tests/lockdown/test_error.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::lockdown::error::{MlxError, MlxResult};
 
 // Every MlxError variant renders to an exact, contract-bearing string via its
@@ -29,68 +29,54 @@ use libmlx::lockdown::error::{MlxError, MlxResult};
 // inline is awkward and the old loop didn't cover it either.)
 #[test]
 fn error_variants_display_their_contract_strings() {
-    check_values(
-        [
-            Check {
-                scenario: "CommandFailed",
-                input: MlxError::CommandFailed("test".to_string()),
-                expect: "Command execution failed: test".to_string(),
-            },
-            Check {
-                scenario: "DeviceNotFound",
-                input: MlxError::DeviceNotFound("test_device".to_string()),
-                expect: "Device not found: test_device".to_string(),
-            },
-            Check {
-                scenario: "InvalidDeviceId",
-                input: MlxError::InvalidDeviceId("invalid".to_string()),
-                expect: "Invalid device ID format: invalid".to_string(),
-            },
-            Check {
-                scenario: "AlreadyLocked",
-                input: MlxError::AlreadyLocked,
-                expect: "Hardware access is already disabled".to_string(),
-            },
-            Check {
-                scenario: "AlreadyUnlocked",
-                input: MlxError::AlreadyUnlocked,
-                expect: "Hardware access is already enabled".to_string(),
-            },
-            Check {
-                scenario: "InvalidKey",
-                input: MlxError::InvalidKey,
-                expect: "Invalid key format or length".to_string(),
-            },
-            Check {
-                scenario: "PermissionDenied",
-                input: MlxError::PermissionDenied,
-                expect: "Permission denied - requires root privileges".to_string(),
-            },
-            Check {
-                scenario: "FlintNotFound",
-                input: MlxError::FlintNotFound,
-                expect: "flint tool not found or not executable".to_string(),
-            },
-            Check {
-                scenario: "ParseError",
-                input: MlxError::ParseError("parse error".to_string()),
-                expect: "Failed to parse command output: parse error".to_string(),
-            },
-            Check {
-                scenario: "DryRun",
-                input: MlxError::DryRun("flint -d 04:00.0 q".to_string()),
-                expect: "Dry run - would have executed: flint -d 04:00.0 q".to_string(),
-            },
-            Check {
-                scenario: "IoError wraps the inner message",
-                input: MlxError::IoError(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "file not found",
-                )),
-                expect: "I/O error: file not found".to_string(),
-            },
-        ],
-        |error| error.to_string(),
+    value_scenarios!(
+        run = |error| error.to_string();
+        "CommandFailed" {
+            MlxError::CommandFailed("test".to_string()) => "Command execution failed: test".to_string(),
+        }
+
+        "DeviceNotFound" {
+            MlxError::DeviceNotFound("test_device".to_string()) => "Device not found: test_device".to_string(),
+        }
+
+        "InvalidDeviceId" {
+            MlxError::InvalidDeviceId("invalid".to_string()) => "Invalid device ID format: invalid".to_string(),
+        }
+
+        "AlreadyLocked" {
+            MlxError::AlreadyLocked => "Hardware access is already disabled".to_string(),
+        }
+
+        "AlreadyUnlocked" {
+            MlxError::AlreadyUnlocked => "Hardware access is already enabled".to_string(),
+        }
+
+        "InvalidKey" {
+            MlxError::InvalidKey => "Invalid key format or length".to_string(),
+        }
+
+        "PermissionDenied" {
+            MlxError::PermissionDenied => "Permission denied - requires root privileges".to_string(),
+        }
+
+        "FlintNotFound" {
+            MlxError::FlintNotFound => "flint tool not found or not executable".to_string(),
+        }
+
+        "ParseError" {
+            MlxError::ParseError("parse error".to_string()) => "Failed to parse command output: parse error".to_string(),
+        }
+
+        "DryRun" {
+            MlxError::DryRun("flint -d 04:00.0 q".to_string()) => "Dry run - would have executed: flint -d 04:00.0 q".to_string(),
+        }
+
+        "IoError wraps the inner message" {
+            MlxError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "file not found",
+            )) => "I/O error: file not found".to_string(),
+        }
     );
 }
 

--- a/crates/libmlx/tests/lockdown/test_lockdown.rs
+++ b/crates/libmlx/tests/lockdown/test_lockdown.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::lockdown::error::MlxError;
 use libmlx::lockdown::lockdown::{LockStatus, LockdownManager, StatusReport};
 use libmlx::lockdown::runner::FlintRunner;
@@ -36,25 +36,19 @@ fn error_kind<T>(result: Result<T, MlxError>) -> &'static str {
 
 #[test]
 fn lock_status_displays_lowercase_name() {
-    check_values(
-        [
-            Check {
-                scenario: "locked",
-                input: LockStatus::Locked,
-                expect: "locked".to_string(),
-            },
-            Check {
-                scenario: "unlocked",
-                input: LockStatus::Unlocked,
-                expect: "unlocked".to_string(),
-            },
-            Check {
-                scenario: "unknown",
-                input: LockStatus::Unknown,
-                expect: "unknown".to_string(),
-            },
-        ],
-        |status| status.to_string(),
+    value_scenarios!(
+        run = |status| status.to_string();
+        "locked" {
+            LockStatus::Locked => "locked".to_string(),
+        }
+
+        "unlocked" {
+            LockStatus::Unlocked => "unlocked".to_string(),
+        }
+
+        "unknown" {
+            LockStatus::Unknown => "unknown".to_string(),
+        }
     );
 }
 
@@ -142,30 +136,23 @@ fn test_manager_error_handling() {
     let runner = FlintRunner::with_path("/fake/flint");
     let manager = LockdownManager::with_runner(runner);
 
-    check_values(
-        [
-            Check {
-                scenario: "lock_device",
-                input: error_kind(manager.lock_device("fake_device", "12345678")),
-                expect: "CommandFailed",
-            },
-            Check {
-                scenario: "unlock_device",
-                input: error_kind(manager.unlock_device("fake_device", "12345678")),
-                expect: "CommandFailed",
-            },
-            Check {
-                scenario: "get_status",
-                input: error_kind(manager.get_status("fake_device")),
-                expect: "CommandFailed",
-            },
-            Check {
-                scenario: "set_device_key",
-                input: error_kind(manager.set_device_key("fake_device", "12345678")),
-                expect: "CommandFailed",
-            },
-        ],
-        |kind| kind,
+    value_scenarios!(
+        run = |kind| kind;
+        "lock_device" {
+            error_kind(manager.lock_device("fake_device", "12345678")) => "CommandFailed",
+        }
+
+        "unlock_device" {
+            error_kind(manager.unlock_device("fake_device", "12345678")) => "CommandFailed",
+        }
+
+        "get_status" {
+            error_kind(manager.get_status("fake_device")) => "CommandFailed",
+        }
+
+        "set_device_key" {
+            error_kind(manager.set_device_key("fake_device", "12345678")) => "CommandFailed",
+        }
     );
 }
 
@@ -180,30 +167,23 @@ mod dry_run_tests {
         let runner = FlintRunner::with_path("/fake/flint").with_dry_run(true);
         let manager = LockdownManager::with_runner(runner);
 
-        check_values(
-            [
-                Check {
-                    scenario: "lock_device",
-                    input: error_kind(manager.lock_device("test_device", "12345678")),
-                    expect: "DryRun",
-                },
-                Check {
-                    scenario: "unlock_device",
-                    input: error_kind(manager.unlock_device("test_device", "12345678")),
-                    expect: "DryRun",
-                },
-                Check {
-                    scenario: "get_status",
-                    input: error_kind(manager.get_status("test_device")),
-                    expect: "DryRun",
-                },
-                Check {
-                    scenario: "set_device_key",
-                    input: error_kind(manager.set_device_key("test_device", "12345678")),
-                    expect: "DryRun",
-                },
-            ],
-            |kind| kind,
+        value_scenarios!(
+            run = |kind| kind;
+            "lock_device" {
+                error_kind(manager.lock_device("test_device", "12345678")) => "DryRun",
+            }
+
+            "unlock_device" {
+                error_kind(manager.unlock_device("test_device", "12345678")) => "DryRun",
+            }
+
+            "get_status" {
+                error_kind(manager.get_status("test_device")) => "DryRun",
+            }
+
+            "set_device_key" {
+                error_kind(manager.set_device_key("test_device", "12345678")) => "DryRun",
+            }
         );
     }
 
@@ -284,42 +264,35 @@ mod mock_runner_tests {
     // matching "already" error only when the mock is primed for that state.
     #[test]
     fn mock_runner_reports_already_state_else_succeeds() {
-        check_values(
-            [
-                Check {
-                    scenario: "disable on a primed-locked device is AlreadyLocked",
-                    input: error_kind(
-                        MockRunner::new()
-                            .with_already_locked()
-                            .disable_hw_access("test_device", "12345678"),
-                    ),
-                    expect: "AlreadyLocked",
-                },
-                Check {
-                    scenario: "enable on a primed-unlocked device is AlreadyUnlocked",
-                    input: error_kind(
-                        MockRunner::new()
-                            .with_already_unlocked()
-                            .enable_hw_access("test_device", "12345678"),
-                    ),
-                    expect: "AlreadyUnlocked",
-                },
-                Check {
-                    scenario: "disable on a fresh device succeeds",
-                    input: error_kind(
-                        MockRunner::new().disable_hw_access("test_device", "12345678"),
-                    ),
-                    expect: "ok",
-                },
-                Check {
-                    scenario: "enable on a fresh device succeeds",
-                    input: error_kind(
-                        MockRunner::new().enable_hw_access("test_device", "12345678"),
-                    ),
-                    expect: "ok",
-                },
-            ],
-            |kind| kind,
+        value_scenarios!(
+            run = |kind| kind;
+            "disable on a primed-locked device is AlreadyLocked" {
+                error_kind(
+                    MockRunner::new()
+                        .with_already_locked()
+                        .disable_hw_access("test_device", "12345678"),
+                ) => "AlreadyLocked",
+            }
+
+            "enable on a primed-unlocked device is AlreadyUnlocked" {
+                error_kind(
+                    MockRunner::new()
+                        .with_already_unlocked()
+                        .enable_hw_access("test_device", "12345678"),
+                ) => "AlreadyUnlocked",
+            }
+
+            "disable on a fresh device succeeds" {
+                error_kind(
+                    MockRunner::new().disable_hw_access("test_device", "12345678"),
+                ) => "ok",
+            }
+
+            "enable on a fresh device succeeds" {
+                error_kind(
+                    MockRunner::new().enable_hw_access("test_device", "12345678"),
+                ) => "ok",
+            }
         );
     }
 }

--- a/crates/libmlx/tests/lockdown/test_runner.rs
+++ b/crates/libmlx/tests/lockdown/test_runner.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{scenarios, value_scenarios};
 use libmlx::lockdown::error::MlxError;
 use libmlx::lockdown::runner::FlintRunner;
 
@@ -38,35 +38,27 @@ fn test_device_id_validation() {
         })
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "PCI address",
-                input: "04:00.0",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "device path",
-                input: "/dev/mst/mt4099_pci_cr0",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "device name",
-                input: "mlx5_0",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "empty string is rejected",
-                input: "",
-                expect: FailsWith("InvalidDeviceId"),
-            },
-            Case {
-                scenario: "spaces are rejected",
-                input: "device with spaces",
-                expect: FailsWith("InvalidDeviceId"),
-            },
-        ],
-        validated,
+    scenarios!(
+        run = validated;
+        "PCI address" {
+            "04:00.0" => Yields(()),
+        }
+
+        "device path" {
+            "/dev/mst/mt4099_pci_cr0" => Yields(()),
+        }
+
+        "device name" {
+            "mlx5_0" => Yields(()),
+        }
+
+        "empty string is rejected" {
+            "" => FailsWith("InvalidDeviceId"),
+        }
+
+        "spaces are rejected" {
+            "device with spaces" => FailsWith("InvalidDeviceId"),
+        }
     );
 }
 
@@ -85,30 +77,23 @@ fn test_dry_run_command_strings() {
         }
     }
 
-    check_values(
-        [
-            Check {
-                scenario: "query",
-                input: dry_run_cmd(runner.query_device("test_device")),
-                expect: "/test/flint -d test_device q".to_string(),
-            },
-            Check {
-                scenario: "disable hw_access",
-                input: dry_run_cmd(runner.disable_hw_access("test_device", "abcdef01")),
-                expect: "/test/flint -d test_device hw_access disable abcdef01".to_string(),
-            },
-            Check {
-                scenario: "enable hw_access",
-                input: dry_run_cmd(runner.enable_hw_access("test_device", "abcdef01")),
-                expect: "/test/flint -d test_device hw_access enable abcdef01".to_string(),
-            },
-            Check {
-                scenario: "set_key",
-                input: dry_run_cmd(runner.set_key("test_device", "12345678")),
-                expect: "/test/flint -d test_device set_key 12345678".to_string(),
-            },
-        ],
-        |cmd| cmd,
+    value_scenarios!(
+        run = |cmd| cmd;
+        "query" {
+            dry_run_cmd(runner.query_device("test_device")) => "/test/flint -d test_device q".to_string(),
+        }
+
+        "disable hw_access" {
+            dry_run_cmd(runner.disable_hw_access("test_device", "abcdef01")) => "/test/flint -d test_device hw_access disable abcdef01".to_string(),
+        }
+
+        "enable hw_access" {
+            dry_run_cmd(runner.enable_hw_access("test_device", "abcdef01")) => "/test/flint -d test_device hw_access enable abcdef01".to_string(),
+        }
+
+        "set_key" {
+            dry_run_cmd(runner.set_key("test_device", "12345678")) => "/test/flint -d test_device set_key 12345678".to_string(),
+        }
     );
 }
 
@@ -126,30 +111,23 @@ fn test_key_validation() {
         })
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "set_key with non-hex key",
-                input: key_error(runner.set_key("fake_device", "invalid_key")),
-                expect: FailsWith("InvalidKey"),
-            },
-            Case {
-                scenario: "set_key with too-short key",
-                input: key_error(runner.set_key("fake_device", "123")),
-                expect: FailsWith("InvalidKey"),
-            },
-            Case {
-                scenario: "set_key with a non-hex digit",
-                input: key_error(runner.set_key("fake_device", "1234567g")),
-                expect: FailsWith("InvalidKey"),
-            },
-            Case {
-                scenario: "enable_hw_access with too-long key",
-                input: key_error(runner.enable_hw_access("fake_device", "toolong123")),
-                expect: FailsWith("InvalidKey"),
-            },
-        ],
-        |result| result,
+    scenarios!(
+        run = |result| result;
+        "set_key with non-hex key" {
+            key_error(runner.set_key("fake_device", "invalid_key")) => FailsWith("InvalidKey"),
+        }
+
+        "set_key with too-short key" {
+            key_error(runner.set_key("fake_device", "123")) => FailsWith("InvalidKey"),
+        }
+
+        "set_key with a non-hex digit" {
+            key_error(runner.set_key("fake_device", "1234567g")) => FailsWith("InvalidKey"),
+        }
+
+        "enable_hw_access with too-long key" {
+            key_error(runner.enable_hw_access("fake_device", "toolong123")) => FailsWith("InvalidKey"),
+        }
     );
 }
 
@@ -162,7 +140,7 @@ fn test_runner_default() {
 // These tests verify the output parsing logic without requiring actual flint execution
 #[cfg(test)]
 mod output_parsing_tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     // FlintRunner's output parsing keys off substrings; this walks the marker
     // strings flint emits (bare, with the -I-/Error prefixes, and embedded in
@@ -170,64 +148,52 @@ mod output_parsing_tests {
     // per-marker loops into one table over `(haystack, needle)`.
     #[test]
     fn detects_status_substrings_in_output() {
-        check_values(
-            [
-                Check {
-                    scenario: "already disabled, bare",
-                    input: ("HW access already disabled", "already disabled"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "already disabled, -I- prefix",
-                    input: ("-I- HW access already disabled", "already disabled"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "already disabled, embedded in surrounding lines",
-                    input: (
-                        "some other text\nHW access already disabled\nmore text",
-                        "already disabled",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "already enabled, bare",
-                    input: ("HW access already enabled", "already enabled"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "already enabled, -I- prefix",
-                    input: ("-I- HW access already enabled", "already enabled"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "already enabled, embedded in surrounding lines",
-                    input: (
-                        "some other text\nHW access already enabled\nmore text",
-                        "already enabled",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "HW access is disabled, bare",
-                    input: ("HW access is disabled", "HW access is disabled"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "HW access is disabled, Error prefix",
-                    input: ("Error: HW access is disabled", "HW access is disabled"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "HW access is disabled, embedded in surrounding lines",
-                    input: (
-                        "some text\nHW access is disabled\nmore text",
-                        "HW access is disabled",
-                    ),
-                    expect: true,
-                },
-            ],
-            |(output, needle)| output.contains(needle),
+        value_scenarios!(
+            run = |(output, needle)| output.contains(needle);
+            "already disabled, bare" {
+                ("HW access already disabled", "already disabled") => true,
+            }
+
+            "already disabled, -I- prefix" {
+                ("-I- HW access already disabled", "already disabled") => true,
+            }
+
+            "already disabled, embedded in surrounding lines" {
+                (
+                    "some other text\nHW access already disabled\nmore text",
+                    "already disabled",
+                ) => true,
+            }
+
+            "already enabled, bare" {
+                ("HW access already enabled", "already enabled") => true,
+            }
+
+            "already enabled, -I- prefix" {
+                ("-I- HW access already enabled", "already enabled") => true,
+            }
+
+            "already enabled, embedded in surrounding lines" {
+                (
+                    "some other text\nHW access already enabled\nmore text",
+                    "already enabled",
+                ) => true,
+            }
+
+            "HW access is disabled, bare" {
+                ("HW access is disabled", "HW access is disabled") => true,
+            }
+
+            "HW access is disabled, Error prefix" {
+                ("Error: HW access is disabled", "HW access is disabled") => true,
+            }
+
+            "HW access is disabled, embedded in surrounding lines" {
+                (
+                    "some text\nHW access is disabled\nmore text",
+                    "HW access is disabled",
+                ) => true,
+            }
         );
     }
 }

--- a/crates/libmlx/tests/profile/test_serialization.rs
+++ b/crates/libmlx/tests/profile/test_serialization.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::profile::error::MlxProfileError;
 use libmlx::profile::profile::MlxConfigProfile;
 use libmlx::profile::serialization::{
@@ -250,25 +250,19 @@ fn test_try_from_protobuf_basic() {
             _ => "other",
         }
     }
-    check_values(
-        [
-            Check {
-                scenario: "BOOL_VAR parses to a bool",
-                input: "BOOL_VAR",
-                expect: "bool",
-            },
-            Check {
-                scenario: "INT_VAR parses to a number",
-                input: "INT_VAR",
-                expect: "number",
-            },
-            Check {
-                scenario: "STRING_VAR parses to a string",
-                input: "STRING_VAR",
-                expect: "string",
-            },
-        ],
-        |key| variant(profile.config.get(key)),
+    value_scenarios!(
+        run = |key| variant(profile.config.get(key));
+        "BOOL_VAR parses to a bool" {
+            "BOOL_VAR" => "bool",
+        }
+
+        "INT_VAR parses to a number" {
+            "INT_VAR" => "number",
+        }
+
+        "STRING_VAR parses to a string" {
+            "STRING_VAR" => "string",
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/command_builder_tests.rs
+++ b/crates/libmlx/tests/runner/command_builder_tests.rs
@@ -21,7 +21,7 @@
 use std::path::Path;
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{scenarios, value_scenarios};
 use libmlx::runner::command_builder::{CommandBuilder, CommandSpec};
 use libmlx::runner::exec_options::ExecOptions;
 
@@ -137,24 +137,19 @@ fn test_build_set_command_spec_empty_assignments() {
 // spec is just the program.
 #[test]
 fn command_spec_displays_program_then_args() {
-    check_values(
-        [
-            Check {
-                scenario: "program with args",
-                input: CommandSpec::new("mlxconfig")
-                    .arg("-d")
-                    .arg("01:00.0")
-                    .arg("q")
-                    .arg("SRIOV_EN"),
-                expect: "mlxconfig -d 01:00.0 q SRIOV_EN".to_string(),
-            },
-            Check {
-                scenario: "program with no args",
-                input: CommandSpec::new("mlxconfig"),
-                expect: "mlxconfig".to_string(),
-            },
-        ],
-        |spec| format!("{spec}"),
+    value_scenarios!(
+        run = |spec| format!("{spec}");
+        "program with args" {
+            CommandSpec::new("mlxconfig")
+            .arg("-d")
+            .arg("01:00.0")
+            .arg("q")
+            .arg("SRIOV_EN") => "mlxconfig -d 01:00.0 q SRIOV_EN".to_string(),
+        }
+
+        "program with no args" {
+            CommandSpec::new("mlxconfig") => "mlxconfig".to_string(),
+        }
     );
 }
 
@@ -190,125 +185,111 @@ fn build_set_assignments_formats_each_value() {
     let options = ExecOptions::default();
     let builder = builder(&options, "01:00.0");
 
-    check_cases(
-        [
-            Case {
-                scenario: "boolean scalar",
-                input: vec![var("SRIOV_EN").with(true).unwrap()],
-                expect: Yields(vec!["SRIOV_EN=true".to_string()]),
-            },
-            Case {
-                scenario: "integer scalar",
-                input: vec![var("NUM_OF_VFS").with(32i64).unwrap()],
-                expect: Yields(vec!["NUM_OF_VFS=32".to_string()]),
-            },
-            Case {
-                scenario: "enum scalar",
-                input: vec![var("POWER_MODE").with("HIGH").unwrap()],
-                expect: Yields(vec!["POWER_MODE=HIGH".to_string()]),
-            },
-            Case {
-                scenario: "preset scalar",
-                input: vec![var("PERFORMANCE_PRESET").with(7u8).unwrap()],
-                expect: Yields(vec!["PERFORMANCE_PRESET=7".to_string()]),
-            },
-            Case {
-                scenario: "binary scalar is hex-encoded",
-                input: vec![
-                    var("DEVICE_UUID")
-                        .with(vec![0x1au8, 0x2bu8, 0x3cu8, 0x4du8])
-                        .unwrap(),
-                ],
-                expect: Yields(vec!["DEVICE_UUID=0x1a2b3c4d".to_string()]),
-            },
-            Case {
-                scenario: "dense boolean array sets every index",
-                input: vec![
-                    var("GPIO_ENABLED")
-                        .with(vec![true, false, true, false])
-                        .unwrap(),
-                ],
-                expect: Yields(vec![
-                    "GPIO_ENABLED[0]=true".to_string(),
-                    "GPIO_ENABLED[1]=false".to_string(),
-                    "GPIO_ENABLED[2]=true".to_string(),
-                    "GPIO_ENABLED[3]=false".to_string(),
-                ]),
-            },
-            Case {
-                scenario: "sparse boolean array skips None slots",
-                input: vec![
-                    var("GPIO_ENABLED")
-                        .with(vec![Some(true), None, Some(false), None])
-                        .unwrap(),
-                ],
-                expect: Yields(vec![
-                    "GPIO_ENABLED[0]=true".to_string(),
-                    "GPIO_ENABLED[2]=false".to_string(),
-                ]),
-            },
-            Case {
-                scenario: "sparse integer array skips None slots",
-                input: vec![
-                    var("THERMAL_SENSORS")
-                        .with(vec![
-                            Some(45i64),
-                            None,
-                            Some(42i64),
-                            None,
-                            Some(39i64),
-                            None,
-                        ])
-                        .unwrap(),
-                ],
-                expect: Yields(vec![
-                    "THERMAL_SENSORS[0]=45".to_string(),
-                    "THERMAL_SENSORS[2]=42".to_string(),
-                    "THERMAL_SENSORS[4]=39".to_string(),
-                ]),
-            },
-            Case {
-                scenario: "sparse enum array skips None slots",
-                input: vec![
-                    var("GPIO_MODES")
-                        .with(vec![
-                            Some("input".to_string()),
-                            Some("output".to_string()),
-                            None,
-                            Some("bidirectional".to_string()),
-                            None,
-                            None,
-                            None,
-                            None,
-                        ])
-                        .unwrap(),
-                ],
-                expect: Yields(vec![
-                    "GPIO_MODES[0]=input".to_string(),
-                    "GPIO_MODES[1]=output".to_string(),
-                    "GPIO_MODES[3]=bidirectional".to_string(),
-                ]),
-            },
-            Case {
-                scenario: "multiple variables, each in input order",
-                input: vec![
-                    var("SRIOV_EN").with(true).unwrap(),
-                    var("NUM_OF_VFS").with(16i64).unwrap(),
-                    var("POWER_MODE").with("HIGH").unwrap(),
-                ],
-                expect: Yields(vec![
-                    "SRIOV_EN=true".to_string(),
-                    "NUM_OF_VFS=16".to_string(),
-                    "POWER_MODE=HIGH".to_string(),
-                ]),
-            },
-            Case {
-                scenario: "no values yields no assignments",
-                input: vec![],
-                expect: Yields(vec![]),
-            },
-        ],
-        |config_values| builder.build_set_assignments(&config_values).map_err(drop),
+    scenarios!(
+        run = |config_values| builder.build_set_assignments(&config_values).map_err(drop);
+        "boolean scalar" {
+            vec![var("SRIOV_EN").with(true).unwrap()] => Yields(vec!["SRIOV_EN=true".to_string()]),
+        }
+
+        "integer scalar" {
+            vec![var("NUM_OF_VFS").with(32i64).unwrap()] => Yields(vec!["NUM_OF_VFS=32".to_string()]),
+        }
+
+        "enum scalar" {
+            vec![var("POWER_MODE").with("HIGH").unwrap()] => Yields(vec!["POWER_MODE=HIGH".to_string()]),
+        }
+
+        "preset scalar" {
+            vec![var("PERFORMANCE_PRESET").with(7u8).unwrap()] => Yields(vec!["PERFORMANCE_PRESET=7".to_string()]),
+        }
+
+        "binary scalar is hex-encoded" {
+            vec![
+                var("DEVICE_UUID")
+                    .with(vec![0x1au8, 0x2bu8, 0x3cu8, 0x4du8])
+                    .unwrap(),
+            ] => Yields(vec!["DEVICE_UUID=0x1a2b3c4d".to_string()]),
+        }
+
+        "dense boolean array sets every index" {
+            vec![
+                var("GPIO_ENABLED")
+                    .with(vec![true, false, true, false])
+                    .unwrap(),
+            ] => Yields(vec![
+                "GPIO_ENABLED[0]=true".to_string(),
+                "GPIO_ENABLED[1]=false".to_string(),
+                "GPIO_ENABLED[2]=true".to_string(),
+                "GPIO_ENABLED[3]=false".to_string(),
+            ]),
+        }
+
+        "sparse boolean array skips None slots" {
+            vec![
+                var("GPIO_ENABLED")
+                    .with(vec![Some(true), None, Some(false), None])
+                    .unwrap(),
+            ] => Yields(vec![
+                "GPIO_ENABLED[0]=true".to_string(),
+                "GPIO_ENABLED[2]=false".to_string(),
+            ]),
+        }
+
+        "sparse integer array skips None slots" {
+            vec![
+                var("THERMAL_SENSORS")
+                    .with(vec![
+                        Some(45i64),
+                        None,
+                        Some(42i64),
+                        None,
+                        Some(39i64),
+                        None,
+                    ])
+                    .unwrap(),
+            ] => Yields(vec![
+                "THERMAL_SENSORS[0]=45".to_string(),
+                "THERMAL_SENSORS[2]=42".to_string(),
+                "THERMAL_SENSORS[4]=39".to_string(),
+            ]),
+        }
+
+        "sparse enum array skips None slots" {
+            vec![
+                var("GPIO_MODES")
+                    .with(vec![
+                        Some("input".to_string()),
+                        Some("output".to_string()),
+                        None,
+                        Some("bidirectional".to_string()),
+                        None,
+                        None,
+                        None,
+                        None,
+                    ])
+                    .unwrap(),
+            ] => Yields(vec![
+                "GPIO_MODES[0]=input".to_string(),
+                "GPIO_MODES[1]=output".to_string(),
+                "GPIO_MODES[3]=bidirectional".to_string(),
+            ]),
+        }
+
+        "multiple variables, each in input order" {
+            vec![
+                var("SRIOV_EN").with(true).unwrap(),
+                var("NUM_OF_VFS").with(16i64).unwrap(),
+                var("POWER_MODE").with("HIGH").unwrap(),
+            ] => Yields(vec![
+                "SRIOV_EN=true".to_string(),
+                "NUM_OF_VFS=16".to_string(),
+                "POWER_MODE=HIGH".to_string(),
+            ]),
+        }
+
+        "no values yields no assignments" {
+            vec![] => Yields(vec![]),
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/exec_options_tests.rs
+++ b/crates/libmlx/tests/runner/exec_options_tests.rs
@@ -20,7 +20,7 @@
 
 use std::time::Duration;
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::runner::exec_options::{ExecOptions, is_destructive_variable};
 
 // Assert `options` holds the documented default configuration. `new()` is meant to
@@ -229,45 +229,35 @@ fn test_backoff_edge_cases() {
 // everything else (other variables, the empty string, mismatched casing) is not.
 #[test]
 fn test_is_destructive_variable() {
-    check_values(
-        [
-            Check {
-                scenario: "the predefined destructive variable",
-                input: "OH_MY_DPU",
-                expect: true,
-            },
-            Check {
-                scenario: "SRIOV_EN is not destructive",
-                input: "SRIOV_EN",
-                expect: false,
-            },
-            Check {
-                scenario: "NUM_OF_VFS is not destructive",
-                input: "NUM_OF_VFS",
-                expect: false,
-            },
-            Check {
-                scenario: "POWER_MODE is not destructive",
-                input: "POWER_MODE",
-                expect: false,
-            },
-            Check {
-                scenario: "the empty string is not destructive",
-                input: "",
-                expect: false,
-            },
-            Check {
-                scenario: "lowercase does not match",
-                input: "oh_my_dpu",
-                expect: false,
-            },
-            Check {
-                scenario: "mixed case does not match",
-                input: "Oh_My_Dpu",
-                expect: false,
-            },
-        ],
-        is_destructive_variable,
+    value_scenarios!(
+        run = is_destructive_variable;
+        "the predefined destructive variable" {
+            "OH_MY_DPU" => true,
+        }
+
+        "SRIOV_EN is not destructive" {
+            "SRIOV_EN" => false,
+        }
+
+        "NUM_OF_VFS is not destructive" {
+            "NUM_OF_VFS" => false,
+        }
+
+        "POWER_MODE is not destructive" {
+            "POWER_MODE" => false,
+        }
+
+        "the empty string is not destructive" {
+            "" => false,
+        }
+
+        "lowercase does not match" {
+            "oh_my_dpu" => false,
+        }
+
+        "mixed case does not match" {
+            "Oh_My_Dpu" => false,
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/executor_tests.rs
+++ b/crates/libmlx/tests/runner/executor_tests.rs
@@ -22,7 +22,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::{Check, check_values, value_scenarios};
 use libmlx::runner::command_builder::{CommandBuilder, CommandSpec};
 use libmlx::runner::error::MlxRunnerError;
 use libmlx::runner::exec_options::ExecOptions;
@@ -85,45 +85,35 @@ fn test_cleanup_temp_file_nonexistent() {
 
 #[test]
 fn test_is_dry_run() {
-    check_values(
-        [
-            Check {
-                scenario: "dry-run on",
-                input: true,
-                expect: true,
-            },
-            Check {
-                scenario: "dry-run off",
-                input: false,
-                expect: false,
-            },
-        ],
-        |dry_run| {
+    value_scenarios!(
+        run = |dry_run| {
             let options = ExecOptions::new().with_dry_run(dry_run);
             CommandExecutor { options: &options }.is_dry_run()
-        },
+        };
+        "dry-run on" {
+            true => true,
+        }
+
+        "dry-run off" {
+            false => false,
+        }
     );
 }
 
 #[test]
 fn test_is_verbose() {
-    check_values(
-        [
-            Check {
-                scenario: "verbose on",
-                input: true,
-                expect: true,
-            },
-            Check {
-                scenario: "verbose off",
-                input: false,
-                expect: false,
-            },
-        ],
-        |verbose| {
+    value_scenarios!(
+        run = |verbose| {
             let options = ExecOptions::new().with_verbose(verbose);
             CommandExecutor { options: &options }.is_verbose()
-        },
+        };
+        "verbose on" {
+            true => true,
+        }
+
+        "verbose off" {
+            false => false,
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/json_parser_tests.rs
+++ b/crates/libmlx/tests/runner/json_parser_tests.rs
@@ -21,7 +21,7 @@
 use std::fs;
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use libmlx::runner::error::MlxRunnerError;
 use libmlx::runner::exec_options::ExecOptions;
 use libmlx::runner::json_parser::JsonResponseParser;
@@ -216,30 +216,8 @@ fn test_missing_file() {
 #[test]
 fn test_boolean_parsing_variations() {
     let registry = common::create_minimal_test_registry();
-    check_cases(
-        [
-            Case {
-                scenario: "True(1)",
-                input: "True(1)",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "False(0)",
-                input: "False(0)",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-            Case {
-                scenario: "TRUE",
-                input: "TRUE",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "FALSE",
-                input: "FALSE",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-        ],
-        |raw| {
+    scenarios!(
+        run = |raw| {
             let json = json!({
                 "Device #1": {
                     "description": "Test Device",
@@ -268,7 +246,22 @@ fn test_boolean_parsing_variations() {
                         .clone()
                 })
                 .map_err(drop)
-        },
+        };
+        "True(1)" {
+            "True(1)" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "False(0)" {
+            "False(0)" => Yields(MlxValueType::Boolean(false)),
+        }
+
+        "TRUE" {
+            "TRUE" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "FALSE" {
+            "FALSE" => Yields(MlxValueType::Boolean(false)),
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/result_types_tests.rs
+++ b/crates/libmlx/tests/runner/result_types_tests.rs
@@ -20,7 +20,7 @@
 
 use std::time::Duration;
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::runner::result_types::{
     ComparisonResult, PlannedChange, QueriedDeviceInfo, QueriedVariable, QueryResult, SyncResult,
     VariableChange,
@@ -69,26 +69,8 @@ fn test_queried_variable_pending_change_detection() {
     let registry = common::create_test_registry();
     let sriov_var = registry.get_variable("SRIOV_EN").unwrap().clone();
 
-    check_values(
-        [
-            Check {
-                scenario: "current != next is a pending change",
-                input: Values {
-                    current: false,
-                    next: true,
-                },
-                expect: true,
-            },
-            Check {
-                scenario: "current == next is not a pending change",
-                input: Values {
-                    current: true,
-                    next: true,
-                },
-                expect: false,
-            },
-        ],
-        |Values { current, next }| {
+    value_scenarios!(
+        run = |Values { current, next }| {
             QueriedVariable {
                 variable: sriov_var.clone(),
                 current_value: sriov_var.with(current).unwrap(),
@@ -98,7 +80,20 @@ fn test_queried_variable_pending_change_detection() {
                 read_only: false,
             }
             .is_pending_change()
-        },
+        };
+        "current != next is a pending change" {
+            Values {
+                current: false,
+                next: true,
+            } => true,
+        }
+
+        "current == next is not a pending change" {
+            Values {
+                current: true,
+                next: true,
+            } => false,
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/runner_integration_tests.rs
+++ b/crates/libmlx/tests/runner/runner_integration_tests.rs
@@ -22,7 +22,7 @@ use std::fs;
 use std::time::Duration;
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use libmlx::runner::error::MlxRunnerError;
 use libmlx::runner::exec_options::ExecOptions;
 use libmlx::runner::runner::MlxConfigRunner;
@@ -69,44 +69,35 @@ fn test_runner_temp_file_prefix() {
 // preset-range rows just assert rejection.
 #[test]
 fn invalid_set_assignments_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "unknown variable names itself",
-                input: &[("SRIOV_EN", "true"), ("NONEXISTENT_VAR", "value")][..],
-                expect: FailsWith("NONEXISTENT_VAR".to_string()),
-            },
-            Case {
-                scenario: "first invalid variable wins over later invalid values",
-                input: &[
-                    ("NONEXISTENT_VAR", "value"),   // Variable not found
-                    ("POWER_MODE", "INVALID_MODE"), // Invalid enum value
-                    ("GPIO_ENABLED[100]", "true"),  // Array index out of bounds
-                ][..],
-                expect: FailsWith("NONEXISTENT_VAR".to_string()),
-            },
-            Case {
-                scenario: "enum value outside allowed options (LOW/MEDIUM/HIGH)",
-                input: &[("POWER_MODE", "INVALID_POWER_MODE")][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "non-boolean value for a boolean variable",
-                input: &[("SRIOV_EN", "maybe")][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "array index past the registry size of 4",
-                input: &[("GPIO_ENABLED[10]", "true")][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "preset above the max of 10",
-                input: &[("PERFORMANCE_PRESET", "20")][..],
-                expect: Fails,
-            },
-        ],
-        set_outcome,
+    scenarios!(
+        run = set_outcome;
+        "unknown variable names itself" {
+            &[("SRIOV_EN", "true"), ("NONEXISTENT_VAR", "value")][..] => FailsWith("NONEXISTENT_VAR".to_string()),
+        }
+
+        "first invalid variable wins over later invalid values" {
+            &[
+                ("NONEXISTENT_VAR", "value"),   // Variable not found
+                ("POWER_MODE", "INVALID_MODE"), // Invalid enum value
+                ("GPIO_ENABLED[100]", "true"),  // Array index out of bounds
+            ][..] => FailsWith("NONEXISTENT_VAR".to_string()),
+        }
+
+        "enum value outside allowed options (LOW/MEDIUM/HIGH)" {
+            &[("POWER_MODE", "INVALID_POWER_MODE")][..] => Fails,
+        }
+
+        "non-boolean value for a boolean variable" {
+            &[("SRIOV_EN", "maybe")][..] => Fails,
+        }
+
+        "array index past the registry size of 4" {
+            &[("GPIO_ENABLED[10]", "true")][..] => Fails,
+        }
+
+        "preset above the max of 10" {
+            &[("PERFORMANCE_PRESET", "20")][..] => Fails,
+        }
     );
 }
 

--- a/crates/libmlx/tests/runner/traits_tests.rs
+++ b/crates/libmlx/tests/runner/traits_tests.rs
@@ -19,7 +19,7 @@
 // Tests for MlxConfigSettable and MlxConfigQueryable traits
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use libmlx::runner::traits::{self, MlxConfigQueryable, MlxConfigSettable};
 use libmlx::variables::value::MlxValueType;
 
@@ -385,50 +385,39 @@ fn test_mlx_config_queryable_vec_variables() {
 // pin the exact `Option<(name, index)>` the parse should yield.
 #[test]
 fn parse_array_index_splits_name_and_index() {
-    check_cases(
-        [
-            Case {
-                scenario: "'ARRAY_VAR[0]'",
-                input: "ARRAY_VAR[0]",
-                expect: Yields(Some(("ARRAY_VAR".to_string(), 0))),
-            },
-            Case {
-                scenario: "'GPIO_ENABLED[15]'",
-                input: "GPIO_ENABLED[15]",
-                expect: Yields(Some(("GPIO_ENABLED".to_string(), 15))),
-            },
-            Case {
-                scenario: "'COMPLEX_ARRAY_NAME[999]'",
-                input: "COMPLEX_ARRAY_NAME[999]",
-                expect: Yields(Some(("COMPLEX_ARRAY_NAME".to_string(), 999))),
-            },
-            Case {
-                scenario: "'SRIOV_EN' is not an indexed name",
-                input: "SRIOV_EN",
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "'POWER_MODE' is not an indexed name",
-                input: "POWER_MODE",
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "'invalid[0]' lowercase name is not an index",
-                input: "invalid[0]",
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "'INVALID[]' has an empty index",
-                input: "INVALID[]",
-                expect: Fails,
-            },
-            Case {
-                scenario: "'VAR[not_a_number]' has a non-numeric index",
-                input: "VAR[not_a_number]",
-                expect: Fails,
-            },
-        ],
-        |name| traits::parse_array_index(name).map_err(drop),
+    scenarios!(
+        run = |name| traits::parse_array_index(name).map_err(drop);
+        "'ARRAY_VAR[0]'" {
+            "ARRAY_VAR[0]" => Yields(Some(("ARRAY_VAR".to_string(), 0))),
+        }
+
+        "'GPIO_ENABLED[15]'" {
+            "GPIO_ENABLED[15]" => Yields(Some(("GPIO_ENABLED".to_string(), 15))),
+        }
+
+        "'COMPLEX_ARRAY_NAME[999]'" {
+            "COMPLEX_ARRAY_NAME[999]" => Yields(Some(("COMPLEX_ARRAY_NAME".to_string(), 999))),
+        }
+
+        "'SRIOV_EN' is not an indexed name" {
+            "SRIOV_EN" => Yields(None),
+        }
+
+        "'POWER_MODE' is not an indexed name" {
+            "POWER_MODE" => Yields(None),
+        }
+
+        "'invalid[0]' lowercase name is not an index" {
+            "invalid[0]" => Yields(None),
+        }
+
+        "'INVALID[]' has an empty index" {
+            "INVALID[]" => Fails,
+        }
+
+        "'VAR[not_a_number]' has a non-numeric index" {
+            "VAR[not_a_number]" => Fails,
+        }
     );
 }
 
@@ -578,48 +567,40 @@ fn test_build_sparse_array_value_invalid_enum() {
 fn get_array_size_from_spec_reads_array_sizes() {
     use libmlx::variables::spec::MlxVariableSpec;
 
-    check_cases(
-        [
-            Case {
-                scenario: "boolean array",
-                input: MlxVariableSpec::builder()
-                    .boolean_array()
-                    .with_size(4)
-                    .build(),
-                expect: Yields(4),
-            },
-            Case {
-                scenario: "integer array",
-                input: MlxVariableSpec::builder()
-                    .integer_array()
-                    .with_size(6)
-                    .build(),
-                expect: Yields(6),
-            },
-            Case {
-                scenario: "enum array",
-                input: MlxVariableSpec::builder()
-                    .enum_array()
-                    .with_options(vec!["a".to_string(), "b".to_string()])
-                    .with_size(8)
-                    .build(),
-                expect: Yields(8),
-            },
-            Case {
-                scenario: "binary array",
-                input: MlxVariableSpec::builder()
-                    .binary_array()
-                    .with_size(2)
-                    .build(),
-                expect: Yields(2),
-            },
-            Case {
-                scenario: "a scalar spec has no array size",
-                input: MlxVariableSpec::builder().boolean().build(),
-                expect: Fails,
-            },
-        ],
-        |spec| traits::get_array_size_from_spec(&spec).map_err(drop),
+    scenarios!(
+        run = |spec| traits::get_array_size_from_spec(&spec).map_err(drop);
+        "boolean array" {
+            MlxVariableSpec::builder()
+            .boolean_array()
+            .with_size(4)
+            .build() => Yields(4),
+        }
+
+        "integer array" {
+            MlxVariableSpec::builder()
+            .integer_array()
+            .with_size(6)
+            .build() => Yields(6),
+        }
+
+        "enum array" {
+            MlxVariableSpec::builder()
+            .enum_array()
+            .with_options(vec!["a".to_string(), "b".to_string()])
+            .with_size(8)
+            .build() => Yields(8),
+        }
+
+        "binary array" {
+            MlxVariableSpec::builder()
+            .binary_array()
+            .with_size(2)
+            .build() => Yields(2),
+        }
+
+        "a scalar spec has no array size" {
+            MlxVariableSpec::builder().boolean().build() => Fails,
+        }
     );
 }
 
@@ -774,50 +755,39 @@ fn test_mlx_config_queryable_array_index_base_variable_not_found() {
 fn array_index_query_validates_against_spec_size() {
     let registry = common::create_test_registry();
 
-    check_cases(
-        [
-            Case {
-                scenario: "GPIO_ENABLED[0]: boolean array size 4, first index",
-                input: "GPIO_ENABLED[0]",
-                expect: Yields(vec!["GPIO_ENABLED[0]".to_string()]),
-            },
-            Case {
-                scenario: "GPIO_ENABLED[3]: boolean array size 4, last valid index",
-                input: "GPIO_ENABLED[3]",
-                expect: Yields(vec!["GPIO_ENABLED[3]".to_string()]),
-            },
-            Case {
-                scenario: "GPIO_ENABLED[4]: boolean array size 4, out of bounds",
-                input: "GPIO_ENABLED[4]",
-                expect: Fails,
-            },
-            Case {
-                scenario: "THERMAL_SENSORS[5]: integer array size 6, last valid index",
-                input: "THERMAL_SENSORS[5]",
-                expect: Yields(vec!["THERMAL_SENSORS[5]".to_string()]),
-            },
-            Case {
-                scenario: "THERMAL_SENSORS[6]: integer array size 6, out of bounds",
-                input: "THERMAL_SENSORS[6]",
-                expect: Fails,
-            },
-            Case {
-                scenario: "GPIO_MODES[0]: enum array size 8, first index",
-                input: "GPIO_MODES[0]",
-                expect: Yields(vec!["GPIO_MODES[0]".to_string()]),
-            },
-            Case {
-                scenario: "GPIO_MODES[7]: enum array size 8, last valid index",
-                input: "GPIO_MODES[7]",
-                expect: Yields(vec!["GPIO_MODES[7]".to_string()]),
-            },
-            Case {
-                scenario: "GPIO_MODES[8]: enum array size 8, out of bounds",
-                input: "GPIO_MODES[8]",
-                expect: Fails,
-            },
-        ],
-        |var_name| (&[var_name]).to_variable_names(&registry).map_err(drop),
+    scenarios!(
+        run = |var_name| (&[var_name]).to_variable_names(&registry).map_err(drop);
+        "GPIO_ENABLED[0]: boolean array size 4, first index" {
+            "GPIO_ENABLED[0]" => Yields(vec!["GPIO_ENABLED[0]".to_string()]),
+        }
+
+        "GPIO_ENABLED[3]: boolean array size 4, last valid index" {
+            "GPIO_ENABLED[3]" => Yields(vec!["GPIO_ENABLED[3]".to_string()]),
+        }
+
+        "GPIO_ENABLED[4]: boolean array size 4, out of bounds" {
+            "GPIO_ENABLED[4]" => Fails,
+        }
+
+        "THERMAL_SENSORS[5]: integer array size 6, last valid index" {
+            "THERMAL_SENSORS[5]" => Yields(vec!["THERMAL_SENSORS[5]".to_string()]),
+        }
+
+        "THERMAL_SENSORS[6]: integer array size 6, out of bounds" {
+            "THERMAL_SENSORS[6]" => Fails,
+        }
+
+        "GPIO_MODES[0]: enum array size 8, first index" {
+            "GPIO_MODES[0]" => Yields(vec!["GPIO_MODES[0]".to_string()]),
+        }
+
+        "GPIO_MODES[7]: enum array size 8, last valid index" {
+            "GPIO_MODES[7]" => Yields(vec!["GPIO_MODES[7]".to_string()]),
+        }
+
+        "GPIO_MODES[8]: enum array size 8, out of bounds" {
+            "GPIO_MODES[8]" => Fails,
+        }
     );
 }
 

--- a/crates/libmlx/tests/variables/test_registry.rs
+++ b/crates/libmlx/tests/variables/test_registry.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::device::filters::{DeviceField, DeviceFilter, DeviceFilterSet, MatchMode};
 use libmlx::variables::registry::MlxVariableRegistry;
 use libmlx::variables::spec::MlxVariableSpec;
@@ -237,25 +237,19 @@ fn test_registry_device_matching_with_filters() {
             match_mode: MatchMode::Regex,
         });
 
-    check_values(
-        [
-            Check {
-                scenario: "matches both filters",
-                input: create_test_device("BlueField3", "MCX623106AS-CDAT", "28.38.1010"),
-                expect: true,
-            },
-            Check {
-                scenario: "matches only the device-type filter",
-                input: create_test_device("BlueField3", "MT40354", "28.38.1010"),
-                expect: false,
-            },
-            Check {
-                scenario: "matches neither filter",
-                input: create_test_device("ConnectX-6", "MT40354", "28.38.1010"),
-                expect: false,
-            },
-        ],
-        |device| registry.matches_device(&device),
+    value_scenarios!(
+        run = |device| registry.matches_device(&device);
+        "matches both filters" {
+            create_test_device("BlueField3", "MCX623106AS-CDAT", "28.38.1010") => true,
+        }
+
+        "matches only the device-type filter" {
+            create_test_device("BlueField3", "MT40354", "28.38.1010") => false,
+        }
+
+        "matches neither filter" {
+            create_test_device("ConnectX-6", "MT40354", "28.38.1010") => false,
+        }
     );
 }
 

--- a/crates/libmlx/tests/variables/test_spec.rs
+++ b/crates/libmlx/tests/variables/test_spec.rs
@@ -17,7 +17,7 @@
 
 use std::mem::discriminant;
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::value_scenarios;
 use libmlx::variables::spec::MlxVariableSpec;
 
 // Each builder method produces its matching variant. The old version called
@@ -25,45 +25,35 @@ use libmlx::variables::spec::MlxVariableSpec;
 // nothing. Comparing discriminants restores the check (variant only, no payload).
 #[test]
 fn test_simple_variable_specs() {
-    check_values(
-        [
-            Check {
-                scenario: "boolean",
-                input: MlxVariableSpec::builder().boolean().build(),
-                expect: discriminant(&MlxVariableSpec::Boolean),
-            },
-            Check {
-                scenario: "integer",
-                input: MlxVariableSpec::builder().integer().build(),
-                expect: discriminant(&MlxVariableSpec::Integer),
-            },
-            Check {
-                scenario: "string",
-                input: MlxVariableSpec::builder().string().build(),
-                expect: discriminant(&MlxVariableSpec::String),
-            },
-            Check {
-                scenario: "binary",
-                input: MlxVariableSpec::builder().binary().build(),
-                expect: discriminant(&MlxVariableSpec::Binary),
-            },
-            Check {
-                scenario: "bytes",
-                input: MlxVariableSpec::builder().bytes().build(),
-                expect: discriminant(&MlxVariableSpec::Bytes),
-            },
-            Check {
-                scenario: "array",
-                input: MlxVariableSpec::builder().array().build(),
-                expect: discriminant(&MlxVariableSpec::Array),
-            },
-            Check {
-                scenario: "opaque",
-                input: MlxVariableSpec::builder().opaque().build(),
-                expect: discriminant(&MlxVariableSpec::Opaque),
-            },
-        ],
-        |spec| discriminant(&spec),
+    value_scenarios!(
+        run = |spec| discriminant(&spec);
+        "boolean" {
+            MlxVariableSpec::builder().boolean().build() => discriminant(&MlxVariableSpec::Boolean),
+        }
+
+        "integer" {
+            MlxVariableSpec::builder().integer().build() => discriminant(&MlxVariableSpec::Integer),
+        }
+
+        "string" {
+            MlxVariableSpec::builder().string().build() => discriminant(&MlxVariableSpec::String),
+        }
+
+        "binary" {
+            MlxVariableSpec::builder().binary().build() => discriminant(&MlxVariableSpec::Binary),
+        }
+
+        "bytes" {
+            MlxVariableSpec::builder().bytes().build() => discriminant(&MlxVariableSpec::Bytes),
+        }
+
+        "array" {
+            MlxVariableSpec::builder().array().build() => discriminant(&MlxVariableSpec::Array),
+        }
+
+        "opaque" {
+            MlxVariableSpec::builder().opaque().build() => discriminant(&MlxVariableSpec::Opaque),
+        }
     );
 }
 

--- a/crates/libmlx/tests/variables/test_value.rs
+++ b/crates/libmlx/tests/variables/test_value.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, Check, check_cases, check_values};
+use carbide_test_support::{Case, scenarios, value_scenarios};
 use libmlx::variables::spec::MlxVariableSpec;
 use libmlx::variables::value::{MlxValueError, MlxValueType};
 use libmlx::variables::variable::MlxConfigVariable;
@@ -92,28 +92,22 @@ fn enum_values_validate_against_the_spec() {
         },
     );
 
-    check_cases(
-        [
-            Case {
-                scenario: "a valid option",
-                input: "medium",
-                expect: Yields(MlxValueType::Enum("medium".to_string())),
-            },
-            Case {
-                scenario: "another valid option",
-                input: "high",
-                expect: Yields(MlxValueType::Enum("high".to_string())),
-            },
-            Case {
-                scenario: "an unknown option",
-                input: "invalid",
-                expect: FailsWith(MlxValueError::InvalidEnumOption {
-                    value: "invalid".to_string(),
-                    allowed: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
-                }),
-            },
-        ],
-        |input| var.with(input).map(|v| v.value),
+    scenarios!(
+        run = |input| var.with(input).map(|v| v.value);
+        "a valid option" {
+            "medium" => Yields(MlxValueType::Enum("medium".to_string())),
+        }
+
+        "another valid option" {
+            "high" => Yields(MlxValueType::Enum("high".to_string())),
+        }
+
+        "an unknown option" {
+            "invalid" => FailsWith(MlxValueError::InvalidEnumOption {
+                value: "invalid".to_string(),
+                allowed: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
+            }),
+        }
     );
 }
 
@@ -124,20 +118,15 @@ fn enum_values_validate_against_the_spec() {
 fn preset_values_respect_the_max() {
     let var = create_test_variable("test_preset", MlxVariableSpec::Preset { max_preset: 5 });
 
-    check_cases(
-        [
-            Case {
-                scenario: "in range",
-                input: 3u8,
-                expect: Yields(MlxValueType::Preset(3)),
-            },
-            Case {
-                scenario: "above the max",
-                input: 10u8,
-                expect: Fails,
-            },
-        ],
-        |input| var.with(input).map(|v| v.value),
+    scenarios!(
+        run = |input| var.with(input).map(|v| v.value);
+        "in range" {
+            3u8 => Yields(MlxValueType::Preset(3)),
+        }
+
+        "above the max" {
+            10u8 => Fails,
+        }
     );
 }
 
@@ -148,25 +137,20 @@ fn preset_values_respect_the_max() {
 fn boolean_arrays_validate_size_and_convert() {
     let var = create_test_variable("test_bool_array", MlxVariableSpec::BooleanArray { size: 4 });
 
-    check_cases(
-        [
-            Case {
-                scenario: "a right-sized Vec<bool> converts to the sparse form",
-                input: vec![true, false, true, false],
-                expect: Yields(MlxValueType::BooleanArray(vec![
-                    Some(true),
-                    Some(false),
-                    Some(true),
-                    Some(false),
-                ])),
-            },
-            Case {
-                scenario: "a wrong-sized input is rejected",
-                input: vec![true, false],
-                expect: Fails,
-            },
-        ],
-        |input| var.with(input).map(|v| v.value),
+    scenarios!(
+        run = |input| var.with(input).map(|v| v.value);
+        "a right-sized Vec<bool> converts to the sparse form" {
+            vec![true, false, true, false] => Yields(MlxValueType::BooleanArray(vec![
+                Some(true),
+                Some(false),
+                Some(true),
+                Some(false),
+            ])),
+        }
+
+        "a wrong-sized input is rejected" {
+            vec![true, false] => Fails,
+        }
     );
 }
 
@@ -389,109 +373,83 @@ fn test_string_parsing_for_single_values() {
     }
 
     let bool_var = create_test_variable("test_bool", MlxVariableSpec::Boolean);
-    check_cases(
-        [
-            Case {
-                scenario: "'true'",
-                input: "true",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "'1'",
-                input: "1",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "'YES'",
-                input: "YES",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "'enabled'",
-                input: "enabled",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "'on'",
-                input: "on",
-                expect: Yields(MlxValueType::Boolean(true)),
-            },
-            Case {
-                scenario: "'false'",
-                input: "false",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-            Case {
-                scenario: "'0'",
-                input: "0",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-            Case {
-                scenario: "'NO'",
-                input: "NO",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-            Case {
-                scenario: "'disabled'",
-                input: "disabled",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-            Case {
-                scenario: "'off'",
-                input: "off",
-                expect: Yields(MlxValueType::Boolean(false)),
-            },
-            Case {
-                scenario: "'maybe' is not a boolean",
-                input: "maybe",
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&bool_var, raw),
+    scenarios!(
+        run = |raw| parsed(&bool_var, raw);
+        "'true'" {
+            "true" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "'1'" {
+            "1" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "'YES'" {
+            "YES" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "'enabled'" {
+            "enabled" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "'on'" {
+            "on" => Yields(MlxValueType::Boolean(true)),
+        }
+
+        "'false'" {
+            "false" => Yields(MlxValueType::Boolean(false)),
+        }
+
+        "'0'" {
+            "0" => Yields(MlxValueType::Boolean(false)),
+        }
+
+        "'NO'" {
+            "NO" => Yields(MlxValueType::Boolean(false)),
+        }
+
+        "'disabled'" {
+            "disabled" => Yields(MlxValueType::Boolean(false)),
+        }
+
+        "'off'" {
+            "off" => Yields(MlxValueType::Boolean(false)),
+        }
+
+        "'maybe' is not a boolean" {
+            "maybe" => Fails,
+        }
     );
 
     let int_var = create_test_variable("test_int", MlxVariableSpec::Integer);
-    check_cases(
-        [
-            Case {
-                scenario: "positive",
-                input: "42",
-                expect: Yields(MlxValueType::Integer(42)),
-            },
-            Case {
-                scenario: "negative",
-                input: "-123",
-                expect: Yields(MlxValueType::Integer(-123)),
-            },
-            Case {
-                scenario: "zero",
-                input: "0",
-                expect: Yields(MlxValueType::Integer(0)),
-            },
-            Case {
-                scenario: "non-number is rejected",
-                input: "not_a_number",
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&int_var, raw),
+    scenarios!(
+        run = |raw| parsed(&int_var, raw);
+        "positive" {
+            "42" => Yields(MlxValueType::Integer(42)),
+        }
+
+        "negative" {
+            "-123" => Yields(MlxValueType::Integer(-123)),
+        }
+
+        "zero" {
+            "0" => Yields(MlxValueType::Integer(0)),
+        }
+
+        "non-number is rejected" {
+            "not_a_number" => Fails,
+        }
     );
 
     let str_var = create_test_variable("test_string", MlxVariableSpec::String);
-    check_cases(
-        [
-            Case {
-                scenario: "stored as-is",
-                input: "hello world",
-                expect: Yields(MlxValueType::String("hello world".to_string())),
-            },
-            Case {
-                scenario: "surrounding whitespace trimmed",
-                input: "  trimmed  ",
-                expect: Yields(MlxValueType::String("trimmed".to_string())),
-            },
-        ],
-        |raw| parsed(&str_var, raw),
+    scenarios!(
+        run = |raw| parsed(&str_var, raw);
+        "stored as-is" {
+            "hello world" => Yields(MlxValueType::String("hello world".to_string())),
+        }
+
+        "surrounding whitespace trimmed" {
+            "  trimmed  " => Yields(MlxValueType::String("trimmed".to_string())),
+        }
     );
 
     let enum_var = create_test_variable(
@@ -500,81 +458,61 @@ fn test_string_parsing_for_single_values() {
             options: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
         },
     );
-    check_cases(
-        [
-            Case {
-                scenario: "a valid option",
-                input: "medium",
-                expect: Yields(MlxValueType::Enum("medium".to_string())),
-            },
-            Case {
-                scenario: "another valid option",
-                input: "high",
-                expect: Yields(MlxValueType::Enum("high".to_string())),
-            },
-            Case {
-                scenario: "trimmed before matching",
-                input: " low ",
-                expect: Yields(MlxValueType::Enum("low".to_string())),
-            },
-            Case {
-                scenario: "an unknown option is rejected",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&enum_var, raw),
+    scenarios!(
+        run = |raw| parsed(&enum_var, raw);
+        "a valid option" {
+            "medium" => Yields(MlxValueType::Enum("medium".to_string())),
+        }
+
+        "another valid option" {
+            "high" => Yields(MlxValueType::Enum("high".to_string())),
+        }
+
+        "trimmed before matching" {
+            " low " => Yields(MlxValueType::Enum("low".to_string())),
+        }
+
+        "an unknown option is rejected" {
+            "invalid" => Fails,
+        }
     );
 
     let preset_var =
         create_test_variable("test_preset", MlxVariableSpec::Preset { max_preset: 10 });
-    check_cases(
-        [
-            Case {
-                scenario: "mid-range",
-                input: "5",
-                expect: Yields(MlxValueType::Preset(5)),
-            },
-            Case {
-                scenario: "the floor",
-                input: "0",
-                expect: Yields(MlxValueType::Preset(0)),
-            },
-            Case {
-                scenario: "the ceiling",
-                input: "10",
-                expect: Yields(MlxValueType::Preset(10)),
-            },
-            Case {
-                scenario: "above the max is rejected",
-                input: "15",
-                expect: Fails,
-            },
-            Case {
-                scenario: "non-number is rejected",
-                input: "not_a_number",
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&preset_var, raw),
+    scenarios!(
+        run = |raw| parsed(&preset_var, raw);
+        "mid-range" {
+            "5" => Yields(MlxValueType::Preset(5)),
+        }
+
+        "the floor" {
+            "0" => Yields(MlxValueType::Preset(0)),
+        }
+
+        "the ceiling" {
+            "10" => Yields(MlxValueType::Preset(10)),
+        }
+
+        "above the max is rejected" {
+            "15" => Fails,
+        }
+
+        "non-number is rejected" {
+            "not_a_number" => Fails,
+        }
     );
 
     // Binary, Bytes, and Opaque all parse hex -- with or without an 0x/0X prefix.
     let binary_var = create_test_variable("test_binary", MlxVariableSpec::Binary);
-    check_cases(
-        [
-            Case {
-                scenario: "0x-prefixed hex",
-                input: "0x1a2b3c",
-                expect: Yields(MlxValueType::Binary(vec![0x1a, 0x2b, 0x3c])),
-            },
-            Case {
-                scenario: "non-hex is rejected",
-                input: "not_hex",
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&binary_var, raw),
+    scenarios!(
+        run = |raw| parsed(&binary_var, raw);
+        "0x-prefixed hex" {
+            "0x1a2b3c" => Yields(MlxValueType::Binary(vec![0x1a, 0x2b, 0x3c])),
+        }
+
+        "non-hex is rejected" {
+            "not_hex" => Fails,
+        }
     );
     let bytes_var = create_test_variable("test_bytes", MlxVariableSpec::Bytes);
     Case {
@@ -629,73 +567,59 @@ fn test_vec_string_parsing_for_array_values() {
     // Boolean array -- dense, sparse ("-" or "" = None), wrong size, bad element.
     let bool_array_var =
         create_test_variable("test_bool_array", MlxVariableSpec::BooleanArray { size: 4 });
-    check_cases(
-        [
-            Case {
-                scenario: "dense",
-                input: vec!["true", "0", "YES", "disabled"],
-                expect: Yields(MlxValueType::BooleanArray(vec![
-                    Some(true),
-                    Some(false),
-                    Some(true),
-                    Some(false),
-                ])),
-            },
-            Case {
-                scenario: "sparse via - and empty string",
-                input: vec!["true", "-", "false", ""],
-                expect: Yields(MlxValueType::BooleanArray(vec![
-                    Some(true),
-                    None,
-                    Some(false),
-                    None,
-                ])),
-            },
-            Case {
-                scenario: "wrong size",
-                input: vec!["true", "false"],
-                expect: Fails,
-            },
-            Case {
-                scenario: "invalid boolean element",
-                input: vec!["true", "maybe", "false", "true"],
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&bool_array_var, raw),
+    scenarios!(
+        run = |raw| parsed(&bool_array_var, raw);
+        "dense" {
+            vec!["true", "0", "YES", "disabled"] => Yields(MlxValueType::BooleanArray(vec![
+                Some(true),
+                Some(false),
+                Some(true),
+                Some(false),
+            ])),
+        }
+
+        "sparse via - and empty string" {
+            vec!["true", "-", "false", ""] => Yields(MlxValueType::BooleanArray(vec![
+                Some(true),
+                None,
+                Some(false),
+                None,
+            ])),
+        }
+
+        "wrong size" {
+            vec!["true", "false"] => Fails,
+        }
+
+        "invalid boolean element" {
+            vec!["true", "maybe", "false", "true"] => Fails,
+        }
     );
 
     // Integer array -- same dense/sparse/size/element coverage.
     let int_array_var =
         create_test_variable("test_int_array", MlxVariableSpec::IntegerArray { size: 3 });
-    check_cases(
-        [
-            Case {
-                scenario: "dense",
-                input: vec!["42", "-123", "0"],
-                expect: Yields(MlxValueType::IntegerArray(vec![
-                    Some(42),
-                    Some(-123),
-                    Some(0),
-                ])),
-            },
-            Case {
-                scenario: "sparse via -",
-                input: vec!["42", "-", "0"],
-                expect: Yields(MlxValueType::IntegerArray(vec![Some(42), None, Some(0)])),
-            },
-            Case {
-                scenario: "wrong size",
-                input: vec!["1", "2"],
-                expect: Fails,
-            },
-            Case {
-                scenario: "invalid integer element",
-                input: vec!["42", "not_a_number", "0"],
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&int_array_var, raw),
+    scenarios!(
+        run = |raw| parsed(&int_array_var, raw);
+        "dense" {
+            vec!["42", "-123", "0"] => Yields(MlxValueType::IntegerArray(vec![
+                Some(42),
+                Some(-123),
+                Some(0),
+            ])),
+        }
+
+        "sparse via -" {
+            vec!["42", "-", "0"] => Yields(MlxValueType::IntegerArray(vec![Some(42), None, Some(0)])),
+        }
+
+        "wrong size" {
+            vec!["1", "2"] => Fails,
+        }
+
+        "invalid integer element" {
+            vec!["42", "not_a_number", "0"] => Fails,
+        }
     );
 
     // Enum array -- trims; dense/sparse pass; wrong size fails; a bad option fails
@@ -711,48 +635,41 @@ fn test_vec_string_parsing_for_array_values() {
             size: 4,
         },
     );
-    check_cases(
-        [
-            Case {
-                scenario: "dense, trimmed",
-                input: vec!["input", " output ", "bidirectional", "input"],
-                expect: Yields(MlxValueType::EnumArray(vec![
-                    Some("input".to_string()),
-                    Some("output".to_string()),
-                    Some("bidirectional".to_string()),
-                    Some("input".to_string()),
-                ])),
-            },
-            Case {
-                scenario: "sparse via - and empty string",
-                input: vec!["input", "-", "output", ""],
-                expect: Yields(MlxValueType::EnumArray(vec![
-                    Some("input".to_string()),
-                    None,
-                    Some("output".to_string()),
-                    None,
-                ])),
-            },
-            Case {
-                scenario: "wrong size",
-                input: vec!["input", "output"],
-                expect: Fails,
-            },
-            Case {
-                scenario: "bad option pins position, value, and allowed set",
-                input: vec!["input", "invalid", "output", "input"],
-                expect: FailsWith(MlxValueError::InvalidEnumArrayOption {
-                    position: 1,
-                    value: "invalid".to_string(),
-                    allowed: vec![
-                        "input".to_string(),
-                        "output".to_string(),
-                        "bidirectional".to_string(),
-                    ],
-                }),
-            },
-        ],
-        |raw| parsed(&enum_array_var, raw),
+    scenarios!(
+        run = |raw| parsed(&enum_array_var, raw);
+        "dense, trimmed" {
+            vec!["input", " output ", "bidirectional", "input"] => Yields(MlxValueType::EnumArray(vec![
+                Some("input".to_string()),
+                Some("output".to_string()),
+                Some("bidirectional".to_string()),
+                Some("input".to_string()),
+            ])),
+        }
+
+        "sparse via - and empty string" {
+            vec!["input", "-", "output", ""] => Yields(MlxValueType::EnumArray(vec![
+                Some("input".to_string()),
+                None,
+                Some("output".to_string()),
+                None,
+            ])),
+        }
+
+        "wrong size" {
+            vec!["input", "output"] => Fails,
+        }
+
+        "bad option pins position, value, and allowed set" {
+            vec!["input", "invalid", "output", "input"] => FailsWith(MlxValueError::InvalidEnumArrayOption {
+                position: 1,
+                value: "invalid".to_string(),
+                allowed: vec![
+                    "input".to_string(),
+                    "output".to_string(),
+                    "bidirectional".to_string(),
+                ],
+            }),
+        }
     );
 
     // Binary array -- hex with or without an 0x/0X prefix, dense and sparse.
@@ -760,38 +677,31 @@ fn test_vec_string_parsing_for_array_values() {
         "test_binary_array",
         MlxVariableSpec::BinaryArray { size: 3 },
     );
-    check_cases(
-        [
-            Case {
-                scenario: "dense, mixed prefixes and whitespace",
-                input: vec!["0x1a2b", "3c4d", " 0X5E6F "],
-                expect: Yields(MlxValueType::BinaryArray(vec![
-                    Some(vec![0x1a, 0x2b]),
-                    Some(vec![0x3c, 0x4d]),
-                    Some(vec![0x5e, 0x6f]),
-                ])),
-            },
-            Case {
-                scenario: "sparse via -",
-                input: vec!["0x1a2b", "-", "3c4d"],
-                expect: Yields(MlxValueType::BinaryArray(vec![
-                    Some(vec![0x1a, 0x2b]),
-                    None,
-                    Some(vec![0x3c, 0x4d]),
-                ])),
-            },
-            Case {
-                scenario: "wrong size",
-                input: vec!["0x1a2b", "3c4d"],
-                expect: Fails,
-            },
-            Case {
-                scenario: "invalid hex element",
-                input: vec!["0x1a2b", "invalid", "3c4d"],
-                expect: Fails,
-            },
-        ],
-        |raw| parsed(&binary_array_var, raw),
+    scenarios!(
+        run = |raw| parsed(&binary_array_var, raw);
+        "dense, mixed prefixes and whitespace" {
+            vec!["0x1a2b", "3c4d", " 0X5E6F "] => Yields(MlxValueType::BinaryArray(vec![
+                Some(vec![0x1a, 0x2b]),
+                Some(vec![0x3c, 0x4d]),
+                Some(vec![0x5e, 0x6f]),
+            ])),
+        }
+
+        "sparse via -" {
+            vec!["0x1a2b", "-", "3c4d"] => Yields(MlxValueType::BinaryArray(vec![
+                Some(vec![0x1a, 0x2b]),
+                None,
+                Some(vec![0x3c, 0x4d]),
+            ])),
+        }
+
+        "wrong size" {
+            vec!["0x1a2b", "3c4d"] => Fails,
+        }
+
+        "invalid hex element" {
+            vec!["0x1a2b", "invalid", "3c4d"] => Fails,
+        }
     );
 
     // A multi-element vec can't satisfy a single-value spec.
@@ -944,83 +854,67 @@ fn test_mixed_dense_and_sparse_operations() {
 // loop into one table over `is_array_type`.
 #[test]
 fn is_array_type_flags_only_typed_arrays() {
-    check_values(
-        [
-            Check {
-                scenario: "boolean array",
-                input: MlxValueType::BooleanArray(vec![Some(true), None, Some(false)]),
-                expect: true,
-            },
-            Check {
-                scenario: "integer array",
-                input: MlxValueType::IntegerArray(vec![Some(42), None, Some(100)]),
-                expect: true,
-            },
-            Check {
-                scenario: "enum array",
-                input: MlxValueType::EnumArray(vec![
-                    Some("option1".to_string()),
-                    None,
-                    Some("option2".to_string()),
-                ]),
-                expect: true,
-            },
-            Check {
-                scenario: "binary array",
-                input: MlxValueType::BinaryArray(vec![
-                    Some(vec![0x01, 0x02]),
-                    None,
-                    Some(vec![0x03, 0x04]),
-                ]),
-                expect: true,
-            },
-            Check {
-                scenario: "boolean scalar",
-                input: MlxValueType::Boolean(true),
-                expect: false,
-            },
-            Check {
-                scenario: "integer scalar",
-                input: MlxValueType::Integer(42),
-                expect: false,
-            },
-            Check {
-                scenario: "string scalar",
-                input: MlxValueType::String("test".to_string()),
-                expect: false,
-            },
-            Check {
-                scenario: "enum scalar",
-                input: MlxValueType::Enum("option".to_string()),
-                expect: false,
-            },
-            Check {
-                scenario: "preset",
-                input: MlxValueType::Preset(5),
-                expect: false,
-            },
-            Check {
-                scenario: "binary scalar",
-                input: MlxValueType::Binary(vec![0x01, 0x02]),
-                expect: false,
-            },
-            Check {
-                scenario: "bytes",
-                input: MlxValueType::Bytes(vec![0x01, 0x02]),
-                expect: false,
-            },
-            Check {
-                scenario: "untyped string array",
-                input: MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]),
-                expect: false,
-            },
-            Check {
-                scenario: "opaque",
-                input: MlxValueType::Opaque(vec![0x01, 0x02]),
-                expect: false,
-            },
-        ],
-        |value| value.is_array_type(),
+    value_scenarios!(
+        run = |value| value.is_array_type();
+        "boolean array" {
+            MlxValueType::BooleanArray(vec![Some(true), None, Some(false)]) => true,
+        }
+
+        "integer array" {
+            MlxValueType::IntegerArray(vec![Some(42), None, Some(100)]) => true,
+        }
+
+        "enum array" {
+            MlxValueType::EnumArray(vec![
+                Some("option1".to_string()),
+                None,
+                Some("option2".to_string()),
+            ]) => true,
+        }
+
+        "binary array" {
+            MlxValueType::BinaryArray(vec![
+                Some(vec![0x01, 0x02]),
+                None,
+                Some(vec![0x03, 0x04]),
+            ]) => true,
+        }
+
+        "boolean scalar" {
+            MlxValueType::Boolean(true) => false,
+        }
+
+        "integer scalar" {
+            MlxValueType::Integer(42) => false,
+        }
+
+        "string scalar" {
+            MlxValueType::String("test".to_string()) => false,
+        }
+
+        "enum scalar" {
+            MlxValueType::Enum("option".to_string()) => false,
+        }
+
+        "preset" {
+            MlxValueType::Preset(5) => false,
+        }
+
+        "binary scalar" {
+            MlxValueType::Binary(vec![0x01, 0x02]) => false,
+        }
+
+        "bytes" {
+            MlxValueType::Bytes(vec![0x01, 0x02]) => false,
+        }
+
+        "untyped string array" {
+            MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]) => false,
+        }
+
+        "opaque" {
+            MlxValueType::Opaque(vec![0x01, 0x02]) => false,
+        }
     );
 }
 
@@ -1031,136 +925,114 @@ fn is_array_type_flags_only_typed_arrays() {
 // "is it ascending?" assertion is subsumed.
 #[test]
 fn get_set_indices_lists_set_positions_for_arrays_only() {
-    check_cases(
-        [
-            Case {
-                scenario: "boolean array, mixed set/unset",
-                input: MlxValueType::BooleanArray(vec![
-                    Some(true),
-                    None,
-                    Some(false),
-                    None,
-                    Some(true),
-                ]),
-                expect: Yields(vec![0, 2, 4]),
-            },
-            Case {
-                scenario: "integer array, leading gap",
-                input: MlxValueType::IntegerArray(vec![None, Some(42), Some(100), None]),
-                expect: Yields(vec![1, 2]),
-            },
-            Case {
-                scenario: "enum array, interior gap",
-                input: MlxValueType::EnumArray(vec![
-                    Some("option1".to_string()),
-                    Some("option2".to_string()),
-                    None,
-                    Some("option3".to_string()),
-                ]),
-                expect: Yields(vec![0, 1, 3]),
-            },
-            Case {
-                scenario: "binary array, interior gaps",
-                input: MlxValueType::BinaryArray(vec![
-                    Some(vec![0x01, 0x02]),
-                    None,
-                    None,
-                    Some(vec![0x03, 0x04]),
-                ]),
-                expect: Yields(vec![0, 3]),
-            },
-            Case {
-                scenario: "all unset",
-                input: MlxValueType::BooleanArray(vec![None, None, None]),
-                expect: Yields(vec![]),
-            },
-            Case {
-                scenario: "all set",
-                input: MlxValueType::IntegerArray(vec![Some(1), Some(2), Some(3), Some(4)]),
-                expect: Yields(vec![0, 1, 2, 3]),
-            },
-            Case {
-                scenario: "empty array",
-                input: MlxValueType::BooleanArray(vec![]),
-                expect: Yields(vec![]),
-            },
-            Case {
-                scenario: "single set element",
-                input: MlxValueType::EnumArray(vec![Some("only_option".to_string())]),
-                expect: Yields(vec![0]),
-            },
-            Case {
-                scenario: "realistic sparse host pattern",
-                input: MlxValueType::EnumArray(vec![
-                    Some("HOST_0".to_string()),
-                    None,
-                    None,
-                    Some("HOST_3".to_string()),
-                    None,
-                    None,
-                    Some("HOST_6".to_string()),
-                    None,
-                ]),
-                expect: Yields(vec![0, 3, 6]),
-            },
-            Case {
-                scenario: "indices stay in ascending order",
-                input: MlxValueType::IntegerArray(vec![
-                    None,
-                    Some(10),
-                    None,
-                    Some(30),
-                    None,
-                    Some(50),
-                ]),
-                expect: Yields(vec![1, 3, 5]),
-            },
-            Case {
-                scenario: "boolean scalar has no indices",
-                input: MlxValueType::Boolean(true),
-                expect: Fails,
-            },
-            Case {
-                scenario: "integer scalar has no indices",
-                input: MlxValueType::Integer(42),
-                expect: Fails,
-            },
-            Case {
-                scenario: "string scalar has no indices",
-                input: MlxValueType::String("test".to_string()),
-                expect: Fails,
-            },
-            Case {
-                scenario: "enum scalar has no indices",
-                input: MlxValueType::Enum("option".to_string()),
-                expect: Fails,
-            },
-            Case {
-                scenario: "preset has no indices",
-                input: MlxValueType::Preset(5),
-                expect: Fails,
-            },
-            Case {
-                scenario: "binary scalar has no indices",
-                input: MlxValueType::Binary(vec![0x01, 0x02]),
-                expect: Fails,
-            },
-            Case {
-                scenario: "bytes have no indices",
-                input: MlxValueType::Bytes(vec![0x01, 0x02]),
-                expect: Fails,
-            },
-            Case {
-                scenario: "untyped string array has no indices",
-                input: MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]),
-                expect: Fails,
-            },
-            Case {
-                scenario: "opaque has no indices",
-                input: MlxValueType::Opaque(vec![0x01, 0x02]),
-                expect: Fails,
-            },
-        ],
-        |value| value.get_set_indices().ok_or(()),
+    scenarios!(
+        run = |value| value.get_set_indices().ok_or(());
+        "boolean array, mixed set/unset" {
+            MlxValueType::BooleanArray(vec![
+                Some(true),
+                None,
+                Some(false),
+                None,
+                Some(true),
+            ]) => Yields(vec![0, 2, 4]),
+        }
+
+        "integer array, leading gap" {
+            MlxValueType::IntegerArray(vec![None, Some(42), Some(100), None]) => Yields(vec![1, 2]),
+        }
+
+        "enum array, interior gap" {
+            MlxValueType::EnumArray(vec![
+                Some("option1".to_string()),
+                Some("option2".to_string()),
+                None,
+                Some("option3".to_string()),
+            ]) => Yields(vec![0, 1, 3]),
+        }
+
+        "binary array, interior gaps" {
+            MlxValueType::BinaryArray(vec![
+                Some(vec![0x01, 0x02]),
+                None,
+                None,
+                Some(vec![0x03, 0x04]),
+            ]) => Yields(vec![0, 3]),
+        }
+
+        "all unset" {
+            MlxValueType::BooleanArray(vec![None, None, None]) => Yields(vec![]),
+        }
+
+        "all set" {
+            MlxValueType::IntegerArray(vec![Some(1), Some(2), Some(3), Some(4)]) => Yields(vec![0, 1, 2, 3]),
+        }
+
+        "empty array" {
+            MlxValueType::BooleanArray(vec![]) => Yields(vec![]),
+        }
+
+        "single set element" {
+            MlxValueType::EnumArray(vec![Some("only_option".to_string())]) => Yields(vec![0]),
+        }
+
+        "realistic sparse host pattern" {
+            MlxValueType::EnumArray(vec![
+                Some("HOST_0".to_string()),
+                None,
+                None,
+                Some("HOST_3".to_string()),
+                None,
+                None,
+                Some("HOST_6".to_string()),
+                None,
+            ]) => Yields(vec![0, 3, 6]),
+        }
+
+        "indices stay in ascending order" {
+            MlxValueType::IntegerArray(vec![
+                None,
+                Some(10),
+                None,
+                Some(30),
+                None,
+                Some(50),
+            ]) => Yields(vec![1, 3, 5]),
+        }
+
+        "boolean scalar has no indices" {
+            MlxValueType::Boolean(true) => Fails,
+        }
+
+        "integer scalar has no indices" {
+            MlxValueType::Integer(42) => Fails,
+        }
+
+        "string scalar has no indices" {
+            MlxValueType::String("test".to_string()) => Fails,
+        }
+
+        "enum scalar has no indices" {
+            MlxValueType::Enum("option".to_string()) => Fails,
+        }
+
+        "preset has no indices" {
+            MlxValueType::Preset(5) => Fails,
+        }
+
+        "binary scalar has no indices" {
+            MlxValueType::Binary(vec![0x01, 0x02]) => Fails,
+        }
+
+        "bytes have no indices" {
+            MlxValueType::Bytes(vec![0x01, 0x02]) => Fails,
+        }
+
+        "untyped string array has no indices" {
+            MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]) => Fails,
+        }
+
+        "opaque has no indices" {
+            MlxValueType::Opaque(vec![0x01, 0x02]) => Fails,
+        }
     );
 }


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-libmlx` tests have a lot of literal conversion and parsing examples now, which is exactly where table-driven coverage helps. The old `Case`/`Check` wrappers still left a fair amount of repeated scaffolding around those values.

This moves the straightforward libmlx tables onto `scenarios!`/`value_scenarios!`, keeping the same explicit inputs and expected outputs. Dynamic lockdown rows and other custom helpers stay on the existing shape where that is still clearer.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p carbide-libmlx`
- `cargo clippy -p carbide-libmlx -- -D warnings`
- `cargo clippy -p carbide-libmlx --tests -- -D warnings`