### PR TITLE
test(ssh-console): table-ify cert and escape-sequence tests; cover BmcVendor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,7 @@ dependencies = [
  "carbide-machine-a-tron",
  "carbide-rpc",
  "carbide-ssh-console-mock-api-server",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-uuid",
  "chrono",

--- a/crates/ssh-console/Cargo.toml
+++ b/crates/ssh-console/Cargo.toml
@@ -77,6 +77,7 @@ size = { features = ["serde"], workspace = true }
 [dev-dependencies]
 bmc-mock = { path = "../bmc-mock" }
 carbide-machine-a-tron = { path = "../machine-a-tron" }
+carbide-test-support = { path = "../test-support" }
 temp-dir = { workspace = true }
 futures = { workspace = true }
 carbide-api-test-helper = { path = "../api-test-helper" }

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -317,146 +317,197 @@ impl EscapeSequence {
     }
 }
 
-#[test]
-fn test_filter_escape_sequence() {
-    // Pass-through: no escapes
-    {
-        let result =
-            EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"hello world", false);
-        assert_eq!(result, (Cow::Borrowed(b"hello world".as_slice()), false));
-        // Make sure we don't allocate
-        assert!(matches!(result.0, Cow::Borrowed(_)));
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{scenarios, value_scenarios};
+
+    use super::*;
+
+    /// One row of the escape-sequence filtering table: which vendor escape to
+    /// apply, the input bytes, and whether the previous slice ended mid-escape.
+    struct FilterCase {
+        escape: EscapeSequence,
+        input: &'static [u8],
+        prev_pending: bool,
     }
 
-    // Only a trailing pending escape byte
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"hello world\x1b", false),
-        (Cow::Borrowed(b"hello world".as_slice()), true)
-    );
+    /// The Lenovo/HPE two-byte escape (`ESC (`), used by most filtering rows.
+    const ESC_PAREN: EscapeSequence = EscapeSequence::Pair((0x1b, &[0x28]));
 
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"\x28", true),
-        (Cow::Borrowed(b"".as_slice()), false)
-    );
+    #[test]
+    fn filter_escape_sequences_removes_escapes_and_tracks_pending() {
+        // Each row runs `filter_escape_sequences`, projecting the borrowed/owned
+        // `Cow` to an owned `Vec<u8>` so the asserted output and the pending flag
+        // both stay visible per case.
+        scenarios!(
+            run = |FilterCase { escape, input, prev_pending }| {
+                let (output, pending) = escape.filter_escape_sequences(input, prev_pending);
+                Ok::<_, ()>((output.into_owned(), pending))
+            };
 
-    assert!(
-        !EscapeSequence::Pair((0x1b, &[0x28]))
-            .filter_escape_sequences(&[0x1b, 0x1b, 0x28, 0x28], false)
-            .0
-            .windows(2)
-            .any(|w| w[0] == 0x1b && w[1] == 0x28)
-    );
+            "ESC ( pass-through and pending lead" {
+                FilterCase { escape: ESC_PAREN, input: b"hello world", prev_pending: false } => Yields((b"hello world".to_vec(), false)),
+                FilterCase { escape: ESC_PAREN, input: b"hello world\x1b", prev_pending: false } => Yields((b"hello world".to_vec(), true)),
+                FilterCase { escape: ESC_PAREN, input: b"\x1b", prev_pending: false } => Yields((b"".to_vec(), true)),
+                FilterCase { escape: ESC_PAREN, input: b"hello world\x1b!", prev_pending: false } => Yields((b"hello world\x1b!".to_vec(), false)),
+            }
 
-    assert!(
-        !EscapeSequence::Pair((0x1b, &[0x28]))
-            .filter_escape_sequences(&[0x1b, 0x28, 0x28], true)
-            .0
-            .windows(2)
-            .any(|w| w[0] == 0x1b && w[1] == 0x28)
-    );
+            "ESC ( escape removed mid-stream" {
+                FilterCase { escape: ESC_PAREN, input: b"hello \x1b\x28 world", prev_pending: false } => Yields((b"hello  world".to_vec(), false)),
+                FilterCase { escape: ESC_PAREN, input: b"hello world\x1b\x28", prev_pending: false } => Yields((b"hello world".to_vec(), false)),
+            }
 
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"\x1b", false),
-        (Cow::Borrowed(b"".as_slice()), true)
-    );
+            "ESC ( with a pending lead from the previous slice" {
+                FilterCase { escape: ESC_PAREN, input: b"\x28", prev_pending: true } => Yields((b"".to_vec(), false)),
+                FilterCase { escape: ESC_PAREN, input: b"Z", prev_pending: true } => Yields((b"\x1bZ".to_vec(), false)),
+                FilterCase { escape: ESC_PAREN, input: b"hello world", prev_pending: true } => Yields((b"\x1bhello world".to_vec(), false)),
+                FilterCase { escape: ESC_PAREN, input: b"\x28hello world", prev_pending: true } => Yields((b"hello world".to_vec(), false)),
+                FilterCase { escape: ESC_PAREN, input: b"\x28hello world\x1b", prev_pending: true } => Yields((b"hello world".to_vec(), true)),
+            }
 
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"hello world\x1b!", false),
-        (Cow::Borrowed(b"hello world\x1b!".as_slice()), false)
-    );
+            "single-byte (Dell ctrl+\\) escape removed" {
+                FilterCase { escape: EscapeSequence::Single(0x1b), input: b"hello world", prev_pending: false } => Yields((b"hello world".to_vec(), false)),
+                FilterCase { escape: EscapeSequence::Single(0x1c), input: b"hello \x1c world", prev_pending: false } => Yields((b"hello  world".to_vec(), false)),
+                FilterCase { escape: EscapeSequence::Single(0x1c), input: b"hello world\x1c", prev_pending: false } => Yields((b"hello world".to_vec(), false)),
+                FilterCase { escape: EscapeSequence::Single(0x1c), input: b"\x1chello world", prev_pending: false } => Yields((b"hello world".to_vec(), false)),
+                FilterCase { escape: EscapeSequence::Single(0x1c), input: b"\x1c", prev_pending: false } => Yields((b"".to_vec(), false)),
+            }
 
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28]))
-            .filter_escape_sequences(b"hello \x1b\x28 world", false),
-        (Cow::Borrowed(b"hello  world".as_slice()), false)
-    );
+            "ipmitool multi-trail escape" {
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: b"~~", prev_pending: false } => Yields((b"~".to_vec(), true)),
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: b"~~~", prev_pending: false } => Yields((b"~~".to_vec(), true)),
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: b"~~.", prev_pending: false } => Yields((b"~".to_vec(), false)),
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: b"~.", prev_pending: false } => Yields((b"".to_vec(), false)),
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: b"~B", prev_pending: false } => Yields((b"".to_vec(), false)),
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: &[b'~', 0x1a], prev_pending: false } => Yields((b"".to_vec(), false)),
+                FilterCase { escape: IPMITOOL_ESCAPE_SEQUENCE, input: &[b'~', 0x18], prev_pending: false } => Yields((b"".to_vec(), false)),
+            }
+        );
 
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28]))
-            .filter_escape_sequences(b"hello world\x1b\x28", false),
-        (Cow::Borrowed(b"hello world".as_slice()), false)
-    );
+        // A clean stream is returned borrowed, with no allocation. This asserts a
+        // structural property (the `Cow` variant) that the value table above can't
+        // express, so it stays a hand-written check.
+        assert!(matches!(
+            ESC_PAREN.filter_escape_sequences(b"hello world", false).0,
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            EscapeSequence::Single(0x1b)
+                .filter_escape_sequences(b"hello world", false)
+                .0,
+            Cow::Borrowed(_)
+        ));
 
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"Z", true),
-        (Cow::Borrowed(b"\x1bZ".as_slice()), false)
-    );
-
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"hello world", true),
-        (Cow::Borrowed(b"\x1bhello world".as_slice()), false)
-    );
-
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"\x28hello world", true),
-        (Cow::Borrowed(b"hello world".as_slice()), false)
-    );
-
-    assert_eq!(
-        EscapeSequence::Pair((0x1b, &[0x28])).filter_escape_sequences(b"\x28hello world\x1b", true),
-        (Cow::Borrowed(b"hello world".as_slice()), true)
-    );
-
-    {
-        let result = EscapeSequence::Single(0x1b).filter_escape_sequences(b"hello world", false);
-        assert_eq!(result, (Cow::Borrowed(b"hello world".as_slice()), false));
-        // Make sure we don't allocate if there's no sequence
-        assert!(matches!(result.0, Cow::Borrowed(_)))
+        // Adjacent escapes must not leave a reconstructable `ESC (` pair in the
+        // output; assert that absence directly rather than the exact bytes.
+        assert!(
+            !ESC_PAREN
+                .filter_escape_sequences(&[0x1b, 0x1b, 0x28, 0x28], false)
+                .0
+                .windows(2)
+                .any(|w| w[0] == 0x1b && w[1] == 0x28)
+        );
+        assert!(
+            !ESC_PAREN
+                .filter_escape_sequences(&[0x1b, 0x28, 0x28], true)
+                .0
+                .windows(2)
+                .any(|w| w[0] == 0x1b && w[1] == 0x28)
+        );
     }
 
