### PR TITLE
fix(scout): skip TPM2_Clear on hosts with no TPM device

### DIFF
--- a/crates/scout/src/tpm.rs
+++ b/crates/scout/src/tpm.rs
@@ -90,8 +90,17 @@ pub(crate) fn tpm_present(tpm_path: &str) -> bool {
 }
 
 /// Clears the TPM storage hierarchies via TPM2_Clear (lockout authorization), after dictionary
-/// lockout setup.
+/// lockout setup. A host with no TPM has nothing to clear so the clear is skipped. A present TPM
+/// that fails to clear stays an error.
 pub(crate) fn clear_tpm(tpm_path: &str) -> Result<(), CarbideClientError> {
+    if !tpm_present(tpm_path) {
+        tracing::warn!(
+            tpm_path = ?tpm_path,
+            "clear_tpm: no TPM device, skipping TPM2_Clear"
+        );
+        return Ok(());
+    }
+
     set_tpm_max_auth_fail()?;
 
     let mut ctx = attest::create_context_from_path(tpm_path).map_err(|e| {
@@ -221,5 +230,11 @@ mod tests {
         assert!(tpm_present("/dev/null"));
         assert!(!tpm_present("device:/dev/forge_scout_nonexistent_tpm"));
         assert!(!tpm_present("/dev/forge_scout_nonexistent_tpm"));
+    }
+
+    #[test]
+    fn clear_tpm_skips_when_no_tpm_device() {
+        // A bogus /dev path reports no TPM, so clear_tpm returns Ok without running TPM2_Clear.
+        assert!(clear_tpm("/dev/forge_scout_nonexistent_tpm").is_ok());
     }
 }


### PR DESCRIPTION
clear_tpm ran TPM2_Clear unconditionally during discovery deprovision (run_no_api -> clear_tpm), which hard-fails on a host with no TPM (/dev/tpmrm0 absent): the scout logs it non-fatally and re-polls, so discovery never reports DiscoverMachine and the machine loops in WaitingForDiscovery. register::run already tolerates no-TPM hosts via is_dpu (absent EK cert gates all attestation), so clear_tpm was the only unconditional TPM call blocking discovery. Map the TCTI to its device file and skip the clear when that device is absent; a present TPM that fails to clear stays a hard error.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

