### PR TITLE
test(ipxe-renderer,rack): cover the cache-strategy, validate(), and node-type matrices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,6 +2130,7 @@ dependencies = [
 name = "carbide-ipxe-renderer"
 version = "0.0.1"
 dependencies = [
+ "carbide-test-support",
  "hex",
  "serde",
  "serde_yaml",
@@ -2558,6 +2559,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-mqtt-common",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-uuid",
  "chrono",
  "eyre",

--- a/crates/ipxe-renderer/Cargo.toml
+++ b/crates/ipxe-renderer/Cargo.toml
@@ -15,3 +15,6 @@ hex = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
+
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }

--- a/crates/ipxe-renderer/src/lib.rs
+++ b/crates/ipxe-renderer/src/lib.rs
@@ -645,6 +645,9 @@ impl DefaultIpxeScriptRenderer {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     fn create_test_ipxeos() -> IpxeScript {
@@ -658,6 +661,253 @@ mod tests {
                 name: "image_url".to_string(),
                 value: "http://example.com/image.qcow2".to_string(),
             }],
+            artifacts: vec![],
+        }
+    }
+
+    /// One row of the cache-strategy URL-selection table: an artifact built from a
+    /// `cache_strategy` and whether a `cached_url` is present, resolved through
+    /// [`resolve_artifact_url`].
+    struct UrlSelectionRow {
+        cache_strategy: IpxeTemplateArtifactCacheStrategy,
+        cached_url: Option<&'static str>,
+    }
+
+    /// Build an artifact from a row and resolve its effective URL. The remote `url`
+    /// and the cached URL are distinct sentinels so the yielded value names which
+    /// one the strategy selected.
+    fn select_url(row: UrlSelectionRow) -> Result<String> {
+        let artifact = IpxeTemplateArtifact {
+            name: "artifact".to_string(),
+            url: "http://remote/url".to_string(),
+            sha: None,
+            auth_type: None,
+            auth_token: None,
+            cache_strategy: row.cache_strategy,
+            cached_url: row.cached_url.map(str::to_string),
+        };
+        resolve_artifact_url(&artifact)
+    }
+
+    #[test]
+    fn resolve_artifact_url_selects_per_cache_strategy() {
+        use IpxeTemplateArtifactCacheStrategy::*;
+
+        check_cases(
+            [
+                Case {
+                    scenario: "CacheAsNeeded prefers the cached URL",
+                    input: UrlSelectionRow {
+                        cache_strategy: CacheAsNeeded,
+                        cached_url: Some("http://cache/url"),
+                    },
+                    expect: Yields("http://cache/url".to_string()),
+                },
+                Case {
+                    scenario: "CacheAsNeeded falls back to the remote URL",
+                    input: UrlSelectionRow {
+                        cache_strategy: CacheAsNeeded,
+                        cached_url: None,
+                    },
+                    expect: Yields("http://remote/url".to_string()),
+                },
+                Case {
+                    scenario: "RemoteOnly always uses the remote URL, ignoring the cache",
+                    input: UrlSelectionRow {
+                        cache_strategy: RemoteOnly,
+                        cached_url: Some("http://cache/url"),
+                    },
+                    expect: Yields("http://remote/url".to_string()),
+                },
+                Case {
+                    scenario: "RemoteOnly uses the remote URL when uncached",
+                    input: UrlSelectionRow {
+                        cache_strategy: RemoteOnly,
+                        cached_url: None,
+                    },
+                    expect: Yields("http://remote/url".to_string()),
+                },
+                Case {
+                    scenario: "LocalOnly uses artifact.url directly, ignoring cached_url",
+                    input: UrlSelectionRow {
+                        cache_strategy: LocalOnly,
+                        cached_url: Some("http://cache/url"),
+                    },
+                    expect: Yields("http://remote/url".to_string()),
+                },
+                Case {
+                    scenario: "LocalOnly uses artifact.url when uncached",
+                    input: UrlSelectionRow {
+                        cache_strategy: LocalOnly,
+                        cached_url: None,
+                    },
+                    expect: Yields("http://remote/url".to_string()),
+                },
+                Case {
+                    scenario: "CachedOnly uses the cached URL when present",
+                    input: UrlSelectionRow {
+                        cache_strategy: CachedOnly,
+                        cached_url: Some("http://cache/url"),
+                    },
+                    expect: Yields("http://cache/url".to_string()),
+                },
+                Case {
+                    scenario: "CachedOnly fails when no cached URL is available",
+                    input: UrlSelectionRow {
+                        cache_strategy: CachedOnly,
+                        cached_url: None,
+                    },
+                    expect: FailsWith("CachedOnlyNotCached".to_string()),
+                },
+            ],
+            |row| select_url(row).map_err(error_variant),
+        );
+    }
+
+    /// A stable name for an [`IpxeScriptError`] variant, so error-matrix rows can
+    /// assert the exact failure with [`FailsWith`] without the error type needing
+    /// `PartialEq`.
+    fn error_variant(error: IpxeScriptError) -> String {
+        let name = match error {
+            IpxeScriptError::TemplateNotFound(_) => "TemplateNotFound",
+            IpxeScriptError::ReservedParameterFound(_) => "ReservedParameterFound",
+            IpxeScriptError::RequiredParameterMissing(_) => "RequiredParameterMissing",
+            IpxeScriptError::ExtraParametersNotSupported => "ExtraParametersNotSupported",
+            IpxeScriptError::HashMismatch { .. } => "HashMismatch",
+            IpxeScriptError::ArtifactNotFound(_) => "ArtifactNotFound",
+            IpxeScriptError::MissingReservedParameter(_) => "MissingReservedParameter",
+            IpxeScriptError::UnexpectedReservedParameter(_) => "UnexpectedReservedParameter",
+            IpxeScriptError::UnreplacedPlaceholders(_) => "UnreplacedPlaceholders",
+            IpxeScriptError::CachedOnlyNotCached(_) => "CachedOnlyNotCached",
+        };
+        name.to_string()
+    }
+
+    /// Build a single CacheAsNeeded artifact, used by error-matrix rows that need
+    /// the Ubuntu template's required artifacts to be present (or deliberately
+    /// absent).
+    fn artifact(name: &str) -> IpxeTemplateArtifact {
+        IpxeTemplateArtifact {
+            name: name.to_string(),
+            url: format!("http://example.com/{name}"),
+            sha: None,
+            auth_type: None,
+            auth_token: None,
+            cache_strategy: IpxeTemplateArtifactCacheStrategy::CacheAsNeeded,
+            cached_url: None,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_each_invalid_definition() {
+        let renderer = DefaultIpxeScriptRenderer::new();
+
+        // qcow template: requires the `image_url` parameter, reserves `base_url`.
+        let qcow = "ea756ddd-add3-5e42-a202-44bfc2d5aac2";
+        // Ubuntu autoinstall template: requires install_iso, kernel, initrd artifacts.
+        let ubuntu = "a7850943-e3cd-5e9a-93ca-9e12f52939cc";
+
+        // A row hashes itself before running so only the failure under test fires
+        // (an unset hash would otherwise trip HashMismatch first); the HashMismatch
+        // row deliberately skips that step.
+        let run = |mut ipxeos: IpxeScript| {
+            if ipxeos.hash != "deliberately-wrong" {
+                ipxeos.hash = renderer.hash(&ipxeos);
+            }
+            renderer.validate(&ipxeos).map_err(error_variant)
+        };
+
+        check_cases(
+            [
+                Case {
+                    scenario: "globally reserved 'extra' parameter name",
+                    input: IpxeScript {
+                        parameters: vec![
+                            IpxeTemplateParameter {
+                                name: "image_url".to_string(),
+                                value: "http://example.com/image.qcow2".to_string(),
+                            },
+                            IpxeTemplateParameter {
+                                name: "extra".to_string(),
+                                value: "value".to_string(),
+                            },
+                        ],
+                        ..base_script(qcow)
+                    },
+                    expect: FailsWith("ReservedParameterFound".to_string()),
+                },
+                Case {
+                    scenario: "template-reserved 'base_url' parameter name",
+                    input: IpxeScript {
+                        parameters: vec![
+                            IpxeTemplateParameter {
+                                name: "image_url".to_string(),
+                                value: "http://example.com/image.qcow2".to_string(),
+                            },
+                            IpxeTemplateParameter {
+                                name: "base_url".to_string(),
+                                value: "http://bad".to_string(),
+                            },
+                        ],
+                        ..base_script(qcow)
+                    },
+                    expect: FailsWith("ReservedParameterFound".to_string()),
+                },
+                Case {
+                    scenario: "required 'image_url' parameter missing",
+                    input: IpxeScript {
+                        parameters: vec![],
+                        ..base_script(qcow)
+                    },
+                    expect: FailsWith("RequiredParameterMissing".to_string()),
+                },
+                Case {
+                    scenario: "required 'initrd' artifact missing",
+                    input: IpxeScript {
+                        parameters: vec![],
+                        artifacts: vec![artifact("install_iso"), artifact("kernel")],
+                        ..base_script(ubuntu)
+                    },
+                    expect: FailsWith("ArtifactNotFound".to_string()),
+                },
+                Case {
+                    scenario: "hash does not match the definition",
+                    input: IpxeScript {
+                        hash: "deliberately-wrong".to_string(),
+                        parameters: vec![IpxeTemplateParameter {
+                            name: "image_url".to_string(),
+                            value: "http://example.com/image.qcow2".to_string(),
+                        }],
+                        ..base_script(qcow)
+                    },
+                    expect: FailsWith("HashMismatch".to_string()),
+                },
+                Case {
+                    scenario: "well-formed qcow definition validates",
+                    input: IpxeScript {
+                        parameters: vec![IpxeTemplateParameter {
+                            name: "image_url".to_string(),
+                            value: "http://example.com/image.qcow2".to_string(),
+                        }],
+                        ..base_script(qcow)
+                    },
+                    expect: Yields(()),
+                },
+            ],
+            run,
+        );
+    }
+
+    /// A minimal script scaffold for the given template, with no parameters or
+    /// artifacts; error-matrix rows fill in only the fields their case exercises.
+    fn base_script(template_id: &str) -> IpxeScript {
+        IpxeScript {
+            name: "Test".to_string(),
+            description: None,
+            hash: String::new(),
+            tenant_id: None,
+            ipxe_template_id: template_id.to_string(),
+            parameters: vec![],
             artifacts: vec![],
         }
     }
@@ -682,105 +932,6 @@ mod tests {
             renderer.validate(&ipxeos),
             Err(IpxeScriptError::HashMismatch { .. })
         ));
-    }
-
-    #[test]
-    fn test_reserved_parameter_validation() {
-        let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = create_test_ipxeos();
-
-        // Add a reserved parameter
-        ipxeos.parameters.push(IpxeTemplateParameter {
-            name: "base_url".to_string(),
-            value: "http://bad.com".to_string(),
-        });
-
-        // Update hash
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        // Validation should fail
-        assert!(matches!(
-            renderer.validate(&ipxeos),
-            Err(IpxeScriptError::ReservedParameterFound(_))
-        ));
-    }
-
-    #[test]
-    fn test_required_parameter_validation() {
-        let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = create_test_ipxeos();
-
-        // Remove required parameter
-        ipxeos.parameters.clear();
-
-        // Update hash
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        // Validation should fail
-        assert!(matches!(
-            renderer.validate(&ipxeos),
-            Err(IpxeScriptError::RequiredParameterMissing(_))
-        ));
-    }
-
-    #[test]
-    fn test_required_artifact_validation() {
-        let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = IpxeScript {
-            name: "Ubuntu 22.04".to_string(),
-            description: Some("Ubuntu autoinstall".to_string()),
-            hash: "placeholder".to_string(),
-            tenant_id: None,
-            ipxe_template_id: "a7850943-e3cd-5e9a-93ca-9e12f52939cc".to_string(),
-            parameters: vec![],
-            artifacts: vec![
-                IpxeTemplateArtifact {
-                    name: "install_iso".to_string(),
-                    url: "http://releases.ubuntu.com/22.04/ubuntu-22.04-live-server-amd64.iso"
-                        .to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::CacheAsNeeded,
-                    cached_url: None,
-                },
-                IpxeTemplateArtifact {
-                    name: "kernel".to_string(),
-                    url: "http://example.com/kernel".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::CacheAsNeeded,
-                    cached_url: None,
-                },
-            ],
-        };
-
-        // Update hash
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        // Validation should fail due to missing initrd artifact
-        assert!(matches!(
-            renderer.validate(&ipxeos),
-            Err(IpxeScriptError::ArtifactNotFound(_))
-        ));
-
-        // Now add the missing artifact
-        ipxeos.artifacts.push(IpxeTemplateArtifact {
-            name: "initrd".to_string(),
-            url: "http://example.com/initrd".to_string(),
-            sha: None,
-            auth_type: None,
-            auth_token: None,
-            cache_strategy: IpxeTemplateArtifactCacheStrategy::CacheAsNeeded,
-            cached_url: None,
-        });
-
-        // Update hash
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        // Validation should now pass
-        assert!(renderer.validate(&ipxeos).is_ok());
     }
 
     #[test]
