### PR TITLE
feat(machine-a-tron): add configurable mock MAC address pool

### DIFF
--- a/crates/api-core/src/test_support/mac_address_pool.rs
+++ b/crates/api-core/src/test_support/mac_address_pool.rs
@@ -15,31 +15,62 @@
  * limitations under the License.
  */
 
-use std::sync::atomic::{AtomicUsize, Ordering};
-
+use carbide_utils::test_support::mac_address_pool as mock_mac_pool;
 use mac_address::MacAddress;
+pub use mock_mac_pool::MacAddressPoolConfig;
 
-#[derive(Copy, Clone, Debug)]
-pub struct MacAddressPoolConfig {
-    /// The first mac address in the pool as a byte array
-    pub start: [u8; 6],
-    /// The amount of addresses in the pool
-    pub length: usize,
-}
+pub const DPU_OOB_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig = MacAddressPoolConfig {
+    start: [0x11, 0x11, 0x11, 0x11, 0x0, 0x0],
+    length: 65536,
+};
+
+pub const DPU_BMC_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig = MacAddressPoolConfig {
+    start: [0x11, 0x11, 0x22, 0x22, 0x0, 0x0],
+    length: 65536,
+};
+
+pub const HOST_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig = MacAddressPoolConfig {
+    start: [0x22, 0x22, 0x11, 0x11, 0x0, 0x0],
+    length: 65536,
+};
+
+pub const HOST_BMC_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig = MacAddressPoolConfig {
+    start: [0x22, 0x22, 0x22, 0x22, 0x0, 0x0],
+    length: 65536,
+};
+
+pub const HOST_NON_DPU_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig = MacAddressPoolConfig {
+    start: [0x33, 0x33, 0x11, 0x11, 0x0, 0x0],
+    length: 65536,
+};
+
+pub const EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig =
+    MacAddressPoolConfig {
+        start: [0x44, 0x44, 0x11, 0x11, 0x0, 0x0],
+        length: 65536,
+    };
+
+pub const EXPECTED_POWER_SHELF_BMC_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig =
+    MacAddressPoolConfig {
+        start: [0x44, 0x44, 0x22, 0x22, 0x0, 0x0],
+        length: 65536,
+    };
+
+pub const EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL_CONFIG: MacAddressPoolConfig =
+    MacAddressPoolConfig {
+        start: [0x44, 0x44, 0x33, 0x33, 0x0, 0x0],
+        length: 65536,
+    };
 
 #[derive(Debug)]
 pub struct MacAddressPool {
-    /// Defines which addresses are available in the pool
-    config: MacAddressPoolConfig,
-    /// How many addresses have already been allocated
-    used: AtomicUsize,
+    inner: mock_mac_pool::MacAddressPool,
 }
 
 impl MacAddressPool {
     pub fn new(config: MacAddressPoolConfig) -> Self {
         Self {
-            config,
-            used: AtomicUsize::new(0),
+            inner: mock_mac_pool::MacAddressPool::new(config),
         }
     }
 
@@ -47,90 +78,47 @@ impl MacAddressPool {
     ///
     /// Will panic once the pool is depleted
     pub fn allocate(&self) -> MacAddress {
-        let offset = self.used.fetch_add(1, Ordering::SeqCst);
-        if offset >= self.config.length {
-            panic!("Mac address pool with config {:?} is depleted", self.config);
-        }
-
-        let mut u64_address = to_u64_be(self.config.start);
-        u64_address += offset as u64;
-
-        let mut bytes = [0u8; 6];
-        // The MAC address is stored by `to_u64_be` stored in the last 6 bytes
-        bytes.copy_from_slice(&u64_address.to_be_bytes()[2..8]);
-
-        MacAddress::new(bytes)
+        self.inner
+            .allocate()
+            .unwrap_or_else(|error| panic!("{error}"))
     }
 
     /// Returns whether an address is part of the pool
     pub fn contains(&self, address: MacAddress) -> bool {
-        let a = to_u64_be(address.bytes());
-        let min = to_u64_be(self.config.start);
-
-        (min..min + self.config.length as u64).contains(&a)
+        self.inner.contains(address)
     }
 }
 
 lazy_static::lazy_static! {
     /// Pool of DPU MAC addresses
     pub static ref DPU_OOB_MAC_ADDRESS_POOL: MacAddressPool =
-        MacAddressPool::new(MacAddressPoolConfig {
-            start: [0x11, 0x11, 0x11, 0x11, 0x0, 0x0],
-            length: 65536,
-        });
+        MacAddressPool::new(DPU_OOB_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of DPU BMC MAC addresses
     pub static ref DPU_BMC_MAC_ADDRESS_POOL: MacAddressPool =
-    MacAddressPool::new(MacAddressPoolConfig {
-        start: [0x11, 0x11, 0x22, 0x22, 0x0, 0x0],
-        length: 65536,
-    });
+        MacAddressPool::new(DPU_BMC_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of Host MAC addresses
     pub static ref HOST_MAC_ADDRESS_POOL: MacAddressPool =
-        MacAddressPool::new(MacAddressPoolConfig {
-            start: [0x22, 0x22, 0x11, 0x11, 0x0, 0x0],
-            length: 65536,
-        });
+        MacAddressPool::new(HOST_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of Host BMC MAC addresses
     pub static ref HOST_BMC_MAC_ADDRESS_POOL: MacAddressPool =
-    MacAddressPool::new(MacAddressPoolConfig {
-        start: [0x22, 0x22, 0x22, 0x22, 0x0, 0x0],
-        length: 65536,
-    });
+        MacAddressPool::new(HOST_BMC_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of Host non-DPU MAC addresses
     pub static ref HOST_NON_DPU_MAC_ADDRESS_POOL: MacAddressPool =
-    MacAddressPool::new(MacAddressPoolConfig {
-        start: [0x33, 0x33, 0x11, 0x11, 0x0, 0x0],
-        length: 65536,
-    });
+        MacAddressPool::new(HOST_NON_DPU_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of Expected Switch BMC MAC addresses
     pub static ref EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL: MacAddressPool =
-    MacAddressPool::new(MacAddressPoolConfig {
-        start: [0x44, 0x44, 0x11, 0x11, 0x0, 0x0],
-        length: 65536,
-    });
+        MacAddressPool::new(EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of Expected Power Shelf BMC MAC addresses
     pub static ref EXPECTED_POWER_SHELF_BMC_MAC_ADDRESS_POOL: MacAddressPool =
-    MacAddressPool::new(MacAddressPoolConfig {
-        start: [0x44, 0x44, 0x22, 0x22, 0x0, 0x0],
-        length: 65536,
-    });
+        MacAddressPool::new(EXPECTED_POWER_SHELF_BMC_MAC_ADDRESS_POOL_CONFIG);
 
     /// Pool of Expected Switch NVOS MAC addresses
     pub static ref EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL: MacAddressPool =
-    MacAddressPool::new(MacAddressPoolConfig {
-        start: [0x44, 0x44, 0x33, 0x33, 0x0, 0x0],
-        length: 65536,
-    });
-}
-
-fn to_u64_be(bytes: [u8; 6]) -> u64 {
-    u64::from_be_bytes([
-        0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
-    ])
+        MacAddressPool::new(EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL_CONFIG);
 }

--- a/crates/api-core/src/tests/mac_address_pool.rs
+++ b/crates/api-core/src/tests/mac_address_pool.rs
@@ -20,7 +20,13 @@
 
 use mac_address::MacAddress;
 
-use crate::test_support::mac_address_pool::{MacAddressPool, MacAddressPoolConfig};
+use crate::test_support::mac_address_pool::{
+    DPU_BMC_MAC_ADDRESS_POOL_CONFIG, DPU_OOB_MAC_ADDRESS_POOL_CONFIG,
+    EXPECTED_POWER_SHELF_BMC_MAC_ADDRESS_POOL_CONFIG, EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL_CONFIG,
+    EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL_CONFIG, HOST_BMC_MAC_ADDRESS_POOL_CONFIG,
+    HOST_MAC_ADDRESS_POOL_CONFIG, HOST_NON_DPU_MAC_ADDRESS_POOL_CONFIG, MacAddressPool,
+    MacAddressPoolConfig,
+};
 
 #[test]
 fn allocate_addresses() {
@@ -63,4 +69,53 @@ fn depleted_pool_panics() {
         MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x16, 0x00])
     );
     pool.allocate();
+}
+
+#[test]
+fn configured_ranges_do_not_overlap() {
+    for (left_index, (left_name, left_config)) in pool_configs().iter().enumerate() {
+        for (right_name, right_config) in pool_configs().iter().skip(left_index + 1) {
+            assert!(
+                !ranges_overlap(*left_config, *right_config),
+                "{left_name} overlaps {right_name}"
+            );
+        }
+    }
+}
+
+fn pool_configs() -> [(&'static str, MacAddressPoolConfig); 8] {
+    [
+        ("dpu_oob", DPU_OOB_MAC_ADDRESS_POOL_CONFIG),
+        ("dpu_bmc", DPU_BMC_MAC_ADDRESS_POOL_CONFIG),
+        ("host", HOST_MAC_ADDRESS_POOL_CONFIG),
+        ("host_bmc", HOST_BMC_MAC_ADDRESS_POOL_CONFIG),
+        ("host_non_dpu", HOST_NON_DPU_MAC_ADDRESS_POOL_CONFIG),
+        (
+            "expected_switch_bmc",
+            EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL_CONFIG,
+        ),
+        (
+            "expected_power_shelf_bmc",
+            EXPECTED_POWER_SHELF_BMC_MAC_ADDRESS_POOL_CONFIG,
+        ),
+        (
+            "expected_switch_nvos",
+            EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL_CONFIG,
+        ),
+    ]
+}
+
+fn ranges_overlap(left: MacAddressPoolConfig, right: MacAddressPoolConfig) -> bool {
+    let left_start = to_u64_be(left.start);
+    let left_end = left_start + left.length as u64;
+    let right_start = to_u64_be(right.start);
+    let right_end = right_start + right.length as u64;
+
+    left_start < right_end && right_start < left_end
+}
+
+fn to_u64_be(bytes: [u8; 6]) -> u64 {
+    u64::from_be_bytes([
+        0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
+    ])
 }

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -22,7 +22,9 @@ use std::sync::Arc;
 use std::time::{self, Duration};
 
 use ::carbide_utils::HostPortPair;
-use ::machine_a_tron::{BmcMockRegistry, HostMachineHandle, MachineATronConfig, MachineConfig};
+use ::machine_a_tron::{
+    BmcMockRegistry, HostMachineHandle, MachineATronConfig, MachineConfig, MockMacAddressPoolConfig,
+};
 use api_test_helper::{
     IntegrationTestEnvironment, domain, instance, machine, metrics, subnet, tenant, utils, vpc,
     vpc_prefix,
@@ -914,6 +916,10 @@ where
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
         mock_bmc_ssh_port: None,
+        mock_mac_address_pool: MockMacAddressPoolConfig {
+            base_mac_address: "02:ff:00:00:00:10".parse().unwrap(),
+            length: 65536,
+        },
     };
 
     let (machine_handles, _mat_handle) = api_test_helper::machine_a_tron::run_local(

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -75,6 +75,7 @@ pub async fn run_local(
         desired_firmware
     );
 
+    let mock_mac_pool = Arc::new(app_config.mock_mac_pool());
     let app_context = Arc::new(MachineATronContext {
         bmc_registration_mode: if let Some(bmc_address_registry) = bmc_address_registry.as_ref() {
             BmcRegistrationMode::BackingInstance(bmc_address_registry.clone())
@@ -87,6 +88,7 @@ pub async fn run_local(
         api_throttler,
         desired_firmware_versions: desired_firmware,
         forge_api_client,
+        mock_mac_pool,
     });
 
     let mat = MachineATron::new(app_context.clone());

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -25,7 +25,9 @@ authors.workspace = true
 [dependencies]
 bmc-vendor = { path = "../bmc-vendor" }
 carbide-rpc = { path = "../rpc", default-features = false }
-carbide-utils = { path = "../utils", default-features = false }
+carbide-utils = { path = "../utils", default-features = false, features = [
+  "test-support",
+] }
 
 arc-swap = { workspace = true }
 axum = { workspace = true }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -38,6 +38,9 @@ pub mod test_support;
 pub mod tls;
 
 pub use bmc_state::{BmcEvent, BmcState};
+pub use carbide_utils::test_support::mac_address_pool::{
+    MacAddressPool, MacAddressPoolConfig as MockMacAddressPoolConfig, MacAddressPoolError,
+};
 pub use combined_server::{CombinedServer, ListenerOrAddress};
 pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -16,16 +16,15 @@
  */
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
+use carbide_utils::test_support::mac_address_pool::{MacAddressPool, MacAddressPoolError};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
 use crate::redfish::update_service::UpdateServiceConfig;
-use crate::{hw, redfish};
-static NEXT_MAC_ADDRESS: AtomicU32 = AtomicU32::new(1);
 use crate::{
     DUMMY_FACTORY_DPU_PASSWORD, DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostHardwareType,
+    hw, redfish,
 };
 
 /// Represents static information we know ahead of time about a host or DPU (independent of any
@@ -48,6 +47,8 @@ pub struct HostMachineInfo {
     pub nvos_mac_addresses: Vec<MacAddress>,
     #[serde(default)]
     pub switch_serial_number: Option<String>,
+    #[serde(skip)]
+    pub discovery_info: Option<rpc::machine_discovery::DiscoveryInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +60,23 @@ pub struct DpuMachineInfo {
     pub serial: String,
     #[serde(flatten)]
     pub settings: DpuSettings,
+    #[serde(skip)]
+    pub discovery_info: Option<rpc::machine_discovery::DiscoveryInfo>,
+}
+
+fn allocate_hardware_mac(mac_pool: &MacAddressPool) -> MacAddress {
+    mac_pool
+        .allocate()
+        .expect("mock MAC address pool must have host hardware addresses")
+}
+
+fn allocate_hardware_mac_array<const N: usize>(mac_pool: &MacAddressPool) -> [MacAddress; N] {
+    let addresses = (0..N)
+        .map(|_| allocate_hardware_mac(mac_pool))
+        .collect::<Vec<_>>();
+    addresses
+        .try_into()
+        .expect("fixed-size MAC allocation must match requested length")
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -91,25 +109,59 @@ impl Default for DpuSettings {
     }
 }
 
-impl Default for DpuMachineInfo {
-    fn default() -> Self {
-        Self::new(HostHardwareType::DellPowerEdgeR750, DpuSettings::default())
-    }
+pub(crate) struct MachineRedfishConfig {
+    pub manager_config: redfish::manager::Config,
+    pub system_config: redfish::computer_system::Config,
+    pub chassis_config: redfish::chassis::ChassisConfig,
+    pub update_service_config: UpdateServiceConfig,
 }
 
 impl DpuMachineInfo {
-    pub fn new(hw_type: HostHardwareType, settings: DpuSettings) -> Self {
-        let bmc_mac_address = next_mac();
-        let host_mac_address = next_mac();
-        let oob_mac_address = next_mac();
-        Self {
+    pub fn allocate(
+        hw_type: HostHardwareType,
+        settings: DpuSettings,
+        mac_pool: &MacAddressPool,
+    ) -> Result<Self, MacAddressPoolError> {
+        let bmc_mac_address = mac_pool.allocate()?;
+        let host_mac_address = mac_pool.allocate()?;
+        let oob_mac_address = mac_pool.allocate()?;
+        Ok(Self::from_known_macs(
+            hw_type,
+            bmc_mac_address,
+            host_mac_address,
+            oob_mac_address,
+            format!("MT{}", oob_mac_address.to_string().replace(':', "")),
+            settings,
+        ))
+    }
+
+    pub fn from_known_macs(
+        hw_type: HostHardwareType,
+        bmc_mac_address: MacAddress,
+        host_mac_address: MacAddress,
+        oob_mac_address: MacAddress,
+        serial: String,
+        settings: DpuSettings,
+    ) -> Self {
+        let info = Self {
             hw_type,
             bmc_mac_address,
             host_mac_address,
             oob_mac_address,
             settings,
-            serial: format!("MT{}", oob_mac_address.to_string().replace(':', "")),
+            serial,
+            discovery_info: None,
+        };
+        Self {
+            discovery_info: Some(info.bluefield3().discovery_info()),
+            ..info
         }
+    }
+
+    pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
+        self.discovery_info
+            .clone()
+            .unwrap_or_else(|| self.bluefield3().discovery_info())
     }
 
     fn bluefield3(&self) -> hw::bluefield3::Bluefield3<'_> {
@@ -148,32 +200,63 @@ impl DpuMachineInfo {
 }
 
 impl HostMachineInfo {
-    pub fn new(hw_type: HostHardwareType, dpus: Vec<DpuMachineInfo>) -> Self {
-        let bmc_mac_address = next_mac();
-        let nvos_mac_addresses = if matches!(hw_type, HostHardwareType::NvidiaSwitchNd5200Ld) {
-            vec![next_mac()]
-        } else {
-            vec![]
-        };
+    pub fn allocate(
+        hw_type: HostHardwareType,
+        dpus: Vec<DpuMachineInfo>,
+        mac_pool: &MacAddressPool,
+    ) -> Result<Self, MacAddressPoolError> {
+        let include_non_dpu_mac_address = dpus.is_empty()
+            && !matches!(
+                hw_type,
+                HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld
+            );
+        let nvos_mac_address_count =
+            usize::from(matches!(hw_type, HostHardwareType::NvidiaSwitchNd5200Ld));
+        let bmc_mac_address = mac_pool.allocate()?;
+        let non_dpu_mac_address = include_non_dpu_mac_address
+            .then(|| mac_pool.allocate())
+            .transpose()?;
+        let nvos_mac_addresses = (0..nvos_mac_address_count)
+            .map(|_| mac_pool.allocate())
+            .collect::<Result<Vec<_>, _>>()?;
         let switch_serial_number = nvos_mac_addresses
             .first()
             .map(|mac| format!("MT{}", mac.to_string().replace(':', "")));
-        Self {
+        Ok(Self::from_known_macs(
             hw_type,
             bmc_mac_address,
-            serial: bmc_mac_address.to_string().replace(':', ""),
-            non_dpu_mac_address: if dpus.is_empty()
-                && !matches!(
-                    hw_type,
-                    HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld
-                ) {
-                Some(next_mac())
-            } else {
-                None
-            },
+            bmc_mac_address.to_string().replace(':', ""),
+            dpus,
+            non_dpu_mac_address,
             nvos_mac_addresses,
             switch_serial_number,
+            mac_pool,
+        ))
+    }
+
+    pub fn from_known_macs(
+        hw_type: HostHardwareType,
+        bmc_mac_address: MacAddress,
+        serial: String,
+        dpus: Vec<DpuMachineInfo>,
+        non_dpu_mac_address: Option<MacAddress>,
+        nvos_mac_addresses: Vec<MacAddress>,
+        switch_serial_number: Option<String>,
+        mac_pool: &MacAddressPool,
+    ) -> Self {
+        let info = Self {
+            hw_type,
+            bmc_mac_address,
+            serial,
             dpus,
+            non_dpu_mac_address,
+            nvos_mac_addresses,
+            switch_serial_number,
+            discovery_info: None,
+        };
+        Self {
+            discovery_info: info.build_discovery_info(mac_pool),
+            ..info
         }
     }
 
@@ -253,104 +336,126 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
-        match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().manager_config(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().manager_config(),
-            HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().manager_config(),
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().manager_config()
-            }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
-                self.generic_server().manager_config()
-            }
-        }
-    }
-
-    pub fn system_config(
+    pub(crate) fn redfish_config(
         &self,
         callbacks: Arc<dyn crate::Callbacks>,
-    ) -> redfish::computer_system::Config {
+        mac_pool: &MacAddressPool,
+    ) -> MachineRedfishConfig {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => {
-                self.dell_poweredge_r750().system_config(callbacks)
+                let hardware = self.dell_poweredge_r750(mac_pool);
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
             }
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().system_config(callbacks),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().system_config(callbacks),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().system_config(callbacks),
+            HostHardwareType::WiwynnGB200Nvl => {
+                let hardware = self.wiwynn_gb200_nvl();
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
+            }
+            HostHardwareType::LenovoGB300Nvl => {
+                let hardware = self.lenovo_gb300_nvl(mac_pool);
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
+            }
+            HostHardwareType::NvidiaDgxGb300 => {
+                let hardware = self.dgx_gb300_nvl(mac_pool);
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
+            }
             HostHardwareType::SupermicroGb300Nvl => {
-                self.supermicro_gb300_nvl().system_config(callbacks)
+                let hardware = self.supermicro_gb300_nvl(mac_pool);
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
             }
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
+            HostHardwareType::LiteOnPowerShelf => {
+                let hardware = self.liteon_power_shelf();
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
+            }
             HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().system_config()
+                let hardware = self.nvidia_switch_nd5200_ld(mac_pool);
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
             }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
+            HostHardwareType::NvidiaDgxH100 => {
+                let hardware = self.nvidia_dgx_h100(mac_pool);
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
+            }
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
-                self.generic_server().system_config(callbacks)
+                let hardware = self.generic_server();
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
             }
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
-        match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().chassis_config(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().chassis_config(),
-            HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().chassis_config(),
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().chassis_config()
-            }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
-                self.generic_server().chassis_config()
-            }
-        }
-    }
-
-    pub fn update_service_config(&self) -> UpdateServiceConfig {
+    fn build_discovery_info(
+        &self,
+        mac_pool: &MacAddressPool,
+    ) -> Option<rpc::machine_discovery::DiscoveryInfo> {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => {
-                self.dell_poweredge_r750().update_service_config()
+                Some(self.dell_poweredge_r750(mac_pool).discovery_info())
             }
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().update_service_config(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().update_service_config(),
+            HostHardwareType::WiwynnGB200Nvl => Some(self.wiwynn_gb200_nvl().discovery_info()),
+            HostHardwareType::LenovoGB300Nvl => {
+                Some(self.lenovo_gb300_nvl(mac_pool).discovery_info())
+            }
+            HostHardwareType::NvidiaDgxGb300 => Some(self.dgx_gb300_nvl(mac_pool).discovery_info()),
             HostHardwareType::SupermicroGb300Nvl => {
-                self.supermicro_gb300_nvl().update_service_config()
+                Some(self.supermicro_gb300_nvl(mac_pool).discovery_info())
             }
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().update_service_config()
+            HostHardwareType::NvidiaDgxH100 => {
+                Some(self.nvidia_dgx_h100(mac_pool).discovery_info())
             }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
-                self.generic_server().update_service_config()
+                Some(self.generic_server().discovery_info())
             }
+            HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => None,
         }
     }
 
     pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
-        match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().discovery_info(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().discovery_info(),
-            HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().discovery_info(),
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().discovery_info(),
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
-                self.generic_server().discovery_info()
-            }
-            HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
-                panic!("discovery_info requested for {}", self.hw_type)
-            }
-        }
+        self.discovery_info
+            .clone()
+            .unwrap_or_else(|| panic!("discovery_info requested for {}", self.hw_type))
     }
 
     pub fn factory_default_account(&self) -> redfish::account_service::Account {
@@ -366,7 +471,10 @@ impl HostMachineInfo {
         )
     }
 
-    fn dell_poweredge_r750(&self) -> hw::dell_poweredge_r750::DellPowerEdgeR750<'_> {
+    fn dell_poweredge_r750(
+        &self,
+        mac_pool: &MacAddressPool,
+    ) -> hw::dell_poweredge_r750::DellPowerEdgeR750<'_> {
         let nics = if self.dpus.is_empty() {
             self.non_dpu_mac_address
                 .iter()
@@ -385,8 +493,8 @@ impl HostMachineInfo {
             product_serial_number: Cow::Borrowed(&self.serial),
             nics,
             embedded_nic: hw::dell_poweredge_r750::EmbeddedNic {
-                port_1: next_mac(),
-                port_2: next_mac(),
+                port_1: allocate_hardware_mac(mac_pool),
+                port_2: allocate_hardware_mac(mac_pool),
             },
         }
     }
@@ -435,7 +543,7 @@ impl HostMachineInfo {
         }
     }
 
-    fn dgx_gb300_nvl(&self) -> hw::dgx_gb300_nvl::DgxGB300Nvl<'_> {
+    fn dgx_gb300_nvl(&self, mac_pool: &MacAddressPool) -> hw::dgx_gb300_nvl::DgxGB300Nvl<'_> {
         let mut dpus = self.dpus.iter();
         // Serials are from the DGX GB300 scrape.
         // GPU_0/1 and GPU_2/3 share a superchip serial; the HGX baseboard
@@ -459,12 +567,12 @@ impl HostMachineInfo {
                 .expect("One DPU must present for DGX GB300 NVL")
                 .bluefield3(),
             embedded_1g_nic: hw::nic_intel_i210::NicIntelI210 {
-                mac_address: next_mac(),
+                mac_address: allocate_hardware_mac(mac_pool),
             },
-            bmc_mac_address_eth0: next_mac(),
-            bmc_mac_address_eth1: next_mac(),
-            bmc_mac_address_usb0: next_mac(),
-            hgx_bmc_mac_address_usb0: next_mac(),
+            bmc_mac_address_eth0: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_eth1: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
+            hgx_bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
             hgx_serial_number: superchip_a_sn.into(),
             topology: hw::nvidia_gbx00::Topology {
                 chassis_physical_slot_number: 25,
@@ -478,7 +586,10 @@ impl HostMachineInfo {
         }
     }
 
-    fn supermicro_gb300_nvl(&self) -> hw::supermicro_gb300_nvl::SupermicroGB300Nvl<'_> {
+    fn supermicro_gb300_nvl(
+        &self,
+        mac_pool: &MacAddressPool,
+    ) -> hw::supermicro_gb300_nvl::SupermicroGB300Nvl<'_> {
         let mut dpus = self.dpus.iter();
         // Serials are from the SMC GB300 tray scrape.
         // GPU_0/1 and GPU_2/3 share a superchip serial; the HGX baseboard
@@ -500,12 +611,12 @@ impl HostMachineInfo {
                 .expect("One DPU must present for SMC GB300 NVL")
                 .bluefield3(),
             embedded_1g_nic: hw::nic_intel_i210::NicIntelI210 {
-                mac_address: next_mac(),
+                mac_address: allocate_hardware_mac(mac_pool),
             },
-            bmc_mac_address_eth0: next_mac(),
-            bmc_mac_address_eth1: next_mac(),
-            bmc_mac_address_usb0: next_mac(),
-            hgx_bmc_mac_address_usb0: next_mac(),
+            bmc_mac_address_eth0: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_eth1: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
+            hgx_bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
             hgx_serial_number: superchip_a_sn.into(),
             topology: hw::nvidia_gbx00::Topology {
                 chassis_physical_slot_number: 25,
@@ -519,7 +630,10 @@ impl HostMachineInfo {
         }
     }
 
-    fn lenovo_gb300_nvl(&self) -> hw::lenovo_gb300_nvl::LenovoGB300Nvl<'_> {
+    fn lenovo_gb300_nvl(
+        &self,
+        mac_pool: &MacAddressPool,
+    ) -> hw::lenovo_gb300_nvl::LenovoGB300Nvl<'_> {
         let mut dpus = self.dpus.iter();
         let cpu0_sn = "0x000000017FFFFFFFFF00000000000001";
         let cpu1_sn = "0x000000017FFFFFFFFF00000000000002";
@@ -535,12 +649,12 @@ impl HostMachineInfo {
                 .expect("One DPU must present for GB300 NVL")
                 .bluefield3(),
             embedded_1g_nic: hw::nic_intel_i210::NicIntelI210 {
-                mac_address: next_mac(),
+                mac_address: allocate_hardware_mac(mac_pool),
             },
-            bmc_mac_address_eth0: next_mac(),
-            bmc_mac_address_eth1: next_mac(),
-            bmc_mac_address_usb0: next_mac(),
-            hgx_bmc_mac_address_usb0: next_mac(),
+            bmc_mac_address_eth0: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_eth1: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
+            hgx_bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
             hgx_serial_number: "012345678901234567890123".into(),
             topology: hw::nvidia_gbx00::Topology {
                 chassis_physical_slot_number: 25,
@@ -588,11 +702,14 @@ impl HostMachineInfo {
         }
     }
 
-    fn nvidia_switch_nd5200_ld(&self) -> hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld<'_> {
+    fn nvidia_switch_nd5200_ld(
+        &self,
+        mac_pool: &MacAddressPool,
+    ) -> hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld<'_> {
         hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld {
             bmc_mac_address_eth0: self.bmc_mac_address,
-            bmc_mac_address_eth1: next_mac(),
-            bmc_mac_address_usb0: next_mac(),
+            bmc_mac_address_eth1: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
             bmc_serial_number: Cow::Borrowed(&self.serial),
             switch_serial_number: self
                 .switch_serial_number
@@ -602,31 +719,37 @@ impl HostMachineInfo {
         }
     }
 
-    fn nvidia_dgx_h100(&self) -> hw::nvidia_dgx_h100::NvidiaDgxH100<'_> {
-        let storage_nic0_p0_mac = next_mac();
-        let storage_nic0_serial = format!("MT{}", storage_nic0_p0_mac.to_string().replace(":", ""));
+    fn nvidia_dgx_h100(&self, mac_pool: &MacAddressPool) -> hw::nvidia_dgx_h100::NvidiaDgxH100<'_> {
+        let ib_nics = [
+            allocate_hardware_mac_array(mac_pool),
+            allocate_hardware_mac_array(mac_pool),
+        ];
+        let mgmt_nic = allocate_hardware_mac(mac_pool);
+        let storage_nic0 = allocate_hardware_mac_array(mac_pool);
+        let storage_nic1 = allocate_hardware_mac_array(mac_pool);
+        let storage_nic0_serial = format!("MT{}", storage_nic0[0].to_string().replace(":", ""));
         hw::nvidia_dgx_h100::NvidiaDgxH100 {
             dgx_system_serial_number: Cow::Borrowed(&self.serial),
             dgx_chassis_serial_number: Cow::Borrowed("1663223000002"),
             ib_nics: [
                 hw::nic_nvidia_cx7::NicNvidiaCx7B {
                     serial_number: "MT2307X00001".into(),
-                    mac_addresses: [(); _].map(|_| next_mac()),
+                    mac_addresses: ib_nics[0],
                 },
                 hw::nic_nvidia_cx7::NicNvidiaCx7B {
                     serial_number: "MT2307X00002".into(),
-                    mac_addresses: [(); _].map(|_| next_mac()),
+                    mac_addresses: ib_nics[1],
                 },
             ],
             mgmt_nic: hw::nic_intel_x550::NicIntelX550 {
-                mac_address: next_mac(),
+                mac_address: mgmt_nic,
             },
             storage_nic0: hw::nic_nvidia_cx7::NicNvidiaCx7A {
                 serial_number: storage_nic0_serial.into(),
-                mac_addresses: [(); _].map(|_| next_mac()),
+                mac_addresses: storage_nic0,
             },
             storage_nic1: hw::nic_intel_e810::NicIntelE810 {
-                mac_addresses: [(); _].map(|_| next_mac()),
+                mac_addresses: storage_nic1,
             },
             dpu: self
                 .dpus
@@ -643,9 +766,9 @@ impl HostMachineInfo {
                 "1652900000007".into(),
                 "1652900000008".into(),
             ],
-            bmc_mac_address_eth0: next_mac(),
-            bmc_mac_address_usb0: next_mac(),
-            hgx_bmc_mac_address_usb0: next_mac(),
+            bmc_mac_address_eth0: allocate_hardware_mac(mac_pool),
+            bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
+            hgx_bmc_mac_address_usb0: allocate_hardware_mac(mac_pool),
         }
     }
 
@@ -665,6 +788,25 @@ impl HostMachineInfo {
 }
 
 impl MachineInfo {
+    pub(crate) fn redfish_config(
+        &self,
+        callbacks: Arc<dyn crate::Callbacks>,
+        mac_pool: &MacAddressPool,
+    ) -> MachineRedfishConfig {
+        match self {
+            MachineInfo::Host(host) => host.redfish_config(callbacks, mac_pool),
+            MachineInfo::Dpu(dpu) => {
+                let hardware = dpu.bluefield3();
+                MachineRedfishConfig {
+                    manager_config: hardware.manager_config(),
+                    system_config: hardware.system_config(callbacks),
+                    chassis_config: hardware.chassis_config(),
+                    update_service_config: hardware.update_service_config(),
+                }
+            }
+        }
+    }
+
     pub fn oem_state(&self) -> redfish::oem::State {
         match self {
             MachineInfo::Host(host) => host.oem_state(),
@@ -674,13 +816,6 @@ impl MachineInfo {
                     dpu.host_mac_address,
                 ),
             ),
-        }
-    }
-
-    pub fn manager_config(&self) -> redfish::manager::Config {
-        match self {
-            MachineInfo::Host(host) => host.manager_config(),
-            MachineInfo::Dpu(dpu) => dpu.bluefield3().manager_config(),
         }
     }
 
@@ -704,30 +839,6 @@ impl MachineInfo {
         match self {
             MachineInfo::Host(h) => h.bmc_product(),
             MachineInfo::Dpu(_) => Some("BlueField-3 DPU"),
-        }
-    }
-
-    pub fn system_config(
-        &self,
-        callbacks: Arc<dyn crate::Callbacks>,
-    ) -> redfish::computer_system::Config {
-        match self {
-            MachineInfo::Host(host) => host.system_config(callbacks),
-            MachineInfo::Dpu(dpu) => dpu.bluefield3().system_config(callbacks),
-        }
-    }
-
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
-        match self {
-            Self::Host(h) => h.chassis_config(),
-            Self::Dpu(dpu) => dpu.bluefield3().chassis_config(),
-        }
-    }
-
-    pub fn update_service_config(&self) -> UpdateServiceConfig {
-        match self {
-            Self::Host(h) => h.update_service_config(),
-            Self::Dpu(dpu) => dpu.bluefield3().update_service_config(),
         }
     }
 
@@ -771,7 +882,7 @@ impl MachineInfo {
     pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
         match self {
             Self::Host(h) => h.discovery_info(),
-            Self::Dpu(dpu) => dpu.bluefield3().discovery_info(),
+            Self::Dpu(dpu) => dpu.discovery_info(),
         }
     }
 
@@ -785,19 +896,6 @@ impl MachineInfo {
             ),
         }
     }
-}
-
-fn next_mac() -> MacAddress {
-    let next_mac_num = NEXT_MAC_ADDRESS.fetch_add(1, Ordering::Acquire);
-
-    let bytes: Vec<u8> = [0x02u8, 0x01]
-        .into_iter()
-        .chain(next_mac_num.to_be_bytes())
-        .collect();
-
-    let mac_bytes = <[u8; 6]>::try_from(bytes).unwrap();
-
-    MacAddress::from(mac_bytes)
 }
 
 /// CPU / GPU / IO-board chassis common to every GB300 tray: NVIDIA HGX reference
@@ -848,5 +946,78 @@ fn gb300_boards<'a>(
                 serial_number: io1.into(),
             },
         ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_utils::test_support::mac_address_pool::MacAddressPoolConfig;
+
+    use super::*;
+
+    #[test]
+    fn dpu_allocate_allocates_unique_macs_from_pool() {
+        let mac_pool = MacAddressPool::new(MacAddressPoolConfig {
+            start: [0x02, 0x01, 0x0, 0x0, 0x0, 0x1],
+            length: 8,
+        });
+        let first = DpuMachineInfo::allocate(
+            HostHardwareType::DellPowerEdgeR750,
+            Default::default(),
+            &mac_pool,
+        )
+        .unwrap();
+        let second = DpuMachineInfo::allocate(
+            HostHardwareType::DellPowerEdgeR750,
+            Default::default(),
+            &mac_pool,
+        )
+        .unwrap();
+
+        assert_ne!(first.bmc_mac_address, second.bmc_mac_address);
+        assert_ne!(first.host_mac_address, second.host_mac_address);
+        assert_ne!(first.oob_mac_address, second.oob_mac_address);
+    }
+
+    #[test]
+    fn host_allocate_allocates_unique_macs_from_pool() {
+        let mac_pool = MacAddressPool::new(MacAddressPoolConfig {
+            start: [0x02, 0x01, 0x0, 0x0, 0x0, 0x1],
+            length: 8,
+        });
+        let first =
+            HostMachineInfo::allocate(HostHardwareType::GenericAmi, vec![], &mac_pool).unwrap();
+        let second =
+            HostMachineInfo::allocate(HostHardwareType::GenericAmi, vec![], &mac_pool).unwrap();
+
+        assert_ne!(first.bmc_mac_address, second.bmc_mac_address);
+        assert_ne!(first.non_dpu_mac_address, second.non_dpu_mac_address);
+    }
+
+    #[test]
+    fn machine_info_discovery_info_is_cached() {
+        let mac_pool = MacAddressPool::new(MacAddressPoolConfig {
+            start: [0x02, 0x01, 0x0, 0x0, 0x0, 0x1],
+            length: 5,
+        });
+        let host =
+            HostMachineInfo::allocate(HostHardwareType::DellPowerEdgeR750, vec![], &mac_pool)
+                .unwrap();
+        let machine_info = MachineInfo::Host(host);
+
+        let _ = machine_info.discovery_info();
+        let _ = machine_info.discovery_info();
+
+        assert_eq!(
+            mac_pool.allocate().unwrap(),
+            MacAddress::new([0x02, 0x01, 0x0, 0x0, 0x0, 0x5])
+        );
+        assert!(matches!(
+            mac_pool.allocate(),
+            Err(MacAddressPoolError::Depleted {
+                attempted_offset: 5,
+                ..
+            })
+        ));
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -26,7 +26,8 @@ use std::sync::Arc;
 use axum::Router;
 use bmc_mock::{
     BmcCommand, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, ListenerOrAddress,
-    MachineInfo, MockPowerState, SetSystemPowerError, SystemPowerControl,
+    MacAddressPool, MachineInfo, MockMacAddressPoolConfig, MockPowerState, SetSystemPowerError,
+    SystemPowerControl,
 };
 use tar_router::TarGzOption;
 use tokio::sync::{RwLock, mpsc};
@@ -155,17 +156,42 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
 fn default_host_mock() -> Router {
     let command_channel = spawn_qemu_reboot_handler();
     let callbacks = Arc::new(ChannelCallbacks::new(command_channel));
-    bmc_mock::machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+    let mac_pool = default_mock_mac_pool();
+    let dpus = vec![
+        DpuMachineInfo::allocate(
             HostHardwareType::WiwynnGB200Nvl,
-            vec![DpuMachineInfo::default(), DpuMachineInfo::default()],
-        )),
+            Default::default(),
+            &mac_pool,
+        )
+        .expect("default mock MAC address pool must have DPU addresses"),
+        DpuMachineInfo::allocate(
+            HostHardwareType::WiwynnGB200Nvl,
+            Default::default(),
+            &mac_pool,
+        )
+        .expect("default mock MAC address pool must have DPU addresses"),
+    ];
+    bmc_mock::machine_router(
+        MachineInfo::Host(
+            HostMachineInfo::allocate(HostHardwareType::WiwynnGB200Nvl, dpus, &mac_pool)
+                .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         callbacks,
         String::default(),
         false,
     )
     .0
 }
+
+fn default_mock_mac_pool() -> MacAddressPool {
+    MacAddressPool::new(DEFAULT_MOCK_MAC_POOL_CONFIG)
+}
+
+const DEFAULT_MOCK_MAC_POOL_CONFIG: MockMacAddressPoolConfig = MockMacAddressPoolConfig {
+    start: [0x02, 0x01, 0x0, 0x0, 0x0, 0x1],
+    length: u32::MAX as usize,
+};
 
 #[derive(Debug)]
 struct ChannelCallbacks {

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -24,8 +24,8 @@ use crate::bmc_state::BmcState;
 use crate::injection::InjectionStore;
 use crate::redfish::manager::ManagerState;
 use crate::{
-    Callbacks, HostHardwareType, MachineInfo, SystemPowerControl, auth_router, middleware_router,
-    redfish,
+    Callbacks, HostHardwareType, MacAddressPool, MachineInfo, SystemPowerControl, auth_router,
+    middleware_router, redfish,
 };
 
 #[derive(Debug)]
@@ -63,13 +63,12 @@ impl AddRoutes for Router<BmcState> {
 /// the provided MachineInfo.
 pub fn machine_router(
     machine_info: MachineInfo,
+    mac_pool: &MacAddressPool,
     callbacks: Arc<dyn Callbacks>,
     mat_host_id: String,
     redfish_auth: bool,
 ) -> (Router, BmcState) {
-    let system_config = machine_info.system_config(callbacks.clone());
-    let chassis_config = machine_info.chassis_config();
-    let update_service_config = machine_info.update_service_config();
+    let redfish_config = machine_info.redfish_config(callbacks.clone(), mac_pool);
     let bmc_vendor = machine_info.bmc_vendor();
     let bmc_product = machine_info.bmc_product();
     let bmc_redfish_version = machine_info.bmc_redfish_version();
@@ -92,15 +91,17 @@ pub fn machine_router(
         }
         MachineInfo::Host(_) => router.add_routes(crate::redfish::oem::dell::idrac::add_routes),
     };
-    let manager = Arc::new(ManagerState::new(&machine_info.manager_config()));
+    let manager = Arc::new(ManagerState::new(&redfish_config.manager_config));
     let system_state = Arc::new(crate::redfish::computer_system::SystemState::from_config(
-        system_config,
+        redfish_config.system_config,
     ));
     let chassis_state = Arc::new(crate::redfish::chassis::ChassisState::from_config(
-        chassis_config,
+        redfish_config.chassis_config,
     ));
     let update_service_state = Arc::new(
-        crate::redfish::update_service::UpdateServiceState::from_config(update_service_config),
+        crate::redfish::update_service::UpdateServiceState::from_config(
+            redfish_config.update_service_config,
+        ),
     );
     let account_service_state = Arc::new(
         crate::redfish::account_service::AccountServiceState::new(factory_default_account),

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -256,17 +256,36 @@ mod tests {
 
     fn test_host_mock() -> Router {
         let callbacks = Arc::new(TestCallbacks {});
-        crate::machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
+        let mac_pool = default_mock_mac_pool();
+        let dpus = vec![
+            DpuMachineInfo::allocate(
                 HostHardwareType::DellPowerEdgeR750,
-                vec![DpuMachineInfo::default()],
-            )),
+                Default::default(),
+                &mac_pool,
+            )
+            .expect("default mock MAC address pool must have DPU addresses"),
+        ];
+        crate::machine_router(
+            MachineInfo::Host(
+                HostMachineInfo::allocate(HostHardwareType::DellPowerEdgeR750, dpus, &mac_pool)
+                    .expect("default mock MAC address pool must have host addresses"),
+            ),
+            &mac_pool,
             callbacks,
             String::default(),
             false,
         )
         .0
     }
+
+    fn default_mock_mac_pool() -> MacAddressPool {
+        MacAddressPool::new(DEFAULT_MOCK_MAC_POOL_CONFIG)
+    }
+
+    const DEFAULT_MOCK_MAC_POOL_CONFIG: MockMacAddressPoolConfig = MockMacAddressPoolConfig {
+        start: [0x02, 0x01, 0x0, 0x0, 0x0, 0x1],
+        length: u32::MAX as usize,
+    };
 
     #[tokio::test]
     async fn test_expand() {

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -22,8 +22,9 @@ use url::Url;
 
 use crate::machine_info::DpuSettings;
 use crate::{
-    BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
-    MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
+    BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MacAddressPool,
+    MachineInfo, MockMacAddressPoolConfig, MockPowerState, SetSystemPowerError, SystemPowerControl,
+    machine_router,
 };
 pub mod axum_http_client;
 
@@ -71,15 +72,40 @@ async fn test_bmc((router, state): (axum::Router, BmcState)) -> TestBmcHandle {
     }
 }
 
+fn default_mock_mac_pool() -> MacAddressPool {
+    MacAddressPool::new(DEFAULT_MOCK_MAC_POOL_CONFIG)
+}
+
+const DEFAULT_MOCK_MAC_POOL_CONFIG: MockMacAddressPoolConfig = MockMacAddressPoolConfig {
+    start: [0x02, 0x01, 0x0, 0x0, 0x0, 0x1],
+    length: u32::MAX as usize,
+};
+
 pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::WiwynnGB200Nvl,
-            vec![
-                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-            ],
-        )),
+        MachineInfo::Host(
+            HostMachineInfo::allocate(
+                HostHardwareType::WiwynnGB200Nvl,
+                vec![
+                    DpuMachineInfo::allocate(
+                        HostHardwareType::WiwynnGB200Nvl,
+                        DpuSettings::default(),
+                        &mac_pool,
+                    )
+                    .expect("default mock MAC address pool must have DPU addresses"),
+                    DpuMachineInfo::allocate(
+                        HostHardwareType::WiwynnGB200Nvl,
+                        DpuSettings::default(),
+                        &mac_pool,
+                    )
+                    .expect("default mock MAC address pool must have DPU addresses"),
+                ],
+                &mac_pool,
+            )
+            .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -88,14 +114,24 @@ pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
 }
 
 pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::LenovoGB300Nvl,
-            vec![DpuMachineInfo::new(
+        MachineInfo::Host(
+            HostMachineInfo::allocate(
                 HostHardwareType::LenovoGB300Nvl,
-                DpuSettings::default(),
-            )],
-        )),
+                vec![
+                    DpuMachineInfo::allocate(
+                        HostHardwareType::LenovoGB300Nvl,
+                        DpuSettings::default(),
+                        &mac_pool,
+                    )
+                    .expect("default mock MAC address pool must have DPU addresses"),
+                ],
+                &mac_pool,
+            )
+            .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -104,14 +140,24 @@ pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
 }
 
 pub async fn dgx_gb300_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::NvidiaDgxGb300,
-            vec![DpuMachineInfo::new(
+        MachineInfo::Host(
+            HostMachineInfo::allocate(
                 HostHardwareType::NvidiaDgxGb300,
-                DpuSettings::default(),
-            )],
-        )),
+                vec![
+                    DpuMachineInfo::allocate(
+                        HostHardwareType::NvidiaDgxGb300,
+                        DpuSettings::default(),
+                        &mac_pool,
+                    )
+                    .expect("default mock MAC address pool must have DPU addresses"),
+                ],
+                &mac_pool,
+            )
+            .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -120,14 +166,24 @@ pub async fn dgx_gb300_bmc() -> TestBmcHandle {
 }
 
 pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::SupermicroGb300Nvl,
