### PR TITLE
change(api,dhcp): new proto types, migrations & dual-stack NetworkDef…

### DIFF
--- a/crates/agent/src/dhcp_server_grpc_client.rs
+++ b/crates/agent/src/dhcp_server_grpc_client.rs
@@ -21,7 +21,7 @@ pub mod proto {
 
 use carbide_rpc_utils::dhcp::{
     DhcpConfig as ModelDhcpConfig, HostConfig as ModelHostConfig,
-    InterfaceInfo as ModelInterfaceInfo,
+    InterfaceInfo as ModelInterfaceInfo, InterfaceInfoV6 as ModelInterfaceInfoV6,
 };
 use carbide_uuid::machine::MachineInterfaceId;
 use proto::dhcp_server_control_client::DhcpServerControlClient;
@@ -47,6 +47,28 @@ impl From<ModelDhcpConfig> for proto::DhcpConfig {
                 .collect(),
             carbide_provisioning_server_ipv4: c.carbide_provisioning_server_ipv4.to_string(),
             carbide_dhcp_server: c.carbide_dhcp_server.to_string(),
+            carbide_nameservers_v6: c
+                .carbide_nameservers_v6
+                .iter()
+                .map(|ip| ip.to_string())
+                .collect(),
+            carbide_ntpservers_v6: c
+                .carbide_ntpservers_v6
+                .iter()
+                .map(|ip| ip.to_string())
+                .collect(),
+            carbide_dhcp_server_v6: c.carbide_dhcp_server_v6.map(|ip| ip.to_string()),
+            dhcpv6_preferred_lifetime_secs: c.dhcpv6_preferred_lifetime_secs,
+            dhcpv6_valid_lifetime_secs: c.dhcpv6_valid_lifetime_secs,
+        }
+    }
+}
+
+impl From<ModelInterfaceInfoV6> for proto::InterfaceInfoV6 {
+    fn from(i: ModelInterfaceInfoV6) -> Self {
+        proto::InterfaceInfoV6 {
+            address: i.address.map(|ip| ip.to_string()),
+            prefix: i.prefix,
         }
     }
 }
@@ -60,6 +82,7 @@ impl From<ModelInterfaceInfo> for proto::InterfaceInfo {
             fqdn: i.fqdn,
             booturl: i.booturl,
             mtu: i.mtu,
+            ipv6: i.ipv6.map(Into::into),
         }
     }
 }

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -3463,6 +3463,7 @@ mod tests {
             rebinding_time_secs: 432000,
             carbide_api_url: None,
             carbide_dhcp_server: Ipv4Addr::from([10, 217, 5, 39]),
+            ..Default::default()
         };
 
         let mut network_config = rpc::ManagedHostNetworkConfigResponse {
@@ -3656,6 +3657,7 @@ mod tests {
             rebinding_time_secs: 432000,
             carbide_api_url: None,
             carbide_dhcp_server: Ipv4Addr::from([10, 217, 5, 39]),
+            ..Default::default()
         };
         let dhcp_contents = super::read_limited(g.path())?;
         assert!(dhcp_contents.contains("vlan196"));

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -34,7 +34,7 @@ applicable.
 | `listen_mode` | `ListenMode` | `Tls` | Transport mode: `plaintext_http1`, `plaintext_http2`, or `tls`. |
 | `auth` | `Option<AuthConfig>` | — | Authentication/authorization settings (see [AuthConfig](#authconfig)). |
 | `pools` | `Option<HashMap<String, ResourcePoolDef>>` | — | Resource pools that allocate IPs, VNIs, etc. Required but `Option` for partial-config merging. |
-| `networks` | `Option<HashMap<String, NetworkDefinition>>` | — | Networks created at startup. Alternative: `CreateNetworkSegment` gRPC. |
+| `networks` | `Option<HashMap<String, NetworkDefinition>>` | — | Networks created at startup. Alternative: `CreateNetworkSegment` gRPC. `NetworkDefinition` supports dual-stack seed-time segments with optional `prefix_v6` and `dhcpv6_link_address`; config edits do not retrofit prefixes onto an already-seeded segment because seed definitions are snapshotted on first create. |
 | `dpu_ipmi_tool_impl` | `Option<String>` | — | IPMI tool implementation for DPU power control (`"prod"` or `"fake"`). |
 | `dpu_ipmi_reboot_attempts` | `Option<u32>` | — | Retry count when IPMI errors during DPU reboot. |
 | `bmc_session_lockout_threshold` | `u32` | `3` | Consecutive BMC HTTP 401/403 responses before session-token login attempts stop for that BMC. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3830,7 +3830,9 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
             &NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Admin,
                 prefix: "172.20.0.0/24".parse().unwrap(),
+                prefix_v6: None,
                 gateway: "172.20.0.1".parse().unwrap(),
+                dhcpv6_link_address: None,
                 mtu: 9000,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -3843,7 +3845,9 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
             &NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Underlay,
                 prefix: "172.99.0.0/26".parse().unwrap(),
+                prefix_v6: None,
                 gateway: "172.99.0.1".parse().unwrap(),
+                dhcpv6_link_address: None,
                 mtu: 1500,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -3856,7 +3860,9 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
             &NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::HostInband,
                 prefix: "10.217.18.192/30".parse().unwrap(),
+                prefix_v6: None,
                 gateway: "10.217.18.193".parse().unwrap(),
+                dhcpv6_link_address: None,
                 mtu: 1500,
                 reserve_first: 1,
                 allocation_strategy: Default::default(),

--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -227,6 +227,7 @@ pub async fn ensure_static_assignments_segment(
         prefixes: vec![NewNetworkPrefix {
             prefix: "169.254.254.254/32".parse().unwrap(),
             gateway: None,
+            dhcpv6_link_address: None,
             num_reserved: 1,
         }],
         vlan_id: None,

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -82,6 +82,8 @@ async fn handle_overlay_from_dpa(
         fqdn: String::new(),
         prefix,
         ntp_servers: ntp_servers.iter().map(ToString::to_string).collect(),
+        dhcpv6_preferred_lifetime_secs: None,
+        dhcpv6_valid_lifetime_secs: None,
     })))
 }
 
@@ -123,6 +125,8 @@ async fn handle_underlay_from_dpa(
         fqdn: String::new(),
         prefix,
         ntp_servers: ntp_servers.iter().map(ToString::to_string).collect(),
+        dhcpv6_preferred_lifetime_secs: None,
+        dhcpv6_valid_lifetime_secs: None,
     })))
 }
 

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -218,6 +218,7 @@ pub async fn find_interface_addresses(
             allocation_type: match a.allocation_type {
                 AllocationType::Dhcp => "dhcp".to_string(),
                 AllocationType::Static => "static".to_string(),
+                AllocationType::Slaac => "slaac".to_string(),
             },
         })
         .collect();

