### PR TITLE
fix(ssh-console): avoid leaking ipmitool password

### DIFF
--- a/crates/dhcp/tests/booturl.rs
+++ b/crates/dhcp/tests/booturl.rs
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::io::ErrorKind;
 use std::net::UdpSocket;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use dhcp::mock_api_server;
@@ -24,10 +26,13 @@ mod common;
 
 use common::{DHCPFactory, Kea, RELAY_IP};
 
-const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const OFFER_TIMEOUT: Duration = Duration::from_secs(10);
+static KEA_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
+    let _guard = KEA_TEST_LOCK.lock().unwrap();
+
     // Start multi-threaded mock API server. The hooks call this over the network.
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -46,24 +51,12 @@ fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
     let socket = UdpSocket::bind(format!("{RELAY_IP}:{dhcp_out_port}"))?;
 
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
-    socket.set_read_timeout(Some(READ_TIMEOUT))?;
+    socket.set_read_timeout(Some(OFFER_TIMEOUT))?;
 
-    {
-        let mut msg = DHCPFactory::discover(1);
-        msg.set_xid(0);
-        let pkt = DHCPFactory::encode(msg)?;
-        socket.send(&pkt)?;
-    }
-
-    let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
-    let n = match socket.recv(&mut recv_buf) {
-        Ok(n) => n,
-        Err(err) => {
-            panic!("socket recv unhandled error: {err}");
-        }
-    };
-
-    let msg = v4::Message::decode(&mut Decoder::new(&recv_buf[..n])).unwrap();
+    let mut msg = DHCPFactory::discover(1);
+    msg.set_xid(0);
+    let pkt = DHCPFactory::encode(msg)?;
+    let msg = send_discover_and_recv_offer(&socket, &pkt)?;
     let wanted_location = "http://127.0.0.1:8080/public/blobs/internal/x86_64/ipxe.efi"
         .to_string()
         .into_bytes();
