### PR TITLE
feat: resolve a host's boot interface from predictions before its first lease

### DIFF
--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -29,7 +29,6 @@ use model::expected_entity::ExpectedEntity;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
 use model::machine_boot_interface::MachineBootInterface;
-use model::network_segment::NetworkSegmentType;
 use model::predicted_machine_interface::PredictedMachineInterface;
 use model::site_explorer::{NicMode, PreingestionState};
 use sqlx::PgConnection;
@@ -53,15 +52,14 @@ use crate::api::{Api, log_machine_id, log_request_data};
 /// machine awaiting its first DHCP lease) resolves from its
 /// `predicted_machine_interfaces` instead: the predicted NIC's MAC and
 /// recorded Redfish interface id form the same [`MachineBootInterface`] the
-/// real row will hold once the lease promotes it. Predictions answer only
-/// when unambiguous -- exactly one non-underlay prediction. Predictions now
-/// carry a `primary_interface` flag, but this resolver doesn't consult it yet,
-/// so with several (e.g. a host whose report lists SuperNICs alongside the boot
-/// NIC) the declared `ExpectedHostNic.primary` is not applied here; resolution
-/// refuses to guess and the action keeps requiring an explicit MAC, which the
-/// matching prediction's recorded id completes.
-/// The machine-controller does not consult predictions at all yet -- its
-/// boot states wait out this window -- a known follow-up.
+/// real row will hold once the lease promotes it. The candidate is chosen by
+/// the shared `pick_boot_prediction` -- the declared `ExpectedHostNic.primary`
+/// (recorded on the prediction), else the sole non-underlay prediction. With
+/// several (e.g. a host whose report lists SuperNICs alongside the boot NIC) and
+/// none declared primary the boot NIC is unknowable; resolution refuses to guess
+/// and the action keeps requiring an explicit MAC, which the matching
+/// prediction's recorded id completes. The machine-controller resolves the same
+/// way, through the same `pick_boot_prediction`.
 ///
 /// Site-explorer's stored default (`ExploredEndpoint::boot_interface()`)
 /// answers only for endpoints no machine owns. An owned machine resolves
@@ -117,15 +115,12 @@ fn resolve_admin_boot_interface_target(
                 // machine-controller's boot_interface_target.
                 return Some(target_for(picked.mac_address, picked.boot_interface()));
             }