-    assert_eq!(
-        EscapeSequence::Single(0x1c).filter_escape_sequences(b"hello \x1c world", false),
-        (Cow::Borrowed(b"hello  world".as_slice()), false)
-    );
+    /// Wraps a [`BmcVendor`] in a struct field so its custom serde is exercised
+    /// through a real (de)serializer; the field is a plain TOML string.
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct Wrap {
+        vendor: BmcVendor,
+    }
 
-    assert_eq!(
-        EscapeSequence::Single(0x1c).filter_escape_sequences(b"hello world\x1c", false),
-        (Cow::Borrowed(b"hello world".as_slice()), false)
-    );
+    const ALL_VENDORS: [(BmcVendor, &str); 7] = [
+        (BmcVendor::Ssh(SshBmcVendor::Dell), "dell"),
+        (BmcVendor::Ssh(SshBmcVendor::Lenovo), "lenovo"),
+        (BmcVendor::Ssh(SshBmcVendor::LenovoAmi), "lenovo_ami"),
+        (BmcVendor::Ssh(SshBmcVendor::Hpe), "hpe"),
+        (BmcVendor::Ssh(SshBmcVendor::Dpu), "dpu"),
+        (BmcVendor::Ipmi(IpmiBmcVendor::Supermicro), "supermicro"),
+        (
+            BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking),
+            "nvidia_viking",
+        ),
+    ];
 
