### PR TITLE
test(ib-fabric): expand fabric utility test enumerations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-health-report",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/ib-fabric/Cargo.toml
+++ b/crates/ib-fabric/Cargo.toml
@@ -48,6 +48,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 figment = { features = ["env", "test", "toml"], workspace = true }
 
 [lints]

--- a/crates/ib-fabric/src/errors.rs
+++ b/crates/ib-fabric/src/errors.rs
@@ -49,3 +49,46 @@ impl IbError {
 }
 
 pub type IbResult<T> = Result<T, IbError>;
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    enum ErrorCase {
+        Fabric,
+        NotFound,
+        InvalidArgument,
+        NotImplemented,
+        Internal,
+    }
+
+    fn error_for(case: ErrorCase) -> IbError {
+        match case {
+            ErrorCase::Fabric => IbError::IBFabricError("ufm failed".to_string()),
+            ErrorCase::NotFound => IbError::NotFoundError {
+                kind: "Machine",
+                id: "machine-1".to_string(),
+            },
+            ErrorCase::InvalidArgument => IbError::InvalidArgument("bad pkey".to_string()),
+            ErrorCase::NotImplemented => IbError::NotImplemented,
+            ErrorCase::Internal => IbError::internal("unexpected state".to_string()),
+        }
+    }
+
+    #[test]
+    fn formats_ib_errors() {
+        value_scenarios!(
+            run = |case| error_for(case).to_string();
+            "user facing errors" {
+                ErrorCase::Fabric => "Failed to call IBFabricManager: ufm failed".to_string(),
+                ErrorCase::NotFound => "Machine not found: machine-1".to_string(),
+                ErrorCase::InvalidArgument => "Argument is invalid: bad pkey".to_string(),
+                ErrorCase::NotImplemented => "The function is not implemented".to_string(),
+                ErrorCase::Internal => "Internal error: unexpected state".to_string(),
+            }
+        );
+    }
+}

