### PR TITLE
Fix No-DPF warning message for zero-dpu deployments

### DIFF
--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -615,7 +615,9 @@ pub async fn show_html(
     }
     .to_query_params();
 
-    let has_dpf_warning = hosts.iter().any(|h| !h.dpf_used_for_ingestion);
+    let has_dpf_warning = hosts
+        .iter()
+        .any(|h| !h.dpus.is_empty() && !h.dpf_used_for_ingestion);
 
     let tmpl = ManagedHostShow {
         grouped_hosts,


### PR DESCRIPTION
We recently started rendering a warning if none of the hosts have dpf_used_for_ingestion set, but this emits a false positive if the host has no DPU's at all. Fix that by not warning on zero-DPU hosts.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

