### PR TITLE
fix(nvlink): Multicast group limit attribute, when creating a partiti…

### DIFF
--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -62,9 +62,10 @@ use tracing::Instrument;
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
 
-/// Multicast groups limit for new NMX-C partitions. Assuming at most 2 partitions per tray and
-// 18 tray default partitions, this is set to floor(1024 / (36+18)).
-const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / (36 + 18);
+/// Multicast groups limit for new NMX-C partitions. Must be a multiple of 4. Assuming at most 2
+/// partitions per tray and 18 tray default partitions, this is floor(1024 / (36+18)) rounded down
+/// to the nearest multiple of 4.
+const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 16;
 
 fn rack_id_from_chassis_snapshots(
     chassis_snapshots: &[&ManagedHostStateSnapshot],


### PR DESCRIPTION
…on, needs to be a multiple of 4.

<!-- Describe what this PR does -->
GB200 NVL partition multicast group limit setting has an additional constraint that the value must be 0 or a multiple of 4. The formula previously used to calculate the default limit was evaluating to a value of 18. This  PR rounds it down to nearest multiple of 4.
NMX-C simulator used for pre-integration testing does not check for this contraint.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

