### PR TITLE
docs: note the full-pair requirement in fetch_host_primary_interface_mac

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -310,11 +310,14 @@ impl EndpointExplorationReport {
     /// The boot interface MAC for this endpoint's explored default -- the boot
     /// interface site-explorer records before any machine owns the endpoint.
     ///
-    /// A declared `ExpectedHostNic.primary` wins when this report has that NIC,
-    /// whatever its type (an integrated NIC as readily as a DPU host-PF), so the
-    /// explored default agrees with the managed store's declared primary across
-    /// the ownership handoff. Absent a declaration, it falls back to the
-    /// automatic pick: the lowest-PCI DPU host-PF interface.
+    /// A declared `ExpectedHostNic.primary` wins when this report has that NIC
+    /// as a full pair -- its MAC present on a system ethernet interface with a
+    /// non-empty Redfish interface id -- whatever its type (an integrated NIC as
+    /// readily as a DPU host-PF), so the explored default agrees with the managed
+    /// store's declared primary across the ownership handoff. A declared NIC
+    /// whose id this report has not resolved yet falls back, alongside the
+    /// no-declaration case, to the automatic pick: the lowest-PCI DPU host-PF
+    /// interface.
     pub fn fetch_host_primary_interface_mac(
         &self,
         explored_dpus: &[ExploredDpu],


### PR DESCRIPTION
## What

Doc-clarity follow-up to #2721 (CodeRabbit's one optional chat note there). **No behavior change** -- a doc comment only.

#2721's doc comment on `fetch_host_primary_interface_mac` said a declared primary wins "when this report has that NIC." The actual gate (`find_interface_id_for_mac`) requires a **full pair** -- the MAC present on a system ethernet interface **and** a non-empty Redfish interface id. A declared NIC whose id this report hasn't resolved yet falls back to the automatic DPU-PF pick, same as the no-declaration case. This spells that out in the public doc so a reader of the doc alone doesn't expect any in-report MAC to win.

## Notes

- **Stacked on #2721** (branch `explored-default-declared-primary`) -- the doc comment this tightens only exists there, so this branches off #2721's commit. Until #2721 merges the diff below includes #2721's change; once #2721 lands I'll rebase this onto `main` so it's just the doc edit.
- Pure doc comment: compilation and behavior are unchanged.

Part of #2662 (epic #2660).


Closes #2662