-    assert_eq!(
-        EscapeSequence::Single(0x1c).filter_escape_sequences(b"\x1chello world", false),
-        (Cow::Borrowed(b"hello world".as_slice()), false)
-    );
+    #[test]
+    fn bmc_vendor_config_string_names_each_variant() {
+        // Driven from `ALL_VENDORS` so a new variant is covered by adding one row there.
+        for (vendor, config_string) in ALL_VENDORS {
+            assert_eq!(vendor.config_string(), config_string, "{vendor:?}");
+        }
+    }
 
-    assert_eq!(
-        EscapeSequence::Single(0x1c).filter_escape_sequences(b"\x1c", false),
-        (Cow::Borrowed(b"".as_slice()), false)
-    );
+    #[test]
+    fn bmc_vendor_from_config_string_parses_each_variant() {
+        // Driven from `ALL_VENDORS` so a new variant is covered by adding one row there.
+        for (vendor, config_string) in ALL_VENDORS {
+            assert_eq!(
+                BmcVendor::from_config_string(config_string),
+                Some(vendor),
+                "{config_string:?}",
+            );
+        }
 
-    let ipmitool_escape_sequence = IPMITOOL_ESCAPE_SEQUENCE;
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(b"~~", false),
-        (Cow::Borrowed(b"~".as_slice()), true)
-    );
+        value_scenarios!(
+            run = |s: &str| BmcVendor::from_config_string(s);
 
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(b"~~~", false),
-        (Cow::Borrowed(b"~~".as_slice()), true)
-    );
+            "an unknown string has no vendor" {
+                "" => None,
+                "bogus" => None,
+            }
+        );
+    }
 
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(b"~~.", false),
-        (Cow::Borrowed(b"~".as_slice()), false)
-    );
+    #[test]
+    fn bmc_vendor_config_string_round_trips() {
+        // config_string -> from_config_string returns the same vendor for every variant.
+        for (vendor, _) in ALL_VENDORS {
+            assert_eq!(
+                BmcVendor::from_config_string(vendor.config_string()),
+                Some(vendor),
+                "{vendor:?}",
+            );
+        }
+    }
 
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(b"~.", false),
-        (Cow::Borrowed(b"".as_slice()), false)
-    );
+    #[test]
+    fn bmc_vendor_serde_round_trips_through_toml() {
+        // The custom Serialize/Deserialize go through a real TOML (de)serializer.
+        for (vendor, config_string) in ALL_VENDORS {
+            let label = format!("{vendor:?}");
+            let wrap = Wrap { vendor };
+            let serialized = toml::to_string(&wrap).expect("serialize");
+            assert_eq!(
+                serialized,
+                format!("vendor = \"{config_string}\"\n"),
+                "{label}"
+            );
+            let deserialized: Wrap = toml::from_str(&serialized).expect("deserialize");
+            assert_eq!(deserialized, wrap, "{label}");
+        }
+    }
 
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(b"~B", false),
-        (Cow::Borrowed(b"".as_slice()), false)
-    );
+    #[test]
+    fn bmc_vendor_deserialize_rejects_an_unknown_string() {
+        scenarios!(
+            run = |s: &str| toml::from_str::<Wrap>(&format!("vendor = \"{s}\"")).map_err(|e| e.to_string());
 
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(&[b'~', 0x1a], false),
-        (Cow::Borrowed(b"".as_slice()), false)
-    );
+            "valid config strings deserialize" {
+                "dell" => Yields(Wrap { vendor: BmcVendor::Ssh(SshBmcVendor::Dell) }),
+                "nvidia_viking" => Yields(Wrap { vendor: BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking) }),
+            }
 
