### PR TITLE
Fix ignored file in devspace build

### DIFF
--- a/dev/deployment/devspace/Dockerfile.api.dockerignore
+++ b/dev/deployment/devspace/Dockerfile.api.dockerignore
@@ -13,7 +13,10 @@
 !include/
 !include/**
 !pxe
-pxe/**
 !pxe/templates
 !pxe/templates/
 !pxe/templates/**
+!pxe/
+!pxe/ipxe/
+!pxe/ipxe/local/
+!pxe/ipxe/local/embed.ipxe

--- a/dev/deployment/devspace/Dockerfile.bmc-proxy.dockerignore
+++ b/dev/deployment/devspace/Dockerfile.bmc-proxy.dockerignore
@@ -9,3 +9,4 @@
 !crates
 !crates/
 !crates/**
+!pxe/ipxe/local/embed.ipxe

--- a/dev/deployment/devspace/Dockerfile.machine-a-tron.dockerignore
+++ b/dev/deployment/devspace/Dockerfile.machine-a-tron.dockerignore
@@ -12,3 +12,7 @@
 !include
 !include/
 !include/**
+!pxe/
+!pxe/ipxe/
+!pxe/ipxe/local/
+!pxe/ipxe/local/embed.ipxe


### PR DESCRIPTION
A recent change added
`include_str!("../../../pxe/ipxe/local/embed.ipxe");` to the ipxe-renderer crate, but that path is currently ignored by the dockerfiles in dev/deployment/devspace. Fix that by un-ignoring that path.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