--- a/crates/api-core/src/network_segment/allocate.rs
+++ b/crates/api-core/src/network_segment/allocate.rs
@@ -182,6 +182,7 @@ impl PrefixAllocator {
             prefixes: vec![NewNetworkPrefix {
                 prefix,
                 gateway,
+                dhcpv6_link_address: None,
                 num_reserved: 0,
             }],
             vlan_id: None,
@@ -240,6 +241,7 @@ impl PrefixAllocator {
             &[NewNetworkPrefix {
                 prefix,
                 gateway,
+                dhcpv6_link_address: None,
                 num_reserved: 0,
             }],
         )

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1590,8 +1590,10 @@ mod tests {
         NetworkDefinition {
             segment_type,
             prefix,
+            prefix_v6: None,
             // Test helper placeholder; callers under test do not use this as a routable gateway.
             gateway: prefix.network(),
+            dhcpv6_link_address: None,
             mtu: 0,
             reserve_first: 0,
             allocation_strategy: Default::default(),

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -197,6 +197,9 @@ async fn test_discover_dpu_by_source_ip(
             circuit_id: None,
             remote_id: None,
             desired_address: None,
+            address_family: None,
+            message_kind: None,
+            duid: None,
         }))
         .await
         .unwrap()
@@ -237,6 +240,9 @@ async fn test_discover_dpu_not_create_machine(
             circuit_id: None,
             remote_id: None,
             desired_address: None,
+            address_family: None,
+            message_kind: None,
+            duid: None,
         }))
         .await
         .unwrap()

--- a/crates/api-core/src/tests/machine_interfaces.rs
+++ b/crates/api-core/src/tests/machine_interfaces.rs
@@ -627,6 +627,9 @@ async fn test_delete_interface(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
             circuit_id: None,
             remote_id: None,
             desired_address: None,
+            address_family: None,
+            message_kind: None,
+            duid: None,
         }))
         .await
         .unwrap()
@@ -677,6 +680,9 @@ async fn test_delete_interface(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
             circuit_id: None,
             remote_id: None,
             desired_address: None,
+            address_family: None,
+            message_kind: None,
+            duid: None,
         }))
         .await
         .unwrap()

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -95,11 +95,13 @@ async fn test_advance_network_prefix_state(
                 NewNetworkPrefix {
                     prefix: "192.0.2.1/24".parse().expect("can't parse network"),
                     gateway: "192.0.2.1".parse().ok(),
+                    dhcpv6_link_address: None,
                     num_reserved: 1,
                 },
                 NewNetworkPrefix {
                     prefix: "2001:db8:f::/64".parse().expect("can't parse network"),
                     gateway: None,
+                    dhcpv6_link_address: None,
                     num_reserved: 100,
                 },
             ],
@@ -499,7 +501,9 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
             NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Admin,
                 prefix: "172.20.0.0/24".parse().unwrap(),
+                prefix_v6: None,
                 gateway: "172.20.0.1".parse().unwrap(),
+                dhcpv6_link_address: None,
                 mtu: 9000,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -511,7 +515,9 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
             NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Underlay,
                 prefix: "172.99.0.0/26".parse().unwrap(),
+                prefix_v6: None,
                 gateway: "172.99.0.1".parse().unwrap(),
+                dhcpv6_link_address: None,
                 mtu: 1500,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -523,7 +529,9 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
             NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::HostInband,
                 prefix: "10.217.18.192/30".parse().unwrap(),
+                prefix_v6: None,
                 gateway: "10.217.18.193".parse().unwrap(),
+                dhcpv6_link_address: None,
                 mtu: 1500,
                 reserve_first: 1,
                 allocation_strategy: Default::default(),
