### PR TITLE
feat(admin-cli): create domains and reverse zones from the CLI

### DIFF
--- a/crates/admin-cli/src/domain/create/args.rs
+++ b/crates/admin-cli/src/domain/create/args.rs
@@ -15,29 +15,20 @@
  * limitations under the License.
  */
 
-mod create;
-mod create_reverse;
-mod show;
-
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowDomain;
-pub use show::cmd::handle_show;
-
-#[cfg(test)]
-mod tests;
-
 use clap::Parser;
 
-use crate::cfg::dispatch::Dispatch;
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Domain information")]
-    Show(show::Args),
+Create a forward domain:
+    $ nico-admin-cli domain create example.com
 
-    #[clap(about = "Create a domain")]
-    Create(create::Args),
+Create a reverse zone by its arpa name:
+    $ nico-admin-cli domain create 168.192.in-addr.arpa
 
-    #[clap(about = "Create a reverse-DNS (PTR) zone from a CIDR")]
-    CreateReverse(create_reverse::Args),
+")]
+pub struct Args {
+    #[clap(help = "The domain name to create (e.g. example.com or 168.192.in-addr.arpa)")]
+    pub name: String,
 }

--- a/crates/admin-cli/src/domain/create/cmd.rs
+++ b/crates/admin-cli/src/domain/create/cmd.rs
@@ -15,29 +15,26 @@
  * limitations under the License.
  */
 
-mod create;
-mod create_reverse;
-mod show;
+use ::rpc::admin_cli::OutputFormat;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowDomain;
-pub use show::cmd::handle_show;
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
 
-#[cfg(test)]
-mod tests;
-
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Domain information")]
-    Show(show::Args),
-
-    #[clap(about = "Create a domain")]
-    Create(create::Args),
-
-    #[clap(about = "Create a reverse-DNS (PTR) zone from a CIDR")]
-    CreateReverse(create_reverse::Args),
+pub async fn handle_create(
+    args: &Args,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let domain = api_client.create_domain(&args.name).await?;
+    if output_format == OutputFormat::Json {
+        println!("{}", serde_json::to_string_pretty(&domain)?);
+    } else {
+        println!(
+            "Created domain '{}' ({})",
+            domain.name,
+            domain.id.unwrap_or_default()
+        );
+    }
+    Ok(())
 }

--- a/crates/admin-cli/src/domain/create/mod.rs
+++ b/crates/admin-cli/src/domain/create/mod.rs
@@ -15,29 +15,17 @@
  * limitations under the License.
  */
 
-mod create;
-mod create_reverse;
-mod show;
+pub mod args;
+pub mod cmd;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowDomain;
-pub use show::cmd::handle_show;
+pub use args::Args;
 
-#[cfg(test)]
-mod tests;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Domain information")]
-    Show(show::Args),
-
-    #[clap(about = "Create a domain")]
-    Create(create::Args),
-
-    #[clap(about = "Create a reverse-DNS (PTR) zone from a CIDR")]
-    CreateReverse(create_reverse::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_create(&self, ctx.config.format, &ctx.api_client).await
+    }
 }

--- a/crates/admin-cli/src/domain/create_reverse/args.rs
+++ b/crates/admin-cli/src/domain/create_reverse/args.rs
@@ -15,29 +15,23 @@
  * limitations under the License.
  */
 
-mod create;
-mod create_reverse;
-mod show;
-
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowDomain;
-pub use show::cmd::handle_show;
-
-#[cfg(test)]
-mod tests;
-
 use clap::Parser;
+use ipnet::IpNet;
 
-use crate::cfg::dispatch::Dispatch;
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
 
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Domain information")]
-    Show(show::Args),
+Create an IPv4 /16 reverse zone:
+    $ nico-admin-cli domain create-reverse 192.168.0.0/16
 
-    #[clap(about = "Create a domain")]
-    Create(create::Args),
+Create an IPv6 reverse zone:
+    $ nico-admin-cli domain create-reverse fd00::/16
 
-    #[clap(about = "Create a reverse-DNS (PTR) zone from a CIDR")]
-    CreateReverse(create_reverse::Args),
+")]
+pub struct Args {
+    #[clap(
+        help = "The network CIDR to create a reverse zone for (e.g. 192.168.0.0/16 or fd00::/16)"
+    )]
+    pub cidr: IpNet,
 }

