### PR TITLE
test(rpc-utils): improve coverage for dhcp and display helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ dependencies = [
  "byte-unit",
  "carbide-health-report",
  "carbide-rpc",
+ "carbide-test-support",
  "carbide-uuid",
  "chrono",
  "config-version",

--- a/crates/rpc-utils/Cargo.toml
+++ b/crates/rpc-utils/Cargo.toml
@@ -38,5 +38,8 @@ thiserror = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -293,3 +293,382 @@ impl IntoIterator for DhcpTimestamps {
         self.timestamps.into_iter()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{scenarios, value_scenarios};
+    use rpc::forge::{
+        FlatInterfaceConfig, InterfaceFunctionType, ManagedHostNetworkConfigResponse,
+        VpcVirtualizationType,
+    };
+
+    use super::*;
+
+    const HOST_INTERFACE_ID: &str = "11111111-1111-1111-1111-111111111111";
+    const DEFAULT_LEASE_TIME_SECS: u32 = 7 * 24 * 60 * 60;
+
+    #[derive(Debug, PartialEq)]
+    struct DhcpConfigSummary {
+        provisioning_server: Ipv4Addr,
+        dhcp_server: Ipv4Addr,
+        ntpservers: Vec<Ipv4Addr>,
+        nameservers: Vec<Ipv4Addr>,
+        lease_time_secs: u32,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct InterfaceSummary {
+        address: Ipv4Addr,
+        gateway: Ipv4Addr,
+        prefix: String,
+        fqdn: String,
+        booturl: Option<String>,
+        mtu: Option<u32>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct HostConfigSummary {
+        host_interface_id: String,
+        host_ip_addresses: Vec<(String, InterfaceSummary)>,
+    }
+
+    fn host_interface_id() -> MachineInterfaceId {
+        HOST_INTERFACE_ID.parse().unwrap()
+    }
+
+    fn interface_config(
+        function_type: InterfaceFunctionType,
+        vlan_id: u32,
+        virtual_function_id: Option<u32>,
+        is_l2_segment: bool,
+        ip: &str,
+        gateway: &str,
+    ) -> FlatInterfaceConfig {
+        FlatInterfaceConfig {
+            function_type: function_type as i32,
+            vlan_id,
+            gateway: gateway.to_string(),
+            ip: ip.to_string(),
+            virtual_function_id,
+            prefix: "192.0.2.0/24".to_string(),
+            fqdn: "host.example.com".to_string(),
+            booturl: Some("http://boot.example.com/ipxe".to_string()),
+            is_l2_segment,
+            mtu: Some(9000),
+            ..Default::default()
+        }
+    }
+
+    fn host_network_config(
+        use_admin_network: bool,
+        admin_interface: Option<FlatInterfaceConfig>,
+        tenant_interfaces: Vec<FlatInterfaceConfig>,
+        virtualization_type: VpcVirtualizationType,
+        host_interface_id: Option<String>,
+    ) -> ManagedHostNetworkConfigResponse {
+        ManagedHostNetworkConfigResponse {
+            use_admin_network,
+            admin_interface,
+            tenant_interfaces,
+            network_virtualization_type: Some(virtualization_type as i32),
+            host_interface_id,
+            ..Default::default()
+        }
+    }
+
+    fn summarize_interface(interface: InterfaceInfo) -> InterfaceSummary {
+        InterfaceSummary {
+            address: interface.address,
+            gateway: interface.gateway,
+            prefix: interface.prefix,
+            fqdn: interface.fqdn,
+            booturl: interface.booturl,
+            mtu: interface.mtu,
+        }
+    }
+
+    fn summarize_host_config(
+        (config, is_dpu_os): (ManagedHostNetworkConfigResponse, bool),
+    ) -> Result<HostConfigSummary, &'static str> {
+        HostConfig::try_from(config, "p0", "vf", "sf", is_dpu_os)
+            .map(|host_config| HostConfigSummary {
+                host_interface_id: host_config.host_interface_id.to_string(),
+                host_ip_addresses: host_config
+                    .host_ip_addresses
+                    .into_iter()
+                    .map(|(name, interface)| (name, summarize_interface(interface)))
+                    .collect(),
+            })
+            .map_err(dhcp_error_kind)
+    }
+
+    fn summarize_dhcp_config(
+        (provisioning_server, ntpservers, nameservers, dhcp_server): (
+            Ipv4Addr,
+            Vec<Ipv4Addr>,
+            Vec<Ipv4Addr>,
+            Ipv4Addr,
+        ),
+    ) -> Result<DhcpConfigSummary, &'static str> {
+        DhcpConfig::from_forge_dhcp_config(
+            provisioning_server,
+            ntpservers,
+            nameservers,
+            dhcp_server,
+        )
+        .map(|config| DhcpConfigSummary {
+            provisioning_server: config.carbide_provisioning_server_ipv4,
+            dhcp_server: config.carbide_dhcp_server,
+            ntpservers: config.carbide_ntpservers,
+            nameservers: config.carbide_nameservers,
+            lease_time_secs: config.lease_time_secs,
+        })
+        .map_err(dhcp_error_kind)
+    }
+
+    fn summarize_flat_interface(
+        config: FlatInterfaceConfig,
+    ) -> Result<InterfaceSummary, &'static str> {
+        InterfaceInfo::try_from(config)
+            .map(summarize_interface)
+            .map_err(dhcp_error_kind)
+    }
+
+    fn dhcp_error_kind(error: DhcpDataError) -> &'static str {
+        match error {
+            DhcpDataError::AddressParseError(_) => "address-parse",
+            DhcpDataError::ParameterMissing(_) => "parameter-missing",
+            DhcpDataError::IpNetworkError(_) => "ip-network",
+            DhcpDataError::RpcConversion(_) => "rpc-conversion",
+            DhcpDataError::UuidConversion(_) => "uuid-conversion",
+            DhcpDataError::UuidParseError(_) => "uuid-parse",
+        }
+    }
+
+    #[test]
+    fn builds_dhcp_config_from_forge_values() {
+        scenarios!(summarize_dhcp_config:
+            "configured addresses" {
+                (
+                    Ipv4Addr::new(192, 0, 2, 10),
+                    vec![Ipv4Addr::new(192, 0, 2, 20)],
+                    vec![Ipv4Addr::new(192, 0, 2, 53)],
+                    Ipv4Addr::new(127, 0, 0, 2),
+                ) => Yields(DhcpConfigSummary {
+                    provisioning_server: Ipv4Addr::new(192, 0, 2, 10),
+                    dhcp_server: Ipv4Addr::new(127, 0, 0, 2),
+                    ntpservers: vec![Ipv4Addr::new(192, 0, 2, 20)],
+                    nameservers: vec![Ipv4Addr::new(192, 0, 2, 53)],
+                    lease_time_secs: DEFAULT_LEASE_TIME_SECS,
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn converts_flat_interface_config() {
+        scenarios!(summarize_flat_interface:
+            "valid interface" {
+                interface_config(
+                    InterfaceFunctionType::Virtual,
+                    100,
+                    Some(3),
+                    false,
+                    "192.0.2.50",
+                    "192.0.2.1/24",
+                ) => Yields(InterfaceSummary {
+                    address: Ipv4Addr::new(192, 0, 2, 50),
+                    gateway: Ipv4Addr::new(192, 0, 2, 1),
+                    prefix: "192.0.2.0/24".to_string(),
+                    fqdn: "host.example.com".to_string(),
+                    booturl: Some("http://boot.example.com/ipxe".to_string()),
+                    mtu: Some(9000),
+                }),
+            }
+
+            "invalid addresses" {
+                interface_config(
+                    InterfaceFunctionType::Virtual,
+                    100,
+                    Some(3),
+                    false,
+                    "not an ip",
+                    "192.0.2.1/24",
+                ) => FailsWith("address-parse"),
+                interface_config(
+                    InterfaceFunctionType::Virtual,
+                    100,
+                    Some(3),
+                    false,
+                    "192.0.2.50",
+                    "not a network",
+                ) => FailsWith("ip-network"),
+            }
+        );
+    }
+
+    #[test]
+    fn converts_host_network_config() {
+        scenarios!(summarize_host_config:
+            "admin network uses vlan circuit id" {
+                (
+                    host_network_config(
+                        true,
+                        Some(interface_config(
+                            InterfaceFunctionType::Physical,
+                            100,
+                            None,
+                            true,
+                            "192.0.2.10",
+                            "192.0.2.1/24",
+                        )),
+                        vec![],
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        Some(HOST_INTERFACE_ID.to_string()),
+                    ),
+                    true,
+                ) => Yields(HostConfigSummary {
+                    host_interface_id: HOST_INTERFACE_ID.to_string(),
+                    host_ip_addresses: vec![(
+                        "vlan100".to_string(),
+                        InterfaceSummary {
+                            address: Ipv4Addr::new(192, 0, 2, 10),
+                            gateway: Ipv4Addr::new(192, 0, 2, 1),
+                            prefix: "192.0.2.0/24".to_string(),
+                            fqdn: "host.example.com".to_string(),
+                            booturl: Some("http://boot.example.com/ipxe".to_string()),
+                            mtu: Some(9000),
+                        },
+                    )],
+                }),
+            }
+
+            "fnn virtual functions use representor circuit id" {
+                (
+                    host_network_config(
+                        false,
+                        None,
+                        vec![interface_config(
+                            InterfaceFunctionType::Virtual,
+                            200,
+                            Some(3),
+                            false,
+                            "192.0.2.20",
+                            "192.0.2.1/24",
+                        )],
+                        VpcVirtualizationType::Fnn,
+                        Some(HOST_INTERFACE_ID.to_string()),
+                    ),
+                    true,
+                ) => Yields(HostConfigSummary {
+                    host_interface_id: HOST_INTERFACE_ID.to_string(),
+                    host_ip_addresses: vec![(
+                        "vf3sf".to_string(),
+                        InterfaceSummary {
+                            address: Ipv4Addr::new(192, 0, 2, 20),
+                            gateway: Ipv4Addr::new(192, 0, 2, 1),
+                            prefix: "192.0.2.0/24".to_string(),
+                            fqdn: "host.example.com".to_string(),
+                            booturl: Some("http://boot.example.com/ipxe".to_string()),
+                            mtu: Some(9000),
+                        },
+                    )],
+                }),
+            }
+
+            "non dpu os uses physical representor" {
+                (
+                    host_network_config(
+                        false,
+                        None,
+                        vec![interface_config(
+                            InterfaceFunctionType::Physical,
+                            300,
+                            None,
+                            true,
+                            "192.0.2.30",
+                            "192.0.2.1/24",
+                        )],
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        Some(HOST_INTERFACE_ID.to_string()),
+                    ),
+                    false,
+                ) => Yields(HostConfigSummary {
+                    host_interface_id: HOST_INTERFACE_ID.to_string(),
+                    host_ip_addresses: vec![(
+                        "p0".to_string(),
+                        InterfaceSummary {
+                            address: Ipv4Addr::new(192, 0, 2, 30),
+                            gateway: Ipv4Addr::new(192, 0, 2, 1),
+                            prefix: "192.0.2.0/24".to_string(),
+                            fqdn: "host.example.com".to_string(),
+                            booturl: Some("http://boot.example.com/ipxe".to_string()),
+                            mtu: Some(9000),
+                        },
+                    )],
+                }),
+            }
+
+            "missing required fields" {
+                (
+                    host_network_config(
+                        true,
+                        None,
+                        vec![],
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        Some(HOST_INTERFACE_ID.to_string()),
+                    ),
+                    true,
+                ) => FailsWith("parameter-missing"),
+                (
+                    host_network_config(
+                        false,
+                        None,
+                        vec![interface_config(
+                            InterfaceFunctionType::Physical,
+                            400,
+                            None,
+                            true,
+                            "192.0.2.40",
+                            "192.0.2.1/24",
+                        )],
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        None,
+                    ),
+                    true,
+                ) => FailsWith("parameter-missing"),
+            }
+        );
+    }
+
+    #[test]
+    fn reports_timestamp_file_paths() {
+        value_scenarios!(
+            run = |path| path.path_str().to_string();
+            "known paths" {
+                DhcpTimestampsFilePath::HbnTmp => "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp".to_string(),
+                DhcpTimestampsFilePath::Hbn => "/var/support/forge-dhcp/logs/dhcp_timestamps.json".to_string(),
+                DhcpTimestampsFilePath::Dpu => "/var/lib/hbn/var/support/forge-dhcp/logs/dhcp_timestamps.json".to_string(),
+                DhcpTimestampsFilePath::Test => "/tmp/timestamps.json".to_string(),
+                DhcpTimestampsFilePath::NotSet => "Not set".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn stores_timestamps_by_host_interface_id() {
+        let id = host_interface_id();
+        let mut timestamps = DhcpTimestamps::default();
+
+        timestamps.add_timestamp(id, "2026-06-13T00:00:00Z".to_string());
+
+        assert_eq!(
+            timestamps.get_timestamp(&id),
+            Some(&"2026-06-13T00:00:00Z".to_string())
+        );
+        assert_eq!(timestamps.into_iter().count(), 1);
+    }
+}

--- a/crates/rpc-utils/src/lib.rs
+++ b/crates/rpc-utils/src/lib.rs
@@ -33,3 +33,45 @@ pub fn reason_to_user_string(p: &rpc::forge::ControllerStateReason) -> Option<St
         Wait | Error => p.outcome_msg.clone(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use rpc::forge::{ControllerStateOutcome, ControllerStateReason};
+
+    use super::*;
+
+    fn reason(outcome: ControllerStateOutcome, message: Option<&str>) -> ControllerStateReason {
+        ControllerStateReason {
+            outcome: outcome as i32,
+            outcome_msg: message.map(str::to_string),
+            source_ref: None,
+        }
+    }
+
+    #[test]
+    fn maps_controller_reasons_to_user_strings() {
+        value_scenarios!(
+            run = |reason| reason_to_user_string(&reason);
+            "visible outcomes" {
+                reason(ControllerStateOutcome::Wait, Some("waiting for host")) => Some("waiting for host".to_string()),
+                reason(ControllerStateOutcome::Error, Some("firmware failed")) => Some("firmware failed".to_string()),
+                reason(ControllerStateOutcome::Wait, None) => None,
+            }
+
+            "hidden outcomes" {
+                reason(ControllerStateOutcome::Transition, Some("transitioning")) => None,
+                reason(ControllerStateOutcome::DoNothing, Some("no-op")) => None,
+                reason(ControllerStateOutcome::Todo, Some("todo")) => None,
+            }
+
+            "invalid outcome" {
+                ControllerStateReason {
+                    outcome: 999,
+                    outcome_msg: Some("ignored".to_string()),
+                    source_ref: None,
+                } => None,
+            }
+        );
+    }
+}

--- a/crates/rpc-utils/src/machine_discovery.rs
+++ b/crates/rpc-utils/src/machine_discovery.rs
@@ -105,3 +105,74 @@ impl From<&CpuAccumulator> for rpc_discovery::CpuInfo {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    fn cpu(vendor: &str, model: &str, socket: u32, core: u32, number: u32) -> rpc_discovery::Cpu {
+        rpc_discovery::Cpu {
+            vendor: vendor.to_string(),
+            model: model.to_string(),
+            frequency: String::new(),
+            number,
+            core,
+            node: 0,
+            socket,
+        }
+    }
+
+    fn cpu_info(
+        vendor: &str,
+        model: &str,
+        sockets: u32,
+        cores: u32,
+        threads: u32,
+    ) -> rpc_discovery::CpuInfo {
+        rpc_discovery::CpuInfo {
+            model: model.to_string(),
+            vendor: vendor.to_string(),
+            sockets,
+            cores,
+            threads,
+        }
+    }
+
+    #[test]
+    fn aggregates_cpu_discovery_records() {
+        value_scenarios!(
+            run = |cpus| aggregate_cpus(&cpus);
+            "empty discovery" {
+                vec![] => vec![],
+            }
+
+            "single socket" {
+                vec![
+                    cpu("GenuineIntel", "Xeon", 0, 0, 0),
+                    cpu("GenuineIntel", "Xeon", 0, 1, 1),
+                ] => vec![cpu_info("GenuineIntel", "Xeon", 1, 2, 2)],
+            }
+
+            "multiple sockets" {
+                vec![
+                    cpu("GenuineIntel", "Xeon", 0, 0, 0),
+                    cpu("GenuineIntel", "Xeon", 1, 0, 1),
+                    cpu("GenuineIntel", "Xeon", 1, 2, 3),
+                // `threads` is the max threads-per-socket count, not total records.
+                ] => vec![cpu_info("GenuineIntel", "Xeon", 2, 3, 2)],
+            }
+
+            "multiple models are sorted" {
+                vec![
+                    cpu("AMD", "Zen B", 0, 0, 0),
+                    cpu("AMD", "Zen A", 0, 1, 1),
+                ] => vec![
+                    cpu_info("AMD", "Zen A", 1, 2, 2),
+                    cpu_info("AMD", "Zen B", 1, 1, 1),
+                ],
+            }
+        );
+    }
+}

--- a/crates/rpc-utils/src/managed_host_display.rs
+++ b/crates/rpc-utils/src/managed_host_display.rs
@@ -659,3 +659,74 @@ impl IfNonEmpty for String {
         if !self.is_empty() { Some(self) } else { None }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    fn memory(size_mb: Option<u32>) -> MemoryDevice {
+        MemoryDevice {
+            size_mb,
+            mem_type: None,
+        }
+    }
+
+    #[test]
+    fn formats_memory_details() {
+        value_scenarios!(
+            run = |devices| get_memory_details(&devices);
+            "missing memory" {
+                Vec::<MemoryDevice>::new() => None,
+                vec![memory(Some(0)), memory(None)] => None,
+            }
+
+            "single device" {
+                vec![memory(Some(32768))] => Some("32 GiB".to_string()),
+            }
+
+            "device breakdown" {
+                vec![
+                    memory(Some(32768)),
+                    memory(Some(32768)),
+                    memory(Some(65536)),
+                ] => Some("128 GiB (32 GiBx2, 64 GiBx1)".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn formats_timestamps_for_display() {
+        value_scenarios!(
+            run = |timestamp| to_time(timestamp, Some("machine-1"));
+            "timestamp values" {
+                None => None,
+                Some(Timestamp::from(UNIX_EPOCH)) => Some("1970-01-01 00:00:00 UTC".to_string()),
+                Some(Timestamp::from(UNIX_EPOCH + Duration::from_secs(1_700_000_000))) => Some("2023-11-14 22:13:20 UTC".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn filters_empty_display_fields() {
+        value_scenarios!(
+            run = |value| value.if_non_empty();
+            "option string" {
+                None::<String> => None,
+                Some(String::new()) => None,
+                Some("value".to_string()) => Some("value".to_string()),
+            }
+        );
+
+        value_scenarios!(
+            run = |value: String| value.if_non_empty();
+            "string" {
+                String::new() => None,
+                "value".to_string() => Some("value".to_string()),
+            }
+        );
+    }
+}


### PR DESCRIPTION
This supports #3914.

## Summary

Pull `carbide-test-support` into `carbide-rpc-utils` and cover the pure conversion paths around controller reasons, CPU aggregation, DHCP config conversion, timestamp paths, and managed-host display helpers.

## Coverage

`cargo llvm-cov -p carbide-rpc-utils --json --summary-only --ignore-filename-regex '/(tests|target)/'`

| Metric | Before | After |
| --- | ---: | ---: |
| Lines | 0/619 (0.00%) | 590/1008 (58.53%) |
| Functions | 0/72 (0.00%) | 49/104 (47.12%) |

## Testing

- `cargo make format-nightly`
- `cargo test -p carbide-rpc-utils`
- `cargo clippy -p carbide-rpc-utils -- -D warnings`
- `cargo clippy -p carbide-rpc-utils --tests -- -D warnings`