### PR TITLE
test(agent): table-ify the agent crate's parser and health tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "carbide-rpc",
  "carbide-rpc-utils",
  "carbide-systemd",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -131,6 +131,7 @@ carbide-version = { path = "../version" }
 tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 ctor = { workspace = true }
 prost = { workspace = true }
 rustls-pemfile = { workspace = true }

--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -456,30 +456,118 @@ impl Options {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Check, check_values, scenarios, value_scenarios};
+
     use super::*;
 
-    #[test]
-    fn test_platform_type_parses_all_valid_values() {
-        assert!(matches!(
-            "dpu-os".parse::<AgentPlatformType>().unwrap(),
-            AgentPlatformType::DpuOs
-        ));
-        assert!(matches!(
-            "containerized".parse::<AgentPlatformType>().unwrap(),
-            AgentPlatformType::Containerized
-        ));
+    /// Names an `AgentPlatformType` so parse results compare as a stable tag --
+    /// the enum is a clap value type and isn't `PartialEq`.
+    fn platform_tag(t: &AgentPlatformType) -> &'static str {
+        match t {
+            AgentPlatformType::DpuOs => "dpu-os",
+            AgentPlatformType::Containerized => "containerized",
+        }
+    }
+
+    /// Names an `HbnConfigMode` for the same reason as [`platform_tag`].
+    fn hbn_mode_tag(m: &HbnConfigMode) -> &'static str {
+        match m {
+            HbnConfigMode::ContainerExec => "container-exec",
+            HbnConfigMode::NvueRest => "nvue-rest",
+        }
     }
 
     #[test]