--- a/crates/admin-cli/src/domain/create_reverse/cmd.rs
+++ b/crates/admin-cli/src/domain/create_reverse/cmd.rs
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::OutputFormat;
+use ipnet::IpNet;
+
+use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::rpc::ApiClient;
+
+pub async fn handle_create_reverse(
+    args: &Args,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let zone = cidr_to_reverse_zone(args.cidr)?;
+    let domain = api_client.create_domain(&zone).await?;
+    if output_format == OutputFormat::Json {
+        println!("{}", serde_json::to_string_pretty(&domain)?);
+    } else {
+        println!(
+            "Created reverse zone '{}' for {} ({})",
+            domain.name,
+            args.cidr,
+            domain.id.unwrap_or_default()
+        );
+    }
+    Ok(())
+}
+
+/// Derive the reverse-DNS zone name for a CIDR: the network octets (IPv4) or
+/// nibbles (IPv6) in reverse order, under `in-addr.arpa` / `ip6.arpa`. The prefix
+/// must be octet-aligned for IPv4 (/8, /16, /24, /32) or nibble-aligned for IPv6
+/// (a multiple of 4); RFC 2317 classless delegation is out of scope.
+pub(crate) fn cidr_to_reverse_zone(cidr: IpNet) -> CarbideCliResult<String> {
+    match cidr {
+        IpNet::V4(net) => {
+            let prefix = net.prefix_len();
+            if prefix == 0 || prefix % 8 != 0 {
+                return Err(CarbideCliError::InvalidReverseZoneCidr(format!(
+                    "IPv4 reverse zones need an octet-aligned prefix (/8, /16, /24, /32), got /{prefix}"
+                )));
+            }
+            let labels = (prefix / 8) as usize;
+            let mut parts: Vec<String> = net.network().octets()[..labels]
+                .iter()
+                .rev()
+                .map(u8::to_string)
+                .collect();
+            parts.push("in-addr.arpa".to_string());
+            Ok(parts.join("."))
+        }
+        IpNet::V6(net) => {
+            let prefix = net.prefix_len();
+            if prefix == 0 || prefix % 4 != 0 {
+                return Err(CarbideCliError::InvalidReverseZoneCidr(format!(
+                    "IPv6 reverse zones need a nibble-aligned prefix (a multiple of 4), got /{prefix}"
+                )));
+            }
+            let octets = net.network().octets();
+            let nibbles = (prefix / 4) as usize;
+            let mut parts: Vec<String> = (0..nibbles)
+                .map(|i| {
+                    let byte = octets[i / 2];
+                    let nibble = if i % 2 == 0 { byte >> 4 } else { byte & 0x0f };
+                    format!("{nibble:x}")
+                })
+                .collect();
+            parts.reverse();
+            parts.push("ip6.arpa".to_string());
+            Ok(parts.join("."))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::cidr_to_reverse_zone;
+
+    #[test]
+    fn derives_reverse_zone_from_cidr() {
+        scenarios!(
+            run = |cidr: &str| cidr_to_reverse_zone(cidr.parse().unwrap()).map_err(drop);
+            "ipv4 octet-aligned prefixes" {
+                "10.0.0.0/8" => Yields("10.in-addr.arpa".to_string()),
+                "192.168.0.0/16" => Yields("168.192.in-addr.arpa".to_string()),
+                "192.0.2.0/24" => Yields("2.0.192.in-addr.arpa".to_string()),
+                "192.0.2.1/32" => Yields("1.2.0.192.in-addr.arpa".to_string()),
+            }
+            "ipv6 nibble-aligned prefixes" {
+                "fd00::/16" => Yields("0.0.d.f.ip6.arpa".to_string()),
+                "2001:db8::/32" => Yields("8.b.d.0.1.0.0.2.ip6.arpa".to_string()),
+            }
+            "host bits below the prefix are ignored" {
+                "192.168.5.7/16" => Yields("168.192.in-addr.arpa".to_string()),
+            }
+            "rejects prefixes that are not octet- or nibble-aligned" {
+                "192.168.0.0/25" => Fails,
+                "fd00::/17" => Fails,
+                "0.0.0.0/0" => Fails,
+            }
+        );
+    }
+}

--- a/crates/admin-cli/src/domain/create_reverse/mod.rs
+++ b/crates/admin-cli/src/domain/create_reverse/mod.rs
@@ -15,29 +15,17 @@
  * limitations under the License.
  */
 
-mod create;
-mod create_reverse;
-mod show;
+pub mod args;
+pub mod cmd;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowDomain;
-pub use show::cmd::handle_show;
+pub use args::Args;
 
-#[cfg(test)]
-mod tests;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Domain information")]
-    Show(show::Args),
-
-    #[clap(about = "Create a domain")]
-    Create(create::Args),
-
-    #[clap(about = "Create a reverse-DNS (PTR) zone from a CIDR")]
-    CreateReverse(create_reverse::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_create_reverse(&self, ctx.config.format, &ctx.api_client).await
+    }
 }

--- a/crates/admin-cli/src/domain/tests.rs
+++ b/crates/admin-cli/src/domain/tests.rs
@@ -56,6 +56,7 @@ fn parse_show_variants() {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.all, args.domain.is_some()),
+                    other => unreachable!("show inputs only parse to Cmd::Show, got {other:?}"),
                 })
                 .map_err(drop)
         };
