### PR TITLE
fix: turn on FNN in struct used during site creation

### DIFF
--- a/rest-api/api/pkg/api/handler/site.go
+++ b/rest-api/api/pkg/api/handler/site.go
@@ -168,8 +168,10 @@ func (csh CreateSiteHandler) Handle(c echo.Context) error {
 			IsSerialConsoleEnabled:   false,
 			Status:                   cdbm.SiteStatusPending,
 			CreatedBy:                dbUser.ID,
+			// New sites default to the v2 networking posture.
 			Config: cdbm.SiteConfig{
-				NetworkSecurityGroup: true, // The default case for a new site is to support NSGs.
+				NativeNetworking:     true,
+				NetworkSecurityGroup: true,
 			},
 		}
 		if apiRequest.Location != nil {

--- a/rest-api/api/pkg/api/handler/site_test.go
+++ b/rest-api/api/pkg/api/handler/site_test.go
@@ -504,6 +504,19 @@ func TestCreateSiteHandler_Handle(t *testing.T) {
 
 				assert.Equal(t, rst.Status, cdbm.SiteStatusPending)
 				assert.Equal(t, len(rst.StatusHistory), 1)
+				require.NotNil(t, rst.Capabilities)
+				assert.True(t, rst.Capabilities.NativeNetworking)
+				assert.True(t, rst.Capabilities.NetworkSecurityGroup)
+
+				createdSiteID, perr := uuid.Parse(rst.ID)
+				require.NoError(t, perr)
+				createdSite, gerr := cdbm.NewSiteDAO(tt.fields.dbSession).GetByID(
+					context.Background(), nil, createdSiteID, nil, false,
+				)
+				require.NoError(t, gerr)
+				require.NotNil(t, createdSite.Config)
+				assert.True(t, createdSite.Config.NativeNetworking)
+				assert.True(t, createdSite.Config.NetworkSecurityGroup)
 
 				if !tt.siteMgrDisabled {
 					assert.NotNil(t, rst.RegistrationToken)

--- a/rest-api/sdk/standard/model_interface.go
+++ b/rest-api/sdk/standard/model_interface.go
@@ -44,7 +44,8 @@ type Interface struct {
 	// A list of IPv4 or IPv6 addresses
 	IpAddresses []string `json:"ipAddresses,omitempty"`
 	// Explicitly requested IP address for the interface. This is only used for VPC Prefix-based interfaces and is not valid for Subnet-based interfaces. The least-significant host bit must be 1.
-	RequestedIpAddress   NullableString                        `json:"requestedIpAddress,omitempty"`
+	RequestedIpAddress NullableString `json:"requestedIpAddress,omitempty"`
+	// Inline interface-local routing profile options. Only valid for VPC Prefix-based interfaces.
 	InlineRoutingProfile NullableInterfaceInlineRoutingProfile `json:"inlineRoutingProfile,omitempty"`
 	// Status of the Interface
 	Status *InterfaceStatus `json:"status,omitempty"`

--- a/rest-api/sdk/standard/model_interface_create_request.go
+++ b/rest-api/sdk/standard/model_interface_create_request.go
@@ -27,7 +27,8 @@ type InterfaceCreateRequest struct {
 	// ID of the VPC Prefix to attach to the Interface
 	VpcPrefixId *string `json:"vpcPrefixId,omitempty"`
 	// Explicitly requested IP address for the interface. It cannot be specified for Subnet-based interfaces. The least-significant host bit must be 1.
-	IpAddress            NullableString                        `json:"ipAddress,omitempty"`
+	IpAddress NullableString `json:"ipAddress,omitempty"`
+	// Inline interface-local routing profile options. It cannot be specified for Subnet-based interfaces.
 	InlineRoutingProfile NullableInterfaceInlineRoutingProfile `json:"inlineRoutingProfile,omitempty"`
 	// Specifies whether this Subnet or VPC Prefix should be attached to the Instance over physical interface.
 	IsPhysical *bool `json:"isPhysical,omitempty"`


### PR DESCRIPTION
REST DB migrations were created to default new sites to FNN VPC creation, but a struct being used during site creation is overriding that.

This PR fixes that so new sites default to FNN.

## Related issues
<!-- Refer to existing GitHub issues here -->

https://github.com/NVIDIA/infra-controller/issues/2522

<!-- Describe what this PR does -->
## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

