### PR TITLE
ci(core): skip Core CI for docs-only changes (docs/, fern/)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
               - '!rest-api/**'
               - '!.github/workflows/rest-*.yml'
               - '!helm/rest/**'
+              - '!docs/**'
+              - '!fern/**'
 
       - name: Decide whether Core CI should run
         id: gate


### PR DESCRIPTION
Closes #2154

Extend the Core CI `changes` gate to exclude root `docs/` and `fern/` so docs-only PRs don't trigger the full Core (Rust) pipeline.

## Change
`.github/workflows/ci.yaml` `non_rest` filter — add `!docs/**` and `!fern/**`.

## Effect
- Docs-only PR → core gate `run_core_ci=false` → Core pipeline skips.
- REST gate already watches only `rest-api/**` + `rest-*.yml` + `helm/rest/**`, so root `docs/`/`fern/` don't trigger REST CI either.
- Docs keep their own CI: `fern-docs-ci.yml` + `fern-docs-preview-build.yml` run on `docs/**`/`fern/**` (the "different set" of checks).
- Both aggregators run `if: always()` on the `changes` gate → resolve skipped→pass, so branch protection isn't blocked.

## Mixed-PR safety
`predicate-quantifier: every` is per-file: a file counts toward `non_rest` only if it matches all patterns (negations included), and the filter is true if ≥1 file qualifies. So a mixed docs+code PR still has its code file qualify → `non_rest` true → Core CI runs (no false-skip). Same mechanism as the existing `!rest-api/**` exclusion.

## Out of scope
`rest-api/docs/**` still triggers REST CI (it's under `rest-api/**`); excluding it needs a different filter approach — separate follow-up if wanted.