### PR TITLE
test(machine-controller): move machine setup test from api-core

### DIFF
--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -125,19 +125,7 @@ pub fn get() -> CarbideConfig {
         )]
         .into_iter()
         .collect(),
-        machine_state_controller: MachineStateControllerConfig {
-            dpu_wait_time: Duration::seconds(1),
-            power_down_wait: Duration::seconds(1),
-            failure_retry_time: Duration::seconds(1),
-            dpu_up_threshold: Duration::weeks(52),
-            controller: StateControllerConfig::default(),
-            scout_reporting_timeout: Duration::weeks(52),
-            uefi_boot_wait: Duration::seconds(0),
-            max_bios_config_retries: MachineStateControllerConfig::max_bios_config_retries_default(
-            ),
-            polling_bios_setup_stuck_threshold:
-                MachineStateControllerConfig::polling_bios_setup_stuck_threshold_default(),
-        },
+        machine_state_controller: MachineStateControllerConfig::test_default(),
         network_segment_state_controller: NetworkSegmentStateControllerConfig {
             network_segment_drain_time: Duration::seconds(2),
             controller: StateControllerConfig::default(),

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -75,7 +75,6 @@ mod machine_interfaces;
 mod machine_metadata;
 mod machine_network;
 mod machine_power;
-mod machine_setup;
 mod machine_states;
 mod machine_topology;
 pub mod machine_update_manager;

--- a/crates/machine-controller/Cargo.toml
+++ b/crates/machine-controller/Cargo.toml
@@ -66,6 +66,8 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 version-compare = { workspace = true }
 
 [dev-dependencies]
+carbide-redfish = { path = "../redfish", features = ["test-support"] }
+
 figment = { workspace = true, features = ["env", "test", "toml"] }
 regex = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/machine-controller/src/config/controller.rs
+++ b/crates/machine-controller/src/config/controller.rs
@@ -84,6 +84,23 @@ pub struct MachineStateControllerConfig {
 }
 
 impl MachineStateControllerConfig {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn test_default() -> Self {
+        Self {
+            dpu_wait_time: Duration::seconds(1),
+            power_down_wait: Duration::seconds(1),
+            failure_retry_time: Duration::seconds(1),
+            dpu_up_threshold: Duration::weeks(52),
+            controller: StateControllerConfig::default(),
+            scout_reporting_timeout: Duration::weeks(52),
+            uefi_boot_wait: Duration::seconds(0),
+            max_bios_config_retries: MachineStateControllerConfig::max_bios_config_retries_default(
+            ),
+            polling_bios_setup_stuck_threshold:
+                MachineStateControllerConfig::polling_bios_setup_stuck_threshold_default(),
+        }
+    }
+
     pub fn dpu_wait_time_default() -> Duration {
         Duration::minutes(5)
     }

--- a/crates/machine-controller/src/config/firmware_global.rs
+++ b/crates/machine-controller/src/config/firmware_global.rs
@@ -97,7 +97,7 @@ pub struct FirmwareGlobal {
 }
 
 impl FirmwareGlobal {
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn test_default() -> Self {
         FirmwareGlobal {
             autoupdate: true,
@@ -116,7 +116,7 @@ impl FirmwareGlobal {
         }
     }
 
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn get_retry_interval() -> Duration {
         Duration::seconds(1)
     }

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+#[cfg(any(test, feature = "test-support"))]
+use std::collections::HashMap;
+
 use model::machine::HostHealthConfig;
 use serde::{Deserialize, Serialize};
 
@@ -44,6 +47,24 @@ pub struct MachineStateHandlerSiteConfig {
     pub spdm_enabled: bool,
 
     pub dpu_enable_secure_boot: bool,
+}
+
+impl MachineStateHandlerSiteConfig {
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn test_default() -> Self {
+        Self {
+            firmware_global: FirmwareGlobal::test_default(),
+            machine_state_controller: MachineStateControllerConfig::test_default(),
+            host_health: HostHealthConfig::default(),
+            selected_profile: libredfish::BiosProfileType::Performance,
+            bios_profiles: HashMap::new(),
+            oem_manager_profiles: HashMap::new(),
+            dpa_enabled: true,
+            dpf_enabled: false,
+            spdm_enabled: false,
+            dpu_enable_secure_boot: true,
+        }
+    }
 }
 
 /// A UTC time window defined by a start and end timestamp.

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -119,6 +119,9 @@ mod helpers;
 mod machine_validation;
 mod power;
 mod sku;
+#[cfg(test)]
+mod test_machine_setup;
+
 use bios_config::{
     BiosConfigJobAdvanceOutcome, BiosConfigOutcome, PollingBiosSetupOutcome,
     advance_bios_config_job, advance_polling_bios_setup, configure_host_bios,

--- a/crates/machine-controller/src/handler/test_machine_setup.rs
+++ b/crates/machine-controller/src/handler/test_machine_setup.rs
@@ -17,17 +17,21 @@
 
 use std::collections::HashMap;
 
+use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimAction};
+use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
+use carbide_secrets::credentials::{CredentialKey, CredentialType};
+use libredfish::BiosProfileType;
+use libredfish::model::service_root::RedfishVendor;
+
+use super::{MachineStateHandlerSiteConfig, call_machine_setup_and_handle_no_dpu_error};
+
 /// Verify that `oem_manager_profiles` from the site config is forwarded to `machine_setup`.
 ///
 /// This test catches regressions where the argument gets dropped or replaced with an empty map.
 #[tokio::test]
 async fn test_oem_manager_profiles_passed_to_machine_setup() {
-    use carbide_redfish::libredfish::RedfishClientPool;
-    use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimAction};
-    use libredfish::BiosProfileType;
-    use libredfish::model::service_root::RedfishVendor;
+    let mut config = MachineStateHandlerSiteConfig::test_default();
 
-    let mut config = crate::tests::common::api_fixtures::get_config();
     // Build an oem_manager_profiles map with a Dell R760 PSU Hot Spare setting.
     // This mirrors the fix for the Dell R760 PSU fan issue (nvbugs-5834644).
     config.oem_manager_profiles = HashMap::from([(
@@ -44,9 +48,6 @@ async fn test_oem_manager_profiles_passed_to_machine_setup() {
         )]),
     )]);
 
-    use carbide_redfish::libredfish::RedfishAuth;
-    use carbide_secrets::credentials::{CredentialKey, CredentialType};
-
     let sim = RedfishSim::default();
     let timepoint = sim.timepoint();
     let client = sim
@@ -61,13 +62,8 @@ async fn test_oem_manager_profiles_passed_to_machine_setup() {
         .await
         .unwrap();
 
-    let result = carbide_machine_controller::handler::call_machine_setup_and_handle_no_dpu_error(
-        client.as_ref(),
-        None,
-        1,
-        &config.machine_state_handler_site_config(),
-    )
-    .await;
+    let result =
+        call_machine_setup_and_handle_no_dpu_error(client.as_ref(), None, 1, &config).await;
 
     assert!(result.is_ok());
 


### PR DESCRIPTION
Move the OEM manager profile forwarding regression test into the machine controller crate and add local test defaults needed to run it there.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

