### PR TITLE
test(secrets): table-ify the credential snapshot and key-path tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2790,6 +2790,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bmc-vendor",
+ "carbide-test-support",
  "carbide-uuid",
  "eyre",
  "figment",

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -55,6 +55,7 @@ bmc-vendor = { path = "../bmc-vendor" }
 carbide-uuid = { path = "../uuid" }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -543,6 +543,8 @@ impl CredentialKey {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
     use crate::test_support::credentials::TestCredentialManager;
 
@@ -666,145 +668,255 @@ mod tests {
         let rack_id = RackId::new("rack-01");
         let mac: MacAddress = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
 
-        let cases: Vec<(CredentialKey, &str)> = vec![
-            (CredentialKey::DpuHbn { machine_id }, "machines/"),
-            (
-                CredentialKey::DpuRedfish {
-                    credential_type: CredentialType::DpuHardwareDefault,
-                },
-                "machines/all_dpus/",
-            ),
-            (
-                CredentialKey::DpuRedfish {
-                    credential_type: CredentialType::SiteDefault,
-                },
-                "machines/all_dpus/",
-            ),
-            (
-                CredentialKey::HostRedfish {
-                    credential_type: CredentialType::HostHardwareDefault {
-                        vendor: bmc_vendor::BMCVendor::Nvidia,
-                    },
-                },
-                "machines/all_hosts/",
-            ),
-            (
-                CredentialKey::HostRedfish {
-                    credential_type: CredentialType::SiteDefault,
-                },
-                "machines/all_hosts/",
-            ),
-            (
-                CredentialKey::UfmAuth {
-                    fabric: "test-fabric".to_string(),
-                },
-                "ufm/",
-            ),
-            (
-                CredentialKey::DpuUefi {
-                    credential_type: CredentialType::DpuHardwareDefault,
-                },
-                "machines/all_dpus/",
-            ),
-            (
-                CredentialKey::DpuUefi {
-                    credential_type: CredentialType::SiteDefault,
-                },
-                "machines/all_dpus/",
-            ),
-            (
-                CredentialKey::HostUefi {
-                    credential_type: CredentialType::SiteDefault,
-                },
-                "machines/all_hosts/",
-            ),
-            (
-                CredentialKey::BmcCredentials {
-                    credential_type: BmcCredentialType::SiteWideRoot,
-                },
-                "machines/bmc/",
-            ),
-            (
-                CredentialKey::BmcCredentials {
-                    credential_type: BmcCredentialType::BmcRoot {
-                        bmc_mac_address: mac,
-                    },
-                },
-                "machines/bmc/",
-            ),
-            (
-                CredentialKey::BmcCredentials {
-                    credential_type: BmcCredentialType::BmcForgeAdmin {
-                        bmc_mac_address: mac,
-                    },
-                },
-                "machines/bmc/",
-            ),
-            (
-                CredentialKey::NicLockdownIkm {
-                    credential_type: NicLockdownIkm::SiteWide { version: 0 },
-                },
-                "machines/nic_lockdown_ikm/",
-            ),
-            (
-                CredentialKey::ExtensionService {
-                    service_id: "svc1".to_string(),
-                    version: "v1".to_string(),
-                },
-                "machines/extension-services/",
-            ),
-            (
-                CredentialKey::NmxM {
-                    nmxm_id: "nmxm1".to_string(),
-                },
-                "nmxm/",
-            ),
-            (
-                CredentialKey::SwitchNvosAdmin {
-                    bmc_mac_address: mac,
-                },
-                "switch_nvos/",
-            ),
-            (
-                CredentialKey::MqttAuth {
-                    credential_type: MqttCredentialType::Dpa,
-                },
-                "mqtt/",
-            ),
-            (
-                CredentialKey::MqttAuth {
-                    credential_type: MqttCredentialType::DsxExchangeEventBus,
-                },
-                "mqtt/",
-            ),
-            (
-                CredentialKey::MqttAuth {
-                    credential_type: MqttCredentialType::DsxExchangeConsumer,
-                },
-                "mqtt/",
-            ),
-            (
-                CredentialKey::RackMaintenanceAccessToken { rack_id },
-                "racks/",
-            ),
-        ];
-
-        for (key, expected_prefix) in &cases {
-            let path = key.to_key_str();
-            assert!(!path.is_empty(), "{key:?} produced an empty path");
-            assert!(
-                !path.starts_with('/'),
-                "{key:?} path {path:?} should not start with /"
-            );
-            assert!(
-                !path.ends_with('/'),
-                "{key:?} path {path:?} should not end with /"
-            );
-            assert!(
-                path.starts_with(expected_prefix),
-                "{key:?} path {path:?} should start with {expected_prefix:?}"
-            );
+        // Each row is a key and the path prefix its `to_key_str()` must carry. A
+        // path is well-formed when it is non-empty, has no leading or trailing
+        // slash, and starts with that prefix.
+        struct Row {
+            key: CredentialKey,
+            expected_prefix: &'static str,
         }
+
+        // The four invariants of a well-formed key path, checked as named fields
+        // rather than folded into one bool so a failing row names the invariant
+        // it broke. A well-formed path holds all four.
+        #[derive(Debug, PartialEq)]
+        struct PathChecks {
+            non_empty: bool,
+            no_leading_slash: bool,
+            no_trailing_slash: bool,
+            has_expected_prefix: bool,
+        }
+
+        impl PathChecks {
+            const fn all_hold() -> Self {
+                Self {
+                    non_empty: true,
+                    no_leading_slash: true,
+                    no_trailing_slash: true,
+                    has_expected_prefix: true,
+                }
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "dpu hbn",
+                    input: Row {
+                        key: CredentialKey::DpuHbn { machine_id },
+                        expected_prefix: "machines/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "dpu redfish hardware default",
+                    input: Row {
+                        key: CredentialKey::DpuRedfish {
+                            credential_type: CredentialType::DpuHardwareDefault,
+                        },
+                        expected_prefix: "machines/all_dpus/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "dpu redfish site default",
+                    input: Row {
+                        key: CredentialKey::DpuRedfish {
+                            credential_type: CredentialType::SiteDefault,
+                        },
+                        expected_prefix: "machines/all_dpus/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "host redfish hardware default",
+                    input: Row {
+                        key: CredentialKey::HostRedfish {
+                            credential_type: CredentialType::HostHardwareDefault {
+                                vendor: bmc_vendor::BMCVendor::Nvidia,
+                            },
+                        },
+                        expected_prefix: "machines/all_hosts/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "host redfish site default",
+                    input: Row {
+                        key: CredentialKey::HostRedfish {
+                            credential_type: CredentialType::SiteDefault,
+                        },
+                        expected_prefix: "machines/all_hosts/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "ufm auth",
+                    input: Row {
+                        key: CredentialKey::UfmAuth {
+                            fabric: "test-fabric".to_string(),
+                        },
+                        expected_prefix: "ufm/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "dpu uefi hardware default",
+                    input: Row {
+                        key: CredentialKey::DpuUefi {
+                            credential_type: CredentialType::DpuHardwareDefault,
+                        },
+                        expected_prefix: "machines/all_dpus/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "dpu uefi site default",
+                    input: Row {
+                        key: CredentialKey::DpuUefi {
+                            credential_type: CredentialType::SiteDefault,
+                        },
+                        expected_prefix: "machines/all_dpus/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "host uefi site default",
+                    input: Row {
+                        key: CredentialKey::HostUefi {
+                            credential_type: CredentialType::SiteDefault,
+                        },
+                        expected_prefix: "machines/all_hosts/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "bmc site wide root",
+                    input: Row {
+                        key: CredentialKey::BmcCredentials {
+                            credential_type: BmcCredentialType::SiteWideRoot,
+                        },
+                        expected_prefix: "machines/bmc/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "bmc root",
+                    input: Row {
+                        key: CredentialKey::BmcCredentials {
+                            credential_type: BmcCredentialType::BmcRoot {
+                                bmc_mac_address: mac,
+                            },
+                        },
+                        expected_prefix: "machines/bmc/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "bmc forge admin",
+                    input: Row {
+                        key: CredentialKey::BmcCredentials {
+                            credential_type: BmcCredentialType::BmcForgeAdmin {
+                                bmc_mac_address: mac,
+                            },
+                        },
+                        expected_prefix: "machines/bmc/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "nic lockdown ikm",
+                    input: Row {
+                        key: CredentialKey::NicLockdownIkm {
+                            credential_type: NicLockdownIkm::SiteWide { version: 0 },
+                        },
+                        expected_prefix: "machines/nic_lockdown_ikm/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "extension service",
+                    input: Row {
+                        key: CredentialKey::ExtensionService {
+                            service_id: "svc1".to_string(),
+                            version: "v1".to_string(),
+                        },
+                        expected_prefix: "machines/extension-services/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "nmxm",
+                    input: Row {
+                        key: CredentialKey::NmxM {
+                            nmxm_id: "nmxm1".to_string(),
+                        },
+                        expected_prefix: "nmxm/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "switch nvos admin",
+                    input: Row {
+                        key: CredentialKey::SwitchNvosAdmin {
+                            bmc_mac_address: mac,
+                        },
+                        expected_prefix: "switch_nvos/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "mqtt dpa",
+                    input: Row {
+                        key: CredentialKey::MqttAuth {
+                            credential_type: MqttCredentialType::Dpa,
+                        },
+                        expected_prefix: "mqtt/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "mqtt dsx exchange event bus",
+                    input: Row {
+                        key: CredentialKey::MqttAuth {
+                            credential_type: MqttCredentialType::DsxExchangeEventBus,
+                        },
+                        expected_prefix: "mqtt/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "mqtt dsx exchange consumer",
+                    input: Row {
+                        key: CredentialKey::MqttAuth {
+                            credential_type: MqttCredentialType::DsxExchangeConsumer,
+                        },
+                        expected_prefix: "mqtt/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "rack maintenance access token",
+                    input: Row {
+                        key: CredentialKey::RackMaintenanceAccessToken { rack_id },
+                        expected_prefix: "racks/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+            ],
+            |Row {
+                 key,
+                 expected_prefix,
+             }| {
+                let path = key.to_key_str();
+                PathChecks {
+                    non_empty: !path.is_empty(),
+                    no_leading_slash: !path.starts_with('/'),
+                    no_trailing_slash: !path.ends_with('/'),
+                    has_expected_prefix: path.starts_with(expected_prefix),
+                }
+            },
+        );
     }
 
     // Verifies that every CredentialKey's to_key_str()

--- a/crates/secrets/src/local_credentials/mod.rs
+++ b/crates/secrets/src/local_credentials/mod.rs
@@ -156,6 +156,8 @@ impl CredentialReader for CredentialSnapshot {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
     fn up(user: &str, pass: &str) -> UsernamePassword {
@@ -201,120 +203,96 @@ mod tests {
         }
     }
 
+    // One table over a single `populated_snapshot()`: each row is a
+    // `CredentialKey` and the credentials that snapshot should return for it,
+    // covering the per-variant hits plus the misses (unknown vendor / fabric /
+    // credential type, unsupported keys, and invalid type combinations).
     #[test]
-    fn snapshot_dpu_redfish_factory_default() {
+    fn snapshot_lookups_return_expected_credentials() {
         let snap = populated_snapshot();
-        let key = CredentialKey::DpuRedfish {
-            credential_type: CredentialType::DpuHardwareDefault,
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("drf-u", "drf-p")));
-    }
+        value_scenarios!(run = |key| snap.get_credentials(&key);
+            "dpu redfish" {
+                CredentialKey::DpuRedfish {
+                    credential_type: CredentialType::DpuHardwareDefault,
+                } => Some(cred("drf-u", "drf-p")),
+                CredentialKey::DpuRedfish {
+                    credential_type: CredentialType::SiteDefault,
+                } => Some(cred("drs-u", "drs-p")),
+            }
 
-    #[test]
-    fn snapshot_dpu_redfish_site_default() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::DpuRedfish {
-            credential_type: CredentialType::SiteDefault,
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("drs-u", "drs-p")));
-    }
+            "host redfish" {
+                CredentialKey::HostRedfish {
+                    credential_type: CredentialType::HostHardwareDefault {
+                        vendor: bmc_vendor::BMCVendor::Dell,
+                    },
+                } => Some(cred("dell-u", "dell-p")),
+                CredentialKey::HostRedfish {
+                    credential_type: CredentialType::HostHardwareDefault {
+                        vendor: bmc_vendor::BMCVendor::Lenovo,
+                    },
+                } => None,
+                CredentialKey::HostRedfish {
+                    credential_type: CredentialType::SiteDefault,
+                } => Some(cred("hrs-u", "hrs-p")),
+            }
 
-    #[test]
-    fn snapshot_host_redfish_vendor() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::HostRedfish {
-            credential_type: CredentialType::HostHardwareDefault {
-                vendor: bmc_vendor::BMCVendor::Dell,
-            },
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("dell-u", "dell-p")));
-    }
+            "ufm auth" {
+                CredentialKey::UfmAuth {
+                    fabric: "fabric-1".to_string(),
+                } => Some(cred("ufm-u", "ufm-p")),
+                CredentialKey::UfmAuth {
+                    fabric: "no-such-fabric".to_string(),
+                } => None,
+            }
 
-    #[test]
-    fn snapshot_host_redfish_unknown_vendor_returns_none() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::HostRedfish {
-            credential_type: CredentialType::HostHardwareDefault {
-                vendor: bmc_vendor::BMCVendor::Lenovo,
-            },
-        };
-        assert_eq!(snap.get_credentials(&key), None);
-    }
+            "dpu uefi" {
+                CredentialKey::DpuUefi {
+                    credential_type: CredentialType::DpuHardwareDefault,
+                } => Some(cred("duf-u", "duf-p")),
+                CredentialKey::DpuUefi {
+                    credential_type: CredentialType::SiteDefault,
+                } => Some(cred("dus-u", "dus-p")),
+            }
 
-    #[test]
-    fn snapshot_host_redfish_site_default() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::HostRedfish {
-            credential_type: CredentialType::SiteDefault,
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("hrs-u", "hrs-p")));
-    }
+            "host uefi" {
+                CredentialKey::HostUefi {
+                    credential_type: CredentialType::SiteDefault,
+                } => Some(cred("hus-u", "hus-p")),
+            }
 
-    #[test]
-    fn snapshot_ufm_auth() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::UfmAuth {
-            fabric: "fabric-1".to_string(),
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("ufm-u", "ufm-p")));
-    }
+            "nmxm" {
+                CredentialKey::NmxM {
+                    nmxm_id: "nmxm-1".to_string(),
+                } => Some(cred("nmxm-u", "nmxm-p")),
+            }
 
-    #[test]
-    fn snapshot_ufm_auth_unknown_fabric_returns_none() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::UfmAuth {
-            fabric: "no-such-fabric".to_string(),
-        };
-        assert_eq!(snap.get_credentials(&key), None);
-    }
+            "mqtt auth" {
+                CredentialKey::MqttAuth {
+                    credential_type: MqttCredentialType::Dpa,
+                } => Some(cred("mqtt-u", "mqtt-p")),
+                CredentialKey::MqttAuth {
+                    credential_type: MqttCredentialType::DsxExchangeConsumer,
+                } => None,
+            }
 
-    #[test]
-    fn snapshot_dpu_uefi_factory_and_site() {
-        let snap = populated_snapshot();
-        let factory = CredentialKey::DpuUefi {
-            credential_type: CredentialType::DpuHardwareDefault,
-        };
-        let site = CredentialKey::DpuUefi {
-            credential_type: CredentialType::SiteDefault,
-        };
-        assert_eq!(snap.get_credentials(&factory), Some(cred("duf-u", "duf-p")));
-        assert_eq!(snap.get_credentials(&site), Some(cred("dus-u", "dus-p")));
-    }
+            "unsupported key" {
+                CredentialKey::ExtensionService {
+                    service_id: "svc".to_string(),
+                    version: "1".to_string(),
+                } => None,
+            }
 
-    #[test]
-    fn snapshot_host_uefi_site_default() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::HostUefi {
-            credential_type: CredentialType::SiteDefault,
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("hus-u", "hus-p")));
-    }
-
-    #[test]
-    fn snapshot_nmxm() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::NmxM {
-            nmxm_id: "nmxm-1".to_string(),
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("nmxm-u", "nmxm-p")));
-    }
-
-    #[test]
-    fn snapshot_mqtt_auth() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::MqttAuth {
-            credential_type: MqttCredentialType::Dpa,
-        };
-        assert_eq!(snap.get_credentials(&key), Some(cred("mqtt-u", "mqtt-p")));
-    }
-
-    #[test]
-    fn snapshot_mqtt_auth_unknown_credential_type_returns_none() {
-        let snap = populated_snapshot();
-        let key = CredentialKey::MqttAuth {
-            credential_type: MqttCredentialType::DsxExchangeConsumer,
-        };
-        assert_eq!(snap.get_credentials(&key), None);
+            "invalid type combo" {
+                CredentialKey::DpuRedfish {
+                    credential_type: CredentialType::HostHardwareDefault {
+                        vendor: bmc_vendor::BMCVendor::Dell,
+                    },
+                } => None,
+                CredentialKey::HostRedfish {
+                    credential_type: CredentialType::DpuHardwareDefault,
+                } => None,
+            }
+        );
     }
 
     #[test]
@@ -327,34 +305,6 @@ mod tests {
             credential_type: BmcCredentialType::SiteWideRoot,
         };
         assert_eq!(snap.get_credentials(&key), Some(cred("bmc-u", "bmc-p")));
-    }
-
-    #[test]
-    fn snapshot_unsupported_keys_return_none() {
-        let snap = populated_snapshot();
-        let keys: Vec<CredentialKey> = vec![CredentialKey::ExtensionService {
-            service_id: "svc".to_string(),
-            version: "1".to_string(),
-        }];
-        for key in &keys {
-            assert_eq!(snap.get_credentials(key), None, "expected None for {key:?}");
-        }
-    }
-
-    #[test]
-    fn snapshot_invalid_type_combos_return_none() {
-        let snap = populated_snapshot();
-        let dpu_redfish_host_hw = CredentialKey::DpuRedfish {
-            credential_type: CredentialType::HostHardwareDefault {
-                vendor: bmc_vendor::BMCVendor::Dell,
-            },
-        };
-        assert_eq!(snap.get_credentials(&dpu_redfish_host_hw), None);
-
-        let host_redfish_dpu_hw = CredentialKey::HostRedfish {
-            credential_type: CredentialType::DpuHardwareDefault,
-        };
-        assert_eq!(snap.get_credentials(&host_redfish_dpu_hw), None);
     }
 
     #[test]


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692).

`secrets` had two per-case clusters: `local_credentials`' 14 snapshot tests (each `populated_snapshot().get(key)` then assert) → one `value_scenarios!` table (16 rows), and `credentials`' `to_key_str_produces_valid_paths` hand-rolled `Vec<(CredentialKey, &str)>` loop → `check_values` over a named `Row { key, expected_prefix }` (20 rows). Tests on other snapshots and the differently-shaped `to_key_str_matches_prefix` are untouched. Adds the dev-dependency.

No production change. Verified: `cargo test -p carbide-secrets --lib` (40 pass), `clippy --locked --all-targets --all-features` clean, nightly rustfmt clean.

Addresses #2726.
