### PR TITLE
fix(api-core): repair a silently-passing state assertion and the ignored rack tests

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -1785,12 +1785,16 @@ async fn test_state_outcome(pool: sqlx::PgPool) {
     let mut txn = env.db_txn().await;
     let host_machine = mh.host().db_machine(&mut txn).await;
     txn.rollback().await.unwrap();
-    let _expected_state = ManagedHostState::DPUInit {
+    let expected_state = ManagedHostState::DPUInit {
         dpu_states: model::machine::DpuInitStates {
             states: HashMap::from([(mh.dpu().id, DpuInitState::WaitingForNetworkConfig)]),
         },
     };
-    assert!(matches!(host_machine.current_state(), _expected_state));
+    assert_eq!(
+        host_machine.current_state(),
+        &expected_state,
+        "machine should be in DPUInit, waiting for network config"
+    );
     assert!(
         matches!(
             host_machine.controller_state_outcome,
@@ -1809,7 +1813,6 @@ async fn test_state_outcome(pool: sqlx::PgPool) {
     let host_machine = mh.host().db_machine(&mut txn).await;
     txn.rollback().await.unwrap();
     let outcome = host_machine.controller_state_outcome.unwrap();
-    dbg!(&outcome);
     assert!(
         matches!(outcome, PersistentStateHandlerOutcome::Wait{ reason, source_ref: Some(source_ref) } if !reason.is_empty() && source_ref.file.ends_with("/handler.rs")),
         "Third iteration should be waiting for DPU agent, and include a wait reason and source reference",

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -760,7 +760,7 @@ fn test_nvos_polling_unknown_state_preserves_status_and_sets_error() {
 /// test_expected_incomplete_device_counts_stays verifies that a rack with a
 /// topology expecting more devices than currently exist stays in Created.
 #[crate::sqlx_test]
-#[ignore]
+#[ignore = "asserts rack state-transition behavior the handler does not currently exhibit; tracked in #2715"]
 async fn test_expected_incomplete_device_counts_stays(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -871,7 +871,6 @@ async fn test_expected_counts_match_but_not_linked_stays(
 /// test_expected_zero_topology_transitions_to_discovering verifies that a rack
 /// with zero expected devices in topology immediately transitions to Discovering.
 #[crate::sqlx_test]
-#[ignore]
 async fn test_expected_zero_topology_transitions_to_discovering(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -888,18 +887,7 @@ async fn test_expected_zero_topology_transitions_to_discovering(
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
 
-    // Create rack with a profile expecting 2 compute, 0 switches, 0 PS.
-    db_rack::create(
-        &mut txn,
-        &rack_id,
-        Some(&RackProfileId::new("Empty")),
-        &RackConfig::default(),
-        None,
-    )
-    .await?;
-
-    // Simulate that both compute trays are already linked by setting
-    // compute_trays to have 2 entries matching expected_compute_trays.
+    // Create the rack with the "Empty" profile, which expects zero devices.
     db_rack::create(
         &mut txn,
         &rack_id,
@@ -949,7 +937,7 @@ async fn test_expected_zero_topology_transitions_to_discovering(
 /// test_expected_more_discovered_than_expected_transitions verifies that a
 /// rack with more discovered compute trays than expected still transitions.
 #[crate::sqlx_test]
-#[ignore]
+#[ignore = "asserts rack state-transition behavior the handler does not currently exhibit; tracked in #2715"]
 async fn test_expected_more_discovered_than_expected_transitions(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1019,7 +1007,7 @@ async fn test_expected_more_discovered_than_expected_transitions(
 /// test_discovering_waits_for_compute_ready verifies that the handler
 /// reports an error for the Discovering state when managed hosts are missing.
 #[crate::sqlx_test]
-#[ignore]
+#[ignore = "asserts rack state-transition behavior the handler does not currently exhibit; tracked in #2715"]
 async fn test_discovering_waits_for_compute_ready(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Wave 1 of the carbide-test-support integration (#2692).

Two real test-coverage holes in api-core:

- `machine_states::test_state_outcome` asserted `matches!(host_machine.current_state(), _expected_state)` -- an irrefutable binding, so it passed for **any** state and tested nothing. Now asserts equality against the `expected_state` value it builds; stray `dbg!` removed.
- Four rack state-controller tests were bare `#[ignore]` (never ran in CI). `test_expected_zero_topology_transitions_to_discovering` was only broken by a duplicate `db_rack::create` in its setup (the second call, mislabeled "simulating linked trays," just re-created the rack) -- fixed and re-enabled.

The other three formerly-ignored tests assert `Created`/`Discovering` transitions the handler does not currently make. Rather than leave them silently dead, each now carries an `#[ignore = "..."]` reason and is tracked in #2715 (handler-fix vs stale-test, per test). This converts 4 invisible dead tests into 1 live test + 3 documented-and-tracked ones.

Verified: rack-handler + machine-states tests run green (44 pass, 3 explicitly ignored, 0 fail).

Addresses #2694. Surfaced follow-up: #2715.