-            vec![DpuMachineInfo::new(
+        MachineInfo::Host(
+            HostMachineInfo::allocate(
                 HostHardwareType::SupermicroGb300Nvl,
-                DpuSettings::default(),
-            )],
-        )),
+                vec![
+                    DpuMachineInfo::allocate(
+                        HostHardwareType::SupermicroGb300Nvl,
+                        DpuSettings::default(),
+                        &mac_pool,
+                    )
+                    .expect("default mock MAC address pool must have DPU addresses"),
+                ],
+                &mac_pool,
+            )
+            .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -136,11 +192,13 @@ pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
 }
 
 pub async fn generic_supermicro_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::GenericSupermicro,
-            vec![],
-        )),
+        MachineInfo::Host(
+            HostMachineInfo::allocate(HostHardwareType::GenericSupermicro, vec![], &mac_pool)
+                .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -149,11 +207,13 @@ pub async fn generic_supermicro_bmc() -> TestBmcHandle {
 }
 
 pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::LiteOnPowerShelf,
-            vec![],
-        )),
+        MachineInfo::Host(
+            HostMachineInfo::allocate(HostHardwareType::LiteOnPowerShelf, vec![], &mac_pool)
+                .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -162,11 +222,13 @@ pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
 }
 
 pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::NvidiaSwitchNd5200Ld,
