### PR TITLE
test(rack-controller): table-ify the validation and maintenance transition tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,6 +2586,7 @@ dependencies = [
  "carbide-health-metrics",
  "carbide-rack",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
  "chrono",

--- a/crates/rack-controller/Cargo.toml
+++ b/crates/rack-controller/Cargo.toml
@@ -45,5 +45,8 @@ sqlx = { workspace = true }
 tracing = { workspace = true }
 tonic = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/rack-controller/src/fabric_manager.rs
+++ b/crates/rack-controller/src/fabric_manager.rs
@@ -327,6 +327,8 @@ pub(super) async fn persist_primary_switch(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     fn switch(node_id: &str) -> FirmwareUpgradeDeviceInfo {
@@ -401,83 +403,108 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn fabric_manager_status_from_entry_returns_running_when_configured() {
-        let entry = rms::ScaleUpFabricServiceStatusEntry {
-            status_json:
-                r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","reason":"","status":"ok"}"#
-                    .to_string(),
-            error_message: String::new(),
-        };
+    fn entry(status_json: &str, error_message: &str) -> rms::ScaleUpFabricServiceStatusEntry {
+        rms::ScaleUpFabricServiceStatusEntry {
+            status_json: status_json.to_string(),
+            error_message: error_message.to_string(),
+        }
+    }
 
+    /// The full derived status plus its product-facing display string, so a
+    /// table row asserts both the parsed fields and the "running"/"not_running"
+    /// outcome the caller acts on.
+    #[derive(Debug, PartialEq)]
+    struct Observed {
+        status: FabricManagerStatus,
+        display: &'static str,
+    }
+
+    fn observe(entry: rms::ScaleUpFabricServiceStatusEntry) -> Observed {
         let status = fabric_manager_status_from_entry("sw-1", &entry);
+        let display = status.display_status();
+        Observed { status, display }
+    }
 
-        assert_eq!(status.fabric_manager_state, FabricManagerState::Ok);
-        assert_eq!(
-            status.addition_info.as_deref(),
-            Some("CONTROL_PLANE_STATE_CONFIGURED")
+    #[test]
+    fn test_fabric_manager_status_from_entry() {
+        check_values(
+            [
+                Check {
+                    scenario: "ok with control-plane configured -> running",
+                    input: entry(
+                        r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","reason":"","status":"ok"}"#,
+                        "",
+                    ),
+                    expect: Observed {
+                        status: FabricManagerStatus {
+                            fabric_manager_state: FabricManagerState::Ok,
+                            addition_info: Some("CONTROL_PLANE_STATE_CONFIGURED".to_string()),
+                            reason: Some(String::new()),
+                            error_message: None,
+                        },
+                        display: "running",
+                    },
+                },
+                Check {
+                    scenario: "not ok -> not_running",
+                    input: entry(
+                        r#"{"addition-info":"","reason":"stopped by user","status":"not ok"}"#,
+                        "",
+                    ),
+                    expect: Observed {
+                        status: FabricManagerStatus {
+                            fabric_manager_state: FabricManagerState::NotOk,
+                            addition_info: Some(String::new()),
+                            reason: Some("stopped by user".to_string()),
+                            error_message: None,
+                        },
+                        display: "not_running",
+                    },
+                },
+                Check {
+                    scenario: "empty status json -> unknown, not_running",
+                    input: entry("", ""),
+                    expect: Observed {
+                        status: FabricManagerStatus {
+                            fabric_manager_state: FabricManagerState::Unknown,
+                            addition_info: None,
+                            reason: None,
+                            error_message: None,
+                        },
+                        display: "not_running",
+                    },
+                },
+                Check {
+                    scenario: "error message surfaces -> unknown, not_running",
+                    input: entry(
+                        r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","status":"ok"}"#,
+                        "nmx-controller not started",
+                    ),
+                    expect: Observed {
+                        status: FabricManagerStatus {
+                            fabric_manager_state: FabricManagerState::Unknown,
+                            addition_info: None,
+                            reason: None,
+                            error_message: Some("nmx-controller not started".to_string()),
+                        },
+                        display: "not_running",
+                    },
+                },
+                Check {
+                    scenario: "malformed json -> unknown, not_running",
+                    input: entry("{not-json", ""),
+                    expect: Observed {
+                        status: FabricManagerStatus {
+                            fabric_manager_state: FabricManagerState::Unknown,
+                            addition_info: None,
+                            reason: None,
+                            error_message: None,
+                        },
+                        display: "not_running",
+                    },
+                },
+            ],
+            observe,
         );
-        assert_eq!(status.reason.as_deref(), Some(""));
-        assert_eq!(status.display_status(), "running");
-    }
-
-    #[test]
-    fn fabric_manager_status_from_entry_returns_not_running_for_not_ok() {
-        let entry = rms::ScaleUpFabricServiceStatusEntry {
-            status_json: r#"{"addition-info":"","reason":"stopped by user","status":"not ok"}"#
-                .to_string(),
-            error_message: String::new(),
-        };
-
-        let status = fabric_manager_status_from_entry("sw-1", &entry);
-
-        assert_eq!(status.fabric_manager_state, FabricManagerState::NotOk);
-        assert_eq!(status.addition_info.as_deref(), Some(""));
-        assert_eq!(status.reason.as_deref(), Some("stopped by user"));
-        assert_eq!(status.display_status(), "not_running");
-    }
-
-    #[test]
-    fn fabric_manager_status_from_entry_returns_not_running_for_empty_status_json() {
-        let entry = rms::ScaleUpFabricServiceStatusEntry {
-            status_json: String::new(),
-            error_message: String::new(),
-        };
-
-        let status = fabric_manager_status_from_entry("sw-1", &entry);
-
-        assert_eq!(status.fabric_manager_state, FabricManagerState::Unknown);
-        assert_eq!(status.display_status(), "not_running");
-    }
-
-    #[test]
-    fn fabric_manager_status_from_entry_returns_not_running_for_error_message() {
-        let entry = rms::ScaleUpFabricServiceStatusEntry {
-            status_json: r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","status":"ok"}"#
-                .to_string(),
-            error_message: "nmx-controller not started".to_string(),
-        };
-
-        let status = fabric_manager_status_from_entry("sw-1", &entry);
-
-        assert_eq!(status.fabric_manager_state, FabricManagerState::Unknown);
-        assert_eq!(
-            status.error_message.as_deref(),
-            Some("nmx-controller not started")
-        );
-        assert_eq!(status.display_status(), "not_running");
-    }
-
-    #[test]
-    fn fabric_manager_status_from_entry_returns_not_running_for_malformed_json() {
-        let entry = rms::ScaleUpFabricServiceStatusEntry {
-            status_json: "{not-json".to_string(),
-            error_message: String::new(),
-        };
-
-        let status = fabric_manager_status_from_entry("sw-1", &entry);
-
-        assert_eq!(status.fabric_manager_state, FabricManagerState::Unknown);
-        assert_eq!(status.display_status(), "not_running");
     }
 }

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -2283,6 +2283,7 @@ pub async fn handle_maintenance(
 #[cfg(test)]
 mod tests {
     use carbide_rack::firmware_update::RackFirmwareInventory;
+    use carbide_test_support::{Check, check_values};
     use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
     use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
     use model::rack::{
@@ -2455,224 +2456,172 @@ mod tests {
         assert_eq!(status.error_message.as_deref(), Some("invalid SOT JSON"));
     }
 
+    /// A firmware-upgrade activity with no version/components/force, the form
+    /// used by the maintenance-state transition tables.
+    fn firmware_upgrade() -> MaintenanceActivity {
+        MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+            force_update: false,
+        }
+    }
+
+    fn nvos_update() -> MaintenanceActivity {
+        MaintenanceActivity::NvosUpdate {
+            config_json: r#"{"Id":"fw-nvos"}"#.into(),
+        }
+    }
+
+    fn scope_of(activities: Vec<MaintenanceActivity>) -> MaintenanceScope {
+        MaintenanceScope {
+            activities,
+            ..Default::default()
+        }
+    }
+
+    fn firmware_start() -> RackMaintenanceState {
+        RackMaintenanceState::FirmwareUpgrade {
+            rack_firmware_upgrade: FirmwareUpgradeState::Start,
+        }
+    }
+
+    fn configure_start() -> RackMaintenanceState {
+        RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::Start,
+        }
+    }
+
+    fn nvos_start() -> RackMaintenanceState {
+        RackMaintenanceState::NVOSUpdate {
+            nvos_update: NvosUpdateState::Start,
+        }
+    }
+
+    fn powering_on() -> RackMaintenanceState {
+        RackMaintenanceState::PowerSequence {
+            rack_power: RackPowerState::PoweringOn,
+        }
+    }
+
     // ── first_maintenance_state ─────────────────────────────────────────
 
     #[test]
-    fn first_maintenance_state_all_activities() {
-        let scope = MaintenanceScope::default();
-        assert!(matches!(
-            first_maintenance_state(&scope),
-            RackMaintenanceState::FirmwareUpgrade {
-                rack_firmware_upgrade: FirmwareUpgradeState::Start,
-            }
-        ));
-    }
-
-    #[test]
-    fn first_maintenance_state_only_firmware() {
-        let scope = MaintenanceScope {
-            activities: vec![MaintenanceActivity::FirmwareUpgrade {
-                firmware_version: None,
-                components: vec![],
-                force_update: false,
-            }],
-            ..Default::default()
-        };
-        assert!(matches!(
-            first_maintenance_state(&scope),
-            RackMaintenanceState::FirmwareUpgrade { .. }
-        ));
-    }
-
-    #[test]
-    fn first_maintenance_state_only_configure() {
-        let scope = MaintenanceScope {
-            activities: vec![MaintenanceActivity::ConfigureNmxCluster],
-            ..Default::default()
-        };
-        assert_eq!(
-            first_maintenance_state(&scope),
-            RackMaintenanceState::ConfigureNmxCluster {
-                configure_nmx_cluster: ConfigureNmxClusterState::Start,
-            },
-        );
-    }
-
-    #[test]
-    fn first_maintenance_state_only_nvos() {
-        let scope = MaintenanceScope {
-            activities: vec![MaintenanceActivity::NvosUpdate {
-                config_json: r#"{"Id":"fw-nvos"}"#.into(),
-            }],
-            ..Default::default()
-        };
-        assert_eq!(
-            first_maintenance_state(&scope),
-            RackMaintenanceState::NVOSUpdate {
-                nvos_update: NvosUpdateState::Start,
-            },
-        );
-    }
-
-    #[test]
-    fn first_maintenance_state_only_power_sequence() {
-        let scope = MaintenanceScope {
-            activities: vec![MaintenanceActivity::PowerSequence],
-            ..Default::default()
-        };
-        assert!(matches!(
-            first_maintenance_state(&scope),
-            RackMaintenanceState::PowerSequence {
-                rack_power: RackPowerState::PoweringOn,
-            }
-        ));
-    }
-
-    #[test]
-    fn first_maintenance_state_configure_and_power() {
-        let scope = MaintenanceScope {
-            activities: vec![
-                MaintenanceActivity::ConfigureNmxCluster,
-                MaintenanceActivity::PowerSequence,
+    fn test_first_maintenance_state() {
+        check_values(
+            [
+                Check {
+                    scenario: "all activities -> firmware first",
+                    input: MaintenanceScope::default(),
+                    expect: firmware_start(),
+                },
+                Check {
+                    scenario: "only firmware -> firmware",
+                    input: scope_of(vec![firmware_upgrade()]),
+                    expect: firmware_start(),
+                },
+                Check {
+                    scenario: "only configure -> configure",
+                    input: scope_of(vec![MaintenanceActivity::ConfigureNmxCluster]),
+                    expect: configure_start(),
+                },
+                Check {
+                    scenario: "only nvos -> nvos",
+                    input: scope_of(vec![nvos_update()]),
+                    expect: nvos_start(),
+                },
+                Check {
+                    scenario: "only power sequence -> power",
+                    input: scope_of(vec![MaintenanceActivity::PowerSequence]),
+                    expect: powering_on(),
+                },
+                Check {
+                    scenario: "configure and power -> configure first",
+                    input: scope_of(vec![
+                        MaintenanceActivity::ConfigureNmxCluster,
+                        MaintenanceActivity::PowerSequence,
+                    ]),
+                    expect: configure_start(),
+                },
             ],
-            ..Default::default()
-        };
-        assert_eq!(
-            first_maintenance_state(&scope),
-            RackMaintenanceState::ConfigureNmxCluster {
-                configure_nmx_cluster: ConfigureNmxClusterState::Start,
-            },
+            |scope| first_maintenance_state(&scope),
         );
     }
 
     // ── next_state_after_firmware ───────────────────────────────────────
 
     #[test]
-    fn after_firmware_all_activities_skips_nvos_without_explicit_json() {
-        let scope = MaintenanceScope::default();
-        assert_eq!(
-            next_state_after_firmware(&scope),
-            next_state_after_nvos(&scope)
-        );
-    }
-
-    #[test]
-    fn after_firmware_without_configure_goes_to_power() {
-        let scope = MaintenanceScope {
-            activities: vec![
-                MaintenanceActivity::FirmwareUpgrade {
-                    firmware_version: None,
-                    components: vec![],
-                    force_update: false,
+    fn test_next_state_after_firmware() {
+        check_values(
+            [
+                // All activities: no explicit NVOS JSON, so NVOS is skipped and
+                // the scope falls through to ConfigureNmxCluster.
+                Check {
+                    scenario: "all activities skips nvos without explicit json -> configure",
+                    input: MaintenanceScope::default(),
+                    expect: configure_start(),
                 },
-                MaintenanceActivity::PowerSequence,
-            ],
-            ..Default::default()
-        };
-        assert!(matches!(
-            next_state_after_firmware(&scope),
-            RackMaintenanceState::PowerSequence { .. }
-        ));
-    }
-
-    #[test]
-    fn after_firmware_only_firmware_goes_to_completed() {
-        let scope = MaintenanceScope {
-            activities: vec![MaintenanceActivity::FirmwareUpgrade {
-                firmware_version: None,
-                components: vec![],
-                force_update: false,
-            }],
-            ..Default::default()
-        };
-        assert_eq!(
-            next_state_after_firmware(&scope),
-            RackMaintenanceState::Completed,
-        );
-    }
-
-    #[test]
-    fn after_firmware_explicit_nvos_preserves_requested_firmware() {
-        let scope = MaintenanceScope {
-            activities: vec![
-                MaintenanceActivity::FirmwareUpgrade {
-                    firmware_version: None,
-                    components: vec![],
-                    force_update: false,
+                Check {
+                    scenario: "firmware and power, no configure -> power",
+                    input: scope_of(vec![firmware_upgrade(), MaintenanceActivity::PowerSequence]),
+                    expect: powering_on(),
                 },
-                MaintenanceActivity::NvosUpdate {
-                    config_json: r#"{"Id":"fw-nvos"}"#.into(),
+                Check {
+                    scenario: "only firmware -> completed",
+                    input: scope_of(vec![firmware_upgrade()]),
+                    expect: RackMaintenanceState::Completed,
+                },
+                Check {
+                    scenario: "explicit nvos preserves requested firmware -> nvos",
+                    input: scope_of(vec![firmware_upgrade(), nvos_update()]),
+                    expect: nvos_start(),
                 },
             ],
-            ..Default::default()
-        };
-        assert_eq!(
-            next_state_after_firmware(&scope),
-            RackMaintenanceState::NVOSUpdate {
-                nvos_update: NvosUpdateState::Start,
-            },
+            |scope| next_state_after_firmware(&scope),
         );
     }
 
     // ── next_state_after_nvos ──────────────────────────────────────────
 
     #[test]
-    fn after_nvos_all_activities_goes_to_configure() {
-        let scope = MaintenanceScope::default();
-        assert_eq!(
-            next_state_after_nvos(&scope),
-            RackMaintenanceState::ConfigureNmxCluster {
-                configure_nmx_cluster: ConfigureNmxClusterState::Start,
-            },
-        );
-    }
-
-    #[test]
-    fn after_nvos_without_configure_goes_to_power() {
-        let scope = MaintenanceScope {
-            activities: vec![
-                MaintenanceActivity::NvosUpdate {
-                    config_json: r#"{"Id":"fw-nvos"}"#.into(),
+    fn test_next_state_after_nvos() {
+        check_values(
+            [
+                Check {
+                    scenario: "all activities -> configure",
+                    input: MaintenanceScope::default(),
+                    expect: configure_start(),
                 },
-                MaintenanceActivity::PowerSequence,
+                Check {
+                    scenario: "nvos and power, no configure -> power",
+                    input: scope_of(vec![nvos_update(), MaintenanceActivity::PowerSequence]),
+                    expect: powering_on(),
+                },
             ],
-            ..Default::default()
-        };
-        assert!(matches!(
-            next_state_after_nvos(&scope),
-            RackMaintenanceState::PowerSequence { .. }
-        ));
+            |scope| next_state_after_nvos(&scope),
+        );
     }
 
     // ── next_state_after_configure ──────────────────────────────────────
 
     #[test]
-    fn after_configure_all_activities_goes_to_power() {
-        let scope = MaintenanceScope::default();
-        assert!(matches!(
-            next_state_after_configure(&scope),
-            RackMaintenanceState::PowerSequence {
-                rack_power: RackPowerState::PoweringOn,
-            }
-        ));
-    }
-
-    #[test]
-    fn after_configure_without_power_goes_to_completed() {
-        let scope = MaintenanceScope {
-            activities: vec![
-                MaintenanceActivity::FirmwareUpgrade {
-                    firmware_version: None,
-                    components: vec![],
-                    force_update: false,
+    fn test_next_state_after_configure() {
+        check_values(
+            [
+                Check {
+                    scenario: "all activities -> power",
+                    input: MaintenanceScope::default(),
+                    expect: powering_on(),
                 },
-                MaintenanceActivity::ConfigureNmxCluster,
+                Check {
+                    scenario: "firmware and configure, no power -> completed",
+                    input: scope_of(vec![
+                        firmware_upgrade(),
+                        MaintenanceActivity::ConfigureNmxCluster,
+                    ]),
+                    expect: RackMaintenanceState::Completed,
+                },
             ],
-            ..Default::default()
-        };
-        assert_eq!(
-            next_state_after_configure(&scope),
-            RackMaintenanceState::Completed,
+            |scope| next_state_after_configure(&scope),
         );
     }
 }

--- a/crates/rack-controller/src/validating.rs
+++ b/crates/rack-controller/src/validating.rs
@@ -397,6 +397,8 @@ pub async fn handle_validating(
 mod tests {
     use std::collections::HashMap;
 
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     fn metadata_with_labels(pairs: &[(&str, &str)]) -> Metadata {
@@ -593,204 +595,234 @@ mod tests {
     // -------------------------------------------------------------------------
     // compute_validation_transition tests
 
-    #[test]
-    fn test_compute_validation_transition_from_in_progress() {
-        let state = RackValidationState::InProgress {
+    /// One transition case: a current sub-state plus the partition summary it is
+    /// evaluated against. The expected value is the next sub-state, or `None` when
+    /// the state machine should hold.
+    struct TransitionCase {
+        state: RackValidationState,
+        summary: RackPartitionSummary,
+    }
+
+    fn in_progress() -> RackValidationState {
+        RackValidationState::InProgress {
             run_id: "run-001".to_string(),
-        };
+        }
+    }
 
-        // Still in progress
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            pending: 2,
-            in_progress: 2,
-            ..Default::default()
-        };
-        assert_eq!(compute_validation_transition(&state, &summary), None);
+    fn partial() -> RackValidationState {
+        RackValidationState::Partial {
+            run_id: "run-001".to_string(),
+        }
+    }
 
-        // One validated
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            pending: 2,
-            in_progress: 1,
-            validated: 1,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::Partial {
-                run_id: "run-001".to_string()
-            })
-        );
+    fn failed_partial() -> RackValidationState {
+        RackValidationState::FailedPartial {
+            run_id: "run-001".to_string(),
+        }
+    }
 
-        // One failed (higher priority than validated)
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            pending: 1,
-            in_progress: 1,
-            validated: 1,
-            failed: 1,
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::FailedPartial {
-                run_id: "run-001".to_string()
-            })
-        );
+    fn failed() -> RackValidationState {
+        RackValidationState::Failed {
+            run_id: "run-001".to_string(),
+        }
+    }
+
+    fn validated() -> RackValidationState {
+        RackValidationState::Validated {
+            run_id: "run-001".to_string(),
+        }
     }
 
     #[test]
-    fn test_compute_validation_transition_from_partial() {
-        let state = RackValidationState::Partial {
-            run_id: "run-001".to_string(),
-        };
-
-        // More in progress
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            in_progress: 2,
-            validated: 2,
-            ..Default::default()
-        };
-        assert_eq!(compute_validation_transition(&state, &summary), None);
-
-        // All validated
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            validated: 4,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::Validated {
-                run_id: "run-001".to_string()
-            })
+    fn test_compute_validation_transition() {
+        check_values(
+            [
+                // ── from InProgress ──────────────────────────────────────
+                Check {
+                    scenario: "in progress / still in progress holds",
+                    input: TransitionCase {
+                        state: in_progress(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            pending: 2,
+                            in_progress: 2,
+                            ..Default::default()
+                        },
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "in progress / one validated -> Partial",
+                    input: TransitionCase {
+                        state: in_progress(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            pending: 2,
+                            in_progress: 1,
+                            validated: 1,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(partial()),
+                },
+                Check {
+                    scenario: "in progress / one failed outranks validated -> FailedPartial",
+                    input: TransitionCase {
+                        state: in_progress(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            pending: 1,
+                            in_progress: 1,
+                            validated: 1,
+                            failed: 1,
+                        },
+                    },
+                    expect: Some(failed_partial()),
+                },
+                // ── from Partial ─────────────────────────────────────────
+                Check {
+                    scenario: "partial / more in progress holds",
+                    input: TransitionCase {
+                        state: partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            in_progress: 2,
+                            validated: 2,
+                            ..Default::default()
+                        },
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "partial / all validated -> Validated",
+                    input: TransitionCase {
+                        state: partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            validated: 4,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(validated()),
+                },
+                Check {
+                    scenario: "partial / one failed -> FailedPartial",
+                    input: TransitionCase {
+                        state: partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            validated: 3,
+                            failed: 1,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(failed_partial()),
+                },
+                // ── from FailedPartial ───────────────────────────────────
+                Check {
+                    scenario: "failed partial / all failed -> Failed",
+                    input: TransitionCase {
+                        state: failed_partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            failed: 4,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(failed()),
+                },
+                Check {
+                    scenario: "failed partial / recovery with some validated -> Partial",
+                    input: TransitionCase {
+                        state: failed_partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            in_progress: 2,
+                            validated: 2,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(partial()),
+                },
+                Check {
+                    scenario: "failed partial / recovery none validated yet -> InProgress",
+                    input: TransitionCase {
+                        state: failed_partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            pending: 2,
+                            in_progress: 2,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(in_progress()),
+                },
+                Check {
+                    scenario: "failed partial / still some failed and some validated holds",
+                    input: TransitionCase {
+                        state: failed_partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            validated: 2,
+                            failed: 2,
+                            ..Default::default()
+                        },
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "failed partial / all partitions reset to idle -> Pending",
+                    input: TransitionCase {
+                        state: failed_partial(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            pending: 4,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(RackValidationState::Pending),
+                },
+                // ── from Failed ──────────────────────────────────────────
+                Check {
+                    scenario: "failed / still all failed holds",
+                    input: TransitionCase {
+                        state: failed(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            failed: 4,
+                            ..Default::default()
+                        },
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "failed / recovery started -> FailedPartial",
+                    input: TransitionCase {
+                        state: failed(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            in_progress: 1,
+                            failed: 3,
+                            ..Default::default()
+                        },
+                    },
+                    expect: Some(failed_partial()),
+                },
+                // ── from Validated (terminal) ────────────────────────────
+                Check {
+                    scenario: "validated / terminal sub-state always holds",
+                    input: TransitionCase {
+                        state: validated(),
+                        summary: RackPartitionSummary {
+                            total_partitions: 4,
+                            validated: 4,
+                            ..Default::default()
+                        },
+                    },
+                    expect: None,
+                },
+            ],
+            |TransitionCase { state, summary }| compute_validation_transition(&state, &summary),
         );
-
-        // One failed
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            validated: 3,
-            failed: 1,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::FailedPartial {
-                run_id: "run-001".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn test_compute_validation_transition_from_failed_partial() {
-        let state = RackValidationState::FailedPartial {
-            run_id: "run-001".to_string(),
-        };
-
-        // All failed -> Failed
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            failed: 4,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::Failed {
-                run_id: "run-001".to_string()
-            })
-        );
-
-        // Recovery: no failures, some validated
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            in_progress: 2,
-            validated: 2,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::Partial {
-                run_id: "run-001".to_string()
-            })
-        );
-
-        // Recovery: no failures, none validated yet
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            pending: 2,
-            in_progress: 2,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::InProgress {
-                run_id: "run-001".to_string()
-            })
-        );
-
-        // Still some failed, some validated
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            validated: 2,
-            failed: 2,
-            ..Default::default()
-        };
-        assert_eq!(compute_validation_transition(&state, &summary), None);
-
-        // All partitions reset to idle (RVS cleared labels before re-run)
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            pending: 4,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::Pending)
-        );
-    }
-
-    #[test]
-    fn test_compute_validation_transition_from_failed() {
-        let state = RackValidationState::Failed {
-            run_id: "run-001".to_string(),
-        };
-
-        // Still all failed
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            failed: 4,
-            ..Default::default()
-        };
-        assert_eq!(compute_validation_transition(&state, &summary), None);
-
-        // Recovery started
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            in_progress: 1,
-            failed: 3,
-            ..Default::default()
-        };
-        assert_eq!(
-            compute_validation_transition(&state, &summary),
-            Some(RackValidationState::FailedPartial {
-                run_id: "run-001".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn test_compute_validation_transition_from_validated() {
-        let state = RackValidationState::Validated {
-            run_id: "run-001".to_string(),
-        };
-
-        // Terminal sub-state -- always returns None.
-        let summary = RackPartitionSummary {
-            total_partitions: 4,
-            validated: 4,
-            ..Default::default()
-        };
-        assert_eq!(compute_validation_transition(&state, &summary), None);
     }
 }


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692).

`rack-controller`'s state-transition tests were one `#[test]` per case -- 25 across `validating`/`maintenance`. They collapse into six `check_values` tables: `compute_validation_transition` (named `TransitionCase { state, summary }`), the three `next_state_after_*` + `first_maintenance_state` (over `MaintenanceScope`), and `fabric_manager_status_from_entry` (row projects to both parsed status and the product-facing `display_status`). Two dynamically-expected cases were pinned to their concrete next states. Out-of-scope tests untouched. Adds the dev-dependency.

25 tests → 6; no production change. Verified: `cargo test -p carbide-rack-controller --lib` (22 pass), `clippy --locked --all-targets --all-features` clean, nightly rustfmt clean.

Addresses #2728.
