### PR TITLE
test(host-support): group hardware tables into scenarios

### DIFF
--- a/crates/host-support/src/agent_config.rs
+++ b/crates/host-support/src/agent_config.rs
@@ -464,7 +464,7 @@ mod tests {
     use std::fs;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -686,43 +686,32 @@ mod tests {
     // `is_default` predicates (total ops).
     #[test]
     fn config_is_default_predicates() {
-        check_values(
-            [
-                Check {
-                    scenario: "machine-identity default is default",
-                    input: MachineIdentityConfig::default(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "machine-identity with changed rps is not default",
-                    input: mid(7, 8, 2, 5, None, None),
-                    expect: false,
-                },
-                Check {
-                    scenario: "machine-identity with proxy url is not default",
-                    input: mid(3, 8, 2, 5, Some("https://x"), None),
-                    expect: false,
-                },
-            ],
-            |c| c.is_default(),
+        value_scenarios!(
+            run = |c| c.is_default();
+            "machine-identity default is default" {
+                MachineIdentityConfig::default() => true,
+            }
+
+            "machine-identity with changed rps is not default" {
+                mid(7, 8, 2, 5, None, None) => false,
+            }
+
+            "machine-identity with proxy url is not default" {
+                mid(3, 8, 2, 5, Some("https://x"), None) => false,
+            }
         );
 
-        check_values(
-            [
-                Check {
-                    scenario: "update default is default",
-                    input: UpdateConfig::default(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "update with override cmd is not default",
-                    input: UpdateConfig {
-                        override_upgrade_cmd: Some("update".to_string()),
-                    },
-                    expect: false,
-                },
-            ],
-            |c| c.is_default(),
+        value_scenarios!(
+            run = |c| c.is_default();
+            "update default is default" {
+                UpdateConfig::default() => true,
+            }
+
+            "update with override cmd is not default" {
+                UpdateConfig {
+                    override_upgrade_cmd: Some("update".to_string()),
+                } => false,
+            }
         );
     }
 
@@ -786,60 +775,47 @@ wait-timeout-secs = 4
 sign-timeout-secs = 9
 "#;
 
-        check_cases(
-            [
-                Case {
-                    scenario: "full config parses",
-                    input: FULL,
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "minimal config without optional service sections parses",
-                    input: MIN_NO_SERVICES,
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "machine-identity section parses",
-                    input: MID_SECTION,
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "completely empty config is rejected (a required field is missing)",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown top-level key is rejected (deny_unknown_fields)",
-                    input: "totally-unknown-key = 5\n",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "interface-id not a uuid fails",
-                    input: "[machine]\ninterface-id = \"not-a-uuid\"\n",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "machine-identity rps wrong type fails",
-                    input: "[machine-identity]\nrequests-per-second = \"seven\"\n",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "rps that overflows u8 fails",
-                    input: "[machine-identity]\nrequests-per-second = 999\n",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "syntactically invalid toml fails",
-                    input: "this is not = = toml",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "fmds addresses with bad cidr fails",
-                    input: "[fmds-armos-networking.config]\naddresses = [\"not-a-cidr\"]\n",
-                    expect: Fails,
-                },
-            ],
-            |raw| toml::from_str::<AgentConfig>(raw).map(drop).map_err(drop),
+        scenarios!(
+            run = |raw| toml::from_str::<AgentConfig>(raw).map(drop).map_err(drop);
+            "full config parses" {
+                FULL => Yields(()),
+            }
+
+            "minimal config without optional service sections parses" {
+                MIN_NO_SERVICES => Yields(()),
+            }
+
+            "machine-identity section parses" {
+                MID_SECTION => Yields(()),
+            }
+
+            "completely empty config is rejected (a required field is missing)" {
+                "" => Fails,
+            }
+
+            "unknown top-level key is rejected (deny_unknown_fields)" {
+                "totally-unknown-key = 5\n" => Fails,
+            }
+
+            "interface-id not a uuid fails" {
+                "[machine]\ninterface-id = \"not-a-uuid\"\n" => Fails,
+            }
+
+            "machine-identity rps wrong type fails" {
+                "[machine-identity]\nrequests-per-second = \"seven\"\n" => Fails,
+            }
+
+            "rps that overflows u8 fails" {
+                "[machine-identity]\nrequests-per-second = 999\n" => Fails,
+            }
+
+            "syntactically invalid toml fails" {
+                "this is not = = toml" => Fails,
+            }
+
+            "fmds addresses with bad cidr fails" {
+                "[fmds-armos-networking.config]\naddresses = [\"not-a-cidr\"]\n" => Fails,
+            }
         );
     }
 
@@ -883,50 +859,39 @@ addresses = ["168.254.169.254/30"]
         let c: AgentConfig = toml::from_str(FULL).unwrap();
         let expected_id = uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200");
 
-        check_values(
-            [
-                Check {
-                    scenario: "api-server",
-                    input: c.forge_system.api_server == "https://127.0.0.1:1234",
-                    expect: true,
-                },
-                Check {
-                    scenario: "interface-id",
-                    input: c.machine.interface_id == Some(expected_id),
-                    expect: true,
-                },
-                Check {
-                    scenario: "is-fake-dpu",
-                    input: c.machine.is_fake_dpu,
-                    expect: true,
-                },
-                Check {
-                    scenario: "metadata-service address",
-                    input: c.metadata_service.address == "0.0.0.0:7777",
-                    expect: true,
-                },
-                Check {
-                    scenario: "telemetry metrics-address",
-                    input: c.telemetry.metrics_address == "0.0.0.0:8888",
-                    expect: true,
-                },
-                Check {
-                    scenario: "hbn root-dir",
-                    input: c.hbn.root_dir == Path::new("/tmp/hbn-root"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "hbn skip-reload",
-                    input: c.hbn.skip_reload,
-                    expect: true,
-                },
-                Check {
-                    scenario: "updates override-upgrade-cmd",
-                    input: c.updates.override_upgrade_cmd == Some("update".to_string()),
-                    expect: true,
-                },
-            ],
-            |b| b,
+        value_scenarios!(
+            run = |b| b;
+            "api-server" {
+                c.forge_system.api_server == "https://127.0.0.1:1234" => true,
+            }
+
+            "interface-id" {
+                c.machine.interface_id == Some(expected_id) => true,
+            }
+
+            "is-fake-dpu" {
+                c.machine.is_fake_dpu => true,
+            }
+
+            "metadata-service address" {
+                c.metadata_service.address == "0.0.0.0:7777" => true,
+            }
+
+            "telemetry metrics-address" {
+                c.telemetry.metrics_address == "0.0.0.0:8888" => true,
+            }
+
+            "hbn root-dir" {
+                c.hbn.root_dir == Path::new("/tmp/hbn-root") => true,
+            }
+
+            "hbn skip-reload" {
+                c.hbn.skip_reload => true,
+            }
+
+            "updates override-upgrade-cmd" {
+                c.updates.override_upgrade_cmd == Some("update".to_string()) => true,
+            }
         );
     }
 
@@ -950,40 +915,31 @@ sign-timeout-secs = 9
         let c: AgentConfig = toml::from_str(MID_SECTION).unwrap();
         let m = &c.machine_identity;
 
-        check_values(
-            [
-                Check {
-                    scenario: "requests-per-second",
-                    input: m.requests_per_second == 7,
-                    expect: true,
-                },
-                Check {
-                    scenario: "burst",
-                    input: m.burst == 12,
-                    expect: true,
-                },
-                Check {
-                    scenario: "wait-timeout-secs",
-                    input: m.wait_timeout_secs == 4,
-                    expect: true,
-                },
-                Check {
-                    scenario: "sign-timeout-secs",
-                    input: m.sign_timeout_secs == 9,
-                    expect: true,
-                },
-                Check {
-                    scenario: "sign-proxy-url unset",
-                    input: m.sign_proxy_url.is_none(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "sign-proxy-tls-root-ca unset",
-                    input: m.sign_proxy_tls_root_ca.is_none(),
-                    expect: true,
-                },
-            ],
-            |b| b,
+        value_scenarios!(
+            run = |b| b;
+            "requests-per-second" {
+                m.requests_per_second == 7 => true,
+            }
+
+            "burst" {
+                m.burst == 12 => true,
+            }
+
+            "wait-timeout-secs" {
+                m.wait_timeout_secs == 4 => true,
+            }
+
+            "sign-timeout-secs" {
+                m.sign_timeout_secs == 9 => true,
+            }
+
+            "sign-proxy-url unset" {
+                m.sign_proxy_url.is_none() => true,
+            }
+
+            "sign-proxy-tls-root-ca unset" {
+                m.sign_proxy_tls_root_ca.is_none() => true,
+            }
         );
 
         // The parsed section validates.
@@ -1004,128 +960,101 @@ interface-id = \"91609f10-c91d-470d-a260-6293ea0c1200\"
         let c: AgentConfig = toml::from_str(MIN_NO_SERVICES).unwrap();
         let expected_id = uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200");
 
-        check_values(
-            [
-                Check {
-                    scenario: "api-server preserved",
-                    input: c.forge_system.api_server == "https://127.0.0.1:1234",
-                    expect: true,
-                },
-                Check {
-                    scenario: "interface-id preserved",
-                    input: c.machine.interface_id == Some(expected_id),
-                    expect: true,
-                },
-                Check {
-                    scenario: "is-fake-dpu defaults false",
-                    input: c.machine.is_fake_dpu,
-                    expect: false,
-                },
-                Check {
-                    scenario: "metadata-service defaults",
-                    input: c.metadata_service == MetadataServiceConfig::default(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "telemetry defaults",
-                    input: c.telemetry == TelemetryConfig::default(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "machine-identity defaults",
-                    input: c.machine_identity == MachineIdentityConfig::default(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "hbn root-dir defaults",
-                    input: c.hbn.root_dir == Path::new(HBN_DEFAULT_ROOT),
-                    expect: true,
-                },
-                Check {
-                    scenario: "hbn skip-reload defaults false",
-                    input: c.hbn.skip_reload,
-                    expect: false,
-                },
-                Check {
-                    scenario: "updates override-upgrade-cmd defaults unset",
-                    input: c.updates.override_upgrade_cmd.is_none(),
-                    expect: true,
-                },
-            ],
-            |b| b,
+        value_scenarios!(
+            run = |b| b;
+            "api-server preserved" {
+                c.forge_system.api_server == "https://127.0.0.1:1234" => true,
+            }
+
+            "interface-id preserved" {
+                c.machine.interface_id == Some(expected_id) => true,
+            }
+
+            "is-fake-dpu defaults false" {
+                c.machine.is_fake_dpu => false,
+            }
+
+            "metadata-service defaults" {
+                c.metadata_service == MetadataServiceConfig::default() => true,
+            }
+
+            "telemetry defaults" {
+                c.telemetry == TelemetryConfig::default() => true,
+            }
+
+            "machine-identity defaults" {
+                c.machine_identity == MachineIdentityConfig::default() => true,
+            }
+
+            "hbn root-dir defaults" {
+                c.hbn.root_dir == Path::new(HBN_DEFAULT_ROOT) => true,
+            }
+
+            "hbn skip-reload defaults false" {
+                c.hbn.skip_reload => false,
+            }
+
+            "updates override-upgrade-cmd defaults unset" {
+                c.updates.override_upgrade_cmd.is_none() => true,
+            }
         );
     }
 
     // Default constructors expose the documented default values.
     #[test]
     fn config_defaults() {
-        check_values(
-            [
-                Check {
-                    scenario: "forge-system api-server",
-                    input: ForgeSystemConfig::default().api_server == DEFAULT_API_SERVER,
-                    expect: true,
-                },
-                Check {
-                    scenario: "metadata-service address",
-                    input: MetadataServiceConfig::default().address
-                        == INSTANCE_METADATA_SERVICE_ADDRESS,
-                    expect: true,
-                },
-                Check {
-                    scenario: "telemetry metrics-address",
-                    input: TelemetryConfig::default().metrics_address
-                        == TELEMETRY_METRICS_SERVICE_ADDRESS,
-                    expect: true,
-                },
-                Check {
-                    scenario: "hbn root-dir",
-                    input: HBNConfig::default().root_dir == Path::new(HBN_DEFAULT_ROOT),
-                    expect: true,
-                },
-                Check {
-                    scenario: "hbn skip-reload",
-                    input: HBNConfig::default().skip_reload,
-                    expect: false,
-                },
-                Check {
-                    scenario: "machine-identity requests-per-second",
-                    input: MachineIdentityConfig::default().requests_per_second
-                        == REQUESTS_PER_SECOND,
-                    expect: true,
-                },
-                Check {
-                    scenario: "machine-identity burst",
-                    input: MachineIdentityConfig::default().burst == BURST,
-                    expect: true,
-                },
-                Check {
-                    scenario: "machine-identity wait-timeout-secs",
-                    input: MachineIdentityConfig::default().wait_timeout_secs == WAIT_TIMEOUT_SECS,
-                    expect: true,
-                },
-                Check {
-                    scenario: "machine-identity sign-timeout-secs",
-                    input: MachineIdentityConfig::default().sign_timeout_secs == SIGN_TIMEOUT_SECS,
-                    expect: true,
-                },
-                Check {
-                    scenario: "iteration-time inventory-update-secs",
-                    input: IterationTime::default().inventory_update_secs == 3600,
-                    expect: true,
-                },
-                Check {
-                    scenario: "iteration-time discovery-retry-secs",
-                    input: IterationTime::default().discovery_retry_secs == 60,
-                    expect: true,
-                },
-                Check {
-                    scenario: "iteration-time discovery-retries-max",
-                    input: IterationTime::default().discovery_retries_max == 10080,
-                    expect: true,
-                },
-            ],
-            |b| b,
+        value_scenarios!(
+            run = |b| b;
+            "forge-system api-server" {
+                ForgeSystemConfig::default().api_server == DEFAULT_API_SERVER => true,
+            }
+
+            "metadata-service address" {
+                MetadataServiceConfig::default().address
+                == INSTANCE_METADATA_SERVICE_ADDRESS => true,
+            }
+
+            "telemetry metrics-address" {
+                TelemetryConfig::default().metrics_address
+                == TELEMETRY_METRICS_SERVICE_ADDRESS => true,
+            }
+
+            "hbn root-dir" {
+                HBNConfig::default().root_dir == Path::new(HBN_DEFAULT_ROOT) => true,
+            }
+
+            "hbn skip-reload" {
+                HBNConfig::default().skip_reload => false,
+            }
+
+            "machine-identity requests-per-second" {
+                MachineIdentityConfig::default().requests_per_second
+                == REQUESTS_PER_SECOND => true,
+            }
+
+            "machine-identity burst" {
+                MachineIdentityConfig::default().burst == BURST => true,
+            }
+
+            "machine-identity wait-timeout-secs" {
+                MachineIdentityConfig::default().wait_timeout_secs == WAIT_TIMEOUT_SECS => true,
+            }
+
+            "machine-identity sign-timeout-secs" {
+                MachineIdentityConfig::default().sign_timeout_secs == SIGN_TIMEOUT_SECS => true,
+            }
+
+            "iteration-time inventory-update-secs" {
+                IterationTime::default().inventory_update_secs == 3600 => true,
+            }
+
+            "iteration-time discovery-retry-secs" {
+                IterationTime::default().discovery_retry_secs == 60 => true,
+            }
+
+            "iteration-time discovery-retries-max" {
+                IterationTime::default().discovery_retries_max == 10080 => true,
+            }
         );
     }
 

--- a/crates/host-support/src/dpa_cmds.rs
+++ b/crates/host-support/src/dpa_cmds.rs
@@ -155,7 +155,7 @@ mod tests {
     use std::collections::HashMap;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
     use rpc::protos::mlx_device::{
         FirmwareFlasherProfile as FirmwareProfilePb, FirmwareSpec as FirmwareSpecPb,
         FlashSpec as FlashSpecPb, SerializableMlxConfigProfile as SerializableProfilePb,
@@ -230,89 +230,75 @@ mod tests {
     // -- TryFrom<Command> for DpaCommand: every oneof arm + every profile sub-path.
     #[test]
     fn command_pb_converts_to_dpa_command() {
-        check_cases(
-            [
-                Case {
-                    scenario: "noop",
-                    input: Command::Noop(fac::MlxDeviceNoop {}),
-                    expect: Yields("noop".to_string()),
-                },
-                Case {
-                    scenario: "lock carries its key",
-                    input: Command::Lock(fac::MlxDeviceLock {
-                        key: "secret".to_string(),
+        scenarios!(
+            run = |cmd: Command| DpaCommand::try_from(cmd).map(|c| op_tag(&c.op));
+            "noop" {
+                Command::Noop(fac::MlxDeviceNoop {}) => Yields("noop".to_string()),
+            }
+
+            "lock carries its key" {
+                Command::Lock(fac::MlxDeviceLock {
+                    key: "secret".to_string(),
+                }) => Yields("lock:secret".to_string()),
+            }
+
+            "lock with empty key" {
+                Command::Lock(fac::MlxDeviceLock { key: String::new() }) => Yields("lock:".to_string()),
+            }
+
+            "unlock carries its key" {
+                Command::Unlock(fac::MlxDeviceUnlock {
+                    key: "secret".to_string(),
+                }) => Yields("unlock:secret".to_string()),
+            }
+
+            "apply_profile with no profile stays None" {
+                Command::ApplyProfile(fac::MlxDeviceApplyProfile {
+                    serialized_profile: None,
+                }) => Yields("apply_profile:false".to_string()),
+            }
+
+            "apply_profile with a valid profile" {
+                Command::ApplyProfile(fac::MlxDeviceApplyProfile {
+                    serialized_profile: Some(valid_serializable_pb()),
+                }) => Yields("apply_profile:true".to_string()),
+            }
+
+            "apply_profile rejects unparseable config" {
+                Command::ApplyProfile(fac::MlxDeviceApplyProfile {
+                    serialized_profile: Some(invalid_serializable_pb()),
+                }) => Fails,
+            }
+
+            "apply_firmware with no profile stays None" {
+                Command::ApplyFirmware(fac::MlxDeviceApplyFirmware { profile: None }) => Yields("apply_firmware:false".to_string()),
+            }
+
+            "apply_firmware with a complete profile" {
+                Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                    profile: Some(valid_firmware_pb()),
+                }) => Yields("apply_firmware:true".to_string()),
+            }
+
+            "apply_firmware rejects a missing firmware_spec" {
+                Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                    profile: Some(FirmwareProfilePb {
+                        firmware_spec: None,
+                        flash_spec: Some(FlashSpecPb::default()),
+                        flash_options: None,
                     }),
-                    expect: Yields("lock:secret".to_string()),
-                },
-                Case {
-                    scenario: "lock with empty key",
-                    input: Command::Lock(fac::MlxDeviceLock { key: String::new() }),
-                    expect: Yields("lock:".to_string()),
-                },
-                Case {
-                    scenario: "unlock carries its key",
-                    input: Command::Unlock(fac::MlxDeviceUnlock {
-                        key: "secret".to_string(),
+                }) => FailsWith("missing firmware_spec".to_string()),
+            }
+
+            "apply_firmware rejects a missing flash_spec" {
+                Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                    profile: Some(FirmwareProfilePb {
+                        firmware_spec: Some(FirmwareSpecPb::default()),
+                        flash_spec: None,
+                        flash_options: None,
                     }),
-                    expect: Yields("unlock:secret".to_string()),
-                },
-                Case {
-                    scenario: "apply_profile with no profile stays None",
-                    input: Command::ApplyProfile(fac::MlxDeviceApplyProfile {
-                        serialized_profile: None,
-                    }),
-                    expect: Yields("apply_profile:false".to_string()),
-                },
-                Case {
-                    scenario: "apply_profile with a valid profile",
-                    input: Command::ApplyProfile(fac::MlxDeviceApplyProfile {
-                        serialized_profile: Some(valid_serializable_pb()),
-                    }),
-                    expect: Yields("apply_profile:true".to_string()),
-                },
-                Case {
-                    scenario: "apply_profile rejects unparseable config",
-                    input: Command::ApplyProfile(fac::MlxDeviceApplyProfile {
-                        serialized_profile: Some(invalid_serializable_pb()),
-                    }),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "apply_firmware with no profile stays None",
-                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware { profile: None }),
-                    expect: Yields("apply_firmware:false".to_string()),
-                },
-                Case {
-                    scenario: "apply_firmware with a complete profile",
-                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
-                        profile: Some(valid_firmware_pb()),
-                    }),
-                    expect: Yields("apply_firmware:true".to_string()),
-                },
-                Case {
-                    scenario: "apply_firmware rejects a missing firmware_spec",
-                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
-                        profile: Some(FirmwareProfilePb {
-                            firmware_spec: None,
-                            flash_spec: Some(FlashSpecPb::default()),
-                            flash_options: None,
-                        }),
-                    }),
-                    expect: FailsWith("missing firmware_spec".to_string()),
-                },
-                Case {
-                    scenario: "apply_firmware rejects a missing flash_spec",
-                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
-                        profile: Some(FirmwareProfilePb {
-                            firmware_spec: Some(FirmwareSpecPb::default()),
-                            flash_spec: None,
-                            flash_options: None,
-                        }),
-                    }),
-                    expect: FailsWith("missing flash_spec".to_string()),
-                },
-            ],
-            |cmd: Command| DpaCommand::try_from(cmd).map(|c| op_tag(&c.op)),
+                }) => FailsWith("missing flash_spec".to_string()),
+            }
         );
     }
 
@@ -320,64 +306,54 @@ mod tests {
     // pci_name is threaded through untouched, so each row also pins it.
     #[test]
     fn dpa_device_command_converts_to_rpc_action() {
-        check_cases(
-            [
-                Case {
-                    scenario: "noop",
-                    input: OpCode::Noop,
-                    expect: Yields(("04:00.0".to_string(), "noop".to_string())),
-                },
-                Case {
-                    scenario: "lock carries its key",
-                    input: OpCode::Lock {
-                        key: "secret".to_string(),
-                    },
-                    expect: Yields(("04:00.0".to_string(), "lock:secret".to_string())),
-                },
-                Case {
-                    scenario: "unlock carries its key",
-                    input: OpCode::Unlock {
-                        key: "secret".to_string(),
-                    },
-                    expect: Yields(("04:00.0".to_string(), "unlock:secret".to_string())),
-                },
-                Case {
-                    scenario: "apply_profile with no profile stays None",
-                    input: OpCode::ApplyProfile {
-                        serialized_profile: None,
-                    },
-                    expect: Yields(("04:00.0".to_string(), "apply_profile:false".to_string())),
-                },
-                Case {
-                    scenario: "apply_profile with a valid profile",
-                    input: OpCode::ApplyProfile {
-                        serialized_profile: Some(valid_serializable_pb().try_into().unwrap()),
-                    },
-                    expect: Yields(("04:00.0".to_string(), "apply_profile:true".to_string())),
-                },
-                Case {
-                    scenario: "apply_firmware with no profile stays None",
-                    input: OpCode::ApplyFirmware { profile: None },
-                    expect: Yields(("04:00.0".to_string(), "apply_firmware:false".to_string())),
-                },
-                Case {
-                    scenario: "apply_firmware with a profile",
-                    input: OpCode::ApplyFirmware {
-                        profile: Some(Box::new(Cow::Owned(
-                            valid_firmware_pb().try_into().unwrap(),
-                        ))),
-                    },
-                    expect: Yields(("04:00.0".to_string(), "apply_firmware:true".to_string())),
-                },
-            ],
-            |op: OpCode<'_>| {
+        scenarios!(
+            run = |op: OpCode<'_>| {
                 let action: fac::MlxDeviceAction = DpaDeviceCommand {
                     pci_name: "04:00.0".to_string(),
                     command: DpaCommand { op },
                 }
                 .try_into()?;
                 Ok::<_, String>((action.pci_name, action_tag(&action.command)))
-            },
+            };
+            "noop" {
+                OpCode::Noop => Yields(("04:00.0".to_string(), "noop".to_string())),
+            }
+
+            "lock carries its key" {
+                OpCode::Lock {
+                    key: "secret".to_string(),
+                } => Yields(("04:00.0".to_string(), "lock:secret".to_string())),
+            }
+
+            "unlock carries its key" {
+                OpCode::Unlock {
+                    key: "secret".to_string(),
+                } => Yields(("04:00.0".to_string(), "unlock:secret".to_string())),
+            }
+
+            "apply_profile with no profile stays None" {
+                OpCode::ApplyProfile {
+                    serialized_profile: None,
+                } => Yields(("04:00.0".to_string(), "apply_profile:false".to_string())),
+            }
+
+            "apply_profile with a valid profile" {
+                OpCode::ApplyProfile {
+                    serialized_profile: Some(valid_serializable_pb().try_into().unwrap()),
+                } => Yields(("04:00.0".to_string(), "apply_profile:true".to_string())),
+            }
+
+            "apply_firmware with no profile stays None" {
+                OpCode::ApplyFirmware { profile: None } => Yields(("04:00.0".to_string(), "apply_firmware:false".to_string())),
+            }
+
+            "apply_firmware with a profile" {
+                OpCode::ApplyFirmware {
+                    profile: Some(Box::new(Cow::Owned(
+                        valid_firmware_pb().try_into().unwrap(),
+                    ))),
+                } => Yields(("04:00.0".to_string(), "apply_firmware:true".to_string())),
+            }
         );
     }
 
@@ -386,86 +362,73 @@ mod tests {
     #[test]
     fn rpc_action_converts_to_dpa_command() {
         use fac::mlx_device_action::Command as C;
-        check_cases(
-            [
-                Case {
-                    scenario: "absent command is treated as noop",
-                    input: None,
-                    expect: Yields("noop".to_string()),
-                },
-                Case {
-                    scenario: "noop",
-                    input: Some(C::Noop(fac::MlxDeviceNoop {})),
-                    expect: Yields("noop".to_string()),
-                },
-                Case {
-                    scenario: "lock carries its key",
-                    input: Some(C::Lock(fac::MlxDeviceLock {
-                        key: "secret".to_string(),
-                    })),
-                    expect: Yields("lock:secret".to_string()),
-                },
-                Case {
-                    scenario: "unlock carries its key",
-                    input: Some(C::Unlock(fac::MlxDeviceUnlock {
-                        key: "secret".to_string(),
-                    })),
-                    expect: Yields("unlock:secret".to_string()),
-                },
-                Case {
-                    scenario: "apply_profile with no profile stays None",
-                    input: Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
-                        serialized_profile: None,
-                    })),
-                    expect: Yields("apply_profile:false".to_string()),
-                },
-                Case {
-                    scenario: "apply_profile with a valid profile",
-                    input: Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
-                        serialized_profile: Some(valid_serializable_pb()),
-                    })),
-                    expect: Yields("apply_profile:true".to_string()),
-                },
-                Case {
-                    scenario: "apply_profile rejects unparseable config",
-                    input: Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
-                        serialized_profile: Some(invalid_serializable_pb()),
-                    })),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "apply_firmware with no profile stays None",
-                    input: Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
-                        profile: None,
-                    })),
-                    expect: Yields("apply_firmware:false".to_string()),
-                },
-                Case {
-                    scenario: "apply_firmware with a complete profile",
-                    input: Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
-                        profile: Some(valid_firmware_pb()),
-                    })),
-                    expect: Yields("apply_firmware:true".to_string()),
-                },
-                Case {
-                    scenario: "apply_firmware rejects a missing firmware_spec",
-                    input: Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
-                        profile: Some(FirmwareProfilePb {
-                            firmware_spec: None,
-                            flash_spec: Some(FlashSpecPb::default()),
-                            flash_options: None,
-                        }),
-                    })),
-                    expect: FailsWith("missing firmware_spec".to_string()),
-                },
-            ],
-            |command: Option<fac::mlx_device_action::Command>| {
+        scenarios!(
+            run = |command: Option<fac::mlx_device_action::Command>| {
                 let action = fac::MlxDeviceAction {
                     pci_name: "04:00.0".to_string(),
                     command,
                 };
                 DpaCommand::try_from(&action).map(|c| op_tag(&c.op))
-            },
+            };
+            "absent command is treated as noop" {
+                None => Yields("noop".to_string()),
+            }
+
+            "noop" {
+                Some(C::Noop(fac::MlxDeviceNoop {})) => Yields("noop".to_string()),
+            }
+
+            "lock carries its key" {
+                Some(C::Lock(fac::MlxDeviceLock {
+                    key: "secret".to_string(),
+                })) => Yields("lock:secret".to_string()),
+            }
+
+            "unlock carries its key" {
+                Some(C::Unlock(fac::MlxDeviceUnlock {
+                    key: "secret".to_string(),
+                })) => Yields("unlock:secret".to_string()),
+            }
+
+            "apply_profile with no profile stays None" {
+                Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
+                    serialized_profile: None,
+                })) => Yields("apply_profile:false".to_string()),
+            }
+
+            "apply_profile with a valid profile" {
+                Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
+                    serialized_profile: Some(valid_serializable_pb()),
+                })) => Yields("apply_profile:true".to_string()),
+            }
+
+            "apply_profile rejects unparseable config" {
+                Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
+                    serialized_profile: Some(invalid_serializable_pb()),
+                })) => Fails,
+            }
+
+            "apply_firmware with no profile stays None" {
+                Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                    profile: None,
+                })) => Yields("apply_firmware:false".to_string()),
+            }
+
+            "apply_firmware with a complete profile" {
+                Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                    profile: Some(valid_firmware_pb()),
+                })) => Yields("apply_firmware:true".to_string()),
+            }
+
+            "apply_firmware rejects a missing firmware_spec" {
+                Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                    profile: Some(FirmwareProfilePb {
+                        firmware_spec: None,
+                        flash_spec: Some(FlashSpecPb::default()),
+                        flash_options: None,
+                    }),
+                })) => FailsWith("missing firmware_spec".to_string()),
+            }
         );
     }
 }

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -996,7 +996,9 @@ fn parse_memtotal_kb(meminfo: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{
+        Case, Check, check_cases, check_values, scenarios, value_scenarios,
+    };
     use tempfile::NamedTempFile;
 
     use super::*;
@@ -1120,26 +1122,20 @@ mod tests {
     // daemonset contract; pin each constant exactly.
     #[test]
     fn init_container_path_constants() {
-        check_values(
-            [
-                Check {
-                    scenario: "init cpu info path",
-                    input: INIT_CPU_INFO_PATH,
-                    expect: "/host-cpu-info",
-                },
-                Check {
-                    scenario: "init mem info path",
-                    input: INIT_MEM_INFO_PATH,
-                    expect: "/host-mem-info",
-                },
-                Check {
-                    scenario: "hw cache path",
-                    input: HW_CACHE_PATH,
-                    expect: "/data/hw_output.json",
-                },
-            ],
+        value_scenarios!(
             // identity: the constant under test is handed in as the input
-            |c| c,
+            run = |c| c;
+            "init cpu info path" {
+                INIT_CPU_INFO_PATH => "/host-cpu-info",
+            }
+
+            "init mem info path" {
+                INIT_MEM_INFO_PATH => "/host-mem-info",
+            }
+
+            "hw cache path" {
+                HW_CACHE_PATH => "/data/hw_output.json",
+            }
         );
     }
 
@@ -1197,50 +1193,39 @@ mod tests {
     // or overflow.
     #[test]
     fn can_parse_int_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "plain decimal",
-                    input: "42",
-                    expect: true,
-                },
-                Check {
-                    scenario: "negative decimal",
-                    input: "-7",
-                    expect: true,
-                },
-                Check {
-                    scenario: "hex value",
-                    input: "0x10de",
-                    expect: true,
-                },
-                Check {
-                    scenario: "hex with no digits after prefix",
-                    input: "0x",
-                    expect: false,
-                },
-                Check {
-                    scenario: "non-numeric text",
-                    input: "GenuineIntel",
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty string",
-                    input: "",
-                    expect: false,
-                },
-                Check {
-                    scenario: "decimal overflows i32",
-                    input: "9999999999",
-                    expect: false,
-                },
-                Check {
-                    scenario: "bad hex digit",
-                    input: "0xZZ",
-                    expect: false,
-                },
-            ],
-            can_parse_int,
+        value_scenarios!(
+            run = can_parse_int;
+            "plain decimal" {
+                "42" => true,
+            }
+
+            "negative decimal" {
+                "-7" => true,
+            }
+
+            "hex value" {
+                "0x10de" => true,
+            }
+
+            "hex with no digits after prefix" {
+                "0x" => false,
+            }
+
+            "non-numeric text" {
+                "GenuineIntel" => false,
+            }
+
+            "empty string" {
+                "" => false,
+            }
+
+            "decimal overflows i32" {
+                "9999999999" => false,
+            }
+
+            "bad hex digit" {
+                "0xZZ" => false,
+            }
         );
     }
 
@@ -1248,35 +1233,8 @@ mod tests {
     // start 0xa2xx or 0xc2xx; everything else is not a DPU.
     #[test]
     fn is_dpu_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "0xa2 prefix is dpu",
-                    input: "0xa2d6",
-                    expect: true,
-                },
-                Check {
-                    scenario: "0xc2 prefix is dpu",
-                    input: "0xc2d2",
-                    expect: true,
-                },
-                Check {
-                    scenario: "other mellanox id not dpu",
-                    input: "0x1021",
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty id not dpu",
-                    input: "",
-                    expect: false,
-                },
-                Check {
-                    scenario: "0xa not enough to match",
-                    input: "0xa1ff",
-                    expect: false,
-                },
-            ],
-            |id| {
+        value_scenarios!(
+            run = |id| {
                 props_ext(
                     id,
                     "Mellanox Technologies",
@@ -1284,7 +1242,26 @@ mod tests {
                     "Ethernet controller",
                 )
                 .is_dpu()
-            },
+            };
+            "0xa2 prefix is dpu" {
+                "0xa2d6" => true,
+            }
+
+            "0xc2 prefix is dpu" {
+                "0xc2d2" => true,
+            }
+
+            "other mellanox id not dpu" {
+                "0x1021" => false,
+            }
+
+            "empty id not dpu" {
+                "" => false,
+            }
+
+            "0xa not enough to match" {
+                "0xa1ff" => false,
+            }
         );
     }
 