@@ -603,7 +611,9 @@ pub async fn test_create_initial_vpc_and_attached_network(
         NetworkDefinition {
             segment_type: NetworkDefinitionSegmentType::HostInband,
             prefix: "10.217.18.192/30".parse().unwrap(),
+            prefix_v6: None,
             gateway: "10.217.18.193".parse().unwrap(),
+            dhcpv6_link_address: None,
             mtu: 1500,
             reserve_first: 1,
             allocation_strategy: Default::default(),
@@ -668,7 +678,9 @@ pub async fn test_create_initial_network_fails_for_missing_vpc_name(
         NetworkDefinition {
             segment_type: NetworkDefinitionSegmentType::HostInband,
             prefix: "10.217.18.192/30".parse().unwrap(),
+            prefix_v6: None,
             gateway: "10.217.18.193".parse().unwrap(),
+            dhcpv6_link_address: None,
             mtu: 1500,
             reserve_first: 1,
             allocation_strategy: Default::default(),

--- a/crates/api-db/migrations/20260615190000_network_prefix_dhcpv6_link_address.sql
+++ b/crates/api-db/migrations/20260615190000_network_prefix_dhcpv6_link_address.sql
@@ -1,0 +1,14 @@
+-- DHCPv6 relay link-address that identifies a segment. Unlike `gateway`,
+-- it is not required to fall within the prefix, so it gets its own column.
+ALTER TABLE network_prefixes
+    ADD COLUMN dhcpv6_link_address INET
+        CONSTRAINT network_prefix_dhcpv6_link_address_ipv6
+            CHECK (dhcpv6_link_address IS NULL OR family(dhcpv6_link_address) = 6)
+        CONSTRAINT network_prefix_dhcpv6_link_address_host
+            CHECK (dhcpv6_link_address IS NULL OR masklen(dhcpv6_link_address) = 128);
+
+-- Disambiguate equality matches: at most one prefix may claim a given
+-- link-address.
+CREATE UNIQUE INDEX network_prefix_dhcpv6_link_address
+    ON network_prefixes (dhcpv6_link_address)
+    WHERE dhcpv6_link_address IS NOT NULL;

--- a/crates/api-db/src/machine_interface/ip_allocator.rs
+++ b/crates/api-db/src/machine_interface/ip_allocator.rs
@@ -192,6 +192,7 @@ async fn test_machine_interface_create_with_ipv6_prefix(
         prefixes: vec![NewNetworkPrefix {
             prefix: "2001:db8:abcd::0/112".parse().unwrap(),
             gateway: None,
+            dhcpv6_link_address: None,
             num_reserved: 2,
         }],
         vlan_id: None,
@@ -269,11 +270,13 @@ async fn test_machine_interface_create_dual_stack(
             NewNetworkPrefix {
                 prefix: "10.99.1.0/24".parse().unwrap(),
                 gateway: Some("10.99.1.1".parse().unwrap()),
+                dhcpv6_link_address: None,
                 num_reserved: 1,
             },
             NewNetworkPrefix {
                 prefix: "2001:db8:99::0/112".parse().unwrap(),
                 gateway: None,
+                dhcpv6_link_address: None,
                 num_reserved: 1,
             },
         ],

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -38,6 +38,7 @@ async fn create_static_assignments_segment(
             prefixes: vec![NewNetworkPrefix {
                 prefix: "169.254.254.254/32".parse().unwrap(),
                 gateway: None,
+                dhcpv6_link_address: None,
                 num_reserved: 1,
             }],
             vlan_id: None,

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -173,8 +173,8 @@ pub async fn insert(
 /// allocation type:
 ///
 /// - `Static`: the old static address is replaced.
-/// - `Dhcp`: the DHCP allocation is removed and replaced with the
-///   static assignment.
+/// - `Dhcp` or `Slaac`: the managed allocation is removed and
+///   replaced with the static assignment.
 #[allow(txn_held_across_await)]
 pub async fn assign_static(
     txn: &mut PgConnection,
@@ -186,9 +186,8 @@ pub async fn assign_static(
     let existing = find_allocation_type_for_family(&mut *txn, interface_id, family).await?;
 
     let result = match existing {
-        Some(AllocationType::Dhcp) => {
-            delete_by_interface_family(&mut *txn, interface_id, family, AllocationType::Dhcp)
-                .await?;
+        Some(allocation_type @ (AllocationType::Dhcp | AllocationType::Slaac)) => {
+            delete_by_interface_family(&mut *txn, interface_id, family, allocation_type).await?;
             AssignStaticResult::ReplacedDhcp
         }
         Some(AllocationType::Static) => {
@@ -278,4 +277,50 @@ pub struct MachineInterfaceSearchResult {
     pub name: String,
     pub network_segment_type: NetworkSegmentType,
     pub allocation_type: AllocationType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies the new SLAAC allocation type survives a database round trip.
+    #[crate::sqlx_test]
+    async fn slaac_allocation_type_round_trips(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+
+        // Create the minimal segment and interface rows needed to own an address.
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version) VALUES ($1, 'V1-T0') RETURNING id",
+        )
+        .bind("slaac-roundtrip")
+        .fetch_one(txn.as_mut())
+        .await?;
+        let interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces (segment_id, mac_address, primary_interface, hostname)
+             VALUES ($1, $2::macaddr, true, 'slaac-roundtrip') RETURNING id",
+        )
+        .bind(segment_id)
+        .bind("02:00:00:00:00:01")
+        .fetch_one(txn.as_mut())
+        .await?;
+
+        // Insert a SLAAC allocation through the public helper and read it back.
+        insert(
+            txn.as_mut(),
+            interface_id,
+            "2001:db8::10".parse()?,
+            AllocationType::Slaac,
+        )
+        .await?;
+        let addresses = find_for_interface(txn.as_mut(), interface_id).await?;
+
+        // Verify the persisted row preserved the new allocation type.
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(addresses[0].allocation_type, AllocationType::Slaac);
+
+        txn.rollback().await?;
+        Ok(())
+    }
 }

--- a/crates/api-db/src/machine_interface_address/test_find_by_address.rs
+++ b/crates/api-db/src/machine_interface_address/test_find_by_address.rs
@@ -46,6 +46,7 @@ async fn find_by_address_bmc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::erro
         prefixes: vec![NewNetworkPrefix {
             prefix: IpNetwork::V4("192.168.0.0/24".parse().unwrap()),
             gateway: Some(IpAddr::V4("192.168.0.1".parse().unwrap())),
+            dhcpv6_link_address: None,
             num_reserved: 14,
         }],
         vlan_id: None,

--- a/crates/api-db/src/network_prefix.rs
+++ b/crates/api-db/src/network_prefix.rs
@@ -178,14 +178,15 @@ pub async fn create_for(
     // tiny amounts of time.
     //
     let mut inserted_prefixes: Vec<NetworkPrefix> = Vec::with_capacity(prefixes.len());
-    let query = "INSERT INTO network_prefixes (segment_id, prefix, gateway, num_reserved)
-            VALUES ($1::uuid, $2::cidr, $3::inet, $4::integer)
+    let query = "INSERT INTO network_prefixes (segment_id, prefix, gateway, dhcpv6_link_address, num_reserved)
+            VALUES ($1::uuid, $2::cidr, $3::inet, $4::inet, $5::integer)
             RETURNING *";
     for prefix in prefixes {
         let new_prefix: NetworkPrefix = sqlx::query_as(query)
             .bind(segment_id)
             .bind(prefix.prefix)
             .bind(prefix.gateway)
+            .bind(prefix.dhcpv6_link_address)
             .bind(prefix.num_reserved)
             .fetch_one(inner_transaction.as_pgconn())
             .await

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -972,7 +972,9 @@ mod tests {
         let def = NetworkDefinition {
             segment_type: NetworkDefinitionSegmentType::Admin,
             prefix: "192.168.1.0/24".parse().unwrap(),
+            prefix_v6: None,
             gateway: "192.168.1.1".parse().unwrap(),
+            dhcpv6_link_address: None,
             mtu: 1500,
             reserve_first: 5,
             allocation_strategy: Default::default(),
@@ -1009,7 +1011,9 @@ mod tests {
         NetworkDefinition {
             segment_type: NetworkDefinitionSegmentType::Admin,
             prefix: prefix.parse().unwrap(),
+            prefix_v6: None,
             gateway: gateway.parse().unwrap(),
+            dhcpv6_link_address: None,
             mtu: 1500,
             reserve_first: 3,
             allocation_strategy: Default::default(),

--- a/crates/api-db/src/test_support/network_segment.rs
+++ b/crates/api-db/src/test_support/network_segment.rs
@@ -32,6 +32,7 @@ pub(crate) fn admin_segment(
         prefixes: vec![NewNetworkPrefix {
             prefix: prefix.parse().unwrap(),
             gateway: Some(gateway.parse().unwrap()),
+            dhcpv6_link_address: None,
             num_reserved,
         }],
         vlan_id: None,

--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -26,12 +26,15 @@ use crate::address_selection_strategy::AddressSelectionStrategy;
 ///   or a DHCP service that integrates directly with carbide-api.
 /// - `Static`: These addresses are assigned and managed explicitly by
 ///   an operator or operator-provided configuration.
+/// - `Slaac`: These IPv6 addresses are client-derived and observed through
+///   DHCPv6 information-request or stateless flows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
 #[sqlx(type_name = "text", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum AllocationType {
     Dhcp,
     Static,
+    Slaac,
 }
 
 impl From<AddressSelectionStrategy> for AllocationType {
@@ -176,6 +179,10 @@ mod tests {
             "static" {
                 AllocationType::Static => r#""static""#.to_string(),
             }
+
+            "slaac" {
+                AllocationType::Slaac => r#""slaac""#.to_string(),
+            }
         );
     }
 
@@ -198,6 +205,10 @@ mod tests {
             "static" {
                 AllocationType::Static => Yields((r#""static""#.to_string(), AllocationType::Static)),
             }
+
+            "slaac" {
+                AllocationType::Slaac => Yields((r#""slaac""#.to_string(), AllocationType::Slaac)),
+            }
         );
     }
 
@@ -215,6 +226,10 @@ mod tests {
 
             "static" {
                 r#""static""# => Yields(AllocationType::Static),
+            }
+
+            "slaac" {
+                r#""slaac""# => Yields(AllocationType::Slaac),
             }
 
             "wrong case rejected" {
@@ -270,8 +285,20 @@ mod tests {
                 (AllocationType::Static, AllocationType::Static) => true,
             }
 
+            "slaac == slaac" {
+                (AllocationType::Slaac, AllocationType::Slaac) => true,
+            }
+
             "dhcp != static" {
                 (AllocationType::Dhcp, AllocationType::Static) => false,
+            }
+
+            "dhcp != slaac" {
+                (AllocationType::Dhcp, AllocationType::Slaac) => false,
+            }
+
+            "static != slaac" {
+                (AllocationType::Static, AllocationType::Slaac) => false,
             }
         );
 

--- a/crates/api-model/src/network_prefix.rs
+++ b/crates/api-model/src/network_prefix.rs
@@ -29,6 +29,8 @@ pub struct NetworkPrefix {
     pub segment_id: NetworkSegmentId,
     pub prefix: IpNetwork,
     pub gateway: Option<IpAddr>,
+    #[serde(default)]
+    pub dhcpv6_link_address: Option<IpAddr>,
     pub num_reserved: i32,
     pub vpc_prefix_id: Option<VpcPrefixId>,
     pub vpc_prefix: Option<IpNetwork>,
@@ -41,6 +43,7 @@ pub struct NetworkPrefix {
 pub struct NewNetworkPrefix {
     pub prefix: IpNetwork,
     pub gateway: Option<IpAddr>,
+    pub dhcpv6_link_address: Option<IpAddr>,
     pub num_reserved: i32,
 }
 
@@ -49,6 +52,7 @@ impl From<NetworkPrefix> for NewNetworkPrefix {
         Self {
             prefix: prefix.prefix,
             gateway: prefix.gateway,
+            dhcpv6_link_address: prefix.dhcpv6_link_address,
             num_reserved: prefix.num_reserved,
         }
     }
@@ -63,6 +67,7 @@ impl<'r> FromRow<'r, PgRow> for NetworkPrefix {
             vpc_prefix: row.try_get("vpc_prefix")?,
             prefix: row.try_get("prefix")?,
             gateway: row.try_get("gateway")?,
+            dhcpv6_link_address: row.try_get("dhcpv6_link_address")?,
             num_reserved: row.try_get("num_reserved")?,
             svi_ip: row.try_get("svi_ip")?,
             num_free_ips: 0,

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -79,8 +79,15 @@ pub struct NetworkDefinition {
     pub segment_type: NetworkDefinitionSegmentType,
     /// CIDR notation
     pub prefix: IpNetwork,
+    /// Optional IPv6 CIDR for dual-stack config-seeded segments.
+    #[serde(default)]
+    pub prefix_v6: Option<IpNetwork>,
     /// Usually the first IP in the prefix range
     pub gateway: IpAddr,
+    /// DHCPv6 relay link-address used to identify this segment. It may
+    /// be outside `prefix_v6`, so it is modeled separately from gateway.
+    #[serde(default)]
+    pub dhcpv6_link_address: Option<IpAddr>,
     /// Typically 9000 for admin network, 1500 for underlay
     pub mtu: i32,
     /// How many addresses to skip before allocating
@@ -341,18 +348,74 @@ impl NewNetworkSegment {
         domain_id: DomainId,
         value: &NetworkDefinition,
     ) -> Result<Self, ModelError> {
-        let prefix = NewNetworkPrefix {
+        // Validate the optional IPv6-specific config before expanding it
+        // into persisted prefix rows.
+        if let Some(prefix_v6) = value.prefix_v6
+            && !prefix_v6.is_ipv6()
+        {
+            return Err(ModelError::InvalidArgument(
+                "NetworkDefinition.prefix_v6 must be an IPv6 prefix.".to_string(),
+            ));
+        }
+
+        if let Some(link_address) = value.dhcpv6_link_address
+            && !link_address.is_ipv6()
+        {
+            return Err(ModelError::InvalidArgument(
+                "NetworkDefinition.dhcpv6_link_address must be an IPv6 address.".to_string(),
+            ));
+        }
+
+        // Keep the one-prefix-per-family invariant explicit before the
+        // database unique index has to reject the insert.
+        if let Some(prefix_v6) = value.prefix_v6
+            && value.prefix.is_ipv6() == prefix_v6.is_ipv6()
+        {
+            return Err(ModelError::InvalidArgument(
+                "NetworkDefinition cannot contain more than one prefix from the same address family."
+                    .to_string(),
+            ));
+        }
+
+        // A DHCPv6 link-address only has meaning when there is a v6 prefix row
+        // to carry it.
+        if value.prefix.is_ipv4()
+            && value.prefix_v6.is_none()
+            && value.dhcpv6_link_address.is_some()
+        {
+            return Err(ModelError::InvalidArgument(
+                "NetworkDefinition.dhcpv6_link_address requires an IPv6 prefix.".to_string(),
+            ));
+        }
+
+        // Expand the config definition into one row for the primary prefix and
+        // an optional second row for the dual-stack IPv6 prefix.
+        let mut prefixes = vec![NewNetworkPrefix {
             prefix: value.prefix,
-            gateway: Some(value.gateway),
+            gateway: value.prefix.is_ipv4().then_some(value.gateway),
+            dhcpv6_link_address: if value.prefix.is_ipv6() {
+                value.dhcpv6_link_address
+            } else {
+                None
+            },
             num_reserved: value.reserve_first,
-        };
+        }];
+        if let Some(prefix_v6) = value.prefix_v6 {
+            prefixes.push(NewNetworkPrefix {
+                prefix: prefix_v6,
+                gateway: None,
+                dhcpv6_link_address: value.dhcpv6_link_address,
+                num_reserved: value.reserve_first,
+            });
+        }
+
         Ok(NewNetworkSegment {
             id: uuid::Uuid::new_v4().into(),
             name: name.to_string(), // Set by the caller later
             subdomain_id: Some(domain_id),
             vpc_id: None,
             mtu: value.mtu,
-            prefixes: vec![prefix],
+            prefixes,
             vlan_id: None,
             vni: None,
             segment_type: value.segment_type.into(),
@@ -575,6 +638,117 @@ mod tests {
 
             "host_inband" {
                 NetworkDefinitionSegmentType::HostInband => NetworkSegmentType::HostInband,
+            }
+        );
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct BuiltPrefix {
+        prefix: String,
+        gateway: Option<String>,
+        dhcpv6_link_address: Option<String>,
+        num_reserved: i32,
+    }
+
+    /// Builds a config network definition for segment expansion tests.
+    fn definition(
+        prefix: &str,
+        prefix_v6: Option<&str>,
+        dhcpv6_link_address: Option<&str>,
+    ) -> NetworkDefinition {
+        NetworkDefinition {
+            segment_type: NetworkDefinitionSegmentType::Admin,
+            prefix: prefix.parse().unwrap(),
+            prefix_v6: prefix_v6.map(|prefix| prefix.parse().unwrap()),
+            gateway: prefix.parse::<IpNetwork>().unwrap().network(),
+            dhcpv6_link_address: dhcpv6_link_address.map(|addr| addr.parse().unwrap()),
+            mtu: 1500,
+            reserve_first: 5,
+            allocation_strategy: AllocationStrategy::Dynamic,
+            vpc_name: None,
+        }
+    }
+
+    /// Expands a network definition and returns the persisted prefix shape.
+    fn build_definition_prefixes(value: NetworkDefinition) -> Result<Vec<BuiltPrefix>, String> {
+        NewNetworkSegment::build_from("test-segment", uuid::Uuid::new_v4().into(), &value)
+            .map(|segment| {
+                segment
+                    .prefixes
+                    .into_iter()
+                    .map(|prefix| BuiltPrefix {
+                        prefix: prefix.prefix.to_string(),
+                        gateway: prefix.gateway.map(|addr| addr.to_string()),
+                        dhcpv6_link_address: prefix
+                            .dhcpv6_link_address
+                            .map(|addr| addr.to_string()),
+                        num_reserved: prefix.num_reserved,
+                    })
+                    .collect()
+            })
+            .map_err(|err| err.to_string())
+    }
+
+    /// Verifies config-seeded segments expand to at most one prefix per family.
+    #[test]
+    fn build_from_network_definition_expands_dual_stack_prefixes() {
+        scenarios!(
+            // Build the config-seeded segment and project the prefix rows that
+            // will be persisted.
+            run = build_definition_prefixes;
+            "v4-only keeps the legacy gateway row" {
+                definition("192.0.2.0/24", None, None) => Yields(vec![
+                    BuiltPrefix {
+                        prefix: "192.0.2.0/24".to_string(),
+                        gateway: Some("192.0.2.0".to_string()),
+                        dhcpv6_link_address: None,
+                        num_reserved: 5,
+                    },
+                ]),
+            }
+
+            "v6-only has no gateway and carries the dhcpv6 link-address" {
+                definition("2001:db8::/64", None, Some("2001:db8:ffff::1")) => Yields(vec![
+                    BuiltPrefix {
+                        prefix: "2001:db8::/64".to_string(),
+                        gateway: None,
+                        dhcpv6_link_address: Some("2001:db8:ffff::1".to_string()),
+                        num_reserved: 5,
+                    },
+                ]),
+            }
+
+            "dual-stack builds one row per family" {
+                definition("192.0.2.0/24", Some("2001:db8::/64"), Some("2001:db8:ffff::1")) => Yields(vec![
+                    BuiltPrefix {
+                        prefix: "192.0.2.0/24".to_string(),
+                        gateway: Some("192.0.2.0".to_string()),
+                        dhcpv6_link_address: None,
+                        num_reserved: 5,
+                    },
+                    BuiltPrefix {
+                        prefix: "2001:db8::/64".to_string(),
+                        gateway: None,
+                        dhcpv6_link_address: Some("2001:db8:ffff::1".to_string()),
+                        num_reserved: 5,
+                    },
+                ]),
+            }
+
+            "prefix_v6 must be IPv6" {
+                definition("192.0.2.0/24", Some("198.51.100.0/24"), None) => Fails,
+            }
+
+            "two IPv6 prefixes are rejected" {
+                definition("2001:db8:1::/64", Some("2001:db8:2::/64"), None) => Fails,
+            }
+
+            "dhcpv6 link-address must be IPv6" {
+                definition("192.0.2.0/24", Some("2001:db8::/64"), Some("192.0.2.1")) => Fails,
+            }
+
+            "dhcpv6 link-address requires a v6 prefix" {
+                definition("192.0.2.0/24", None, Some("2001:db8::1")) => Fails,
             }
         );
     }

--- a/crates/api-model/src/vpc/capability.rs
+++ b/crates/api-model/src/vpc/capability.rs
@@ -918,6 +918,7 @@ mod tests {
                 .map(|p| NewNetworkPrefix {
                     prefix: p.parse().unwrap(),
                     gateway: None,
+                    dhcpv6_link_address: None,
                     num_reserved: 0,
                 })
                 .collect(),

--- a/crates/dhcp-server/proto/dhcp_server_control.proto
+++ b/crates/dhcp-server/proto/dhcp_server_control.proto
@@ -48,10 +48,16 @@ message DhcpConfig {
     repeated string carbide_ntpservers = 6;
     string carbide_provisioning_server_ipv4 = 7;
     string carbide_dhcp_server = 8;
+    repeated string carbide_nameservers_v6 = 9;
+    repeated string carbide_ntpservers_v6 = 10;
+    optional string carbide_dhcp_server_v6 = 11;
+    uint32 dhcpv6_preferred_lifetime_secs = 12;
+    uint32 dhcpv6_valid_lifetime_secs = 13;
 }
 
 // Mirrors utils::models::dhcp::InterfaceInfo.
-// IPv4 addresses are encoded as dotted-decimal strings.
+// IPv4 addresses are encoded as dotted-decimal strings. IPv6 details are
+// absent for v4-only hosts.
 message InterfaceInfo {
     string address = 1;
     string gateway = 2;
@@ -59,6 +65,13 @@ message InterfaceInfo {
     string fqdn = 4;
     optional string booturl = 5;
     optional uint32 mtu = 6;
+    optional InterfaceInfoV6 ipv6 = 7;
+}
+
+message InterfaceInfoV6 {
+    // Absent for SLAAC-only entries; present for stateful /128.
+    optional string address = 1;
+    string prefix = 2;
 }
 
 // Mirrors utils::models::dhcp::HostConfig.

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -20,6 +20,7 @@ use std::net::SocketAddr;
 use carbide_rpc_utils::dhcp::{
     DhcpConfig as ModelDhcpConfig, DhcpTimestamps, DhcpTimestampsFilePath,
     HostConfig as ModelHostConfig, InterfaceInfo as ModelInterfaceInfo,
+    InterfaceInfoV6 as ModelInterfaceInfoV6,
 };
 use carbide_uuid::machine::MachineInterfaceId;
 use tokio::sync::mpsc;
@@ -76,6 +77,30 @@ impl TryFrom<proto::DhcpConfig> for ModelDhcpConfig {
                 .collect::<Result<Vec<_>, _>>()?,
             carbide_provisioning_server_ipv4: c.carbide_provisioning_server_ipv4.parse()?,
             carbide_dhcp_server: c.carbide_dhcp_server.parse()?,
+            carbide_nameservers_v6: c
+                .carbide_nameservers_v6
+                .iter()
+                .map(|s| s.parse())
+                .collect::<Result<Vec<_>, _>>()?,
+            carbide_ntpservers_v6: c
+                .carbide_ntpservers_v6
+                .iter()
+                .map(|s| s.parse())
+                .collect::<Result<Vec<_>, _>>()?,
+            carbide_dhcp_server_v6: c.carbide_dhcp_server_v6.map(|s| s.parse()).transpose()?,
+            dhcpv6_preferred_lifetime_secs: c.dhcpv6_preferred_lifetime_secs,
+            dhcpv6_valid_lifetime_secs: c.dhcpv6_valid_lifetime_secs,
+        })
+    }
+}
+
+impl TryFrom<proto::InterfaceInfoV6> for ModelInterfaceInfoV6 {
+    type Error = DhcpError;
+
+    fn try_from(i: proto::InterfaceInfoV6) -> Result<Self, Self::Error> {
+        Ok(ModelInterfaceInfoV6 {
+            address: i.address.map(|s| s.parse()).transpose()?,
+            prefix: i.prefix,
         })
     }
 }
@@ -91,6 +116,7 @@ impl TryFrom<proto::InterfaceInfo> for ModelInterfaceInfo {
             fqdn: i.fqdn,
             booturl: i.booturl,
             mtu: i.mtu,
+            ipv6: i.ipv6.map(ModelInterfaceInfoV6::try_from).transpose()?,
         })
     }
 }

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -554,6 +554,8 @@ impl Test {
             booturl: None,
             last_invalidation_time: None,
             ntp_servers: vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()],
+            dhcpv6_preferred_lifetime_secs: None,
+            dhcpv6_valid_lifetime_secs: None,
         })
     }
 }

--- a/crates/dhcp-server/src/modes/dpu.rs
+++ b/crates/dhcp-server/src/modes/dpu.rs
@@ -45,6 +45,8 @@ fn from_host_conf(value: &InterfaceInfo, interface_id: MachineInterfaceId) -> Dh
         booturl: value.booturl.clone(),
         last_invalidation_time: None,
         ntp_servers: vec![],
+        dhcpv6_preferred_lifetime_secs: None,
+        dhcpv6_valid_lifetime_secs: None,
     }
 }
 

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -177,6 +177,9 @@ impl DecodedPacket {
             circuit_id: handler.get_circuit_id(self, circuit_id),
             remote_id: self.get_remote_id(),
             desired_address: None,
+            address_family: None,
+            message_kind: None,
+            duid: None,
         }
     }
 
@@ -542,6 +545,7 @@ mod test {
             fqdn: "fqdn1".to_string(),
             booturl: None,
             mtu: None,
+            ipv6: None,
         };
         let interface_mtu_9000 = crate::packet_handler::InterfaceInfo {
             address: <std::net::Ipv4Addr as std::str::FromStr>::from_str("20.22.2.2")
@@ -554,6 +558,7 @@ mod test {
             fqdn: "fqdn2".to_string(),
             booturl: None,
             mtu: Some(9000),
+            ipv6: None,
         };
         let mut interface_mtu_65537 = interface_mtu_none.clone();
         interface_mtu_65537.mtu = Some(65537);

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -56,6 +56,9 @@ impl Machine {
                     circuit_id: discovery.circuit_id.clone(),
                     remote_id: discovery.remote_id.clone(),
                     desired_address: discovery.desired_address.map(|addr| addr.to_string()),
+                    address_family: None,
+                    message_kind: None,
+                    duid: None,
                 });
 
                 client

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -64,6 +64,8 @@ pub fn base_dhcp_response(mac_address: MacAddress) -> rpc::DhcpRecord {
         booturl: None,
         last_invalidation_time: None,
         ntp_servers: vec!["198.51.100.10".to_string(), "198.51.100.11".to_string()],
+        dhcpv6_preferred_lifetime_secs: None,
+        dhcpv6_valid_lifetime_secs: None,
     }
 }
 

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -16,7 +16,7 @@
  */
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
 use carbide_uuid::UuidConversionError;
@@ -40,6 +40,16 @@ pub struct DhcpConfig {
     pub carbide_ntpservers: Vec<Ipv4Addr>,
     pub carbide_provisioning_server_ipv4: Ipv4Addr,
     pub carbide_dhcp_server: Ipv4Addr,
+    #[serde(default)]
+    pub carbide_nameservers_v6: Vec<Ipv6Addr>,
+    #[serde(default)]
+    pub carbide_ntpservers_v6: Vec<Ipv6Addr>,
+    #[serde(default)]
+    pub carbide_dhcp_server_v6: Option<Ipv6Addr>,
+    #[serde(default)]
+    pub dhcpv6_preferred_lifetime_secs: u32,
+    #[serde(default)]
+    pub dhcpv6_valid_lifetime_secs: u32,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -72,6 +82,11 @@ impl Default for DhcpConfig {
             // These two must be updated with valid values.
             carbide_provisioning_server_ipv4: Ipv4Addr::from([127, 0, 0, 1]),
             carbide_dhcp_server: Ipv4Addr::from([127, 0, 0, 1]),
+            carbide_nameservers_v6: vec![],
+            carbide_ntpservers_v6: vec![],
+            carbide_dhcp_server_v6: None,
+            dhcpv6_preferred_lifetime_secs: 0,
+            dhcpv6_valid_lifetime_secs: 0,
         }
     }
 }
@@ -113,6 +128,17 @@ pub struct InterfaceInfo {
     pub booturl: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mtu: Option<u32>,
+    // TODO(ipv6-only): the v4 fields above are still required. IPv6-only
+    // hosts will need those fields to become optional in a later milestone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipv6: Option<InterfaceInfoV6>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InterfaceInfoV6 {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub address: Option<Ipv6Addr>,
+    pub prefix: String,
 }
 impl Default for InterfaceInfo {
     fn default() -> Self {
@@ -123,6 +149,7 @@ impl Default for InterfaceInfo {
             fqdn: Default::default(),
             booturl: None,
             mtu: None,
+            ipv6: None,
         }
     }
 }
@@ -192,6 +219,7 @@ impl TryFrom<::rpc::forge::FlatInterfaceConfig> for InterfaceInfo {
             fqdn: value.fqdn,
             booturl: value.booturl,
             mtu: value.mtu,
+            ipv6: None,
         })
     }
 }
@@ -296,7 +324,7 @@ impl IntoIterator for DhcpTimestamps {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{scenarios, value_scenarios};
@@ -642,6 +670,90 @@ mod tests {
                 ) => FailsWith("parameter-missing"),
             }
         );
+    }
+
+    /// Verifies DHCP config IPv6 fields round-trip and old configs default them.
+    #[test]
+    fn dhcp_config_v6_fields_round_trip_and_default_when_absent() {
+        let config = DhcpConfig {
+            carbide_nameservers_v6: vec!["2001:db8::53".parse().unwrap()],
+            carbide_ntpservers_v6: vec!["2001:db8::123".parse().unwrap()],
+            carbide_dhcp_server_v6: Some("2001:db8::1".parse().unwrap()),
+            dhcpv6_preferred_lifetime_secs: 3600,
+            dhcpv6_valid_lifetime_secs: 7200,
+            ..Default::default()
+        };
+
+        // Serialize a populated config and verify the IPv6 fields survive.
+        let wire = serde_json::to_string(&config).expect("dhcp config serializes");
+        let recovered: DhcpConfig = serde_json::from_str(&wire).expect("dhcp config deserializes");
+        assert_eq!(
+            recovered.carbide_nameservers_v6,
+            vec![Ipv6Addr::from_str("2001:db8::53").unwrap()]
+        );
+        assert_eq!(
+            recovered.carbide_ntpservers_v6,
+            vec![Ipv6Addr::from_str("2001:db8::123").unwrap()]
+        );
+        assert_eq!(
+            recovered.carbide_dhcp_server_v6,
+            Some(Ipv6Addr::from_str("2001:db8::1").unwrap())
+        );
+        assert_eq!(recovered.dhcpv6_preferred_lifetime_secs, 3600);
+        assert_eq!(recovered.dhcpv6_valid_lifetime_secs, 7200);
+
+        // Deserialize old-style JSON and verify the new fields default cleanly.
+        let old_wire = r#"{
+            "lease_time_secs": 604800,
+            "renewal_time_secs": 3600,
+            "rebinding_time_secs": 432000,
+            "carbide_nameservers": [],
+            "carbide_api_url": null,
+            "carbide_ntpservers": [],
+            "carbide_provisioning_server_ipv4": "127.0.0.1",
+            "carbide_dhcp_server": "127.0.0.1"
+        }"#;
+        let old_config: DhcpConfig =
+            serde_json::from_str(old_wire).expect("old dhcp config deserializes");
+        assert!(old_config.carbide_nameservers_v6.is_empty());
+        assert!(old_config.carbide_ntpservers_v6.is_empty());
+        assert_eq!(old_config.carbide_dhcp_server_v6, None);
+        assert_eq!(old_config.dhcpv6_preferred_lifetime_secs, 0);
+        assert_eq!(old_config.dhcpv6_valid_lifetime_secs, 0);
+    }
+
+    /// Verifies per-interface IPv6 details round-trip and old host configs default them.
+    #[test]
+    fn interface_info_ipv6_round_trip_and_defaults_when_absent() {
+        let interface = InterfaceInfo {
+            address: Ipv4Addr::new(192, 0, 2, 10),
+            gateway: Ipv4Addr::new(192, 0, 2, 1),
+            prefix: "192.0.2.0/24".to_string(),
+            fqdn: "host.example.com".to_string(),
+            booturl: None,
+            mtu: Some(9000),
+            ipv6: Some(InterfaceInfoV6 {
+                address: Some("2001:db8::10".parse().unwrap()),
+                prefix: "2001:db8::/64".to_string(),
+            }),
+        };
+
+        // Serialize a populated interface and verify the IPv6 sub-record survives.
+        let wire = serde_json::to_string(&interface).expect("interface serializes");
+        let recovered: InterfaceInfo = serde_json::from_str(&wire).expect("interface deserializes");
+        assert_eq!(recovered.ipv6, interface.ipv6);
+
+        // Deserialize old-style JSON and verify the IPv6 field defaults to absent.
+        let old_wire = r#"{
+            "address": "192.0.2.10",
+            "gateway": "192.0.2.1",
+            "prefix": "192.0.2.0/24",
+            "fqdn": "host.example.com",
+            "booturl": null
+        }"#;
+        let old_interface: InterfaceInfo =
+            serde_json::from_str(old_wire).expect("old interface deserializes");
+        assert_eq!(old_interface.ipv6, None);
     }
 
     #[test]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3816,6 +3816,23 @@ message DhcpDiscovery {
   optional string circuit_id = 5;
   optional string remote_id = 6;
   optional string desired_address = 7;
+  optional AddressFamily address_family = 8;
+  optional MessageKind message_kind = 9;
+  optional bytes duid = 10;
+}
+
+enum AddressFamily {
+  ADDRESS_FAMILY_UNSPECIFIED = 0;
+  ADDRESS_FAMILY_V4 = 1;
+  ADDRESS_FAMILY_V6 = 2;
+}
+
+enum MessageKind {
+  MESSAGE_KIND_UNSPECIFIED = 0;
+  MESSAGE_KIND_V4_DISCOVER = 1;
+  MESSAGE_KIND_V6_SOLICIT = 2;
+  MESSAGE_KIND_V6_REQUEST = 3;
+  MESSAGE_KIND_V6_INFO_REQUEST = 4;
 }
 
 message ExpireDhcpLeaseRequest {
@@ -3860,6 +3877,9 @@ message DhcpRecord {
 
   // Per site NTP server IPs
   repeated string ntp_servers = 13;
+
+  optional uint32 dhcpv6_preferred_lifetime_secs = 14;
+  optional uint32 dhcpv6_valid_lifetime_secs = 15;
 }
 
 message NetworkSegmentList {
@@ -4061,7 +4081,7 @@ message ManagedHostNetworkConfigResponse {
   // for them.
   bool stateful_acls_enabled = 21;
 
-  // site-level configured NTP server IPs 
+  // site-level configured NTP server IPs
   // If empty, the agent may fall back to resolving carbide-ntp.forge for compatibility.
   repeated string ntp_servers = 22;
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1010,4 +1010,60 @@ mod tests {
         assert_eq!(ts, created_system_time);
         assert_eq!(ts2, updated_system_time);
     }
+
+    /// Verifies the additive DHCP discovery IPv6 fields survive protobuf encoding.
+    #[test]
+    fn dhcp_discovery_round_trips_with_ipv6_fields() {
+        let discovery = forge::DhcpDiscovery {
+            mac_address: "00:11:22:33:44:55".to_string(),
+            relay_address: "2001:db8::1".to_string(),
+            vendor_string: Some("vendor".to_string()),
+            link_address: Some("2001:db8::2".to_string()),
+            circuit_id: Some("circuit".to_string()),
+            remote_id: Some("remote".to_string()),
+            desired_address: Some("2001:db8::10".to_string()),
+            address_family: Some(2),
+            message_kind: Some(2),
+            duid: Some(vec![0, 1, 0, 1, 0xaa, 0xbb]),
+        };
+
+        // Encode then decode so prost field numbering is exercised directly.
+        let encoded = discovery.encode_to_vec();
+        let decoded = forge::DhcpDiscovery::decode(&encoded[..]).unwrap();
+
+        // Verify the newly-added IPv6 fields survive the protobuf round trip.
+        assert_eq!(decoded.address_family, Some(2));
+        assert_eq!(decoded.message_kind, Some(2));
+        assert_eq!(decoded.duid, Some(vec![0, 1, 0, 1, 0xaa, 0xbb]));
+    }
+
+    /// Verifies the additive DHCP record IPv6 fields survive protobuf encoding.
+    #[test]
+    fn dhcp_record_round_trips_with_ipv6_fields() {
+        let record = forge::DhcpRecord {
+            machine_id: None,
+            machine_interface_id: None,
+            segment_id: None,
+            subdomain_id: None,
+            fqdn: "host.example.com".to_string(),
+            mac_address: "00:11:22:33:44:55".to_string(),
+            address: "2001:db8::10".to_string(),
+            mtu: 9000,
+            prefix: "2001:db8::/64".to_string(),
+            gateway: None,
+            booturl: None,
+            last_invalidation_time: None,
+            ntp_servers: vec![],
+            dhcpv6_preferred_lifetime_secs: Some(3600),
+            dhcpv6_valid_lifetime_secs: Some(7200),
+        };
+
+        // Encode then decode so prost field numbering is exercised directly.
+        let encoded = record.encode_to_vec();
+        let decoded = forge::DhcpRecord::decode(&encoded[..]).unwrap();
+
+        // Verify the newly-added IPv6 fields survive the protobuf round trip.
+        assert_eq!(decoded.dhcpv6_preferred_lifetime_secs, Some(3600));
+        assert_eq!(decoded.dhcpv6_valid_lifetime_secs, Some(7200));
+    }
 }

--- a/crates/rpc/src/model/dhcp_record.rs
+++ b/crates/rpc/src/model/dhcp_record.rs
@@ -35,6 +35,8 @@ impl From<DhcpRecord> for rpc::forge::DhcpRecord {
             booturl: None, // TODO(ajf): extend database, synthesize URL
             last_invalidation_time: Some(record.last_invalidation_time.into()),
             ntp_servers: vec![],
+            dhcpv6_preferred_lifetime_secs: None,
+            dhcpv6_valid_lifetime_secs: None,
         }
     }
 }

--- a/crates/rpc/src/model/network_prefix.rs
+++ b/crates/rpc/src/model/network_prefix.rs
@@ -39,6 +39,7 @@ impl TryFrom<rpc::forge::NetworkPrefix> for NewNetworkPrefix {
                 ),
                 None => None,
             },
+            dhcpv6_link_address: None,
             num_reserved: value.reserve_first,
         })
     }

--- a/crates/rpc/src/model/network_segment.rs
+++ b/crates/rpc/src/model/network_segment.rs
@@ -87,6 +87,21 @@ impl TryFrom<rpc::forge::NetworkSegmentCreationRequest> for NewNetworkSegment {
             .map(NewNetworkPrefix::try_from)
             .collect::<Result<Vec<NewNetworkPrefix>, RpcDataConversionError>>()?;
 
+        let ipv4_prefix_count = prefixes
+            .iter()
+            .filter(|prefix| prefix.prefix.is_ipv4())
+            .count();
+        let ipv6_prefix_count = prefixes
+            .iter()
+            .filter(|prefix| prefix.prefix.is_ipv6())
+            .count();
+        if ipv4_prefix_count > 1 || ipv6_prefix_count > 1 {
+            return Err(RpcDataConversionError::InvalidArgument(
+                "Network segment cannot contain more than one prefix from the same address family."
+                    .to_string(),
+            ));
+        }
+
         let id = value.id.unwrap_or_else(|| uuid::Uuid::new_v4().into());
 
         let segment_type: NetworkSegmentType = value.segment_type.rpc_try_into()?;
@@ -330,6 +345,26 @@ mod tests {
                     ],
                     NetworkSegmentType::Admin,
                 ) => Yields((2, false)),
+            }
+
+            "two IPv4 prefixes rejected" {
+                make_test_creation_request(
+                    vec![
+                        ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
+                        ipv4_prefix("198.51.100.0/24", Some("198.51.100.1")),
+                    ],
+                    NetworkSegmentType::Admin,
+                ) => Fails,
+            }
+
+            "two IPv6 prefixes rejected" {
+                make_test_creation_request(
+                    vec![
+                        ipv6_prefix("2001:db8:1::/64"),
+                        ipv6_prefix("2001:db8:2::/64"),
+                    ],
+                    NetworkSegmentType::Admin,
+                ) => Fails,
             }
 
             "tenant /64 IPv6 allowed" {


### PR DESCRIPTION
<!-- Describe what this PR does -->

Adds the additive proto, model, and schema surface needed for the IPv6 DHCP milestone without enabling DHCPv6 serving yet.

This PR is intended to be additive and inert for DHCPv4 behavior. The new wire/config/schema fields are present for later milestones, but DHCPv6 request handling and Kea/DPU DHCPv6 serving are not enabled here.

Closes #2381.

## Related issues
<!-- Refer to existing GitHub issues here -->
https://github.com/NVIDIA/infra-controller/issues/2381

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

