### PR TITLE
refactor(site-explorer): clarify the ACPowercycle-fallback log and scope its test

### DIFF
--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -2570,7 +2570,7 @@ impl SiteExplorer {
             tracing::warn!(
                 %bmc_ip_address,
                 error = %power_cycle_err,
-                "PowerCycle refused; falling back to ACPowercycle to apply the queued NIC mode change",
+                "PowerCycle failed; falling back to ACPowercycle to apply the queued NIC mode change",
             );
             self.redfish_power_control(
                 bmc_ip_address,

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -2735,10 +2735,17 @@ async fn test_site_explorer_falls_back_to_ac_powercycle_when_powercycle_refused(
         .redfish_power_control_calls
         .lock()
         .unwrap();
-    let powercycle_pos = power_calls
+    // Scope the fallback-order check to the host under test so another
+    // endpoint's power actions can't skew the `PowerCycle`-before-`ACPowercycle`
+    // positions.
+    let host_power_calls = power_calls
+        .iter()
+        .filter(|(addr, _)| addr.ip() == host_bmc_ip)
+        .collect::<Vec<_>>();
+    let powercycle_pos = host_power_calls
         .iter()
         .position(|(_, action)| matches!(action, libredfish::SystemPowerControl::PowerCycle));
-    let acpowercycle_pos = power_calls
+    let acpowercycle_pos = host_power_calls
         .iter()
         .position(|(_, action)| matches!(action, libredfish::SystemPowerControl::ACPowercycle));
     assert!(


### PR DESCRIPTION
Follow-up to #2718, addressing CodeRabbit's review of that PR.

Two small changes to the `PowerCycle` -> `ACPowercycle` fallback from #2718:

- **Log clarity.** The warning announced "PowerCycle refused", but the fallback
  fires on *any* `PowerCycle` failure, not only a vendor that declines the
  action. It now reports the observed failure and leaves the cause to the
  attached `error` field.
- **Test precision.** The fallback-order test computed its
  `PowerCycle`-before-`ACPowercycle` positions across every recorded power call;
  they are now scoped to the host under test.

**Deliberately not done -- gating the fallback on an explicit "refused" signal**
(CodeRabbit's other suggestion). The signal that distinguishes a real refusal
(`RedfishError::NotSupported` / a 4xx from the BMC) exists in `libredfish`, but
site-explorer flattens every Redfish error into a stringly
`EndpointExplorationError` before the fallback sees it -- so gating cleanly would
mean a new error variant + mapper plumbing + test-mock rework. It also would not
be reliable for the vendor that matters: Dell returns a generic error in lockdown
(per a standing `libredfish` TODO), not `NotSupported`. Since `ACPowercycle` is
the normal reset for most vendors and a power cycle is the intended action
regardless, the broad fallback is correct as-is.

Supports #2635.


Closes #2635