@@ -2035,197 +2186,6 @@ mod tests {
         assert_eq!(
             rendered_hash, template_hash,
             "Rendered script should match template exactly (static template with no placeholders)"
-        );
-    }
-
-    #[test]
-    fn test_render_artifact_remote_only_ignores_cached_url() {
-        let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = IpxeScript {
-            name: "RemoteOnly test".to_string(),
-            description: None,
-            hash: "placeholder".to_string(),
-            tenant_id: None,
-            ipxe_template_id: "a7850943-e3cd-5e9a-93ca-9e12f52939cc".to_string(),
-            parameters: vec![],
-            artifacts: vec![
-                IpxeTemplateArtifact {
-                    name: "install_iso".to_string(),
-                    url: "http://releases.ubuntu.com/22.04/ubuntu.iso".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::RemoteOnly,
-                    cached_url: None,
-                },
-                IpxeTemplateArtifact {
-                    name: "kernel".to_string(),
-                    url: "http://remote.example.com/kernel".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::RemoteOnly,
-                    cached_url: Some("http://local-cache/kernel".to_string()),
-                },
-                IpxeTemplateArtifact {
-                    name: "initrd".to_string(),
-                    url: "http://remote.example.com/initrd".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::RemoteOnly,
-                    cached_url: Some("http://local-cache/initrd".to_string()),
-                },
-            ],
-        };
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        let reserved_params = vec![
-            IpxeTemplateParameter {
-                name: "base_url".to_string(),
-                value: "http://pxe.local".to_string(),
-            },
-            IpxeTemplateParameter {
-                name: "console".to_string(),
-                value: "ttyS0,115200".to_string(),
-            },
-        ];
-
-        let result = renderer.render(&ipxeos, &reserved_params);
-        assert!(result.is_ok(), "Render failed: {:?}", result.err());
-
-        let script = result.unwrap();
-        assert!(
-            script.contains("http://remote.example.com/kernel"),
-            "RemoteOnly should use remote URL, not local"
-        );
-        assert!(
-            !script.contains("http://local-cache/kernel"),
-            "RemoteOnly should NOT use cached_url"
-        );
-    }
-
-    #[test]
-    fn test_render_artifact_local_only_uses_site_url() {
-        let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = IpxeScript {
-            name: "LocalOnly test".to_string(),
-            description: None,
-            hash: "placeholder".to_string(),
-            tenant_id: None,
-            ipxe_template_id: "a7850943-e3cd-5e9a-93ca-9e12f52939cc".to_string(),
-            parameters: vec![],
-            artifacts: vec![
-                IpxeTemplateArtifact {
-                    name: "install_iso".to_string(),
-                    url: "http://releases.ubuntu.com/22.04/ubuntu.iso".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::LocalOnly,
-                    cached_url: None,
-                },
-                IpxeTemplateArtifact {
-                    name: "kernel".to_string(),
-                    url: "http://site-local.example.com/kernel".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::LocalOnly,
-                    cached_url: None,
-                },
-                IpxeTemplateArtifact {
-                    name: "initrd".to_string(),
-                    url: "http://site-local.example.com/initrd".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::LocalOnly,
-                    cached_url: None,
-                },
-            ],
-        };
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        let reserved_params = vec![
-            IpxeTemplateParameter {
-                name: "base_url".to_string(),
-                value: "http://pxe.local".to_string(),
-            },
-            IpxeTemplateParameter {
-                name: "console".to_string(),
-                value: "ttyS0,115200".to_string(),
-            },
-        ];
-
-        let result = renderer.render(&ipxeos, &reserved_params);
-        assert!(result.is_ok(), "Render failed: {:?}", result.err());
-
-        let script = result.unwrap();
-        assert!(
-            script.contains("http://site-local.example.com/kernel"),
-            "LocalOnly should use url directly (site-local URL)"
-        );
-    }
-
-    #[test]
-    fn test_render_artifact_cached_only_fails_without_cached_url() {
-        let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = IpxeScript {
-            name: "CachedOnly missing test".to_string(),
-            description: None,
-            hash: "placeholder".to_string(),
-            tenant_id: None,
-            ipxe_template_id: "a7850943-e3cd-5e9a-93ca-9e12f52939cc".to_string(),
-            parameters: vec![],
-            artifacts: vec![
-                IpxeTemplateArtifact {
-                    name: "install_iso".to_string(),
-                    url: "http://releases.ubuntu.com/22.04/ubuntu.iso".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::CacheAsNeeded,
-                    cached_url: None,
-                },
-                IpxeTemplateArtifact {
-                    name: "kernel".to_string(),
-                    url: "http://remote.example.com/kernel".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::CachedOnly,
-                    cached_url: None, // not cached yet - should fail
-                },
-                IpxeTemplateArtifact {
-                    name: "initrd".to_string(),
-                    url: "http://remote.example.com/initrd".to_string(),
-                    sha: None,
-                    auth_type: None,
-                    auth_token: None,
-                    cache_strategy: IpxeTemplateArtifactCacheStrategy::CacheAsNeeded,
-                    cached_url: None,
-                },
-            ],
-        };
-        ipxeos.hash = renderer.hash(&ipxeos);
-
-        let reserved_params = vec![
-            IpxeTemplateParameter {
-                name: "base_url".to_string(),
-                value: "http://pxe.local".to_string(),
-            },
-            IpxeTemplateParameter {
-                name: "console".to_string(),
-                value: "ttyS0,115200".to_string(),
-            },
-        ];
-
-        let result = renderer.render(&ipxeos, &reserved_params);
-        assert!(
-            matches!(result, Err(IpxeScriptError::CachedOnlyNotCached(_))),
-            "CachedOnly without cached_url should fail: {:?}",
-            result
         );
     }
 }

