### PR TITLE
feat(dns): answer PTR queries in the DNS lookup handler

### DIFF
--- a/crates/api-core/src/handlers/dns.rs
+++ b/crates/api-core/src/handlers/dns.rs
@@ -86,6 +86,44 @@ async fn lookup_records_by_qname(
     Ok(result)
 }
 
+/// Resolve a reverse-DNS (PTR) query. The qname is an address in `in-addr.arpa` /
+/// `ip6.arpa` form, so we parse it back to an `IpAddr` and look the holding
+/// interface up by address (rather than matching a per-row arpa string in a view).
+/// An unparseable name, or one no interface holds, yields no records.
+async fn lookup_ptr_record(
+    txn: impl DbReader<'_>,
+    query_name: &str,
+) -> Result<Vec<DnsResourceRecordReply>, tonic::Status> {
+    tracing::debug!(qname = %query_name, "looking up PTR record");
+
+    let qname_with_dot = if !query_name.ends_with('.') {
+        format!("{}.", query_name)
+    } else {
+        query_name.to_string()
+    };
+
+    let Some(address) = db::dns::arpa_qname_to_ip(&qname_with_dot) else {
+        return Ok(vec![]);
+    };
+
+    let result = resource_record::find_ptr_record(txn, address)
+        .await
+        .map_err(CarbideError::from)?
+        .into_iter()
+        .map(|record| DnsResourceRecordReply {
+            qtype: DnsResourceRecordType::PTR.to_string(),
+            qname: qname_with_dot.clone(),
+            ttl: record.ttl as u32,
+            content: record.ptr_content,
+            domain_id: Some(record.domain_id.to_string()),
+            scope_mask: None,
+            auth: None,
+        })
+        .collect::<Vec<_>>();
+
+    Ok(result)
+}
+
 pub async fn get_all_domains(
     api: &Api,
     _request: Request<protos::dns::GetAllDomainsRequest>,
@@ -186,6 +224,10 @@ pub async fn lookup_record(
             let normalized = db::dns::normalize_domain(&qname);
             let record = lookup_soa_record(&api.database_connection, &normalized).await?;
             vec![record]
+        }
+        DnsResourceRecordType::PTR => {
+            // Reverse DNS: parse the arpa qname back to an address and look up by it.
+            lookup_ptr_record(&api.database_connection, &qname).await?
         }
         _ => {
             // For all other types (A, AAAA, MX, CNAME, etc.):

--- a/crates/api-core/src/tests/dns.rs
+++ b/crates/api-core/src/tests/dns.rs
@@ -342,6 +342,143 @@ async fn test_dns_aaaa(pool: sqlx::PgPool) {
     assert!(shortname_a.content.parse::<IpAddr>().unwrap().is_ipv4());
 }
 
+// test_dns_ptr verifies that a reverse-DNS (PTR) query resolves an address to the
+// fully-qualified hostname of the interface that holds it. The handler parses the
+// in-addr.arpa / ip6.arpa qname back to an address and looks the interface up by
+// address, so this exercises both the IPv4 and IPv6 reverse paths end to end.
+#[crate::sqlx_test]
+async fn test_dns_ptr(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let api = &env.api;
+
+    let (host_id, _dpu_id) = create_managed_host(&env).await.into();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let interface = db::machine_interface::get_machine_interface_primary(&host_id, &mut txn)
+        .await
+        .unwrap();
+
+    // The primary interface already holds an IPv4 address from the managed host
+    // creation flow; reuse it for the IPv4 reverse lookup. (An interface may hold
+    // at most one address per family, so we cannot add a second IPv4 here.)
+    let ipv4_addr = interface
+        .addresses
+        .iter()
+        .copied()
+        .find(|addr| addr.is_ipv4())
+        .expect("primary interface should have an IPv4 address");
+
+    // Add an IPv6 address so the IPv6 reverse path has something to resolve.
+    let ipv6_addr: IpAddr = "fd00::1".parse().unwrap();
+    sqlx::query("INSERT INTO machine_interface_addresses (interface_id, address) VALUES ($1, $2)")
+        .bind(interface.id)
+        .bind(ipv6_addr)
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    // PTR content is the interface's fully-qualified hostname, matching the
+    // forward (shortname) view's name for the same interface.
+    let expected_fqdn = format!("{}.{}.", interface.hostname, DOMAIN_NAME);
+
+    // Each case issues one PTR lookup. `expected` is the FQDN of the single
+    // record we expect back, or None when the query should resolve to nothing.
+    struct PtrCase {
+        description: &'static str,
+        qname: String,
+        expected: Option<String>,
+    }
+
+    let cases = [
+        PtrCase {
+            description: "IPv4 reverse lookup resolves to the interface FQDN",
+            qname: ip_to_arpa(ipv4_addr),
+            expected: Some(expected_fqdn.clone()),
+        },
+        PtrCase {
+            description: "IPv6 reverse lookup resolves to the interface FQDN",
+            qname: ip_to_arpa(ipv6_addr),
+            expected: Some(expected_fqdn.clone()),
+        },
+        PtrCase {
+            description: "an address no interface holds resolves to nothing",
+            qname: "1.113.0.203.in-addr.arpa.".to_string(),
+            expected: None,
+        },
+        PtrCase {
+            description: "a qname that does not parse yields nothing, not an error",
+            qname: "not.an.address.in-addr.arpa.".to_string(),
+            expected: None,
+        },
+    ];
+
+    for case in cases {
+        let records = lookup_ptr(api, &case.qname).await;
+        match case.expected {
+            Some(expected_content) => {
+                assert_eq!(
+                    records.len(),
+                    1,
+                    "{}: expected one record",
+                    case.description
+                );
+                assert_eq!(records[0].qtype, "PTR", "{}", case.description);
+                assert_eq!(
+                    records[0].qname, case.qname,
+                    "{}: the queried qname is echoed back",
+                    case.description
+                );
+                assert_eq!(records[0].content, expected_content, "{}", case.description);
+            }
+            None => assert!(records.is_empty(), "{}", case.description),
+        }
+    }
+}
+
+/// Issue a PTR `lookup_record` query and return the reply records.
+async fn lookup_ptr(
+    api: &crate::api::Api,
+    qname: &str,
+) -> Vec<rpc::protos::dns::DnsResourceRecord> {
+    api.lookup_record(tonic::Request::new(
+        rpc::protos::dns::DnsResourceRecordLookupRequest {
+            qname: qname.to_string(),
+            zone_id: uuid::Uuid::new_v4().to_string(),
+            local: None,
+            remote: None,
+            qtype: "PTR".to_string(),
+            real_remote: None,
+        },
+    ))
+    .await
+    .unwrap()
+    .into_inner()
+    .records
+}
+
+/// Build the reverse-DNS qname for an address: the octets (IPv4) or nibbles
+/// (IPv6) in reverse order, each as its own label, then the arpa suffix.
+fn ip_to_arpa(addr: IpAddr) -> String {
+    let mut qname = String::new();
+    match addr {
+        IpAddr::V4(addr) => {
+            for octet in addr.octets().into_iter().rev() {
+                qname.push_str(&format!("{octet}."));
+            }
+            qname.push_str("in-addr.arpa.");
+        }
+        IpAddr::V6(addr) => {
+            for octet in addr.octets().into_iter().rev() {
+                qname.push_str(&format!("{:x}.{:x}.", octet & 0x0f, octet >> 4));
+            }
+            qname.push_str("ip6.arpa.");
+        }
+    }
+    qname
+}
+
 // Get the current number of rows in the dns_records view,
 // which is expected to start at 0, and then progress, as
 // the test continues.

--- a/crates/api-db/migrations/20260620153439_machine_interface_addresses_address_index.sql
+++ b/crates/api-db/migrations/20260620153439_machine_interface_addresses_address_index.sql
@@ -1,0 +1,5 @@
+-- Index machine_interface_addresses by address. Reverse-DNS (PTR) resolution
+-- parses a query name into an address and then looks the interface up by that
+-- address, so this turns that lookup into an index probe rather than a scan.
+CREATE INDEX machine_interface_addresses_address_idx
+    ON machine_interface_addresses (address);

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -271,4 +271,118 @@ mod tests {
             assert!(records.contains(&expected_record));
         }
     }
+
+    #[crate::sqlx_test]
+    async fn find_ptr_record_resolves_address_to_hostname(pool: sqlx::PgPool) {
+        sqlx::query(
+            "INSERT INTO domains (id, name)
+             VALUES ('10000000-0000-0000-0000-000000000001', 'dwrt1.com')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO network_segments (id, name, version)
+             VALUES ('20000000-0000-0000-0000-000000000001', 'tenant-segment', 'test')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machines (id, dpf)
+             VALUES ('host-1', '{\"enabled\": true, \"used_for_ingestion\": false}'::jsonb)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // host-1 has three interfaces on the same domain: the primary, a BMC, and a
+        // plain (non-primary, non-BMC) data interface.
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id, machine_id, segment_id, mac_address, domain_id,
+                primary_interface, hostname, association_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000001', 'host-1',
+                '20000000-0000-0000-0000-000000000001', '02:00:00:00:00:01',
+                '10000000-0000-0000-0000-000000000001', true, 'host-1', 'Machine'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id, machine_id, segment_id, mac_address, domain_id,
+                primary_interface, hostname, association_type, interface_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000002', 'host-1',
+                '20000000-0000-0000-0000-000000000001', '02:00:00:00:00:02',
+                '10000000-0000-0000-0000-000000000001', false, 'host-1-bmc', 'Machine', 'Bmc'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id, machine_id, segment_id, mac_address, domain_id,
+                primary_interface, hostname, association_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000003', 'host-1',
+                '20000000-0000-0000-0000-000000000001', '02:00:00:00:00:03',
+                '10000000-0000-0000-0000-000000000001', false, 'host-1-data', 'Machine'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        for (interface_id, address) in [
+            ("30000000-0000-0000-0000-000000000001", "192.168.0.1"),
+            ("30000000-0000-0000-0000-000000000002", "192.168.0.2"),
+            ("30000000-0000-0000-0000-000000000003", "192.168.0.3"),
+        ] {
+            sqlx::query(
+                "INSERT INTO machine_interface_addresses (interface_id, address)
+                 VALUES ($1::uuid, $2::inet)",
+            )
+            .bind(interface_id)
+            .bind(address)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Primary and BMC interfaces answer PTR (matching the forward shortname view);
+        // the plain data interface and an address no interface holds do not.
+        let cases = [
+            ("192.168.0.1", Some("host-1.dwrt1.com.")),
+            ("192.168.0.2", Some("host-1-bmc.dwrt1.com.")),
+            ("192.168.0.3", None),
+            ("10.9.9.9", None),
+        ];
+        for (address, expected) in cases {
+            let records = super::resource_record::find_ptr_record(&pool, address.parse().unwrap())
+                .await
+                .unwrap();
+            match expected {
+                Some(fqdn) => {
+                    assert_eq!(records.len(), 1, "address {address}");
+                    assert_eq!(records[0].ptr_content, fqdn, "address {address}");
+                }
+                None => assert!(
+                    records.is_empty(),
+                    "address {address} should resolve to nothing"
+                ),
+            }
+        }
+    }
 }

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -19,10 +19,54 @@ pub mod domain;
 pub mod domain_metadata;
 pub mod resource_record;
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 pub fn normalize_domain(name: &str) -> String {
     let normalize_domain = name.trim_end_matches('.').to_lowercase();
     tracing::debug!("Normalized domain name: {} to: {}", name, normalize_domain);
     normalize_domain
+}
+
+/// Parse a reverse-DNS (PTR) query name into the address it points at -- the
+/// inverse of the `in-addr.arpa` (IPv4) / `ip6.arpa` (IPv6) form. Returns `None`
+/// for anything that is not a well-formed arpa name, so the caller answers
+/// NotFound rather than guessing.
+pub fn arpa_qname_to_ip(qname: &str) -> Option<IpAddr> {
+    let name = qname.trim_end_matches('.').to_ascii_lowercase();
+
+    if let Some(reversed) = name.strip_suffix(".in-addr.arpa") {
+        // Four decimal octets, least-significant label first.
+        let octets: Vec<&str> = reversed.split('.').collect();
+        if octets.len() != 4 {
+            return None;
+        }
+        let mut addr = [0u8; 4];
+        for (byte, octet) in addr.iter_mut().zip(octets.iter().rev()) {
+            *byte = octet.parse().ok()?;
+        }
+        Some(IpAddr::V4(Ipv4Addr::from(addr)))
+    } else if let Some(reversed) = name.strip_suffix(".ip6.arpa") {
+        // Thirty-two hex nibbles, least-significant label first.
+        let nibbles: Vec<&str> = reversed.split('.').collect();
+        if nibbles.len() != 32 {
+            return None;
+        }
+        let mut addr = [0u8; 16];
+        for (i, nibble) in nibbles.iter().rev().enumerate() {
+            if nibble.len() != 1 {
+                return None;
+            }
+            let value = u8::from_str_radix(nibble, 16).ok()?;
+            if i % 2 == 0 {
+                addr[i / 2] = value << 4;
+            } else {
+                addr[i / 2] |= value;
+            }
+        }
+        Some(IpAddr::V6(Ipv6Addr::from(addr)))
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -37,6 +81,38 @@ mod tests {
         let expected = "example.com";
         let normalized = super::normalize_domain(domain_name);
         assert_eq!(normalized, expected);
+    }
+
+    #[test]
+    fn parses_arpa_qname_to_ip() {
+        use std::net::{IpAddr, Ipv4Addr};
+
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |qname: &str| super::arpa_qname_to_ip(qname);
+            "ipv4 in-addr.arpa" {
+                "1.0.168.192.in-addr.arpa." => Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                "3.2.1.10.in-addr.arpa." => Some(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))),
+            }
+            "ipv6 ip6.arpa" {
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."
+                    => Some("2001:db8::1".parse::<IpAddr>().unwrap()),
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa."
+                    => Some("::1".parse::<IpAddr>().unwrap()),
+            }
+            "rejects non-arpa and malformed" {
+                "host.example.com." => None,
+                "1.2.3.in-addr.arpa." => None,
+                "300.0.0.0.in-addr.arpa." => None,
+                "1.0.168.192.in-addr.arpa.extra." => None,
+            }
+            "normalizes case" {
+                "1.0.168.192.IN-ADDR.ARPA." => Some(IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1))),
+                "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.B.D.0.1.0.0.2.IP6.ARPA."
+                    => Some("2001:db8::1".parse::<IpAddr>().unwrap()),
+            }
+        );
     }
 
     #[crate::sqlx_test]

