### PR TITLE
feat: honor a declared primary NIC in the explored boot default

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -307,10 +307,28 @@ impl ExploredEndpoint {
 }
 
 impl EndpointExplorationReport {
+    /// The boot interface MAC for this endpoint's explored default -- the boot
+    /// interface site-explorer records before any machine owns the endpoint.
+    ///
+    /// A declared `ExpectedHostNic.primary` wins when this report has that NIC,
+    /// whatever its type (an integrated NIC as readily as a DPU host-PF), so the
+    /// explored default agrees with the managed store's declared primary across
+    /// the ownership handoff. Absent a declaration, it falls back to the
+    /// automatic pick: the lowest-PCI DPU host-PF interface.
     pub fn fetch_host_primary_interface_mac(
         &self,
         explored_dpus: &[ExploredDpu],
+        declared_primary: Option<MacAddress>,
     ) -> Option<MacAddress> {
+        // A declared primary wins as long as the report has it as a full pair
+        // (`find_interface_id_for_mac` scans every system ethernet interface,
+        // integrated NICs included).
+        if let Some(declared) = declared_primary
+            && self.find_interface_id_for_mac(declared).is_some()
+        {
+            return Some(declared);
+        }
+
         let system = self.systems.first()?;
 
         // Gather explored DPUs mac.

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1323,9 +1323,15 @@ impl SiteExplorer {
             // If we know the booting interface of the host, we should use this for deciding
             // primary interface.
             let mut is_sorted = false;
+            // A declared `ExpectedHostNic.primary` (when the matched expected
+            // machine sets one) wins over the automatic DPU-PF pick, so the
+            // explored default names the same NIC the managed store will.
+            let declared_primary = expected_explored_endpoint_index
+                .matched_expected_machine(&ep.address)
+                .and_then(|expected| expected.data.declared_primary_mac());
             if let Some(mac_address) = ep
                 .report
-                .fetch_host_primary_interface_mac(&dpus_explored_for_host)
+                .fetch_host_primary_interface_mac(&dpus_explored_for_host, declared_primary)
             {
                 // Capture the boot interface's [stable] Redfish interface id
                 // alongside its MAC. Only persist when both resolve from the

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -2252,11 +2252,55 @@ async fn test_fetch_host_primary_interface_mac(
         });
     }
 
+    // No declaration: the automatic pick stands -- the lowest-PCI DPU host-PF
+    // (the second mock DPU, given the device paths set above).
     let expected_mac: MacAddress = mock_dpus[1].host_mac_address;
     let mac = host_report
-        .fetch_host_primary_interface_mac(&explored_dpus)
+        .fetch_host_primary_interface_mac(&explored_dpus, None)
         .unwrap();
     assert_eq!(mac, expected_mac);
+
+    // A declared primary on a DPU host-PF wins over the automatic pick -- here
+    // the first DPU, which the PCI ordering would NOT have chosen.
+    let declared_dpu_pf = mock_dpus[0].host_mac_address;
+    assert_eq!(
+        host_report
+            .fetch_host_primary_interface_mac(&explored_dpus, Some(declared_dpu_pf))
+            .unwrap(),
+        declared_dpu_pf,
+    );
+
+    // The headline case: a declared *integrated* NIC -- which the DPU-only
+    // automatic pick can never name -- becomes the explored default.
+    let integrated_nic = host_report
+        .systems
+        .first()
+        .unwrap()
+        .ethernet_interfaces
+        .iter()
+        .filter_map(|e| e.mac_address)
+        .find(|mac| {
+            !explored_dpus
+                .iter()
+                .any(|d| d.host_pf_mac_address == Some(*mac))
+        })
+        .expect("the fixture host should have a non-DPU integrated NIC");
+    assert_eq!(
+        host_report
+            .fetch_host_primary_interface_mac(&explored_dpus, Some(integrated_nic))
+            .unwrap(),
+        integrated_nic,
+    );
+
+    // A declared MAC absent from this report is ignored -- the automatic pick
+    // stands.
+    let absent_mac: MacAddress = "de:ad:be:ef:00:01".parse().unwrap();
+    assert_eq!(
+        host_report
+            .fetch_host_primary_interface_mac(&explored_dpus, Some(absent_mac))
+            .unwrap(),
+        expected_mac,
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## What

The Store-A / site-explorer counterpart to #2657: a declared `ExpectedHostNic.primary` now wins in the **explored boot default** too -- the boot interface site-explorer records in `explored_endpoints` before any machine owns the endpoint, which a preingestion admin action (`machine_setup`, `set_dpu_first_boot_order`, Restore) reads.

`fetch_host_primary_interface_mac` (`api-model/src/site_explorer/mod.rs`) filtered NICs to DPU host-PF MACs, then picked lowest-PCI -- so it structurally couldn't name an integrated NIC. A host declaring an integrated NIC as primary got a DPU NIC (or nothing) as its explored default.

Now the picker takes a `declared_primary: Option<MacAddress>` and returns it when this report has that NIC as a full pair (reusing the existing `find_interface_id_for_mac`, which scans every system ethernet interface -- integrated NICs included), whatever the NIC type. The site-explorer caller (`lib.rs`) feeds it the matched expected machine's declared primary via `ExpectedMachineData::declared_primary_mac()` (the resolver from #2657). Absent a declaration, today's lowest-PCI DPU-PF pick stands, byte-for-byte.

Net: the explored default and the managed store (#2657) agree on the declaration across the ownership handoff, completing "declared primary is load-bearing everywhere."

## Notes

- Independent of #2657 (different code path); narrow impact -- pre-ownership / preingestion admin actions only.
- Loosens `fetch_host_primary_interface_mac` from its DPU-only assumption; the only caller is `lib.rs` (the exploration loop) and the existing test, both updated. The no-declaration path is unchanged, so DPU-PF-assuming behavior is preserved.

## Test plan

- `cargo clippy --all-features --tests` clean over the touched crates; `cargo +nightly-2026-06-16 fmt --all`.
- Extended `test_fetch_host_primary_interface_mac`: declared DPU host-PF wins over the lowest-PCI pick; **declared integrated NIC becomes the default** (the headline case the DPU-only pick could never produce); a declared MAC absent from the report falls back to the DPU pick; no declaration → unchanged.

Part of #2662 (epic #2660).


Closes #2662
