### PR TITLE
Fix iPXE NICo branding

### DIFF
--- a/crates/dhcp/tests/booturl.rs
+++ b/crates/dhcp/tests/booturl.rs
@@ -14,8 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::io::ErrorKind;
 use std::net::UdpSocket;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use dhcp::mock_api_server;
 use dhcproto::{Decodable, Decoder, v4};
@@ -24,7 +25,41 @@ mod common;
 
 use common::{DHCPFactory, Kea, RELAY_IP};
 
-const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const READ_TIMEOUT: Duration = Duration::from_millis(200);
+const OFFER_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn recv_offer(socket: &UdpSocket, request: &[u8]) -> Result<v4::Message, eyre::Report> {
+    let deadline = Instant::now() + OFFER_TIMEOUT;
+    let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
+
+    loop {
+        // Retransmit on each receive timeout, matching DHCP-over-UDP retry
+        // behavior and avoiding a race with Kea finishing startup.
+        socket.send(request)?;
+        match socket.recv(&mut recv_buf) {
+            Ok(n) => {
+                let msg = v4::Message::decode(&mut Decoder::new(&recv_buf[..n]))
+                    .map_err(|err| eyre::eyre!("failed to decode DHCP response: {err}"))?;
+                return Ok(msg);
+            }
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted
+                ) =>
+            {
+                if Instant::now() >= deadline {
+                    return Err(eyre::eyre!(
+                        "timed out waiting for DHCP offer after {OFFER_TIMEOUT:?}: {err}"
+                    ));
+                }
+            }
+            Err(err) => {
+                return Err(eyre::eyre!("socket recv unhandled error: {err}"));
+            }
+        }
+    }
+}
 
 #[test]
 fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
