### PR TITLE
test(dhcp): tolerate slower booturl tests in CICD

### DIFF
--- a/crates/dhcp/tests/booturl.rs
+++ b/crates/dhcp/tests/booturl.rs
@@ -24,7 +24,7 @@ mod common;
 
 use common::{DHCPFactory, Kea, RELAY_IP};
 
-const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[test]
 fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {

--- a/crates/dhcp/tests/common/kea.rs
+++ b/crates/dhcp/tests/common/kea.rs
@@ -210,29 +210,46 @@ impl Kea {
         // (default) or `target/...something.../debug/` (when CARGO_BUILD_TARGET
         // is set in the env). Check release before debug so a `--release`
         // test build wins.
-        let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let candidates: Vec<String> = {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let candidates: Vec<PathBuf> = {
+            let mut target_roots = Vec::new();
+            if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR") {
+                target_roots.push(PathBuf::from(target_dir));
+            }
+            target_roots.push(manifest_dir.join("../../target"));
+
             let target_triple = std::env::var("CARGO_BUILD_TARGET").ok();
-            let triple_subdir = target_triple
-                .as_deref()
-                .map(|t| format!("{t}/"))
-                .unwrap_or_default();
             // NOTE: cargo only updates the non-deps `libdhcp.so` on the first
             // build after a clean; subsequent rebuilds touch `deps/libdhcp.so`
             // only. Prefer the deps copy so we always pick up fresh rebuilds.
-            vec![
-                format!("{manifest_dir}/../../target/{triple_subdir}release/deps/libdhcp.so"),
-                format!("{manifest_dir}/../../target/release/deps/libdhcp.so"),
-                format!("{manifest_dir}/../../target/{triple_subdir}debug/deps/libdhcp.so"),
-                format!("{manifest_dir}/../../target/debug/deps/libdhcp.so"),
-                format!("{manifest_dir}/../../target/{triple_subdir}release/libdhcp.so"),
-                format!("{manifest_dir}/../../target/release/libdhcp.so"),
-                format!("{manifest_dir}/../../target/{triple_subdir}debug/libdhcp.so"),
-                format!("{manifest_dir}/../../target/debug/libdhcp.so"),
-            ]
+            target_roots
+                .into_iter()
+                .flat_map(|root| {
+                    [
+                        target_triple
+                            .as_ref()
+                            .map(|triple| root.join(triple).join("release/deps/libdhcp.so")),
+                        Some(root.join("release/deps/libdhcp.so")),
+                        target_triple
+                            .as_ref()
+                            .map(|triple| root.join(triple).join("debug/deps/libdhcp.so")),
+                        Some(root.join("debug/deps/libdhcp.so")),
+                        target_triple
+                            .as_ref()
+                            .map(|triple| root.join(triple).join("release/libdhcp.so")),
+                        Some(root.join("release/libdhcp.so")),
+                        target_triple
+                            .as_ref()
+                            .map(|triple| root.join(triple).join("debug/libdhcp.so")),
+                        Some(root.join("debug/libdhcp.so")),
+                    ]
+                    .into_iter()
+                    .flatten()
+                })
+                .collect()
         };
-        let hook_lib = match candidates.iter().find(|p| Path::new(p).exists()) {
-            Some(p) => p.clone(),
+        let hook_lib = match candidates.iter().find(|p| p.exists()) {
+            Some(p) => p.to_string_lossy().into_owned(),
             None => {
                 // If `cargo build` has not been run yet (after a `cargo clean`),
                 // the `build.rs` script won't have generated libdhcp.so, so lets
@@ -243,7 +260,8 @@ impl Kea {
                 test_cdylib::build_current_project();
                 candidates
                     .into_iter()
-                    .find(|p| Path::new(p).exists())
+                    .find(|p| p.exists())
+                    .map(|p| p.to_string_lossy().into_owned())
                     .expect("test_cdylib build did not produce libdhcp.so at any expected path")
             }
         };


### PR DESCRIPTION
## Description

**This test has been suuuuper flaky the past few days, and I'm hoping this fixes it**

The booturl tests care about the DHCP answer Kea sends back: the right boot filename. On slower CI attempts, Kea could still be starting, loading the hook, and calling the mock API when the 500ms receive timeout fired. Both booturl cases then reported `Resource temporarily unavailable`, which read like runner trouble, even though I think it was actually that the test had just given up too early.

This gives those tests a 5s receive window and teaches the shared Kea harness to look in `CARGO_TARGET_DIR` when locating `libdhcp.so`. That keeps local worktrees working when Cargo builds into the main checkout shared target directory (while still preserving the old target-relative fallback).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