--- a/crates/ib-fabric/src/ib/disable.rs
+++ b/crates/ib-fabric/src/ib/disable.rs
@@ -83,3 +83,127 @@ impl IBFabric for DisableIBFabric {
         Err(IbError::IBFabricError("ib fabric is disabled".to_string()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async};
+
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    enum DisabledOperation {
+        GetFabricConfig,
+        GetNetwork,
+        GetNetworks,
+        BindPorts,
+        UpdateQos,
+        FindPort,
+        UnbindPorts,
+        Versions,
+        RawGet,
+    }
+
+    fn ib_network() -> IBNetwork {
+        IBNetwork {
+            name: "tenant".to_string(),
+            pkey: 1,
+            ipoib: true,
+            qos_conf: None,
+            associated_guids: None,
+            membership: None,
+        }
+    }
+
+    fn qos_conf() -> IBQosConf {
+        IBQosConf {
+            mtu: Default::default(),
+            service_level: Default::default(),
+            rate_limit: Default::default(),
+        }
+    }
+
+    async fn run_disabled_operation(operation: DisabledOperation) -> Result<(), String> {
+        let fabric = DisableIBFabric {};
+        match operation {
+            DisabledOperation::GetFabricConfig => fabric.get_fabric_config().await.map(|_| ()),
+            DisabledOperation::GetNetwork => fabric
+                .get_ib_network(1, GetPartitionOptions::default())
+                .await
+                .map(|_| ()),
+            DisabledOperation::GetNetworks => fabric
+                .get_ib_networks(GetPartitionOptions::default())
+                .await
+                .map(|_| ()),
+            DisabledOperation::BindPorts => {
+                fabric
+                    .bind_ib_ports(ib_network(), vec!["guid-1".to_string()])
+                    .await
+            }
+            DisabledOperation::UpdateQos => fabric.update_partition_qos_conf(1, &qos_conf()).await,
+            DisabledOperation::FindPort => fabric.find_ib_port(None).await.map(|_| ()),
+            DisabledOperation::UnbindPorts => {
+                fabric.unbind_ib_ports(1, vec!["guid-1".to_string()]).await
+            }
+            DisabledOperation::Versions => fabric.versions().await.map(|_| ()),
+            DisabledOperation::RawGet => fabric.raw_get("/app/ufm_version").await.map(|_| ()),
+        }
+        .map_err(|error| error.to_string())
+    }
+
+    #[tokio::test]
+    async fn disabled_fabric_rejects_operations() {
+        let disabled = "Failed to call IBFabricManager: ib fabric is disabled".to_string();
+        check_cases_async(
+            [
+                Case {
+                    scenario: "get fabric config",
+                    input: DisabledOperation::GetFabricConfig,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "get network",
+                    input: DisabledOperation::GetNetwork,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "get networks",
+                    input: DisabledOperation::GetNetworks,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "bind ports",
+                    input: DisabledOperation::BindPorts,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "update qos",
+                    input: DisabledOperation::UpdateQos,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "find port",
+                    input: DisabledOperation::FindPort,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "unbind ports",
+                    input: DisabledOperation::UnbindPorts,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "versions",
+                    input: DisabledOperation::Versions,
+                    expect: FailsWith(disabled.clone()),
+                },
+                Case {
+                    scenario: "raw get",
+                    input: DisabledOperation::RawGet,
+                    expect: FailsWith(disabled),
+                },
+            ],
+            run_disabled_operation,
+        )
+        .await;
+    }
+}

--- a/crates/ib-fabric/src/ib/mod.rs
+++ b/crates/ib-fabric/src/ib/mod.rs
@@ -176,3 +176,161 @@ impl IBFabricManager for IBFabricManagerImpl {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use carbide_secrets::SecretsError;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    struct NoopCredentialReader;
+
+    #[async_trait]
+    impl CredentialReader for NoopCredentialReader {
+        async fn get_credentials(
+            &self,
+            _key: &CredentialKey,
+        ) -> Result<Option<Credentials>, SecretsError> {
+            Ok(None)
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum ManagerCase {
+        ValidDisabled,
+        EmptyEndpointList,
+        MultipleEndpoints,
+        InvalidEndpoint,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ManagerConfigSummary {
+        endpoint_count: usize,
+        manager_type: &'static str,
+        max_partition_per_tenant: i32,
+        allow_insecure_fabric_configuration: bool,
+        fabric_manager_run_interval_secs: u64,
+    }
+
+    fn credential_reader() -> Arc<dyn CredentialReader> {
+        Arc::new(NoopCredentialReader)
+    }
+
+    fn manager_type_name(manager_type: IBFabricManagerType) -> &'static str {
+        match manager_type {
+            IBFabricManagerType::Disable => "disable",
+            #[cfg(feature = "test-support")]
+            IBFabricManagerType::Mock => "mock",
+            IBFabricManagerType::Rest => "rest",
+        }
+    }
+
+    fn summarize_manager_config(config: IBFabricManagerConfig) -> ManagerConfigSummary {
+        ManagerConfigSummary {
+            endpoint_count: config.endpoints.len(),
+            manager_type: manager_type_name(config.manager_type),
+            max_partition_per_tenant: config.max_partition_per_tenant,
+            allow_insecure_fabric_configuration: config.allow_insecure_fabric_configuration,
+            fabric_manager_run_interval_secs: config.fabric_manager_run_interval.as_secs(),
+        }
+    }
+
+    fn config_for_case(case: ManagerCase) -> IBFabricManagerConfig {
+        let mut config = IBFabricManagerConfig::default();
+        match case {
+            ManagerCase::ValidDisabled => {
+                config.endpoints.insert(
+                    "fabric-a".to_string(),
+                    vec!["https://127.0.0.1:443".to_string()],
+                );
+            }
+            ManagerCase::EmptyEndpointList => {
+                config.endpoints.insert("fabric-a".to_string(), vec![]);
+            }
+            ManagerCase::MultipleEndpoints => {
+                config.endpoints.insert(
+                    "fabric-a".to_string(),
+                    vec![
+                        "https://127.0.0.1:443".to_string(),
+                        "https://127.0.0.2:443".to_string(),
+                    ],
+                );
+            }
+            ManagerCase::InvalidEndpoint => {
+                config
+                    .endpoints
+                    .insert("fabric-a".to_string(), vec!["not a uri".to_string()]);
+            }
+        }
+        config
+    }
+
+    fn create_manager(case: ManagerCase) -> Result<ManagerConfigSummary, &'static str> {
+        create_ib_fabric_manager(credential_reader(), config_for_case(case))
+            .map(|manager| summarize_manager_config(manager.get_config()))
+            .map_err(manager_error_kind)
+    }
+
+    fn manager_error_kind(error: eyre::Report) -> &'static str {
+        let error = error.to_string();
+        if error.contains("Exactly 1 endpoint") {
+            "endpoint-count"
+        } else if error.contains("not a valid HTTP(S) URI") {
+            "invalid-uri"
+        } else {
+            "unknown"
+        }
+    }
+
+    #[test]
+    fn default_manager_config_uses_disabled_defaults() {
+        assert_eq!(
+            summarize_manager_config(IBFabricManagerConfig::default()),
+            ManagerConfigSummary {
+                endpoint_count: 0,
+                manager_type: "disable",
+                max_partition_per_tenant: config::IBFabricConfig::default_max_partition_per_tenant(
+                ),
+                allow_insecure_fabric_configuration: false,
+                fabric_manager_run_interval_secs: 60,
+            }
+        );
+    }
+
+    #[test]
+    fn validates_manager_endpoints() {
+        scenarios!(create_manager:
+            "valid config" {
+                ManagerCase::ValidDisabled => Yields(ManagerConfigSummary {
+                    endpoint_count: 1,
+                    manager_type: "disable",
+                    max_partition_per_tenant: config::IBFabricConfig::default_max_partition_per_tenant(),
+                    allow_insecure_fabric_configuration: false,
+                    fabric_manager_run_interval_secs: 60,
+                }),
+            }
+
+            "invalid endpoints" {
+                ManagerCase::EmptyEndpointList => FailsWith("endpoint-count"),
+                ManagerCase::MultipleEndpoints => FailsWith("endpoint-count"),
+                ManagerCase::InvalidEndpoint => FailsWith("invalid-uri"),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_manager_returns_disabled_client() {
+        let manager =
+            create_ib_fabric_manager(credential_reader(), IBFabricManagerConfig::default())
+                .unwrap();
+        let client = manager.new_client("fabric-a").await.unwrap();
+
+        assert_eq!(
+            client.get_fabric_config().await.unwrap_err().to_string(),
+            "Failed to call IBFabricManager: ib fabric is disabled"
+        );
+    }
+}

--- a/crates/ib-fabric/src/ib/ufmclient/mod.rs
+++ b/crates/ib-fabric/src/ib/ufmclient/mod.rs
@@ -603,103 +603,83 @@ impl Ufm {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
-    #[test]
-    fn test_filter_port() {
-        struct TestCase {
-            name: String,
-            ports: Vec<Port>,
-            pkey_guids: Option<HashSet<String>>,
-            guids: Option<HashSet<String>>,
-            port_state: Option<String>,
-            expected: Vec<Port>,
+    #[derive(Clone, Copy, Debug)]
+    enum FilterCase {
+        NoFilter,
+        PkeyGuids,
+        Guids,
+        GuidAndPkeyIntersection,
+        GuidAndPkeyIntersectionSecondPort,
+        PortState,
+        PortStateIsCaseInsensitive,
+        GuidAndMissingPortState,
+    }
+
+    fn port(guid: &str, logical_state: &str) -> Port {
+        Port {
+            guid: guid.to_string(),
+            logical_state: logical_state.to_string(),
+            ..Port::default()
         }
+    }
 
-        let p1_id = String::from("p1");
-        let p1 = Port {
-            guid: p1_id.clone(),
-            logical_state: "Active".to_string(),
-            ..Port::default()
-        };
+    fn guid_set(guids: &[&str]) -> Option<HashSet<String>> {
+        Some(guids.iter().map(|guid| (*guid).to_string()).collect())
+    }
 
-        let p2_id = String::from("p2");
-        let p2 = Port {
-            guid: p2_id.clone(),
-            logical_state: "Down".to_string(),
-            ..Port::default()
-        };
-
-        let p3_id = String::from("p3");
-        let p3 = Port {
-            guid: p3_id.clone(),
-            logical_state: "Initialize".to_string(),
-            ..Port::default()
-        };
-
-        let cases = vec![
-            TestCase {
-                name: String::from("no filter"),
-                ports: vec![p1.clone(), p2.clone(), p3.clone()],
-                pkey_guids: None,
-                guids: None,
-                port_state: None,
-                expected: vec![p1.clone(), p2.clone(), p3.clone()],
-            },
-            TestCase {
-                name: String::from("filter by pkey guids"),
-                ports: vec![p1.clone(), p2.clone(), p3.clone()],
-                pkey_guids: Some(HashSet::from_iter([p1_id.clone()])),
-                guids: None,
-                port_state: None,
-                expected: vec![p1.clone()],
-            },
-            TestCase {
-                name: String::from("filter by guids"),
-                ports: vec![p1.clone(), p2.clone(), p3.clone()],
-                pkey_guids: None,
-                guids: Some(HashSet::from_iter([p1_id.clone()])),
-                port_state: None,
-                expected: vec![p1.clone()],
-            },
-            TestCase {
-                name: String::from("filter by guids (1) and pkey guids (1,2)"),
-                ports: vec![p1.clone(), p2.clone(), p3.clone()],
-                pkey_guids: Some(HashSet::from_iter([p1_id.clone(), p2_id.clone()])),
-                guids: Some(HashSet::from_iter([p1_id.clone()])),
-                port_state: None,
-                expected: vec![p1.clone()],
-            },
-            TestCase {
-                name: String::from("filter by guids (2,3) and pkey guids (1,2)"),
-                ports: vec![p1.clone(), p2.clone(), p3.clone()],
-                pkey_guids: Some(HashSet::from_iter([p1_id.clone(), p2_id.clone()])),
-                guids: Some(HashSet::from_iter([p2_id, p3_id])),
-                port_state: None,
-                expected: vec![p2.clone()],
-            },
-            TestCase {
-                name: String::from("filter by port statet"),
-                ports: vec![p1.clone(), p2.clone(), p3.clone()],
-                pkey_guids: None,
-                guids: None,
-                port_state: Some("Active".to_string()),
-                expected: vec![p1.clone()],
-            },
-            TestCase {
-                name: String::from("filter by guids and port state"),
-                ports: vec![p1, p2, p3],
-                pkey_guids: None,
-                guids: Some(HashSet::from_iter([p1_id])),
-                port_state: Some("Disabled".to_string()),
-                expected: vec![],
-            },
+    fn filter_port_guids(case: FilterCase) -> Vec<String> {
+        let ports = vec![
+            port("p1", "Active"),
+            port("p2", "Down"),
+            port("p3", "Initialize"),
         ];
+        let (pkey_guids, guids, port_state) = match case {
+            FilterCase::NoFilter => (None, None, None),
+            FilterCase::PkeyGuids => (guid_set(&["p1"]), None, None),
+            FilterCase::Guids => (None, guid_set(&["p1"]), None),
+            FilterCase::GuidAndPkeyIntersection => {
+                (guid_set(&["p1", "p2"]), guid_set(&["p1"]), None)
+            }
+            FilterCase::GuidAndPkeyIntersectionSecondPort => {
+                (guid_set(&["p1", "p2"]), guid_set(&["p2", "p3"]), None)
+            }
+            FilterCase::PortState => (None, None, Some("Active".to_string())),
+            FilterCase::PortStateIsCaseInsensitive => (None, None, Some(" active ".to_string())),
+            FilterCase::GuidAndMissingPortState => {
+                (None, guid_set(&["p1"]), Some("Disabled".to_string()))
+            }
+        };
 
-        for c in cases {
-            let got = Ufm::filter_ports(c.ports, c.pkey_guids, c.guids, c.port_state);
-            assert_eq!(c.expected, got, "{}", c.name);
-        }
+        Ufm::filter_ports(ports, pkey_guids, guids, port_state)
+            .into_iter()
+            .map(|port| port.guid)
+            .collect()
+    }
+
+    #[test]
+    fn filters_ports() {
+        value_scenarios!(filter_port_guids:
+            "unfiltered" {
+                FilterCase::NoFilter => vec!["p1".to_string(), "p2".to_string(), "p3".to_string()],
+            }
+
+            "guid filters" {
+                FilterCase::PkeyGuids => vec!["p1".to_string()],
+                FilterCase::Guids => vec!["p1".to_string()],
+                FilterCase::GuidAndPkeyIntersection => vec!["p1".to_string()],
+                FilterCase::GuidAndPkeyIntersectionSecondPort => vec!["p2".to_string()],
+            }
+
+            "state filters" {
+                FilterCase::PortState => vec!["p1".to_string()],
+                FilterCase::PortStateIsCaseInsensitive => vec!["p1".to_string()],
+                FilterCase::GuidAndMissingPortState => Vec::<String>::new(),
+            }
+        );
     }
 }
 

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -1270,59 +1270,58 @@ fn is_pkey_in_managed_range(pkey: PartitionKey, fabric_definition: &IbFabricDefi
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
     #[test]
-    fn test_parse_num() {
-        assert_eq!(0, parse_num("0x0000000000000000").unwrap());
-        assert_eq!(1, parse_num("0x0000000000000001").unwrap());
-        assert_eq!(0, parse_num("0x00").unwrap());
-        assert_eq!(1, parse_num("0x01").unwrap());
-    }
+    fn parses_numbers() {
+        value_scenarios!(parse_num:
+            "hex" {
+                "0x0000000000000000" => Some(0),
+                "0x0000000000000001" => Some(1),
+                "0x00" => Some(0),
+                "0x01" => Some(1),
+                "0xff" => Some(255),
+            }
 
-    // ============================================================
-    // Unit Tests for parse_guids_from_alert
-    // ============================================================
+            "decimal" {
+                "0" => Some(0),
+                "1" => Some(1),
+                "2303" => Some(2303),
+            }
 
-    #[test]
-    fn test_parse_guids_single() {
-        let message = "IB port cleanup pending - IB Monitor will unbind. GUIDs: 946dae03006104f8";
-        let result = parse_guids_from_alert(message);
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0], "946dae03006104f8");
-    }
-
-    #[test]
-    fn test_parse_guids_multiple() {
-        let message = "IB port cleanup pending - IB Monitor will unbind. GUIDs: 946dae03006104f8; abc123def4567890; fedcba9876543210";
-        let result = parse_guids_from_alert(message);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0], "946dae03006104f8");
-        assert_eq!(result[1], "abc123def4567890");
-        assert_eq!(result[2], "fedcba9876543210");
+            "invalid" {
+                "" => None,
+                "0x" => None,
+                "not-a-number" => None,
+            }
+        );
     }
 
     #[test]
-    fn test_parse_guids_wrong_prefix() {
-        let message = "Wrong prefix message";
-        let result = parse_guids_from_alert(message);
-        assert_eq!(result.len(), 0);
-    }
+    fn parses_cleanup_alert_guids() {
+        value_scenarios!(parse_guids_from_alert:
+            "valid alerts" {
+                "IB port cleanup pending - IB Monitor will unbind. GUIDs: 946dae03006104f8" => vec![
+                    "946dae03006104f8".to_string(),
+                ],
+                "IB port cleanup pending - IB Monitor will unbind. GUIDs: 946dae03006104f8; abc123def4567890; fedcba9876543210" => vec![
+                    "946dae03006104f8".to_string(),
+                    "abc123def4567890".to_string(),
+                    "fedcba9876543210".to_string(),
+                ],
+                "IB port cleanup pending - IB Monitor will unbind. GUIDs:  abc  ;  def  " => vec![
+                    "abc".to_string(),
+                    "def".to_string(),
+                ],
+            }
 
-    #[test]
-    fn test_parse_guids_empty() {
-        let message = "IB port cleanup pending - IB Monitor will unbind. GUIDs: ";
-        let result = parse_guids_from_alert(message);
-        assert_eq!(result.len(), 0);
-    }
-
-    #[test]
-    fn test_parse_guids_with_whitespace() {
-        let message = "IB port cleanup pending - IB Monitor will unbind. GUIDs:  abc  ;  def  ";
-        let result = parse_guids_from_alert(message);
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], "abc");
-        assert_eq!(result[1], "def");
+            "ignored messages" {
+                "Wrong prefix message" => Vec::<String>::new(),
+                "IB port cleanup pending - IB Monitor will unbind. GUIDs: " => Vec::<String>::new(),
+            }
+        );
     }
 
     // ============================================================
@@ -1394,75 +1393,40 @@ mod tests {
     }
 
     #[test]
-    fn test_pkey_in_range_decimal() {
-        let fabric = make_fabric_definition(vec![("256", "2303")]);
-        // 0x100 = 256, should be in range
-        let pkey = PartitionKey::try_from(256u16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
+    fn checks_managed_pkey_ranges() {
+        value_scenarios!(
+            run = |(pkey, ranges): (u16, Vec<(&str, &str)>)| {
+                let fabric = make_fabric_definition(ranges);
+                let pkey = PartitionKey::try_from(pkey).unwrap();
+                is_pkey_in_managed_range(pkey, &fabric)
+            };
+            "decimal range" {
+                (256, vec![("256", "2303")]) => true,
+                (2302, vec![("256", "2303")]) => true,
+                (1280, vec![("256", "2303")]) => true,
+                (255, vec![("256", "2303")]) => false,
+                (2303, vec![("256", "2303")]) => false,
+                (0x5000, vec![("256", "2303")]) => false,
+            }
 
-        // 0x8FE = 2302, should be in range (end is exclusive)
-        let pkey = PartitionKey::try_from(2302u16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
+            "hex range" {
+                (0x100, vec![("0x100", "0x8FF")]) => true,
+                (0x8FE, vec![("0x100", "0x8FF")]) => true,
+                (0x8FF, vec![("0x100", "0x8FF")]) => false,
+            }
 
-        // 0x500 = 1280, should be in range
-        let pkey = PartitionKey::try_from(1280u16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
-    }
+            "multiple ranges" {
+                (150, vec![("100", "200"), ("500", "600")]) => true,
+                (550, vec![("100", "200"), ("500", "600")]) => true,
+                (300, vec![("100", "200"), ("500", "600")]) => false,
+            }
 
-    #[test]
-    fn test_pkey_outside_range() {
-        let fabric = make_fabric_definition(vec![("256", "2303")]);
-
-        // 0x5000 = 20480, should be OUTSIDE range
-        let pkey = PartitionKey::try_from(0x5000u16).unwrap();
-        assert!(!is_pkey_in_managed_range(pkey, &fabric));
-
-        // 255 is just below range
-        let pkey = PartitionKey::try_from(255u16).unwrap();
-        assert!(!is_pkey_in_managed_range(pkey, &fabric));
-
-        // 2303 is the exclusive end, should be OUTSIDE range
-        let pkey = PartitionKey::try_from(2303u16).unwrap();
-        assert!(!is_pkey_in_managed_range(pkey, &fabric));
-    }
-
-    #[test]
-    fn test_pkey_in_range_hex() {
-        let fabric = make_fabric_definition(vec![("0x100", "0x8FF")]);
-
-        // 0x100 = 256, should be in range
-        let pkey = PartitionKey::try_from(0x100u16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
-
-        // 0x8FE = 2302, should be in range (end is exclusive)
-        let pkey = PartitionKey::try_from(0x8FEu16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
-    }
-
-    #[test]
-    fn test_pkey_multiple_ranges() {
-        let fabric = make_fabric_definition(vec![("100", "200"), ("500", "600")]);
-
-        // In first range
-        let pkey = PartitionKey::try_from(150u16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
-
-        // In second range
-        let pkey = PartitionKey::try_from(550u16).unwrap();
-        assert!(is_pkey_in_managed_range(pkey, &fabric));
-
-        // Between ranges (not managed)
-        let pkey = PartitionKey::try_from(300u16).unwrap();
-        assert!(!is_pkey_in_managed_range(pkey, &fabric));
-    }
-
-    #[test]
-    fn test_pkey_empty_ranges() {
-        let fabric = make_fabric_definition(vec![]);
-
-        // No ranges configured, nothing is managed
-        let pkey = PartitionKey::try_from(256u16).unwrap();
-        assert!(!is_pkey_in_managed_range(pkey, &fabric));
+            "empty or invalid ranges" {
+                (256, vec![]) => false,
+                (256, vec![("not-a-number", "300")]) => false,
+                (256, vec![("100", "not-a-number")]) => false,
+            }
+        );
     }
 
     // ============================================================

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -554,3 +554,68 @@ fn truncate_error_for_metric_label(mut error: String) -> String {
     error.truncate(upto);
     error
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    fn operation_metric_value(operation: UfmOperation) -> String {
+        opentelemetry::Value::from(operation).to_string()
+    }
+
+    fn status_metric_value(status: UfmOperationStatus) -> String {
+        opentelemetry::Value::from(status).to_string()
+    }
+
+    #[test]
+    fn enumerates_ufm_operations_and_statuses() {
+        assert_eq!(
+            UfmOperation::values().collect::<Vec<_>>(),
+            vec![
+                UfmOperation::BindGuidToPkey,
+                UfmOperation::UnbindGuidFromPkey
+            ]
+        );
+        assert_eq!(
+            UfmOperationStatus::values().collect::<Vec<_>>(),
+            vec![UfmOperationStatus::Ok, UfmOperationStatus::Error]
+        );
+    }
+
+    #[test]
+    fn converts_ufm_operations_to_metric_values() {
+        value_scenarios!(operation_metric_value:
+            "operations" {
+                UfmOperation::BindGuidToPkey => "bind_guid_to_pkey".to_string(),
+                UfmOperation::UnbindGuidFromPkey => "unbind_guid_from_pkey".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn converts_ufm_operation_statuses_to_metric_values() {
+        value_scenarios!(status_metric_value:
+            "statuses" {
+                UfmOperationStatus::Ok => "ok".to_string(),
+                UfmOperationStatus::Error => "error".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn creates_empty_monitor_metrics() {
+        let metrics = IbFabricMonitorMetrics::new();
+
+        assert_eq!(metrics.num_fabrics, 0);
+        assert!(metrics.fabrics.is_empty());
+        assert_eq!(metrics.num_machine_ib_status_updates, 0);
+        assert!(metrics.num_machines_by_port_states.is_empty());
+        assert!(metrics.num_machines_by_ports_with_partitions.is_empty());
+        assert_eq!(metrics.num_machines_with_missing_pkeys, 0);
+        assert_eq!(metrics.num_machines_with_unexpected_pkeys, 0);
+        assert_eq!(metrics.num_machines_with_unknown_pkeys, 0);
+        assert!(metrics.applied_changes.is_empty());
+    }
+}


### PR DESCRIPTION
This supports #3914.

## Summary

Pull `carbide-test-support` into `carbide-ib-fabric` and expand scenario coverage for error formatting, disabled fabric behavior, manager validation, UFM filtering, parser helpers, managed PKey ranges, and metric enum conversions.

## Coverage

`cargo llvm-cov -p carbide-ib-fabric --json --summary-only --ignore-filename-regex '/(tests|target)/'`

| Metric | Before | After |
| --- | ---: | ---: |
| Lines | 983/2816 (34.91%) | 1316/3056 (43.06%) |
| Functions | 74/264 (28.03%) | 117/289 (40.48%) |

## Testing

- `cargo make format-nightly`
- `cargo test -p carbide-ib-fabric`
- `cargo clippy -p carbide-ib-fabric -- -D warnings`
- `cargo clippy -p carbide-ib-fabric --tests -- -D warnings`