-            // The rows offered no boot candidate: the machine's predicted
-            // NICs answer, but only when unambiguous -- exactly one
-            // non-underlay prediction. Predictions now carry a primary flag,
-            // but this resolver doesn't consult it yet, so with several the
-            // declared intent isn't applied here.
-            let mut bootable = candidates.predicted.iter().filter(|predicted| {
-                predicted.expected_network_segment_type != NetworkSegmentType::Underlay
-            });
-            if let (Some(predicted), None) = (bootable.next(), bootable.next()) {
+            // The rows offered no boot candidate: the machine's predicted NICs
+            // answer, via the shared `pick_boot_prediction` -- the declared
+            // primary, else the sole non-underlay prediction. With several and
+            // none declared primary the boot NIC is unknowable, so it returns
+            // `None` and the action keeps requiring an explicit MAC.
+            if let Some(predicted) = model::machine::pick_boot_prediction(&candidates.predicted) {
                 return Some(target_for(
                     predicted.mac_address,
                     predicted.boot_interface(),
@@ -1123,6 +1118,8 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
 
 #[cfg(test)]
 mod tests {
+    use model::network_segment::NetworkSegmentType;
+
     use super::*;
 
     fn row(mac: &str, primary: bool, boot_interface_id: Option<&str>) -> MachineInterfaceSnapshot {
@@ -1353,6 +1350,30 @@ mod tests {
             Some(BootInterfaceTarget::Pair(pair(
                 "00:00:5e:00:53:02",
                 "NIC.Slot.7-1-1"
+            ))),
+        );
+    }
+
+    // A declared-primary prediction disambiguates a multi-prediction host:
+    // `pick_boot_prediction` selects it, so resolution targets the declared NIC
+    // rather than refusing. (Multiple NON-primary predictions still refuse --
+    // see `no_mac_multiple_predictions_refuse_to_guess_a_boot_device`.)
+    #[test]
+    fn no_mac_declared_primary_prediction_wins_over_other_predictions() {
+        let declared_primary = PredictedMachineInterface {
+            primary_interface: true,
+            ..predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1"))
+        };
+        let other = predicted("00:00:5e:00:53:02", Some("NIC.Slot.7-1-1"));
+        let c = BootInterfaceCandidates {
+            interfaces: vec![],
+            predicted: vec![other, declared_primary],
+        };
+        assert_eq!(
+            resolve_admin_boot_interface_target(None, Some(&c), None),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:01",
+                "NIC.Embedded.1-1-1"
             ))),
         );
     }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -65,6 +65,7 @@ use crate::machine_interface::InterfaceType;
 use crate::machine_interface_address::InterfaceAssociationType;
 use crate::network_segment::NetworkSegmentType;
 use crate::power_manager::PowerOptions;
+use crate::predicted_machine_interface::PredictedMachineInterface;
 use crate::state_history::StateHistoryRecord;
 
 pub mod slas;
@@ -304,6 +305,38 @@ fn pick_boot_interface_pair(
     interfaces: &[MachineInterfaceSnapshot],
 ) -> Option<MachineBootInterface> {
     pick_boot_interface(interfaces).and_then(MachineInterfaceSnapshot::boot_interface)
+}
+
+/// Pick the predicted interface a host should boot from in the window before
+/// its first DHCP lease creates a real `machine_interfaces` row. Mirrors
+/// `pick_boot_interface`'s precedence, one rung down -- predictions, not rows:
+///
+/// 1. A prediction flagged `primary_interface` wins -- the declared
+///    `ExpectedHostNic.primary`, recorded onto the prediction at minting.
+/// 2. Otherwise the sole non-underlay prediction. With several and none
+///    declared primary the boot NIC is unknowable (e.g. a host whose report
+///    lists SuperNICs alongside the boot NIC), so this returns `None` rather
+///    than guess against whichever NIC happens to sort first.
+///
+/// Public because both the machine-controller and admin boot-interface
+/// resolution apply it for the pre-first-lease window, when the real rows
+/// offer no candidate yet. Callers map the chosen prediction to a boot target
+/// via `PredictedMachineInterface::boot_interface()`.
+pub fn pick_boot_prediction(
+    predictions: &[PredictedMachineInterface],
+) -> Option<&PredictedMachineInterface> {
+    // The declared primary wins, exactly as in `pick_boot_interface`.
+    if let Some(primary) = predictions.iter().find(|p| p.primary_interface) {
+        return Some(primary);
+    }
+    // Otherwise only a sole non-underlay prediction is unambiguous.
+    let mut non_underlay = predictions
+        .iter()
+        .filter(|p| p.expected_network_segment_type != NetworkSegmentType::Underlay);
+    match (non_underlay.next(), non_underlay.next()) {
+        (Some(only), None) => Some(only),
+        _ => None,
+    }
 }
 
 impl ManagedHostStateSnapshot {
@@ -3449,6 +3482,77 @@ mod tests {
         let primary =
             build_mock_interface("10:00:00:00:00:01", true, Some(NetworkSegmentType::Admin));
         assert_eq!(pick_boot_interface_pair(&[primary]), None);
+    }
+
+    /// Build a mock `PredictedMachineInterface` with the fields
+    /// `pick_boot_prediction` inspects (MAC, primary flag, segment type).
+    fn build_mock_prediction(
+        mac: &str,
+        primary: bool,
+        segment_type: NetworkSegmentType,
+    ) -> PredictedMachineInterface {
+        PredictedMachineInterface {
+            id: uuid::Uuid::nil(),
+            machine_id: MachineId::from_str(
+                "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng",
+            )
+            .unwrap(),
+            mac_address: mac.parse().unwrap(),
+            expected_network_segment_type: segment_type,
+            boot_interface_id: None,
+            primary_interface: primary,
+        }
+    }
+
+    // A declared-primary prediction wins outright, mirroring pick_boot_interface
+    // -- regardless of how many other predictions there are.
+    #[test]
+    fn pick_boot_prediction_returns_the_declared_primary() {
+        let predictions = vec![
+            build_mock_prediction("05:00:00:00:00:01", false, NetworkSegmentType::HostInband),
+            build_mock_prediction("10:00:00:00:00:01", true, NetworkSegmentType::HostInband),
+            build_mock_prediction("20:00:00:00:00:01", false, NetworkSegmentType::HostInband),
+        ];
+        assert_eq!(
+            pick_boot_prediction(&predictions).map(|p| p.mac_address),
+            Some("10:00:00:00:00:01".parse().unwrap())
+        );
+    }
+
+    // With no declared primary, a sole non-underlay prediction is unambiguous.
+    #[test]
+    fn pick_boot_prediction_returns_the_sole_non_underlay_prediction() {
+        let predictions = vec![
+            build_mock_prediction("01:00:00:00:00:01", false, NetworkSegmentType::Underlay),
+            build_mock_prediction("10:00:00:00:00:01", false, NetworkSegmentType::HostInband),
+        ];
+        assert_eq!(
+            pick_boot_prediction(&predictions).map(|p| p.mac_address),
+            Some("10:00:00:00:00:01".parse().unwrap())
+        );
+    }
+
+    // Several non-underlay predictions and none declared primary: the boot NIC
+    // is unknowable, so refuse to guess rather than program boot order against
+    // whichever sorts first (the Gigawatt SuperNIC safety case).
+    #[test]
+    fn pick_boot_prediction_refuses_multiple_non_primary_predictions() {
+        let predictions = vec![
+            build_mock_prediction("10:00:00:00:00:01", false, NetworkSegmentType::HostInband),
+            build_mock_prediction("20:00:00:00:00:01", false, NetworkSegmentType::HostInband),
+        ];
+        assert!(pick_boot_prediction(&predictions).is_none());
+    }
+
+    // Underlay predictions are never a boot candidate on their own.
+    #[test]
+    fn pick_boot_prediction_ignores_underlay_only_predictions() {
+        let predictions = vec![build_mock_prediction(
+            "01:00:00:00:00:01",
+            false,
+            NetworkSegmentType::Underlay,
+        )];
+        assert!(pick_boot_prediction(&predictions).is_none());
     }
 
     // Check the case  where only the BMC has been discovered so far (which

--- a/crates/machine-controller/src/boot_interface.rs
+++ b/crates/machine-controller/src/boot_interface.rs
@@ -17,26 +17,63 @@
 //! Resolving how to target a host's boot interface for Redfish setup calls.
 
 use carbide_redfish::boot_interface::BootInterfaceTarget;
-use model::machine::ManagedHostStateSnapshot;
+use mac_address::MacAddress;
+use model::machine::{ManagedHostStateSnapshot, pick_boot_prediction};
+use model::machine_boot_interface::MachineBootInterface;
+use model::predicted_machine_interface::PredictedMachineInterface;
 
 /// Resolve how to target this host's boot interface for Redfish setup calls.
 ///
-/// Uses the host's primary `machine_interface`: when that row has a captured
-/// Redfish interface id, the full pair is returned (enabling the MAC-first /
-/// interface-id fallback); otherwise it targets the MAC alone. Both come from the
-/// same row, so the pair can never name a different interface than the MAC.
+/// The host's own `machine_interface` row wins the moment it exists: when that
+/// row has a captured Redfish interface id, the full pair is returned (enabling
+/// the MAC-first / interface-id fallback); otherwise it targets the MAC alone.
+/// Both come from the same row, so the pair can never name a different interface
+/// than the MAC.
 ///
-/// Returns `None` only when the host has no boot interface at all (e.g. only the
-/// BMC has been discovered, or the primary NIC hasn't appeared yet).
+/// Before that first DHCP lease creates a row -- the window a zero-DPU or
+/// NIC-mode host sits in, since it gets no primary row at ingestion -- the host's
+/// `predictions` answer instead, via `pick_boot_prediction` (the declared
+/// primary, else the sole non-underlay prediction). The predicted MAC and
+/// recorded id form the same pair the real row will hold once the lease promotes
+/// it.
+///
+/// Returns `None` only when the host has no boot interface at all -- no row and
+/// no usable prediction (e.g. only the BMC has been discovered, or several
+/// predictions with no declared primary).
 pub fn boot_interface_target(
     mh_snapshot: &ManagedHostStateSnapshot,
+    predictions: &[PredictedMachineInterface],
 ) -> Option<BootInterfaceTarget> {
-    if let Some(boot_interface) = mh_snapshot.boot_interface() {
-        return Some(BootInterfaceTarget::Pair(boot_interface));
+    boot_interface_target_from(
+        mh_snapshot.boot_interface(),
+        mh_snapshot.boot_interface_mac(),
+        predictions,
+    )
+}
+
+/// The boot-target decision, split out from the snapshot lookup so it can be
+/// unit-tested directly without constructing a full `ManagedHostStateSnapshot`
+/// -- the same split `pick_boot_interface_mac`/`_pair` use in api-model. The
+/// host's own row wins (its captured pair, else its MAC alone); only when it
+/// owns no boot row does the predicted boot interface answer.
+fn boot_interface_target_from(
+    row_pair: Option<MachineBootInterface>,
+    row_mac: Option<MacAddress>,
+    predictions: &[PredictedMachineInterface],
+) -> Option<BootInterfaceTarget> {
+    if let Some(pair) = row_pair {
+        return Some(BootInterfaceTarget::Pair(pair));
     }
-    mh_snapshot
-        .boot_interface_mac()
-        .map(BootInterfaceTarget::MacOnly)
+    if let Some(mac) = row_mac {
+        return Some(BootInterfaceTarget::MacOnly(mac));
+    }
+    // No real row yet -- fall back to the host's predicted boot interface.
+    pick_boot_prediction(predictions).map(|prediction| {
+        prediction.boot_interface().map_or(
+            BootInterfaceTarget::MacOnly(prediction.mac_address),
+            BootInterfaceTarget::Pair,
+        )
+    })
 }
 
 /// What a Redfish boot step should do with a host's boot interface.
@@ -51,7 +88,8 @@ pub fn boot_interface_target(
 pub enum BootInterfaceResolution {
     /// The boot interface resolved; target it.
     Ready(BootInterfaceTarget),
-    /// A zero-DPU host whose boot NIC has not been discovered yet -- wait.
+    /// A zero-DPU host with no boot interface yet -- neither a real row nor a
+    /// usable prediction -- so wait for its boot NIC to appear.
     AwaitingNic,
     /// A host that should already have a boot interface is missing one.
     Missing,
@@ -59,9 +97,12 @@ pub enum BootInterfaceResolution {
 
 /// Resolve this host's boot interface for a Redfish boot step, classifying a
 /// missing one as either "wait for the NIC" (zero-DPU) or "fault".
-pub fn resolve_boot_interface(mh_snapshot: &ManagedHostStateSnapshot) -> BootInterfaceResolution {
+pub fn resolve_boot_interface(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    predictions: &[PredictedMachineInterface],
+) -> BootInterfaceResolution {
     classify_boot_interface(
-        boot_interface_target(mh_snapshot),
+        boot_interface_target(mh_snapshot, predictions),
         mh_snapshot.has_managed_dpus(),
     )
 }
@@ -82,8 +123,73 @@ fn classify_boot_interface(
 #[cfg(test)]
 mod tests {
     use mac_address::MacAddress;
+    use model::network_segment::NetworkSegmentType;
 
     use super::*;
+
+    fn prediction(mac: &str, boot_interface_id: Option<&str>) -> PredictedMachineInterface {
+        PredictedMachineInterface {
+            id: uuid::Uuid::nil(),
+            machine_id: "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng"
+                .parse()
+                .unwrap(),
+            mac_address: mac.parse().unwrap(),
+            expected_network_segment_type: NetworkSegmentType::HostInband,
+            boot_interface_id: boot_interface_id.map(String::from),
+            primary_interface: false,
+        }
+    }
+
+    // The host's own row wins over any prediction: a captured id gives the pair.
+    #[test]
+    fn boot_target_prefers_the_owned_row_over_predictions() {
+        let pair = MachineBootInterface {
+            mac_address: "10:00:00:00:00:01".parse().unwrap(),
+            interface_id: "NIC.Slot.5-1".to_string(),
+        };
+        assert_eq!(
+            boot_interface_target_from(
+                Some(pair.clone()),
+                Some("10:00:00:00:00:01".parse().unwrap()),
+                &[prediction("20:00:00:00:00:01", Some("NIC.Embedded.1-1-1"))],
+            ),
+            Some(BootInterfaceTarget::Pair(pair)),
+        );
+    }
+
+    // No owned row yet: the predicted boot interface answers (pre-first-lease),
+    // as a full pair when the prediction carries the Redfish id.
+    #[test]
+    fn boot_target_falls_back_to_the_prediction_before_the_first_lease() {
+        assert_eq!(
+            boot_interface_target_from(
+                None,
+                None,
+                &[prediction("20:00:00:00:00:01", Some("NIC.Embedded.1-1-1"))],
+            ),
+            Some(BootInterfaceTarget::Pair(MachineBootInterface {
+                mac_address: "20:00:00:00:00:01".parse().unwrap(),
+                interface_id: "NIC.Embedded.1-1-1".to_string(),
+            })),
+        );
+    }
+
+    // A prediction with no captured id targets the MAC alone.
+    #[test]
+    fn boot_target_prediction_without_id_is_mac_only() {
+        assert_eq!(
+            boot_interface_target_from(None, None, &[prediction("20:00:00:00:00:01", None)]),
+            Some(BootInterfaceTarget::MacOnly(
+                "20:00:00:00:00:01".parse().unwrap()
+            )),
+        );
+    }
+
+    // No row and no usable prediction: nothing to target, so the caller waits.
+    #[test]
+    fn boot_target_is_none_without_row_or_prediction() {
+        assert_eq!(boot_interface_target_from(None, None, &[]), None);
+    }
 
     #[test]
     fn classify_waits_for_a_zero_dpu_host_without_a_boot_interface() {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -85,6 +85,7 @@ use model::machine::{
     dpf_based_dpu_provisioning_possible, get_display_ids,
 };
 use model::power_manager::PowerHandlingOutcome;
+use model::predicted_machine_interface::PredictedMachineInterface;
 use model::resource_pool::common::CommonPools;
 use model::site_explorer::ExploredEndpoint;
 use sku::{handle_bom_validation_requested, handle_bom_validation_state};
@@ -3259,11 +3260,13 @@ async fn handle_dpu_reprovision(
                 .create_redfish_client_from_machine(&state.host_snapshot)
                 .await?;
 
+            let predictions = load_boot_predictions(ctx, &state.host_snapshot.id).await?;
             match advance_polling_bios_setup(
                 redfish_client.as_ref(),
                 state,
                 *retry_count,
                 &ctx.services.site_config.machine_state_controller,
+                &predictions,
             )
             .await?
             {
@@ -3505,6 +3508,23 @@ fn dpu_reprovision_host_boot_failed_state(
     }
 }
 
+/// Load the host's predicted boot-interface candidates -- the interfaces a
+/// zero-DPU or NIC-mode host offers before its first DHCP lease creates real
+/// `machine_interfaces` rows. Empty once the host owns its rows (and for DPU
+/// hosts, which get their primary row at attach), so the resolver simply finds
+/// no prediction to fall back to.
+async fn load_boot_predictions(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    machine_id: &MachineId,
+) -> Result<Vec<PredictedMachineInterface>, StateHandlerError> {
+    // A pooled read connection, not a transaction -- this read-only lookup runs
+    // on the frequently-invoked boot-config path and needs no transaction.
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    let predictions =
+        db::predicted_machine_interface::find_by_machine_id(&mut conn, machine_id).await?;
+    Ok(predictions)
+}
+
 /// Check whether host BIOS and DPU-first boot order remediation is required.
 async fn check_host_boot_config(
     redfish_client: &dyn Redfish,
@@ -3530,8 +3550,10 @@ async fn check_host_boot_config(
 
     // Resolve the interface whose boot option should be first in host UEFI. A
     // zero-DPU host whose boot NIC has not taken its first HostInband lease yet
-    // has no boot interface to resolve -- wait for it rather than failing.
-    let boot_interface = match resolve_boot_interface(mh_snapshot) {
+    // falls back to its predicted boot NIC, and only waits when even that is
+    // unavailable.
+    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    let boot_interface = match resolve_boot_interface(mh_snapshot, &predictions) {
         BootInterfaceResolution::Ready(target) => target,
         BootInterfaceResolution::AwaitingNic => {
             return Ok(HostBootConfigDecision::Wait(format!(
@@ -5635,11 +5657,14 @@ impl StateHandler for HostMachineStateHandler {
                         .services
                         .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
                         .await?;
+                    let predictions =
+                        load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
                     match advance_polling_bios_setup(
                         redfish_client.as_ref(),
                         mh_snapshot,
                         *retry_count,
                         &ctx.services.site_config.machine_state_controller,
+                        &predictions,
                     )
                     .await?
                     {
@@ -10828,11 +10853,13 @@ async fn handle_instance_host_platform_config(
                 },
             };
 
+            let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
             match advance_polling_bios_setup(
                 redfish_client.as_ref(),
                 mh_snapshot,
                 retry_count,
                 &ctx.services.site_config.machine_state_controller,
+                &predictions,
             )
             .await?
             {
@@ -10929,6 +10956,7 @@ async fn set_host_boot_order(
     mh_snapshot: &ManagedHostStateSnapshot,
     set_boot_order_info: SetBootOrderInfo,
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
+    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
             // There used to be a `force_dpu_nic_mode`-gated short-circuit
@@ -10943,11 +10971,12 @@ async fn set_host_boot_order(
             // resulting `NoDpu` error as `Ok` and still hits `CheckBootOrder`
             // for verification.
             //
-            // Resolve the boot NIC MAC the same way `CheckHostConfig` does,
-            // supporting hosts with DPU(s) and zero DPUs alike. A zero-DPU host
-            // whose boot NIC has not taken its first HostInband lease yet has no
-            // boot interface to resolve -- wait for it rather than failing.
-            let boot_interface = match resolve_boot_interface(mh_snapshot) {
+            // Resolve the boot NIC the same way `CheckHostConfig` does,
+            // supporting hosts with DPU(s) and zero DPUs alike. Before the first
+            // HostInband lease creates a real row, a zero-DPU/NIC-mode host
+            // resolves via its predictions; it waits only when neither a real row
+            // nor a usable prediction exists.
+            let boot_interface = match resolve_boot_interface(mh_snapshot, &predictions) {
                 BootInterfaceResolution::Ready(target) => target,
                 BootInterfaceResolution::AwaitingNic => {
                     return Ok(SetBootOrderOutcome::Wait(format!(
@@ -11240,7 +11269,7 @@ async fn set_host_boot_order(
 
             let retry_count = set_boot_order_info.retry_count;
 
-            let boot_interface = match resolve_boot_interface(mh_snapshot) {
+            let boot_interface = match resolve_boot_interface(mh_snapshot, &predictions) {
                 BootInterfaceResolution::Ready(target) => target,
                 BootInterfaceResolution::AwaitingNic => {
                     return Ok(SetBootOrderOutcome::Wait(format!(

--- a/crates/machine-controller/src/handler/bios_config.rs
+++ b/crates/machine-controller/src/handler/bios_config.rs
@@ -24,6 +24,7 @@ use libredfish::{Redfish, SystemPowerControl};
 use model::machine::{
     BiosConfigInfo, BiosConfigState, ManagedHostState, ManagedHostStateSnapshot, PowerState,
 };
+use model::predicted_machine_interface::PredictedMachineInterface;
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -90,7 +91,8 @@ pub(super) async fn configure_host_bios(
     mh_snapshot: &ManagedHostStateSnapshot,
     retry_count: u32,
 ) -> Result<BiosConfigOutcome, StateHandlerError> {
-    let boot_interface = boot_interface_target(mh_snapshot);
+    let predictions = super::load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    let boot_interface = boot_interface_target(mh_snapshot, &predictions);
 
     let bios_job_id = match call_machine_setup_and_handle_no_dpu_error(
         redfish_client,
@@ -381,8 +383,9 @@ pub(super) async fn advance_polling_bios_setup(
     mh_snapshot: &ManagedHostStateSnapshot,
     retry_count: u32,
     machine_controller_config: &MachineStateControllerConfig,
+    predictions: &[PredictedMachineInterface],
 ) -> Result<PollingBiosSetupOutcome, StateHandlerError> {
-    let boot_interface = boot_interface_target(mh_snapshot);
+    let boot_interface = boot_interface_target(mh_snapshot, predictions);
     let stuck_for = mh_snapshot.host_snapshot.state.version.since_state_change();
 
     let is_bios_setup_result = match &boot_interface {
@@ -459,7 +462,8 @@ pub(super) async fn handle_bios_setup_failed_recovery(
     mh_snapshot: &ManagedHostStateSnapshot,
     recovered_state: ManagedHostState,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let boot_interface = boot_interface_target(mh_snapshot);
+    let predictions = super::load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    let boot_interface = boot_interface_target(mh_snapshot, &predictions);
     let redfish_client = ctx
         .services
         .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)


### PR DESCRIPTION
## What

Gives the machine-controller the same predicted-boot-interface fallback the admin path got in #2528, so a zero-DPU / NIC-mode host can be boot-targeted *before* its first DHCP lease instead of waiting.

A zero-DPU or NIC-mode host gets no primary `machine_interfaces` row at ingestion, so until its NIC leases the controller's boot states had nothing to target. `boot_interface_target` / `resolve_boot_interface` now fall back to the host's predicted boot interface; the real row still wins the moment it exists, and `AwaitingNic` (the #2688 wait) now fires only when there's no row *and* no usable prediction.

The selection rule lives in one shared `pick_boot_prediction` (api-model): the declared `ExpectedHostNic.primary` (recorded on the prediction in #2657) wins, else the sole non-underlay prediction, else it refuses to guess. The admin `resolve_admin_boot_interface_target` is routed through the same selector, so it now honors the declared-primary flag for multi-NIC hosts (previously it refused) and the two paths can't drift.

## Notes

- Predictions are loaded on demand at each resolve site (mirroring the admin path's `boot_interface_candidates`), via a `load_boot_predictions` helper -- not added to `ManagedHostStateSnapshot` (a fixed SQL-template view loaded broadly). The `machine_id` index added in #2657 keeps that query cheap.
- The boot-target composition is split into a pure `boot_interface_target_from`, the same "unit-test without a full snapshot" split api-model uses for `pick_boot_interface_mac`/`_pair`.

## Test plan

- `cargo clippy --all-features --tests` clean over the touched crates; `cargo +nightly fmt`.
- New tests: `pick_boot_prediction` precedence (primary / sole non-underlay / refuse-multiple / underlay-filtered); controller `boot_interface_target_from` (row wins over predictions, prediction fallback as pair, MAC-only without id, none → wait); admin declared-primary disambiguation. Existing `boot_interface_resolution` + `classify_*` tests still pass.

Part of #2658 (epic #2660).


Closes #2658
