### PR TITLE
test(api-core): parameterize cross-entity test duplication

### DIFF
--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -2275,39 +2275,83 @@ mod tests {
         }
     }
 
-    #[test]
-    fn error_to_status_unavailable() {
-        let st =
-            component_manager_error_to_status(ComponentManagerError::Unavailable("gone".into()));
-        assert_eq!(st.code(), Code::Unavailable);
-        assert!(st.message().contains("gone"));
+    /// Yields a real `tonic::transport::Error` so the `Transport` arm can be
+    /// exercised without a live connection: an invalid endpoint URI fails to parse
+    /// synchronously into exactly that error type.
+    fn transport_error() -> tonic::transport::Error {
+        tonic::transport::Endpoint::new("not a valid uri")
+            .expect_err("an invalid endpoint URI should fail to parse")
+    }
+
+    /// One `component_manager_error_to_status` mapping: the source error, the gRPC
+    /// `Code` it must produce, and (where the message is part of the contract) a
+    /// substring the propagated status message must contain.
+    struct ErrorToStatusCase {
+        scenario: &'static str,
+        error: ComponentManagerError,
+        expected_code: Code,
+        message_contains: Option<&'static str>,
     }
 
     #[test]
-    fn error_to_status_not_found() {
-        let st =
-            component_manager_error_to_status(ComponentManagerError::NotFound("missing".into()));
-        assert_eq!(st.code(), Code::NotFound);
-    }
+    fn error_to_status_maps_each_variant() {
+        let cases = [
+            ErrorToStatusCase {
+                scenario: "unavailable propagates its message",
+                error: ComponentManagerError::Unavailable("gone".into()),
+                expected_code: Code::Unavailable,
+                message_contains: Some("gone"),
+            },
+            ErrorToStatusCase {
+                scenario: "not found",
+                error: ComponentManagerError::NotFound("missing".into()),
+                expected_code: Code::NotFound,
+                message_contains: None,
+            },
+            ErrorToStatusCase {
+                scenario: "invalid argument",
+                error: ComponentManagerError::InvalidArgument("bad".into()),
+                expected_code: Code::InvalidArgument,
+                message_contains: None,
+            },
+            ErrorToStatusCase {
+                scenario: "internal",
+                error: ComponentManagerError::Internal("oops".into()),
+                expected_code: Code::Internal,
+                message_contains: None,
+            },
+            ErrorToStatusCase {
+                scenario: "status passthrough preserves the original code",
+                error: ComponentManagerError::Status(Status::permission_denied("nope")),
+                expected_code: Code::PermissionDenied,
+                message_contains: None,
+            },
+            ErrorToStatusCase {
+                scenario: "transport maps to unavailable",
+                error: ComponentManagerError::Transport(transport_error()),
+                expected_code: Code::Unavailable,
+                message_contains: Some("transport error"),
+            },
+            ErrorToStatusCase {
+                scenario: "rms maps to internal",
+                error: ComponentManagerError::Rms("rms boom".into()),
+                expected_code: Code::Internal,
+                message_contains: Some("RMS error"),
+            },
+        ];
 
-    #[test]
-    fn error_to_status_invalid_argument() {
-        let st =
-            component_manager_error_to_status(ComponentManagerError::InvalidArgument("bad".into()));
-        assert_eq!(st.code(), Code::InvalidArgument);
-    }
-
-    #[test]
-    fn error_to_status_internal() {
-        let st = component_manager_error_to_status(ComponentManagerError::Internal("oops".into()));
-        assert_eq!(st.code(), Code::Internal);
-    }
-
-    #[test]
-    fn error_to_status_passthrough() {
-        let original = Status::permission_denied("nope");
-        let st = component_manager_error_to_status(ComponentManagerError::Status(original));
-        assert_eq!(st.code(), Code::PermissionDenied);
+        for case in cases {
+            let status = component_manager_error_to_status(case.error);
+            assert_eq!(status.code(), case.expected_code, "{}", case.scenario);
+            if let Some(substring) = case.message_contains {
+                assert!(
+                    status.message().contains(substring),
+                    "{}: message {:?} should contain {substring:?}",
+                    case.scenario,
+                    status.message(),
+                );
+            }
+        }
     }
 
     #[test]
@@ -2466,39 +2510,20 @@ mod tests {
     }
 
     #[test]
-    fn power_action_on() {
-        let action = map_power_action(SystemPowerControl::On as i32).unwrap();
-        assert!(matches!(action, PowerAction::On));
-    }
-
-    #[test]
-    fn power_action_graceful_shutdown() {
-        let action = map_power_action(SystemPowerControl::GracefulShutdown as i32).unwrap();
-        assert!(matches!(action, PowerAction::GracefulShutdown));
-    }
-
-    #[test]
-    fn power_action_force_off() {
-        let action = map_power_action(SystemPowerControl::ForceOff as i32).unwrap();
-        assert!(matches!(action, PowerAction::ForceOff));
-    }
-
-    #[test]
-    fn power_action_graceful_restart() {
-        let action = map_power_action(SystemPowerControl::GracefulRestart as i32).unwrap();
-        assert!(matches!(action, PowerAction::GracefulRestart));
-    }
-
-    #[test]
-    fn power_action_force_restart() {
-        let action = map_power_action(SystemPowerControl::ForceRestart as i32).unwrap();
-        assert!(matches!(action, PowerAction::ForceRestart));
-    }
-
-    #[test]
-    fn power_action_ac_powercycle() {
-        let action = map_power_action(SystemPowerControl::AcPowercycle as i32).unwrap();
-        assert!(matches!(action, PowerAction::AcPowercycle));
+    fn power_action_maps_each_control() {
+        use carbide_test_support::Outcome::*;
+        // Map the rejection error to its `Code` so rows share one comparable error
+        // type; every row here is a successful control-to-action mapping.
+        carbide_test_support::scenarios!(run = |raw| map_power_action(raw).map_err(|s| s.code());
+            "control maps to action" {
+                SystemPowerControl::On as i32 => Yields(PowerAction::On),
+                SystemPowerControl::GracefulShutdown as i32 => Yields(PowerAction::GracefulShutdown),
+                SystemPowerControl::ForceOff as i32 => Yields(PowerAction::ForceOff),
+                SystemPowerControl::GracefulRestart as i32 => Yields(PowerAction::GracefulRestart),
+                SystemPowerControl::ForceRestart as i32 => Yields(PowerAction::ForceRestart),
+                SystemPowerControl::AcPowercycle as i32 => Yields(PowerAction::AcPowercycle),
+            }
+        );
     }
 
     #[test]

--- a/crates/api-core/src/tests/common/health_crud.rs
+++ b/crates/api-core/src/tests/common/health_crud.rs
@@ -1,0 +1,295 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Shared health-override CRUD behaviors, written once and driven per entity.
+//!
+//! Power shelves, switches, and racks each expose the same health-override
+//! surface — insert / list / remove an override, see it on the entity's status,
+//! and roll it into the aggregation metrics — over entity-specific RPCs. Rather
+//! than re-prove each behavior per entity, the behaviors live here once. An entity
+//! supplies its differences as closures ([`HealthCrud`]): how to insert, list,
+//! remove, and read back an override for one of its IDs, plus a representative
+//! alerting report and an empty (healthy) report. Each entity's `#[sqlx_test]`
+//! builds a [`HealthCrud`] over a single pool and calls the shared checks.
+//!
+//! Entity-unique behavior — rack override precedence and propagation to host
+//! aggregate health — stays in the per-entity test module; only the behaviors that
+//! are identical across all three are shared here.
+
+use carbide_utils::test_support::test_meter::TestMeter;
+use health_report::HealthReport;
+use rpc::forge::{HealthReportApplyMode, HealthReportEntry, HealthSourceOrigin};
+use tonic::Status;
+
+/// The health-override fields common to every entity's status, as read back from a
+/// `find` RPC: the merged health report and the per-source override origins.
+pub struct HealthStatusView {
+    pub health: Option<rpc::health::HealthReport>,
+    pub health_sources: Vec<HealthSourceOrigin>,
+}
+
+/// One entity's health-override CRUD surface, expressed as closures over a single
+/// pool. The shared checks below drive these instead of any concrete entity's RPCs.
+///
+/// `Id` is the entity ID type; closures take it by value so the same harness can be
+/// pointed at a real ID or a freshly-minted nonexistent one.
+pub struct HealthCrud<Id, Ins, Lst, Rem, Fnd> {
+    /// A persisted entity's ID, used by the behaviors that operate on a live entity.
+    pub real_id: Id,
+    /// An ID that was never persisted, used by the "missing entity" check.
+    pub nonexistent_id: Id,
+    /// A representative report carrying one alert (entity-specific alert ID).
+    pub alert: HealthReport,
+    /// A source identifier the alert report is filed under.
+    pub alert_source: &'static str,
+    /// An override RPC: file `report` under its source for `id`, in `mode`.
+    pub insert: Ins,
+    /// A list RPC: the override entries currently held for `id`.
+    pub list: Lst,
+    /// A remove RPC: drop the override filed under `source` for `id`.
+    pub remove: Rem,
+    /// A find RPC: read back `id`'s status health view.
+    pub find: Fnd,
+}
+
+impl<Id, Ins, Lst, Rem, Fnd> HealthCrud<Id, Ins, Lst, Rem, Fnd>
+where
+    Id: Clone,
+    Ins: AsyncFn(Id, HealthReport, HealthReportApplyMode) -> Result<(), Status>,
+    Lst: AsyncFn(Id) -> Result<Vec<HealthReportEntry>, Status>,
+    Rem: AsyncFn(Id, String) -> Result<(), Status>,
+    Fnd: AsyncFn(Id) -> Result<HealthStatusView, Status>,
+{
+    /// Insert an override, confirm exactly one entry lists with the expected source
+    /// and one alert, remove it, and confirm the list is empty again.
+    pub async fn check_insert_list_remove(&self) {
+        (self.insert)(
+            self.real_id.clone(),
+            self.alert.clone(),
+            HealthReportApplyMode::Merge,
+        )
+        .await
+        .expect("insert override");
+
+        let entries = (self.list)(self.real_id.clone())
+            .await
+            .expect("list overrides");
+        assert_eq!(entries.len(), 1, "exactly one override should be listed");
+        let listed: HealthReport = entries[0]
+            .report
+            .clone()
+            .unwrap()
+            .try_into()
+            .expect("listed report converts back");
+        assert_eq!(listed.source, self.alert_source);
+        assert_eq!(listed.alerts.len(), 1);
+
+        (self.remove)(self.real_id.clone(), self.alert_source.to_string())
+            .await
+            .expect("remove override");
+
+        let entries = (self.list)(self.real_id.clone())
+            .await
+            .expect("list overrides after remove");
+        assert_eq!(entries.len(), 0, "override should be gone after remove");
+    }
+
+    /// Inserting the same override repeatedly is idempotent: still one entry.
+    pub async fn check_idempotent_insert(&self) {
+        for _ in 0..3 {
+            (self.insert)(
+                self.real_id.clone(),
+                self.alert.clone(),
+                HealthReportApplyMode::Merge,
+            )
+            .await
+            .expect("repeated insert override");
+        }
+
+        let entries = (self.list)(self.real_id.clone())
+            .await
+            .expect("list overrides");
+        assert_eq!(entries.len(), 1, "repeated inserts should collapse to one");
+    }
+
+    /// Removing a source that was never filed is a `NotFound`.
+    pub async fn check_remove_nonexistent_source(&self) {
+        let status = (self.remove)(self.real_id.clone(), "nonexistent-source".to_string())
+            .await
+            .expect_err("removing an unknown source should error");
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    /// Inserting an override for an entity that does not exist is an error.
+    pub async fn check_missing_entity(&self) {
+        let status = (self.insert)(
+            self.nonexistent_id.clone(),
+            self.alert.clone(),
+            HealthReportApplyMode::Merge,
+        )
+        .await
+        .expect_err("inserting an override for a nonexistent entity should error");
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    /// A `Replace`-mode override lists with `Replace` mode and clears on remove.
+    pub async fn check_replace_mode(&self, replace_report: HealthReport, replace_source: &str) {
+        (self.insert)(
+            self.real_id.clone(),
+            replace_report,
+            HealthReportApplyMode::Replace,
+        )
+        .await
+        .expect("insert replace override");
+
+        let entries = (self.list)(self.real_id.clone())
+            .await
+            .expect("list overrides");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].mode, HealthReportApplyMode::Replace as i32);
+
+        (self.remove)(self.real_id.clone(), replace_source.to_string())
+            .await
+            .expect("remove replace override");
+
+        let entries = (self.list)(self.real_id.clone())
+            .await
+            .expect("list overrides after remove");
+        assert_eq!(entries.len(), 0);
+    }
+
+    /// An inserted override is visible on the entity's status from a `find` RPC:
+    /// the merged health carries alerts, and the override source is recorded.
+    pub async fn check_visible_in_find(&self) {
+        (self.insert)(
+            self.real_id.clone(),
+            self.alert.clone(),
+            HealthReportApplyMode::Merge,
+        )
+        .await
+        .expect("insert override");
+
+        let view = (self.find)(self.real_id.clone())
+            .await
+            .expect("find entity");
+
+        let health = view.health.expect("status should carry a health report");
+        let health: HealthReport = health.try_into().expect("health converts back");
+        assert!(
+            !health.alerts.is_empty(),
+            "status health should contain alerts"
+        );
+
+        assert_eq!(view.health_sources.len(), 1);
+        assert_eq!(view.health_sources[0].source, self.alert_source);
+        assert_eq!(
+            view.health_sources[0].mode,
+            HealthReportApplyMode::Merge as i32
+        );
+    }
+}
+
+/// Drives the shared health-override aggregation metrics for one entity: an
+/// override (merge, then replace) flips the per-entity override and status gauges,
+/// and the entity never emits the legacy `alerts_suppressed` alias.
+///
+/// `metric_entity` is the entity token in the metric names (e.g. `power_shelves`),
+/// `run_iteration` advances that entity's controller, and `insert`/`alert`/`empty`
+/// supply the entity's override RPC and reports.
+pub async fn check_health_aggregation<Id, Ins, Iter>(
+    metric_entity: &str,
+    real_id: Id,
+    alert: HealthReport,
+    empty: HealthReport,
+    meter: &TestMeter,
+    insert: Ins,
+    run_iteration: Iter,
+) where
+    Id: Clone,
+    Ins: AsyncFn(Id, HealthReport, HealthReportApplyMode) -> Result<(), Status>,
+    Iter: AsyncFn(),
+{
+    let overrides_metric = format!("carbide_{metric_entity}_health_overrides_count");
+    let status_metric = format!("carbide_{metric_entity}_health_status_count");
+
+    let sorted = |name: &str| {
+        let mut m = meter.formatted_metrics(name);
+        m.sort();
+        m
+    };
+
+    run_iteration().await;
+    assert_eq!(
+        sorted(&overrides_metric),
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+    assert_eq!(
+        sorted(&status_metric),
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    insert(real_id.clone(), alert, HealthReportApplyMode::Merge)
+        .await
+        .expect("insert merge override");
+    run_iteration().await;
+    assert_eq!(
+        sorted(&overrides_metric),
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
+        ]
+    );
+    assert_eq!(
+        sorted(&status_metric),
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
+        ]
+    );
+
+    insert(real_id, empty, HealthReportApplyMode::Replace)
+        .await
+        .expect("insert replace override");
+    run_iteration().await;
+    assert_eq!(
+        sorted(&overrides_metric),
+        vec![
+            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
+            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
+        ]
+    );
+    assert_eq!(
+        sorted(&status_metric),
+        vec![
+            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
+            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
+        ]
+    );
+
+    assert!(
+        meter
+            .formatted_metrics("carbide_alerts_suppressed_count")
+            .is_empty(),
+        "{metric_entity} should not emit the legacy alerts_suppressed alias"
+    );
+}

--- a/crates/api-core/src/tests/common/mod.rs
+++ b/crates/api-core/src/tests/common/mod.rs
@@ -24,6 +24,10 @@ pub mod api_fixtures;
 #[cfg(test)]
 pub mod attestation;
 pub mod endpoint;
+// Only this crate's own `#[cfg(test)]` health-override tests drive these shared CRUD
+// helpers; gate them out of test-support-only builds to keep dead-code detection honest.
+#[cfg(test)]
+pub mod health_crud;
 pub mod metadata;
 pub mod network_segment;
 pub mod rpc_builder;

--- a/crates/api-core/src/tests/explored_endpoint_find.rs
+++ b/crates/api-core/src/tests/explored_endpoint_find.rs
@@ -105,48 +105,9 @@ async fn test_find_explored_endpoints_by_ids(
     Ok(())
 }
 
-#[crate::sqlx_test()]
-async fn test_find_explored_endpoints_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let endpoint_ids: Vec<String> = (1..=end_index).map(|i| format!("141.219.24.{i}")).collect();
-
-    let request =
-        tonic::Request::new(::rpc::site_explorer::ExploredEndpointsByIdsRequest { endpoint_ids });
-
-    let response = env.api.find_explored_endpoints_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing too many IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_explored_endpoints_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-
-    let request =
-        tonic::Request::new(::rpc::site_explorer::ExploredEndpointsByIdsRequest::default());
-
-    let response = env.api.find_explored_endpoints_by_ids(request).await;
-    // validate
-    assert!(response.is_err(), "expected an error when passing no IDs");
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_explored_endpoints_by_ids` are
+// shared API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.
 
 #[crate::sqlx_test]
 async fn test_admin_bmc_reset(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {

--- a/crates/api-core/src/tests/explored_managed_host_find.rs
+++ b/crates/api-core/src/tests/explored_managed_host_find.rs
@@ -118,45 +118,6 @@ async fn test_find_explored_managed_hosts_by_ids(
     Ok(())
 }
 
-#[crate::sqlx_test()]
-async fn test_find_explored_managed_hosts_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let host_ids: Vec<String> = (1..=end_index).map(|i| format!("141.219.24.{i}")).collect();
-
-    let request =
-        tonic::Request::new(::rpc::site_explorer::ExploredManagedHostsByIdsRequest { host_ids });
-
-    let response = env.api.find_explored_managed_hosts_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing too many IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_explored_managed_hosts_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-
-    let request =
-        tonic::Request::new(::rpc::site_explorer::ExploredManagedHostsByIdsRequest::default());
-
-    let response = env.api.find_explored_managed_hosts_by_ids(request).await;
-    // validate
-    assert!(response.is_err(), "expected an error when passing no IDs");
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_explored_managed_hosts_by_ids` are
+// shared API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.

--- a/crates/api-core/src/tests/find_by_ids_guards.rs
+++ b/crates/api-core/src/tests/find_by_ids_guards.rs
@@ -1,0 +1,404 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Shared `find_*_by_ids` request guards, proven once across representative RPCs.
+//!
+//! Every `find_*_by_ids` RPC validates its ID list with the same two API-layer
+//! guards before touching configuration or the database: it rejects an empty list
+//! with `"at least one ID must be provided"`, and a list longer than
+//! `max_find_by_ids` with `"no more than {max} IDs can be accepted"`. The messages
+//! are byte-identical across handlers (see `handlers/*.rs`), so each guard is
+//! exercised once here over a representative spread of RPCs rather than re-proven
+//! per entity in every `*_find.rs`. Each row builds and calls one RPC; the row is
+//! labeled by RPC name so a failure says which RPC drifted from the shared guard.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use ::rpc::forge as rpc;
+use carbide_uuid::infiniband::IBPartitionId;
+use carbide_uuid::instance::InstanceId;
+use carbide_uuid::machine::MachineId;
+use carbide_uuid::network::NetworkSegmentId;
+use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::switch::SwitchId;
+use carbide_uuid::vpc::VpcId;
+use data_encoding::BASE32_DNSSEC;
+use rpc::forge_server::Forge;
+use sha2::{Digest, Sha256};
+use tonic::{Code, Request, Status};
+
+use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
+
+/// The shared empty-list guard message, returned ahead of any DB work.
+const EMPTY_MESSAGE: &str = "at least one ID must be provided";
+
+/// One representative RPC, plus the `find_*_by_ids` call to exercise its guard.
+///
+/// `call` builds and dispatches a single RPC against the shared `env`, discarding
+/// the success payload — the guard cases never reach a successful response, so the
+/// only thing that matters is the error each RPC returns.
+struct RpcGuardCase {
+    /// The RPC under test; used as the failure label so a regression names the RPC.
+    rpc: &'static str,
+    /// The `find_*_by_ids` call, already bound to its request.
+    call: Pin<Box<dyn Future<Output = Result<(), Status>>>>,
+}
+
+/// Builds machine IDs the way the machine handler expects (TPM-derived, base32),
+/// since the empty case below shares this file's representative spread.
+fn machine_id(index: u32) -> MachineId {
+    let serial = format!("machine_{index}");
+    let hash: [u8; 32] = Sha256::new_with_prefix(serial.as_bytes()).finalize().into();
+    let encoded = BASE32_DNSSEC.encode(&hash);
+    format!(
+        "{}s{}",
+        carbide_uuid::machine::MachineType::Dpu.id_prefix(),
+        encoded
+    )
+    .parse()
+    .unwrap()
+}
+
+/// The representative RPCs exercised for the over-max guard, each handed a list of
+/// `max_find_by_ids + 1` IDs. The IDs need not be real: the guard fires on length
+/// before any lookup.
+fn over_max_cases(env: &TestEnv) -> Vec<RpcGuardCase> {
+    let over = env.config.max_find_by_ids + 1;
+    let api = env.api.clone();
+
+    vec![
+        RpcGuardCase {
+            rpc: "find_machines_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_machines_by_ids(Request::new(rpc::MachinesByIdsRequest {
+                        machine_ids: (1..=over).map(machine_id).collect(),
+                        ..Default::default()
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_instances_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    let instance_ids: Vec<InstanceId> =
+                        (1..=over).map(|_| uuid::Uuid::new_v4().into()).collect();
+                    api.find_instances_by_ids(Request::new(rpc::InstancesByIdsRequest {
+                        instance_ids,
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_switches_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    let switch_ids: Vec<SwitchId> = (0..over)
+                        .map(|_| SwitchId::from(uuid::Uuid::new_v4()))
+                        .collect();
+                    api.find_switches_by_ids(Request::new(rpc::SwitchesByIdsRequest { switch_ids }))
+                        .await
+                        .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_power_shelves_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    let power_shelf_ids: Vec<PowerShelfId> = (0..over)
+                        .map(|_| PowerShelfId::from(uuid::Uuid::new_v4()))
+                        .collect();
+                    api.find_power_shelves_by_ids(Request::new(rpc::PowerShelvesByIdsRequest {
+                        power_shelf_ids,
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_vpcs_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_vpcs_by_ids(Request::new(rpc::VpcsByIdsRequest {
+                        vpc_ids: (0..over)
+                            .map(|_| VpcId::from(uuid::Uuid::new_v4()))
+                            .collect(),
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_network_segments_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    let network_segments_ids: Vec<NetworkSegmentId> =
+                        (1..=over).map(|_| uuid::Uuid::new_v4().into()).collect();
+                    api.find_network_segments_by_ids(Request::new(
+                        rpc::NetworkSegmentsByIdsRequest {
+                            network_segments_ids,
+                            include_history: false,
+                            include_num_free_ips: false,
+                        },
+                    ))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_ib_partitions_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    let ib_partition_ids: Vec<IBPartitionId> =
+                        (1..=over).map(|_| uuid::Uuid::new_v4().into()).collect();
+                    api.find_ib_partitions_by_ids(Request::new(rpc::IbPartitionsByIdsRequest {
+                        ib_partition_ids,
+                        include_history: false,
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_tenant_keysets_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_tenant_keysets_by_ids(Request::new(rpc::TenantKeysetsByIdsRequest {
+                        keyset_ids: (1..=over)
+                            .map(|i| rpc::TenantKeysetIdentifier {
+                                organization_id: "tenant_org_1".to_string(),
+                                keyset_id: format!("keyset_id_{i}"),
+                            })
+                            .collect(),
+                        include_key_data: false,
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_explored_managed_hosts_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_explored_managed_hosts_by_ids(Request::new(
+                        ::rpc::site_explorer::ExploredManagedHostsByIdsRequest {
+                            host_ids: (1..=over).map(|i| format!("141.219.24.{i}")).collect(),
+                        },
+                    ))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_explored_endpoints_by_ids",
+            call: Box::pin(async move {
+                api.find_explored_endpoints_by_ids(Request::new(
+                    ::rpc::site_explorer::ExploredEndpointsByIdsRequest {
+                        endpoint_ids: (1..=over).map(|i| format!("141.219.24.{i}")).collect(),
+                    },
+                ))
+                .await
+                .map(|_| ())
+            }),
+        },
+    ]
+}
+
+/// The same representative RPCs exercised for the empty-list guard, each handed an
+/// empty ID list (a default request).
+fn empty_cases(env: &TestEnv) -> Vec<RpcGuardCase> {
+    let api = env.api.clone();
+
+    vec![
+        RpcGuardCase {
+            rpc: "find_machines_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_machines_by_ids(Request::new(rpc::MachinesByIdsRequest::default()))
+                        .await
+                        .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_instances_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_instances_by_ids(Request::new(rpc::InstancesByIdsRequest::default()))
+                        .await
+                        .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_switches_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_switches_by_ids(Request::new(rpc::SwitchesByIdsRequest {
+                        switch_ids: vec![],
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_power_shelves_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_power_shelves_by_ids(Request::new(rpc::PowerShelvesByIdsRequest {
+                        power_shelf_ids: vec![],
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_vpcs_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_vpcs_by_ids(Request::new(rpc::VpcsByIdsRequest::default()))
+                        .await
+                        .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_network_segments_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_network_segments_by_ids(Request::new(
+                        rpc::NetworkSegmentsByIdsRequest::default(),
+                    ))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_ib_partitions_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_ib_partitions_by_ids(Request::new(rpc::IbPartitionsByIdsRequest {
+                        ib_partition_ids: Vec::new(),
+                        include_history: false,
+                    }))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_tenant_keysets_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_tenant_keysets_by_ids(Request::new(
+                        rpc::TenantKeysetsByIdsRequest::default(),
+                    ))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_explored_managed_hosts_by_ids",
+            call: Box::pin({
+                let api = api.clone();
+                async move {
+                    api.find_explored_managed_hosts_by_ids(Request::new(
+                        ::rpc::site_explorer::ExploredManagedHostsByIdsRequest::default(),
+                    ))
+                    .await
+                    .map(|_| ())
+                }
+            }),
+        },
+        RpcGuardCase {
+            rpc: "find_explored_endpoints_by_ids",
+            call: Box::pin(async move {
+                api.find_explored_endpoints_by_ids(Request::new(
+                    ::rpc::site_explorer::ExploredEndpointsByIdsRequest::default(),
+                ))
+                .await
+                .map(|_| ())
+            }),
+        },
+    ]
+}
+
+#[crate::sqlx_test]
+async fn find_by_ids_rejects_empty_id_list(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    for case in empty_cases(&env) {
+        let err = case.call.await.expect_err(&format!(
+            "{}: expected an error for an empty ID list",
+            case.rpc
+        ));
+        assert_eq!(err.code(), Code::InvalidArgument, "{}", case.rpc);
+        assert_eq!(err.message(), EMPTY_MESSAGE, "{}", case.rpc);
+    }
+}
+
+#[crate::sqlx_test]
+async fn find_by_ids_rejects_too_many_ids(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let expected = format!(
+        "no more than {} IDs can be accepted",
+        env.config.max_find_by_ids
+    );
+
+    for case in over_max_cases(&env) {
+        let err = case.call.await.expect_err(&format!(
+            "{}: expected an error when passing more than max IDs",
+            case.rpc
+        ));
+        assert_eq!(err.code(), Code::InvalidArgument, "{}", case.rpc);
+        assert_eq!(err.message(), expected, "{}", case.rpc);
+    }
+}

--- a/crates/api-core/src/tests/ib_partition_find.rs
+++ b/crates/api-core/src/tests/ib_partition_find.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::forge as rpc;
 use carbide_ib_fabric::config::IBFabricConfig;
-use carbide_uuid::infiniband::IBPartitionId;
 use rpc::forge_server::Forge;
 
 use crate::tests::common;
@@ -160,74 +159,7 @@ async fn test_find_ib_partitions_by_ids(pool: sqlx::PgPool) {
     );
 }
 
-#[crate::sqlx_test()]
-async fn test_find_ib_partitions_by_ids_over_max(pool: sqlx::PgPool) {
-    let mut config = common::api_fixtures::get_config();
-    config.ib_config = Some(IBFabricConfig {
-        enabled: true,
-        ..Default::default()
-    });
-
-    let env = common::api_fixtures::create_test_env_with_overrides(
-        pool,
-        TestEnvOverrides::with_config(config),
-    )
-    .await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let ib_partition_ids: Vec<IBPartitionId> = (1..=end_index)
-        .map(|_| uuid::Uuid::new_v4().into())
-        .collect();
-
-    let request = tonic::Request::new(rpc::IbPartitionsByIdsRequest {
-        ib_partition_ids,
-        include_history: false,
-    });
-
-    let response = env.api.find_ib_partitions_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_ib_partitions_by_ids_none(pool: sqlx::PgPool) {
-    let mut config = common::api_fixtures::get_config();
-    config.ib_config = Some(IBFabricConfig {
-        enabled: true,
-        ..Default::default()
-    });
-
-    let env = common::api_fixtures::create_test_env_with_overrides(
-        pool,
-        TestEnvOverrides::with_config(config),
-    )
-    .await;
-
-    let request_none = tonic::Request::new(rpc::IbPartitionsByIdsRequest {
-        ib_partition_ids: Vec::new(),
-        include_history: false,
-    });
-
-    let response_none = env.api.find_ib_partitions_by_ids(request_none).await;
-    // validate
-    assert!(
-        response_none.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response_none.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_ib_partitions_by_ids` are shared
+// API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`. The shared test exercises this RPC under the
+// default env: the guard fires on the ID-list length before any IB-config check.

--- a/crates/api-core/src/tests/instance_find.rs
+++ b/crates/api-core/src/tests/instance_find.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::forge as rpc;
 use base64::prelude::*;
-use carbide_uuid::instance::InstanceId;
 use rpc::forge_server::Forge;
 use tonic::Request;
 
@@ -386,51 +385,9 @@ async fn test_find_instances_by_ids(pool: sqlx::PgPool) {
     }
 }
 
-#[crate::sqlx_test()]
-async fn test_find_instances_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let instance_ids: Vec<InstanceId> = (1..=end_index)
-        .map(|_| uuid::Uuid::new_v4().into())
-        .collect();
-
-    let request = tonic::Request::new(rpc::InstancesByIdsRequest { instance_ids });
-
-    let response = env.api.find_instances_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_instances_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-
-    let request = tonic::Request::new(rpc::InstancesByIdsRequest::default());
-
-    let response = env.api.find_instances_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_instances_by_ids` are shared
+// API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.
 
 #[crate::sqlx_test]
 async fn test_find_instances_by_machine_id_none(pool: sqlx::PgPool) {

--- a/crates/api-core/src/tests/machine_find.rs
+++ b/crates/api-core/src/tests/machine_find.rs
@@ -20,7 +20,6 @@ use carbide_uuid::machine::{MACHINE_ID_PREFIX_LENGTH, MachineId, MachineType};
 use carbide_uuid::rack::RackId;
 use common::api_fixtures::dpu::create_dpu_machine;
 use common::api_fixtures::{create_managed_host, create_test_env, site_explorer};
-use data_encoding::BASE32_DNSSEC;
 use db::ObjectFilter;
 use itertools::Itertools;
 use mac_address::MacAddress;
@@ -30,11 +29,7 @@ use model::machine::machine_id::host_id_from_dpu_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::test_support::ManagedHostConfig;
 use rpc::forge::forge_server::Forge;
-use rpc::forge::{
-    AssociateMachinesWithInstanceTypeRequest, FindInstanceTypeIdsRequest, MachinesByIdsRequest,
-};
-use sha2::{Digest, Sha256};
-use tonic::Request;
+use rpc::forge::{AssociateMachinesWithInstanceTypeRequest, FindInstanceTypeIdsRequest};
 
 use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::test_support::mac_address_pool::DPU_OOB_MAC_ADDRESS_POOL;
@@ -581,61 +576,9 @@ async fn test_attached_dpu_machine_ids_multi_dpu(pool: sqlx::PgPool) {
     }
 }
 
-#[crate::sqlx_test()]
-async fn test_find_machines_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-
-    // create vector of machine IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let machine_ids = (1..=end_index)
-        .map(|index| {
-            let serial = format!("machine_{index}");
-            let hash: [u8; 32] = Sha256::new_with_prefix(serial.as_bytes()).finalize().into();
-            let encoded = BASE32_DNSSEC.encode(&hash);
-            format!("{}s{}", MachineType::Dpu.id_prefix(), encoded)
-                .parse()
-                .unwrap()
-        })
-        .collect();
-    //build request
-    let request: Request<MachinesByIdsRequest> = Request::new(MachinesByIdsRequest {
-        machine_ids,
-        ..Default::default()
-    });
-    // execute
-    let response = env.api.find_machines_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing more than allowed number of machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_machines_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-
-    let request = tonic::Request::new(::rpc::forge::MachinesByIdsRequest::default());
-
-    let response = env.api.find_machines_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_machines_by_ids` are shared
+// API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.
 
 #[crate::sqlx_test]
 async fn test_machine_capabilities_response(

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -40,6 +40,7 @@ mod expected_switch;
 mod explored_endpoint_find;
 mod explored_managed_host_find;
 mod extension_service;
+mod find_by_ids_guards;
 mod finder;
 mod host_bmc_firmware_test;
 mod ib_fabric_find;

--- a/crates/api-core/src/tests/network_segment_find.rs
+++ b/crates/api-core/src/tests/network_segment_find.rs
@@ -18,7 +18,6 @@
 #![allow(deprecated)]
 
 use ::rpc::forge as rpc;
-use carbide_uuid::network::NetworkSegmentId;
 use rpc::forge_server::Forge;
 
 use crate::tests::common::api_fixtures::network_segment::create_network_segment;
@@ -187,52 +186,6 @@ async fn test_find_network_segment_by_ids(pool: sqlx::PgPool) {
     }
 }
 
-#[crate::sqlx_test()]
-async fn test_find_network_segments_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let network_segments_ids: Vec<NetworkSegmentId> = (1..=end_index)
-        .map(|_| uuid::Uuid::new_v4().into())
-        .collect();
-
-    let request = tonic::Request::new(rpc::NetworkSegmentsByIdsRequest {
-        network_segments_ids,
-        include_history: false,
-        include_num_free_ips: false,
-    });
-
-    let response = env.api.find_network_segments_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_network_segments_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
-
-    let request = tonic::Request::new(rpc::NetworkSegmentsByIdsRequest::default());
-
-    let response = env.api.find_network_segments_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_network_segments_by_ids` are
+// shared API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.

--- a/crates/api-core/src/tests/power_shelf_find.rs
+++ b/crates/api-core/src/tests/power_shelf_find.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use carbide_uuid::power_shelf::PowerShelfId;
 use rpc::forge::forge_server::Forge;
 
 use crate::tests::common::api_fixtures::create_test_env;
@@ -67,55 +66,9 @@ async fn test_find_power_shelf_ids_and_by_ids(
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_find_power_shelves_by_ids_empty_returns_error(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-
-    let result = env
-        .api
-        .find_power_shelves_by_ids(tonic::Request::new(rpc::forge::PowerShelvesByIdsRequest {
-            power_shelf_ids: vec![],
-        }))
-        .await;
-    assert!(result.is_err());
-    assert_eq!(
-        result.err().unwrap().message(),
-        "at least one ID must be provided"
-    );
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_find_power_shelves_by_ids_over_max(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-
-    let count = env.config.max_find_by_ids + 1;
-    let power_shelf_ids: Vec<PowerShelfId> = (0..count)
-        .map(|_| PowerShelfId::from(uuid::Uuid::new_v4()))
-        .collect();
-
-    let result = env
-        .api
-        .find_power_shelves_by_ids(tonic::Request::new(rpc::forge::PowerShelvesByIdsRequest {
-            power_shelf_ids,
-        }))
-        .await;
-    assert!(result.is_err());
-    assert_eq!(
-        result.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-
-    Ok(())
-}
+// The empty-list and over-max guards for `find_power_shelves_by_ids` are shared
+// API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.
 
 #[crate::sqlx_test]
 async fn test_find_power_shelf_ids_excludes_deleted(

--- a/crates/api-core/src/tests/power_shelf_health.rs
+++ b/crates/api-core/src/tests/power_shelf_health.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_uuid::power_shelf::PowerShelfId;
 use health_report::{HealthAlertClassification, HealthProbeAlert, HealthReport};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as rpc_forge};
@@ -22,8 +23,9 @@ use tonic::Request;
 
 use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, create_test_env_with_overrides, get_config,
+    TestEnv, TestEnvOverrides, create_test_env_with_overrides, get_config,
 };
+use crate::tests::common::health_crud::{HealthCrud, HealthStatusView, check_health_aggregation};
 
 fn alert_report(source: &str) -> HealthReport {
     HealthReport {
@@ -55,106 +57,106 @@ fn empty_healthy_report(source: &str) -> HealthReport {
     }
 }
 
+async fn test_env(pool: sqlx::PgPool) -> TestEnv {
+    create_test_env_with_overrides(pool, TestEnvOverrides::with_config(get_config())).await
+}
+
+/// Builds the power-shelf health-override CRUD surface over `env` for `id`. The
+/// shared checks in [`crate::tests::common::health_crud`] drive these closures.
+// The four `impl AsyncFn` members are intentionally distinct unnameable closure
+// types; there is nothing to factor into a `type` alias.
+#[allow(clippy::type_complexity)]
+fn power_shelf_crud(
+    env: &TestEnv,
+    id: PowerShelfId,
+) -> HealthCrud<
+    PowerShelfId,
+    impl AsyncFn(
+        PowerShelfId,
+        HealthReport,
+        rpc_forge::HealthReportApplyMode,
+    ) -> Result<(), tonic::Status>,
+    impl AsyncFn(PowerShelfId) -> Result<Vec<rpc_forge::HealthReportEntry>, tonic::Status>,
+    impl AsyncFn(PowerShelfId, String) -> Result<(), tonic::Status>,
+    impl AsyncFn(PowerShelfId) -> Result<HealthStatusView, tonic::Status>,
+> {
+    HealthCrud {
+        real_id: id,
+        nonexistent_id: PowerShelfId::from(uuid::Uuid::new_v4()),
+        alert: alert_report("external-monitor"),
+        alert_source: "external-monitor",
+        insert: async move |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.api
+                .insert_power_shelf_health_report(Request::new(
+                    rpc_forge::InsertPowerShelfHealthReportRequest {
+                        power_shelf_id: Some(id),
+                        health_report_entry: Some(rpc_forge::HealthReportEntry {
+                            report: Some(report),
+                            mode: mode as i32,
+                        }),
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        list: async move |id| {
+            Ok(env
+                .api
+                .list_power_shelf_health_reports(Request::new(
+                    rpc_forge::ListPowerShelfHealthReportsRequest {
+                        power_shelf_id: Some(id),
+                    },
+                ))
+                .await?
+                .into_inner()
+                .health_report_entries)
+        },
+        remove: async move |id, source| {
+            env.api
+                .remove_power_shelf_health_report(Request::new(
+                    rpc_forge::RemovePowerShelfHealthReportRequest {
+                        power_shelf_id: Some(id),
+                        source,
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        find: async move |id| {
+            let resp = env
+                .api
+                .find_power_shelves(Request::new(rpc_forge::PowerShelfQuery {
+                    power_shelf_id: Some(id),
+                    name: None,
+                }))
+                .await?
+                .into_inner();
+            assert_eq!(resp.power_shelves.len(), 1);
+            let status = resp.power_shelves[0].status.clone().unwrap();
+            Ok(HealthStatusView {
+                health: status.health,
+                health_sources: status.health_sources,
+            })
+        },
+    }
+}
+
 #[crate::sqlx_test]
 async fn test_insert_list_remove_power_shelf_health_report(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
-
-    let report = alert_report("external-monitor");
-
-    env.api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(report.clone().into()),
-                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                }),
-            },
-        ))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_power_shelf_health_reports(Request::new(
-            rpc_forge::ListPowerShelfHealthReportsRequest {
-                power_shelf_id: Some(power_shelf_id),
-            },
-        ))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-    let listed_report: HealthReport = list_resp.health_report_entries[0]
-        .report
-        .clone()
-        .unwrap()
-        .try_into()
-        .unwrap();
-    assert_eq!(listed_report.source, "external-monitor");
-    assert_eq!(listed_report.alerts.len(), 1);
-
-    env.api
-        .remove_power_shelf_health_report(Request::new(
-            rpc_forge::RemovePowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                source: "external-monitor".to_string(),
-            },
-        ))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_power_shelf_health_reports(Request::new(
-            rpc_forge::ListPowerShelfHealthReportsRequest {
-                power_shelf_id: Some(power_shelf_id),
-            },
-        ))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 0);
-
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id).check_insert_list_remove().await;
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
-    let report = alert_report("external-monitor");
-
-    for _ in 0..3 {
-        env.api
-            .insert_power_shelf_health_report(Request::new(
-                rpc_forge::InsertPowerShelfHealthReportRequest {
-                    power_shelf_id: Some(power_shelf_id),
-                    health_report_entry: Some(rpc_forge::HealthReportEntry {
-                        report: Some(report.clone().into()),
-                        mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                    }),
-                },
-            ))
-            .await?;
-    }
-
-    let list_resp = env
-        .api
-        .list_power_shelf_health_reports(Request::new(
-            rpc_forge::ListPowerShelfHealthReportsRequest {
-                power_shelf_id: Some(power_shelf_id),
-            },
-        ))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id).check_idempotent_insert().await;
     Ok(())
 }
 
@@ -162,115 +164,29 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 async fn test_remove_nonexistent_source(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
-
-    let result = env
-        .api
-        .remove_power_shelf_health_report(Request::new(
-            rpc_forge::RemovePowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                source: "nonexistent-source".to_string(),
-            },
-        ))
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id)
+        .check_remove_nonexistent_source()
         .await;
-
-    assert!(result.is_err());
-    let status = result.unwrap_err();
-    assert_eq!(status.code(), tonic::Code::NotFound);
-
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_missing_power_shelf_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let nonexistent_id = carbide_uuid::power_shelf::PowerShelfId::from(uuid::Uuid::new_v4());
-    let report = alert_report("external-monitor");
-
-    let result = env
-        .api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(nonexistent_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(report.into()),
-                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                }),
-            },
-        ))
-        .await;
-
-    assert!(
-        result.is_err(),
-        "Expected NotFound for nonexistent power shelf"
-    );
-
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id).check_missing_entity().await;
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_replace_mode(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
-
-    let replace_report = empty_healthy_report("admin-override");
-    env.api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(replace_report.into()),
-                    mode: rpc_forge::HealthReportApplyMode::Replace as i32,
-                }),
-            },
-        ))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_power_shelf_health_reports(Request::new(
-            rpc_forge::ListPowerShelfHealthReportsRequest {
-                power_shelf_id: Some(power_shelf_id),
-            },
-        ))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-    assert_eq!(
-        list_resp.health_report_entries[0].mode,
-        rpc_forge::HealthReportApplyMode::Replace as i32
-    );
-
-    env.api
-        .remove_power_shelf_health_report(Request::new(
-            rpc_forge::RemovePowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                source: "admin-override".to_string(),
-            },
-        ))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_power_shelf_health_reports(Request::new(
-            rpc_forge::ListPowerShelfHealthReportsRequest {
-                power_shelf_id: Some(power_shelf_id),
-            },
-        ))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 0);
-
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id)
+        .check_replace_mode(empty_healthy_report("admin-override"), "admin-override")
+        .await;
     Ok(())
 }
 
@@ -278,55 +194,9 @@ async fn test_replace_mode(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error:
 async fn test_health_visible_in_find_power_shelves(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
-
-    let report = alert_report("external-monitor");
-    env.api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(report.into()),
-                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                }),
-            },
-        ))
-        .await?;
-
-    let resp = env
-        .api
-        .find_power_shelves(Request::new(rpc_forge::PowerShelfQuery {
-            power_shelf_id: Some(power_shelf_id),
-            name: None,
-        }))
-        .await?
-        .into_inner();
-
-    assert_eq!(resp.power_shelves.len(), 1);
-    let ps = &resp.power_shelves[0];
-    let ps_status = ps.status.as_ref().unwrap();
-
-    assert!(
-        ps_status.health.is_some(),
-        "Power shelf should have health field"
-    );
-    let health: HealthReport = ps_status.health.clone().unwrap().try_into().unwrap();
-    assert!(
-        !health.alerts.is_empty(),
-        "Power shelf health should contain alerts"
-    );
-
-    assert_eq!(ps_status.health_sources.len(), 1);
-    assert_eq!(ps_status.health_sources[0].source, "external-monitor");
-    assert_eq!(
-        ps_status.health_sources[0].mode,
-        rpc_forge::HealthReportApplyMode::Merge as i32
-    );
-
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id).check_visible_in_find().await;
     Ok(())
 }
 
@@ -334,118 +204,31 @@ async fn test_health_visible_in_find_power_shelves(
 async fn test_power_shelf_health_aggregation(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
-
-    env.run_power_shelf_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_power_shelves_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_power_shelves_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
-        ]
-    );
-
-    env.api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(alert_report("external-monitor").into()),
-                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                }),
-            },
-        ))
-        .await?;
-    env.run_power_shelf_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_power_shelves_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_power_shelves_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
-        ]
-    );
-
-    env.api
-        .insert_power_shelf_health_report(Request::new(
-            rpc_forge::InsertPowerShelfHealthReportRequest {
-                power_shelf_id: Some(power_shelf_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(empty_healthy_report("admin-override").into()),
-                    mode: rpc_forge::HealthReportApplyMode::Replace as i32,
-                }),
-            },
-        ))
-        .await?;
-    env.run_power_shelf_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_power_shelves_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_power_shelves_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
-        ]
-    );
-
-    assert!(
-        env.test_meter
-            .formatted_metrics("carbide_alerts_suppressed_count")
-            .is_empty(),
-        "power shelves should not emit the legacy alerts_suppressed alias"
-    );
-
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    check_health_aggregation(
+        "power_shelves",
+        id,
+        alert_report("external-monitor"),
+        empty_healthy_report("admin-override"),
+        &env.test_meter,
+        async |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.api
+                .insert_power_shelf_health_report(Request::new(
+                    rpc_forge::InsertPowerShelfHealthReportRequest {
+                        power_shelf_id: Some(id),
+                        health_report_entry: Some(rpc_forge::HealthReportEntry {
+                            report: Some(report),
+                            mode: mode as i32,
+                        }),
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        async || env.run_power_shelf_controller_iteration().await,
+    )
+    .await;
     Ok(())
 }

--- a/crates/api-core/src/tests/rack_health.rs
+++ b/crates/api-core/src/tests/rack_health.rs
@@ -30,9 +30,10 @@ use tonic::Request;
 use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, create_managed_host, create_managed_host_with_config,
+    TestEnv, TestEnvOverrides, create_managed_host, create_managed_host_with_config,
     create_test_env_with_overrides, get_config, send_health_report_entry,
 };
+use crate::tests::common::health_crud::{HealthCrud, HealthStatusView, check_health_aggregation};
 
 fn leak_alert_report(source: &str) -> HealthReport {
     HealthReport {
@@ -65,99 +66,102 @@ fn empty_healthy_report(source: &str) -> HealthReport {
     }
 }
 
+async fn test_env(pool: sqlx::PgPool) -> TestEnv {
+    create_test_env_with_overrides(pool, TestEnvOverrides::with_config(get_config())).await
+}
+
+/// Persists a rack and returns its ID.
+async fn new_rack(pool: &sqlx::PgPool) -> Result<RackId, Box<dyn std::error::Error>> {
+    let mut txn = pool.acquire().await?;
+    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
+    Ok(rack_id)
+}
+
+/// Builds the rack health-override CRUD surface over `env` for `id`. The shared
+/// checks in [`crate::tests::common::health_crud`] drive these closures.
+// The four `impl AsyncFn` members are intentionally distinct unnameable closure
+// types; there is nothing to factor into a `type` alias.
+#[allow(clippy::type_complexity)]
+fn rack_crud(
+    env: &TestEnv,
+    id: RackId,
+) -> HealthCrud<
+    RackId,
+    impl AsyncFn(RackId, HealthReport, rpc_forge::HealthReportApplyMode) -> Result<(), tonic::Status>,
+    impl AsyncFn(RackId) -> Result<Vec<rpc_forge::HealthReportEntry>, tonic::Status>,
+    impl AsyncFn(RackId, String) -> Result<(), tonic::Status>,
+    impl AsyncFn(RackId) -> Result<HealthStatusView, tonic::Status>,
+> {
+    HealthCrud {
+        real_id: id,
+        nonexistent_id: RackId::new(uuid::Uuid::new_v4().to_string()),
+        alert: leak_alert_report("dsx-exchange-consumer"),
+        alert_source: "dsx-exchange-consumer",
+        insert: async move |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.api
+                .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
+                    rack_id: Some(id),
+                    health_report_entry: Some(rpc_forge::HealthReportEntry {
+                        report: Some(report),
+                        mode: mode as i32,
+                    }),
+                }))
+                .await
+                .map(|_| ())
+        },
+        list: async move |id| {
+            Ok(env
+                .api
+                .list_rack_health_reports(Request::new(rpc_forge::ListRackHealthReportsRequest {
+                    rack_id: Some(id),
+                }))
+                .await?
+                .into_inner()
+                .health_report_entries)
+        },
+        remove: async move |id, source| {
+            env.api
+                .remove_rack_health_report(Request::new(rpc_forge::RemoveRackHealthReportRequest {
+                    rack_id: Some(id),
+                    source,
+                }))
+                .await
+                .map(|_| ())
+        },
+        find: async move |id| {
+            let resp = env
+                .api
+                .find_racks_by_ids(Request::new(rpc_forge::RacksByIdsRequest {
+                    rack_ids: vec![id],
+                }))
+                .await?
+                .into_inner();
+            assert_eq!(resp.racks.len(), 1);
+            let status = resp.racks[0].status.clone().unwrap();
+            Ok(HealthStatusView {
+                health: status.health,
+                health_sources: status.health_sources,
+            })
+        },
+    }
+}
+
 #[crate::sqlx_test]
 async fn test_insert_list_remove_rack_override(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let mut txn = pool.acquire().await?;
-    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
-    drop(txn);
-
-    let report = leak_alert_report("dsx-exchange-consumer");
-
-    env.api
-        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
-            rack_id: Some(rack_id.clone()),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(report.clone().into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_rack_health_reports(Request::new(rpc_forge::ListRackHealthReportsRequest {
-            rack_id: Some(rack_id.clone()),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-    let listed_report: HealthReport = list_resp.health_report_entries[0]
-        .report
-        .clone()
-        .unwrap()
-        .try_into()
-        .unwrap();
-    assert_eq!(listed_report.source, "dsx-exchange-consumer");
-    assert_eq!(listed_report.alerts.len(), 1);
-
-    env.api
-        .remove_rack_health_report(Request::new(rpc_forge::RemoveRackHealthReportRequest {
-            rack_id: Some(rack_id.clone()),
-            source: "dsx-exchange-consumer".to_string(),
-        }))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_rack_health_reports(Request::new(rpc_forge::ListRackHealthReportsRequest {
-            rack_id: Some(rack_id.clone()),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 0);
-
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    rack_crud(&env, rack_id).check_insert_list_remove().await;
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let mut txn = pool.acquire().await?;
-    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
-    drop(txn);
-
-    let report = leak_alert_report("dsx-exchange-consumer");
-
-    for _ in 0..3 {
-        env.api
-            .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
-                rack_id: Some(rack_id.clone()),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(report.clone().into()),
-                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                }),
-            }))
-            .await?;
-    }
-
-    let list_resp = env
-        .api
-        .list_rack_health_reports(Request::new(rpc_forge::ListRackHealthReportsRequest {
-            rack_id: Some(rack_id.clone()),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    rack_crud(&env, rack_id).check_idempotent_insert().await;
     Ok(())
 }
 
@@ -165,53 +169,66 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 async fn test_remove_nonexistent_source(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let mut txn = pool.acquire().await?;
-    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
-    drop(txn);
-
-    let result = env
-        .api
-        .remove_rack_health_report(Request::new(rpc_forge::RemoveRackHealthReportRequest {
-            rack_id: Some(rack_id.clone()),
-            source: "nonexistent-source".to_string(),
-        }))
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    rack_crud(&env, rack_id)
+        .check_remove_nonexistent_source()
         .await;
-
-    assert!(result.is_err());
-    let status = result.unwrap_err();
-    assert_eq!(status.code(), tonic::Code::NotFound);
-
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_missing_rack_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let nonexistent_rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
-    let report = leak_alert_report("dsx-exchange-consumer");
-
-    let result = env
-        .api
-        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
-            rack_id: Some(nonexistent_rack_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(report.into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await;
-
-    assert!(result.is_err(), "Expected NotFound for nonexistent rack");
-
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    rack_crud(&env, rack_id).check_missing_entity().await;
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_rack_health_visible_in_find_racks_by_ids(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    rack_crud(&env, rack_id).check_visible_in_find().await;
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_rack_health_aggregation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    check_health_aggregation(
+        "racks",
+        rack_id,
+        leak_alert_report("dsx-exchange-consumer"),
+        empty_healthy_report("admin-override"),
+        &env.test_meter,
+        async |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.api
+                .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
+                    rack_id: Some(id),
+                    health_report_entry: Some(rpc_forge::HealthReportEntry {
+                        report: Some(report),
+                        mode: mode as i32,
+                    }),
+                }))
+                .await
+                .map(|_| ())
+        },
+        async || env.run_rack_controller_iteration().await,
+    )
+    .await;
+    Ok(())
+}
+
+// ---- Rack-specific behaviors: propagation to host aggregate health and the
+// host-vs-rack override precedence rules. These have no power-shelf or switch
+// counterpart, so they stay here rather than in the shared CRUD helper.
 
 #[crate::sqlx_test]
 async fn test_propagation_to_host_aggregate_health(
@@ -516,181 +533,6 @@ async fn test_dsx_consumer_contract(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         list_resp.health_report_entries.len(),
         0,
         "All overrides should be removed after DSX consumer clear"
-    );
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_rack_health_visible_in_find_racks_by_ids(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let mut txn = pool.acquire().await?;
-    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
-    drop(txn);
-
-    let report = leak_alert_report("dsx-exchange-consumer");
-    env.api
-        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
-            rack_id: Some(rack_id.clone()),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(report.into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await?;
-
-    let rack_resp = env
-        .api
-        .find_racks_by_ids(Request::new(rpc_forge::RacksByIdsRequest {
-            rack_ids: vec![rack_id.clone()],
-        }))
-        .await?
-        .into_inner();
-
-    assert_eq!(rack_resp.racks.len(), 1);
-    let rack = &rack_resp.racks[0];
-    let rack_status = rack.status.as_ref().unwrap();
-    assert!(
-        rack_status.health.is_some(),
-        "Rack should have health field"
-    );
-    let health: HealthReport = rack_status.health.clone().unwrap().try_into().unwrap();
-    assert!(
-        !health.alerts.is_empty(),
-        "Rack health should contain alerts"
-    );
-
-    assert_eq!(rack_status.health_sources.len(), 1);
-    assert_eq!(
-        rack_status.health_sources[0].source,
-        "dsx-exchange-consumer"
-    );
-    assert_eq!(
-        rack_status.health_sources[0].mode,
-        rpc_forge::HealthReportApplyMode::Merge as i32
-    );
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_rack_health_aggregation(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let mut txn = pool.acquire().await?;
-    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await?;
-    drop(txn);
-
-    env.run_rack_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_racks_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_racks_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
-        ]
-    );
-
-    env.api
-        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
-            rack_id: Some(rack_id.clone()),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(leak_alert_report("dsx-exchange-consumer").into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await?;
-    env.run_rack_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_racks_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_racks_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
-        ]
-    );
-
-    env.api
-        .insert_rack_health_report(Request::new(rpc_forge::InsertRackHealthReportRequest {
-            rack_id: Some(rack_id.clone()),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(empty_healthy_report("admin-override").into()),
-                mode: rpc_forge::HealthReportApplyMode::Replace as i32,
-            }),
-        }))
-        .await?;
-    env.run_rack_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_racks_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_racks_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
-        ]
-    );
-
-    assert!(
-        env.test_meter
-            .formatted_metrics("carbide_alerts_suppressed_count")
-            .is_empty(),
-        "racks should not emit the legacy alerts_suppressed alias"
     );
 
     Ok(())

--- a/crates/api-core/src/tests/switch_find.rs
+++ b/crates/api-core/src/tests/switch_find.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use carbide_uuid::switch::SwitchId;
 use rpc::forge::forge_server::Forge;
 
 use crate::tests::common::api_fixtures::create_test_env;
@@ -67,55 +66,9 @@ async fn test_find_switch_ids_and_by_ids(
     Ok(())
 }
 
-#[crate::sqlx_test]
-async fn test_find_switches_by_ids_empty_returns_error(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-
-    let result = env
-        .api
-        .find_switches_by_ids(tonic::Request::new(rpc::forge::SwitchesByIdsRequest {
-            switch_ids: vec![],
-        }))
-        .await;
-    assert!(result.is_err());
-    assert_eq!(
-        result.err().unwrap().message(),
-        "at least one ID must be provided"
-    );
-
-    Ok(())
-}
-
-#[crate::sqlx_test]
-async fn test_find_switches_by_ids_over_max(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-
-    let count = env.config.max_find_by_ids + 1;
-    let switch_ids: Vec<SwitchId> = (0..count)
-        .map(|_| SwitchId::from(uuid::Uuid::new_v4()))
-        .collect();
-
-    let result = env
-        .api
-        .find_switches_by_ids(tonic::Request::new(rpc::forge::SwitchesByIdsRequest {
-            switch_ids,
-        }))
-        .await;
-    assert!(result.is_err());
-    assert_eq!(
-        result.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-
-    Ok(())
-}
+// The empty-list and over-max guards for `find_switches_by_ids` are shared
+// API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.
 
 #[crate::sqlx_test]
 async fn test_find_switch_ids_excludes_deleted(

--- a/crates/api-core/src/tests/switch_health.rs
+++ b/crates/api-core/src/tests/switch_health.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_uuid::switch::SwitchId;
 use health_report::{HealthAlertClassification, HealthProbeAlert, HealthReport};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as rpc_forge};
@@ -22,8 +23,9 @@ use tonic::Request;
 
 use crate::tests::common::api_fixtures::site_explorer::new_switch;
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, create_test_env_with_overrides, get_config,
+    TestEnv, TestEnvOverrides, create_test_env_with_overrides, get_config,
 };
+use crate::tests::common::health_crud::{HealthCrud, HealthStatusView, check_health_aggregation};
 
 fn alert_report(source: &str) -> HealthReport {
     HealthReport {
@@ -55,95 +57,102 @@ fn empty_healthy_report(source: &str) -> HealthReport {
     }
 }
 
+async fn test_env(pool: sqlx::PgPool) -> TestEnv {
+    create_test_env_with_overrides(pool, TestEnvOverrides::with_config(get_config())).await
+}
+
+/// Builds the switch health-override CRUD surface over `env` for `id`. The shared
+/// checks in [`crate::tests::common::health_crud`] drive these closures.
+// The four `impl AsyncFn` members are intentionally distinct unnameable closure
+// types; there is nothing to factor into a `type` alias.
+#[allow(clippy::type_complexity)]
+fn switch_crud(
+    env: &TestEnv,
+    id: SwitchId,
+) -> HealthCrud<
+    SwitchId,
+    impl AsyncFn(SwitchId, HealthReport, rpc_forge::HealthReportApplyMode) -> Result<(), tonic::Status>,
+    impl AsyncFn(SwitchId) -> Result<Vec<rpc_forge::HealthReportEntry>, tonic::Status>,
+    impl AsyncFn(SwitchId, String) -> Result<(), tonic::Status>,
+    impl AsyncFn(SwitchId) -> Result<HealthStatusView, tonic::Status>,
+> {
+    HealthCrud {
+        real_id: id,
+        nonexistent_id: SwitchId::from(uuid::Uuid::new_v4()),
+        alert: alert_report("external-monitor"),
+        alert_source: "external-monitor",
+        insert: async move |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.api
+                .insert_switch_health_report(Request::new(
+                    rpc_forge::InsertSwitchHealthReportRequest {
+                        switch_id: Some(id),
+                        health_report_entry: Some(rpc_forge::HealthReportEntry {
+                            report: Some(report),
+                            mode: mode as i32,
+                        }),
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        list: async move |id| {
+            Ok(env
+                .api
+                .list_switch_health_reports(Request::new(
+                    rpc_forge::ListSwitchHealthReportsRequest {
+                        switch_id: Some(id),
+                    },
+                ))
+                .await?
+                .into_inner()
+                .health_report_entries)
+        },
+        remove: async move |id, source| {
+            env.api
+                .remove_switch_health_report(Request::new(
+                    rpc_forge::RemoveSwitchHealthReportRequest {
+                        switch_id: Some(id),
+                        source,
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        find: async move |id| {
+            let resp = env
+                .api
+                .find_switches(Request::new(rpc_forge::SwitchQuery {
+                    switch_id: Some(id),
+                    name: None,
+                }))
+                .await?
+                .into_inner();
+            assert_eq!(resp.switches.len(), 1);
+            let status = resp.switches[0].status.clone().unwrap();
+            Ok(HealthStatusView {
+                health: status.health,
+                health_sources: status.health_sources,
+            })
+        },
+    }
+}
+
 #[crate::sqlx_test]
 async fn test_insert_list_remove_switch_override(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let switch_id = new_switch(&env, None, None).await?;
-
-    let report = alert_report("external-monitor");
-
-    env.api
-        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(report.clone().into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
-            switch_id: Some(switch_id),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-    let listed_report: HealthReport = list_resp.health_report_entries[0]
-        .report
-        .clone()
-        .unwrap()
-        .try_into()
-        .unwrap();
-    assert_eq!(listed_report.source, "external-monitor");
-    assert_eq!(listed_report.alerts.len(), 1);
-
-    env.api
-        .remove_switch_health_report(Request::new(rpc_forge::RemoveSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            source: "external-monitor".to_string(),
-        }))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
-            switch_id: Some(switch_id),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 0);
-
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id).check_insert_list_remove().await;
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let switch_id = new_switch(&env, None, None).await?;
-
-    let report = alert_report("external-monitor");
-
-    for _ in 0..3 {
-        env.api
-            .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-                switch_id: Some(switch_id),
-                health_report_entry: Some(rpc_forge::HealthReportEntry {
-                    report: Some(report.clone().into()),
-                    mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-                }),
-            }))
-            .await?;
-    }
-
-    let list_resp = env
-        .api
-        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
-            switch_id: Some(switch_id),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id).check_idempotent_insert().await;
     Ok(())
 }
 
@@ -151,100 +160,29 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 async fn test_remove_nonexistent_source(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let switch_id = new_switch(&env, None, None).await?;
-
-    let result = env
-        .api
-        .remove_switch_health_report(Request::new(rpc_forge::RemoveSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            source: "nonexistent-source".to_string(),
-        }))
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id)
+        .check_remove_nonexistent_source()
         .await;
-
-    assert!(result.is_err());
-    let status = result.unwrap_err();
-    assert_eq!(status.code(), tonic::Code::NotFound);
-
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_missing_switch_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let nonexistent_switch_id = carbide_uuid::switch::SwitchId::from(uuid::Uuid::new_v4());
-    let report = alert_report("external-monitor");
-
-    let result = env
-        .api
-        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-            switch_id: Some(nonexistent_switch_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(report.into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await;
-
-    assert!(result.is_err(), "Expected NotFound for nonexistent switch");
-
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id).check_missing_entity().await;
     Ok(())
 }
 
 #[crate::sqlx_test]
 async fn test_replace_mode_override(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let switch_id = new_switch(&env, None, None).await?;
-
-    let replace_report = empty_healthy_report("admin-override");
-    env.api
-        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(replace_report.into()),
-                mode: rpc_forge::HealthReportApplyMode::Replace as i32,
-            }),
-        }))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
-            switch_id: Some(switch_id),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 1);
-    assert_eq!(
-        list_resp.health_report_entries[0].mode,
-        rpc_forge::HealthReportApplyMode::Replace as i32
-    );
-
-    env.api
-        .remove_switch_health_report(Request::new(rpc_forge::RemoveSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            source: "admin-override".to_string(),
-        }))
-        .await?;
-
-    let list_resp = env
-        .api
-        .list_switch_health_reports(Request::new(rpc_forge::ListSwitchHealthReportsRequest {
-            switch_id: Some(switch_id),
-        }))
-        .await?
-        .into_inner();
-    assert_eq!(list_resp.health_report_entries.len(), 0);
-
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id)
+        .check_replace_mode(empty_healthy_report("admin-override"), "admin-override")
+        .await;
     Ok(())
 }
 
@@ -252,53 +190,9 @@ async fn test_replace_mode_override(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 async fn test_switch_health_visible_in_find_switches(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let switch_id = new_switch(&env, None, None).await?;
-
-    let report = alert_report("external-monitor");
-    env.api
-        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(report.into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await?;
-
-    let switch_resp = env
-        .api
-        .find_switches(Request::new(rpc_forge::SwitchQuery {
-            switch_id: Some(switch_id),
-            name: None,
-        }))
-        .await?
-        .into_inner();
-
-    assert_eq!(switch_resp.switches.len(), 1);
-    let switch = &switch_resp.switches[0];
-
-    let switch_status = switch.status.as_ref().unwrap();
-    assert!(
-        switch_status.health.is_some(),
-        "Switch should have health field"
-    );
-    let health: HealthReport = switch_status.health.clone().unwrap().try_into().unwrap();
-    assert!(
-        !health.alerts.is_empty(),
-        "Switch health should contain alerts"
-    );
-
-    assert_eq!(switch_status.health_sources.len(), 1);
-    assert_eq!(switch_status.health_sources[0].source, "external-monitor");
-    assert_eq!(
-        switch_status.health_sources[0].mode,
-        rpc_forge::HealthReportApplyMode::Merge as i32
-    );
-
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id).check_visible_in_find().await;
     Ok(())
 }
 
@@ -306,114 +200,31 @@ async fn test_switch_health_visible_in_find_switches(
 async fn test_switch_health_aggregation(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env =
-        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(get_config()))
-            .await;
-
-    let switch_id = new_switch(&env, None, None).await?;
-
-    env.run_switch_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_switches_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 0".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_switches_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
-        ]
-    );
-
-    env.api
-        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(alert_report("external-monitor").into()),
-                mode: rpc_forge::HealthReportApplyMode::Merge as i32,
-            }),
-        }))
-        .await?;
-    env.run_switch_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_switches_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 0".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_switches_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 1".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 0".to_string(),
-        ]
-    );
-
-    env.api
-        .insert_switch_health_report(Request::new(rpc_forge::InsertSwitchHealthReportRequest {
-            switch_id: Some(switch_id),
-            health_report_entry: Some(rpc_forge::HealthReportEntry {
-                report: Some(empty_healthy_report("admin-override").into()),
-                mode: rpc_forge::HealthReportApplyMode::Replace as i32,
-            }),
-        }))
-        .await?;
-    env.run_switch_controller_iteration().await;
-
-    let mut override_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_switches_health_overrides_count");
-    override_metrics.sort();
-    assert_eq!(
-        override_metrics,
-        vec![
-            "{fresh=\"true\",override_type=\"merge\"} 1".to_string(),
-            "{fresh=\"true\",override_type=\"replace\"} 1".to_string(),
-        ]
-    );
-
-    let mut status_metrics = env
-        .test_meter
-        .formatted_metrics("carbide_switches_health_status_count");
-    status_metrics.sort();
-    assert_eq!(
-        status_metrics,
-        vec![
-            "{fresh=\"true\",healthy=\"false\"} 0".to_string(),
-            "{fresh=\"true\",healthy=\"true\"} 1".to_string(),
-        ]
-    );
-
-    assert!(
-        env.test_meter
-            .formatted_metrics("carbide_alerts_suppressed_count")
-            .is_empty(),
-        "switches should not emit the legacy alerts_suppressed alias"
-    );
-
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    check_health_aggregation(
+        "switches",
+        id,
+        alert_report("external-monitor"),
+        empty_healthy_report("admin-override"),
+        &env.test_meter,
+        async |id, report: HealthReport, mode| {
+            let report: rpc::health::HealthReport = report.into();
+            env.api
+                .insert_switch_health_report(Request::new(
+                    rpc_forge::InsertSwitchHealthReportRequest {
+                        switch_id: Some(id),
+                        health_report_entry: Some(rpc_forge::HealthReportEntry {
+                            report: Some(report),
+                            mode: mode as i32,
+                        }),
+                    },
+                ))
+                .await
+                .map(|_| ())
+        },
+        async || env.run_switch_controller_iteration().await,
+    )
+    .await;
     Ok(())
 }

--- a/crates/api-core/src/tests/tenant_keyset_find.rs
+++ b/crates/api-core/src/tests/tenant_keyset_find.rs
@@ -17,7 +17,6 @@
 
 use ::rpc::forge as rpc;
 use rpc::forge_server::Forge;
-use tonic::Code;
 
 use crate::tests::common::api_fixtures::create_test_env;
 use crate::tests::common::api_fixtures::tenant::create_tenant_keyset;
@@ -119,62 +118,6 @@ async fn test_find_tenant_keysets_by_ids(pool: sqlx::PgPool) {
     assert!(keyset3_valid);
 }
 
-#[crate::sqlx_test()]
-async fn test_find_tenant_keysets_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let keyset_ids: Vec<rpc::TenantKeysetIdentifier> = (1..=end_index)
-        .map(|i| rpc::TenantKeysetIdentifier {
-            organization_id: "tenant_org_1".to_string(),
-            keyset_id: format!("keyset_id_{i}"),
-        })
-        .collect();
-    let include_key_data = false;
-    let request = tonic::Request::new(rpc::TenantKeysetsByIdsRequest {
-        keyset_ids,
-        include_key_data,
-    });
-
-    let response = env.api.find_tenant_keysets_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.as_ref().err().unwrap().code(),
-        Code::InvalidArgument
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_tenant_keysets_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-
-    let request = tonic::Request::new(rpc::TenantKeysetsByIdsRequest::default());
-
-    let response = env.api.find_tenant_keysets_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.as_ref().err().unwrap().code(),
-        Code::InvalidArgument
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_tenant_keysets_by_ids` are shared
+// API-layer code, proven once across representative RPCs in
+// `tests::find_by_ids_guards`.

--- a/crates/api-core/src/tests/vpc_find.rs
+++ b/crates/api-core/src/tests/vpc_find.rs
@@ -135,49 +135,8 @@ async fn test_find_vpcs_by_ids(pool: sqlx::PgPool) {
     assert_eq!(vpc3, vpc_list.vpcs[0]);
 }
 
-#[crate::sqlx_test()]
-async fn test_find_vpcs_by_ids_over_max(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-
-    // create vector of IDs with more than max allowed
-    // it does not matter if these are real or not, since we are testing an error back for passing more than max
-    let end_index: u32 = env.config.max_find_by_ids + 1;
-    let vpc_ids = (1..=end_index).map(|_| VpcId::default()).collect();
-
-    let request = tonic::Request::new(rpc::VpcsByIdsRequest { vpc_ids });
-
-    let response = env.api.find_vpcs_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        format!(
-            "no more than {} IDs can be accepted",
-            env.config.max_find_by_ids
-        )
-    );
-}
-
-#[crate::sqlx_test()]
-async fn test_find_vpcs_by_ids_none(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-
-    let request = tonic::Request::new(rpc::VpcsByIdsRequest::default());
-
-    let response = env.api.find_vpcs_by_ids(request).await;
-    // validate
-    assert!(
-        response.is_err(),
-        "expected an error when passing no machine IDs"
-    );
-    assert_eq!(
-        response.err().unwrap().message(),
-        "at least one ID must be provided",
-    );
-}
+// The empty-list and over-max guards for `find_vpcs_by_ids` are shared API-layer
+// code, proven once across representative RPCs in `tests::find_by_ids_guards`.
 
 #[crate::sqlx_test]
 async fn find_vpc_by_name(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Wave 1 of the carbide-test-support integration (#2692).

Three pockets of api-core cross-entity duplication, consolidated:

- **by-ids guards** — every `find_*_by_ids` RPC re-proved the same two API-layer guards (empty list, over-max) once per entity (~20 `#[sqlx_test]` tests across ten `*_find.rs`). Now two shared tests (`find_by_ids_guards.rs`), each looping a labeled spread of the ten RPCs over one pool and asserting the exact `InvalidArgument` code + message per RPC. Guard fires before any DB work, so once per guard suffices.
- **health-override CRUD** — the power-shelf / switch / rack suites repeated six CRUD behaviors fn-for-fn; the bodies move into a `HealthCrud` harness driven by per-entity closures (`common/health_crud.rs`), each entity's `#[sqlx_test]` calling the shared checks over its own pool. Rack's unique precedence/propagation tests stay per-entity.
- **component_manager** — `power_action_*` (6) and `error_to_status_*` (5) per-variant tests become two tables; the error-mapping table **adds** the previously-untested `Transport`→`Unavailable` and `Rms`→`Internal` arms, so coverage goes up.

No production change; ~1,500 lines of duplicated suite collapse into two shared harnesses. Verified against Postgres (changed modules: 70 tests pass), clippy-clean with `-D warnings`.

Addresses #2699.