@@ -65,6 +66,55 @@ fn parse_show_variants() {
 
         "--all flag (deprecated)" {
             &["domain", "show", "--all"][..] => Yields((true, false)),
+        }
+    );
+}
+
+// create takes a single positional domain name and requires it.
+#[test]
+fn parse_create_variants() {
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => args.name,
+                    other => unreachable!("create inputs only parse to Cmd::Create, got {other:?}"),
+                })
+                .map_err(drop)
+        };
+        "create takes a domain name" {
+            &["domain", "create", "168.192.in-addr.arpa"][..]
+                => Yields("168.192.in-addr.arpa".to_string()),
+        }
+        "create requires a name" {
+            &["domain", "create"][..] => Fails,
+        }
+    );
+}
+
+// create-reverse takes a single positional CIDR; clap rejects a non-CIDR.
+#[test]
+fn parse_create_reverse_variants() {
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::CreateReverse(args) => args.cidr.to_string(),
+                    other => unreachable!(
+                        "create-reverse inputs only parse to Cmd::CreateReverse, got {other:?}"
+                    ),
+                })
+                .map_err(drop)
+        };
+        "create-reverse takes a CIDR" {
+            &["domain", "create-reverse", "192.168.0.0/16"][..]
+                => Yields("192.168.0.0/16".to_string()),
+        }
+        "create-reverse rejects a non-CIDR" {
+            &["domain", "create-reverse", "not-a-cidr"][..] => Fails,
+        }
+        "create-reverse requires a CIDR" {
+            &["domain", "create-reverse"][..] => Fails,
         }
     );
 }

--- a/crates/admin-cli/src/errors.rs
+++ b/crates/admin-cli/src/errors.rs
@@ -48,6 +48,9 @@ pub enum CarbideCliError {
     #[error("Invalid datetime format: {0}. Use 'YYYY-MM-DD HH:MM:SS' or 'HH:MM:SS'")]
     InvalidDateTimeFromUserInput(String),
 
+    #[error("{0}")]
+    InvalidReverseZoneCidr(String),
+
     #[error("Segment not found.")]
     SegmentNotFound,
 

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -481,6 +481,13 @@ impl ApiClient {
         Ok(self.0.find_domain(request).await?)
     }
 
+    pub async fn create_domain(&self, name: &str) -> CarbideCliResult<::rpc::protos::dns::Domain> {
+        let request = ::rpc::protos::dns::CreateDomainRequest {
+            name: name.to_string(),
+        };
+        Ok(self.0.create_domain(request).await?)
+    }
+
     pub async fn machine_insert_health_report_override(
         &self,
         id: MachineId,


### PR DESCRIPTION
## Summary

`nico-admin-cli domain` gains two subcommands so operators can create DNS domains and reverse (PTR) zones directly. Previously `domain` only had `show` — a domain could be created at startup (`initial_domain_name` config, a one-time bootstrap) or via the `CreateDomain` gRPC endpoint by hand, with no operator CLI.

- `domain create <name>` — wraps the existing `CreateDomain` RPC (which already accepts arpa zone names).
- `domain create-reverse <cidr>` — derives the `in-addr.arpa` / `ip6.arpa` zone from a CIDR (network octets/nibbles reversed, in Rust) and creates it. Requires an octet-aligned IPv4 prefix (/8, /16, /24, /32) or nibble-aligned IPv6 prefix (a multiple of 4); RFC 2317 classless delegation is out of scope.
- Both mirror the existing `domain show` module structure (args / cmd / `Run`).

Tests: clap structure + argument parsing for both subcommands, plus a table for the CIDR → zone derivation (IPv4/IPv6 aligned prefixes, host-bit masking, rejected non-aligned prefixes).

> Note: the issue's premise — that reverse zones were "creatable today via `nico-admin-cli domain create`" — was inaccurate; that command did not exist. This adds it, so it implements what the issue framed as the optional "Option B."

Implements #2645. Completes the #2630 reverse-DNS epic.

Draft pending review.
