### PR TITLE
tests(test-harness): Make object model more clear

### DIFF
--- a/crates/api-core/src/test_support/fixture_config.rs
+++ b/crates/api-core/src/test_support/fixture_config.rs
@@ -75,11 +75,13 @@ impl DpuConfigExt for DpuConfig {
 }
 
 pub trait ManagedHostConfigExt {
-    fn with_serial(serial: String) -> Self;
-    fn with_dpus(dpus: Vec<DpuConfig>) -> Self;
-    fn with_expected_state(expected_state: ManagedHostState) -> Self;
-    fn with_hardware_info_template(hardware_info_template: HardwareInfoTemplate) -> Self;
-    fn with_expected_machine_data(expected_machine_data: ExpectedMachineData) -> Self;
+    fn zero_dpu() -> Self;
+    fn with_serial(self, serial: String) -> Self;
+    fn with_dpus(self, dpus: Vec<DpuConfig>) -> Self;
+    fn with_dpu_count(self, dpu_count: usize) -> Self;
+    fn with_expected_state(self, expected_state: ManagedHostState) -> Self;
+    fn with_hardware_info_template(self, hardware_info_template: HardwareInfoTemplate) -> Self;
+    fn with_expected_machine_data(self, expected_machine_data: ExpectedMachineData) -> Self;
     fn with_admin_dhcp_fallback(self) -> Self;
 }
 
