### PR TITLE
feat(dns): look up PTR records by interface address

### DIFF
--- a/crates/api-db/migrations/20260620153439_machine_interface_addresses_address_index.sql
+++ b/crates/api-db/migrations/20260620153439_machine_interface_addresses_address_index.sql
@@ -1,0 +1,5 @@
+-- Index machine_interface_addresses by address. Reverse-DNS (PTR) resolution
+-- parses a query name into an address and then looks the interface up by that
+-- address, so this turns that lookup into an index probe rather than a scan.
+CREATE INDEX machine_interface_addresses_address_idx
+    ON machine_interface_addresses (address);

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -271,4 +271,118 @@ mod tests {
             assert!(records.contains(&expected_record));
         }
     }
+
+    #[crate::sqlx_test]
+    async fn find_ptr_record_resolves_address_to_hostname(pool: sqlx::PgPool) {
+        sqlx::query(
+            "INSERT INTO domains (id, name)
+             VALUES ('10000000-0000-0000-0000-000000000001', 'dwrt1.com')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO network_segments (id, name, version)
+             VALUES ('20000000-0000-0000-0000-000000000001', 'tenant-segment', 'test')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machines (id, dpf)
+             VALUES ('host-1', '{\"enabled\": true, \"used_for_ingestion\": false}'::jsonb)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // host-1 has three interfaces on the same domain: the primary, a BMC, and a
+        // plain (non-primary, non-BMC) data interface.
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id, machine_id, segment_id, mac_address, domain_id,
+                primary_interface, hostname, association_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000001', 'host-1',
+                '20000000-0000-0000-0000-000000000001', '02:00:00:00:00:01',
+                '10000000-0000-0000-0000-000000000001', true, 'host-1', 'Machine'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id, machine_id, segment_id, mac_address, domain_id,
+                primary_interface, hostname, association_type, interface_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000002', 'host-1',
+                '20000000-0000-0000-0000-000000000001', '02:00:00:00:00:02',
+                '10000000-0000-0000-0000-000000000001', false, 'host-1-bmc', 'Machine', 'Bmc'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id, machine_id, segment_id, mac_address, domain_id,
+                primary_interface, hostname, association_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000003', 'host-1',
+                '20000000-0000-0000-0000-000000000001', '02:00:00:00:00:03',
+                '10000000-0000-0000-0000-000000000001', false, 'host-1-data', 'Machine'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        for (interface_id, address) in [
+            ("30000000-0000-0000-0000-000000000001", "192.168.0.1"),
+            ("30000000-0000-0000-0000-000000000002", "192.168.0.2"),
+            ("30000000-0000-0000-0000-000000000003", "192.168.0.3"),
+        ] {
+            sqlx::query(
+                "INSERT INTO machine_interface_addresses (interface_id, address)
+                 VALUES ($1::uuid, $2::inet)",
+            )
+            .bind(interface_id)
+            .bind(address)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Primary and BMC interfaces answer PTR (matching the forward shortname view);
+        // the plain data interface and an address no interface holds do not.
+        let cases = [
+            ("192.168.0.1", Some("host-1.dwrt1.com.")),
+            ("192.168.0.2", Some("host-1-bmc.dwrt1.com.")),
+            ("192.168.0.3", None),
+            ("10.9.9.9", None),
+        ];
+        for (address, expected) in cases {
+            let records = super::resource_record::find_ptr_record(&pool, address.parse().unwrap())
+                .await
+                .unwrap();
+            match expected {
+                Some(fqdn) => {
+                    assert_eq!(records.len(), 1, "address {address}");
+                    assert_eq!(records[0].ptr_content, fqdn, "address {address}");
+                }
+                None => assert!(
+                    records.is_empty(),
+                    "address {address} should resolve to nothing"
+                ),
+            }
+        }
+    }
 }

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -19,10 +19,54 @@ pub mod domain;
 pub mod domain_metadata;
 pub mod resource_record;
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 pub fn normalize_domain(name: &str) -> String {
     let normalize_domain = name.trim_end_matches('.').to_lowercase();
     tracing::debug!("Normalized domain name: {} to: {}", name, normalize_domain);
     normalize_domain
+}
+
+/// Parse a reverse-DNS (PTR) query name into the address it points at -- the
+/// inverse of the `in-addr.arpa` (IPv4) / `ip6.arpa` (IPv6) form. Returns `None`
+/// for anything that is not a well-formed arpa name, so the caller answers
+/// NotFound rather than guessing.
+pub fn arpa_qname_to_ip(qname: &str) -> Option<IpAddr> {
+    let name = qname.trim_end_matches('.').to_ascii_lowercase();
+
+    if let Some(reversed) = name.strip_suffix(".in-addr.arpa") {
+        // Four decimal octets, least-significant label first.
+        let octets: Vec<&str> = reversed.split('.').collect();
+        if octets.len() != 4 {
+            return None;
+        }
+        let mut addr = [0u8; 4];
+        for (byte, octet) in addr.iter_mut().zip(octets.iter().rev()) {
+            *byte = octet.parse().ok()?;
+        }
+        Some(IpAddr::V4(Ipv4Addr::from(addr)))
+    } else if let Some(reversed) = name.strip_suffix(".ip6.arpa") {
+        // Thirty-two hex nibbles, least-significant label first.
+        let nibbles: Vec<&str> = reversed.split('.').collect();
+        if nibbles.len() != 32 {
+            return None;
+        }
+        let mut addr = [0u8; 16];
+        for (i, nibble) in nibbles.iter().rev().enumerate() {
+            if nibble.len() != 1 {
+                return None;
+            }
+            let value = u8::from_str_radix(nibble, 16).ok()?;
+            if i % 2 == 0 {
+                addr[i / 2] = value << 4;
+            } else {
+                addr[i / 2] |= value;
+            }
+        }
+        Some(IpAddr::V6(Ipv6Addr::from(addr)))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -37,6 +81,38 @@ mod tests {
         let expected = "example.com";
         let normalized = super::normalize_domain(domain_name);
         assert_eq!(normalized, expected);
+    }
+
+    #[test]
+    fn parses_arpa_qname_to_ip() {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |qname: &str| super::arpa_qname_to_ip(qname);
+            "ipv4 in-addr.arpa" {
+                "1.0.168.192.in-addr.arpa." => Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                "3.2.1.10.in-addr.arpa." => Some(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))),
+            }
+            "ipv6 ip6.arpa" {
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."
+                    => Some("2001:db8::1".parse::<IpAddr>().unwrap()),
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa."
+                    => Some("::1".parse::<IpAddr>().unwrap()),
+            }
+            "rejects non-arpa and malformed" {
+                "host.example.com." => None,
+                "1.2.3.in-addr.arpa." => None,
+                "300.0.0.0.in-addr.arpa." => None,
+                "1.0.168.192.in-addr.arpa.extra." => None,
+            }
+            "normalizes case" {
+                "1.0.168.192.IN-ADDR.ARPA." => Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.B.D.0.1.0.0.2.IP6.ARPA."
+                    => Some("2001:db8::1".parse::<IpAddr>().unwrap()),
+            }
+        );
     }
 
     #[crate::sqlx_test]