-            vec![],
-        )),
+        MachineInfo::Host(
+            HostMachineInfo::allocate(HostHardwareType::NvidiaSwitchNd5200Ld, vec![], &mac_pool)
+                .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -175,11 +237,13 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
 }
 
 pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::DellPowerEdgeR750,
-            vec![],
-        )),
+        MachineInfo::Host(
+            HostMachineInfo::allocate(HostHardwareType::DellPowerEdgeR750, vec![], &mac_pool)
+                .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -188,11 +252,13 @@ pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
 }
 
 pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Dpu(DpuMachineInfo::new(
-            HostHardwareType::DellPowerEdgeR750,
-            settings,
-        )),
+        MachineInfo::Dpu(
+            DpuMachineInfo::allocate(HostHardwareType::DellPowerEdgeR750, settings, &mac_pool)
+                .expect("default mock MAC address pool must have DPU addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
         false,
@@ -201,8 +267,13 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
 }
 
 pub async fn generic_ami_bmc() -> TestBmcHandle {
+    let mac_pool = default_mock_mac_pool();
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(HostHardwareType::GenericAmi, vec![])),
+        MachineInfo::Host(
+            HostMachineInfo::allocate(HostHardwareType::GenericAmi, vec![], &mac_pool)
+                .expect("default mock MAC address pool must have host addresses"),
+        ),
+        &mac_pool,
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -222,12 +293,18 @@ mod test {
 
     #[tokio::test]
     async fn transport_supports_expand_query_through_mock_expander() {
+        let mac_pool = default_mock_mac_pool();
         let client = AxumRouterHttpClient::new(
             machine_router(
-                MachineInfo::Host(HostMachineInfo::new(
-                    HostHardwareType::DellPowerEdgeR750,
-                    vec![],
-                )),
+                MachineInfo::Host(
+                    HostMachineInfo::allocate(
+                        HostHardwareType::DellPowerEdgeR750,
+                        vec![],
+                        &mac_pool,
+                    )
+                    .expect("default mock MAC address pool must have host addresses"),
+                ),
+                &mac_pool,
                 Arc::new(NoopCallbacks),
                 "test-host-id".to_string(),
                 false,

--- a/crates/machine-a-tron/Cargo.toml
+++ b/crates/machine-a-tron/Cargo.toml
@@ -46,7 +46,7 @@ thiserror = { workspace = true }
 axum = { workspace = true }
 crossterm = { features = ["event-stream"], workspace = true }
 ratatui = { workspace = true }
-mac_address = { workspace = true }
+mac_address = { features = ["serde"], workspace = true }
 futures = { workspace = true }
 figment = { features = ["toml"], workspace = true }
 reqwest = { default-features = false, features = [
@@ -63,8 +63,8 @@ rand = { workspace = true }
 russh = { workspace = true }
 
 # [local-dependencies]
-carbide-rpc = { path = "../rpc" }
 bmc-mock = { path = "../bmc-mock" }
+carbide-rpc = { path = "../rpc" }
 carbide-tls = { path = "../tls" }
 carbide-version = { path = "../version" }
 carbide-uuid = { path = "../uuid" }

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -51,8 +51,13 @@ impl BmcMockWrapper {
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
     ) -> Self {
-        let (bmc_mock_router, bmc_mock_state) =
-            bmc_mock::machine_router(machine_info.clone(), callbacks, host_id.to_string(), true);
+        let (bmc_mock_router, bmc_mock_state) = bmc_mock::machine_router(
+            machine_info.clone(),
+            &app_context.mock_mac_pool,
+            callbacks,
+            host_id.to_string(),
+            true,
+        );
 
         BmcMockWrapper {
             machine_info,

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -20,7 +20,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo};
+use bmc_mock::{
+    DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo, MacAddressPool,
+    MockMacAddressPoolConfig as BmcMockMacAddressPoolConfig,
+};
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
 use duration_str::deserialize_duration;
@@ -191,6 +194,9 @@ pub struct MachineATronConfig {
     #[serde(default = "default_bmc_mock_port")]
     pub bmc_mock_port: u16,
 
+    #[serde(default = "default_mock_mac_address_pool_config")]
+    pub mock_mac_address_pool: MockMacAddressPoolConfig,
+
     /// Set this to true if you want each mock machine to run a mock BMC ssh server. This is useful
     /// for testing things like ssh-console.
     #[serde(default = "default_false")]
@@ -249,7 +255,26 @@ pub struct MachineATronConfig {
     pub api_refresh_interval: Duration,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct MockMacAddressPoolConfig {
+    pub base_mac_address: MacAddress,
+    pub length: usize,
+}
+
+impl From<MockMacAddressPoolConfig> for BmcMockMacAddressPoolConfig {
+    fn from(value: MockMacAddressPoolConfig) -> Self {
+        Self {
+            start: value.base_mac_address.bytes(),
+            length: value.length,
+        }
+    }
+}
+
 impl MachineATronConfig {
+    pub fn mock_mac_pool(&self) -> MacAddressPool {
+        MacAddressPool::new(self.mock_mac_address_pool.into())
+    }
+
     pub fn read_persisted_machines(
         &self,
     ) -> eyre::Result<Option<HashMap<String, Vec<PersistedHostMachine>>>> {
@@ -337,17 +362,18 @@ pub struct PersistedHostMachine {
     pub bmc_dhcp_id: Uuid,
 }
 
-impl From<PersistedHostMachine> for HostMachineInfo {
-    fn from(value: PersistedHostMachine) -> Self {
-        Self {
-            hw_type: value.hw_type.unwrap_or_default(),
-            bmc_mac_address: value.bmc_mac_address,
-            serial: value.serial,
-            dpus: value.dpus.into_iter().map(Into::into).collect(),
-            non_dpu_mac_address: value.non_dpu_mac_address,
-            nvos_mac_addresses: value.nvos_mac_addresses,
-            switch_serial_number: value.switch_serial_number,
-        }
+impl PersistedHostMachine {
+    pub fn into_host_info(self, mac_pool: &MacAddressPool) -> HostMachineInfo {
+        HostMachineInfo::from_known_macs(
+            self.hw_type.unwrap_or_default(),
+            self.bmc_mac_address,
+            self.serial,
+            self.dpus.into_iter().map(Into::into).collect(),
+            self.non_dpu_mac_address,
+            self.nvos_mac_addresses,
+            self.switch_serial_number,
+            mac_pool,
+        )
     }
 }
 
@@ -369,19 +395,26 @@ pub struct PersistedDpuMachine {
 
 impl From<PersistedDpuMachine> for DpuMachineInfo {
     fn from(value: PersistedDpuMachine) -> Self {
-        Self {
-            hw_type: value.hw_type.unwrap_or_default(),
-            bmc_mac_address: value.bmc_mac_address,
-            host_mac_address: value.host_mac_address,
-            oob_mac_address: value.oob_mac_address,
-            serial: value.serial,
-            settings: value.settings,
-        }
+        DpuMachineInfo::from_known_macs(
+            value.hw_type.unwrap_or_default(),
+            value.bmc_mac_address,
+            value.host_mac_address,
+            value.oob_mac_address,
+            value.serial,
+            value.settings,
+        )
     }
 }
 
 fn default_bmc_mock_port() -> u16 {
     2000
+}
+
+fn default_mock_mac_address_pool_config() -> MockMacAddressPoolConfig {
+    MockMacAddressPoolConfig {
+        base_mac_address: MacAddress::new([0x02, 0xaa, 0x0, 0x0, 0x0, 0x1]),
+        length: u32::MAX as usize,
+    }
 }
 
 fn default_template_dir() -> String {
@@ -433,6 +466,7 @@ pub struct MachineATronContext {
     /// firmware, DPU's can mock that they already have this installed.
     pub desired_firmware_versions: Vec<DesiredFirmwareVersionEntry>,
     pub forge_api_client: ForgeApiClient,
+    pub mock_mac_pool: Arc<MacAddressPool>,
 }
 
 impl MachineATronContext {
@@ -515,5 +549,44 @@ scout_run_interval = "5s"
         let round_tripped = toml::from_str::<MachineATronConfig>(&serialized)
             .expect("Could not deserialize serialized config");
         assert_eq!(round_tripped, cfg);
+        assert_eq!(
+            cfg.mock_mac_address_pool,
+            default_mock_mac_address_pool_config()
+        );
+    }
+
+    #[test]
+    fn test_configures_mock_mac_address_pool() {
+        let cfg_str = r#"
+carbide_api_url = "https://carbide-api.forge:443"
+log_file = "mat.log"
+interface = "br-77cbb29de011"
+bmc_mock_port = 1266
+mock_mac_address_pool = { base_mac_address = "02:aa:00:00:00:10", length = 32 }
+configure_carbide_bmc_proxy_host = "192.168.1.20"
+
+[machines.config]
+host_count = 1
+dpu_per_host_count = 1
+dpu_reboot_delay = 1
+host_reboot_delay = 1
+vpc_count = 0
+admin_dhcp_relay_address = "192.168.176.1"
+oob_dhcp_relay_address = "192.168.192.1"
+subnets_per_vpc = 0
+    "#;
+
+        let cfg = toml::from_str::<MachineATronConfig>(cfg_str).expect("Could not parse config");
+        assert_eq!(
+            cfg.mock_mac_address_pool,
+            MockMacAddressPoolConfig {
+                base_mac_address: "02:aa:00:00:00:10".parse().unwrap(),
+                length: 32,
+            }
+        );
+        assert_eq!(
+            cfg.mock_mac_pool().allocate().unwrap(),
+            "02:aa:00:00:00:10".parse().unwrap()
+        );
     }
 }

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -70,14 +70,7 @@ impl DpuMachine {
         let dpu_index = persisted_dpu_machine.dpu_index;
         let (bmc_control_tx, bmc_control_rx) = mpsc::unbounded_channel();
 
-        let dpu_info = DpuMachineInfo {
-            hw_type: persisted_dpu_machine.hw_type.unwrap_or_default(),
-            bmc_mac_address: persisted_dpu_machine.bmc_mac_address,
-            host_mac_address: persisted_dpu_machine.host_mac_address,
-            oob_mac_address: persisted_dpu_machine.oob_mac_address,
-            serial: persisted_dpu_machine.serial.clone(),
-            settings: persisted_dpu_machine.settings.clone(),
-        };
+        let dpu_info = persisted_dpu_machine.clone().into();
         let state_machine = MachineStateMachine::from_persisted(
             PersistedMachine::Dpu(persisted_dpu_machine),
             config,
@@ -127,14 +120,16 @@ impl DpuMachine {
             .unwrap_or_default()
             .fill_missing_from_desired_firmware(&app_context.desired_firmware_versions);
 
-        let dpu_info = DpuMachineInfo::new(
+        let dpu_info = DpuMachineInfo::allocate(
             hw_type,
             DpuSettings {
                 nic_mode: config.dpus_in_nic_mode,
                 firmware_versions: firmware_versions.into(),
                 ..Default::default()
             },
-        );
+            &app_context.mock_mac_pool,
+        )
+        .expect("machine-a-tron mock MAC address pool must have DPU addresses");
         let state_machine = MachineStateMachine::new(
             MachineInfo::Dpu(dpu_info.clone()),
             config,

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -90,20 +90,9 @@ impl HostMachine {
                 )
             })
             .collect::<Vec<_>>();
-        let host_info = HostMachineInfo {
-            hw_type: persisted_host_machine.hw_type.unwrap_or_default(),
-            bmc_mac_address: persisted_host_machine.bmc_mac_address,
-            serial: persisted_host_machine.serial.clone(),
-            dpus: persisted_host_machine
-                .dpus
-                .iter()
-                .cloned()
-                .map(Into::into)
-                .collect(),
-            non_dpu_mac_address: persisted_host_machine.non_dpu_mac_address,
-            nvos_mac_addresses: persisted_host_machine.nvos_mac_addresses.clone(),
-            switch_serial_number: persisted_host_machine.switch_serial_number.clone(),
-        };
+        let host_info = persisted_host_machine
+            .clone()
+            .into_host_info(&app_context.mock_mac_pool);
         let dpus = dpu_machines
             .into_iter()
             .map(|d| d.start(true))
@@ -175,10 +164,12 @@ impl HostMachine {
                 )
             })
             .collect::<Vec<_>>();
-        let host_info = HostMachineInfo::new(
+        let host_info = HostMachineInfo::allocate(
             config.hw_type,
             dpu_machines.iter().map(|d| d.dpu_info().clone()).collect(),
-        );
+            &app_context.mock_mac_pool,
+        )
+        .expect("machine-a-tron mock MAC address pool must have host addresses");
         let dpus = dpu_machines
             .into_iter()
             .map(|d| d.start(true))

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -36,8 +36,8 @@ use std::time::{Duration, Instant};
 
 pub use bmc_mock_wrapper::BmcMockRegistry;
 pub use config::{
-    MachineATronArgs, MachineATronConfig, MachineATronContext, MachineConfig, PersistedDpuMachine,
-    PersistedHostMachine,
+    MachineATronArgs, MachineATronConfig, MachineATronContext, MachineConfig,
+    MockMacAddressPoolConfig, PersistedDpuMachine, PersistedHostMachine,
 };
 pub use dpu_machine::DpuMachineHandle;
 pub use host_machine::HostMachineHandle;

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -23,9 +23,9 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::{
-    BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostMachineInfo,
-    HostnameQuerying, MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError,
-    SetSystemPowerResult, SystemPowerControl,
+    BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostnameQuerying,
+    MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
+    SystemPowerControl,
 };
 use carbide_network::virtualization::build_dual_stack_list;
 use carbide_uuid::machine::MachineId;
@@ -219,28 +219,26 @@ impl MachineStateMachine {
     ) -> MachineStateMachine {
         let (initial_os_image, tpm_ek_certificate, bmc_dhcp_id, machine_dhcp_id, machine_info) =
             match persisted_machine {
-                PersistedMachine::Host(h) => (
-                    h.installed_os,
-                    h.tpm_ek_certificate,
-                    h.bmc_dhcp_id,
-                    h.machine_dhcp_id,
-                    MachineInfo::Host(HostMachineInfo {
-                        hw_type: h.hw_type.unwrap_or_default(),
-                        bmc_mac_address: h.bmc_mac_address,
-                        serial: h.serial,
-                        dpus: h.dpus.into_iter().map(Into::into).collect(),
-                        non_dpu_mac_address: h.non_dpu_mac_address,
-                        nvos_mac_addresses: h.nvos_mac_addresses,
-                        switch_serial_number: h.switch_serial_number,
-                    }),
-                ),
-                PersistedMachine::Dpu(d) => (
-                    d.installed_os,
-                    None,
-                    d.bmc_dhcp_id,
-                    d.machine_dhcp_id,
-                    MachineInfo::Dpu(d.into()),
-                ),
+                PersistedMachine::Host(h) => {
+                    let host_info = h.clone().into_host_info(&app_context.mock_mac_pool);
+                    (
+                        h.installed_os,
+                        h.tpm_ek_certificate,
+                        h.bmc_dhcp_id,
+                        h.machine_dhcp_id,
+                        MachineInfo::Host(host_info),
+                    )
+                }
+                PersistedMachine::Dpu(d) => {
+                    let dpu_info = d.clone().into();
+                    (
+                        d.installed_os,
+                        None,
+                        d.bmc_dhcp_id,
+                        d.machine_dhcp_id,
+                        MachineInfo::Dpu(dpu_info),
+                    )
+                }
             };
         let (fsm, actions) = MachineFsm::init(true, Self::is_bmc_only(&machine_info, &config));
         MachineStateMachine {

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -136,6 +136,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let bmc_mock_port = app_config.bmc_mock_port;
     let tui_enabled = app_config.tui_enabled;
+    let mock_mac_pool = Arc::new(app_config.mock_mac_pool());
 
     let app_context = Arc::new(MachineATronContext {
         app_config,
@@ -145,6 +146,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         api_throttler,
         desired_firmware_versions,
         forge_api_client,
+        mock_mac_pool,
     });
 
     let info = app_context.forge_api_client.version(false).await?;

--- a/crates/utils/src/test_support/mac_address_pool.rs
+++ b/crates/utils/src/test_support/mac_address_pool.rs
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::fmt;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use mac_address::MacAddress;
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct MacAddressPoolConfig {
+    /// The first MAC address in the pool as a byte array.
+    pub start: [u8; 6],
+    /// The number of addresses in the pool.
+    pub length: usize,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum MacAddressPoolError {
+    Depleted {
+        config: MacAddressPoolConfig,
+        attempted_offset: usize,
+    },
+}
+
+impl fmt::Display for MacAddressPoolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MacAddressPoolError::Depleted { config, .. } => {
+                write!(f, "Mac address pool with config {config:?} is depleted")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MacAddressPoolError {}
+
+#[derive(Debug)]
+pub struct MacAddressPool {
+    config: MacAddressPoolConfig,
+    used: AtomicUsize,
+}
+
+impl MacAddressPool {
+    pub const fn new(config: MacAddressPoolConfig) -> Self {
+        Self {
+            config,
+            used: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn config(&self) -> MacAddressPoolConfig {
+        self.config
+    }
+
+    pub fn allocate(&self) -> Result<MacAddress, MacAddressPoolError> {
+        loop {
+            let offset = self.used.load(Ordering::SeqCst);
+            if offset >= self.config.length {
+                return Err(MacAddressPoolError::Depleted {
+                    config: self.config,
+                    attempted_offset: offset,
+                });
+            }
+
+            if self
+                .used
+                .compare_exchange(offset, offset + 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return Ok(mac_address_at_offset(self.config.start, offset));
+            }
+        }
+    }
+
+    pub fn contains(&self, address: MacAddress) -> bool {
+        let address = to_u64_be(address.bytes());
+        let min = to_u64_be(self.config.start);
+        let Some(max) = min.checked_add(self.config.length as u64) else {
+            return false;
+        };
+
+        (min..max).contains(&address)
+    }
+}
+
+fn mac_address_at_offset(start: [u8; 6], offset: usize) -> MacAddress {
+    let u64_address = to_u64_be(start) + offset as u64;
+    let mut bytes = [0u8; 6];
+    bytes.copy_from_slice(&u64_address.to_be_bytes()[2..8]);
+    MacAddress::new(bytes)
+}
+
+fn to_u64_be(bytes: [u8; 6]) -> u64 {
+    u64::from_be_bytes([
+        0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5],
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocate_addresses() {
+        let pool = MacAddressPool::new(MacAddressPoolConfig {
+            start: [0x11, 0x12, 0x13, 0x14, 0x15, 0x1],
+            length: 256,
+        });
+        assert!(!pool.contains(MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x15, 0])));
+
+        for i in 1..=255 {
+            let expected = MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x15, i as u8]);
+            assert_eq!(pool.allocate().unwrap(), expected);
+            assert!(pool.contains(expected));
+        }
+        let expected = MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x16, 0]);
+        assert_eq!(pool.allocate().unwrap(), expected);
+        assert!(pool.contains(expected));
+        assert!(!pool.contains(MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x16, 1])));
+    }
+
+    #[test]
+    fn depleted_pool_returns_error() {
+        let config = MacAddressPoolConfig {
+            start: [0x11, 0x12, 0x13, 0x14, 0x15, 0xFF],
+            length: 2,
+        };
+        let pool = MacAddressPool::new(config);
+
+        assert_eq!(
+            pool.allocate().unwrap(),
+            MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x15, 0xFF])
+        );
+        assert_eq!(
+            pool.allocate().unwrap(),
+            MacAddress::new([0x11, 0x12, 0x13, 0x14, 0x16, 0x00])
+        );
+        assert_eq!(
+            pool.allocate(),
+            Err(MacAddressPoolError::Depleted {
+                config,
+                attempted_offset: 2,
+            })
+        );
+    }
+}

--- a/crates/utils/src/test_support/mod.rs
+++ b/crates/utils/src/test_support/mod.rs
@@ -16,4 +16,5 @@
  */
 
 pub mod certs;
+pub mod mac_address_pool;
 pub mod test_meter;


### PR DESCRIPTION
Extract mock MAC allocation into a shared allocator crate and thread an explicit pool through bmc-mock and machine-a-tron. Use the pool for mock machine, hardware, Redfish, and discovery MAC generation, and add machine-a-tron config for customizing the mock MAC address range.

## Related issues

#2617 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