@@ -48,22 +83,13 @@ fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
-    {
+    let pkt = {
         let mut msg = DHCPFactory::discover(1);
         msg.set_xid(0);
-        let pkt = DHCPFactory::encode(msg)?;
-        socket.send(&pkt)?;
-    }
-
-    let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
-    let n = match socket.recv(&mut recv_buf) {
-        Ok(n) => n,
-        Err(err) => {
-            panic!("socket recv unhandled error: {err}");
-        }
+        DHCPFactory::encode(msg)?
     };
 
-    let msg = v4::Message::decode(&mut Decoder::new(&recv_buf[..n])).unwrap();
+    let msg = recv_offer(&socket, &pkt)?;
     let wanted_location = "http://127.0.0.1:8080/public/blobs/internal/x86_64/ipxe.efi"
         .to_string()
         .into_bytes();
@@ -111,22 +137,13 @@ fn test_booturl_from_api() -> Result<(), eyre::Report> {
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
-    {
+    let pkt = {
         let mut msg = DHCPFactory::discover(0xAA);
         msg.set_xid(0);
-        let pkt = DHCPFactory::encode(msg)?;
-        socket.send(&pkt)?;
-    }
-
-    let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
-    let n = match socket.recv(&mut recv_buf) {
-        Ok(n) => n,
-        Err(err) => {
-            panic!("socket recv unhandled error: {err}");
-        }
+        DHCPFactory::encode(msg)?
     };
 
-    let msg = v4::Message::decode(&mut Decoder::new(&recv_buf[..n])).unwrap();
+    let msg = recv_offer(&socket, &pkt)?;
 
     let wanted_location =
         "https://api-specified-ipxe-url.forge/public/blobs/internal/x86_64/ipxe.efi"

--- a/crates/ipxe-renderer/src/lib.rs
+++ b/crates/ipxe-renderer/src/lib.rs
@@ -20,6 +20,9 @@ use std::collections::HashMap;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+const STATIC_IPXE_MENU_TEMPLATE_ID: &str = "c816a939-0993-5ebf-82dd-5227ad215703";
+const STATIC_IPXE_MENU_TEMPLATE: &str = include_str!("../../../pxe/ipxe/local/embed.ipxe");
+
 /// iPXE OS definition with template-based rendering support
 #[derive(Debug, Clone)]
 pub struct IpxeScript {
@@ -64,7 +67,7 @@ pub struct IpxeTemplateArtifact {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum IpxeTemplateScope {
-    /// Carbide-core usage only.
+    /// NICo Core usage only.
     #[default]
     Internal,
     /// Usable by tenant.
@@ -135,7 +138,7 @@ pub trait IpxeScriptRenderer {
     /// Render generates the final iPXE script from an IpxeScript object.
     /// Artifact URLs are replaced by local cached URLs when available (cached_url).
     /// `reserved_params` must contain exactly the reserved parameters defined
-    /// in the template (provided by carbide-core).
+    /// in the template (provided by NICo Core).
     fn render(
         &self,
         ipxeos: &IpxeScript,
@@ -190,7 +193,13 @@ impl DefaultIpxeScriptRenderer {
         let templates = template_collection
             .templates
             .into_iter()
-            .map(|t| (t.name.clone(), t))
+            .map(|mut t| {
+                if t.id == STATIC_IPXE_MENU_TEMPLATE_ID {
+                    t.template = STATIC_IPXE_MENU_TEMPLATE.to_string();
+                }
+
+                (t.name.clone(), t)
+            })
             .collect();
 
         Self { templates }
@@ -1047,6 +1056,47 @@ mod tests {
         assert!(templates.contains(&"carbide-menu-static-ipxe".to_string()));
         // Only assert minimum count (templates referenced in tests); new entries in templates.yaml are allowed
         assert!(templates.len() >= 11);
+    }
+
+    #[test]
+    fn test_static_ipxe_menu_uses_nico_branding() {
+        const BRANDING_H: &str = include_str!("../../../pxe/ipxe/local/branding.h");
+
+        let renderer = DefaultIpxeScriptRenderer::new();
+        let menu_template = renderer
+            .get_template_by_id(STATIC_IPXE_MENU_TEMPLATE_ID)
+            .expect("static iPXE menu template should exist");
+
+        assert_eq!(menu_template.template, STATIC_IPXE_MENU_TEMPLATE);
+
+        for (name, contents) in [
+            ("embedded iPXE script", STATIC_IPXE_MENU_TEMPLATE),
+            ("iPXE branding header", BRANDING_H),
+            (
+                "renderer static menu description",
+                menu_template.description.as_str(),
+            ),
+        ] {
+            assert!(contents.contains("NICo"), "{name} should mention NICo");
+        }
+
+        for (name, contents) in [
+            ("embedded iPXE script", STATIC_IPXE_MENU_TEMPLATE),
+            ("iPXE branding header", BRANDING_H),
+            (
+                "renderer static menu description",
+                menu_template.description.as_str(),
+            ),
+        ] {
+            assert!(
+                !contents.contains("Carbide") && !contents.contains("carbide"),
+                "{name} should not mention Carbide"
+            );
+            assert!(
+                !contents.contains("Forge") && !contents.contains("forge"),
+                "{name} should not mention Forge"
+            );
+        }
     }
 
     #[test]

--- a/crates/ipxe-renderer/templates.yaml
+++ b/crates/ipxe-renderer/templates.yaml
@@ -24,7 +24,7 @@ templates:
       # Safety check:
       iseq ${arch} unknown && echo "Unsupported architecture." && sleep 5 && exit 1 ||
 
-      # 2. Get carbide-core-generated reserved values (base URL for local artifacts and console specific to hardware):
+      # 2. Get NICo Core generated reserved values (base URL for local artifacts and console specific to hardware):
       set base_url {{base_url}}
       set console {{console}}
 
@@ -53,7 +53,7 @@ templates:
       # Safety check:
       iseq ${arch} unknown && echo "Unsupported architecture." && sleep 5 && exit 1 ||
 
-      # 2. Get carbide-core-generated reserved values (base URL for local artifacts and console specific to hardware):
+      # 2. Get NICo Core generated reserved values (base URL for local artifacts and console specific to hardware):
       set base_url {{base_url}}
       set console {{console}}
 
@@ -326,66 +326,7 @@ templates:
 
   - id: c816a939-0993-5ebf-82dd-5227ad215703
     name: carbide-menu-static-ipxe
-    description: Carbide Menu
+    description: NICo Menu
     scope: public
-    template: |
-      #!ipxe
-      
-      set esc:hex 1b
-      set bold ${esc:string}[1m
-      set boldoff ${esc:string}[22m
-      
-      set white ${esc:string}[37m
-      
-      #color --rgb 0x76b900 7
-      #cpair --foreground 7 --background 9 0
-      
-      :start
-      echo ${bold}${white}Carbide${boldoff} - ${version}
-      prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open carbide menu... && goto carbide_menu || goto carbide
-      
-      :whoami
-      ifconf -c dhcp
-      # carbide-pxe identifies the booting machine by its client IP (read from
-      # X-Forwarded-For when proxied, TCP socket peer otherwise) and resolves
-      # to a machine_interface_id via find_by_ip. iPXE doesn't need to encode
-      # anything identity-related in the URL -- the network layer carries it.
-      time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
-      goto carbide_menu
-
-      :carbide
-      ifconf -c dhcp
-      time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
-      
-      :carbide_menu
-      menu Carbide - ${hostname}
-      item carbide Boot according to Carbide workflow
-      item whoami Print information about this machine
-      item localboot Boot to local drive
-      #item netconfig Manual network configuration
-      #item vlan Manual VLAN configuration
-      item retry Retry boot
-      item debug iPXE Debug Shell
-      item reboot Reboot System
-      choose --default carbide --timeout 5000 target && goto ${target}
-      prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open carbide menu...
-      goto carbide_menu
-      
-      :localboot
-      exit
-      
-      :retry
-      goto start
-      
-      :error_handler
-      prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to continue (4 seconds timeout)...
-      goto carbide_menu
-      
-      :debug
-      echo Type "exit" to return to menu
-      shell
-      goto carbide_menu
-      
-      :reboot
-      reboot
-      goto start
+    # Populated from pxe/ipxe/local/embed.ipxe by DefaultIpxeScriptRenderer::new.
+    template: ""

--- a/pxe/ipxe/local/branding.h
+++ b/pxe/ipxe/local/branding.h
@@ -1,11 +1,11 @@
 #undef PRODUCT_NAME
-#define PRODUCT_NAME "Carbide"
+#define PRODUCT_NAME "NICo"
 
 #undef PRODUCT_SHORT_NAME
-#define PRODUCT_SHORT_NAME "carbide"
+#define PRODUCT_SHORT_NAME "nico"
 
 #undef PRODUCT_URI
 #define PRODUCT_URI "http://nvidia.com"
 
 #undef PRODUCT_TAG_LINE
-#define PRODUCT_TAG_LINE "Carbide Bare Metal provisioning"
+#define PRODUCT_TAG_LINE "NICo bare-metal provisioning"

--- a/pxe/ipxe/local/branding.h
+++ b/pxe/ipxe/local/branding.h
@@ -1,5 +1,5 @@
 #undef PRODUCT_NAME
-#define PRODUCT_NAME "NICo"
+#define PRODUCT_NAME "NVIDIA Infra Controller"
 
 #undef PRODUCT_SHORT_NAME
 #define PRODUCT_SHORT_NAME "nico"

--- a/pxe/ipxe/local/embed.ipxe
+++ b/pxe/ipxe/local/embed.ipxe
@@ -10,25 +10,25 @@ set white ${esc:string}[37m
 #cpair --foreground 7 --background 9 0
 
 :start
-echo ${bold}${white}Carbide${boldoff} - ${version}
-prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open carbide menu... && goto carbide_menu || goto carbide
+echo ${bold}${white}NICo${boldoff} - ${version}
+prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open NICo menu... && goto nico_menu || goto nico
 
 :whoami
 ifconf -c dhcp
-# carbide-pxe identifies the booting machine by its client IP (read from
+# nico-pxe identifies the booting machine by its client IP (read from
 # X-Forwarded-For when proxied, TCP socket peer otherwise) and resolves
 # to a machine_interface_id via find_by_ip. iPXE doesn't need to encode
 # anything identity-related in the URL -- the network layer carries it.
 time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
-goto carbide_menu
+goto nico_menu
 
-:carbide
+:nico
 ifconf -c dhcp
 time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
 
-:carbide_menu
-menu Carbide - ${hostname}
-item carbide Boot according to Carbide workflow
+:nico_menu
+menu NICo - ${hostname}
+item nico Boot according to NICo workflow
 item whoami Print information about this machine
 item localboot Boot to local drive
 #item netconfig Manual network configuration
@@ -36,9 +36,9 @@ item localboot Boot to local drive
 item retry Retry boot
 item debug iPXE Debug Shell
 item reboot Reboot System
-choose --default carbide --timeout 5000 target && goto ${target}
-prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open carbide menu...
-goto carbide_menu
+choose --default nico --timeout 5000 target && goto ${target}
+prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to open NICo menu...
+goto nico_menu
 
 :localboot
 exit
@@ -48,12 +48,12 @@ goto start
 
 :error_handler
 prompt --key p --timeout 4000 Hit the ${bold}p${boldoff} key to continue (4 seconds timeout)...
-goto carbide_menu
+goto nico_menu
 
 :debug
 echo Type "exit" to return to menu
 shell
-goto carbide_menu
+goto nico_menu
 
 :reboot
 reboot


### PR DESCRIPTION
## Summary
- update compiled iPXE product branding from Carbide to NICo
- update the embedded iPXE boot banner, prompt, menu, and labels to use NICo
- make pxe/ipxe/local/embed.ipxe the single source of truth for the static iPXE menu renderer template
- preserve the existing static template slug for compatibility
- add a regression test for old branding and template synchronization
- stabilize the DHCP booturl integration test against Kea startup/readiness timing seen in CI

Fixes #2541

## Verification
- git diff --check
- docker cargo +nightly-2026-05-27 fmt --all -- --check
- docker cargo test -p carbide-ipxe-renderer test_static_ipxe_menu_uses_nico_branding
- python3 YAML parse/assertion for crates/ipxe-renderer/templates.yaml deferring the static menu to embed.ipxe
- rg confirmed no Carbide/Forge hits in pxe/ipxe/local/branding.h or pxe/ipxe/local/embed.ipxe
- docker run isolated public Rust/Kea environment: cargo test -p carbide-dhcp --test booturl -- --nocapture
- docker rustfmt crates/dhcp/tests/booturl.rs

Note: the host PATH still does not provide cargo/cargo-make/rustfmt; the focused Rust validation above was run in Docker against an isolated copy.
