### PR TITLE
Fix devspace build after nico rename

### DIFF
--- a/dev/deployment/devspace/Dockerfile.api
+++ b/dev/deployment/devspace/Dockerfile.api
@@ -27,7 +27,7 @@ COPY . .
 
 RUN --mount=type=cache,id=nico-devspace-cargo-home,target=/cargo-home,sharing=locked \
   --mount=type=cache,id=nico-devspace-cargo-target,target=/cargo-target,sharing=locked \
-  cargo build -p carbide-api --bin carbide-api -p nico-admin-cli --locked && \
+  cargo build -p carbide-api -p nico-admin-cli --locked && \
   mkdir -p /artifacts && \
   cp /cargo-target/debug/carbide-api /cargo-target/debug/nico-admin-cli /artifacts/
 


### PR DESCRIPTION
The devspace build is broken because the Dockerfile is trying to copy a binary that doesn't exist.

Using --bin for one of the crates but not the other seems to not actually write the binary out to the target dir. We don't need the --bin argument anyway though, since the [[bin]] section in each crate's Cargo.toml already lists the correct binary.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

