### PR TITLE
chore: rename column in site explorer report

### DIFF
--- a/crates/admin-cli/src/site_explorer/get_report/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/get_report/cmd.rs
@@ -441,7 +441,7 @@ fn convert_endpoints_to_nice_table(endpoints: &[ExploredEndpoint]) -> Box<Table>
         "BMC Mac Address",
         "Vendor",
         "MachineId",
-        "Preingt State",
+        "Pre-ingestion State",
         "Serial Number",
         "Last Exploration Error",
     ];


### PR DESCRIPTION
## Description
Change "Preingt State" label in forge-admin-cli site-explorer get-report-endpoint => "Pre-ingestion State".

`| Preingt State | Serial Number  | Last Exploration Error |
`

The other column headers are all spelled out, "Preingt" isn't obvious in meaning and so spell it out, too.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

After the change:

`| Pre-ingestion State | Serial Number  | Last Exploration Error |`