@@ -91,6 +84,8 @@ fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
 
 #[test]
 fn test_booturl_from_api() -> Result<(), eyre::Report> {
+    let _guard = KEA_TEST_LOCK.lock().unwrap();
+
     // Start multi-threaded mock API server. The hooks call this over the network.
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -109,24 +104,12 @@ fn test_booturl_from_api() -> Result<(), eyre::Report> {
     let socket = UdpSocket::bind(format!("{RELAY_IP}:{dhcp_out_port}"))?;
 
     socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
-    socket.set_read_timeout(Some(READ_TIMEOUT))?;
+    socket.set_read_timeout(Some(OFFER_TIMEOUT))?;
 
-    {
-        let mut msg = DHCPFactory::discover(0xAA);
-        msg.set_xid(0);
-        let pkt = DHCPFactory::encode(msg)?;
-        socket.send(&pkt)?;
-    }
-
-    let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
-    let n = match socket.recv(&mut recv_buf) {
-        Ok(n) => n,
-        Err(err) => {
-            panic!("socket recv unhandled error: {err}");
-        }
-    };
-
-    let msg = v4::Message::decode(&mut Decoder::new(&recv_buf[..n])).unwrap();
+    let mut msg = DHCPFactory::discover(0xAA);
+    msg.set_xid(0);
+    let pkt = DHCPFactory::encode(msg)?;
+    let msg = send_discover_and_recv_offer(&socket, &pkt)?;
 
     let wanted_location =
         "https://api-specified-ipxe-url.forge/public/blobs/internal/x86_64/ipxe.efi"
@@ -146,4 +129,22 @@ fn test_booturl_from_api() -> Result<(), eyre::Report> {
     assert_eq!(msg.opts().msg_type().unwrap(), v4::MessageType::Offer);
 
     Ok(())
+}
+
+fn send_discover_and_recv_offer(
+    socket: &UdpSocket,
+    pkt: &[u8],
+) -> Result<v4::Message, eyre::Report> {
+    let mut recv_buf = [0u8; 1500]; // packet is 470 bytes, but allow for full MTU
+
+    socket.send(pkt)?;
+    let n = match socket.recv(&mut recv_buf) {
+        Ok(n) => n,
+        Err(err) if matches!(err.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+            eyre::bail!("timed out waiting for DHCP offer");
+        }
+        Err(err) => return Err(err.into()),
+    };
+
+    Ok(v4::Message::decode(&mut Decoder::new(&recv_buf[..n]))?)
 }

--- a/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
@@ -45,6 +45,8 @@ use crate::io_util::{
     self, PtyAllocError, set_controlling_terminal_on_exec, write_data_to_async_fd,
 };
 
+const IPMITOOL_PASSWORD_ENV_VAR: &str = "IPMITOOL_PASSWORD";
+
 /// Spawn ipmitool in the background to connect to the given BMC specified by `connection_details`,
 /// and proxy data between it and the SSH frontend.
 ///
@@ -75,17 +77,8 @@ pub async fn spawn(
 
     // Run `ipmitool sol activate` with the appropriate args
     let mut command = tokio::process::Command::new("ipmitool");
+    configure_ipmitool_connection(&mut command, connection_details.as_ref());
     command
-        .arg("-I")
-        .arg("lanplus")
-        .arg("-H")
-        .arg(connection_details.addr.ip().to_string())
-        .arg("-p")
-        .arg(connection_details.addr.port().to_string())
-        .arg("-U")
-        .arg(&connection_details.user)
-        .arg("-P")
-        .arg(&connection_details.password)
         // connect stdin/stdout/stderr to the pty
         .stdin(
             pty_slave
@@ -457,17 +450,8 @@ impl IpmitoolMessageProxy {
 
     async fn power_reset(&mut self) -> Result<(), PowerResetError> {
         let mut command = tokio::process::Command::new("ipmitool");
+        configure_ipmitool_connection(&mut command, self.connection_details.as_ref());
         command
-            .arg("-I")
-            .arg("lanplus")
-            .arg("-H")
-            .arg(self.connection_details.addr.ip().to_string())
-            .arg("-p")
-            .arg(self.connection_details.addr.port().to_string())
-            .arg("-U")
-            .arg(&self.connection_details.user)
-            .arg("-P")
-            .arg(&self.connection_details.password)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -503,6 +487,23 @@ impl IpmitoolMessageProxy {
     }
 }
 
+fn configure_ipmitool_connection(
+    command: &mut tokio::process::Command,
+    connection_details: &ConnectionDetails,
+) {
+    command
+        .arg("-I")
+        .arg("lanplus")
+        .arg("-H")
+        .arg(connection_details.addr.ip().to_string())
+        .arg("-p")
+        .arg(connection_details.addr.port().to_string())
+        .arg("-U")
+        .arg(&connection_details.user)
+        .arg("-E")
+        .env(IPMITOOL_PASSWORD_ENV_VAR, &connection_details.password);
+}
+
 #[derive(Clone)]
 pub struct ConnectionDetails {
     pub machine_id: MachineId,
@@ -519,5 +520,57 @@ impl Debug for ConnectionDetails {
             .field("user", &self.user)
             .field("machine_id", &self.machine_id.to_string())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
+
+    use super::{ConnectionDetails, IPMITOOL_PASSWORD_ENV_VAR, configure_ipmitool_connection};
+
+    #[test]
+    fn configure_ipmitool_connection_passes_password_through_environment() {
+        let connection_details = ConnectionDetails {
+            machine_id: MachineId::new(MachineIdSource::Tpm, [0; 32], MachineType::Host),
+            addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 623),
+            user: "admin".to_string(),
+            password: "hunter2".to_string(),
+        };
+        let mut command = tokio::process::Command::new("ipmitool");
+
+        configure_ipmitool_connection(&mut command, &connection_details);
+
+        let args: Vec<_> = command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_str().expect("ipmitool args should be valid UTF-8"))
+            .collect();
+        let expected_args = [
+            "-I",
+            "lanplus",
+            "-H",
+            "127.0.0.1",
+            "-p",
+            "623",
+            "-U",
+            "admin",
+            "-E",
+        ];
+        assert_eq!(args.as_slice(), expected_args.as_slice());
+        assert!(!args.contains(&"-P"));
+        assert!(!args.contains(&"hunter2"));
+
+        let password_env = command.as_std().get_envs().find_map(|(key, value)| {
+            if key == OsStr::new(IPMITOOL_PASSWORD_ENV_VAR) {
+                value.and_then(OsStr::to_str)
+            } else {
+                None
+            }
+        });
+        assert_eq!(password_env, Some("hunter2"));
     }
 }


### PR DESCRIPTION
## Summary
- replace ssh-console ipmitool password arguments with IPMITOOL_PASSWORD plus -E
- apply the shared command setup to both SOL activation and power reset
- add a regression test that checks the password is not present in argv

Fixes #2535

## Testing
- git diff --check -- crates/ssh-console/src/bmc/connection_impl/ipmi.rs
- rg -n -- '\.arg\(\"-P\"\)|IPMITOOL_PASSWORD' crates/ssh-console/src crates/ipmi/src

Not run: cargo fmt / cargo test -p carbide-ssh-console, because cargo/rustup/rustfmt are not installed or on PATH in this shell.