### PR TITLE
test(pxe): add enumerated coverage for additional pxe scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,6 +2521,7 @@ dependencies = [
  "bytes",
  "carbide-host-support",
  "carbide-rpc",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-uuid",
  "carbide-version",

--- a/crates/pxe/Cargo.toml
+++ b/crates/pxe/Cargo.toml
@@ -61,6 +61,7 @@ uuid = { features = ["v4", "serde"], workspace = true }
 carbide-version = { path = "../version" }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/pxe/src/config.rs
+++ b/crates/pxe/src/config.rs
@@ -67,3 +67,213 @@ impl RuntimeConfig {
         Ok(this)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+    use std::sync::Mutex;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    const RUNTIME_CONFIG_ENV_KEYS: &[&str] = &[
+        "CARBIDE_PXE_URL",
+        "CARBIDE_API_INTERNAL_URL",
+        "CARBIDE_API_URL",
+        "CARBIDE_STATIC_PXE_URL",
+        "FORGE_ROOT_CAFILE_PATH",
+        "FORGE_CLIENT_CERT_PATH",
+        "FORGE_CLIENT_KEY_PATH",
+        "PXE_BIND_ADDRESS",
+        "PXE_BIND_PORT",
+        "CARBIDE_PXE_TEMPLATE_DIRECTORY",
+    ];
+
+    #[derive(Debug)]
+    struct ConfigEnv {
+        vars: &'static [(&'static str, &'static str)],
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct RuntimeConfigSummary {
+        internal_api_url: String,
+        client_facing_api_url: String,
+        pxe_url: String,
+        static_pxe_url: String,
+        forge_root_ca_path: String,
+        server_cert_path: String,
+        server_key_path: String,
+        bind_address: IpAddr,
+        bind_port: u16,
+        template_directory: String,
+    }
+
+    struct EnvSnapshot {
+        values: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvSnapshot {
+        fn capture(keys: &[&'static str]) -> Self {
+            Self {
+                values: keys.iter().map(|key| (*key, env::var(key).ok())).collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            for (key, value) in &self.values {
+                match value {
+                    Some(value) => set_env(key, value),
+                    None => remove_env(key),
+                }
+            }
+        }
+    }
+
+    fn set_env(key: &str, value: &str) {
+        // SAFETY: these tests hold ENV_LOCK while mutating process environment.
+        unsafe { env::set_var(key, value) }
+    }
+
+    fn remove_env(key: &str) {
+        // SAFETY: these tests hold ENV_LOCK while mutating process environment.
+        unsafe { env::remove_var(key) }
+    }
+
+    fn clear_env(keys: &[&str]) {
+        for key in keys {
+            remove_env(key);
+        }
+    }
+
+    fn summarize_config(config: RuntimeConfig) -> RuntimeConfigSummary {
+        RuntimeConfigSummary {
+            internal_api_url: config.internal_api_url,
+            client_facing_api_url: config.client_facing_api_url,
+            pxe_url: config.pxe_url,
+            static_pxe_url: config.static_pxe_url,
+            forge_root_ca_path: config.forge_root_ca_path,
+            server_cert_path: config.server_cert_path,
+            server_key_path: config.server_key_path,
+            bind_address: config.bind_address,
+            bind_port: config.bind_port,
+            template_directory: config.template_directory,
+        }
+    }
+
+    /// Caller must hold `ENV_LOCK` before invoking this function.
+    fn runtime_config_from_env(input: ConfigEnv) -> Result<RuntimeConfigSummary, &'static str> {
+        clear_env(RUNTIME_CONFIG_ENV_KEYS);
+        for (key, value) in input.vars {
+            set_env(key, value);
+        }
+        RuntimeConfig::from_env()
+            .map(summarize_config)
+            .map_err(config_error_kind)
+    }
+
+    fn config_error_kind(error: String) -> &'static str {
+        match error.as_str() {
+            "Could not extract FORGE_ROOT_CAFILE_PATH from environment" => "missing-root-ca",
+            "Could not extract FORGE_CLIENT_CERT_PATH from environment" => "missing-client-cert",
+            "Could not extract FORGE_CLIENT_KEY_PATH from environment" => "missing-client-key",
+            "not a parsable bind address for runtime config?" => "bad-bind-address",
+            "not a parsable bind port for runtime config?" => "bad-bind-port",
+            other => panic!("unmapped runtime config error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn builds_runtime_config_from_environment() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let _snapshot = EnvSnapshot::capture(RUNTIME_CONFIG_ENV_KEYS);
+
+        scenarios!(
+            run = runtime_config_from_env;
+            "required values with defaults" {
+                ConfigEnv {
+                    vars: &[
+                        ("FORGE_ROOT_CAFILE_PATH", "/certs/root.pem"),
+                        ("FORGE_CLIENT_CERT_PATH", "/certs/client.pem"),
+                        ("FORGE_CLIENT_KEY_PATH", "/certs/client.key"),
+                    ],
+                } => Yields(RuntimeConfigSummary {
+                    internal_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079".to_string(),
+                    client_facing_api_url: "https://carbide-api.forge".to_string(),
+                    pxe_url: "http://carbide-pxe.forge".to_string(),
+                    static_pxe_url: "http://carbide-pxe.forge".to_string(),
+                    forge_root_ca_path: "/certs/root.pem".to_string(),
+                    server_cert_path: "/certs/client.pem".to_string(),
+                    server_key_path: "/certs/client.key".to_string(),
+                    bind_address: "0.0.0.0".parse().unwrap(),
+                    bind_port: 8080,
+                    template_directory: "/opt/carbide/pxe/templates".to_string(),
+                }),
+            }
+
+            "explicit values" {
+                ConfigEnv {
+                    vars: &[
+                        ("CARBIDE_API_INTERNAL_URL", "https://internal.example.com"),
+                        ("CARBIDE_API_URL", "https://client.example.com"),
+                        ("CARBIDE_PXE_URL", "http://pxe.example.com"),
+                        ("CARBIDE_STATIC_PXE_URL", "http://static-pxe.example.com"),
+                        ("FORGE_ROOT_CAFILE_PATH", "/explicit/root.pem"),
+                        ("FORGE_CLIENT_CERT_PATH", "/explicit/client.pem"),
+                        ("FORGE_CLIENT_KEY_PATH", "/explicit/client.key"),
+                        ("PXE_BIND_ADDRESS", "127.0.0.1"),
+                        ("PXE_BIND_PORT", "9090"),
+                        ("CARBIDE_PXE_TEMPLATE_DIRECTORY", "/templates"),
+                    ],
+                } => Yields(RuntimeConfigSummary {
+                    internal_api_url: "https://internal.example.com".to_string(),
+                    client_facing_api_url: "https://client.example.com".to_string(),
+                    pxe_url: "http://pxe.example.com".to_string(),
+                    static_pxe_url: "http://static-pxe.example.com".to_string(),
+                    forge_root_ca_path: "/explicit/root.pem".to_string(),
+                    server_cert_path: "/explicit/client.pem".to_string(),
+                    server_key_path: "/explicit/client.key".to_string(),
+                    bind_address: "127.0.0.1".parse().unwrap(),
+                    bind_port: 9090,
+                    template_directory: "/templates".to_string(),
+                }),
+            }
+
+            "missing required values" {
+                ConfigEnv { vars: &[] } => FailsWith("missing-root-ca"),
+                ConfigEnv {
+                    vars: &[("FORGE_ROOT_CAFILE_PATH", "/certs/root.pem")],
+                } => FailsWith("missing-client-cert"),
+                ConfigEnv {
+                    vars: &[
+                        ("FORGE_ROOT_CAFILE_PATH", "/certs/root.pem"),
+                        ("FORGE_CLIENT_CERT_PATH", "/certs/client.pem"),
+                    ],
+                } => FailsWith("missing-client-key"),
+            }
+
+            "invalid bind settings" {
+                ConfigEnv {
+                    vars: &[
+                        ("FORGE_ROOT_CAFILE_PATH", "/certs/root.pem"),
+                        ("FORGE_CLIENT_CERT_PATH", "/certs/client.pem"),
+                        ("FORGE_CLIENT_KEY_PATH", "/certs/client.key"),
+                        ("PXE_BIND_ADDRESS", "not an ip"),
+                    ],
+                } => FailsWith("bad-bind-address"),
+                ConfigEnv {
+                    vars: &[
+                        ("FORGE_ROOT_CAFILE_PATH", "/certs/root.pem"),
+                        ("FORGE_CLIENT_CERT_PATH", "/certs/client.pem"),
+                        ("FORGE_CLIENT_KEY_PATH", "/certs/client.key"),
+                        ("PXE_BIND_PORT", "not a port"),
+                    ],
+                } => FailsWith("bad-bind-port"),
+            }
+        );
+    }
+}

--- a/crates/pxe/src/extractors/machine_architecture.rs
+++ b/crates/pxe/src/extractors/machine_architecture.rs
@@ -53,3 +53,55 @@ impl From<MachineArchitecture> for rpc::MachineArchitecture {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{scenarios, value_scenarios};
+
+    use super::*;
+
+    fn parse_arch(value: &str) -> Result<&'static str, &'static str> {
+        MachineArchitecture::try_from(value)
+            .map(|arch| match arch {
+                MachineArchitecture::Arm => "arm",
+                MachineArchitecture::X86 => "x86",
+            })
+            .map_err(|error| match error {
+                PxeRequestError::MalformedBuildArch(_) => "malformed-build-arch",
+                _ => "unexpected",
+            })
+    }
+
+    #[test]
+    fn parses_machine_architecture_identifiers() {
+        scenarios!(parse_arch:
+            "named identifiers" {
+                "arm64" => Yields("arm"),
+                "x86_64" => Yields("x86"),
+            }
+
+            "numeric identifiers" {
+                "0" => Yields("arm"),
+                "1" => Yields("x86"),
+            }
+
+            "invalid identifiers" {
+                "" => FailsWith("malformed-build-arch"),
+                "amd64" => FailsWith("malformed-build-arch"),
+                "2" => FailsWith("malformed-build-arch"),
+            }
+        );
+    }
+
+    #[test]
+    fn converts_machine_architecture_to_rpc_enum() {
+        value_scenarios!(
+            run = |arch| rpc::MachineArchitecture::from(arch) as i32;
+            "rpc enum" {
+                MachineArchitecture::Arm => rpc::MachineArchitecture::Arm as i32,
+                MachineArchitecture::X86 => rpc::MachineArchitecture::X86 as i32,
+            }
+        );
+    }
+}

--- a/crates/pxe/src/middleware/logging.rs
+++ b/crates/pxe/src/middleware/logging.rs
@@ -113,24 +113,46 @@ fn render_logfmt(props: &BTreeMap<&'static str, String>) -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
-    #[test]
-    fn test_logfmt() {
+    fn render(entries: Vec<(&'static str, &'static str)>) -> String {
         let mut props = BTreeMap::new();
-        props.insert("method", "GET".to_string());
-        props.insert("path", "/boot".to_string());
-        props.insert("remote_ip", "127.0.0.1".to_string());
-        assert_eq!(
-            render_logfmt(&props),
-            "method=GET path=/boot remote_ip=127.0.0.1"
-        );
+        for (key, value) in entries {
+            props.insert(key, value.to_string());
+        }
+        render_logfmt(&props)
+    }
 
-        props.insert("z", "with whitespace".to_string());
-        props.insert("e", "".to_string());
-        assert_eq!(
-            render_logfmt(&props),
-            "e=\"\" method=GET path=/boot remote_ip=127.0.0.1 z=\"with whitespace\""
+    #[test]
+    fn renders_logfmt() {
+        value_scenarios!(
+            render:
+            "plain values" {
+                vec![
+                    ("method", "GET"),
+                    ("path", "/boot"),
+                    ("remote_ip", "127.0.0.1"),
+                ] => "method=GET path=/boot remote_ip=127.0.0.1".to_string(),
+            }
+
+            "quoted values" {
+                vec![
+                    ("method", "GET"),
+                    ("path", "/boot"),
+                    ("remote_ip", "127.0.0.1"),
+                    ("z", "with whitespace"),
+                    ("e", ""),
+                ] => "e=\"\" method=GET path=/boot remote_ip=127.0.0.1 z=\"with whitespace\"".to_string(),
+            }
+
+            "escaped values" {
+                vec![
+                    ("message", "quoted \"value\""),
+                    ("path", "a=b"),
+                ] => "message=\"quoted \\\"value\\\"\" path=\"a=b\"".to_string(),
+            }
         );
     }
 }

--- a/crates/pxe/src/rpc_error.rs
+++ b/crates/pxe/src/rpc_error.rs
@@ -72,3 +72,88 @@ impl Display for PxeRequestError {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ErrorCase {
+        MissingClientConfig,
+        MissingMachineId,
+        InvalidBuildArch,
+        MalformedMachineId,
+        MalformedBuildArch,
+    }
+
+    fn error_for(case: ErrorCase) -> PxeRequestError {
+        match case {
+            ErrorCase::MissingClientConfig => PxeRequestError::MissingClientConfig,
+            ErrorCase::MissingMachineId => PxeRequestError::MissingMachineId,
+            ErrorCase::InvalidBuildArch => PxeRequestError::InvalidBuildArch,
+            ErrorCase::MalformedMachineId => {
+                PxeRequestError::MalformedMachineId("bad uuid".to_string())
+            }
+            ErrorCase::MalformedBuildArch => {
+                PxeRequestError::MalformedBuildArch("bad arch".to_string())
+            }
+        }
+    }
+
+    fn display_error(case: ErrorCase) -> String {
+        error_for(case).to_string()
+    }
+
+    fn debug_matches_display(case: ErrorCase) -> bool {
+        let error = error_for(case);
+        format!("{error:?}") == error.to_string()
+    }
+
+    fn response_status(case: ErrorCase) -> StatusCode {
+        error_for(case).into_response().status()
+    }
+
+    #[test]
+    fn formats_pxe_request_errors() {
+        value_scenarios!(display_error:
+            "missing inputs" {
+                ErrorCase::MissingClientConfig => "Missing client configuration from server config (should not reach this case)".to_string(),
+                ErrorCase::MissingMachineId => "Missing Machine Identifier (UUID) specified in URI parameter uuid".to_string(),
+                ErrorCase::InvalidBuildArch => "Invalid build arch specified in URI parameter buildarch".to_string(),
+            }
+
+            "malformed inputs" {
+                ErrorCase::MalformedMachineId => "Malformed Machine UUID: bad uuid".to_string(),
+                ErrorCase::MalformedBuildArch => "Malformed build arch: bad arch".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn debug_matches_display_for_pxe_request_errors() {
+        value_scenarios!(debug_matches_display:
+            "debug" {
+                ErrorCase::MissingClientConfig => true,
+                ErrorCase::MissingMachineId => true,
+                ErrorCase::InvalidBuildArch => true,
+                ErrorCase::MalformedMachineId => true,
+                ErrorCase::MalformedBuildArch => true,
+            }
+        );
+    }
+
+    #[test]
+    fn converts_pxe_request_errors_to_bad_request_responses() {
+        value_scenarios!(response_status:
+            "response status" {
+                ErrorCase::MissingClientConfig => StatusCode::BAD_REQUEST,
+                ErrorCase::MissingMachineId => StatusCode::BAD_REQUEST,
+                ErrorCase::InvalidBuildArch => StatusCode::BAD_REQUEST,
+                ErrorCase::MalformedMachineId => StatusCode::BAD_REQUEST,
+                ErrorCase::MalformedBuildArch => StatusCode::BAD_REQUEST,
+            }
+        );
+    }
+}


### PR DESCRIPTION
This supports #3914.

## Summary

Pull `carbide-test-support` into `carbide-pxe` and add scenario tables for runtime env parsing, machine architecture parsing, PXE request errors, and logfmt rendering.

## Coverage

`cargo llvm-cov -p carbide-pxe --json --summary-only --ignore-filename-regex '/(tests|target)/'`

| Metric | Before | After |
| --- | ---: | ---: |
| Lines | 392/1086 (36.10%) | 684/1299 (52.66%) |
| Functions | 20/101 (19.80%) | 61/126 (48.41%) |

## Testing

- `cargo make format-nightly`
- `cargo test -p carbide-pxe`
- `cargo clippy -p carbide-pxe -- -D warnings`
- `cargo clippy -p carbide-pxe --tests -- -D warnings`