--- a/crates/rack/Cargo.toml
+++ b/crates/rack/Cargo.toml
@@ -51,5 +51,8 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/rack/src/rms_node_type.rs
+++ b/crates/rack/src/rms_node_type.rs
@@ -214,9 +214,59 @@ fn normalize(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use model::rack_type::RackHardwareTopology;
 
     use super::*;
+
+    /// Which RMS node-type resolver a table row exercises.
+    #[derive(Clone, Copy, Debug)]
+    enum Role {
+        Compute,
+        Switch,
+        PowerShelf,
+    }
+
+    /// One row of the product-family x role x vendor resolution matrix: a profile
+    /// built from a product family and a per-role vendor string, resolved through
+    /// the `role`'s `*_for_profile` function.
+    struct ResolveRow {
+        product_family: Option<RackProductFamily>,
+        role: Role,
+        vendor: Option<&'static str>,
+    }
+
+    /// Build a profile from a row and resolve it through the row's role function.
+    fn resolve(row: ResolveRow) -> Result<rms::NodeType, NodeTypeError> {
+        let mut profile = RackProfile {
+            product_family: row.product_family,
+            ..Default::default()
+        };
+        let vendor = row.vendor.map(str::to_string);
+        match row.role {
+            Role::Compute => {
+                profile.rack_capabilities.compute.vendor = vendor;
+                compute_node_type_for_profile(&profile)
+            }
+            Role::Switch => {
+                profile.rack_capabilities.switch.vendor = vendor;
+                switch_node_type_for_profile(&profile)
+            }
+            Role::PowerShelf => {
+                profile.rack_capabilities.power_shelf.vendor = vendor;
+                power_shelf_node_type_for_profile(&profile)
+            }
+        }
+    }
+
+    /// Construct the `UnsupportedVendor` error a row is expected to fail with.
+    fn unsupported(role: &'static str, vendor: &str) -> NodeTypeError {
+        NodeTypeError::UnsupportedVendor {
+            role,
+            vendor: vendor.to_string(),
+        }
+    }
 
     fn profile_with_product_family(product_family: RackProductFamily) -> RackProfile {
         RackProfile {
@@ -226,81 +276,187 @@ mod tests {
     }
 
     #[test]
-    fn compute_node_type_maps_gb200_nvidia() {
-        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
-        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
+    fn resolves_the_product_family_role_vendor_matrix() {
+        use RackProductFamily::{Gb200, Gb300};
 
-        let node_type = compute_node_type_for_profile(&profile);
-
-        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb200Nvidia));
-    }
-
-    #[test]
-    fn compute_node_type_maps_gb300_nvidia() {
-        let mut profile = profile_with_product_family(RackProductFamily::Gb300);
-        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
-
-        let node_type = compute_node_type_for_profile(&profile);
-
-        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb300Nvidia));
-    }
-
-    #[test]
-    fn compute_node_type_maps_gb300_lenovo() {
-        let mut profile = profile_with_product_family(RackProductFamily::Gb300);
-        profile.rack_capabilities.compute.vendor = Some("Lenovo".to_string());
-
-        let node_type = compute_node_type_for_profile(&profile);
-
-        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb300Lenovo));
-    }
-
-    #[test]
-    fn switch_node_type_maps_gb200_and_gb300() {
-        let mut gb200 = profile_with_product_family(RackProductFamily::Gb200);
-        gb200.rack_capabilities.switch.vendor = Some("NVIDIA".to_string());
-
-        let mut gb300 = profile_with_product_family(RackProductFamily::Gb300);
-        gb300.rack_capabilities.switch.vendor = Some("NVIDIA".to_string());
-
-        assert_eq!(
-            switch_node_type_for_profile(&gb200),
-            Ok(rms::NodeType::SwitchGb200Nvidia)
-        );
-        assert_eq!(
-            switch_node_type_for_profile(&gb300),
-            Ok(rms::NodeType::SwitchGb300Nvidia)
-        );
-    }
-
-    #[test]
-    fn switch_node_type_requires_vendor() {
-        let profile = profile_with_product_family(RackProductFamily::Gb200);
-
-        let node_type = switch_node_type_for_profile(&profile);
-
-        assert_eq!(
-            node_type,
-            Err(NodeTypeError::UnsupportedVendor {
-                role: "switch",
-                vendor: String::new()
-            })
-        );
-    }
-
-    #[test]
-    fn switch_node_type_uses_profile_vendor_for_validation() {
-        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
-        profile.rack_capabilities.switch.vendor = Some("Other".to_string());
-
-        let node_type = switch_node_type_for_profile(&profile);
-
-        assert_eq!(
-            node_type,
-            Err(NodeTypeError::UnsupportedVendor {
-                role: "switch",
-                vendor: "Other".to_string()
-            })
+        check_cases(
+            [
+                // Compute: NVIDIA on every family; Lenovo only on GB300.
+                Case {
+                    scenario: "compute gb200 nvidia",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Compute,
+                        vendor: Some("NVIDIA"),
+                    },
+                    expect: Yields(rms::NodeType::ComputeGb200Nvidia),
+                },
+                Case {
+                    scenario: "compute gb300 nvidia",
+                    input: ResolveRow {
+                        product_family: Some(Gb300),
+                        role: Role::Compute,
+                        vendor: Some("NVIDIA"),
+                    },
+                    expect: Yields(rms::NodeType::ComputeGb300Nvidia),
+                },
+                Case {
+                    scenario: "compute gb300 lenovo",
+                    input: ResolveRow {
+                        product_family: Some(Gb300),
+                        role: Role::Compute,
+                        vendor: Some("Lenovo"),
+                    },
+                    expect: Yields(rms::NodeType::ComputeGb300Lenovo),
+                },
+                Case {
+                    scenario: "compute gb200 lenovo is unsupported (lenovo is gb300-only)",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Compute,
+                        vendor: Some("Lenovo"),
+                    },
+                    expect: FailsWith(unsupported("compute", "Lenovo")),
+                },
+                Case {
+                    scenario: "compute missing vendor",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Compute,
+                        vendor: None,
+                    },
+                    expect: FailsWith(unsupported("compute", "")),
+                },
+                Case {
+                    scenario: "compute unsupported vendor",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Compute,
+                        vendor: Some("Other"),
+                    },
+                    expect: FailsWith(unsupported("compute", "Other")),
+                },
+                Case {
+                    scenario: "compute missing product family",
+                    input: ResolveRow {
+                        product_family: None,
+                        role: Role::Compute,
+                        vendor: Some("NVIDIA"),
+                    },
+                    expect: FailsWith(NodeTypeError::MissingProductFamily),
+                },
+                // Switch: NVIDIA on every family; anything else unsupported.
+                Case {
+                    scenario: "switch gb200 nvidia",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Switch,
+                        vendor: Some("NVIDIA"),
+                    },
+                    expect: Yields(rms::NodeType::SwitchGb200Nvidia),
+                },
+                Case {
+                    scenario: "switch gb300 nvidia",
+                    input: ResolveRow {
+                        product_family: Some(Gb300),
+                        role: Role::Switch,
+                        vendor: Some("NVIDIA"),
+                    },
+                    expect: Yields(rms::NodeType::SwitchGb300Nvidia),
+                },
+                Case {
+                    scenario: "switch missing vendor",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Switch,
+                        vendor: None,
+                    },
+                    expect: FailsWith(unsupported("switch", "")),
+                },
+                Case {
+                    scenario: "switch unsupported vendor",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::Switch,
+                        vendor: Some("Other"),
+                    },
+                    expect: FailsWith(unsupported("switch", "Other")),
+                },
+                Case {
+                    scenario: "switch missing product family",
+                    input: ResolveRow {
+                        product_family: None,
+                        role: Role::Switch,
+                        vendor: Some("NVIDIA"),
+                    },
+                    expect: FailsWith(NodeTypeError::MissingProductFamily),
+                },
+                // Power shelf: LiteOn and Delta on every family; anything else unsupported.
+                Case {
+                    scenario: "power shelf gb200 liteon",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::PowerShelf,
+                        vendor: Some("LiteOn"),
+                    },
+                    expect: Yields(rms::NodeType::PowershelfGb200Liteon),
+                },
+                Case {
+                    scenario: "power shelf gb200 delta",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::PowerShelf,
+                        vendor: Some("Delta"),
+                    },
+                    expect: Yields(rms::NodeType::PowershelfGb200Delta),
+                },
+                Case {
+                    scenario: "power shelf gb300 liteon",
+                    input: ResolveRow {
+                        product_family: Some(Gb300),
+                        role: Role::PowerShelf,
+                        vendor: Some("LiteOn"),
+                    },
+                    expect: Yields(rms::NodeType::PowershelfGb300Liteon),
+                },
+                Case {
+                    scenario: "power shelf gb300 delta",
+                    input: ResolveRow {
+                        product_family: Some(Gb300),
+                        role: Role::PowerShelf,
+                        vendor: Some("Delta"),
+                    },
+                    expect: Yields(rms::NodeType::PowershelfGb300Delta),
+                },
+                Case {
+                    scenario: "power shelf missing vendor",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::PowerShelf,
+                        vendor: None,
+                    },
+                    expect: FailsWith(unsupported("power shelf", "")),
+                },
+                Case {
+                    scenario: "power shelf unsupported vendor",
+                    input: ResolveRow {
+                        product_family: Some(Gb200),
+                        role: Role::PowerShelf,
+                        vendor: Some("Other"),
+                    },
+                    expect: FailsWith(unsupported("power shelf", "Other")),
+                },
+                Case {
+                    scenario: "power shelf missing product family",
+                    input: ResolveRow {
+                        product_family: None,
+                        role: Role::PowerShelf,
+                        vendor: Some("LiteOn"),
+                    },
+                    expect: FailsWith(NodeTypeError::MissingProductFamily),
+                },
+            ],
+            resolve,
         );
     }
 
