### PR TITLE
preingestion: power off host before BMC firmware update

### DIFF
--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -34,6 +34,7 @@ use common::api_fixtures::{
     self, TestEnv, TestManagedHost, create_test_env_with_overrides, get_config,
 };
 use db::{self, DatabaseError};
+use libredfish::SystemPowerControl;
 use model::firmware::{Firmware, FirmwareComponent, FirmwareComponentType, FirmwareEntry};
 use model::instance::status::tenant::TenantState;
 use model::machine::{HostReprovisionState, InstanceState, ManagedHostState};
@@ -369,6 +370,45 @@ async fn insert_endpoint(
         txn,
     )
     .await
+}
+
+fn enable_host_bmc_preingestion_power_off_before_update(config: &mut CarbideConfig) {
+    let bmc_component = config
+        .host_models
+        .get_mut("1")
+        .expect("PowerEdge R750 fixture is missing")
+        .components
+        .get_mut(&FirmwareComponentType::Bmc)
+        .expect("PowerEdge R750 BMC firmware fixture is missing");
+
+    let firmware = bmc_component
+        .known_firmware
+        .iter_mut()
+        .find(|firmware| firmware.version == "6.00.30.00")
+        .expect("PowerEdge R750 target BMC firmware is missing");
+    firmware.preingestion_power_off_host_before_update = true;
+}
+
+fn add_bluefield_bmc_with_preingestion_power_off_before_update(config: &mut CarbideConfig) {
+    let mut firmware = config
+        .host_models
+        .get("1")
+        .expect("PowerEdge R750 fixture is missing")
+        .clone();
+    firmware.model = "BlueField-3 DPU".to_string();
+    let bmc_component = firmware
+        .components
+        .get_mut(&FirmwareComponentType::Bmc)
+        .expect("PowerEdge R750 BMC firmware fixture is missing");
+    let firmware_entry = bmc_component
+        .known_firmware
+        .iter_mut()
+        .find(|firmware| firmware.version == "6.00.30.00")
+        .expect("PowerEdge R750 target BMC firmware is missing");
+    firmware_entry.preingestion_power_off_host_before_update = true;
+    config
+        .host_models
+        .insert("bluefield-power-off-test".to_string(), firmware);
 }
 
 fn build_exploration_report(
@@ -958,6 +998,124 @@ fn test_merge_firmware_configs_write(
     let mut file = dir.clone();
     file.push("metadata.toml");
     fs::write(file, contents)?;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_preingestion_host_bmc_power_off_before_update(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = get_config();
+    enable_host_bmc_preingestion_power_off_before_update(&mut config);
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(config)).await;
+
+    let mgr = PreingestionManager::new(
+        pool.clone(),
+        env.config.preingestion_manager(),
+        env.redfish_sim.clone(),
+        env.test_meter.meter(),
+        None,
+        None,
+        None,
+        env.api.work_lock_manager_handle.clone(),
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder("b8:3f:d2:90:97:a6", "192.0.2.1")
+                .vendor_string("iDRac")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    let addr = response.address.as_str();
+    let mut txn = pool.begin().await.unwrap();
+    insert_endpoint_version(&mut txn, addr, "4.9", "1.13.2", false).await?;
+    txn.commit().await?;
+
+    let timepoint = env.redfish_sim.timepoint();
+    mgr.run_single_iteration().await?;
+
+    let actions = env.redfish_sim.actions_since(&timepoint).all_hosts();
+    assert!(
+        actions.contains(&RedfishSimAction::Power(SystemPowerControl::ForceOff)),
+        "Expected preingestion to power off host before host BMC firmware update; actions: {actions:?}"
+    );
+
+    let mut txn = pool.begin().await.unwrap();
+    let endpoints =
+        db::explored_endpoints::find_preingest_not_waiting_not_error(txn.as_mut()).await?;
+    assert_eq!(endpoints.len(), 1);
+    let endpoint = endpoints.first().unwrap();
+    match &endpoint.preingestion_state {
+        PreingestionState::UpgradeFirmwareWait { upgrade_type, .. } => {
+            assert_eq!(*upgrade_type, FirmwareComponentType::Bmc);
+        }
+        _ => {
+            panic!("Bad preingestion state: {endpoint:?}");
+        }
+    }
+    txn.commit().await?;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_preingestion_bluefield_bmc_power_off_before_update_is_ignored(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = get_config();
+    add_bluefield_bmc_with_preingestion_power_off_before_update(&mut config);
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(config)).await;
+
+    let mgr = PreingestionManager::new(
+        pool.clone(),
+        env.config.preingestion_manager(),
+        env.redfish_sim.clone(),
+        env.test_meter.meter(),
+        None,
+        None,
+        None,
+        env.api.work_lock_manager_handle.clone(),
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder("b8:3f:d2:90:97:a6", "192.0.2.1")
+                .vendor_string("iDRac")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    let addr = response.address.as_str();
+    let mut txn = pool.begin().await.unwrap();
+    insert_endpoint(
+        &mut txn,
+        addr,
+        "fm100hsag07peffp850l14kvmhrqjf9h6jslilfahaknhvb6sq786c0g3jg",
+        "Dell Inc.",
+        "BlueField-3 DPU",
+        "4.9",
+        "1.13.2",
+    )
+    .await?;
+    txn.commit().await?;
+
+    let timepoint = env.redfish_sim.timepoint();
+    mgr.run_single_iteration().await?;
+
+    let actions = env.redfish_sim.actions_since(&timepoint).all_hosts();
+    assert!(
+        !actions.contains(&RedfishSimAction::Power(SystemPowerControl::ForceOff)),
+        "Expected preingestion to keep BlueField/DPU powered before BMC firmware update; actions: {actions:?}"
+    );
 
     Ok(())
 }

--- a/crates/api-model/src/firmware.rs
+++ b/crates/api-model/src/firmware.rs
@@ -189,6 +189,10 @@ pub struct FirmwareEntry {
     // If set, we will pass the firmware type to libredfish which for some platforms will install only one part of a multi-firmware package.
     pub install_only_specified: bool,
     pub power_drains_needed: Option<u32>,
+    /// If true, preingestion powers off the host immediately before starting
+    /// this host BMC firmware update.
+    #[serde(default)]
+    pub preingestion_power_off_host_before_update: bool,
     #[serde(default)]
     // this firmware entry is only applicable in preingestion.
     // BF3s are the only machine with multiple firmware entries for a given firmware compoanent type (BMC FWs).
@@ -231,6 +235,7 @@ impl FirmwareEntry {
             mandatory_upgrade_from_priority: None,
             install_only_specified: false,
             power_drains_needed: None,
+            preingestion_power_off_host_before_update: false,
             preingestion_exclusive_config: false,
             pre_update_resets: false,
             script: None,

--- a/crates/firmware/src/tests/config.rs
+++ b/crates/firmware/src/tests/config.rs
@@ -121,6 +121,7 @@ preingest_upgrade_when_below = "1.27.260418"
 version = "1.27.260418"
 filename = "/opt/carbide/firmware/lenovo-thinksystem_hs350x_v3-bmc-1.27.260418/lnvgy_fw_BMC_igc602j-1.27_anyos_noarch.ima"
 default = true
+preingestion_power_off_host_before_update = true
 "#;
     let mut config: FirmwareConfig = Default::default();
     config.add_test_override(cfg.to_string());
@@ -131,17 +132,15 @@ default = true
         .unwrap();
 
     assert_eq!(server.vendor, bmc_vendor::BMCVendor::Lenovo);
-    assert_eq!(
-        server
-            .components
-            .get(&FirmwareComponentType::Bmc)
-            .unwrap()
-            .known_firmware
-            .first()
-            .unwrap()
-            .version,
-        "1.27.260418"
-    );
+    let firmware = server
+        .components
+        .get(&FirmwareComponentType::Bmc)
+        .unwrap()
+        .known_firmware
+        .first()
+        .unwrap();
+    assert_eq!(firmware.version, "1.27.260418");
+    assert!(firmware.preingestion_power_off_host_before_update);
     Ok(())
 }
 
@@ -158,6 +157,7 @@ current_version_reported_as = "BMCImage1"
 version = "1.27.260418"
 filename = "/opt/carbide/firmware/lenovo-thinksystem_hs350x_v3-bmc-1.27.260418/lnvgy_fw_BMC_igc602j-1.27_anyos_noarch.ima"
 default = true
+preingestion_power_off_host_before_update = true
 "#;
     let lenovoami_cfg = r#"
 model = "ThinkSystem HS350X V3"

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -45,7 +45,7 @@ use libredfish::{PowerState, Redfish, RedfishError, SystemPowerControl};
 use model::firmware::{Firmware, FirmwareComponentType, FirmwareEntry};
 use model::site_explorer::{
     ExploredEndpoint, InitialBmcResetPhase, InitialResetPhase, NicMode, PowerDrainState,
-    PreingestionState, TimeSyncResetPhase,
+    PreingestionState, TimeSyncResetPhase, is_bluefield_model,
 };
 use opentelemetry::metrics::Meter;
 use sqlx::PgPool;
@@ -677,6 +677,14 @@ impl PreingestionManagerStatic {
 
                     if !repeat && to_install.pre_update_resets {
                         self.pre_update_resets(db, endpoint, None, None).await?;
+                        return Ok((true, false));
+                    }
+
+                    if to_install.preingestion_power_off_host_before_update
+                        && !self
+                            .preingestion_power_off_host_before_update(db, endpoint, fw_type)
+                            .await
+                    {
                         return Ok((true, false));
                     }
 
@@ -1483,10 +1491,26 @@ impl PreingestionManagerStatic {
         redfish_client: &dyn libredfish::Redfish,
         endpoint: &ExploredEndpoint,
     ) -> bool {
+        if !self.execute_power_off(redfish_client, endpoint).await {
+            return false;
+        }
+        if let Err(e) = redfish_client.bmc_reset().await {
+            tracing::warn!("Could not reset BMC on {}: {e}", endpoint.address);
+            return false;
+        }
+        true
+    }
+
+    /// Helper: Power off host and verify that the host is off
+    /// Returns true if successful, false if any step failed
+    async fn execute_power_off(
+        &self,
+        redfish_client: &dyn libredfish::Redfish,
+        endpoint: &ExploredEndpoint,
+    ) -> bool {
         match redfish_client.power(SystemPowerControl::ForceOff).await {
             Ok(()) => {}
             Err(e) if matches!(e, RedfishError::UnnecessaryOperation) => {
-                // ignore because it is already off
                 tracing::debug!("Power off not needed on {}: {e}", endpoint.address);
             }
             Err(e) => {
@@ -1506,11 +1530,57 @@ impl PreingestionManagerStatic {
             tracing::warn!("Host {} did not turn off when requested", endpoint.address);
             return false;
         }
-        if let Err(e) = redfish_client.bmc_reset().await {
-            tracing::warn!("Could not reset BMC on {}: {e}", endpoint.address);
-            return false;
-        }
         true
+    }
+
+    /// Power off the host immediately before starting a host BMC firmware update.
+    /// Returns false when preingestion should retry later.
+    async fn preingestion_power_off_host_before_update(
+        &self,
+        db: &PgPool,
+        endpoint: &ExploredEndpoint,
+        fw_type: FirmwareComponentType,
+    ) -> bool {
+        if !fw_type.is_bmc() {
+            tracing::warn!(
+                "Ignoring preingestion_power_off_host_before_update for non-host-BMC firmware {:?} on {}",
+                fw_type,
+                endpoint.address
+            );
+            return true;
+        }
+
+        if endpoint.report.is_dpu()
+            || endpoint
+                .report
+                .model()
+                .is_some_and(|model| is_bluefield_model(&model))
+        {
+            tracing::warn!(
+                "Ignoring preingestion_power_off_host_before_update for BlueField/DPU endpoint {}; DPU must remain powered for firmware update",
+                endpoint.address
+            );
+            return true;
+        }
+
+        let redfish_client = match self
+            .redfish_client_pool
+            .create_client_for_ingested_host(endpoint.address, db)
+            .await
+        {
+            Ok(redfish_client) => redfish_client,
+            Err(e) => {
+                tracing::warn!("Redfish connection to {} failed: {e}", endpoint.address);
+                return false;
+            }
+        };
+
+        tracing::info!(
+            "Powering off host {} before BMC firmware update",
+            endpoint.address
+        );
+        self.execute_power_off(redfish_client.as_ref(), endpoint)
+            .await
     }
 
     /// Helper: Wait for BMC reset and power on the host


### PR DESCRIPTION
## Summary
- add `preingestion_power_off_host_before_update` firmware-entry flag
- power off host immediately before preingestion host BMC firmware updates when the flag is set
- ignore the flag for DPU/BlueField endpoints because DPU must remain powered for firmware update
- cover host-BMC power-off behavior and LenovoAMI firmware-config fallback in tests

## Deployment note
This PR does not add a new checked-in Lenovo HS350 firmware entry. To enable this for the Lenovo HS350 / HS350X V3 runtime config that already performs the BMC firmware update, set this on the existing BMC `known_firmware` entry:

```toml
preingestion_power_off_host_before_update = true
```

The LenovoAMI fallback test verifies that an endpoint reporting `LenovoAMI` can still match the Lenovo HS350 firmware metadata carrying this flag.

## Testing
- `cargo check -q -p carbide-preingestion-manager`
- `cargo test -q -p carbide-firmware lenovoami -- --nocapture`
- `cargo test -q -p carbide-api-core --no-default-features power_off_before_update --no-run`
- `cargo fmt`