### PR TITLE
fix(dns): fold domain case as ASCII, matching the reverse-DNS parser

### DIFF
--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -22,9 +22,9 @@ pub mod resource_record;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 pub fn normalize_domain(name: &str) -> String {
-    let normalize_domain = name.trim_end_matches('.').to_lowercase();
-    tracing::debug!("Normalized domain name: {} to: {}", name, normalize_domain);
-    normalize_domain
+    let normalized_domain = name.trim_end_matches('.').to_ascii_lowercase();
+    tracing::debug!(input = %name, normalized = %normalized_domain, "normalized domain name");
+    normalized_domain
 }
 
 /// Parse a reverse-DNS (PTR) query name into the address it points at -- the
@@ -77,10 +77,16 @@ mod tests {
 
     #[test]
     fn test_normalize_domain_name() {
-        let domain_name = "example.com.";
-        let expected = "example.com";
-        let normalized = super::normalize_domain(domain_name);
-        assert_eq!(normalized, expected);
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |name: &str| super::normalize_domain(name);
+            "strips the trailing dot and folds case to ASCII lowercase" {
+                "example.com." => "example.com".to_string(),
+                "EXAMPLE.COM." => "example.com".to_string(),
+                "Example.Com" => "example.com".to_string(),
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`normalize_domain` folded domain case with `to_lowercase` (Unicode-aware), while `arpa_qname_to_ip` (the reverse-DNS parser from #2637) uses `to_ascii_lowercase`. DNS names are ASCII (RFC 1123) and case-insensitivity is ASCII-scoped (RFC 4343), so this aligns `normalize_domain` to the same ASCII primitive — the two now fold case identically, by construction.

- `to_lowercase` → `to_ascii_lowercase`: no change for a valid ASCII domain; the two differ only on non-ASCII input, which is not valid in a DNS name.
- The debug log moves to structured (logfmt) fields.
- The test now covers the case folding it had skipped — its only input was already lowercase — with an uppercase and a mixed-case name.

Addresses CodeRabbit's open comment on #2691. Supports #2637; part of the #2630 (reverse DNS) effort.

Draft pending review.