-    assert_eq!(
-        ipmitool_escape_sequence.filter_escape_sequences(&[b'~', 0x18], false),
-        (Cow::Borrowed(b"".as_slice()), false)
-    );
+            "an unknown string is rejected" {
+                "bogus" => Fails,
+            }
+        );
+    }
 }

--- a/crates/ssh-console/src/ssh_cert_parsing.rs
+++ b/crates/ssh-console/src/ssh_cert_parsing.rs
@@ -120,183 +120,120 @@ fn get_user_from_key_id<'a>(key_id: &'a str, key_id_format: &KeyIdFormat) -> Opt
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
-    #[test]
-    fn test_get_user_from_key_id() {
-        let key_id = "group=group1 user=ksimon roles=role1,role2,role3";
-        let parsed_user = get_user_from_key_id(
-            key_id,
-            &KeyIdFormat {
-                field_separator: " ".to_string(),
-                user_field: "user".to_string(),
-                role_field: "roles".to_string(),
-                role_separator: ",".to_string(),
-            },
-        );
-        assert_eq!(parsed_user, Some("ksimon"));
+    /// A custom [`KeyIdFormat`] for the scenarios that exercise non-default
+    /// separators or field names. Spelled out so each row reads as the format it
+    /// means; [`KeyIdFormat::default()`] covers the common `" "`/`","` case.
+    fn key_id_fmt(
+        field_separator: &str,
+        user_field: &str,
+        role_field: &str,
+        role_separator: &str,
+    ) -> KeyIdFormat {
+        KeyIdFormat {
+            field_separator: field_separator.into(),
+            user_field: user_field.into(),
+            role_field: role_field.into(),
+            role_separator: role_separator.into(),
+        }
+    }
+
+    /// One row of the [`key_id_contains_role`] table: a Key ID, the role to look
+    /// for, and the format that governs how the Key ID is split.
+    struct RoleCase {
+        key_id: &'static str,
+        role: &'static str,
+        format: KeyIdFormat,
+    }
+
+    /// One row of the [`get_user_from_key_id`] table: a Key ID and the format that
+    /// governs how the user field is found.
+    struct UserCase {
+        key_id: &'static str,
+        format: KeyIdFormat,
     }
 
     #[test]
-    fn test_key_id_contains_role() {
-        let key_id = "group=group1 user=ksimon roles=role1,role2,role3";
-        assert!(key_id_contains_role(
-            key_id,
-            "role1",
-            &KeyIdFormat::default()
-        ));
-        assert!(key_id_contains_role(
-            key_id,
-            "role3",
-            &KeyIdFormat::default()
-        ));
-        assert!(!key_id_contains_role(
-            key_id,
-            "fakerole",
-            &KeyIdFormat::default()
-        ));
-    }
+    fn key_id_contains_role_finds_declared_roles() {
+        value_scenarios!(
+            run = |RoleCase { key_id, role, format }| key_id_contains_role(key_id, role, &format);
 
-    #[test]
-    fn test_key_id_contains_role_exact_match_not_substring() {
-        // "role" should not match "role1"
-        let key_id = "group=g user=u roles=role1,role2";
-        assert!(!key_id_contains_role(
-            key_id,
-            "role",
-            &KeyIdFormat::default()
-        ));
-        assert!(key_id_contains_role(
-            key_id,
-            "role2",
-            &KeyIdFormat::default()
-        ));
-    }
+            "declared roles, default format" {
+                RoleCase { key_id: "group=group1 user=ksimon roles=role1,role2,role3", role: "role1", format: KeyIdFormat::default() } => true,
+                RoleCase { key_id: "group=group1 user=ksimon roles=role1,role2,role3", role: "role3", format: KeyIdFormat::default() } => true,
+                RoleCase { key_id: "group=group1 user=ksimon roles=role1,role2,role3", role: "fakerole", format: KeyIdFormat::default() } => false,
+            }
 
-    #[test]
-    fn test_key_id_contains_role_missing_roles_field() {
-        let key_id = "group=g user=u";
-        assert!(!key_id_contains_role(
-            key_id,
-            "role1",
-            &KeyIdFormat::default()
-        ));
-    }
+            "exact match, not substring" {
+                RoleCase { key_id: "group=g user=u roles=role1,role2", role: "role", format: KeyIdFormat::default() } => false,
+                RoleCase { key_id: "group=g user=u roles=role1,role2", role: "role2", format: KeyIdFormat::default() } => true,
+            }
 
-    #[test]
-    fn test_key_id_contains_role_empty_roles_value() {
-        let key_id = "group=g user=u roles=";
-        assert!(!key_id_contains_role(
-            key_id,
-            "anything",
-            &KeyIdFormat::default()
-        ));
-    }
+            "missing or empty roles field" {
+                RoleCase { key_id: "group=g user=u", role: "role1", format: KeyIdFormat::default() } => false,
+                RoleCase { key_id: "group=g user=u roles=", role: "anything", format: KeyIdFormat::default() } => false,
+            }
 
-    #[test]
-    fn test_key_id_contains_role_trailing_separator() {
-        // Trailing separator yields an empty last token; should still find existing roles.
-        let key_id = "group=g user=u roles=role1,role2,";
-        assert!(key_id_contains_role(
-            key_id,
-            "role1",
-            &KeyIdFormat::default()
-        ));
-        assert!(key_id_contains_role(
-            key_id,
-            "role2",
-            &KeyIdFormat::default()
-        ));
-        assert!(!key_id_contains_role(
-            key_id,
-            "role3",
-            &KeyIdFormat::default()
-        ));
-    }
+            "trailing role separator" {
+                RoleCase { key_id: "group=g user=u roles=role1,role2,", role: "role1", format: KeyIdFormat::default() } => true,
+                RoleCase { key_id: "group=g user=u roles=role1,role2,", role: "role2", format: KeyIdFormat::default() } => true,
+                RoleCase { key_id: "group=g user=u roles=role1,role2,", role: "role3", format: KeyIdFormat::default() } => false,
+            }
 
-    #[test]
-    fn test_key_id_contains_role_custom_role_separator() {
-        // Roles separated by semicolons
-        let key_id = "group=g user=u roles=alpha;beta;gamma";
-        let fmt = KeyIdFormat {
-            field_separator: " ".into(),
-            user_field: "user".into(),
-            role_field: "roles".into(),
-            role_separator: ";".into(),
-        };
-        assert!(key_id_contains_role(key_id, "beta", &fmt));
-        assert!(!key_id_contains_role(key_id, "delta", &fmt));
-    }
+            "custom role separator" {
+                RoleCase { key_id: "group=g user=u roles=alpha;beta;gamma", role: "beta", format: key_id_fmt(" ", "user", "roles", ";") } => true,
+                RoleCase { key_id: "group=g user=u roles=alpha;beta;gamma", role: "delta", format: key_id_fmt(" ", "user", "roles", ";") } => false,
+            }
 
-    #[test]
-    fn test_key_id_contains_role_custom_field_separator() {
-        // Fields separated by '|'
-        let key_id = "group=g|user=u|roles=a,b,c";
-        let fmt = KeyIdFormat {
-            field_separator: "|".into(),
-            user_field: "user".into(),
-            role_field: "roles".into(),
-            role_separator: ",".into(),
-        };
-        assert!(key_id_contains_role(key_id, "b", &fmt));
-    }
+            "custom field separator" {
+                RoleCase { key_id: "group=g|user=u|roles=a,b,c", role: "b", format: key_id_fmt("|", "user", "roles", ",") } => true,
+            }
 
-    #[test]
-    fn test_key_id_contains_role_fields_any_order() {
-        // Different field order should not matter
-        let key_id = "roles=r1,r2 group=g user=u";
-        assert!(key_id_contains_role(key_id, "r2", &KeyIdFormat::default()));
-    }
+            "fields in any order" {
+                RoleCase { key_id: "roles=r1,r2 group=g user=u", role: "r2", format: KeyIdFormat::default() } => true,
+            }
 
-    #[test]
-    fn test_get_user_from_key_id_missing_user_field() {
-        let key_id = "group=g roles=r1,r2";
-        let parsed_user = get_user_from_key_id(key_id, &KeyIdFormat::default());
-        assert_eq!(parsed_user, None);
-    }
+            "custom fields and separator" {
+                RoleCase { key_id: "tenant=acme|login=alice|scopes=read;write", role: "write", format: key_id_fmt("|", "login", "scopes", ";") } => true,
+            }
 
-    #[test]
-    fn test_get_user_from_key_id_custom_fields_and_separator() {
-        let key_id = "tenant=acme|login=alice|scopes=read;write";
-        let fmt = KeyIdFormat {
-            field_separator: "|".into(),
-            user_field: "login".into(),
-            role_field: "scopes".into(),
-            role_separator: ";".into(),
-        };
-        assert_eq!(get_user_from_key_id(key_id, &fmt), Some("alice"));
-        assert!(key_id_contains_role(key_id, "write", &fmt));
-    }
+            "duplicate roles" {
+                RoleCase { key_id: "group=g user=u roles=dup,dup", role: "dup", format: KeyIdFormat::default() } => true,
+            }
 
-    #[test]
-    fn test_get_user_from_key_id_with_extra_equals_in_value() {
-        // Values may contain '='; split_once should still produce the correct (k, v)
-        let key_id = "group=g user=alice=dev roles=r1,r2";
-        assert_eq!(
-            get_user_from_key_id(key_id, &KeyIdFormat::default()),
-            Some("alice=dev")
+            "role field name must match" {
+                // Roles under a different field name; the default format does not find them.
+                RoleCase { key_id: "group=g user=u permissions=a,b,c", role: "a", format: KeyIdFormat::default() } => false,
+                // With a matching role_field it does.
+                RoleCase { key_id: "group=g user=u permissions=a,b,c", role: "a", format: key_id_fmt(" ", "user", "permissions", ",") } => true,
+            }
         );
     }
 
     #[test]
-    fn test_key_id_contains_role_duplicate_roles() {
-        let key_id = "group=g user=u roles=dup,dup";
-        assert!(key_id_contains_role(key_id, "dup", &KeyIdFormat::default()));
-    }
+    fn get_user_from_key_id_extracts_the_user() {
+        value_scenarios!(
+            run = |UserCase { key_id, format }| get_user_from_key_id(key_id, &format);
 
-    #[test]
-    fn test_key_id_contains_role_unknown_role_field_name() {
-        // Roles are under a different field name; default format should not find them
-        let key_id = "group=g user=u permissions=a,b,c";
-        assert!(!key_id_contains_role(key_id, "a", &KeyIdFormat::default()));
+            "user present, default format" {
+                UserCase { key_id: "group=group1 user=ksimon roles=role1,role2,role3", format: KeyIdFormat::default() } => Some("ksimon"),
+            }
 
-        // But with matching role_field it should work
-        let fmt = KeyIdFormat {
-            field_separator: " ".into(),
-            user_field: "user".into(),
-            role_field: "permissions".into(),
-            role_separator: ",".into(),
-        };
-        assert!(key_id_contains_role(key_id, "a", &fmt));
+            "missing user field" {
+                UserCase { key_id: "group=g roles=r1,r2", format: KeyIdFormat::default() } => None,
+            }
+
+            "custom fields and separator" {
+                UserCase { key_id: "tenant=acme|login=alice|scopes=read;write", format: key_id_fmt("|", "login", "scopes", ";") } => Some("alice"),
+            }
+
+            "value contains an equals sign" {
+                // Values may contain '='; split_once still yields the correct (k, v).
+                UserCase { key_id: "group=g user=alice=dev roles=r1,r2", format: KeyIdFormat::default() } => Some("alice=dev"),
+            }
+        );
     }
 }


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692).

`ssh-console`: 14 `ssh_cert_parsing` single-assertion tests → two `value_scenarios!` tables (`RoleCase` / `UserCase`); the fat `test_filter_escape_sequence` (~23 inline blocks) → one `check_cases` table asserting both output bytes and the pending flag per case (structural `Cow::Borrowed` / window checks kept inline). Plus **new** `BmcVendor` coverage the crate lacked: all 7 config strings render/parse, round-trip, survive a TOML serde cycle, and reject an unknown string. Adds the dev-dependency.

No production change. Verified: `cargo test -p carbide-ssh-console --lib` (23 pass), `clippy --locked --all-targets --all-features` clean, nightly rustfmt clean.

Addresses #2727.