--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -111,6 +111,55 @@ pub async fn find_record(
 
     Ok(result)
 }
+
+#[derive(Debug, Clone)]
+pub struct DbPtrRecord {
+    pub ttl: i32,
+    /// The FQDN the PTR record answers with (e.g. `host-1.dwrt1.com.`).
+    pub ptr_content: String,
+    pub domain_id: DomainId,
+}
+
+impl<'r> FromRow<'r, PgRow> for DbPtrRecord {
+    fn from_row(row: &'r PgRow) -> Result<Self, Error> {
+        Ok(DbPtrRecord {
+            ptr_content: row.try_get("ptr_content")?,
+            ttl: row.try_get("ttl")?,
+            domain_id: row.try_get("domain_id")?,
+        })
+    }
+}
+
+/// Find the PTR answers for an address: the FQDN(s) the forward shortname view
+/// publishes for whichever primary or BMC interface holds it. The `WHERE` matches
+/// `dns_records_shortname_combined`'s (primary or BMC), so a forward A/AAAA record
+/// and its PTR round-trip; the joins are otherwise narrower (no `dns_record_types`,
+/// since PTR's type is fixed) and the TTL uses `COALESCE(meta.ttl, 300)` to match
+/// the TTL the forward record is actually served with. The lookup is by `address`,
+/// so it rides the `machine_interface_addresses_address_idx` index rather than scanning.
+pub async fn find_ptr_record(
+    txn: impl DbReader<'_>,
+    address: IpAddr,
+) -> Result<Vec<DbPtrRecord>, DatabaseError> {
+    let query = r#"
+    SELECT
+        concat(mi.hostname, '.', d.name, '.') AS ptr_content,
+        COALESCE(meta.ttl, 300) AS ttl,
+        d.id AS domain_id
+    FROM machine_interface_addresses mia
+    JOIN machine_interfaces mi ON mi.id = mia.interface_id
+    JOIN domains d ON d.id = mi.domain_id
+    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+    WHERE mia.address = $1::inet
+      AND (mi.primary_interface = TRUE OR mi.interface_type = 'Bmc')"#;
+
+    sqlx::query_as::<_, DbPtrRecord>(query)
+        .bind(address.to_string())
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn get_all_records_all_domains(
     txn: impl DbReader<'_>,
 ) -> Result<Vec<DbResourceRecord>, DatabaseError> {


### PR DESCRIPTION
## Summary

The handler that makes the `LookupRecord` RPC answer reverse DNS. A `PTR` query name is an address in `in-addr.arpa` / `ip6.arpa` form, not a hostname, so it cannot go through the qname view lookup that serves A/AAAA/SOA — a new `PTR` arm parses the name back to an `IpAddr` with `arpa_qname_to_ip` (#2637) and resolves it with `find_ptr_record` (#2639).

- New `lookup_ptr_record` helper: arpa qname → `IpAddr` → the holding interface's FQDN.
- Each reply echoes the queried name back as its `qname` (the form the PowerDNS remote backend expects); a name that does not parse, or that no interface holds, yields an empty answer rather than an error.
- End-to-end test: resolves both an IPv4 and an IPv6 address on a managed host's interface to its FQDN, plus the empty-answer cases (an unheld address and an unparseable name).

This completes the resolver side of reverse DNS; carbide-dns's PTR unlock is #2643.

Implements #2641. Part of the #2630 epic (reverse DNS / PTR records).

> Stacked on #2639 (the address lookup) and #2637 (the arpa parser). Until those merge, this PR's diff also shows their commits.

Draft pending review.
