### PR TITLE
feat(dns): parse reverse-DNS (PTR) query names into IP addresses

### DIFF
--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -19,10 +19,54 @@ pub mod domain;
 pub mod domain_metadata;
 pub mod resource_record;
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 pub fn normalize_domain(name: &str) -> String {
     let normalize_domain = name.trim_end_matches('.').to_lowercase();
     tracing::debug!("Normalized domain name: {} to: {}", name, normalize_domain);
     normalize_domain
+}
+
+/// Parse a reverse-DNS (PTR) query name into the address it points at -- the
+/// inverse of the `in-addr.arpa` (IPv4) / `ip6.arpa` (IPv6) form. Returns `None`
+/// for anything that is not a well-formed arpa name, so the caller answers
+/// NotFound rather than guessing.
+pub fn arpa_qname_to_ip(qname: &str) -> Option<IpAddr> {
+    let name = qname.trim_end_matches('.').to_ascii_lowercase();
+
+    if let Some(reversed) = name.strip_suffix(".in-addr.arpa") {
+        // Four decimal octets, least-significant label first.
+        let octets: Vec<&str> = reversed.split('.').collect();
+        if octets.len() != 4 {
+            return None;
+        }
+        let mut addr = [0u8; 4];
+        for (byte, octet) in addr.iter_mut().zip(octets.iter().rev()) {
+            *byte = octet.parse().ok()?;
+        }
+        Some(IpAddr::V4(Ipv4Addr::from(addr)))
+    } else if let Some(reversed) = name.strip_suffix(".ip6.arpa") {
+        // Thirty-two hex nibbles, least-significant label first.
+        let nibbles: Vec<&str> = reversed.split('.').collect();
+        if nibbles.len() != 32 {
+            return None;
+        }
+        let mut addr = [0u8; 16];
+        for (i, nibble) in nibbles.iter().rev().enumerate() {
+            if nibble.len() != 1 {
+                return None;
+            }
+            let value = u8::from_str_radix(nibble, 16).ok()?;
+            if i % 2 == 0 {
+                addr[i / 2] = value << 4;
+            } else {
+                addr[i / 2] |= value;
+            }
+        }
+        Some(IpAddr::V6(Ipv6Addr::from(addr)))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -37,6 +81,38 @@ mod tests {
         let expected = "example.com";
         let normalized = super::normalize_domain(domain_name);
         assert_eq!(normalized, expected);
+    }
+
+    #[test]
+    fn parses_arpa_qname_to_ip() {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |qname: &str| super::arpa_qname_to_ip(qname);
+            "ipv4 in-addr.arpa" {
+                "1.0.168.192.in-addr.arpa." => Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                "3.2.1.10.in-addr.arpa." => Some(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))),
+            }
+            "ipv6 ip6.arpa" {
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."
+                    => Some("2001:db8::1".parse::<IpAddr>().unwrap()),
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa."
+                    => Some("::1".parse::<IpAddr>().unwrap()),
+            }
+            "rejects non-arpa and malformed" {
+                "host.example.com." => None,
+                "1.2.3.in-addr.arpa." => None,
+                "300.0.0.0.in-addr.arpa." => None,
+                "1.0.168.192.in-addr.arpa.extra." => None,
+            }
+            "normalizes case" {
+                "1.0.168.192.IN-ADDR.ARPA." => Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.B.D.0.1.0.0.2.IP6.ARPA."
+                    => Some("2001:db8::1".parse::<IpAddr>().unwrap()),
+            }
+        );
     }
 
     #[crate::sqlx_test]


### PR DESCRIPTION
## Summary

The conversion foundation for reverse DNS (PTR). A PTR query name is an address in `in-addr.arpa` / `ip6.arpa` form; resolving it means going **name → address**, which is a clean inverse — so this does it in Rust instead of a large PL/pgSQL function:

- `arpa_qname_to_ip(&str) -> Option<IpAddr>` reverses the four octets (IPv4) or 32 nibbles (IPv6); `Ipv6Addr` assembles the address, so the IPv6 case is a few lines. Returns `None` for non-arpa / malformed names.
- Table tests (`value_scenarios!`) cover IPv4, IPv6, and the reject cases.

The PTR handler will parse the incoming qname with this and look the interface up by **address** (an indexed `WHERE address = $ip`), rather than computing an arpa string for every row in a view. The address index + `find_ptr_record` land with #2639; the handler with #2641.

> **Reworked from the original SQL approach** (a `nico_ip_to_arpa_qname` PL/pgSQL function + `dns_records_ptr` view). Doing the inverse in Rust avoids a large SQL function, keeps the logic testable in one place, and makes the lookup a plain indexed address equality. The existing `nico_inet_to_dns_hostname` (forward instance DNS) is tracked for the same treatment separately.

Implements #2637. Part of the #2630 epic (reverse DNS / PTR records).

Draft pending review.
