### PR TITLE
fix(tests): avoid Kea port conflicts in DHCP integration tests

### DIFF
--- a/crates/dhcp/tests/booturl.rs
+++ b/crates/dhcp/tests/booturl.rs
@@ -23,7 +23,7 @@ use dhcproto::{Decodable, Decoder, v4};
 
 mod common;
 
-use common::{DHCPFactory, Kea, RELAY_IP};
+use common::{DHCPFactory, Kea};
 
 const READ_TIMEOUT: Duration = Duration::from_millis(200);
 const OFFER_TIMEOUT: Duration = Duration::from_secs(10);
@@ -70,17 +70,7 @@ fn test_booturl_internal_with_mtu() -> Result<(), eyre::Report> {
         .unwrap();
     let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
 
-    let dhcp_out_port = 6667;
-    let dhcp_in_port = 6668;
-
-    // Start Kea process. Stops on drop.
-    let mut kea = Kea::new(api_server.local_http_addr(), dhcp_in_port, dhcp_out_port)?;
-    kea.run()?;
-
-    // UDP socket to Kea. We're pretending to be dhcp-relay.
-    let socket = UdpSocket::bind(format!("{RELAY_IP}:{dhcp_out_port}"))?;
-
-    socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
+    let (_kea, socket) = Kea::start(api_server.local_http_addr(), None)?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
     let pkt = {
@@ -124,17 +114,7 @@ fn test_booturl_from_api() -> Result<(), eyre::Report> {
         .unwrap();
     let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
 
-    let dhcp_out_port = 6669;
-    let dhcp_in_port = 6670;
-
-    // Start Kea process. Stops on drop.
-    let mut kea = Kea::new(api_server.local_http_addr(), dhcp_in_port, dhcp_out_port)?;
-    kea.run()?;
-
-    // UDP socket to Kea. We're pretending to be dhcp-relay.
-    let socket = UdpSocket::bind(format!("{RELAY_IP}:{dhcp_out_port}"))?;
-
-    socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
+    let (_kea, socket) = Kea::start(api_server.local_http_addr(), None)?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
     let pkt = {

--- a/crates/dhcp/tests/common/kea.rs
+++ b/crates/dhcp/tests/common/kea.rs
@@ -16,57 +16,138 @@
  */
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
-use std::net::{Ipv4Addr, UdpSocket};
+use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::{Condvar, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use serde_json::json;
 use tempfile::TempDir;
 
-/// One row from kea's memfile CSV (kea-leases4.csv). Only the fields the
-/// lease4 hook tests care about are exposed.
-//
-// dead_code is allowed because not every test binary that includes `common`
-// inspects the lease file -- the existing booturl/multithreaded tests only
-// look at packets.
-#[allow(dead_code)]
-#[derive(Debug, Clone)]
-pub struct LeaseEntry {
-    pub address: Ipv4Addr,
-    pub hwaddr: String,
-    /// 0 = default (active). Other states (declined, expired-reclaimed)
-    /// shouldn't appear in our tests but are exposed for completeness.
-    pub state: u32,
+use super::dhcp_factory::RELAY_IP;
+
+const KEA_READY_TIMEOUT: Duration = Duration::from_secs(15);
+const KEA_START_ATTEMPTS: usize = 5;
+const KEA_EXIT_SETTLE: Duration = Duration::from_millis(100);
+
+// Kea binds loopback DHCP ports and loads the same hook library in each test.
+// Within one test process, keep one Kea child alive at a time to avoid
+// CI-only loopback/startup flakes. Separate test binaries can still run Kea
+// concurrently; dynamic ports and startup retries handle that case. The condvar
+// keeps waiters asleep without holding the mutex for a full test.
+static KEA_RUN_GATE: OnceLock<KeaRunGate> = OnceLock::new();
+
+struct KeaRunGate {
+    state: Mutex<KeaRunState>,
+    available: Condvar,
+}
+
+#[derive(Default)]
+struct KeaRunState {
+    running: bool,
+}
+
+struct KeaRunPermit {
+    gate: &'static KeaRunGate,
+}
+
+impl KeaRunGate {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(KeaRunState::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    fn acquire(&'static self) -> KeaRunPermit {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while state.running {
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        state.running = true;
+
+        KeaRunPermit { gate: self }
+    }
+
+    fn release(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.running = false;
+        self.available.notify_one();
+    }
+}
+
+impl Drop for KeaRunPermit {
+    fn drop(&mut self) {
+        self.gate.release();
+    }
 }
 
 pub struct Kea {
     temp_conf_file: PathBuf,
-    #[allow(dead_code)] // only read by tests that inspect the memfile
-    lease_file: PathBuf,
 
     dhcp_in_port: u16,
     dhcp_out_port: u16,
+    dhcp_in_port_reservation: Option<UdpSocket>,
 
     // Hold this around so that when Kea is dropped, TempDir is dropped and cleaned up
     temp_base_directory: TempDir,
 
     process: Option<Child>,
+    _run_permit: Option<KeaRunPermit>,
 }
 
 impl Kea {
-    // Start the Kea DHCP server as a sub-process and return a handle to it
-    // Stops when the returned object is dropped.
-    pub fn new(
+    /// Reserve dynamic DHCP ports, start Kea, and return it with a connected
+    /// relay socket. The Kea process is stopped when the harness drops. Tests
+    /// that inspect Kea's memfile can pass an externally-owned lease path.
+    pub fn start(
+        api_server_url: &str,
+        lease_file: Option<&Path>,
+    ) -> Result<(Kea, UdpSocket), eyre::Report> {
+        // Acquire before reserving ports so waiters do not hold loopback port
+        // reservations while another Kea test is running in this process.
+        let run_permit = KEA_RUN_GATE.get_or_init(KeaRunGate::new).acquire();
+        let relay_socket = UdpSocket::bind(format!("{RELAY_IP}:0"))?;
+        let dhcp_out_port = relay_socket.local_addr()?.port();
+        let (dhcp_in_port, dhcp_in_port_reservation) = Self::reserve_dhcp_in_port()?;
+
+        let mut kea = Kea::new_inner(
+            api_server_url,
+            dhcp_in_port,
+            dhcp_out_port,
+            Some(dhcp_in_port_reservation),
+            lease_file,
+        )?;
+        kea.run(run_permit)?;
+        relay_socket.connect(format!("127.0.0.1:{}", kea.dhcp_in_port))?;
+
+        Ok((kea, relay_socket))
+    }
+
+    fn new_inner(
         api_server_url: &str,
         dhcp_in_port: u16,
         dhcp_out_port: u16,
+        dhcp_in_port_reservation: Option<UdpSocket>,
+        lease_file: Option<&Path>,
     ) -> Result<Kea, eyre::Report> {
         let temp_base_directory = tempfile::tempdir()?;
 
         let temp_conf_file = temp_base_directory.path().join("kea-dhcp4.conf");
-        let lease_file = temp_base_directory.path().join("kea-leases4.csv");
+        let lease_file = lease_file
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| temp_base_directory.path().join("kea-leases4.csv"));
 
         let mut temp_conf_fd = File::create(&temp_conf_file)?;
         temp_conf_fd.write_all(Kea::config(api_server_url, &lease_file).as_bytes())?;
@@ -76,85 +157,66 @@ impl Kea {
 
         Ok(Kea {
             temp_conf_file,
-            lease_file,
             temp_base_directory,
             dhcp_in_port,
             dhcp_out_port,
+            dhcp_in_port_reservation,
             process: None,
+            _run_permit: None,
         })
     }
 
-    /// Path to the persistent lease file Kea writes (memfile backend with persist=true).
-    /// Used by tests to assert on what got persisted.
-    #[allow(dead_code)]
-    pub fn lease_file_path(&self) -> &Path {
-        &self.lease_file
+    fn reserve_dhcp_in_port() -> Result<(u16, UdpSocket), eyre::Report> {
+        let dhcp_in_port_reservation = UdpSocket::bind("0.0.0.0:0")?;
+        let dhcp_in_port = dhcp_in_port_reservation.local_addr()?.port();
+
+        Ok((dhcp_in_port, dhcp_in_port_reservation))
     }
 
-    /// Read kea-leases4.csv and return all entries. Skips the header row.
-    /// Returns an empty Vec if the file doesn't exist yet (Kea writes it
-    /// lazily on first lease event).
-    #[allow(dead_code)]
-    pub fn read_leases(&self) -> Vec<LeaseEntry> {
-        let Ok(file) = File::open(&self.lease_file) else {
-            return Vec::new();
-        };
-        let mut entries = Vec::new();
-        for (i, line) in BufReader::new(file).lines().enumerate() {
-            let Ok(line) = line else { continue };
-            // Header is "address,hwaddr,client_id,...,state,user_context,pool_id"
-            if i == 0 || line.is_empty() {
-                continue;
+    fn refresh_dhcp_in_port(&mut self) -> Result<(), eyre::Report> {
+        // The relay/output port stays fixed because `start` keeps its
+        // socket bound; only Kea's receive port needs a fresh try.
+        let (dhcp_in_port, dhcp_in_port_reservation) = Self::reserve_dhcp_in_port()?;
+
+        self.dhcp_in_port = dhcp_in_port;
+        self.dhcp_in_port_reservation = Some(dhcp_in_port_reservation);
+
+        Ok(())
+    }
+
+    fn run(&mut self, run_permit: KeaRunPermit) -> Result<(), eyre::Report> {
+        let mut run_permit = Some(run_permit);
+        let mut last_exit = None;
+        for attempt in 1..=KEA_START_ATTEMPTS {
+            match self.run_once()? {
+                Some(status) => {
+                    last_exit = Some((self.dhcp_in_port, status));
+                    if attempt == KEA_START_ATTEMPTS {
+                        break;
+                    }
+
+                    println!(
+                        "KEA exited before binding DHCP port {} on attempt {attempt}/{KEA_START_ATTEMPTS}: {status}; retrying with a fresh DHCP receive port",
+                        self.dhcp_in_port
+                    );
+                    self.refresh_dhcp_in_port()?;
+                }
+                None => {
+                    self._run_permit = run_permit.take();
+                    return Ok(());
+                }
             }
-            let cols: Vec<&str> = line.split(',').collect();
-            if cols.len() < 10 {
-                continue;
-            }
-            let Ok(address) = cols[0].parse::<Ipv4Addr>() else {
-                continue;
-            };
-            let Ok(state) = cols[9].parse::<u32>() else {
-                continue;
-            };
-            entries.push(LeaseEntry {
-                address,
-                hwaddr: cols[1].to_string(),
-                state,
-            });
         }
-        entries
+
+        let (port, status) = last_exit.expect("at least one Kea start attempt should have run");
+        Err(eyre::eyre!(
+            "Kea exited before binding DHCP port {port} after {KEA_START_ATTEMPTS} attempts: {status}"
+        ))
     }
 
-    /// Convenience: find the active lease entry for a given MAC string
-    /// (kea writes MAC as colon-separated lowercase hex, e.g. "02:00:00:00:00:01").
-    #[allow(dead_code)]
-    pub fn find_lease(&self, hwaddr: &str) -> Option<LeaseEntry> {
-        self.read_leases()
-            .into_iter()
-            .find(|l| l.hwaddr == hwaddr && l.state == 0)
-    }
+    fn run_once(&mut self) -> Result<Option<ExitStatus>, eyre::Report> {
+        drop(self.dhcp_in_port_reservation.take());
 
-    /// Poll the lease file for an entry matching `hwaddr` whose address is
-    /// `expected`, up to `timeout`. Returns true if found, false if the
-    /// deadline passes. Useful because Kea's persist-to-disk can lag the
-    /// gRPC ACK by a few ms.
-    #[allow(dead_code)]
-    pub fn wait_for_lease(&self, hwaddr: &str, expected: Ipv4Addr, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
-        loop {
-            if let Some(lease) = self.find_lease(hwaddr)
-                && lease.address == expected
-            {
-                return true;
-            }
-            if Instant::now() >= deadline {
-                return false;
-            }
-            thread::sleep(Duration::from_millis(50));
-        }
-    }
-
-    pub fn run(&mut self) -> Result<(), eyre::Report> {
         let mut process = Command::new("/usr/sbin/kea-dhcp4")
             .env("KEA_PIDFILE_DIR", self.temp_base_directory.path())
             .env("KEA_LOCKFILE_DIR", self.temp_base_directory.path())
@@ -177,32 +239,59 @@ impl Kea {
         });
         thread::spawn(move || {
             for line in stderr.lines() {
-                println!("KEA STDOUT: {}", line.unwrap());
+                println!("KEA STDERR: {}", line.unwrap());
             }
         });
+
+        self.process = Some(process);
 
         // Poll until Kea binds its DHCP receive port, so the test doesn't race.
         // Trying to bind the same port ourselves: success means Kea hasn't taken it yet;
         // AddrInUse means Kea is listening and we're ready to proceed.
-        let deadline = Instant::now() + Duration::from_secs(15);
+        let deadline = Instant::now() + KEA_READY_TIMEOUT;
         loop {
             thread::sleep(Duration::from_millis(100));
+            if let Some(status) = self.process.as_mut().unwrap().try_wait()? {
+                self.process = None;
+                return Ok(Some(status));
+            }
             match UdpSocket::bind(format!("0.0.0.0:{}", self.dhcp_in_port)) {
-                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => break,
+                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                    thread::sleep(KEA_EXIT_SETTLE);
+                    if let Some(status) = self.process.as_mut().unwrap().try_wait()? {
+                        self.process = None;
+                        return Ok(Some(status));
+                    }
+                    break;
+                }
                 Ok(_) => {}
                 Err(e) => return Err(eyre::eyre!("Unexpected error probing Kea readiness: {e}")),
             }
             if Instant::now() >= deadline {
+                self.stop_process();
                 return Err(eyre::eyre!(
-                    "Kea did not bind DHCP port {} within 15 seconds",
+                    "Kea did not bind DHCP port {} within {KEA_READY_TIMEOUT:?}",
                     self.dhcp_in_port
                 ));
             }
         }
 
-        self.process = Some(process);
+        Ok(None)
+    }
 
-        Ok(())
+    fn stop_process(&mut self) {
+        if let Some(process) = &mut self.process {
+            // Rust stdlib can only send a KILL (9) to sub-process. Thankfully dhcp already depends on
+            // libc so we can use that.
+            unsafe {
+                libc::kill(process.id() as i32, libc::SIGTERM);
+            }
+            thread::sleep(Duration::from_millis(100));
+            if let Ok(None) = process.try_wait() {
+                process.kill().unwrap(); // -9
+            }
+        }
+        self.process = None;
     }
 
     fn config(api_server_url: &str, lease_file: &Path) -> String {
@@ -322,16 +411,6 @@ impl Kea {
 
 impl Drop for Kea {
     fn drop(&mut self) {
-        if let Some(process) = &mut self.process {
-            // Rust stdlib can only send a KILL (9) to sub-process. Thankfully dhcp already depends on
-            // libc so we can use that.
-            unsafe {
-                libc::kill(process.id() as i32, libc::SIGTERM);
-            }
-            thread::sleep(Duration::from_millis(100));
-            if let Ok(None) = process.try_wait() {
-                process.kill().unwrap(); // -9
-            }
-        }
+        self.stop_process();
     }
 }

--- a/crates/dhcp/tests/common/mod.rs
+++ b/crates/dhcp/tests/common/mod.rs
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 mod dhcp_factory;
-mod kea;
+pub(crate) mod kea;
 
-pub use dhcp_factory::{DHCPFactory, RELAY_IP};
+pub use dhcp_factory::DHCPFactory;
 pub use kea::Kea;
-#[allow(unused_imports)] // not every test binary inspects lease entries
-pub use kea::LeaseEntry;

--- a/crates/dhcp/tests/lease4_hook_test.rs
+++ b/crates/dhcp/tests/lease4_hook_test.rs
@@ -23,7 +23,10 @@
 //! with what Carbide returns from DiscoverDhcp -- regardless of what address
 //! the client requested in option 50 or ciaddr.
 
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::net::{Ipv4Addr, UdpSocket};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use dhcp::mock_api_server;
@@ -31,7 +34,7 @@ use dhcproto::{Decodable, Decoder, v4};
 
 mod common;
 
-use common::{DHCPFactory, Kea, RELAY_IP};
+use common::{DHCPFactory, Kea};
 
 const READ_TIMEOUT: Duration = Duration::from_millis(500);
 /// Memfile writes are usually flushed within a few ms of the ACK.
@@ -90,34 +93,116 @@ fn default_mock_addr(idx: u8) -> Ipv4Addr {
     Ipv4Addr::new(172, 20, 0, idx)
 }
 
+/// One row from kea's memfile CSV (kea-leases4.csv). Only the fields these
+/// lease4 hook tests care about are exposed.
+#[derive(Debug, Clone)]
+struct LeaseEntry {
+    address: Ipv4Addr,
+    hwaddr: String,
+    /// 0 = default (active). Other states (declined, expired-reclaimed)
+    /// shouldn't appear in our tests but are exposed for completeness.
+    state: u32,
+}
+
+trait LeaseFileExt {
+    fn read_leases(&self) -> Vec<LeaseEntry>;
+    fn find_lease(&self, hwaddr: &str) -> Option<LeaseEntry>;
+    fn wait_for_lease(&self, hwaddr: &str, expected: Ipv4Addr, timeout: Duration) -> bool;
+}
+
+impl LeaseFileExt for Harness {
+    /// Read kea-leases4.csv and return all entries. Skips the header row.
+    /// Returns an empty Vec if the file doesn't exist yet (Kea writes it
+    /// lazily on first lease event).
+    fn read_leases(&self) -> Vec<LeaseEntry> {
+        let Ok(file) = File::open(&self.lease_file_path) else {
+            return Vec::new();
+        };
+        let mut entries = Vec::new();
+        for (i, line) in BufReader::new(file).lines().enumerate() {
+            let Ok(line) = line else { continue };
+            // Header is "address,hwaddr,client_id,...,state,user_context,pool_id"
+            if i == 0 || line.is_empty() {
+                continue;
+            }
+            let cols: Vec<&str> = line.split(',').collect();
+            if cols.len() < 10 {
+                continue;
+            }
+            let Ok(address) = cols[0].parse::<Ipv4Addr>() else {
+                continue;
+            };
+            let Ok(state) = cols[9].parse::<u32>() else {
+                continue;
+            };
+            entries.push(LeaseEntry {
+                address,
+                hwaddr: cols[1].to_string(),
+                state,
+            });
+        }
+        entries
+    }
+
+    /// Convenience: find the active lease entry for a given MAC string
+    /// (kea writes MAC as colon-separated lowercase hex, e.g. "02:00:00:00:00:01").
+    fn find_lease(&self, hwaddr: &str) -> Option<LeaseEntry> {
+        self.read_leases()
+            .into_iter()
+            .find(|l| l.hwaddr == hwaddr && l.state == 0)
+    }
+
+    /// Poll the lease file for an entry matching `hwaddr` whose address is
+    /// `expected`, up to `timeout`. Returns true if found, false if the
+    /// deadline passes. Useful because Kea's persist-to-disk can lag the
+    /// gRPC ACK by a few ms.
+    fn wait_for_lease(&self, hwaddr: &str, expected: Ipv4Addr, timeout: Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(lease) = self.find_lease(hwaddr)
+                && lease.address == expected
+            {
+                return true;
+            }
+            if std::time::Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
 /// tokio rt + mock API + Kea + socket pretending to be the relay.
 struct Harness {
     _rt: tokio::runtime::Runtime,
     api_server: mock_api_server::MockAPIServer,
-    kea: Kea,
+    _kea: Kea,
     socket: UdpSocket,
+    _lease_dir: tempfile::TempDir,
+    lease_file_path: PathBuf,
 }
 
 impl Harness {
-    fn new(in_port: u16, out_port: u16) -> Self {
+    fn new() -> Self {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
         let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let lease_dir = tempfile::tempdir().unwrap();
+        let lease_file_path = lease_dir.path().join("kea-leases4.csv");
 
-        let mut kea = Kea::new(api_server.local_http_addr(), in_port, out_port).unwrap();
-        kea.run().unwrap();
-
-        let socket = UdpSocket::bind(format!("{RELAY_IP}:{out_port}")).unwrap();
-        socket.connect(format!("127.0.0.1:{in_port}")).unwrap();
+        let (kea, socket) =
+            Kea::start(api_server.local_http_addr(), Some(&lease_file_path)).unwrap();
         socket.set_read_timeout(Some(READ_TIMEOUT)).unwrap();
 
         Harness {
             _rt: rt,
             api_server,
-            kea,
+            _kea: kea,
             socket,
+            _lease_dir: lease_dir,
+            lease_file_path,
         }
     }
 }
@@ -128,7 +213,7 @@ impl Harness {
 #[test]
 fn lease4_select_persists_carbide_ip_on_happy_path() -> Result<(), eyre::Report> {
     let idx = 0x20;
-    let h = Harness::new(7100, 7101);
+    let h = Harness::new();
 
     // DISCOVER → OFFER
     let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
@@ -149,8 +234,7 @@ fn lease4_select_persists_carbide_ip_on_happy_path() -> Result<(), eyre::Report>
     // Memfile must contain the carbide address (not whatever Kea would have
     // picked on its own from the 0.0.0.0/0 pool).
     assert!(
-        h.kea
-            .wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT),
+        h.wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT),
         "expected memfile entry ({}, {})",
         mac_for_idx(idx),
         default_mock_addr(idx)
@@ -168,7 +252,7 @@ fn lease4_select_persists_carbide_ip_on_happy_path() -> Result<(), eyre::Report>
 fn lease4_select_overrides_rogue_option_50_in_memfile() -> Result<(), eyre::Report> {
     let idx = 0x21;
     let rogue_ip = Ipv4Addr::new(192, 168, 99, 99);
-    let h = Harness::new(7102, 7103);
+    let h = Harness::new();
 
     // DISCOVER → OFFER (so kea has a state for this MAC and accepts the
     // following REQUEST). The OFFER's yiaddr is the carbide-allocated IP.
@@ -189,15 +273,14 @@ fn lease4_select_overrides_rogue_option_50_in_memfile() -> Result<(), eyre::Repo
     // The memfile must hold Carbide's IP, not the rogue value the client
     // asked for in option 50. This is what lease4_select uniquely enforces.
     assert!(
-        h.kea
-            .wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT),
+        h.wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT),
         "memfile should contain carbide IP {} for MAC {}, not the rogue option-50 value {rogue_ip}",
         default_mock_addr(idx),
         mac_for_idx(idx),
     );
 
     // And specifically nothing in the memfile should have the rogue address.
-    let leases = h.kea.read_leases();
+    let leases = h.read_leases();
     assert!(
         !leases.iter().any(|l| l.address == rogue_ip),
         "rogue IP {rogue_ip} should never be persisted, but found in leases: {leases:?}",
@@ -213,7 +296,7 @@ fn lease4_select_overrides_rogue_option_50_in_memfile() -> Result<(), eyre::Repo
 fn pkt4_receive_drops_when_carbide_returns_no_address() -> Result<(), eyre::Report> {
     let idx = 0x22;
     let helper_idx = 0x24;
-    let h = Harness::new(7104, 7105);
+    let h = Harness::new();
 
     // Learn Kea's server identifier from a different MAC. The failure case
     // below needs a SELECTING-state REQUEST so it exercises the persistence
@@ -247,7 +330,7 @@ fn pkt4_receive_drops_when_carbide_returns_no_address() -> Result<(), eyre::Repo
     // Key assertion: no active memfile entry for this MAC. Wait a beat so we
     // don't race a lazy memfile flush in the success-but-not-yet-visible case.
     std::thread::sleep(Duration::from_millis(200));
-    let leases = h.kea.read_leases();
+    let leases = h.read_leases();
     assert!(
         !leases
             .iter()
@@ -274,7 +357,7 @@ fn pkt4_receive_drops_when_carbide_returns_no_address() -> Result<(), eyre::Repo
 #[test]
 fn lease4_renew_preserves_memfile_on_steady_state_renewal() -> Result<(), eyre::Report> {
     let idx = 0x23;
-    let h = Harness::new(7106, 7107);
+    let h = Harness::new();
 
     // Initial DORA.
     let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
@@ -286,10 +369,7 @@ fn lease4_renew_preserves_memfile_on_steady_state_renewal() -> Result<(), eyre::
     )
     .expect("kea did not respond to REQUEST");
     assert_eq!(ack.opts().msg_type().unwrap(), v4::MessageType::Ack);
-    assert!(
-        h.kea
-            .wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT)
-    );
+    assert!(h.wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT));
 
     // Renewing REQUEST: ciaddr = the IP we currently hold.
     let renew_ack = send_and_recv(&h.socket, request_renewing(idx, default_mock_addr(idx)))
@@ -300,7 +380,6 @@ fn lease4_renew_preserves_memfile_on_steady_state_renewal() -> Result<(), eyre::
     // Memfile still has the carbide IP. The lease4_renew hook fired (we'd see
     // a NAK or no response if it failed) and was a no-op on this matching path.
     let lease = h
-        .kea
         .find_lease(&mac_for_idx(idx))
         .expect("active lease should still exist after renewal");
     assert_eq!(lease.address, default_mock_addr(idx));
@@ -323,7 +402,7 @@ fn check_memfile_on_option_54() -> Result<(), eyre::Report> {
     let idx = 0x24;
     let bogus_request_ip = Ipv4Addr::new(192, 168, 99, 99);
     let fake_server_id = Ipv4Addr::new(10, 99, 99, 99); // not kea's identifier
-    let h = Harness::new(7108, 7109);
+    let h = Harness::new();
 
     // DISCOVER first, so kea has cached per-packet state for this MAC.
     let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
@@ -351,14 +430,14 @@ fn check_memfile_on_option_54() -> Result<(), eyre::Report> {
 
     // Whatever kea did, the rogue IP shouldn't be persisted.
     std::thread::sleep(Duration::from_millis(200));
-    let leases = h.kea.read_leases();
+    let leases = h.read_leases();
     assert!(
         !leases.iter().any(|l| l.address == bogus_request_ip),
         "bogus option-50 IP {bogus_request_ip} should never appear in memfile, found: {leases:?}",
     );
 
     // And if there *is* an active entry for this MAC, it must be NICo's IP.
-    if let Some(lease) = h.kea.find_lease(&mac_for_idx(idx)) {
+    if let Some(lease) = h.find_lease(&mac_for_idx(idx)) {
         assert_eq!(
             lease.address,
             default_mock_addr(idx),
@@ -385,7 +464,7 @@ fn check_memfile_on_option_54() -> Result<(), eyre::Report> {
 fn reboot_with_stale_remembered_ip_does_not_pollute_memfile() -> Result<(), eyre::Report> {
     let idx = 0x27;
     let remembered_wrong_ip = Ipv4Addr::new(192, 168, 99, 99);
-    let h = Harness::new(7112, 7113);
+    let h = Harness::new();
 
     // No prior DISCOVER -- this is the BMC's first packet after reboot.
     // INIT-REBOOT REQUEST: option 50 set, no ciaddr, no Option 54.
@@ -408,7 +487,7 @@ fn reboot_with_stale_remembered_ip_does_not_pollute_memfile() -> Result<(), eyre
     }
 
     std::thread::sleep(Duration::from_millis(200));
-    let leases = h.kea.read_leases();
+    let leases = h.read_leases();
 
     // The remembered wrong IP must never be persisted.
     assert!(
@@ -417,7 +496,7 @@ fn reboot_with_stale_remembered_ip_does_not_pollute_memfile() -> Result<(), eyre
     );
 
     // If anything was persisted for this MAC, it must be carbide's IP.
-    if let Some(lease) = h.kea.find_lease(&mac_for_idx(idx)) {
+    if let Some(lease) = h.find_lease(&mac_for_idx(idx)) {
         assert_eq!(
             lease.address,
             default_mock_addr(idx),

--- a/crates/dhcp/tests/multithreaded_kea_test.rs
+++ b/crates/dhcp/tests/multithreaded_kea_test.rs
@@ -16,7 +16,6 @@
  */
 use std::collections::HashMap;
 use std::io::ErrorKind;
-use std::net::UdpSocket;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::channel;
@@ -28,7 +27,7 @@ use dhcproto::{Decodable, Decoder, v4};
 
 mod common;
 
-use common::{DHCPFactory, Kea, RELAY_IP};
+use common::{DHCPFactory, Kea};
 
 // Must be u8 to be used a idx (last part of MAC and link IP)
 // Must not exceed Kea config 'packet-queue-size', below, or packets  will be dropped.
@@ -52,16 +51,7 @@ fn test_real_kea_multithreaded() -> Result<(), eyre::Report> {
         .unwrap();
     let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
 
-    let dhcp_in_port = 7000;
-    let dhcp_out_port = 7001;
-
-    // Start Kea process. Stops on drop.
-    let mut kea = Kea::new(api_server.local_http_addr(), dhcp_in_port, dhcp_out_port)?;
-    kea.run()?;
-
-    // UDP socket to Kea. We're pretending to be dhcp-relay.
-    let socket = UdpSocket::bind(format!("{RELAY_IP}:{dhcp_out_port}"))?;
-    socket.connect(format!("127.0.0.1:{dhcp_in_port}"))?;
+    let (_kea, socket) = Kea::start(api_server.local_http_addr(), None)?;
     socket.set_read_timeout(Some(READ_TIMEOUT))?;
 
     let socket = Arc::new(socket);


### PR DESCRIPTION
Recently we have multiple tests DHCP fails. This PR fixes possible port conflict for multiple tests run in parallel by:
1. Serializing them using "permit" and waiting for permit
2. Using dynamic ports for Kea / test side

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

