### PR TITLE
feat(site-explorer): fall back to ACPowercycle when a vendor refuses PowerCycle

### DIFF
--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1628,6 +1628,7 @@ pub async fn create_test_env_with_overrides(
         reports: Arc::new(std::sync::Mutex::new(Default::default())),
         power_states: Arc::new(std::sync::Mutex::new(Default::default())),
         redfish_power_control_calls: Arc::new(std::sync::Mutex::new(Default::default())),
+        power_control_failures: Arc::new(std::sync::Mutex::new(Default::default())),
         set_nic_mode_calls: Arc::new(std::sync::Mutex::new(Default::default())),
         explore_endpoint_calls: Arc::new(std::sync::Mutex::new(Default::default())),
     };

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1243,11 +1243,12 @@ impl SiteExplorer {
 
                         if !all_dpus_configured_properly_in_host {
                             // A queued `set_nic_mode` only takes effect after a host
-                            // power cycle, so drive one for every vendor -- the
-                            // Redfish `ComputerSystem.Reset` action is standard
-                            // across BMCs -- throttled by `reset_rate_limit`. A BMC
-                            // that refuses the request surfaces the host as needing
-                            // a manual power cycle via the pairing-blocker metric.
+                            // power cycle, so drive one for every vendor --
+                            // `redfish_powercycle` issues `PowerCycle` and falls back
+                            // to a cold `ACPowercycle` for vendors that refuse it --
+                            // throttled by `reset_rate_limit`. A BMC that refuses both
+                            // surfaces the host as needing a manual power cycle via
+                            // the pairing-blocker metric.
                             let time_since_redfish_powercycle = Utc::now().signed_duration_since(
                                 ep.last_redfish_powercycle.unwrap_or_default(),
                             );
@@ -1277,10 +1278,11 @@ impl SiteExplorer {
                                 // loop stays visible to operators instead of
                                 // rebooting hourly in silence.
                                 //
-                                // TODO(chet): If the power cycle doesn't appear to
-                                // be flipping the NIC to the expected mode, this is
-                                // where we'd want to introduce a cold power cycle
-                                // (`ForceOff`/`On` or similar).
+                                // The reset above already escalates a refused
+                                // `PowerCycle` to a cold `ACPowercycle`
+                                // (`redfish_powercycle`), so a host still unflipped
+                                // here is mid-flight or genuinely stuck -- either way
+                                // it stays visible via the metric.
                                 metrics.increment_host_dpu_pairing_blocker(
                                     PairingBlockerReason::ManualPowerCycleRequired,
                                 );
@@ -2546,9 +2548,30 @@ impl SiteExplorer {
             })
     }
 
+    /// Drive a power cycle to apply a queued BlueField NIC-mode change.
+    ///
+    /// `PowerCycle` (Redfish `ComputerSystem.Reset`) is implemented only by Dell
+    /// and the DPU BMCs; other host vendors -- and Vikings -- refuse it. Fall
+    /// back to `ACPowercycle`, the cold AC cycle the HPE/Lenovo/Supermicro/GBx00
+    /// wrappers implement, so the queued change still applies without an
+    /// operator. If both are refused the error propagates and the caller
+    /// surfaces `ManualPowerCycleRequired`.
     async fn redfish_powercycle(&self, bmc_ip_address: IpAddr) -> SiteExplorerResult<()> {
-        self.redfish_power_control(bmc_ip_address, libredfish::SystemPowerControl::PowerCycle)
+        if let Err(power_cycle_err) = self
+            .redfish_power_control(bmc_ip_address, libredfish::SystemPowerControl::PowerCycle)
+            .await
+        {
+            tracing::warn!(
+                %bmc_ip_address,
+                error = %power_cycle_err,
+                "PowerCycle refused; falling back to ACPowercycle to apply the queued NIC mode change",
+            );
+            self.redfish_power_control(
+                bmc_ip_address,
+                libredfish::SystemPowerControl::ACPowercycle,
+            )
             .await?;
+        }
 
         let mut txn = self.txn_begin().await?;
 

--- a/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
+++ b/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
@@ -37,6 +37,10 @@ pub struct MockEndpointExplorer {
         Arc<Mutex<HashMap<IpAddr, Result<EndpointExplorationReport, EndpointExplorationError>>>>,
     pub power_states: Arc<Mutex<HashMap<IpAddr, PowerState>>>,
     pub redfish_power_control_calls: Arc<Mutex<Vec<(SocketAddr, SystemPowerControl)>>>,
+    /// Power-control actions that `redfish_power_control` should reject (the
+    /// call is still recorded). Lets tests exercise the PowerCycle ->
+    /// ACPowercycle fallback for a vendor that refuses `PowerCycle`.
+    pub power_control_failures: Arc<Mutex<Vec<SystemPowerControl>>>,
     /// Records every call to `set_nic_mode` (BMC address + requested target
     /// mode) so tests can assert the auto-correct path fired with the
     /// right arguments.
@@ -48,6 +52,12 @@ pub struct MockEndpointExplorer {
 impl MockEndpointExplorer {
     pub fn explore_endpoint_call_count(&self) -> usize {
         self.explore_endpoint_calls.lock().unwrap().len()
+    }
+
+    /// Make `redfish_power_control` reject the given action, so tests can
+    /// simulate a vendor that refuses `PowerCycle`.
+    pub fn fail_power_control(&self, action: SystemPowerControl) {
+        self.power_control_failures.lock().unwrap().push(action);
     }
 
     pub fn insert_endpoints(&self, endpoints: Vec<(IpAddr, EndpointExplorationReport)>) {
@@ -154,6 +164,16 @@ impl EndpointExplorer for MockEndpointExplorer {
             .lock()
             .unwrap()
             .push((address, action));
+        if self
+            .power_control_failures
+            .lock()
+            .unwrap()
+            .contains(&action)
+        {
+            return Err(EndpointExplorationError::Unreachable {
+                details: Some(format!("mock: {action:?} refused")),
+            });
+        }
         Ok(())
     }
 

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -2606,6 +2606,114 @@ async fn test_site_explorer_power_cycles_non_dell_host_to_apply_nic_mode(
     Ok(())
 }
 
+/// `PowerCycle` is implemented only by Dell and the DPU BMCs; other vendors --
+/// and Vikings -- refuse it. When that happens, site-explorer falls back to a
+/// cold `ACPowercycle` so the queued NIC-mode change still applies without an
+/// operator, rather than parking immediately on `ManualPowerCycleRequired`.
+#[sqlx_test]
+async fn test_site_explorer_falls_back_to_ac_powercycle_when_powercycle_refused(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+
+    // DPU reports DPU mode; the operator-declared NicMode override forces the
+    // correction (and therefore the reset).
+    let dpu_config = DpuConfig {
+        nic_mode: Some(NicMode::Dpu),
+        ..DpuConfig::default()
+    };
+    let mock_host = ManagedHostConfig {
+        dpus: vec![dpu_config.clone()],
+        vendor: Some(bmc_vendor::BMCVendor::Lenovo),
+        ..ManagedHostConfig::default()
+    };
+    let host_bmc_mac = mock_host.bmc_mac_address;
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: host_bmc_mac,
+            data: ExpectedMachineData {
+                bmc_username: "ADMIN".to_string(),
+                bmc_password: "PASS".to_string(),
+                serial_number: "EM-2635-AC-FALLBACK".to_string(),
+                metadata: Metadata::new_with_default_name(),
+                dpu_mode: DpuMode::NicMode,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut host_bmc = env.new_machine(&host_bmc_mac.to_string(), "SomeVendor");
+    let mut dpu_bmc = env.new_machine(&dpu_config.bmc_mac_address.to_string(), "NVIDIA/BF/BMC");
+    host_bmc.discover_dhcp(env.api()).await?;
+    dpu_bmc.discover_dhcp(env.api()).await?;
+
+    let host_bmc_ip: IpAddr = host_bmc.ip.parse()?;
+    let dpu_bmc_ip: IpAddr = dpu_bmc.ip.parse()?;
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        retained_boot_interface_window: None,
+        explorations_per_run: 10,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    };
+    let explorer = env.test_site_explorer(explorer_config);
+    // This vendor refuses `PowerCycle` (like a Viking); the reset must fall
+    // back to the cold `ACPowercycle`.
+    explorer
+        .endpoint_explorer()
+        .fail_power_control(libredfish::SystemPowerControl::PowerCycle);
+    explorer.insert_endpoints(
+        mock_host
+            .exploration_results(Some(host_bmc_ip), &[(0, dpu_bmc_ip)])?
+            .into_endpoints(),
+    );
+
+    // First iteration: initial endpoint exploration.
+    explorer.run_single_iteration().await.unwrap();
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(host_bmc_ip, &mut txn).await?;
+    db::explored_endpoints::set_preingestion_complete(dpu_bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    // Second iteration: matching issues `set_nic_mode`, then the reset path
+    // tries `PowerCycle`, gets refused, and falls back to `ACPowercycle`.
+    explorer.run_single_iteration().await.unwrap();
+
+    let power_calls = explorer
+        .endpoint_explorer()
+        .redfish_power_control_calls
+        .lock()
+        .unwrap();
+    let powercycle_pos = power_calls
+        .iter()
+        .position(|(_, action)| matches!(action, libredfish::SystemPowerControl::PowerCycle));
+    let acpowercycle_pos = power_calls
+        .iter()
+        .position(|(_, action)| matches!(action, libredfish::SystemPowerControl::ACPowercycle));
+    assert!(
+        powercycle_pos.is_some(),
+        "expected `PowerCycle` to be attempted; power calls so far: {power_calls:?}"
+    );
+    assert!(
+        acpowercycle_pos.is_some(),
+        "expected the `ACPowercycle` fallback after `PowerCycle` was refused; power calls so far: {power_calls:?}"
+    );
+    // A fallback is only correct if `PowerCycle` is the one tried first.
+    assert!(
+        powercycle_pos < acpowercycle_pos,
+        "expected `PowerCycle` (at {powercycle_pos:?}) before the `ACPowercycle` fallback (at {acpowercycle_pos:?}); power calls: {power_calls:?}"
+    );
+
+    Ok(())
+}
+
 /// Regression guard for the fallback-serial path (#2631): a DPU paired only
 /// through `fallback_dpu_serial_numbers` must get the same NIC-mode enforcement
 /// as a host-reported one. The host BMC here enumerates no DPU over PCIe -- the


### PR DESCRIPTION
A queued BlueField NIC-mode change only applies after a real power cycle, and site-explorer drives one for every vendor once it sees a DPU in the wrong mode. But `PowerCycle` (Redfish `ComputerSystem.Reset`) is implemented only by Dell and the DPU BMCs -- other host vendors, and Vikings, refuse it -- so on those hosts the reset never landed and the flip parked on `ManualPowerCycleRequired`.

`redfish_powercycle` now falls back to a cold `ACPowercycle` (implemented by the HPE/Lenovo/Supermicro/GBx00 wrappers) when `PowerCycle` is refused, so the change applies without an operator. If both resets are refused the error still surfaces as `ManualPowerCycleRequired`, unchanged.

The mock endpoint explorer gains per-action failure injection, and a new test drives a non-Dell host whose `PowerCycle` is refused and asserts the `ACPowercycle` fallback fires (after `PowerCycle` is tried first).

Supports #2635


Closes #2635
