### PR TITLE
test(component-manager): table-ify the rms/nsm/psm enum-mapping tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "carbide-redfish",
  "carbide-secrets",
  "carbide-sqlx-testing",
+ "carbide-test-support",
  "carbide-uuid",
  "chrono",
  "libredfish",

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -47,6 +47,7 @@ tracing = { workspace = true }
 carbide-api-test-helper = { path = "../api-test-helper" }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing" }
+carbide-test-support = { path = "../test-support" }
 uuid = { workspace = true }
 
 [build-dependencies]

--- a/crates/component-manager/src/config.rs
+++ b/crates/component-manager/src/config.rs
@@ -108,6 +108,8 @@ impl BackendTlsConfig {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     #[test]
@@ -118,75 +120,138 @@ mod tests {
         assert_eq!(cfg.compute_tray_backend, ComputeBackend::Rms);
     }
 
-    fn tls_config(
-        cert_dir: Option<&str>,
-        ca: Option<&str>,
-        cert: Option<&str>,
-        key: Option<&str>,
-    ) -> BackendTlsConfig {
+    /// One `BackendTlsConfig` worth of path inputs for a resolver table.
+    struct Row {
+        cert_dir: Option<&'static str>,
+        ca: Option<&'static str>,
+        cert: Option<&'static str>,
+        key: Option<&'static str>,
+    }
+
+    fn tls_config(row: Row) -> BackendTlsConfig {
         BackendTlsConfig {
-            cert_dir: cert_dir.map(String::from),
-            ca_cert_path: ca.map(String::from),
-            client_cert_path: cert.map(String::from),
-            client_key_path: key.map(String::from),
+            cert_dir: row.cert_dir.map(String::from),
+            ca_cert_path: row.ca.map(String::from),
+            client_cert_path: row.cert.map(String::from),
+            client_key_path: row.key.map(String::from),
             domain: None,
         }
     }
 
     #[test]
-    fn resolve_ca_cert_explicit_path_wins() {
-        let cfg = tls_config(Some("/dir"), Some("/explicit/ca.pem"), None, None);
-        assert_eq!(cfg.resolve_ca_cert_path().unwrap(), "/explicit/ca.pem");
-    }
-
-    #[test]
-    fn resolve_ca_cert_falls_back_to_dir() {
-        let cfg = tls_config(Some("/certs"), None, None, None);
-        assert_eq!(cfg.resolve_ca_cert_path().unwrap(), "/certs/ca.crt");
-    }
-
-    #[test]
-    fn resolve_ca_cert_none_when_nothing_set() {
-        let cfg = tls_config(None, None, None, None);
-        assert!(cfg.resolve_ca_cert_path().is_none());
-    }
-
-    #[test]
-    fn resolve_client_cert_explicit_path_wins() {
-        let cfg = tls_config(Some("/dir"), None, Some("/explicit/client.pem"), None);
-        assert_eq!(
-            cfg.resolve_client_cert_path().unwrap(),
-            "/explicit/client.pem"
+    fn resolve_ca_cert_path_explicit_wins_then_dir_then_none() {
+        check_values(
+            [
+                Check {
+                    scenario: "explicit path wins",
+                    input: Row {
+                        cert_dir: Some("/dir"),
+                        ca: Some("/explicit/ca.pem"),
+                        cert: None,
+                        key: None,
+                    },
+                    expect: Some("/explicit/ca.pem".to_string()),
+                },
+                Check {
+                    scenario: "falls back to dir",
+                    input: Row {
+                        cert_dir: Some("/certs"),
+                        ca: None,
+                        cert: None,
+                        key: None,
+                    },
+                    expect: Some("/certs/ca.crt".to_string()),
+                },
+                Check {
+                    scenario: "none when nothing set",
+                    input: Row {
+                        cert_dir: None,
+                        ca: None,
+                        cert: None,
+                        key: None,
+                    },
+                    expect: None,
+                },
+            ],
+            |row| tls_config(row).resolve_ca_cert_path(),
         );
     }
 
     #[test]
-    fn resolve_client_cert_falls_back_to_dir() {
-        let cfg = tls_config(Some("/certs"), None, None, None);
-        assert_eq!(cfg.resolve_client_cert_path().unwrap(), "/certs/tls.crt");
+    fn resolve_client_cert_path_explicit_wins_then_dir_then_none() {
+        check_values(
+            [
+                Check {
+                    scenario: "explicit path wins",
+                    input: Row {
+                        cert_dir: Some("/dir"),
+                        ca: None,
+                        cert: Some("/explicit/client.pem"),
+                        key: None,
+                    },
+                    expect: Some("/explicit/client.pem".to_string()),
+                },
+                Check {
+                    scenario: "falls back to dir",
+                    input: Row {
+                        cert_dir: Some("/certs"),
+                        ca: None,
+                        cert: None,
+                        key: None,
+                    },
+                    expect: Some("/certs/tls.crt".to_string()),
+                },
+                Check {
+                    scenario: "none when nothing set",
+                    input: Row {
+                        cert_dir: None,
+                        ca: None,
+                        cert: None,
+                        key: None,
+                    },
+                    expect: None,
+                },
+            ],
+            |row| tls_config(row).resolve_client_cert_path(),
+        );
     }
 
     #[test]
-    fn resolve_client_cert_none_when_nothing_set() {
-        let cfg = tls_config(None, None, None, None);
-        assert!(cfg.resolve_client_cert_path().is_none());
-    }
-
-    #[test]
-    fn resolve_client_key_explicit_path_wins() {
-        let cfg = tls_config(Some("/dir"), None, None, Some("/explicit/key.pem"));
-        assert_eq!(cfg.resolve_client_key_path().unwrap(), "/explicit/key.pem");
-    }
-
-    #[test]
-    fn resolve_client_key_falls_back_to_dir() {
-        let cfg = tls_config(Some("/certs"), None, None, None);
-        assert_eq!(cfg.resolve_client_key_path().unwrap(), "/certs/tls.key");
-    }
-
-    #[test]
-    fn resolve_client_key_none_when_nothing_set() {
-        let cfg = tls_config(None, None, None, None);
-        assert!(cfg.resolve_client_key_path().is_none());
+    fn resolve_client_key_path_explicit_wins_then_dir_then_none() {
+        check_values(
+            [
+                Check {
+                    scenario: "explicit path wins",
+                    input: Row {
+                        cert_dir: Some("/dir"),
+                        ca: None,
+                        cert: None,
+                        key: Some("/explicit/key.pem"),
+                    },
+                    expect: Some("/explicit/key.pem".to_string()),
+                },
+                Check {
+                    scenario: "falls back to dir",
+                    input: Row {
+                        cert_dir: Some("/certs"),
+                        ca: None,
+                        cert: None,
+                        key: None,
+                    },
+                    expect: Some("/certs/tls.key".to_string()),
+                },
+                Check {
+                    scenario: "none when nothing set",
+                    input: Row {
+                        cert_dir: None,
+                        ca: None,
+                        cert: None,
+                        key: None,
+                    },
+                    expect: None,
+                },
+            ],
+            |row| tls_config(row).resolve_client_key_path(),
+        );
     }
 }

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -373,73 +373,64 @@ impl NvSwitchManager for NsmSwitchBackend {
 #[cfg(test)]
 mod tests {
     use carbide_secrets::credentials::Credentials;
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
     #[test]
-    fn nsm_state_queued() {
-        assert_eq!(
-            map_nsm_update_state(nsm::UpdateState::Queued as i32),
-            FirmwareState::Queued,
+    fn nsm_update_state_maps_each_variant() {
+        value_scenarios!(run = |state: nsm::UpdateState| map_nsm_update_state(state as i32);
+            "queued" {
+                nsm::UpdateState::Queued => FirmwareState::Queued,
+            }
+
+            "in progress" {
+                nsm::UpdateState::Copy => FirmwareState::InProgress,
+                nsm::UpdateState::Upload => FirmwareState::InProgress,
+                nsm::UpdateState::Install => FirmwareState::InProgress,
+                nsm::UpdateState::PollCompletion => FirmwareState::InProgress,
+                nsm::UpdateState::PowerCycle => FirmwareState::InProgress,
+                nsm::UpdateState::WaitReachable => FirmwareState::InProgress,
+            }
+
+            "verifying" {
+                nsm::UpdateState::Verify => FirmwareState::Verifying,
+                nsm::UpdateState::Cleanup => FirmwareState::Verifying,
+            }
+
+            "completed" {
+                nsm::UpdateState::Completed => FirmwareState::Completed,
+            }
+
+            "failed" {
+                nsm::UpdateState::Failed => FirmwareState::Failed,
+            }
+
+            "cancelled" {
+                nsm::UpdateState::Cancelled => FirmwareState::Cancelled,
+            }
         );
     }
 
     #[test]
-    fn nsm_state_in_progress_variants() {
-        for state in [
-            nsm::UpdateState::Copy,
-            nsm::UpdateState::Upload,
-            nsm::UpdateState::Install,
-            nsm::UpdateState::PollCompletion,
-            nsm::UpdateState::PowerCycle,
-            nsm::UpdateState::WaitReachable,
-        ] {
-            assert_eq!(
-                map_nsm_update_state(state as i32),
-                FirmwareState::InProgress,
-                "expected InProgress for {state:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn nsm_state_verifying_variants() {
-        for state in [nsm::UpdateState::Verify, nsm::UpdateState::Cleanup] {
-            assert_eq!(
-                map_nsm_update_state(state as i32),
-                FirmwareState::Verifying,
-                "expected Verifying for {state:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn nsm_state_completed() {
-        assert_eq!(
-            map_nsm_update_state(nsm::UpdateState::Completed as i32),
-            FirmwareState::Completed,
+    fn nsm_update_state_unknown_for_unrecognized_value() {
+        value_scenarios!(map_nsm_update_state:
+            "unrecognized" {
+                9999 => FirmwareState::Unknown,
+            }
         );
     }
 
     #[test]
-    fn nsm_state_failed() {
-        assert_eq!(
-            map_nsm_update_state(nsm::UpdateState::Failed as i32),
-            FirmwareState::Failed,
+    fn to_nsm_component_maps_each_variant() {
+        value_scenarios!(run = |component: NvSwitchComponent| to_nsm_component(&component);
+            "components" {
+                NvSwitchComponent::Bmc => nsm::NvSwitchComponent::NvswitchComponentBmc,
+                NvSwitchComponent::Cpld => nsm::NvSwitchComponent::NvswitchComponentCpld,
+                NvSwitchComponent::Bios => nsm::NvSwitchComponent::NvswitchComponentBios,
+                NvSwitchComponent::Nvos => nsm::NvSwitchComponent::NvswitchComponentNvos,
+            }
         );
-    }
-
-    #[test]
-    fn nsm_state_cancelled() {
-        assert_eq!(
-            map_nsm_update_state(nsm::UpdateState::Cancelled as i32),
-            FirmwareState::Cancelled,
-        );
-    }
-
-    #[test]
-    fn nsm_state_unknown_for_unrecognized_value() {
-        assert_eq!(map_nsm_update_state(9999), FirmwareState::Unknown);
     }
 
     #[test]
@@ -474,25 +465,5 @@ mod tests {
         let nvos_creds = nvos.credentials.as_ref().unwrap();
         assert_eq!(nvos_creds.username, "nvadmin");
         assert_eq!(nvos_creds.password, "nvos_pass");
-    }
-
-    #[test]
-    fn to_nsm_component_all_variants() {
-        assert_eq!(
-            to_nsm_component(&NvSwitchComponent::Bmc),
-            nsm::NvSwitchComponent::NvswitchComponentBmc
-        );
-        assert_eq!(
-            to_nsm_component(&NvSwitchComponent::Cpld),
-            nsm::NvSwitchComponent::NvswitchComponentCpld
-        );
-        assert_eq!(
-            to_nsm_component(&NvSwitchComponent::Bios),
-            nsm::NvSwitchComponent::NvswitchComponentBios
-        );
-        assert_eq!(
-            to_nsm_component(&NvSwitchComponent::Nvos),
-            nsm::NvSwitchComponent::NvswitchComponentNvos
-        );
     }
 }

--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -426,58 +426,38 @@ impl PowerShelfManager for PsmPowerShelfBackend {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
     #[test]
-    fn psm_state_queued() {
-        assert_eq!(
-            map_psm_fw_state(psm::FirmwareUpdateState::Queued as i32),
-            FirmwareState::Queued,
+    fn psm_fw_state_maps_each_variant() {
+        value_scenarios!(run = |state: psm::FirmwareUpdateState| map_psm_fw_state(state as i32);
+            "states" {
+                psm::FirmwareUpdateState::Queued => FirmwareState::Queued,
+                psm::FirmwareUpdateState::Verifying => FirmwareState::Verifying,
+                psm::FirmwareUpdateState::Completed => FirmwareState::Completed,
+                psm::FirmwareUpdateState::Failed => FirmwareState::Failed,
+            }
         );
     }
 
     #[test]
-    fn psm_state_verifying() {
-        assert_eq!(
-            map_psm_fw_state(psm::FirmwareUpdateState::Verifying as i32),
-            FirmwareState::Verifying,
+    fn psm_fw_state_unknown_for_unrecognized_value() {
+        value_scenarios!(map_psm_fw_state:
+            "unrecognized" {
+                9999 => FirmwareState::Unknown,
+            }
         );
     }
 
     #[test]
-    fn psm_state_completed() {
-        assert_eq!(
-            map_psm_fw_state(psm::FirmwareUpdateState::Completed as i32),
-            FirmwareState::Completed,
-        );
-    }
-
-    #[test]
-    fn psm_state_failed() {
-        assert_eq!(
-            map_psm_fw_state(psm::FirmwareUpdateState::Failed as i32),
-            FirmwareState::Failed,
-        );
-    }
-
-    #[test]
-    fn psm_state_unknown_for_unrecognized_value() {
-        assert_eq!(map_psm_fw_state(9999), FirmwareState::Unknown);
-    }
-
-    #[test]
-    fn vendor_mapping_unknown() {
-        assert_eq!(
-            map_vendor(&PowerShelfVendor::Unknown),
-            psm::PmcVendor::PmcTypeUnknown as i32,
-        );
-    }
-
-    #[test]
-    fn vendor_mapping_liteon() {
-        assert_eq!(
-            map_vendor(&PowerShelfVendor::Liteon),
-            psm::PmcVendor::PmcTypeLiteon as i32,
+    fn vendor_maps_each_variant() {
+        value_scenarios!(run = |vendor: PowerShelfVendor| map_vendor(&vendor);
+            "vendors" {
+                PowerShelfVendor::Unknown => psm::PmcVendor::PmcTypeUnknown as i32,
+                PowerShelfVendor::Liteon => psm::PmcVendor::PmcTypeLiteon as i32,
+            }
         );
     }
 

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -2040,6 +2040,7 @@ impl ComputeTrayManager for RmsBackend {
 #[cfg(test)]
 mod tests {
     use api_test_helper::mock_rms::MockRmsApi;
+    use carbide_test_support::value_scenarios;
     use carbide_uuid::machine::MachineId;
     use carbide_uuid::power_shelf::PowerShelfId;
     use carbide_uuid::rack::RackId;
@@ -2070,130 +2071,92 @@ mod tests {
     // ---- Mapping unit tests ----
 
     #[test]
-    fn power_action_on_maps_to_power_on() {
-        assert_eq!(
-            to_rms_power_operation(PowerAction::On),
-            rms::PowerOperation::On as i32,
+    fn power_action_maps_to_rms_operation() {
+        value_scenarios!(to_rms_power_operation:
+            "power on" {
+                PowerAction::On => rms::PowerOperation::On as i32,
+            }
+
+            "power off" {
+                PowerAction::GracefulShutdown => rms::PowerOperation::Off as i32,
+                PowerAction::ForceOff => rms::PowerOperation::Off as i32,
+            }
+
+            "reset" {
+                PowerAction::GracefulRestart => rms::PowerOperation::Reset as i32,
+                PowerAction::ForceRestart => rms::PowerOperation::Reset as i32,
+                PowerAction::AcPowercycle => rms::PowerOperation::Reset as i32,
+            }
         );
     }
 
     #[test]
-    fn power_action_shutdown_maps_to_power_off() {
-        assert_eq!(
-            to_rms_power_operation(PowerAction::GracefulShutdown),
-            rms::PowerOperation::Off as i32,
-        );
-    }
-
-    #[test]
-    fn power_action_force_off_maps_to_power_off() {
-        assert_eq!(
-            to_rms_power_operation(PowerAction::ForceOff),
-            rms::PowerOperation::Off as i32,
-        );
-    }
-
-    #[test]
-    fn power_action_restart_maps_to_power_reset() {
-        for action in [
-            PowerAction::GracefulRestart,
-            PowerAction::ForceRestart,
-            PowerAction::AcPowercycle,
-        ] {
-            assert_eq!(
-                to_rms_power_operation(action),
-                rms::PowerOperation::Reset as i32,
-                "expected PowerReset for {action:?}",
-            );
-        }
-    }
-
-    #[test]
-    fn firmware_job_state_queued() {
-        assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Queued as i32),
-            FirmwareState::Queued,
-        );
-    }
-
-    #[test]
-    fn firmware_job_state_running() {
-        assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Running as i32),
-            FirmwareState::InProgress,
-        );
-    }
-
-    #[test]
-    fn firmware_job_state_completed() {
-        assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Completed as i32),
-            FirmwareState::Completed,
-        );
-    }
-
-    #[test]
-    fn firmware_job_state_failed() {
-        assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Failed as i32),
-            FirmwareState::Failed,
+    fn firmware_job_state_maps_each_variant() {
+        value_scenarios!(run = |state: rms::FirmwareJobState| map_rms_firmware_job_state(state as i32);
+            "states" {
+                rms::FirmwareJobState::Queued => FirmwareState::Queued,
+                rms::FirmwareJobState::Running => FirmwareState::InProgress,
+                rms::FirmwareJobState::Completed => FirmwareState::Completed,
+                rms::FirmwareJobState::Failed => FirmwareState::Failed,
+            }
         );
     }
 
     #[test]
     fn firmware_job_state_unknown_for_unrecognized_value() {
-        assert_eq!(map_rms_firmware_job_state(9999), FirmwareState::Unknown);
+        value_scenarios!(map_rms_firmware_job_state:
+            "unrecognized" {
+                9999 => FirmwareState::Unknown,
+            }
+        );
     }
 
     #[test]
     fn switch_system_image_job_state_maps_cancelled_and_verifying() {
-        assert_eq!(
-            map_rms_switch_system_image_job_state("cancelled"),
-            FirmwareState::Cancelled,
-        );
-        assert_eq!(
-            map_rms_switch_system_image_job_state("verifying"),
-            FirmwareState::Verifying,
+        value_scenarios!(map_rms_switch_system_image_job_state:
+            "cancelled" {
+                "cancelled" => FirmwareState::Cancelled,
+            }
+
+            "verifying" {
+                "verifying" => FirmwareState::Verifying,
+            }
         );
     }
 
     #[test]
     fn aggregate_firmware_job_states_prioritizes_active_over_unknown() {
-        assert_eq!(
-            aggregate_firmware_job_states(&[
-                FirmwareState::Completed,
-                FirmwareState::Unknown,
-                FirmwareState::InProgress,
-            ]),
-            FirmwareState::InProgress,
-        );
-        assert_eq!(
-            aggregate_firmware_job_states(&[
-                FirmwareState::Completed,
-                FirmwareState::Queued,
-                FirmwareState::Unknown,
-            ]),
-            FirmwareState::Queued,
+        value_scenarios!(run = |states| aggregate_firmware_job_states(states);
+            "active wins over unknown" {
+                &[
+                    FirmwareState::Completed,
+                    FirmwareState::Unknown,
+                    FirmwareState::InProgress,
+                ] => FirmwareState::InProgress,
+                &[
+                    FirmwareState::Completed,
+                    FirmwareState::Queued,
+                    FirmwareState::Unknown,
+                ] => FirmwareState::Queued,
+            }
         );
     }
 
     #[test]
     fn aggregate_firmware_job_states_terminal_failures_win() {
-        assert_eq!(
-            aggregate_firmware_job_states(&[
-                FirmwareState::Failed,
-                FirmwareState::InProgress,
-                FirmwareState::Unknown,
-            ]),
-            FirmwareState::Failed,
-        );
-        assert_eq!(
-            aggregate_firmware_job_states(&[
-                FirmwareState::Cancelled,
-                FirmwareState::InProgress,
-                FirmwareState::Unknown,
-            ]),
-            FirmwareState::Cancelled,
+        value_scenarios!(run = |states| aggregate_firmware_job_states(states);
+            "terminal failures win" {
+                &[
+                    FirmwareState::Failed,
+                    FirmwareState::InProgress,
+                    FirmwareState::Unknown,
+                ] => FirmwareState::Failed,
+                &[
+                    FirmwareState::Cancelled,
+                    FirmwareState::InProgress,
+                    FirmwareState::Unknown,
+                ] => FirmwareState::Cancelled,
+            }
         );
     }
 


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692).

`component-manager`'s backend enum mappings were proved one `#[test]` per variant (~36 across `rms`/`nsm`/`psm`). They collapse into `value_scenarios!` / `check_values` tables, one per mapping function (unrecognized-value cases get their own small table since their input type differs). The three `BackendTlsConfig::resolve_*_path` helpers → one `check_values` table each over a named `Row`. Pass-through mappings use the `fn:` shorthand (clippy flags `|x| f(x)` as redundant); transforming rows keep `run =`. Adds the dev-dependency.

~36 tests → 17; no production change. Verified: `cargo test -p component-manager --lib` (78 pass), `clippy --locked --all-targets --all-features` clean, nightly rustfmt clean.

Addresses #2725.