@@ -332,38 +488,6 @@ mod tests {
     }
 
     #[test]
-    fn power_shelf_node_type_uses_profile_vendor() {
-        let mut gb200_liteon = profile_with_product_family(RackProductFamily::Gb200);
-        gb200_liteon.rack_capabilities.power_shelf.vendor = Some("LiteOn".to_string());
-
-        let mut gb300_delta = profile_with_product_family(RackProductFamily::Gb300);
-        gb300_delta.rack_capabilities.power_shelf.vendor = Some("Delta".to_string());
-
-        assert_eq!(
-            power_shelf_node_type_for_profile(&gb200_liteon),
-            Ok(rms::NodeType::PowershelfGb200Liteon)
-        );
-
-        assert_eq!(
-            power_shelf_node_type_for_profile(&gb300_delta),
-            Ok(rms::NodeType::PowershelfGb300Delta)
-        );
-    }
-
-    #[test]
-    fn power_shelf_node_type_requires_supported_vendor() {
-        let profile = profile_with_product_family(RackProductFamily::Gb200);
-
-        assert_eq!(
-            power_shelf_node_type_for_profile(&profile),
-            Err(NodeTypeError::UnsupportedVendor {
-                role: "power shelf",
-                vendor: String::new()
-            })
-        );
-    }
-
-    #[test]
     fn product_family_not_topology_selects_node_type() {
         let mut profile = profile_with_product_family(RackProductFamily::Gb300);
         profile.rack_hardware_topology = Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology);