@@ -109,43 +111,47 @@ impl FixtureDefault for ManagedHostConfig {
 }
 
 impl ManagedHostConfigExt for ManagedHostConfig {
-    fn with_serial(serial: String) -> Self {
-        Self {
-            serial,
-            ..ManagedHostConfig::default()
-        }
+    fn zero_dpu() -> Self {
+        Self::default().with_dpu_count(0)
     }
 
-    fn with_dpus(dpus: Vec<DpuConfig>) -> Self {
-        Self {
-            dpus,
-            ..ManagedHostConfig::default()
-        }
+    fn with_serial(self, serial: String) -> Self {
+        Self { serial, ..self }
     }
 
-    fn with_expected_state(expected_state: ManagedHostState) -> Self {
+    fn with_dpu_count(self, dpu_count: usize) -> Self {
+        self.with_dpus((0..dpu_count).map(|_| DpuConfig::default()).collect())
+    }
+
+    fn with_dpus(self, dpus: Vec<DpuConfig>) -> Self {
+        Self { dpus, ..self }
+    }
+
+    fn with_expected_state(self, expected_state: ManagedHostState) -> Self {
         Self {
             expected_state,
-            ..ManagedHostConfig::default()
+            ..self
         }
     }
 
-    fn with_hardware_info_template(hardware_info_template: HardwareInfoTemplate) -> Self {
+    fn with_hardware_info_template(self, hardware_info_template: HardwareInfoTemplate) -> Self {
         Self {
             hardware_info_template,
-            ..ManagedHostConfig::default()
+            ..self
         }
     }
 
-    fn with_admin_dhcp_fallback(mut self) -> Self {
-        self.admin_dhcp_fallback = true;
-        self
-    }
-
-    fn with_expected_machine_data(expected_machine_data: ExpectedMachineData) -> Self {
+    fn with_expected_machine_data(self, expected_machine_data: ExpectedMachineData) -> Self {
         Self {
             expected_machine_data: Some(expected_machine_data),
-            ..ManagedHostConfig::default()
+            ..self
+        }
+    }
+
+    fn with_admin_dhcp_fallback(self) -> Self {
+        Self {
+            admin_dhcp_fallback: true,
+            ..self
         }
     }
 }

--- a/crates/api-core/src/tests/boot_interface_resolution.rs
+++ b/crates/api-core/src/tests/boot_interface_resolution.rs
@@ -33,7 +33,7 @@ use carbide_uuid::machine::MachineId;
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
 use model::network_segment::NetworkSegmentType;
-use model::test_support::{DpuConfig, ManagedHostConfig};
+use model::test_support::ManagedHostConfig;
 use rpc::forge;
 use rpc::forge::forge_server::Forge;
 
@@ -53,11 +53,9 @@ use crate::tests::common::api_fixtures::network_segment::{
 async fn host_with_moved_primary(
     env: &api_fixtures::TestEnv,
 ) -> Result<(MachineId, MacAddress), Box<dyn std::error::Error>> {
-    let host = api_fixtures::site_explorer::new_host(
-        env,
-        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
-    )
-    .await?;
+    let host =
+        api_fixtures::site_explorer::new_host(env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
     let host_id = host.host_snapshot.id;
 
     let (promote_id, promote_mac) = {
@@ -208,8 +206,7 @@ async fn test_set_dpu_first_resolves_a_zero_dpu_host_without_an_explored_default
     env.run_network_segment_controller_iteration().await;
     env.run_network_segment_controller_iteration().await;
 
-    let host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+    let host = api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
     let host_id = host.host_snapshot.id;
 
     let inband_mac = {
@@ -256,11 +253,9 @@ async fn test_boot_interface_candidates_skips_dpu_machines(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
 
-    let host = api_fixtures::site_explorer::new_host(
-        &env,
-        ManagedHostConfig::with_dpus(vec![DpuConfig::default()]),
-    )
-    .await?;
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(1))
+            .await?;
     let host_id = host.host_snapshot.id;
     let dpu_id = host
         .dpu_snapshots

--- a/crates/api-core/src/tests/client_resolution.rs
+++ b/crates/api-core/src/tests/client_resolution.rs
@@ -159,7 +159,7 @@ async fn test_zero_dpu_cloud_init_prefers_instance_when_ip_matches_host_interfac
     env.run_network_segment_controller_iteration().await;
     env.run_network_segment_controller_iteration().await;
 
-    let mh = create_managed_host_with_config(&env, ManagedHostConfig::with_dpus(Vec::new())).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
     assert!(
         mh.dpu_ids.is_empty(),
         "zero-DPU fixture should produce no DPU machines"

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -2257,7 +2257,7 @@ pub async fn create_managed_host_with_dpf_multi(
             DpuConfig::with_hardware_info_template(HardwareInfoTemplate::Custom(DPU_BF3_INFO_JSON))
         })
         .collect();
-    let mh_config = ManagedHostConfig::with_dpus(dpu_configs);
+    let mh_config = ManagedHostConfig::default().with_dpus(dpu_configs);
     let mh = site_explorer::new_mock_host_with_dpf(env, mh_config)
         .await
         .expect("Failed to create a new host");
@@ -2280,8 +2280,7 @@ pub async fn create_managed_host_with_ek(env: &TestEnv, ek_cert: &[u8]) -> TestM
 /// Create a managed host with `dpu_count` DPUs (default config)
 pub async fn create_managed_host_multi_dpu(env: &TestEnv, dpu_count: usize) -> TestManagedHost {
     assert!(dpu_count >= 1, "need to specify at least 1 dpu");
-    let config =
-        ManagedHostConfig::with_dpus((0..dpu_count).map(|_| DpuConfig::default()).collect());
+    let config = ManagedHostConfig::default().with_dpu_count(dpu_count);
     create_managed_host_with_config(env, config).await
 }
 
@@ -2327,7 +2326,7 @@ pub async fn create_managed_host_with_hardware_info_template(
     hardware_info_template: HardwareInfoTemplate,
 ) -> TestManagedHost {
     insert_nvlink_nmxc_endpoint_from_managed_host(env, &hardware_info_template).await;
-    let config = ManagedHostConfig::with_hardware_info_template(hardware_info_template);
+    let config = ManagedHostConfig::default().with_hardware_info_template(hardware_info_template);
     let mh = site_explorer::new_host(env, config).await.unwrap();
     TestManagedHost {
         id: mh.host_snapshot.id,

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -47,7 +47,7 @@ use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
 use model::rack::RackConfig;
 use model::site_explorer::{Chassis, EndpointExplorationReport, EndpointType};
 use model::switch::{NewSwitch, SwitchConfig};
-use model::test_support::{DpuConfig, ManagedHostConfig};
+use model::test_support::ManagedHostConfig;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self, HealthReportEntry, InsertMachineHealthReportRequest};
 use rpc::forge_agent_control_response::{Action, LegacyAction};
@@ -1646,8 +1646,7 @@ pub async fn new_host_with_machine_validation(
     machine_validation_result_data: Option<rpc::forge::MachineValidationResult>,
     error: Option<String>,
 ) -> eyre::Result<ManagedHostStateSnapshot> {
-    let managed_host =
-        ManagedHostConfig::with_dpus((0..dpu_count).map(|_| DpuConfig::default()).collect());
+    let managed_host = ManagedHostConfig::default().with_dpu_count(dpu_count.into());
     register_expected_machine(env, &managed_host, None).await;
     let mut mock_explored_host = MockExploredHost::new(env, managed_host);
 

--- a/crates/api-core/src/tests/instance_allocate.rs
+++ b/crates/api-core/src/tests/instance_allocate.rs
@@ -299,7 +299,7 @@ async fn test_zero_dpu_instance_allocation_rejects_explicit_interfaces(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
 
     // Ingest zero DPU host
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
@@ -377,7 +377,7 @@ async fn test_zero_dpu_instance_allocation_auto(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
 
     // Ingest zero DPU host
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
@@ -490,7 +490,7 @@ async fn test_zero_dpu_instance_allocation_rejects_missing_auto(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
 
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
@@ -1114,7 +1114,7 @@ async fn test_zero_dpu_host_verifies_boot_order_during_platform_configuration(
     // Ingest zero-DPU host. site-explorer runs it through the machine state
     // controller, which hits HostInit -> HostPlatformConfiguration, where
     // `CheckHostConfig` lives.
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
     // Advance the state controller until the host converges on Ready.
@@ -1151,7 +1151,7 @@ async fn test_reject_zero_dpu_instance_with_tenant_network_segment(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
 
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
@@ -1235,7 +1235,7 @@ async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
     crate::handlers::instance::allocate(
@@ -1362,7 +1362,7 @@ async fn test_reject_zero_dpu_instance_with_extension_services(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
 
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
@@ -1423,7 +1423,7 @@ async fn test_instance_allocation_rejects_auto_with_explicit_interfaces(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
-    let config = ManagedHostConfig::with_dpus(vec![]);
+    let config = ManagedHostConfig::zero_dpu();
 
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
     let host_inband_segment =
@@ -1495,11 +1495,9 @@ async fn test_instance_allocation_rejects_auto_with_explicit_interfaces(
 async fn test_instance_allocation_rejects_auto_on_dpu_host(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    use model::test_support::DpuConfig;
-
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
     // Default ManagedHostConfig has one DPU.
-    let config = ManagedHostConfig::with_dpus(vec![DpuConfig::default()]);
+    let config = ManagedHostConfig::default().with_dpu_count(1);
 
     let dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -770,7 +770,7 @@ async fn test_dhcp_allows_zero_dpu_host_with_instance(
     .await;
     create_host_inband_network_segment(&env.api, None).await;
 
-    let mh = create_managed_host_with_config(&env, ManagedHostConfig::with_dpus(Vec::new())).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
     assert!(
         mh.dpu_ids.is_empty(),
         "zero-DPU fixture should produce no DPU machines"

--- a/crates/api-core/src/tests/machine_find.rs
+++ b/crates/api-core/src/tests/machine_find.rs
@@ -172,10 +172,11 @@ async fn test_find_machine_with_sku(pool: sqlx::PgPool) {
     txn.commit().await.unwrap();
 
     let sku_id = "sku id".to_string();
-    let host_config = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        sku_id: Some(sku_id.clone()),
-        ..Default::default()
-    });
+    let host_config =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            sku_id: Some(sku_id.clone()),
+            ..Default::default()
+        });
     let mh = create_managed_host_with_config(&env, host_config).await;
 
     let machine = mh.host().rpc_machine().await;
@@ -216,10 +217,11 @@ async fn test_find_machine_by_rack_id(pool: sqlx::PgPool) {
         .unwrap();
     drop(txn);
 
-    let host_config = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        rack_id: rack_id.clone().into(),
-        ..Default::default()
-    });
+    let host_config =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            rack_id: rack_id.clone().into(),
+            ..Default::default()
+        });
     let mh = create_managed_host_with_config(&env, host_config).await;
 
     let machine = mh.host().rpc_machine().await;

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -461,7 +461,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
 
     assert!(!response.address.is_empty());
 
-    let mock_host = ManagedHostConfig::with_dpus(vec![mock_dpu.clone()]);
+    let mock_host = ManagedHostConfig::default().with_dpus(vec![mock_dpu.clone()]);
     let mut dpu_report: EndpointExplorationReport = mock_dpu.clone().into();
     dpu_report.generate_machine_id(false)?;
 
@@ -3337,7 +3337,7 @@ async fn zero_dpu_host_with_instance(pool: sqlx::PgPool) -> (TestEnv, TestManage
     .await;
     create_host_inband_network_segment(&env.api, None).await;
 
-    let mh = create_managed_host_with_config(&env, ManagedHostConfig::with_dpus(Vec::new())).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
     assert!(
         mh.dpu_ids.is_empty(),
         "zero-DPU fixture should produce no DPU machines"

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -46,7 +46,7 @@ use model::test_support::{HardwareInfoTemplate, ManagedHostConfig};
 use rpc::forge::TenantState;
 use rpc::forge::forge_server::Forge;
 
-use crate::test_support::fixture_config::ManagedHostConfigExt;
+use crate::test_support::fixture_config::{FixtureDefault, ManagedHostConfigExt};
 use crate::test_support::mac_address_pool::{
     EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL, EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL,
 };
@@ -2421,7 +2421,8 @@ async fn test_rack_switch_create_instance_with_nvl_config_use_nmxc_simulator(poo
     insert_nvlink_nmxc_endpoint_from_managed_host(&env, &hardware_info_template).await;
     let mh_snapshot = new_host(
         &env,
-        ManagedHostConfig::with_hardware_info_template(hardware_info_template)
+        ManagedHostConfig::default()
+            .with_hardware_info_template(hardware_info_template)
             .with_admin_dhcp_fallback(),
     )
     .await

--- a/crates/api-core/src/tests/rack_health.rs
+++ b/crates/api-core/src/tests/rack_health.rs
@@ -27,7 +27,7 @@ use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as rpc_forge};
 use tonic::Request;
 
-use crate::test_support::fixture_config::ManagedHostConfigExt as _;
+use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host, create_managed_host_with_config,
@@ -229,10 +229,11 @@ async fn test_propagation_to_host_aggregate_health(
         .await?;
     drop(txn);
 
-    let host_config = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        rack_id: Some(rack_id.clone()),
-        ..Default::default()
-    });
+    let host_config =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        });
     let mh = create_managed_host_with_config(&env, host_config).await;
     let host_machine_id = mh.id;
 
@@ -289,10 +290,11 @@ async fn test_host_allocatability_blocked_by_rack_override(
         .await?;
     drop(txn);
 
-    let host_config = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        rack_id: Some(rack_id.clone()),
-        ..Default::default()
-    });
+    let host_config =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        });
     let mh = create_managed_host_with_config(&env, host_config).await;
     let host_machine_id = mh.id;
 

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -48,7 +48,7 @@ use state_controller::db_write_batch::DbWriteBatch;
 use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
 use tonic::Request;
 
-use crate::test_support::fixture_config::ManagedHostConfigExt as _;
+use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::tests::common::api_fixtures::site_explorer::{create_expected_switches, new_host};
 use crate::tests::common::api_fixtures::{
     TestEnv, TestEnvOverrides, create_test_env_with_overrides, get_config,
@@ -190,7 +190,7 @@ async fn create_single_compute_rack(
 
     let host = new_host(
         env,
-        ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
             rack_id: Some(rack_id.clone()),
             ..Default::default()
         }),
@@ -225,7 +225,7 @@ async fn create_two_compute_rack(
 
     let host_a = new_host(
         env,
-        ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
             rack_id: Some(rack_id.clone()),
             ..Default::default()
         }),
@@ -233,7 +233,7 @@ async fn create_two_compute_rack(
     .await?;
     let host_b = new_host(
         env,
-        ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
             rack_id: Some(rack_id.clone()),
             ..Default::default()
         }),

--- a/crates/api-core/src/tests/set_primary_dpu.rs
+++ b/crates/api-core/src/tests/set_primary_dpu.rs
@@ -78,7 +78,7 @@ async fn test_set_primary_dpu_rejects_zero_dpu_host(
     env.run_network_segment_controller_iteration().await;
 
     let zero_dpu_host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
 
     let result = env
         .api

--- a/crates/api-core/src/tests/set_primary_interface.rs
+++ b/crates/api-core/src/tests/set_primary_interface.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use carbide_uuid::machine::MachineInterfaceId;
 use ipnetwork::IpNetwork;
 use model::network_segment::NetworkSegmentType;
-use model::test_support::{DpuConfig, ManagedHostConfig};
+use model::test_support::ManagedHostConfig;
 use rpc::forge;
 use rpc::forge::forge_server::Forge;
 
@@ -82,7 +82,7 @@ async fn test_set_primary_interface_does_not_apply_the_zero_dpu_guard(
     env.run_network_segment_controller_iteration().await;
 
     let zero_dpu_host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
 
     // A well-formed but non-existent interface id: the handler must try to look
     // it up -- which is only reachable once it's past the would-be zero-DPU
@@ -131,11 +131,9 @@ async fn test_set_primary_interface_promotes_a_non_primary_interface(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
 
-    let host = api_fixtures::site_explorer::new_host(
-        &env,
-        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
-    )
-    .await?;
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
     let host_id = host.host_snapshot.id;
 
     // One host interface is primary; pick a different (non-primary) host NIC to promote.
@@ -207,11 +205,9 @@ async fn test_set_primary_interface_rejects_non_admin_interface_on_dpu_host(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
 
-    let host = api_fixtures::site_explorer::new_host(
-        &env,
-        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
-    )
-    .await?;
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
     let host_id = host.host_snapshot.id;
 
     // A non-primary host interface to target. The host's other DPU interface
@@ -314,7 +310,7 @@ async fn test_set_primary_interface_promotes_a_zero_dpu_host_interface(
     env.run_network_segment_controller_iteration().await;
 
     let zero_dpu_host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
     let host_id = zero_dpu_host.host_snapshot.id;
 
     // A zero-DPU host's plain NIC lands on the HostInband segment and is not flagged
@@ -374,11 +370,9 @@ async fn test_set_primary_interface_repairs_dpu_host_with_no_admin_primary(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
 
-    let host = api_fixtures::site_explorer::new_host(
-        &env,
-        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
-    )
-    .await?;
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
     let host_id = host.host_snapshot.id;
 
     // The current Admin primary, plus a non-primary Admin interface to promote.

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -133,15 +133,14 @@ async fn test_site_explorer_new_host_fixture(
     create_host_inband_network_segment(&env.api, None).await;
 
     let zero_dpu_host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(Vec::new()))
-            .await?;
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
     assert_eq!(zero_dpu_host.dpu_snapshots.len(), 0);
 
     let single_dpu_host =
         api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default()).await?;
     assert_eq!(single_dpu_host.dpu_snapshots.len(), 1);
 
-    let config = ManagedHostConfig::with_dpus((0..2).map(|_| DpuConfig::default()).collect());
+    let config = ManagedHostConfig::default().with_dpu_count(2);
     let two_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
     assert_eq!(two_dpu_host.dpu_snapshots.len(), 2);
 

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -631,7 +631,7 @@ pub mod tests {
 
         // Create machine config with expected state
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(
                     BomValidatingContext {
                         machine_validation_context: Some(MachineValidationContext::Discovery),
@@ -673,7 +673,7 @@ pub mod tests {
     async fn test_leave_waiting_when_assigned(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(
                     BomValidatingContext {
                         machine_validation_context: Some(MachineValidationContext::Discovery),
@@ -720,12 +720,15 @@ pub mod tests {
     async fn test_stuck_in_waiting_without_sku(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
 
-        let mut config = ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
-            bom_validating_state: BomValidating::WaitingForSkuAssignment(BomValidatingContext {
-                machine_validation_context: Some(MachineValidationContext::Discovery),
-                ..BomValidatingContext::default()
-            }),
-        });
+        let mut config =
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(
+                    BomValidatingContext {
+                        machine_validation_context: Some(MachineValidationContext::Discovery),
+                        ..BomValidatingContext::default()
+                    },
+                ),
+            });
         config.auto_assign_sku_in_fixture = false;
 
         let mh = create_managed_host_with_config(&env, config).await;
@@ -764,12 +767,15 @@ pub mod tests {
 
         // Expect WaitingForSkuAssignment, but machine will never enter that state
         // because allow_allocation=true makes it skip directly to MachineValidation
-        let mut config = ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
-            bom_validating_state: BomValidating::WaitingForSkuAssignment(BomValidatingContext {
-                machine_validation_context: Some(MachineValidationContext::Discovery),
-                ..BomValidatingContext::default()
-            }),
-        });
+        let mut config =
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
+                bom_validating_state: BomValidating::WaitingForSkuAssignment(
+                    BomValidatingContext {
+                        machine_validation_context: Some(MachineValidationContext::Discovery),
+                        ..BomValidatingContext::default()
+                    },
+                ),
+            });
         config.auto_assign_sku_in_fixture = false;
 
         // This will panic because machine never enters WaitingForSkuAssignment
@@ -790,7 +796,7 @@ pub mod tests {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
 
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::SkuMissing(BomValidatingContext {
                     machine_validation_context: Some(MachineValidationContext::Discovery),
                     ..BomValidatingContext::default()
@@ -885,7 +891,7 @@ pub mod tests {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
 
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::SkuMissing(BomValidatingContext {
                     machine_validation_context: Some(MachineValidationContext::Discovery),
                     ..BomValidatingContext::default()
@@ -955,7 +961,7 @@ pub mod tests {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, true).await;
 
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::SkuMissing(BomValidatingContext {
                     machine_validation_context: Some(MachineValidationContext::Discovery),
                     ..BomValidatingContext::default()
@@ -1042,7 +1048,7 @@ pub mod tests {
         let env = create_test_env_for_bom_validation(pool.clone(), true, None, false).await;
 
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::SkuMissing(BomValidatingContext {
                     machine_validation_context: Some(MachineValidationContext::Discovery),
                     ..BomValidatingContext::default()
@@ -1128,7 +1134,7 @@ pub mod tests {
     ) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(
                     BomValidatingContext {
                         machine_validation_context: Some(MachineValidationContext::Discovery),
@@ -1539,7 +1545,7 @@ pub mod tests {
     async fn test_auto_match_sku(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
         let env = create_test_env_for_bom_validation(pool.clone(), false, None, false).await;
         let managed_host_config =
-            ManagedHostConfig::with_expected_state(ManagedHostState::BomValidating {
+            ManagedHostConfig::default().with_expected_state(ManagedHostState::BomValidating {
                 bom_validating_state: BomValidating::WaitingForSkuAssignment(
                     BomValidatingContext {
                         machine_validation_context: Some(MachineValidationContext::Discovery),

--- a/crates/api-web/src/tests/env.rs
+++ b/crates/api-web/src/tests/env.rs
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
+use carbide_api_core::test_support::fixture_config::{
+    FixtureDefault as _, ManagedHostConfigExt as _,
+};
 use carbide_test_harness::dns::TestDomain;
 use carbide_test_harness::network::segment::TestNetworkSegment;
 use carbide_test_harness::prelude::*;
 use model::machine::ManagedHostState;
+use model::test_support::ManagedHostConfig;
 
 pub struct TestEnv {
     pub test_harness: TestHarness,
@@ -66,7 +70,7 @@ impl TestEnv {
         let mut host = self
             .test_harness
             .managed_host_builder(&self.site_explorer, self.underlay_segment)
-            .with_dpu_count(dpu_count)
+            .with_config(ManagedHostConfig::default().with_dpu_count(dpu_count))
             .build()
             .await;
 

--- a/crates/api-web/src/tests/env.rs
+++ b/crates/api-web/src/tests/env.rs
@@ -66,23 +66,25 @@ impl TestEnv {
         &self.domain
     }
 
-    pub async fn create_ready_managed_host(&self, dpu_count: usize) -> TestManagedHost {
-        let mut host = self
+    pub async fn create_ready_managed_host(
+        &self,
+        dpu_count: usize,
+    ) -> (TestManagedHost, TestManagedHostBuildData) {
+        let (mut host, build_data) = self
             .test_harness
             .managed_host_builder(&self.site_explorer, self.underlay_segment)
             .with_config(ManagedHostConfig::default().with_dpu_count(dpu_count))
             .build()
             .await;
 
-        host.discover_host_primary_iface(self.api(), self.admin_segment)
+        host.host.discover_primary_iface(self.admin_segment).await;
+        for dpu in &host.dpus {
+            dpu.discover_oob_iface(self.admin_segment).await;
+        }
+        host.report_dpu_network_status().await;
+        host.insert_empty_host_health_report("test-harness-health")
             .await;
-        host.discover_dpu_oob_ifaces(self.api(), self.admin_segment)
-            .await;
-        host.report_dpu_network_status(self.api()).await;
-        host.insert_empty_host_health_report(self.api(), "test-harness-health")
-            .await;
-        host.advance_host_state(&self.test_harness, ManagedHostState::Ready)
-            .await;
-        host
+        host.advance_state(ManagedHostState::Ready).await;
+        (host, build_data)
     }
 }

--- a/crates/api-web/src/tests/health.rs
+++ b/crates/api-web/src/tests/health.rs
@@ -62,7 +62,8 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
     .await;
 
     // Health page for Machine which was force deleted
-    let host_machine_id = env.create_ready_managed_host(1).await.host_machine_id;
+    let mh = env.create_ready_managed_host(1).await.0;
+    let host_machine_id = mh.host.id;
     env.api()
         .admin_force_delete_machine(tonic::Request::new(AdminForceDeleteMachineRequest {
             host_query: host_machine_id.to_string(),
@@ -89,7 +90,8 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
 async fn test_add_remove_health_report_via_web_ui(pool: sqlx::PgPool) {
     let env = TestEnv::new(pool).await;
     let app = make_test_app(&env.test_harness);
-    let host_machine_id = env.create_ready_managed_host(1).await.host_machine_id;
+    let mh = env.create_ready_managed_host(1).await.0;
+    let host_machine_id = mh.host.id;
 
     let payload = r#"{
         "mode": "Merge",
@@ -167,9 +169,9 @@ async fn test_add_remove_nvlink_domain_health_report_via_web_ui(pool: sqlx::PgPo
 async fn test_add_replace_remove_dpu_health_report_via_web_ui(pool: sqlx::PgPool) {
     let env = TestEnv::new(pool).await;
     let app = make_test_app(&env.test_harness);
-    let host = env.create_ready_managed_host(1).await;
-    let host_machine_id = host.host_machine_id;
-    let dpu_machine_id = host.dpu_machine_id(0);
+    let mh = env.create_ready_managed_host(1).await.0;
+    let host_machine_id = mh.host.id;
+    let dpu_machine_id = mh.dpu(0).id;
 
     let merge_payload = r#"{
         "mode": "Merge",

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -16,10 +16,10 @@
  */
 use axum::body::Body;
 use carbide_rpc_utils::ManagedHostOutput;
+use carbide_test_harness::TestMachine as _;
 use db::{machine, managed_host};
 use http_body_util::BodyExt;
 use hyper::http::StatusCode;
-use model::hardware_info::HardwareInfo;
 use model::machine::{InstanceState, LoadSnapshotOptions, ManagedHostState, RetryInfo};
 use tower::ServiceExt;
 
@@ -77,7 +77,8 @@ async fn test_ok(pool: sqlx::PgPool) {
 async fn test_multi_dpu(pool: sqlx::PgPool) {
     let env = TestEnv::new(pool).await;
     let app = make_test_app(&env.test_harness);
-    let host_machine_id = env.create_ready_managed_host(2).await.host_machine_id;
+    let mh = env.create_ready_managed_host(2).await.0;
+    let host_machine_id = mh.host.id;
 
     let response = app
         .oneshot(
@@ -131,14 +132,13 @@ async fn test_multi_dpu(pool: sqlx::PgPool) {
 #[crate::sqlx_test]
 async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     let env = TestEnv::new(pool).await;
-    let host = env.create_ready_managed_host(2).await;
-    let hardware_info = HardwareInfo::from(&host.managed_host);
+    let (mh, build_data) = env.create_ready_managed_host(2).await;
+    let hardware_info = mh.host.hardware_info();
+    let dpu_1 = mh.dpu(0);
+    let dpu_2 = mh.dpu(1);
 
     // Get info from the test managed host so we know what to assert on in the ManagedHostRowDisplay.
-    let machine_id = host.host_machine_id;
-    let host_bmc_ip = host.host_bmc_ip;
-    let dpu_1_bmc_ip = host.dpu_bmc_ip(0);
-    let dpu_2_bmc_ip = host.dpu_bmc_ip(1);
+    let machine_id = mh.host.id;
 
     let snapshots = managed_host::load_all(
         &env.api().database_connection,
@@ -174,11 +174,8 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert_eq!(row.num_gpus, hardware_info.gpus.len(),);
     assert!(!row.time_in_state_above_sla);
     assert!(!row.time_in_state.is_empty()); // Should match something like "0 seconds"
-    assert_eq!(row.host_bmc_ip, host_bmc_ip.to_string());
-    assert_eq!(
-        row.host_bmc_mac,
-        host.managed_host.bmc_mac_address.to_string()
-    );
+    assert_eq!(row.host_bmc_ip, build_data.host_bmc_ip().to_string());
+    assert_eq!(row.host_bmc_mac, mh.host.bmc_mac.to_string());
     assert_eq!(
         row.vendor,
         hardware_info.dmi_data.as_ref().unwrap().sys_vendor
@@ -191,15 +188,7 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert!(!row.health_sources.is_empty());
     assert!(row.health_probe_alerts.is_empty());
     assert!(!row.host_admin_ip.is_empty());
-    assert_eq!(
-        row.host_admin_mac,
-        hardware_info
-            .network_interfaces
-            .first()
-            .unwrap()
-            .mac_address
-            .to_string()
-    );
+    assert_eq!(row.host_admin_mac, mh.host.primary_mac().to_string());
     assert!(row.state_reason.is_empty());
 
     assert_eq!(row.dpus.len(), 2);
@@ -208,30 +197,18 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
         row.dpus[0].machine_id,
         snapshot.dpu_snapshots[0].id.to_string()
     );
-    assert_eq!(row.dpus[0].bmc_ip, dpu_1_bmc_ip.to_string());
-    assert_eq!(
-        row.dpus[0].bmc_mac,
-        host.managed_host.dpus[0].bmc_mac_address.to_string()
-    );
-    assert_eq!(
-        row.dpus[0].oob_mac,
-        host.managed_host.dpus[0].oob_mac_address.to_string()
-    );
+    assert_eq!(row.dpus[0].bmc_ip, build_data.dpu_bmc_ip(0).to_string());
+    assert_eq!(row.dpus[0].bmc_mac, dpu_1.bmc_mac.to_string());
+    assert_eq!(row.dpus[0].oob_mac, dpu_1.oob_mac().to_string());
     assert!(!row.dpus[0].oob_ip.is_empty(), "dpu should show an oob ip");
 
     assert_eq!(
         row.dpus[1].machine_id,
         snapshot.dpu_snapshots[1].id.to_string()
     );
-    assert_eq!(row.dpus[1].bmc_ip, dpu_2_bmc_ip.to_string());
-    assert_eq!(
-        row.dpus[1].bmc_mac,
-        host.managed_host.dpus[1].bmc_mac_address.to_string()
-    );
-    assert_eq!(
-        row.dpus[1].oob_mac,
-        host.managed_host.dpus[1].oob_mac_address.to_string()
-    );
+    assert_eq!(row.dpus[1].bmc_ip, build_data.dpu_bmc_ip(1).to_string());
+    assert_eq!(row.dpus[1].bmc_mac, dpu_2.bmc_mac.to_string());
+    assert_eq!(row.dpus[1].oob_mac, dpu_2.oob_mac().to_string());
     assert!(!row.dpus[1].oob_ip.is_empty(), "dpu should show an oob ip");
 
     Ok(())
@@ -240,7 +217,7 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
 #[crate::sqlx_test]
 async fn test_managed_host_html_uses_runtime_sla_config(pool: sqlx::PgPool) {
     let env = TestEnv::new(pool).await;
-    let host = env.create_ready_managed_host(1).await;
+    let mh = env.create_ready_managed_host(1).await.0;
 
     let assigned_booting_state = ManagedHostState::Assigned {
         instance_state: InstanceState::BootingWithDiscoveryImage {
@@ -254,7 +231,7 @@ async fn test_managed_host_html_uses_runtime_sla_config(pool: sqlx::PgPool) {
             .unwrap();
 
     let mut txn = env.test_harness.db_txn().await;
-    let host_machine = host.host_db_machine(&mut txn).await;
+    let host_machine = mh.host.db_machine(&mut txn).await;
     machine::advance(
         &host_machine,
         &mut txn,

--- a/crates/site-explorer/tests/health_report.rs
+++ b/crates/site-explorer/tests/health_report.rs
@@ -111,13 +111,14 @@ async fn test_site_explorer_health_report(pool: PgPool) -> Result<(), Box<dyn st
     // Site Explorer needs to run against BMC IPs on an underlay segment. The
     // old api-core fixture mutated a tenant segment into underlay for this;
     // TestHarness creates an underlay segment directly.
-    let created_host = test_harness
+    let (created_host, build_data) = test_harness
         .managed_host_builder(&explorer, underlay_segment)
         .with_dpu_network_status_reported()
         .build()
         .await;
+    let host_bmc_ip = build_data.host_bmc_ip();
 
-    let host_machine = find_machine(test_harness.api(), created_host.host_machine_id).await?;
+    let host_machine = find_machine(test_harness.api(), created_host.host.id).await?;
     let alerts = &host_machine.health.as_ref().unwrap().alerts;
     assert!(
         alerts.is_empty(),
@@ -126,13 +127,13 @@ async fn test_site_explorer_health_report(pool: PgPool) -> Result<(), Box<dyn st
 
     // Now mark the Machine as unreachable. A health alert should be emitted
     explorer.insert_endpoint_result(
-        created_host.host_bmc_ip,
+        host_bmc_ip,
         Err(EndpointExplorationError::Unreachable { details: None }),
     );
 
     explorer.run_single_iteration().await?;
 
-    let host_machine = find_machine(test_harness.api(), created_host.host_machine_id).await?;
+    let host_machine = find_machine(test_harness.api(), created_host.host.id).await?;
 
     let mut alerts = host_machine.health.as_ref().unwrap().alerts.clone();
     assert_eq!(
@@ -150,7 +151,7 @@ async fn test_site_explorer_health_report(pool: PgPool) -> Result<(), Box<dyn st
         alerts,
         vec![rpc::health::HealthProbeAlert {
             id: "BmcExplorationFailure".to_string(),
-            target: Some(created_host.host_bmc_ip.to_string()),
+            target: Some(host_bmc_ip.to_string()),
             in_alert_since: None,
             message: "Endpoint exploration failed: The endpoint was not reachable due to a generic network issue: None"
                 .to_string(),
@@ -176,12 +177,15 @@ async fn test_orphan_managed_host_alert_emitted(
     let underlay_segment = network_controller.create_underlay_segment(&domain).await;
     network_controller.create_admin_segment(&domain).await;
     let explorer = test_site_explorer(&test_harness, site_explorer_config());
-    let created_host = test_harness
+    let (created_host, _) = test_harness
         .managed_host_builder(&explorer, underlay_segment)
         .build()
         .await;
-    let host_bmc_mac = created_host.managed_host.bmc_mac_address;
-    let chassis_serial = created_host.managed_host.serial.clone();
+    let host_bmc_mac = created_host.host.bmc_mac;
+    let chassis_serial = created_host
+        .host
+        .serial()
+        .expect("created host should have a serial number");
 
     // Orphan the host by deleting its expected_machines entry.
     let mut txn = pool.begin().await?;
@@ -190,7 +194,7 @@ async fn test_orphan_managed_host_alert_emitted(
 
     // Run an iteration: audit_exploration_results should emit the orphan alert.
     explorer.run_single_iteration().await?;
-    let alerts = find_machine(test_harness.api(), created_host.host_machine_id)
+    let alerts = find_machine(test_harness.api(), created_host.host.id)
         .await?
         .health
         .unwrap()
@@ -217,7 +221,7 @@ async fn test_orphan_managed_host_alert_emitted(
     txn.commit().await?;
 
     explorer.run_single_iteration().await?;
-    let alerts = find_machine(test_harness.api(), created_host.host_machine_id)
+    let alerts = find_machine(test_harness.api(), created_host.host.id)
         .await?
         .health
         .unwrap()

--- a/crates/site-explorer/tests/machine_creator.rs
+++ b/crates/site-explorer/tests/machine_creator.rs
@@ -207,7 +207,7 @@ async fn test_machine_creator_creates_managed_host(
 
     let mock_dpu = DpuConfig::with_serial(dpu_serial.clone());
     dhcp_discover_dpu_oob_iface(env.api(), env.underlay_segment, mock_dpu.oob_mac_address).await;
-    let mock_host = ManagedHostConfig::with_dpus(vec![mock_dpu.clone()]);
+    let mock_host = ManagedHostConfig::default().with_dpus(vec![mock_dpu.clone()]);
     let mut fixture = explored_host_fixture(&env, &mock_host).await;
 
     assert_eq!(fixture.dpu_machine_ids[&0].to_string(), expected_machine_id,);
@@ -378,8 +378,7 @@ async fn test_machine_creator_creates_multi_dpu_managed_host(
     txn.commit().await?;
 
     let mut oob_interfaces = Vec::new();
-    let mock_host =
-        ManagedHostConfig::with_dpus((0..NUM_DPUS).map(|_| DpuConfig::default()).collect());
+    let mock_host = ManagedHostConfig::default().with_dpu_count(NUM_DPUS);
     for dpu in &mock_host.dpus {
         dhcp_discover_dpu_oob_iface(env.api(), env.underlay_segment, dpu.oob_mac_address).await;
         let mut txn = env.pool.begin().await?;
@@ -737,7 +736,7 @@ async fn test_machine_creator_creates_managed_host_with_dpf_disabled(
             dpf_enabled: Some(false),
             ..Default::default()
         }),
-        ..ManagedHostConfig::with_dpus(vec![mock_dpu.clone()])
+        ..ManagedHostConfig::default().with_dpus(vec![mock_dpu.clone()])
     };
     let mut fixture = explored_host_fixture(&env, &mock_host).await;
 
@@ -789,7 +788,7 @@ async fn test_machine_creator_creates_managed_host_with_dpf_enabled(
             dpf_enabled: Some(true),
             ..Default::default()
         }),
-        ..ManagedHostConfig::with_dpus(vec![mock_dpu.clone()])
+        ..ManagedHostConfig::default().with_dpus(vec![mock_dpu.clone()])
     };
     let mut fixture = explored_host_fixture(&env, &mock_host).await;
 

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -2635,7 +2635,7 @@ async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
     let dpu = DpuConfig::default();
     let host_pf_mac = dpu.host_mac_address;
     let managed_host = ManagedHostConfig::default().with_dpus(vec![dpu]);
-    let created_host = test_harness
+    let (created_host, _) = test_harness
         .managed_host_builder(&explorer, underlay_segment)
         .with_config(managed_host)
         .build()
@@ -2645,7 +2645,8 @@ async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
     // preingestion complete. Its second iteration creates the predicted host-PF
     // interface with the Redfish boot interface id from the endpoint report.
     created_host
-        .dhcp_discover_host_primary_iface(test_harness.api(), admin_segment)
+        .host
+        .dhcp_discover_primary_iface(admin_segment)
         .await;
 
     // Third iteration: the DHCP-created row is matched by MAC and receives
@@ -2654,11 +2655,10 @@ async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
 
     let mut txn = test_harness.db_txn().await;
     let interfaces =
-        db::machine_interface::find_by_machine_ids(&mut txn, &[created_host.host_machine_id])
-            .await?;
+        db::machine_interface::find_by_machine_ids(&mut txn, &[created_host.host.id]).await?;
     txn.commit().await?;
     let primary = interfaces
-        .get(&created_host.host_machine_id)
+        .get(&created_host.host.id)
         .into_iter()
         .flatten()
         .find(|i| i.primary_interface)

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -1428,7 +1428,7 @@ async fn test_site_explorer_audit_exploration_results(
 
     // Make a mock host for machines[4] to generate the report
     // This serial is from the create_expected_machine.sql seed.
-    let machine_4_host = ManagedHostConfig::with_serial("VVG121GJ".to_string());
+    let machine_4_host = ManagedHostConfig::default().with_serial("VVG121GJ".to_string());
 
     let explorer_config = SiteExplorerConfig {
         enabled: Arc::new(true.into()),
@@ -2214,8 +2214,9 @@ async fn test_fetch_host_primary_interface_mac(
             .unwrap(),
     );
 
-    let host_report: EndpointExplorationReport =
-        ManagedHostConfig::with_dpus(mock_dpus.clone()).into();
+    let host_report: EndpointExplorationReport = ManagedHostConfig::default()
+        .with_dpus(mock_dpus.clone())
+        .into();
 
     const NUM_DPUS: usize = 2;
 
@@ -2431,7 +2432,8 @@ async fn test_site_explorer_auto_corrects_nic_mode_per_expected_machine(
         nic_mode: Some(NicMode::Dpu),
         ..DpuConfig::default()
     };
-    let mock_host = model::test_support::ManagedHostConfig::with_dpus(vec![dpu_config.clone()]);
+    let mock_host =
+        model::test_support::ManagedHostConfig::default().with_dpus(vec![dpu_config.clone()]);
     let host_bmc_mac = mock_host.bmc_mac_address;
 
     // Seed an ExpectedMachine with `dpu_mode: NicMode` that matches the
@@ -2632,7 +2634,7 @@ async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
 
     let dpu = DpuConfig::default();
     let host_pf_mac = dpu.host_mac_address;
-    let managed_host = ManagedHostConfig::with_dpus(vec![dpu]);
+    let managed_host = ManagedHostConfig::default().with_dpus(vec![dpu]);
     let created_host = test_harness
         .managed_host_builder(&explorer, underlay_segment)
         .with_config(managed_host)

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -39,12 +39,18 @@ use crate::network::segment::TestNetworkSegment;
 pub mod asset;
 pub mod builder;
 pub mod dns;
+pub mod machine;
+pub mod machine_dpu;
+pub mod machine_host;
 pub mod managed_host;
 pub mod network;
 pub mod prelude;
 pub mod resource_pool;
 
-pub use managed_host::{TestManagedHost, TestManagedHostBuilder};
+pub use machine::TestMachine;
+pub use machine_dpu::TestDpuMachine;
+pub use machine_host::TestHostMachine;
+pub use managed_host::{TestManagedHost, TestManagedHostBuildData, TestManagedHostBuilder};
 
 pub struct TestHarness {
     api: Arc<ApiHandle>,

--- a/crates/test-harness/src/machine.rs
+++ b/crates/test-harness/src/machine.rs
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::future::Future;
+
+use carbide_api_core::test_support::Api;
+use carbide_uuid::machine::MachineId;
+use model::hardware_info::HardwareInfo;
+use model::machine::Machine;
+use model::machine::machine_search_config::MachineSearchConfig;
+use tonic::IntoRequest;
+
+use crate::rpc::forge::forge_server::Forge;
+use crate::rpc::forge::{DhcpRecord, MachineDiscoveryResult};
+use crate::rpc::{DiscoveryData, DiscoveryInfo};
+
+pub trait TestMachine {
+    fn id(&self) -> MachineId;
+
+    fn api(&self) -> &Api;
+
+    fn rpc_machine(&self) -> impl Future<Output = crate::rpc::Machine> + '_ {
+        async move {
+            self.api()
+                .find_machines_by_ids(
+                    crate::rpc::forge::MachinesByIdsRequest {
+                        machine_ids: vec![self.id()],
+                        include_history: true,
+                    }
+                    .into_request(),
+                )
+                .await
+                .expect("machine lookup by id should succeed")
+                .into_inner()
+                .machines
+                .remove(0)
+        }
+    }
+
+    fn db_machine<'a, 'txn>(
+        &'a self,
+        txn: &'a mut sqlx::PgTransaction<'txn>,
+    ) -> impl Future<Output = Machine> + 'a {
+        async move {
+            db::machine::find_one(txn.as_mut(), &self.id(), MachineSearchConfig::default())
+                .await
+                .expect("machine lookup should succeed")
+                .expect("machine should exist")
+        }
+    }
+
+    fn machine(&self) -> impl Future<Output = Machine> + '_ {
+        async move {
+            let mut txn = self
+                .api()
+                .database_connection
+                .begin()
+                .await
+                .expect("database transaction should start");
+            let machine = self.db_machine(&mut txn).await;
+            txn.commit()
+                .await
+                .expect("database transaction should commit");
+            machine
+        }
+    }
+}
+
+pub(crate) trait TestMachinePrivate: TestMachine {
+    async fn discover_machine(
+        &self,
+        dhcp_record: &DhcpRecord,
+        hardware_info: HardwareInfo,
+    ) -> MachineDiscoveryResult {
+        self.api()
+            .discover_machine(
+                crate::rpc::forge::MachineDiscoveryInfo {
+                    machine_interface_id: Some(
+                        *dhcp_record
+                            .machine_interface_id
+                            .as_ref()
+                            .expect("DHCP record should include a machine interface id"),
+                    ),
+                    create_machine: true,
+                    discovery_data: Some(DiscoveryData::Info(
+                        DiscoveryInfo::try_from(hardware_info)
+                            .expect("hardware info should convert to discovery info"),
+                    )),
+                    ..Default::default()
+                }
+                .into_request(),
+            )
+            .await
+            .expect("machine discovery should succeed")
+            .into_inner()
+    }
+}

--- a/crates/test-harness/src/machine_dpu.rs
+++ b/crates/test-harness/src/machine_dpu.rs
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use carbide_api_core::test_support::Api;
+use carbide_uuid::machine::MachineId;
+use mac_address::MacAddress;
+use model::hardware_info::HardwareInfo;
+use model::test_support::DpuConfig;
+
+use crate::machine::{TestMachine, TestMachinePrivate};
+use crate::network::segment::TestNetworkSegment;
+use crate::rpc::forge::forge_server::Forge;
+use crate::rpc::forge::{DhcpDiscovery, DhcpRecord, ManagedHostNetworkConfigRequest};
+
+#[derive(Clone)]
+pub struct TestDpuMachine {
+    pub id: MachineId,
+    pub bmc_mac: MacAddress,
+    pub api: Arc<Api>,
+    hardware_info: HardwareInfo,
+    oob_mac: MacAddress,
+}
+
+impl TestDpuMachine {
+    pub(crate) fn new(id: MachineId, api: Arc<Api>, config: &DpuConfig) -> Self {
+        Self {
+            id,
+            bmc_mac: config.bmc_mac_address,
+            api,
+            hardware_info: HardwareInfo::from(config),
+            oob_mac: config.oob_mac_address,
+        }
+    }
+
+    pub fn oob_mac(&self) -> MacAddress {
+        self.oob_mac
+    }
+
+    pub async fn dhcp_discover_oob_iface(&self, segment: TestNetworkSegment) -> DhcpRecord {
+        self.api
+            .discover_dhcp(
+                DhcpDiscovery::builder(self.oob_mac(), segment.relay_address)
+                    .vendor_string("SomeVendor")
+                    .tonic_request(),
+            )
+            .await
+            .expect("DPU OOB interface DHCP discovery should succeed")
+            .into_inner()
+    }
+
+    pub async fn discover_oob_iface(&self, segment: TestNetworkSegment) {
+        let dhcp_record = self.dhcp_discover_oob_iface(segment).await;
+        let discovered_id = self
+            .discover_machine(&dhcp_record, self.hardware_info.clone())
+            .await
+            .machine_id
+            .expect("DPU discovery should return a machine id");
+        assert_eq!(
+            discovered_id, self.id,
+            "DPU discovery should resolve to the expected test machine"
+        );
+    }
+
+    /// Simulate forge-dpu-agent fetching, applying, and reporting DPU network status.
+    pub async fn record_network_status(&self) {
+        record_dpu_network_status(&self.api, self.id).await;
+    }
+}
+
+impl TestMachine for TestDpuMachine {
+    fn id(&self) -> MachineId {
+        self.id
+    }
+
+    fn api(&self) -> &Api {
+        &self.api
+    }
+}
+
+impl TestMachinePrivate for TestDpuMachine {}
+
+async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
+    let network_config = api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .expect("managed host network config should be available")
+        .into_inner();
+
+    let instance_network_config_version =
+        if network_config.instance_network_config_version.is_empty() {
+            None
+        } else {
+            Some(network_config.instance_network_config_version.clone())
+        };
+    let instance_config_version = api
+        .find_instance_by_machine_id(tonic::Request::new(dpu_machine_id))
+        .await
+        .expect("instance lookup by machine id should succeed")
+        .into_inner()
+        .instances
+        .pop()
+        .map(|instance| {
+            if !network_config.use_admin_network {
+                assert_eq!(
+                    instance_network_config_version
+                        .as_ref()
+                        .expect("instance network config version should be set")
+                        .as_str(),
+                    instance.network_config_version,
+                    "Different network config versions reported via FindInstanceByMachineId and GetManagedHostNetworkConfig"
+                );
+            }
+            instance.config_version
+        });
+
+    let interfaces = if network_config.use_admin_network {
+        let iface = network_config
+            .admin_interface
+            .as_ref()
+            .expect("admin interface should be available when using admin network");
+        vec![crate::rpc::forge::InstanceInterfaceStatusObservation {
+            function_type: iface.function_type,
+            virtual_function_id: None,
+            mac_address: None,
+            addresses: vec![iface.ip.clone()],
+            prefixes: vec![iface.interface_prefix.clone()],
+            gateways: vec![iface.gateway.clone()],
+            network_security_group: None,
+            internal_uuid: iface.internal_uuid.clone(),
+        }]
+    } else {
+        network_config
+            .tenant_interfaces
+            .iter()
+            .map(
+                |iface| crate::rpc::forge::InstanceInterfaceStatusObservation {
+                    function_type: iface.function_type,
+                    virtual_function_id: iface.virtual_function_id,
+                    mac_address: None,
+                    addresses: vec![iface.ip.clone()],
+                    prefixes: vec![iface.interface_prefix.clone()],
+                    gateways: vec![iface.gateway.clone()],
+                    network_security_group: None,
+                    internal_uuid: iface.internal_uuid.clone(),
+                },
+            )
+            .collect()
+    };
+
+    let dpu_extension_services = network_config
+        .dpu_extension_services
+        .iter()
+        .map(
+            |extension_service| crate::rpc::forge::DpuExtensionServiceStatusObservation {
+                service_id: extension_service.service_id.clone(),
+                service_type: extension_service.service_type,
+                service_name: String::new(),
+                version: extension_service.version.to_string(),
+                state: crate::rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceRunning
+                    as i32,
+                components: vec![],
+                message: String::new(),
+                removed: extension_service.removed.clone(),
+            },
+        )
+        .collect();
+
+    api.record_dpu_network_status(tonic::Request::new(crate::rpc::forge::DpuNetworkStatus {
+        dpu_machine_id: Some(dpu_machine_id),
+        dpu_agent_version: Some("test-dpu-agent-version".to_string()),
+        observed_at: None,
+        dpu_health: Some(crate::rpc::health::HealthReport {
+            source: "forge-dpu-agent".to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts: vec![],
+        }),
+        network_config_version: Some(network_config.managed_host_config_version.clone()),
+        instance_id: network_config.instance_id,
+        instance_config_version,
+        instance_network_config_version,
+        interfaces,
+        network_config_error: None,
+        client_certificate_expiry_unix_epoch_secs: None,
+        fabric_interfaces: vec![],
+        last_dhcp_requests: vec![],
+        dpu_extension_service_version: network_config
+            .instance
+            .map(|instance| instance.dpu_extension_service_version),
+        dpu_extension_services,
+    }))
+    .await
+    .expect("DPU network status should be recorded");
+}

--- a/crates/test-harness/src/machine_host.rs
+++ b/crates/test-harness/src/machine_host.rs
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use carbide_api_core::test_support::Api;
+use carbide_uuid::machine::MachineId;
+use mac_address::MacAddress;
+use model::hardware_info::HardwareInfo;
+use model::machine::machine_id::from_hardware_info;
+use model::test_support::ManagedHostConfig;
+
+use crate::machine::{TestMachine, TestMachinePrivate};
+use crate::network::segment::TestNetworkSegment;
+use crate::rpc::forge::forge_server::Forge;
+use crate::rpc::forge::{DhcpDiscovery, DhcpRecord};
+
+#[derive(Clone)]
+pub struct TestHostMachine {
+    pub id: MachineId,
+    pub bmc_mac: MacAddress,
+    pub api: Arc<Api>,
+    hardware_info: HardwareInfo,
+    primary_mac: MacAddress,
+}
+
+impl TestHostMachine {
+    pub(crate) fn new(id: MachineId, api: Arc<Api>, config: &ManagedHostConfig) -> Self {
+        Self {
+            id,
+            bmc_mac: config.bmc_mac_address,
+            api,
+            hardware_info: HardwareInfo::from(config),
+            primary_mac: config.dhcp_mac_address(),
+        }
+    }
+
+    pub fn hardware_info(&self) -> HardwareInfo {
+        self.hardware_info.clone()
+    }
+
+    pub fn serial(&self) -> Option<String> {
+        let hardware_info = self.hardware_info();
+        let dmi = hardware_info.dmi_data?;
+        if !dmi.product_serial.is_empty() {
+            Some(dmi.product_serial)
+        } else if !dmi.chassis_serial.is_empty() {
+            Some(dmi.chassis_serial)
+        } else {
+            None
+        }
+    }
+
+    pub fn primary_mac(&self) -> MacAddress {
+        self.primary_mac
+    }
+
+    pub async fn dhcp_discover_primary_iface(&self, segment: TestNetworkSegment) -> DhcpRecord {
+        self.api
+            .discover_dhcp(
+                DhcpDiscovery::builder(self.primary_mac(), segment.relay_address)
+                    .vendor_string("Bluefield")
+                    .tonic_request(),
+            )
+            .await
+            .expect("host primary interface DHCP discovery should succeed")
+            .into_inner()
+    }
+
+    pub async fn discover_primary_iface(&mut self, segment: TestNetworkSegment) {
+        let dhcp_record = self.dhcp_discover_primary_iface(segment).await;
+        let hardware_info = self.hardware_info();
+        let expected_id =
+            from_hardware_info(&hardware_info).expect("host hardware info should yield stable id");
+        let discovered_id = self
+            .discover_machine(&dhcp_record, hardware_info)
+            .await
+            .machine_id
+            .expect("host discovery should return a machine id");
+        assert_eq!(
+            discovered_id, expected_id,
+            "host discovery should resolve to the stable test machine"
+        );
+        self.id = discovered_id;
+    }
+}
+
+impl TestMachine for TestHostMachine {
+    fn id(&self) -> MachineId {
+        self.id
+    }
+
+    fn api(&self) -> &Api {
+        &self.api
+    }
+}
+
+impl TestMachinePrivate for TestHostMachine {}

--- a/crates/test-harness/src/managed_host.rs
+++ b/crates/test-harness/src/managed_host.rs
@@ -19,9 +19,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use carbide_api_core::test_support::Api;
-use carbide_api_core::test_support::fixture_config::{
-    FixtureDefault as _, ManagedHostConfigExt as _,
-};
+use carbide_api_core::test_support::fixture_config::FixtureDefault as _;
 use carbide_site_explorer::test_support::TestSiteExplorer;
 use carbide_uuid::machine::MachineId;
 use mac_address::MacAddress;
@@ -29,7 +27,7 @@ use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
 use model::hardware_info::HardwareInfo;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{Machine, ManagedHostState};
-use model::test_support::{DpuConfig, ManagedHostConfig};
+use model::test_support::ManagedHostConfig;
 
 use crate::TestHarness;
 use crate::network::segment::TestNetworkSegment;
@@ -181,7 +179,7 @@ pub struct TestManagedHostBuilder<'a> {
     test_harness: &'a TestHarness,
     site_explorer: &'a TestSiteExplorer,
     segment: TestNetworkSegment,
-    managed_host: ManagedHostConfig,
+    config: Option<ManagedHostConfig>,
     report_dpu_network_status: bool,
 }
 
@@ -195,41 +193,38 @@ impl<'a> TestManagedHostBuilder<'a> {
             test_harness,
             site_explorer,
             segment,
-            managed_host: ManagedHostConfig::default(),
+            config: None,
             report_dpu_network_status: false,
         }
     }
 
-    pub fn with_config(mut self, managed_host: ManagedHostConfig) -> Self {
-        self.managed_host = managed_host;
-        self
+    pub fn with_dpu_network_status_reported(self) -> Self {
+        Self {
+            report_dpu_network_status: true,
+            ..self
+        }
     }
 
-    pub fn with_dpu_count(self, dpu_count: usize) -> Self {
-        assert!(dpu_count >= 1, "need to specify at least 1 DPU");
-        self.with_config(ManagedHostConfig::with_dpus(
-            (0..dpu_count).map(|_| DpuConfig::default()).collect(),
-        ))
-    }
-
-    /// Report DPU network status as part of `build`.
-    pub fn with_dpu_network_status_reported(mut self) -> Self {
-        self.report_dpu_network_status = true;
-        self
+    pub fn with_config(self, config: ManagedHostConfig) -> Self {
+        Self {
+            config: Some(config),
+            ..self
+        }
     }
 
     pub async fn build(self) -> TestManagedHost {
-        register_expected_machine(self.test_harness, &self.managed_host).await;
+        let config = self.config.unwrap_or_else(ManagedHostConfig::default);
+        register_expected_machine(self.test_harness, &config).await;
 
         let host_bmc_ip = discover_bmc(
             self.test_harness.api(),
-            self.managed_host.bmc_mac_address,
+            config.bmc_mac_address,
             self.segment,
             "SomeVendor",
         )
         .await;
         let mut dpu_bmc_ips = Vec::new();
-        for (dpu_index, dpu) in self.managed_host.dpus.iter().enumerate() {
+        for (dpu_index, dpu) in config.dpus.iter().enumerate() {
             let dpu_index = dpu_index.try_into().expect("DPU index should fit into u8");
             let bmc_ip = discover_bmc(
                 self.test_harness.api(),
@@ -241,8 +236,7 @@ impl<'a> TestManagedHostBuilder<'a> {
             dpu_bmc_ips.push((dpu_index, bmc_ip));
         }
 
-        let results = self
-            .managed_host
+        let results = config
             .exploration_results(Some(host_bmc_ip), &dpu_bmc_ips)
             .expect("managed host exploration results should be generated");
         let dpu_machine_ids = results.dpu_machine_ids();
@@ -284,7 +278,7 @@ impl<'a> TestManagedHostBuilder<'a> {
             .expect("database transaction should commit");
 
         let managed_host = TestManagedHost {
-            managed_host: self.managed_host,
+            managed_host: config,
             host_bmc_ip,
             dpu_bmc_ips,
             host_machine_id,

--- a/crates/test-harness/src/managed_host.rs
+++ b/crates/test-harness/src/managed_host.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use carbide_api_core::test_support::Api;
 use carbide_api_core::test_support::fixture_config::FixtureDefault as _;
@@ -25,153 +25,99 @@ use carbide_uuid::machine::MachineId;
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
 use model::hardware_info::HardwareInfo;
-use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{Machine, ManagedHostState};
+use model::machine::ManagedHostState;
+use model::machine::machine_id::host_id_from_dpu_hardware_info;
+use model::site_explorer::EndpointExplorationReport;
 use model::test_support::ManagedHostConfig;
 
 use crate::TestHarness;
+use crate::machine::TestMachine;
+use crate::machine_dpu::TestDpuMachine;
+use crate::machine_host::TestHostMachine;
 use crate::network::segment::TestNetworkSegment;
 use crate::rpc::forge::forge_server::Forge;
-use crate::rpc::forge::{
-    DhcpDiscovery, DhcpRecord, HealthReportEntry, InsertMachineHealthReportRequest,
-    MachineDiscoveryResult, ManagedHostNetworkConfigRequest,
-};
-use crate::rpc::{DiscoveryData, DiscoveryInfo};
+use crate::rpc::forge::{DhcpDiscovery, HealthReportEntry, InsertMachineHealthReportRequest};
 
+#[derive(Clone)]
 pub struct TestManagedHost {
-    pub managed_host: ManagedHostConfig,
-    pub host_bmc_ip: IpAddr,
-    pub dpu_bmc_ips: Vec<(u8, IpAddr)>,
-    pub host_machine_id: MachineId,
-    pub dpu_machine_ids: HashMap<u8, MachineId>,
+    pub host: TestHostMachine,
+    pub dpus: Vec<TestDpuMachine>,
+    pub api: Arc<Api>,
 }
 
 impl TestManagedHost {
-    pub fn dpu_machine_id(&self, dpu_index: u8) -> MachineId {
-        *self
-            .dpu_machine_ids
-            .get(&dpu_index)
-            .expect("DPU machine id should exist")
+    pub fn dpu(&self, dpu_index: usize) -> &TestDpuMachine {
+        self.dpus
+            .get(dpu_index)
+            .unwrap_or_else(|| panic!("DPU {dpu_index} should exist"))
     }
 
-    pub fn dpu_bmc_ip(&self, dpu_index: u8) -> IpAddr {
-        self.dpu_bmc_ips
-            .iter()
-            .find(|(index, _)| *index == dpu_index)
-            .map(|(_, ip)| *ip)
-            .expect("DPU BMC IP should exist")
+    pub fn first_dpu(&self) -> &TestDpuMachine {
+        self.dpu(0)
     }
 
-    pub async fn dhcp_discover_host_primary_iface(
-        &self,
-        api: &Api,
-        segment: TestNetworkSegment,
-    ) -> DhcpRecord {
-        api.discover_dhcp(
-            DhcpDiscovery::builder(self.managed_host.dhcp_mac_address(), segment.relay_address)
-                .vendor_string("Bluefield")
-                .tonic_request(),
-        )
-        .await
-        .expect("host primary interface DHCP discovery should succeed")
-        .into_inner()
-    }
-
-    pub async fn discover_host_primary_iface(&mut self, api: &Api, segment: TestNetworkSegment) {
-        let dhcp_record = self.dhcp_discover_host_primary_iface(api, segment).await;
-        self.host_machine_id =
-            discover_machine(api, &dhcp_record, HardwareInfo::from(&self.managed_host))
-                .await
-                .machine_id
-                .expect("host discovery should return a machine id");
-    }
-
-    pub async fn dhcp_discover_dpu_oob_ifaces(
-        &self,
-        api: &Api,
-        segment: TestNetworkSegment,
-    ) -> Vec<DhcpRecord> {
-        let mut dhcp_records = Vec::new();
-        for dpu in &self.managed_host.dpus {
-            let dhcp_record = api
-                .discover_dhcp(
-                    DhcpDiscovery::builder(dpu.oob_mac_address, segment.relay_address)
-                        .vendor_string("SomeVendor")
-                        .tonic_request(),
-                )
-                .await
-                .expect("DPU OOB interface DHCP discovery should succeed")
-                .into_inner();
-            dhcp_records.push(dhcp_record);
-        }
-        dhcp_records
-    }
-
-    pub async fn discover_dpu_oob_ifaces(&mut self, api: &Api, segment: TestNetworkSegment) {
-        let dhcp_records = self.dhcp_discover_dpu_oob_ifaces(api, segment).await;
-        for (dpu_index, (dpu, dhcp_record)) in self
-            .managed_host
-            .dpus
-            .iter()
-            .zip(dhcp_records.iter())
-            .enumerate()
-        {
-            let dpu_index = dpu_index.try_into().expect("DPU index should fit into u8");
-            self.dpu_machine_ids.insert(
-                dpu_index,
-                discover_machine(api, dhcp_record, HardwareInfo::from(dpu))
-                    .await
-                    .machine_id
-                    .expect("DPU discovery should return a machine id"),
-            );
-        }
-    }
-
-    pub async fn insert_empty_host_health_report(&self, api: &Api, source: impl Into<String>) {
-        api.insert_machine_health_report(tonic::Request::new(InsertMachineHealthReportRequest {
-            health_report_entry: Some(HealthReportEntry {
-                report: Some(crate::rpc::health::HealthReport {
-                    source: source.into(),
-                    triggered_by: None,
-                    observed_at: None,
-                    successes: vec![],
-                    alerts: vec![],
+    pub async fn insert_empty_host_health_report(&self, source: impl Into<String>) {
+        self.api
+            .insert_machine_health_report(tonic::Request::new(InsertMachineHealthReportRequest {
+                health_report_entry: Some(HealthReportEntry {
+                    report: Some(crate::rpc::health::HealthReport {
+                        source: source.into(),
+                        triggered_by: None,
+                        observed_at: None,
+                        successes: vec![],
+                        alerts: vec![],
+                    }),
+                    ..Default::default()
                 }),
-                ..Default::default()
-            }),
-            machine_id: Some(self.host_machine_id),
-        }))
-        .await
-        .expect("empty host health report should be inserted");
+                machine_id: Some(self.host.id),
+            }))
+            .await
+            .expect("empty host health report should be inserted");
     }
 
-    pub async fn advance_host_state(&self, test_harness: &TestHarness, state: ManagedHostState) {
-        let mut txn = test_harness.db_txn().await;
-        let machine = self.host_db_machine(&mut txn).await;
+    pub async fn advance_state(&self, state: ManagedHostState) {
+        let mut txn = self
+            .api
+            .database_connection
+            .begin()
+            .await
+            .expect("database transaction should start");
+        let machine = self.host.db_machine(&mut txn).await;
         db::machine::advance(&machine, &mut txn, &state, None)
             .await
-            .expect("host state should be advanced");
+            .expect("managed host state should be advanced");
         txn.commit()
             .await
             .expect("database transaction should commit");
     }
 
-    pub async fn host_db_machine(&self, txn: &mut sqlx::PgTransaction<'_>) -> Machine {
-        db::machine::find_one(
-            txn.as_mut(),
-            &self.host_machine_id,
-            MachineSearchConfig::default(),
-        )
-        .await
-        .expect("host machine lookup should succeed")
-        .expect("host machine should exist")
+    pub async fn report_dpu_network_status(&self) {
+        for dpu in &self.dpus {
+            dpu.record_network_status().await;
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TestManagedHostBuildData {
+    host_bmc_ip: IpAddr,
+    dpu_bmc_ips: Vec<IpAddr>,
+}
+
+impl TestManagedHostBuildData {
+    pub fn host_bmc_ip(&self) -> IpAddr {
+        self.host_bmc_ip
     }
 
-    /// Simulate forge-dpu-agent fetching, applying, and reporting DPU network status.
-    pub async fn report_dpu_network_status(&self, api: &Api) {
-        for dpu_machine_id in self.dpu_machine_ids.values() {
-            record_dpu_network_status(api, *dpu_machine_id).await;
-        }
+    pub fn dpu_bmc_ip(&self, dpu_index: usize) -> IpAddr {
+        *self
+            .dpu_bmc_ips
+            .get(dpu_index)
+            .unwrap_or_else(|| panic!("DPU {dpu_index} BMC IP should exist"))
+    }
+
+    pub fn first_dpu_bmc_ip(&self) -> IpAddr {
+        self.dpu_bmc_ip(0)
     }
 }
 
@@ -212,7 +158,7 @@ impl<'a> TestManagedHostBuilder<'a> {
         }
     }
 
-    pub async fn build(self) -> TestManagedHost {
+    pub async fn build(self) -> (TestManagedHost, TestManagedHostBuildData) {
         let config = self.config.unwrap_or_else(ManagedHostConfig::default);
         register_expected_machine(self.test_harness, &config).await;
 
@@ -268,31 +214,49 @@ impl<'a> TestManagedHostBuilder<'a> {
             .await
             .expect("second site explorer iteration should succeed");
 
-        let mut txn = self.test_harness.db_txn().await;
-        let host_machine_id = db::machine::find_id_by_bmc_ip(&mut txn, &host_bmc_ip)
-            .await
-            .expect("host machine lookup by BMC IP should succeed")
-            .expect("host machine should have been created for the explored BMC");
-        txn.commit()
-            .await
-            .expect("database transaction should commit");
-
+        let api = self.test_harness.api_arc();
+        let dpus = (0..config.dpus.len())
+            .map(|dpu_index| {
+                let dpu_index = dpu_index.try_into().expect("DPU index should fit into u8");
+                TestDpuMachine::new(
+                    *dpu_machine_ids
+                        .get(&dpu_index)
+                        .expect("DPU machine id should exist"),
+                    api.clone(),
+                    &config.dpus[dpu_index as usize],
+                )
+            })
+            .collect();
         let managed_host = TestManagedHost {
-            managed_host: config,
-            host_bmc_ip,
-            dpu_bmc_ips,
-            host_machine_id,
-            dpu_machine_ids,
+            host: TestHostMachine::new(host_machine_id(&config), api.clone(), &config),
+            dpus,
+            api,
         };
 
         if self.report_dpu_network_status {
-            managed_host
-                .report_dpu_network_status(self.test_harness.api())
-                .await;
+            managed_host.report_dpu_network_status().await;
         }
 
-        managed_host
+        let build_data = TestManagedHostBuildData {
+            host_bmc_ip,
+            dpu_bmc_ips: dpu_bmc_ips.iter().map(|(_, ip)| *ip).collect(),
+        };
+
+        (managed_host, build_data)
     }
+}
+
+fn host_machine_id(config: &ManagedHostConfig) -> MachineId {
+    if let Some(dpu) = config.dpus.first() {
+        return host_id_from_dpu_hardware_info(&HardwareInfo::from(dpu))
+            .expect("host machine id should be derived from DPU hardware info");
+    }
+
+    let mut report: EndpointExplorationReport = config.clone().into();
+    *report
+        .generate_machine_id(true)
+        .expect("host exploration report should generate a machine id")
+        .expect("host exploration report should include a generated machine id")
 }
 
 async fn register_expected_machine(test_harness: &TestHarness, managed_host: &ManagedHostConfig) {
@@ -335,147 +299,4 @@ async fn discover_bmc(
     .address
     .parse()
     .expect("DHCP response address should be an IP address")
-}
-
-async fn discover_machine(
-    api: &Api,
-    dhcp_record: &DhcpRecord,
-    hardware_info: HardwareInfo,
-) -> MachineDiscoveryResult {
-    api.discover_machine(tonic::Request::new(
-        crate::rpc::forge::MachineDiscoveryInfo {
-            machine_interface_id: Some(
-                *dhcp_record
-                    .machine_interface_id
-                    .as_ref()
-                    .expect("DHCP record should include a machine interface id"),
-            ),
-            create_machine: true,
-            discovery_data: Some(DiscoveryData::Info(
-                DiscoveryInfo::try_from(hardware_info)
-                    .expect("hardware info should convert to discovery info"),
-            )),
-            ..Default::default()
-        },
-    ))
-    .await
-    .expect("machine discovery should succeed")
-    .into_inner()
-}
-
-async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
-    let network_config = api
-        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
-        }))
-        .await
-        .expect("managed host network config should be available")
-        .into_inner();
-
-    let instance_network_config_version =
-        if network_config.instance_network_config_version.is_empty() {
-            None
-        } else {
-            Some(network_config.instance_network_config_version.clone())
-        };
-    let instance_config_version = api
-        .find_instance_by_machine_id(tonic::Request::new(dpu_machine_id))
-        .await
-        .expect("instance lookup by machine id should succeed")
-        .into_inner()
-        .instances
-        .pop()
-        .map(|instance| {
-            if !network_config.use_admin_network {
-                assert_eq!(
-                    instance_network_config_version
-                        .as_ref()
-                        .expect("instance network config version should be set")
-                        .as_str(),
-                    instance.network_config_version,
-                    "Different network config versions reported via FindInstanceByMachineId and GetManagedHostNetworkConfig"
-                );
-            }
-            instance.config_version
-        });
-
-    let interfaces = if network_config.use_admin_network {
-        let iface = network_config
-            .admin_interface
-            .as_ref()
-            .expect("admin interface should be available when using admin network");
-        vec![crate::rpc::forge::InstanceInterfaceStatusObservation {
-            function_type: iface.function_type,
-            virtual_function_id: None,
-            mac_address: None,
-            addresses: vec![iface.ip.clone()],
-            prefixes: vec![iface.interface_prefix.clone()],
-            gateways: vec![iface.gateway.clone()],
-            network_security_group: None,
-            internal_uuid: iface.internal_uuid.clone(),
-        }]
-    } else {
-        network_config
-            .tenant_interfaces
-            .iter()
-            .map(
-                |iface| crate::rpc::forge::InstanceInterfaceStatusObservation {
-                    function_type: iface.function_type,
-                    virtual_function_id: iface.virtual_function_id,
-                    mac_address: None,
-                    addresses: vec![iface.ip.clone()],
-                    prefixes: vec![iface.interface_prefix.clone()],
-                    gateways: vec![iface.gateway.clone()],
-                    network_security_group: None,
-                    internal_uuid: iface.internal_uuid.clone(),
-                },
-            )
-            .collect()
-    };
-
-    let dpu_extension_services = network_config
-        .dpu_extension_services
-        .iter()
-        .map(
-            |extension_service| crate::rpc::forge::DpuExtensionServiceStatusObservation {
-                service_id: extension_service.service_id.clone(),
-                service_type: extension_service.service_type,
-                service_name: "".to_string(),
-                version: extension_service.version.to_string(),
-                state: crate::rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceRunning
-                    as i32,
-                components: vec![],
-                message: "".to_string(),
-                removed: extension_service.removed.clone(),
-            },
-        )
-        .collect();
-
-    api.record_dpu_network_status(tonic::Request::new(crate::rpc::forge::DpuNetworkStatus {
-        dpu_machine_id: Some(dpu_machine_id),
-        dpu_agent_version: Some("test-dpu-agent-version".to_string()),
-        observed_at: None,
-        dpu_health: Some(crate::rpc::health::HealthReport {
-            source: "forge-dpu-agent".to_string(),
-            triggered_by: None,
-            observed_at: None,
-            successes: vec![],
-            alerts: vec![],
-        }),
-        network_config_version: Some(network_config.managed_host_config_version.clone()),
-        instance_id: network_config.instance_id,
-        instance_config_version,
-        instance_network_config_version,
-        interfaces,
-        network_config_error: None,
-        client_certificate_expiry_unix_epoch_secs: None,
-        fabric_interfaces: vec![],
-        last_dhcp_requests: vec![],
-        dpu_extension_service_version: network_config
-            .instance
-            .map(|instance| instance.dpu_extension_service_version),
-        dpu_extension_services,
-    }))
-    .await
-    .expect("DPU network status should be recorded");
 }

--- a/crates/test-harness/src/prelude.rs
+++ b/crates/test-harness/src/prelude.rs
@@ -22,4 +22,7 @@ pub use sqlx_testing;
 
 pub use crate::asset::{TestPowerShelf, TestRack, TestSwitch};
 pub use crate::resource_pool::ResourcePoolBuilder;
-pub use crate::{Api, TestHarness, TestManagedHost, TestManagedHostBuilder, TestSiteExplorer, rpc};
+pub use crate::{
+    Api, TestDpuMachine, TestHarness, TestHostMachine, TestMachine, TestManagedHost,
+    TestManagedHostBuildData, TestManagedHostBuilder, TestSiteExplorer, rpc,
+};


### PR DESCRIPTION
## Description

Two refactorings in this PR. Each in individual commit:
1. Better way of generation ManagedHostConfig by making modification chaining possible and some convenience constructors like zero_dpu().
2. Introduce TestDpuMachine / TestHostMachine + TestMachine trait that provides common function to them. TestManagedHost now contains "host" and "dpus" instead of being bag of IP and MAC-addresses  

## Related issues

#2001

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
