### PR TITLE
feat(dhcp): include the host's IPv6 DNS resolvers in the agent's DHCP config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "carbide-rpc",
  "carbide-rpc-utils",
  "carbide-systemd",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -131,6 +131,7 @@ carbide-version = { path = "../version" }
 tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 ctor = { workspace = true }
 prost = { workspace = true }
 rustls-pemfile = { workspace = true }

--- a/crates/agent/src/dhcp.rs
+++ b/crates/agent/src/dhcp.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use ::rpc::forge as rpc;
 use carbide_rpc_utils::dhcp::HostConfig;
@@ -64,12 +64,14 @@ pub fn build_server_config(
     pxe_ip: Ipv4Addr,
     ntpservers: Vec<Ipv4Addr>,
     nameservers: Vec<Ipv4Addr>,
+    nameservers_v6: Vec<Ipv6Addr>,
     loopback_ip: Ipv4Addr,
 ) -> Result<String, eyre::Report> {
     let dhcp_config = carbide_rpc_utils::dhcp::DhcpConfig::from_forge_dhcp_config(
         pxe_ip,
         ntpservers,
         nameservers,
+        nameservers_v6,
         loopback_ip,
     )?;
 

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fs::File;
 use std::io::Read;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
@@ -136,6 +136,21 @@ pub struct ServiceAddresses {
     pub pxe_ips: Vec<IpAddr>,
     pub ntpservers: Vec<IpAddr>,
     pub nameservers: Vec<IpAddr>,
+}
+
+/// Split a dual-stack nameserver list into its IPv4 and IPv6 members, so the
+/// gRPC and file-write DHCP-config paths derive both families the same way.
+fn split_nameservers_by_family(nameservers: &[IpAddr]) -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+    nameservers
+        .iter()
+        .copied()
+        .fold((Vec::new(), Vec::new()), |(mut v4, mut v6), addr| {
+            match addr {
+                IpAddr::V4(v4_addr) => v4.push(v4_addr),
+                IpAddr::V6(v6_addr) => v6.push(v6_addr),
+            }
+            (v4, v6)
+        })
 }
 
 fn build_dhcp_ntp_servers(
@@ -1066,14 +1081,7 @@ async fn update_dhcp_via_grpc(
     };
     let loopback_ip: Ipv4Addr = mh_nc.loopback_ip.parse()?;
 
-    let nameservers_v4 = service_addrs
-        .nameservers
-        .iter()
-        .filter_map(|x| match x {
-            IpAddr::V4(x) => Some(*x),
-            _ => None,
-        })
-        .collect::<Vec<Ipv4Addr>>();
+    let (nameservers_v4, nameservers_v6) = split_nameservers_by_family(&service_addrs.nameservers);
 
     let ntpservers_v4 = build_dhcp_ntp_servers(network_config, service_addrs);
 
@@ -1095,6 +1103,7 @@ async fn update_dhcp_via_grpc(
         pxe_ip_v4,
         ntpservers_v4,
         nameservers_v4,
+        nameservers_v6,
         loopback_ip,
     )?;
     let mut host_config = carbide_rpc_utils::dhcp::HostConfig::try_from(
@@ -1471,18 +1480,10 @@ fn write_dhcp_v4_server_config(
 
     let loopback_ip = mh_nc.loopback_ip.parse()?;
 
-    // Filter to IPv4, since this is specifically for the DHCPv4 server
-    // config, and the input ServiceAddresses holds both families.
-    // Again, we'll eventually have a specific builder for a DHCPv6
-    // that does similar things with ServiceAddresses, but for IPv6.
-    let nameservers_v4 = service_addrs
-        .nameservers
-        .iter()
-        .filter_map(|x| match x {
-            IpAddr::V4(x) => Some(*x),
-            _ => None,
-        })
-        .collect::<Vec<Ipv4Addr>>();
+    // Split the dual-stack nameservers by family: the IPv4 set drives the
+    // DHCPv4 options written here, while the IPv6 set is held in the config for
+    // the eventual DHCPv6 / RA consumer (inert in this path for now).
+    let (nameservers_v4, nameservers_v6) = split_nameservers_by_family(&service_addrs.nameservers);
 
     let ntpservers_v4 = build_dhcp_ntp_servers(nc, service_addrs);
 
@@ -1517,8 +1518,13 @@ fn write_dhcp_v4_server_config(
         Err(err) => tracing::error!("Write DHCP server {}: {err:#}", dhcp_server_path.server),
     }
 
-    let next_contents =
-        dhcp::build_server_config(pxe_ip_v4, ntpservers_v4, nameservers_v4, loopback_ip)?;
+    let next_contents = dhcp::build_server_config(
+        pxe_ip_v4,
+        ntpservers_v4,
+        nameservers_v4,
+        nameservers_v6,
+        loopback_ip,
+    )?;
     match write(
         next_contents,
         &dhcp_server_path.config,
@@ -1923,7 +1929,7 @@ impl InterfaceTranslationMode {
 mod tests {
     use std::fs;
     use std::io::Write;
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
 
@@ -3303,6 +3309,31 @@ mod tests {
         eprint!("Diff output:\n{}", r.report());
         assert!(r.is_identical());
         Ok(())
+    }
+
+    #[test]
+    fn split_nameservers_by_family_partitions_by_family() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |input: Vec<IpAddr>| -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+                split_nameservers_by_family(&input)
+            };
+            "splits nameservers by family" {
+                vec![
+                    IpAddr::from([10, 0, 0, 1]),
+                    "2001:db8::1".parse::<IpAddr>().unwrap(),
+                    IpAddr::from([10, 0, 0, 2]),
+                ] => (
+                    vec![Ipv4Addr::new(10, 0, 0, 1), Ipv4Addr::new(10, 0, 0, 2)],
+                    vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()],
+                ),
+                vec![IpAddr::from([10, 0, 0, 1])] => (vec![Ipv4Addr::new(10, 0, 0, 1)], vec![]),
+                vec!["2001:db8::1".parse::<IpAddr>().unwrap()]
+                    => (vec![], vec!["2001:db8::1".parse::<Ipv6Addr>().unwrap()]),
+                vec![] => (vec![], vec![]),
+            }
+        );
     }
 
     fn validate_dhcp_config(received: DhcpConfig, expected: DhcpConfig) {

--- a/crates/rpc-utils/src/dhcp.rs
+++ b/crates/rpc-utils/src/dhcp.rs
@@ -96,10 +96,12 @@ impl DhcpConfig {
         carbide_provisioning_server_ipv4: Ipv4Addr,
         carbide_ntpservers: Vec<Ipv4Addr>,
         carbide_nameservers: Vec<Ipv4Addr>,
+        carbide_nameservers_v6: Vec<Ipv6Addr>,
         loopback_ip: Ipv4Addr,
     ) -> Result<Self, DhcpDataError> {
         Ok(DhcpConfig {
             carbide_nameservers,
+            carbide_nameservers_v6,
             carbide_ntpservers,
             carbide_provisioning_server_ipv4,
             carbide_dhcp_server: loopback_ip,
@@ -344,6 +346,7 @@ mod tests {
         dhcp_server: Ipv4Addr,
         ntpservers: Vec<Ipv4Addr>,
         nameservers: Vec<Ipv4Addr>,
+        nameservers_v6: Vec<Ipv6Addr>,
         lease_time_secs: u32,
     }
 
@@ -434,10 +437,11 @@ mod tests {
     }
 
     fn summarize_dhcp_config(
-        (provisioning_server, ntpservers, nameservers, dhcp_server): (
+        (provisioning_server, ntpservers, nameservers, nameservers_v6, dhcp_server): (
             Ipv4Addr,
             Vec<Ipv4Addr>,
             Vec<Ipv4Addr>,
+            Vec<Ipv6Addr>,
             Ipv4Addr,
         ),
     ) -> Result<DhcpConfigSummary, &'static str> {
@@ -445,6 +449,7 @@ mod tests {
             provisioning_server,
             ntpservers,
             nameservers,
+            nameservers_v6,
             dhcp_server,
         )
         .map(|config| DhcpConfigSummary {
@@ -452,6 +457,7 @@ mod tests {
             dhcp_server: config.carbide_dhcp_server,
             ntpservers: config.carbide_ntpservers,
             nameservers: config.carbide_nameservers,
+            nameservers_v6: config.carbide_nameservers_v6,
             lease_time_secs: config.lease_time_secs,
         })
         .map_err(dhcp_error_kind)
@@ -484,12 +490,14 @@ mod tests {
                     Ipv4Addr::new(192, 0, 2, 10),
                     vec![Ipv4Addr::new(192, 0, 2, 20)],
                     vec![Ipv4Addr::new(192, 0, 2, 53)],
+                    vec!["2001:db8::53".parse::<Ipv6Addr>().unwrap()],
                     Ipv4Addr::new(127, 0, 0, 2),
                 ) => Yields(DhcpConfigSummary {
                     provisioning_server: Ipv4Addr::new(192, 0, 2, 10),
                     dhcp_server: Ipv4Addr::new(127, 0, 0, 2),
                     ntpservers: vec![Ipv4Addr::new(192, 0, 2, 20)],
                     nameservers: vec![Ipv4Addr::new(192, 0, 2, 53)],
+                    nameservers_v6: vec!["2001:db8::53".parse::<Ipv6Addr>().unwrap()],
                     lease_time_secs: DEFAULT_LEASE_TIME_SECS,
                 }),
             }


### PR DESCRIPTION
## Summary

The dual-stack `DhcpConfig` field `carbide_nameservers_v6` landed in #2672, but nothing fills it — `from_forge_dhcp_config` and the agent's config builders are still IPv4-only. This has the agent populate it from the DPU's `ServiceAddresses` (which already holds both families):

- A `split_nameservers_by_family` helper splits the nameservers once, used at both DHCP-config build sites (the gRPC control path and the on-disk config path) so they can't diverge.
- `from_forge_dhcp_config` / `build_server_config` thread the IPv6 set through into the config.
- The IPv4 DHCPv4 option-6 path is unchanged; the IPv6 set stays inert until a delivery channel (DHCPv6 / RA) consumes it.

Tests cover `from_forge_dhcp_config` populating the field and the family split.

Implements #2640. Part of the #2628 epic (dual-stack DNS resolver advertisement).

> **Reworked onto current main.** The original version stacked on #2685 (Task 1), now closed as superseded by #2672 — which already added the proto/model fields this PR builds on. So this PR is now just the agent-population step.

Draft pending review.