@@ -372,47 +496,6 @@ mod tests {
         let node_type = switch_node_type_for_profile(&profile);
 
         assert_eq!(node_type, Ok(rms::NodeType::SwitchGb300Nvidia));
-    }
-
-    #[test]
-    fn compute_node_type_requires_vendor() {
-        let profile = profile_with_product_family(RackProductFamily::Gb200);
-
-        let err = compute_node_type_for_profile(&profile);
-
-        assert_eq!(
-            err,
-            Err(NodeTypeError::UnsupportedVendor {
-                role: "compute",
-                vendor: String::new()
-            })
-        );
-    }
-
-    #[test]
-    fn compute_node_type_requires_product_family() {
-        let mut profile = RackProfile::default();
-        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
-
-        let err = compute_node_type_for_profile(&profile);
-
-        assert_eq!(err, Err(NodeTypeError::MissingProductFamily));
-    }
-
-    #[test]
-    fn unsupported_vendor_returns_error() {
-        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
-        profile.rack_capabilities.compute.vendor = Some("Other".to_string());
-
-        let err = compute_node_type_for_profile(&profile);
-
-        assert_eq!(
-            err,
-            Err(NodeTypeError::UnsupportedVendor {
-                role: "compute",
-                vendor: "Other".to_string()
-            })
-        );
     }
 
     #[test]


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692) -- coverage adds.

`ipxe-renderer`: the artifact-URL cache strategy and the `validate()` error matrix each become a `check_cases` table -- every strategy (incl. `CachedOnly` present/absent) and every `validate()` error (`ReservedParameterFound`, `RequiredParameterMissing`, `ArtifactNotFound`, `HashMismatch`) is a row. `rack`: `rms_node_type` gains an 18-row product-family x role x vendor matrix pinning every `NodeType` and `NodeTypeError`. Subsumed single-case tests removed; behavior-distinct ones kept. Adds the dev-dependency.

No production change. Verified: `cargo test -p carbide-ipxe-renderer` (34) + `-p carbide-rack` (13), `clippy --locked --all-targets --all-features` clean, nightly rustfmt clean.

Addresses #2732.