@@ -1293,80 +1270,70 @@ mod tests {
     // "Infiniband controller" (case-insensitive). Any other combination false.
     #[test]
     fn mlnx_ib_capable_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "mellanox + slot + infiniband subclass",
-                    input: props_ext(
-                        "0xa2d6",
-                        "Mellanox Technologies",
-                        Some("0000:08:00.0"),
-                        "Infiniband controller",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "vendor case-insensitive match",
-                    input: props_ext(
-                        "0xa2d6",
-                        "mellanox technologies",
-                        Some("0000:08:00.0"),
-                        "Infiniband controller",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "subclass case-insensitive match",
-                    input: props_ext(
-                        "0xa2d6",
-                        "Mellanox Technologies",
-                        Some("0000:08:00.0"),
-                        "infiniband controller",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "ethernet subclass -> false",
-                    input: props_ext(
-                        "0xa2d6",
-                        "Mellanox Technologies",
-                        Some("0000:08:00.0"),
-                        "Ethernet controller",
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "non-mellanox vendor -> false",
-                    input: props_ext(
-                        "0xa2d6",
-                        "Intel Corporation",
-                        Some("0000:08:00.0"),
-                        "Infiniband controller",
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "slot None -> false",
-                    input: props_ext(
-                        "0xa2d6",
-                        "Mellanox Technologies",
-                        None,
-                        "Infiniband controller",
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty slot -> false",
-                    input: props_ext(
-                        "0xa2d6",
-                        "Mellanox Technologies",
-                        Some(""),
-                        "Infiniband controller",
-                    ),
-                    expect: false,
-                },
-            ],
-            |p| p.mlnx_ib_capable(),
+        value_scenarios!(
+            run = |p| p.mlnx_ib_capable();
+            "mellanox + slot + infiniband subclass" {
+                props_ext(
+                    "0xa2d6",
+                    "Mellanox Technologies",
+                    Some("0000:08:00.0"),
+                    "Infiniband controller",
+                ) => true,
+            }
+
+            "vendor case-insensitive match" {
+                props_ext(
+                    "0xa2d6",
+                    "mellanox technologies",
+                    Some("0000:08:00.0"),
+                    "Infiniband controller",
+                ) => true,
+            }
+
+            "subclass case-insensitive match" {
+                props_ext(
+                    "0xa2d6",
+                    "Mellanox Technologies",
+                    Some("0000:08:00.0"),
+                    "infiniband controller",
+                ) => true,
+            }
+
+            "ethernet subclass -> false" {
+                props_ext(
+                    "0xa2d6",
+                    "Mellanox Technologies",
+                    Some("0000:08:00.0"),
+                    "Ethernet controller",
+                ) => false,
+            }
+
+            "non-mellanox vendor -> false" {
+                props_ext(
+                    "0xa2d6",
+                    "Intel Corporation",
+                    Some("0000:08:00.0"),
+                    "Infiniband controller",
+                ) => false,
+            }
+
+            "slot None -> false" {
+                props_ext(
+                    "0xa2d6",
+                    "Mellanox Technologies",
+                    None,
+                    "Infiniband controller",
+                ) => false,
+            }
+
+            "empty slot -> false" {
+                props_ext(
+                    "0xa2d6",
+                    "Mellanox Technologies",
+                    Some(""),
+                    "Infiniband controller",
+                ) => false,
+            }
         );
     }
 
@@ -1473,26 +1440,21 @@ mod tests {
     // Err, Some -> Ok(()). Error is not PartialEq so use Fails + Yields(()).
     #[test]
     fn validate_enumerated_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "missing dpu_info fails",
-                    input: rpc_discovery::DiscoveryInfo {
-                        dpu_info: None,
-                        ..Default::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "present dpu_info passes",
-                    input: rpc_discovery::DiscoveryInfo {
-                        dpu_info: Some(Default::default()),
-                        ..Default::default()
-                    },
-                    expect: Yields(()),
-                },
-            ],
-            |info| validate_enumerated(&info).map_err(drop),
+        scenarios!(
+            run = |info| validate_enumerated(&info).map_err(drop);
+            "missing dpu_info fails" {
+                rpc_discovery::DiscoveryInfo {
+                    dpu_info: None,
+                    ..Default::default()
+                } => Fails,
+            }
+
+            "present dpu_info passes" {
+                rpc_discovery::DiscoveryInfo {
+                    dpu_info: Some(Default::default()),
+                    ..Default::default()
+                } => Yields(()),
+            }
         );
     }
 }

--- a/crates/host-support/src/hardware_enumeration/dpu.rs
+++ b/crates/host-support/src/hardware_enumeration/dpu.rs
@@ -335,7 +335,7 @@ pub fn get_dpu_info() -> Result<DpuData, DpuEnumerationError> {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use crate::hardware_enumeration::dpu;
 
@@ -344,50 +344,39 @@ mod tests {
     // input -- valid versions, boundary `40`, and garbage -- must yield `false`.
     #[test]
     fn is_lldp_working_always_false() {
-        check_values(
-            [
-                Check {
-                    scenario: "below the 40 boundary",
-                    input: "xx.39.yyyy",
-                    expect: false,
-                },
-                Check {
-                    scenario: "at the 40 boundary",
-                    input: "xx.40.yyyy",
-                    expect: false,
-                },
-                Check {
-                    scenario: "above the 40 boundary",
-                    input: "xx.41.yyyy",
-                    expect: false,
-                },
-                Check {
-                    scenario: "non-numeric middle chunk",
-                    input: "xx.zz.yyyy",
-                    expect: false,
-                },
-                Check {
-                    scenario: "no dots at all",
-                    input: "junk",
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty string",
-                    input: "",
-                    expect: false,
-                },
-                Check {
-                    scenario: "well-formed high version",
-                    input: "22.99.1000",
-                    expect: false,
-                },
-                Check {
-                    scenario: "single leading dot",
-                    input: ".40.",
-                    expect: false,
-                },
-            ],
-            dpu::is_lldp_working,
+        value_scenarios!(
+            run = dpu::is_lldp_working;
+            "below the 40 boundary" {
+                "xx.39.yyyy" => false,
+            }
+
+            "at the 40 boundary" {
+                "xx.40.yyyy" => false,
+            }
+
+            "above the 40 boundary" {
+                "xx.41.yyyy" => false,
+            }
+
+            "non-numeric middle chunk" {
+                "xx.zz.yyyy" => false,
+            }
+
+            "no dots at all" {
+                "junk" => false,
+            }
+
+            "empty string" {
+                "" => false,
+            }
+
+            "well-formed high version" {
+                "22.99.1000" => false,
+            }
+
+            "single leading dot" {
+                ".40." => false,
+            }
         );
     }
 
@@ -400,54 +389,46 @@ mod tests {
     // The yielded value for each row is `(first_ip, ip_count, name, remote_port)`.
     #[test]
     fn get_port_lldp_info_translates_fixture() {
-        check_cases(
-            [
-                Case {
-                    scenario: "oob_net0: single (scalar) mgmt-ip",
-                    input: "oob_net0",
-                    expect: Yields((
-                        "10.180.253.66".to_string(),
-                        1,
-                        "RNO1-M03-B17-IPMI-01".to_string(),
-                        "ifname=swp7".to_string(),
-                    )),
-                },
-                Case {
-                    scenario: "p0: array mgmt-ip keeps first (v4) and counts both",
-                    input: "p0",
-                    expect: Yields((
-                        "10.180.253.67".to_string(),
-                        2,
-                        "RNO1-M03-B17-IPMI-01".to_string(),
-                        "ifname=swp7".to_string(),
-                    )),
-                },
-                Case {
-                    scenario: "p1: distinct array mgmt-ip, first is v4",
-                    input: "p1",
-                    expect: Yields((
-                        "10.180.253.66".to_string(),
-                        2,
-                        "RNO1-M03-B17-IPMI-01".to_string(),
-                        "ifname=swp7".to_string(),
-                    )),
-                },
-                Case {
-                    scenario: "unknown port: not present in the fixture interface map",
-                    input: "p99",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty port name: also absent",
-                    input: "",
-                    expect: Fails,
-                },
-            ],
-            |port| {
+        scenarios!(
+            run = |port| {
                 let info = dpu::get_port_lldp_info(port).map_err(drop)?;
                 let first_ip = info.ip_address.first().cloned().unwrap_or_default();
                 Ok::<_, ()>((first_ip, info.ip_address.len(), info.name, info.remote_port))
-            },
+            };
+            "oob_net0: single (scalar) mgmt-ip" {
+                "oob_net0" => Yields((
+                    "10.180.253.66".to_string(),
+                    1,
+                    "RNO1-M03-B17-IPMI-01".to_string(),
+                    "ifname=swp7".to_string(),
+                )),
+            }
+
+            "p0: array mgmt-ip keeps first (v4) and counts both" {
+                "p0" => Yields((
+                    "10.180.253.67".to_string(),
+                    2,
+                    "RNO1-M03-B17-IPMI-01".to_string(),
+                    "ifname=swp7".to_string(),
+                )),
+            }
+
+            "p1: distinct array mgmt-ip, first is v4" {
+                "p1" => Yields((
+                    "10.180.253.66".to_string(),
+                    2,
+                    "RNO1-M03-B17-IPMI-01".to_string(),
+                    "ifname=swp7".to_string(),
+                )),
+            }
+
+            "unknown port: not present in the fixture interface map" {
+                "p99" => Fails,
+            }
+
+            "empty port name: also absent" {
+                "" => Fails,
+            }
         );
     }
 
@@ -458,31 +439,25 @@ mod tests {
     // The yielded value is whether every expected token appears in the rendered field.
     #[test]
     fn get_port_lldp_info_formats_fields() {
-        check_cases(
-            [
-                Case {
-                    scenario: "id renders mac type=value for oob_net0",
-                    input: ("oob_net0", &["mac=", "0c:29:ef:d9:1c:20"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "description carried verbatim for p0",
-                    input: ("p0", &["Cumulus Linux", "DELL S3048ON"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "local_port echoes the requested port",
-                    input: ("p1", &["p1"][..]),
-                    expect: Yields(true),
-                },
-            ],
-            |(port, tokens): (&str, &[&str])| {
+        scenarios!(
+            run = |(port, tokens): (&str, &[&str])| {
                 let info = dpu::get_port_lldp_info(port).map_err(drop)?;
                 // Concatenate the formatted fields this row may inspect; every token
                 // must appear somewhere across id / description / local_port.
                 let haystack = format!("{} {} {}", info.id, info.description, info.local_port);
                 Ok::<_, ()>(tokens.iter().all(|t| haystack.contains(t)))
-            },
+            };
+            "id renders mac type=value for oob_net0" {
+                ("oob_net0", &["mac=", "0c:29:ef:d9:1c:20"][..]) => Yields(true),
+            }
+
+            "description carried verbatim for p0" {
+                ("p0", &["Cumulus Linux", "DELL S3048ON"][..]) => Yields(true),
+            }
+
+            "local_port echoes the requested port" {
+                ("p1", &["p1"][..]) => Yields(true),
+            }
         );
     }
 }

--- a/crates/host-support/src/hardware_enumeration/tpm.rs
+++ b/crates/host-support/src/hardware_enumeration/tpm.rs
@@ -175,7 +175,7 @@ mod tests {
     use std::io;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
     use rcgen::{CertifiedKey, generate_simple_self_signed};
 
     use super::*;
@@ -298,101 +298,92 @@ mod tests {
 
         // Input is a (runner, expected-bytes-if-any) pair; the closure runs the
         // runner and returns the cert vec, dropping the non-PartialEq error.
-        check_cases(
-            [
-                Case {
-                    scenario: "primary tool returns the certificate; no NV probing",
-                    input: FakeRunner::new(vec![FakeCall {
-                        program: TPM2_GET_EK_CERTIFICATE,
-                        args: vec![],
-                        result: Ok(successful_output(&primary_cert)),
-                    }]),
-                    expect: Yields(primary_cert.clone()),
-                },
-                Case {
-                    scenario: "primary fails, falls back to first NV index",
-                    input: {
-                        let nv_stdout = cert_with_trailing_nv_bytes(&fallback_cert);
-                        let mut calls = vec![
-                            primary_tool_failed_call(),
-                            nv_read_call(
-                                TPM_EK_CERT_NV_INDICES[0],
-                                Ok(successful_output(&nv_stdout)),
-                            ),
-                        ];
-                        calls.extend(failing_nv_tail(1));
-                        FakeRunner::new(calls)
-                    },
-                    expect: Yields(fallback_cert),
-                },
-                Case {
-                    scenario: "skips NV index whose stdout is not a certificate",
-                    input: {
-                        let mut calls = vec![
-                            primary_tool_failed_call(),
-                            nv_read_call(
-                                TPM_EK_CERT_NV_INDICES[0],
-                                Ok(successful_output(b"not a certificate")),
-                            ),
-                            nv_read_call(
-                                TPM_EK_CERT_NV_INDICES[1],
-                                Ok(successful_output(&valid_cert)),
-                            ),
-                        ];
-                        calls.extend(failing_nv_tail(2));
-                        FakeRunner::new(calls)
-                    },
-                    expect: Yields(valid_cert),
-                },
-                Case {
-                    scenario: "concatenates multiple NV certs in tool order",
-                    input: {
-                        let first_nv = cert_with_trailing_nv_bytes(&first_cert);
-                        let second_nv = cert_with_trailing_nv_bytes(&second_cert);
-                        let mut calls = vec![
-                            primary_tool_failed_call(),
-                            nv_read_call(
-                                TPM_EK_CERT_NV_INDICES[0],
-                                Ok(successful_output(&first_nv)),
-                            ),
-                            nv_read_call(
-                                TPM_EK_CERT_NV_INDICES[1],
-                                Ok(successful_output(&second_nv)),
-                            ),
-                        ];
-                        calls.extend(failing_nv_tail(2));
-                        FakeRunner::new(calls)
-                    },
-                    expect: Yields(concatenated.clone()),
-                },
-                Case {
-                    scenario: "primary fails and every NV index fails: no cert found",
-                    input: {
-                        let mut calls = vec![primary_tool_failed_call()];
-                        calls.extend(failing_nv_tail(0));
-                        FakeRunner::new(calls)
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "primary subprocess spawn errors, every NV index fails",
-                    input: {
-                        let mut calls = vec![FakeCall {
-                            program: TPM2_GET_EK_CERTIFICATE,
-                            args: vec![],
-                            result: Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
-                        }];
-                        calls.extend(failing_nv_tail(0));
-                        FakeRunner::new(calls)
-                    },
-                    expect: Fails,
-                },
-            ],
-            |runner| {
+        scenarios!(
+            run = |runner| {
                 let cert = get_ek_certificate_with_runner(&runner).map_err(drop)?;
                 assert!(runner.calls.borrow().is_empty(), "runner not drained");
                 Ok::<_, ()>(cert)
-            },
+            };
+            "primary tool returns the certificate; no NV probing" {
+                FakeRunner::new(vec![FakeCall {
+                    program: TPM2_GET_EK_CERTIFICATE,
+                    args: vec![],
+                    result: Ok(successful_output(&primary_cert)),
+                }]) => Yields(primary_cert.clone()),
+            }
+
+            "primary fails, falls back to first NV index" {
+                {
+                    let nv_stdout = cert_with_trailing_nv_bytes(&fallback_cert);
+                    let mut calls = vec![
+                        primary_tool_failed_call(),
+                        nv_read_call(
+                            TPM_EK_CERT_NV_INDICES[0],
+                            Ok(successful_output(&nv_stdout)),
+                        ),
+                    ];
+                    calls.extend(failing_nv_tail(1));
+                    FakeRunner::new(calls)
+                } => Yields(fallback_cert),
+            }
+
+            "skips NV index whose stdout is not a certificate" {
+                {
+                    let mut calls = vec![
+                        primary_tool_failed_call(),
+                        nv_read_call(
+                            TPM_EK_CERT_NV_INDICES[0],
+                            Ok(successful_output(b"not a certificate")),
+                        ),
+                        nv_read_call(
+                            TPM_EK_CERT_NV_INDICES[1],
+                            Ok(successful_output(&valid_cert)),
+                        ),
+                    ];
+                    calls.extend(failing_nv_tail(2));
+                    FakeRunner::new(calls)
+                } => Yields(valid_cert),
+            }
+
+            "concatenates multiple NV certs in tool order" {
+                {
+                    let first_nv = cert_with_trailing_nv_bytes(&first_cert);
+                    let second_nv = cert_with_trailing_nv_bytes(&second_cert);
+                    let mut calls = vec![
+                        primary_tool_failed_call(),
+                        nv_read_call(
+                            TPM_EK_CERT_NV_INDICES[0],
+                            Ok(successful_output(&first_nv)),
+                        ),
+                        nv_read_call(
+                            TPM_EK_CERT_NV_INDICES[1],
+                            Ok(successful_output(&second_nv)),
+                        ),
+                    ];
+                    calls.extend(failing_nv_tail(2));
+                    FakeRunner::new(calls)
+                } => Yields(concatenated.clone()),
+            }
+
+            "primary fails and every NV index fails: no cert found" {
+                {
+                    let mut calls = vec![primary_tool_failed_call()];
+                    calls.extend(failing_nv_tail(0));
+                    FakeRunner::new(calls)
+                } => Fails,
+            }
+
+            "primary subprocess spawn errors, every NV index fails" {
+                {
+                    let mut calls = vec![FakeCall {
+                        program: TPM2_GET_EK_CERTIFICATE,
+                        args: vec![],
+                        result: Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
+                    }];
+                    calls.extend(failing_nv_tail(0));
+                    FakeRunner::new(calls)
+                } => Fails,
+            }
         );
     }
 
@@ -401,55 +392,47 @@ mod tests {
     /// `CommandOutput`. Error type is not `PartialEq`, so failures use `Fails`.
     #[test]
     fn checked_stdout_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "success returns stdout verbatim",
-                    input: CommandOutput {
-                        status_success: true,
-                        status_code: Some(0),
-                        stdout: b"payload".to_vec(),
-                        stderr: vec![],
-                    },
-                    expect: Yields(b"payload".to_vec()),
-                },
-                Case {
-                    scenario: "success with empty stdout returns empty",
-                    input: CommandOutput {
-                        status_success: true,
-                        status_code: Some(0),
-                        stdout: vec![],
-                        stderr: b"warning".to_vec(),
-                    },
-                    expect: Yields(vec![]),
-                },
-                Case {
-                    scenario: "non-success with utf8 stderr fails",
-                    input: failed_output("boom"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-success with no status code fails",
-                    input: CommandOutput {
-                        status_success: false,
-                        status_code: None,
-                        stdout: vec![],
-                        stderr: vec![],
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-success with invalid utf8 stderr still fails (no panic)",
-                    input: CommandOutput {
-                        status_success: false,
-                        status_code: Some(1),
-                        stdout: vec![],
-                        stderr: vec![0xff, 0xfe],
-                    },
-                    expect: Fails,
-                },
-            ],
-            |output| checked_stdout(output).map_err(drop),
+        scenarios!(
+            run = |output| checked_stdout(output).map_err(drop);
+            "success returns stdout verbatim" {
+                CommandOutput {
+                    status_success: true,
+                    status_code: Some(0),
+                    stdout: b"payload".to_vec(),
+                    stderr: vec![],
+                } => Yields(b"payload".to_vec()),
+            }
+
+            "success with empty stdout returns empty" {
+                CommandOutput {
+                    status_success: true,
+                    status_code: Some(0),
+                    stdout: vec![],
+                    stderr: b"warning".to_vec(),
+                } => Yields(vec![]),
+            }
+
+            "non-success with utf8 stderr fails" {
+                failed_output("boom") => Fails,
+            }
+
+            "non-success with no status code fails" {
+                CommandOutput {
+                    status_success: false,
+                    status_code: None,
+                    stdout: vec![],
+                    stderr: vec![],
+                } => Fails,
+            }
+
+            "non-success with invalid utf8 stderr still fails (no panic)" {
+                CommandOutput {
+                    status_success: false,
+                    status_code: Some(1),
+                    stdout: vec![],
+                    stderr: vec![0xff, 0xfe],
+                } => Fails,
+            }
         );
     }
 
@@ -460,35 +443,27 @@ mod tests {
         let cert = test_ek_cert_der("tool");
         let cert_with_trailing = cert_with_trailing_nv_bytes(&cert);
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid DER returns the full stdout",
-                    input: successful_output(&cert),
-                    expect: Yields(cert.clone()),
-                },
-                Case {
-                    scenario: "trailing bytes are NOT trimmed (full stdout returned)",
-                    input: successful_output(&cert_with_trailing),
-                    expect: Yields(cert_with_trailing.clone()),
-                },
-                Case {
-                    scenario: "non-certificate stdout fails to parse",
-                    input: successful_output(b"not a certificate"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty stdout fails to parse",
-                    input: successful_output(b""),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "subprocess non-success fails before parsing",
-                    input: failed_output("tool error"),
-                    expect: Fails,
-                },
-            ],
-            |output| cert_from_output(TPM2_GET_EK_CERTIFICATE, output).map_err(drop),
+        scenarios!(
+            run = |output| cert_from_output(TPM2_GET_EK_CERTIFICATE, output).map_err(drop);
+            "valid DER returns the full stdout" {
+                successful_output(&cert) => Yields(cert.clone()),
+            }
+
+            "trailing bytes are NOT trimmed (full stdout returned)" {
+                successful_output(&cert_with_trailing) => Yields(cert_with_trailing.clone()),
+            }
+
+            "non-certificate stdout fails to parse" {
+                successful_output(b"not a certificate") => Fails,
+            }
+
+            "empty stdout fails to parse" {
+                successful_output(b"") => Fails,
+            }
+
+            "subprocess non-success fails before parsing" {
+                failed_output("tool error") => Fails,
+            }
         );
     }
 
@@ -499,35 +474,27 @@ mod tests {
         let cert = test_ek_cert_der("nv");
         let cert_with_trailing = cert_with_trailing_nv_bytes(&cert);
 
-        check_cases(
-            [
-                Case {
-                    scenario: "exact-length DER returns it unchanged",
-                    input: successful_output(&cert),
-                    expect: Yields(cert.clone()),
-                },
-                Case {
-                    scenario: "trailing NV padding is trimmed to the cert bytes",
-                    input: successful_output(&cert_with_trailing),
-                    expect: Yields(cert.clone()),
-                },
-                Case {
-                    scenario: "non-certificate stdout fails to parse",
-                    input: successful_output(b"not a certificate"),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty stdout fails to parse",
-                    input: successful_output(b""),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "subprocess non-success fails before parsing",
-                    input: failed_output("nv error"),
-                    expect: Fails,
-                },
-            ],
-            |output| cert_from_nv_output(TPM2_NV_READ, output).map_err(drop),
+        scenarios!(
+            run = |output| cert_from_nv_output(TPM2_NV_READ, output).map_err(drop);
+            "exact-length DER returns it unchanged" {
+                successful_output(&cert) => Yields(cert.clone()),
+            }
+
+            "trailing NV padding is trimmed to the cert bytes" {
+                successful_output(&cert_with_trailing) => Yields(cert.clone()),
+            }
+
+            "non-certificate stdout fails to parse" {
+                successful_output(b"not a certificate") => Fails,
+            }
+
+            "empty stdout fails to parse" {
+                successful_output(b"") => Fails,
+            }
+
+            "subprocess non-success fails before parsing" {
+                failed_output("nv error") => Fails,
+            }
         );
     }
 
@@ -536,53 +503,46 @@ mod tests {
     /// token-contains predicate.
     #[test]
     fn tpm_error_display_contains_tokens() {
-        check_values(
-            [
-                Check {
-                    scenario: "Subprocess names the program",
-                    input: (
-                        TpmError::Subprocess(
-                            TPM2_NV_READ,
-                            io::Error::new(io::ErrorKind::NotFound, "x"),
-                        ),
-                        &[TPM2_NV_READ, "Unable to invoke"][..],
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "SubprocessStatusNotOk names the stderr",
-                    input: (
-                        TpmError::SubprocessStatusNotOk(Some(2), "boom".to_string()),
-                        &["boom", "exit code"][..],
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "InvalidEkCertificate names the source",
-                    input: (
-                        TpmError::InvalidEkCertificate(TPM2_GET_EK_CERTIFICATE),
-                        &[TPM2_GET_EK_CERTIFICATE, "DER X.509"][..],
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "EkCertificateNotFound names primary and nv errors",
-                    input: (
-                        TpmError::EkCertificateNotFound {
-                            primary_error: Box::new(TpmError::InvalidEkCertificate(
-                                TPM2_GET_EK_CERTIFICATE,
-                            )),
-                            nv_errors: "0x01c00002: nope".to_string(),
-                        },
-                        &["NV fallback errors", "0x01c00002: nope"][..],
-                    ),
-                    expect: true,
-                },
-            ],
-            |(error, tokens)| {
+        value_scenarios!(
+            run = |(error, tokens)| {
                 let rendered = error.to_string();
                 tokens.iter().all(|t| rendered.contains(t))
-            },
+            };
+            "Subprocess names the program" {
+                (
+                    TpmError::Subprocess(
+                        TPM2_NV_READ,
+                        io::Error::new(io::ErrorKind::NotFound, "x"),
+                    ),
+                    &[TPM2_NV_READ, "Unable to invoke"][..],
+                ) => true,
+            }
+
+            "SubprocessStatusNotOk names the stderr" {
+                (
+                    TpmError::SubprocessStatusNotOk(Some(2), "boom".to_string()),
+                    &["boom", "exit code"][..],
+                ) => true,
+            }
+
+            "InvalidEkCertificate names the source" {
+                (
+                    TpmError::InvalidEkCertificate(TPM2_GET_EK_CERTIFICATE),
+                    &[TPM2_GET_EK_CERTIFICATE, "DER X.509"][..],
+                ) => true,
+            }
+
+            "EkCertificateNotFound names primary and nv errors" {
+                (
+                    TpmError::EkCertificateNotFound {
+                        primary_error: Box::new(TpmError::InvalidEkCertificate(
+                            TPM2_GET_EK_CERTIFICATE,
+                        )),
+                        nv_errors: "0x01c00002: nope".to_string(),
+                    },
+                    &["NV fallback errors", "0x01c00002: nope"][..],
+                ) => true,
+            }
         );
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-host-support` tests already enumerate the hardware parsing and normalization examples, but the old row structs made the small tables feel heavier than the hardware values being checked.

This moves the straightforward hardware tables onto `scenarios!`/`value_scenarios!` and keeps the same concrete inputs and expected outputs. Related rows now sit under a shared label, which makes the host-support examples easier to read without changing the coverage intent.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p carbide-host-support`
- `cargo clippy -p carbide-host-support -- -D warnings`
- `cargo clippy -p carbide-host-support --tests -- -D warnings`