-    fn test_platform_type_rejects_unknown_value() {
-        let err = "banana".parse::<AgentPlatformType>().unwrap_err();
+    fn test_platform_type_from_str() {
+        scenarios!(run = |s: &str| s
+            .parse::<AgentPlatformType>()
+            .map(|t| platform_tag(&t))
+            .map_err(|e| e.to_string());
+            "valid values map to their variant" {
+                "dpu-os" => Yields("dpu-os"),
+                "containerized" => Yields("containerized"),
+            }
+
+            "unknown values are rejected" {
+                // `init-container` is now a dedicated subcommand, not a platform-type
+                // value; callers must use the subcommand instead.
+                "banana" => Fails,
+                "init-container" => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn test_platform_type_rejects_unknown_value_naming_the_input() {
+        // The rejection message echoes the offending value so operators can see
+        // what they mistyped.
+        for bad in ["banana", "init-container"] {
+            let err = bad.parse::<AgentPlatformType>().unwrap_err();
+            assert!(err.to_string().contains(bad), "error should name {bad}");
+        }
+    }
+
+    #[test]
+    fn test_hbn_config_mode_from_str() {
+        scenarios!(run = |s: &str| s
+            .parse::<HbnConfigMode>()
+            .map(|m| hbn_mode_tag(&m))
+            .map_err(|e| e.to_string());
+            "valid modes map to their variant" {
+                "container-exec" => Yields("container-exec"),
+                "nvue-rest" => Yields("nvue-rest"),
+            }
+
+            "unknown modes are rejected" {
+                "banana" => Fails,
+                "" => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn test_hbn_config_mode_rejects_unknown_value_naming_the_input() {
+        let err = "banana".parse::<HbnConfigMode>().unwrap_err();
         assert!(err.to_string().contains("banana"));
     }
 
     #[test]
     fn test_is_dpu_os_only_true_for_dpu_os() {
-        assert!(AgentPlatformType::DpuOs.is_dpu_os());
-        assert!(!AgentPlatformType::Containerized.is_dpu_os());
+        check_values(
+            [
+                Check {
+                    scenario: "dpu-os is the DPU OS",
+                    input: AgentPlatformType::DpuOs,
+                    expect: true,
+                },
+                Check {
+                    scenario: "containerized is not the DPU OS",
+                    input: AgentPlatformType::Containerized,
+                    expect: false,
+                },
+            ],
+            |t| t.is_dpu_os(),
+        );
+    }
+
+    #[test]
+    fn test_is_container_exec_only_true_for_container_exec() {
+        check_values(
+            [
+                Check {
+                    scenario: "container-exec uses crictl exec",
+                    input: HbnConfigMode::ContainerExec,
+                    expect: true,
+                },
+                Check {
+                    scenario: "nvue-rest does not use crictl exec",
+                    input: HbnConfigMode::NvueRest,
+                    expect: false,
+                },
+            ],
+            |m| m.is_container_exec(),
+        );
     }
 
     #[test]
@@ -524,15 +612,14 @@ mod tests {
 
     #[test]
     fn test_hardware_subcommand_accepts_remaining_platform_types() {
-        for value in ["dpu-os", "containerized"] {
-            let opts = Options::try_parse_from([
-                "forge-dpu-agent",
-                "hardware",
-                "--agent-platform-type",
-                value,
-            ])
-            .unwrap_or_else(|e| panic!("hardware --agent-platform-type={value} should parse: {e}"));
-            assert!(matches!(opts.cmd, Some(AgentCommand::Hardware(_))));
-        }
+        value_scenarios!(run = |value: &str| {
+            Options::try_parse_from(["forge-dpu-agent", "hardware", "--agent-platform-type", value])
+                .is_ok_and(|opts| matches!(opts.cmd, Some(AgentCommand::Hardware(_))))
+        };
+            "remaining platform types parse as the hardware subcommand" {
+                "dpu-os" => true,
+                "containerized" => true,
+            }
+        );
     }
 }

--- a/crates/agent/src/containerd/image.rs
+++ b/crates/agent/src/containerd/image.rs
@@ -94,3 +94,55 @@ where
             ))
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    /// Builds the `ImageNameComponent` a well-formed `repository/name:version`
+    /// string should split into.
+    fn component(repository: &str, name: &str, version: &str) -> ImageNameComponent {
+        ImageNameComponent {
+            repository: repository.to_string(),
+            name: name.to_string(),
+            version: version.to_string(),
+        }
+    }
+
+    /// Splits the `repoTags` of an `Image` through `container_image_name_to_component`
+    /// by deserializing a minimal `Image` JSON, returning either the parsed
+    /// components or the deserialization error message.
+    fn split_repo_tags(repo_tags: &[&str]) -> Result<Vec<ImageNameComponent>, String> {
+        let json = serde_json::json!({ "id": "img-1", "repoTags": repo_tags });
+        serde_json::from_value::<Image>(json)
+            .map(|image| image.names)
+            .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn test_container_image_name_to_component() {
+        scenarios!(run = |tags: &[&str]| split_repo_tags(tags);
+            "well-formed names split into repository, name, and version" {
+                ["nvcr.io/nvidia/doca/doca_hbn:1.5.0-doca2.2.0"].as_slice()
+                    => Yields(vec![component("nvcr.io/nvidia/doca", "doca_hbn", "1.5.0-doca2.2.0")]),
+                // The repository greedily absorbs every leading path segment.
+                ["docker.io/library/busybox:latest"].as_slice()
+                    => Yields(vec![component("docker.io/library", "busybox", "latest")]),
+                ["a/b:c", "x/y/z:1"].as_slice()
+                    => Yields(vec![component("a", "b", "c"), component("x/y", "z", "1")]),
+                [].as_slice() => Yields(vec![]),
+            }
+
+            "names missing a component are rejected" {
+                // No version (no colon), and no repository (no slash).
+                ["nvcr.io/nvidia/doca_hbn"].as_slice() => Fails,
+                ["doca_hbn:1.5.0"].as_slice() => Fails,
+                // One bad entry fails the whole list.
+                ["a/b:c", "bogus"].as_slice() => Fails,
+            }
+        );
+    }
+}

--- a/crates/agent/src/health.rs
+++ b/crates/agent/src/health.rs
@@ -716,6 +716,9 @@ pub async fn nvue_api_health(nvue_client: &NvueClient) -> HealthReport {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Check, check_values, scenarios, value_scenarios};
+
     use super::*;
 
     // Should these gaps be tabs? Yes. Are they tabs? No. `supervisorctl` outputs spaces.
@@ -761,121 +764,173 @@ overlay          41G   12G   27G  31% /run/containerd/io.containerd.runtime.v2.t
 tmpfs           3.4G     0  3.4G   0% /run/user/1002
 "#;
 
+    /// Builds the expected `DiskUtilization` for one `df -HP` row, in the column
+    /// order the output lists them: device, size, used, available, then the
+    /// utilization percentage.
+    fn disk(
+        device: &str,
+        size: &str,
+        used: &str,
+        available: &str,
+        utilization: u32,
+    ) -> DiskUtilization {
+        DiskUtilization {
+            device: device.to_string(),
+            size: size.to_string(),
+            used: used.to_string(),
+            available: available.to_string(),
+            utilization,
+        }
+    }
+
     #[test]
     fn test_parse_disk_utilization() {
-        let utilizations = super::parse_disk_utilization(DISKUTIL_OUT).unwrap();
+        let parsed = super::parse_disk_utilization(DISKUTIL_OUT).unwrap();
+        // Every mountpoint in the fixture is accounted for, so a stray or missing
+        // row is caught alongside the per-row field checks below.
+        assert_eq!(parsed.utilizations.len(), 10);
 
-        assert_eq!(
-            utilizations.utilizations,
-            HashMap::from_iter([(
-                "/dev/shm".to_string(),
-                DiskUtilization {
-                    device: "tmpfs".to_string(),
-                    utilization: 1,
-                    available: "17G".to_string(),
-                    used: "4.1k".to_string(),
-                    size: "17G".to_string()
-                }
-            ),
-            (
-                "/run".to_string(),
-                DiskUtilization {
-                    device: "tmpfs".to_string(),
-                    utilization: 1,
-                    available: "6.7G".to_string(),
-                    used: "17M".to_string(),
-                    size: "6.8G".to_string()
-                }
-            ),(
-                "/run/lock".to_string(),
-                DiskUtilization {
-                    device: "tmpfs".to_string(),
-                    utilization: 1,
-                    available: "5.3M".to_string(),
-                    used: "8.2k".to_string(),
-                    size: "5.3M".to_string()
-                }
-            ),(
-                "/".to_string(),
-                DiskUtilization {
-                    device: "/dev/mmcblk0p2".to_string(),
-                    utilization: 31,
-                    available: "27G".to_string(),
-                    used: "12G".to_string(),
-                    size: "41G".to_string()
-                }
-            ),(
-                "/boot/efi".to_string(),
-                DiskUtilization {
-                    device: "/dev/mmcblk0p1".to_string(),
-                    utilization: 18,
-                    available: "43M".to_string(),
-                    used: "9.0M".to_string(),
-                    size: "52M".to_string()
-                }
-            ),(
-                "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/3c9db06a2021f14b6cb98d0583ae43909f282c6d670dd9da071bddf333caaa4e/shm".to_string(),
-                DiskUtilization {
-                    device: "shm".to_string(),
-                    utilization: 0,
-                    available: "68M".to_string(),
-                    used: "0".to_string(),
-                    size: "68M".to_string()
-                }
-            ),(
-                "/run/containerd/io.containerd.runtime.v2.task/k8s.io/3c9db06a2021f14b6cb98d0583ae43909f282c6d670dd9da071bddf333caaa4e/rootfs".to_string(),
-                DiskUtilization {
-                    device: "overlay".to_string(),
-                    utilization: 31,
-                    available: "27G".to_string(),
-                    used: "12G".to_string(),
-                    size: "41G".to_string()
-                }
-            ),(
-                "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/5e38cefc8507fcf3b872fa12f21bdbcc09244832c24a34871ef9d8d519fa37b9/shm".to_string(),
-                DiskUtilization {
-                    device: "shm".to_string(),
-                    utilization: 1,
-                    available: "68M".to_string(),
-                    used: "8.2k".to_string(),
-                    size: "68M".to_string()
-                }
-            ),(
-                "/run/containerd/io.containerd.runtime.v2.task/k8s.io/5e38cefc8507fcf3b872fa12f21bdbcc09244832c24a34871ef9d8d519fa37b9/rootfs".to_string(),
-                DiskUtilization {
-                    device: "overlay".to_string(),
-                    utilization: 31,
-                    available: "27G".to_string(),
-                    used: "12G".to_string(),
-                    size: "41G".to_string()
-                }
-            ),(
-                "/run/user/1002".to_string(),
-                DiskUtilization {
-                    device: "tmpfs".to_string(),
-                    utilization: 0,
-                    available: "3.4G".to_string(),
-                    used: "0".to_string(),
-                    size: "3.4G".to_string()
-                }
-            )])
+        check_values(
+            [
+                Check {
+                    scenario: "/dev/shm",
+                    input: "/dev/shm",
+                    expect: Some(disk("tmpfs", "17G", "4.1k", "17G", 1)),
+                },
+                Check {
+                    scenario: "/run",
+                    input: "/run",
+                    expect: Some(disk("tmpfs", "6.8G", "17M", "6.7G", 1)),
+                },
+                Check {
+                    scenario: "/run/lock",
+                    input: "/run/lock",
+                    expect: Some(disk("tmpfs", "5.3M", "8.2k", "5.3M", 1)),
+                },
+                Check {
+                    scenario: "rootfs",
+                    input: "/",
+                    expect: Some(disk("/dev/mmcblk0p2", "41G", "12G", "27G", 31)),
+                },
+                Check {
+                    scenario: "/boot/efi",
+                    input: "/boot/efi",
+                    expect: Some(disk("/dev/mmcblk0p1", "52M", "9.0M", "43M", 18)),
+                },
+                Check {
+                    scenario: "containerd sandbox shm",
+                    input: "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/3c9db06a2021f14b6cb98d0583ae43909f282c6d670dd9da071bddf333caaa4e/shm",
+                    expect: Some(disk("shm", "68M", "0", "68M", 0)),
+                },
+                Check {
+                    scenario: "containerd task rootfs",
+                    input: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/3c9db06a2021f14b6cb98d0583ae43909f282c6d670dd9da071bddf333caaa4e/rootfs",
+                    expect: Some(disk("overlay", "41G", "12G", "27G", 31)),
+                },
+                Check {
+                    scenario: "second containerd sandbox shm",
+                    input: "/run/containerd/io.containerd.grpc.v1.cri/sandboxes/5e38cefc8507fcf3b872fa12f21bdbcc09244832c24a34871ef9d8d519fa37b9/shm",
+                    expect: Some(disk("shm", "68M", "8.2k", "68M", 1)),
+                },
+                Check {
+                    scenario: "second containerd task rootfs",
+                    input: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/5e38cefc8507fcf3b872fa12f21bdbcc09244832c24a34871ef9d8d519fa37b9/rootfs",
+                    expect: Some(disk("overlay", "41G", "12G", "27G", 31)),
+                },
+                Check {
+                    scenario: "/run/user/1002",
+                    input: "/run/user/1002",
+                    expect: Some(disk("tmpfs", "3.4G", "0", "3.4G", 0)),
+                },
+                Check {
+                    scenario: "unlisted mountpoint is absent",
+                    input: "/nope",
+                    expect: None,
+                },
+            ],
+            |mount_point| parsed.utilizations.get(mount_point).cloned(),
         );
     }
 
     #[test]
-    fn test_parse_supervisorctl_status() -> eyre::Result<()> {
-        let st = parse_status(SUPERVISORCTL_STATUS_OUT)?;
-        assert_eq!(st.status_of("frr"), SctlState::Running);
-        assert_eq!(st.status_of("ifreload"), SctlState::Exited);
-        assert_eq!(st.status_of("nvued"), SctlState::Stopped);
-        Ok(())
+    fn test_parse_supervisorctl_status() {
+        let st = parse_status(SUPERVISORCTL_STATUS_OUT).unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "running service",
+                    input: "frr",
+                    expect: SctlState::Running,
+                },
+                Check {
+                    scenario: "exited service",
+                    input: "ifreload",
+                    expect: SctlState::Exited,
+                },
+                Check {
+                    scenario: "stopped service",
+                    input: "nvued",
+                    expect: SctlState::Stopped,
+                },
+                Check {
+                    scenario: "absent service reports Unknown",
+                    input: "not-a-service",
+                    expect: SctlState::Unknown,
+                },
+            ],
+            |service| st.status_of(service),
+        );
     }
 
     #[test]
     fn test_parse_mlxprivhost() {
-        assert_eq!(
-            super::parse_mlxprivhost(MLXPRIVHOST_OUT).unwrap(),
-            "RESTRICTED"
+        scenarios!(run = |s| parse_mlxprivhost(s).map_err(|e| e.to_string());
+            "well-formed output yields the level" {
+                MLXPRIVHOST_OUT => Yields("RESTRICTED".to_string()),
+            }
+
+            "malformed output is rejected" {
+                // No `level` line at all, and a level line without the `:` separator.
+                "Host configurations\n-------------------\n" => Fails,
+                "level RESTRICTED" => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sctl_state_from_str() {
+        value_scenarios!(run = |s: &str| s.parse::<SctlState>().expect("from_str is infallible");
+            "each supervisorctl state name maps to its variant" {
+                "STOPPED" => SctlState::Stopped,
+                "STARTING" => SctlState::Starting,
+                "RUNNING" => SctlState::Running,
+                "BACKOFF" => SctlState::Backoff,
+                "STOPPING" => SctlState::Stopping,
+                "EXITED" => SctlState::Exited,
+                "FATAL" => SctlState::Fatal,
+            }
+
+            "an unrecognized state falls through to Unknown" {
+                "UNKNOWN" => SctlState::Unknown,
+                "wat" => SctlState::Unknown,
+                "" => SctlState::Unknown,
+            }
+        );
+    }
+
+    #[test]
+    fn test_sctl_state_display() {
+        value_scenarios!(run = |state: SctlState| state.to_string();
+            "every variant renders its supervisorctl name" {
+                SctlState::Stopped => "STOPPED".to_string(),
+                SctlState::Starting => "STARTING".to_string(),
+                SctlState::Running => "RUNNING".to_string(),
+                SctlState::Backoff => "BACKOFF".to_string(),
+                SctlState::Stopping => "STOPPING".to_string(),
+                SctlState::Exited => "EXITED".to_string(),
+                SctlState::Fatal => "FATAL".to_string(),
+                SctlState::Unknown => "UNKNOWN".to_string(),
+            }
         );
     }
 }

--- a/crates/agent/src/health/bgp.rs
+++ b/crates/agent/src/health/bgp.rs
@@ -371,6 +371,8 @@ struct BgpPeer {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     const BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SUCCESS: &str =
@@ -386,245 +388,181 @@ mod tests {
     const BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_FAILED_ALL_PEERS: &str =
         include_str!("../hbn_bgp_summary_with_route_server_failed_all_peers.json");
 
-    #[test]
-    fn test_check_bgp_success() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SUCCESS,
-            &[],
-            2,
-            &[],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        assert!(hr.alerts.is_empty());
-        Ok(())
+    /// One `verify_bgp_summary` scenario: a BGP summary JSON plus the host routes
+    /// and route servers that frame what's expected, and the exact alerts the
+    /// resulting health report should hold (sorted by `(id, target)`).
+    struct Row {
+        scenario: &'static str,
+        json: &'static str,
+        host_routes: &'static [&'static str],
+        route_servers: &'static [&'static str],
+        expected_alerts: Vec<health_report::HealthProbeAlert>,
+    }
+
+    /// Builds a TOR-peering alert for `port`, the most common alert these
+    /// scenarios produce.
+    fn tor_alert(port: &str, message: &str, critical: bool) -> health_report::HealthProbeAlert {
+        make_alert(
+            probe_ids::BgpPeeringTor.clone(),
+            Some(port.to_string()),
+            message.to_string(),
+            critical,
+        )
     }
 
     #[test]
-    fn test_check_bgp_no_route_server_failed_tor_peers() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_NO_ROUTE_SERVER_FAILED_TOR_PEERS,
-            &[],
-            2,
-            &[],
-            HBNDeviceNames::hbn_23(),
+    fn verify_bgp_summary_emits_expected_alerts() {
+        check_values(
+            [
+                Row {
+                    scenario: "all sessions established, no alerts",
+                    json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SUCCESS,
+                    host_routes: &[],
+                    route_servers: &[],
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "both TOR peers down is critical",
+                    json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_FAILED_TOR_PEERS,
+                    host_routes: &[],
+                    route_servers: &[],
+                    expected_alerts: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            true,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            true,
+                        ),
+                    ],
+                },
+                Row {
+                    scenario: "single TOR peer down is not critical",
+                    json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SINGLE_FAILED_TOR_PEER,
+                    host_routes: &[],
+                    route_servers: &[],
+                    expected_alerts: vec![tor_alert(
+                        "p0_if",
+                        "Session p0_if is not Established, but in state Idle",
+                        false,
+                    )],
+                },
+                Row {
+                    scenario: "tenant route in host_routes is expected, no alerts",
+                    json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_WITH_TENANT_ROUTES,
+                    host_routes: &["10.217.4.78"],
+                    route_servers: &[],
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "tenant route absent from host_routes is unexpected",
+                    json: BGP_SUMMARY_JSON_NO_ROUTE_SERVER_WITH_TENANT_ROUTES,
+                    host_routes: &[],
+                    route_servers: &[],
+                    expected_alerts: vec![make_alert(
+                        probe_ids::UnexpectedBgpPeer.clone(),
+                        Some("10.217.4.78".to_string()),
+                        "Unexpected BGP session referencing peer 10.217.4.78 was found in ipv4_unicast"
+                            .to_string(),
+                        true,
+                    )],
+                },
+                Row {
+                    scenario: "route server present but not in route_servers list",
+                    json: BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_AND_TENANT_ROUTES,
+                    host_routes: &["10.217.19.211"],
+                    route_servers: &[],
+                    expected_alerts: vec![
+                        tor_alert(
+                            "p0_if",
+                            "Expected session for p0_if was not found in BGP peer data",
+                            true,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Expected session for p1_if was not found in BGP peer data",
+                            true,
+                        ),
+                        make_alert(
+                            probe_ids::UnexpectedBgpPeer.clone(),
+                            Some("10.217.126.67".to_string()),
+                            "Unexpected BGP session referencing peer 10.217.126.67 was found in l2_vpn_evpn"
+                                .to_string(),
+                            true,
+                        ),
+                    ],
+                },
+                Row {
+                    scenario: "route server and tenant routes both expected, no alerts",
+                    json: BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_AND_TENANT_ROUTES,
+                    host_routes: &["10.217.19.211"],
+                    route_servers: &["10.217.126.67"],
+                    expected_alerts: vec![],
+                },
+                Row {
+                    scenario: "route server and both TOR peers down",
+                    json: BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_FAILED_ALL_PEERS,
+                    host_routes: &[],
+                    route_servers: &["10.217.126.67"],
+                    expected_alerts: vec![
+                        make_alert(
+                            probe_ids::BgpPeeringRouteServer.clone(),
+                            Some("10.217.126.67".to_string()),
+                            "Session 10.217.126.67 is not Established, but in state Active"
+                                .to_string(),
+                            true,
+                        ),
+                        tor_alert(
+                            "p0_if",
+                            "Session p0_if is not Established, but in state Idle",
+                            true,
+                        ),
+                        tor_alert(
+                            "p1_if",
+                            "Session p1_if is not Established, but in state Idle",
+                            true,
+                        ),
+                    ],
+                },
+            ]
+            .map(|mut row| {
+                // Sort the expected alerts the same way the run closure sorts the
+                // produced ones, so rows can list alerts in any readable order.
+                sort_alerts(&mut row.expected_alerts);
+                let expect = row.expected_alerts.clone();
+                Check {
+                    scenario: row.scenario,
+                    input: row,
+                    expect,
+                }
+            }),
+            |row: Row| {
+                let route_servers: Vec<String> =
+                    row.route_servers.iter().map(|s| s.to_string()).collect();
+                let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
+                let mut health_data = BgpHealthData::default();
+                verify_bgp_summary(
+                    &mut health_data,
+                    row.json,
+                    row.host_routes,
+                    2,
+                    &route_servers,
+                    HBNDeviceNames::hbn_23(),
+                );
+                health_data.into_health_report(&mut hr);
+                let mut alerts = hr.alerts;
+                sort_alerts(&mut alerts);
+                alerts
+            },
         );
-        health_data.into_health_report(&mut hr);
-        assert_eq!(hr.alerts.len(), 2);
-        hr.alerts
-            .sort_by(|alert1, alert2| alert1.target.cmp(&alert2.target));
-
-        assert_eq!(
-            hr.alerts[0],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p0_if".to_string()),
-                "Session p0_if is not Established, but in state Idle".to_string(),
-                true
-            )
-        );
-        assert_eq!(
-            hr.alerts[1],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p1_if".to_string()),
-                "Session p1_if is not Established, but in state Idle".to_string(),
-                true
-            )
-        );
-        Ok(())
     }
 
-    #[test]
-    fn test_check_bgp_no_route_server_single_failed_tor_peer() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SINGLE_FAILED_TOR_PEER,
-            &[],
-            2,
-            &[],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        assert_eq!(hr.alerts.len(), 1);
-        hr.alerts
-            .sort_by(|alert1, alert2| alert1.target.cmp(&alert2.target));
-
-        assert_eq!(
-            hr.alerts[0],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p0_if".to_string()),
-                "Session p0_if is not Established, but in state Idle".to_string(),
-                false
-            )
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_check_bgp_no_route_server_with_tenant_routes() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_NO_ROUTE_SERVER_WITH_TENANT_ROUTES,
-            &["10.217.4.78"],
-            2,
-            &[],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        assert!(hr.alerts.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn test_check_bgp_no_route_server_unexpected_tenant_route() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_NO_ROUTE_SERVER_WITH_TENANT_ROUTES,
-            &[],
-            2,
-            &[],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        assert_eq!(hr.alerts.len(), 1);
-        assert_eq!(
-            hr.alerts[0],
-            make_alert(
-                probe_ids::UnexpectedBgpPeer.clone(),
-                Some("10.217.4.78".to_string()),
-                "Unexpected BGP session referencing peer 10.217.4.78 was found in ipv4_unicast"
-                    .to_string(),
-                true
-            )
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_check_bgp_unexpected_route_server() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_AND_TENANT_ROUTES,
-            &["10.217.19.211"],
-            2,
-            &[],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        hr.alerts.sort_by(|alert1, alert2| {
-            (&alert1.id, &alert1.target).cmp(&(&alert2.id, &alert2.target))
-        });
-
-        assert_eq!(
-            hr.alerts[0],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p0_if".to_string()),
-                "Expected session for p0_if was not found in BGP peer data".to_string(),
-                true
-            )
-        );
-        assert_eq!(
-            hr.alerts[1],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p1_if".to_string()),
-                "Expected session for p1_if was not found in BGP peer data".to_string(),
-                true
-            )
-        );
-        assert_eq!(
-            hr.alerts[2],
-            make_alert(
-                probe_ids::UnexpectedBgpPeer.clone(),
-                Some("10.217.126.67".to_string()),
-                "Unexpected BGP session referencing peer 10.217.126.67 was found in l2_vpn_evpn"
-                    .to_string(),
-                true
-            )
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_check_bgp_with_route_server_and_tenant_routes() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_AND_TENANT_ROUTES,
-            &["10.217.19.211"],
-            2,
-            &["10.217.126.67".to_string()],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        assert!(hr.alerts.is_empty());
-        Ok(())
-    }
-
-    #[test]
-    fn test_check_bgp_with_route_server_failed_all_peers() -> eyre::Result<()> {
-        let mut hr = health_report::HealthReport::empty("forge-dpu-agent".to_string());
-        let mut health_data = BgpHealthData::default();
-        verify_bgp_summary(
-            &mut health_data,
-            BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_FAILED_ALL_PEERS,
-            &[],
-            2,
-            &["10.217.126.67".to_string()],
-            HBNDeviceNames::hbn_23(),
-        );
-        health_data.into_health_report(&mut hr);
-        assert_eq!(hr.alerts.len(), 3);
-        hr.alerts
-            .sort_by(|alert1, alert2| alert1.target.cmp(&alert2.target));
-
-        assert_eq!(
-            hr.alerts[0],
-            make_alert(
-                probe_ids::BgpPeeringRouteServer.clone(),
-                Some("10.217.126.67".to_string()),
-                "Session 10.217.126.67 is not Established, but in state Active".to_string(),
-                true
-            )
-        );
-        assert_eq!(
-            hr.alerts[1],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p0_if".to_string()),
-                "Session p0_if is not Established, but in state Idle".to_string(),
-                true
-            )
-        );
-        assert_eq!(
-            hr.alerts[2],
-            make_alert(
-                probe_ids::BgpPeeringTor.clone(),
-                Some("p1_if".to_string()),
-                "Session p1_if is not Established, but in state Idle".to_string(),
-                true
-            )
-        );
-        Ok(())
+    /// Orders alerts by `(id, target)` so a produced report and its expected
+    /// report compare element-by-element regardless of insertion order.
+    fn sort_alerts(alerts: &mut [health_report::HealthProbeAlert]) {
+        alerts.sort_by(|a, b| (&a.id, &a.target).cmp(&(&b.id, &b.target)));
     }
 }

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -1705,110 +1705,118 @@ struct TmplVni {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
+
+    /// One `split_prefixes_by_family` scenario: the input prefixes, an optional
+    /// VPC allow-list `filter` (as prefix strings, parsed inside the run), the
+    /// `start_index` each family bucket counts from, and the `(ipv4, ipv6)`
+    /// `Prefix` buckets the split should yield.
+    struct SplitRow {
+        prefixes: Vec<&'static str>,
+        filter: Option<Vec<&'static str>>,
+        start_index: usize,
+    }
+
+    /// Builds a `Prefix` from its index and CIDR string -- the shape
+    /// `split_prefixes_by_family` produces -- so expected buckets read as a list
+    /// of `(index, prefix)` pairs.
+    fn prefix(index: &str, cidr: &str) -> Prefix {
+        Prefix {
+            Index: index.to_string(),
+            Prefix: cidr.to_string(),
+        }
+    }
 
     #[test]
     fn test_split_prefixes_by_family() {
-        let prefixes = vec![
-            "10.0.0.0/8".to_string(),
-            "2001:db8::/32".to_string(),
-            "192.168.0.0/16".to_string(),
-            "fd00::/8".to_string(),
-        ];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1000);
+        value_scenarios!(run = |row: SplitRow| {
+            let prefixes: Vec<String> = row.prefixes.iter().map(|s| s.to_string()).collect();
+            let filter = row
+                .filter
+                .map(|f| parse_prefixes(&f.iter().map(|s| s.to_string()).collect::<Vec<_>>()));
+            split_prefixes_by_family(&prefixes, filter.as_deref(), row.start_index)
+        };
+            "mixed families share the start index" {
+                SplitRow {
+                    prefixes: vec!["10.0.0.0/8", "2001:db8::/32", "192.168.0.0/16", "fd00::/8"],
+                    filter: None,
+                    start_index: 1000,
+                } => (
+                    vec![prefix("1000", "10.0.0.0/8"), prefix("1001", "192.168.0.0/16")],
+                    vec![prefix("1000", "2001:db8::/32"), prefix("1001", "fd00::/8")],
+                ),
+            }
 
-        assert_eq!(ipv4.len(), 2);
-        assert_eq!(ipv6.len(), 2);
+            "ipv4 only" {
+                SplitRow {
+                    prefixes: vec!["10.0.0.0/8", "172.16.0.0/12"],
+                    filter: None,
+                    start_index: 1,
+                } => (
+                    vec![prefix("1", "10.0.0.0/8"), prefix("2", "172.16.0.0/12")],
+                    vec![],
+                ),
+            }
 
-        assert_eq!(ipv4[0].Index, "1000");
-        assert_eq!(ipv4[0].Prefix, "10.0.0.0/8");
-        assert_eq!(ipv4[1].Index, "1001");
-        assert_eq!(ipv4[1].Prefix, "192.168.0.0/16");
+            "ipv6 only" {
+                SplitRow {
+                    prefixes: vec!["2001:db8::/32", "fd00::/8"],
+                    filter: None,
+                    start_index: 1,
+                } => (
+                    vec![],
+                    vec![prefix("1", "2001:db8::/32"), prefix("2", "fd00::/8")],
+                ),
+            }
 
-        assert_eq!(ipv6[0].Index, "1000");
-        assert_eq!(ipv6[0].Prefix, "2001:db8::/32");
-        assert_eq!(ipv6[1].Index, "1001");
-        assert_eq!(ipv6[1].Prefix, "fd00::/8");
-    }
+            "empty input" {
+                SplitRow {
+                    prefixes: vec![],
+                    filter: None,
+                    start_index: 1000,
+                } => (vec![], vec![]),
+            }
 
-    #[test]
-    fn test_split_prefixes_ipv4_only() {
-        let prefixes = vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
+            "unparseable prefixes are dropped" {
+                SplitRow {
+                    prefixes: vec!["not-a-cidr", "10.0.0.0/8"],
+                    filter: None,
+                    start_index: 1,
+                } => (vec![prefix("1", "10.0.0.0/8")], vec![]),
+            }
 
-        assert_eq!(ipv4.len(), 2);
-        assert!(ipv6.is_empty());
-    }
+            "ipv4-mapped ipv6 sorts into the v6 bucket" {
+                // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) parse as V6.
+                SplitRow {
+                    prefixes: vec!["::ffff:192.0.2.33/128", "10.0.0.0/8", "2001:db8::/32"],
+                    filter: None,
+                    start_index: 1,
+                } => (
+                    vec![prefix("1", "10.0.0.0/8")],
+                    vec![prefix("1", "::ffff:192.0.2.33/128"), prefix("2", "2001:db8::/32")],
+                ),
+            }
 
-    #[test]
-    fn test_split_prefixes_ipv6_only() {
-        let prefixes = vec!["2001:db8::/32".to_string(), "fd00::/8".to_string()];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
-
-        assert!(ipv4.is_empty());
-        assert_eq!(ipv6.len(), 2);
-    }
-
-    #[test]
-    fn test_split_prefixes_empty() {
-        let prefixes: Vec<String> = vec![];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1000);
-
-        assert!(ipv4.is_empty());
-        assert!(ipv6.is_empty());
-    }
-
-    #[test]
-    fn test_split_prefixes_unparseable_dropped() {
-        let prefixes = vec!["not-a-cidr".to_string(), "10.0.0.0/8".to_string()];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
-
-        assert_eq!(ipv4.len(), 1);
-        assert_eq!(ipv4[0].Prefix, "10.0.0.0/8");
-        assert_eq!(ipv4[0].Index, "1");
-        assert!(ipv6.is_empty());
-    }
-
-    #[test]
-    fn test_split_prefixes_ipv4_mapped_ipv6() {
-        // IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) parse as V6
-        let prefixes = vec![
-            "::ffff:192.0.2.33/128".to_string(),
-            "10.0.0.0/8".to_string(),
-            "2001:db8::/32".to_string(),
-        ];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
-
-        assert_eq!(ipv4.len(), 1);
-        assert_eq!(ipv4[0].Prefix, "10.0.0.0/8");
-
-        assert_eq!(ipv6.len(), 2);
-        assert_eq!(ipv6[0].Prefix, "::ffff:192.0.2.33/128");
-        assert_eq!(ipv6[1].Prefix, "2001:db8::/32");
-    }
-
-    #[test]
-    fn test_split_prefixes_filters_to_containing_prefixes() {
-        // Build mixed-family inputs with one contained and one excluded prefix per family.
-        let prefixes = vec![
-            "192.0.2.64/26".to_string(),
-            "198.51.100.0/24".to_string(),
-            "2001:db8:1::/64".to_string(),
-            "2001:db9::/48".to_string(),
-        ];
-        let filter = parse_prefixes(&["192.0.2.0/24".to_string(), "2001:db8::/32".to_string()]);
-
-        // Filter through the VPC allow-list while preserving family-specific indexes.
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, Some(&filter), 1);
-
-        // Verify only prefixes contained by the filter remain.
-        let ipv4_prefixes: Vec<_> = ipv4.iter().map(|prefix| prefix.Prefix.as_str()).collect();
-        let ipv6_prefixes: Vec<_> = ipv6.iter().map(|prefix| prefix.Prefix.as_str()).collect();
-
-        assert_eq!(ipv4_prefixes, vec!["192.0.2.64/26"]);
-        assert_eq!(ipv6_prefixes, vec!["2001:db8:1::/64"]);
-        assert_eq!(ipv4[0].Index, "1");
-        assert_eq!(ipv6[0].Index, "1");
+            "filter keeps only prefixes contained by the allow-list" {
+                // One contained and one excluded prefix per family; family-specific
+                // indexes are preserved.
+                SplitRow {
+                    prefixes: vec![
+                        "192.0.2.64/26",
+                        "198.51.100.0/24",
+                        "2001:db8:1::/64",
+                        "2001:db9::/48",
+                    ],
+                    filter: Some(vec!["192.0.2.0/24", "2001:db8::/32"]),
+                    start_index: 1,
+                } => (
+                    vec![prefix("1", "192.0.2.64/26")],
+                    vec![prefix("1", "2001:db8:1::/64")],
+                ),
+            }
+        );
     }
 
     /// Helper to build a minimal NvueConfig for template rendering tests.


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692).

`carbide-agent` proved its parsers and health probes one `#[test]` per case. They collapse into `carbide-test-support` tables: the eight BGP-summary cases → one `check_values` table over a named `Row { scenario, json, host_routes, route_servers, expected_alerts }` comparing the whole alert vec; prefix-family split, platform-type parse, disk/supervisorctl status, and mlxprivhost each get their own table. Also fills untested gaps -- `SupervisorctlState`/`HbnConfigMode` from-str + Display (incl. the `Unknown` fallthrough), the `is_container_exec` predicate, and the container-image regex. Adds the dev-dependency.

Parser errors compare as `Fails` (`eyre::Report` isn't `PartialEq`); where the message is the contract a focused companion test keeps it. No production change. Verified: `cargo test -p carbide-agent` (137 pass), `clippy --locked --all-targets --all-features -p carbide-agent` clean, nightly rustfmt clean.

Addresses #2729.