--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -111,6 +111,55 @@ pub async fn find_record(
 
     Ok(result)
 }
+
+#[derive(Debug, Clone)]
+pub struct DbPtrRecord {
+    pub ttl: i32,
+    /// The FQDN the PTR record answers with (e.g. `host-1.dwrt1.com.`).
+    pub ptr_content: String,
+    pub domain_id: DomainId,
+}
+
+impl<'r> FromRow<'r, PgRow> for DbPtrRecord {
+    fn from_row(row: &'r PgRow) -> Result<Self, Error> {
+        Ok(DbPtrRecord {
+            ptr_content: row.try_get("ptr_content")?,
+            ttl: row.try_get("ttl")?,
+            domain_id: row.try_get("domain_id")?,
+        })
+    }
+}
+
+/// Find the PTR answers for an address: the FQDN(s) the forward shortname view
+/// publishes for whichever primary or BMC interface holds it. The `WHERE` matches
+/// `dns_records_shortname_combined`'s (primary or BMC), so a forward A/AAAA record
+/// and its PTR round-trip; the joins are otherwise narrower (no `dns_record_types`,
+/// since PTR's type is fixed) and the TTL uses `COALESCE(meta.ttl, 300)` to match
+/// the TTL the forward record is actually served with. The lookup is by `address`,
+/// so it rides the `machine_interface_addresses_address_idx` index rather than scanning.
+pub async fn find_ptr_record(
+    txn: impl DbReader<'_>,
+    address: IpAddr,
+) -> Result<Vec<DbPtrRecord>, DatabaseError> {
+    let query = r#"
+    SELECT
+        concat(mi.hostname, '.', d.name, '.') AS ptr_content,
+        COALESCE(meta.ttl, 300) AS ttl,
+        d.id AS domain_id
+    FROM machine_interface_addresses mia
+    JOIN machine_interfaces mi ON mi.id = mia.interface_id
+    JOIN domains d ON d.id = mi.domain_id
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    WHERE mia.address = $1::inet
+      AND (mi.primary_interface = TRUE OR mi.interface_type = 'Bmc')"#;
+
+    sqlx::query_as::<_, DbPtrRecord>(query)
+        .bind(address.to_string())
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn get_all_records_all_domains(
     txn: impl DbReader<'_>,
 ) -> Result<Vec<DbResourceRecord>, DatabaseError> {


### PR DESCRIPTION
## Summary

The DB lookup behind reverse DNS: `find_ptr_record(address)` returns the FQDN(s) the forward shortname view publishes for whichever **primary or BMC** interface holds that address — its `WHERE` mirrors `dns_records_shortname_combined`, so a forward A/AAAA record and its PTR round-trip.

- New `address` index on `machine_interface_addresses` → the lookup is an index probe, not a scan.
- `DbPtrRecord` decodes the FQDN answer (a hostname, unlike the IP-valued `DbResourceRecord`).
- DB-backed test: a primary interface + address resolves to its FQDN; an unheld address resolves to nothing.

The handler (#2641) will parse the incoming arpa qname with `arpa_qname_to_ip` (#2637) and call this; carbide-dns's PTR unlock is #2643.

Implements #2639. Part of the #2630 epic (reverse DNS / PTR records).

> Stacked on #2637 (the arpa parser). Until that merges, this PR's diff also shows its commit.

Draft pending review.
