### PR TITLE
test(small crates): adopt carbide-test-support across five parser/serde suites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -928,6 +928,7 @@ dependencies = [
 name = "bms-dsx-exchange"
 version = "0.1.0"
 dependencies = [
+ "carbide-test-support",
  "chrono",
  "serde",
  "serde_json",
@@ -1843,6 +1844,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-rpc",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-uuid",
  "carbide-version",
@@ -2144,6 +2146,7 @@ dependencies = [
  "aes-gcm 0.10.3",
  "async-trait",
  "base64",
+ "carbide-test-support",
  "hex",
  "rand 0.10.1",
  "serde",
@@ -2717,6 +2720,7 @@ version = "0.0.1"
 dependencies = [
  "axum",
  "carbide-rpc",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-uuid",
  "clap",

--- a/crates/bms-dsx-exchange/Cargo.toml
+++ b/crates/bms-dsx-exchange/Cargo.toml
@@ -11,5 +11,8 @@ serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/bms-dsx-exchange/src/lib.rs
+++ b/crates/bms-dsx-exchange/src/lib.rs
@@ -331,29 +331,102 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_rack_metadata() {
-        let metadata = parse_supported_metadata(
-            "BMS/v1/PUB/Metadata/Rack/RackLiquidIsolationRequest/site/rack-01",
-            r#"{
-                "pointType": "RackLiquidIsolationRequest",
-                "objectType": "Rack",
-                "rackName": "Rack-01",
-                "rackId": "rack-01",
-                "integration": "CM"
-            }"#
-            .as_bytes(),
-        )
-        .unwrap()
-        .unwrap();
+    fn parses_supported_metadata() {
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::scenarios;
 
-        assert_eq!(
-            metadata.point_type(),
-            POINT_TYPE_RACK_LIQUID_ISOLATION_REQUEST
-        );
-        assert_eq!(metadata.integration(), "CM");
-        assert_eq!(
-            metadata.value_topic(),
-            "BMS/v1/CM/Value/Rack/RackLiquidIsolationRequest/site/rack-01"
+        /// A metadata topic paired with its raw JSON payload.
+        struct Message {
+            topic: &'static str,
+            payload: &'static str,
+        }
+
+        // Each success row pins the three observable fields the parse derives:
+        // the canonical point type, the integration, and the value topic.
+        scenarios!(
+            run = |Message { topic, payload }: Message| {
+                parse_supported_metadata(topic, payload.as_bytes())
+                    .map(|maybe| {
+                        maybe.map(|m| {
+                            (
+                                m.point_type().to_string(),
+                                m.integration().to_string(),
+                                m.value_topic().to_string(),
+                            )
+                        })
+                    })
+                    // The error type isn't PartialEq; the failing rows assert only
+                    // that the input is rejected, so carry the message as a String.
+                    .map_err(|e| e.to_string())
+            };
+            "a supported point type parses, deriving the value topic from the metadata topic" {
+                Message {
+                    topic: "BMS/v1/PUB/Metadata/Rack/RackLiquidIsolationRequest/site/rack-01",
+                    payload: r#"{
+                        "pointType": "RackLiquidIsolationRequest",
+                        "objectType": "Rack",
+                        "rackName": "Rack-01",
+                        "rackId": "rack-01",
+                        "integration": "CM"
+                    }"#,
+                } => Yields(Some((
+                    POINT_TYPE_RACK_LIQUID_ISOLATION_REQUEST.to_string(),
+                    "CM".to_string(),
+                    "BMS/v1/CM/Value/Rack/RackLiquidIsolationRequest/site/rack-01".to_string(),
+                ))),
+                Message {
+                    topic: "BMS/v1/PUB/Metadata/System/HeartbeatTimestampIntegration/site",
+                    payload: r#"{
+                        "pointType": "HeartbeatTimestampIntegration",
+                        "objectType": "System",
+                        "integration": "CM"
+                    }"#,
+                } => Yields(Some((
+                    POINT_TYPE_HEARTBEAT_TIMESTAMP_INTEGRATION.to_string(),
+                    "CM".to_string(),
+                    "BMS/v1/CM/Value/System/HeartbeatTimestampIntegration/site".to_string(),
+                ))),
+                // The value topic is derived from the metadata topic, not the payload's
+                // point type — here the topic names a different request than the body.
+                Message {
+                    topic: "BMS/v1/PUB/Metadata/Rack/RackElectricalIsolationRequest/site/rack-01",
+                    payload: r#"{
+                        "pointType": "RackLiquidIsolationRequest",
+                        "objectType": "Rack",
+                        "rackName": "Rack-01",
+                        "rackId": "rack-01",
+                        "integration": "CM"
+                    }"#,
+                } => Yields(Some((
+                    POINT_TYPE_RACK_LIQUID_ISOLATION_REQUEST.to_string(),
+                    "CM".to_string(),
+                    "BMS/v1/CM/Value/Rack/RackElectricalIsolationRequest/site/rack-01".to_string(),
+                ))),
+            }
+            "an empty required field is rejected (MissingMetadataField)" {
+                Message {
+                    topic: "BMS/v1/PUB/Metadata/Rack/RackLiquidIsolationRequest/site/rack-01",
+                    payload: r#"{
+                        "pointType": "RackLiquidIsolationRequest",
+                        "objectType": "Rack",
+                        "rackName": "Rack-01",
+                        "rackId": "rack-01",
+                        "integration": ""
+                    }"#,
+                } => Fails,
+            }
+            "a topic that is not a metadata topic is rejected (InvalidMetadataTopic)" {
+                Message {
+                    topic: "BMS/v1/CM/Value/Rack/RackLiquidIsolationRequest/site/rack-01",
+                    payload: r#"{
+                        "pointType": "RackLiquidIsolationRequest",
+                        "objectType": "Rack",
+                        "rackName": "Rack-01",
+                        "rackId": "rack-01",
+                        "integration": "CM"
+                    }"#,
+                } => Fails,
+            }
         );
     }
 
@@ -370,102 +443,6 @@ mod tests {
                 "timestamp": 1_712_345_678_901_i64,
                 "quality": "1"
             })
-        );
-    }
-
-    #[test]
-    fn parses_heartbeat_metadata() {
-        let metadata = parse_supported_metadata(
-            "BMS/v1/PUB/Metadata/System/HeartbeatTimestampIntegration/site",
-            r#"{
-                "pointType": "HeartbeatTimestampIntegration",
-                "objectType": "System",
-                "integration": "CM"
-            }"#
-            .as_bytes(),
-        )
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(
-            metadata.point_type(),
-            POINT_TYPE_HEARTBEAT_TIMESTAMP_INTEGRATION
-        );
-        assert_eq!(metadata.integration(), "CM");
-        assert_eq!(
-            metadata.value_topic(),
-            "BMS/v1/CM/Value/System/HeartbeatTimestampIntegration/site"
-        );
-    }
-
-    #[test]
-    fn rejects_supported_metadata_empty_required_field() {
-        let error = parse_supported_metadata(
-            "BMS/v1/PUB/Metadata/Rack/RackLiquidIsolationRequest/site/rack-01",
-            r#"{
-                "pointType": "RackLiquidIsolationRequest",
-                "objectType": "Rack",
-                "rackName": "Rack-01",
-                "rackId": "rack-01",
-                "integration": ""
-            }"#
-            .as_bytes(),
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            error,
-            BmsDsxExchangeError::MissingMetadataField {
-                field: "integration",
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn rejects_invalid_metadata_topic() {
-        let error = parse_supported_metadata(
-            "BMS/v1/CM/Value/Rack/RackLiquidIsolationRequest/site/rack-01",
-            r#"{
-                "pointType": "RackLiquidIsolationRequest",
-                "objectType": "Rack",
-                "rackName": "Rack-01",
-                "rackId": "rack-01",
-                "integration": "CM"
-            }"#
-            .as_bytes(),
-        )
-        .unwrap_err();
-
-        assert!(matches!(
-            error,
-            BmsDsxExchangeError::InvalidMetadataTopic { .. }
-        ));
-    }
-
-    #[test]
-    fn uses_metadata_topic_to_derive_value_topic() {
-        let metadata = parse_supported_metadata(
-            "BMS/v1/PUB/Metadata/Rack/RackElectricalIsolationRequest/site/rack-01",
-            r#"{
-                "pointType": "RackLiquidIsolationRequest",
-                "objectType": "Rack",
-                "rackName": "Rack-01",
-                "rackId": "rack-01",
-                "integration": "CM"
-            }"#
-            .as_bytes(),
-        )
-        .unwrap()
-        .unwrap();
-
-        assert_eq!(
-            metadata.point_type(),
-            POINT_TYPE_RACK_LIQUID_ISOLATION_REQUEST
-        );
-        assert_eq!(
-            metadata.value_topic(),
-            "BMS/v1/CM/Value/Rack/RackElectricalIsolationRequest/site/rack-01"
         );
     }
 }

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -502,33 +502,49 @@ mod tests {
 
     #[test]
     fn classify_failure_maps_grpc_codes_to_dns_response_codes() {
+        use carbide_test_support::value_scenarios;
         use tonic::Code;
 
-        let cases = [
-            (Code::NotFound, ResponseCode::NXDomain, false),
-            (Code::InvalidArgument, ResponseCode::FormErr, false),
-            (Code::Unimplemented, ResponseCode::NotImp, false),
-            (Code::PermissionDenied, ResponseCode::Refused, false),
-            (Code::Unauthenticated, ResponseCode::Refused, false),
-            (Code::Internal, ResponseCode::ServFail, true),
-            (Code::Unavailable, ResponseCode::ServFail, true),
-            (Code::DeadlineExceeded, ResponseCode::ServFail, true),
-            (Code::ResourceExhausted, ResponseCode::ServFail, true),
-            (Code::Aborted, ResponseCode::ServFail, true),
-            (Code::Unknown, ResponseCode::ServFail, true),
-        ];
-
-        for (code, expected_code, expected_transient) in cases {
-            let classification = classify_failure(code);
-            assert_eq!(
-                classification.code, expected_code,
-                "response code for {code:?}"
-            );
-            assert_eq!(
-                classification.transient, expected_transient,
-                "transience for {code:?}"
-            );
+        /// The classification a gRPC code is expected to produce: the DNS
+        /// response code returned to the client and whether it is transient.
+        #[derive(Debug, PartialEq)]
+        struct Expected {
+            code: ResponseCode,
+            transient: bool,
         }
+
+        value_scenarios!(
+            run = |code| {
+                let NegativeClassification { code, transient } = classify_failure(code);
+                Expected { code, transient }
+            };
+            "stable, authoritative negatives" {
+                // The name genuinely does not exist.
+                Code::NotFound => Expected { code: ResponseCode::NXDomain, transient: false },
+                // A malformed query stays malformed on retry.
+                Code::InvalidArgument => Expected { code: ResponseCode::FormErr, transient: false },
+                // The upstream does not implement this qtype/operation.
+                Code::Unimplemented => Expected { code: ResponseCode::NotImp, transient: false },
+            }
+            "policy refusals" {
+                Code::PermissionDenied => Expected { code: ResponseCode::Refused, transient: false },
+                Code::Unauthenticated => Expected { code: ResponseCode::Refused, transient: false },
+            }
+            "transient failures cached briefly as ServFail" {
+                Code::Internal => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::Unavailable => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::DeadlineExceeded => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::ResourceExhausted => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::Aborted => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::Cancelled => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::AlreadyExists => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::FailedPrecondition => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::OutOfRange => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::DataLoss => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::Ok => Expected { code: ResponseCode::ServFail, transient: true },
+                Code::Unknown => Expected { code: ResponseCode::ServFail, transient: true },
+            }
+        );
     }
 
     #[test]

--- a/crates/dsx-exchange-consumer/Cargo.toml
+++ b/crates/dsx-exchange-consumer/Cargo.toml
@@ -58,5 +58,8 @@ mqttea = { path = "../mqttea" }
 [build-dependencies]
 carbide-version = { path = "../version" }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/dsx-exchange-consumer/src/health_updater.rs
+++ b/crates/dsx-exchange-consumer/src/health_updater.rs
@@ -361,42 +361,31 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_point_path_metadata() {
-        let topic = "BMS/v1/some/point/path/Metadata";
-        assert_eq!(
-            extract_point_path(topic, TEST_PREFIX),
-            Some("some/point/path")
+    fn test_extract_point_path() {
+        use carbide_test_support::value_scenarios;
+
+        struct Topic {
+            topic: &'static str,
+            prefix: &'static str,
+        }
+
+        value_scenarios!(
+            run = |Topic { topic, prefix }| extract_point_path(topic, prefix);
+            "the point path sits between the prefix and the suffix" {
+                Topic { topic: "BMS/v1/some/point/path/Metadata", prefix: TEST_PREFIX }
+                    => Some("some/point/path"),
+                Topic { topic: "BMS/v1/some/point/path/Value", prefix: TEST_PREFIX }
+                    => Some("some/point/path"),
+                Topic { topic: "custom/prefix/some/point/path/Value", prefix: "custom/prefix/" }
+                    => Some("some/point/path"),
+            }
+            "a topic that does not match yields nothing" {
+                // Neither a /Metadata nor a /Value suffix.
+                Topic { topic: "BMS/v1/some/point/path/Unknown", prefix: TEST_PREFIX } => None,
+                // The prefix does not match.
+                Topic { topic: "BMS/v1/some/point/path/Value", prefix: "wrong/prefix/" } => None,
+            }
         );
-    }
-
-    #[test]
-    fn test_extract_point_path_value() {
-        let topic = "BMS/v1/some/point/path/Value";
-        assert_eq!(
-            extract_point_path(topic, TEST_PREFIX),
-            Some("some/point/path")
-        );
-    }
-
-    #[test]
-    fn test_extract_point_path_unknown() {
-        let topic = "BMS/v1/some/point/path/Unknown";
-        assert_eq!(extract_point_path(topic, TEST_PREFIX), None);
-    }
-
-    #[test]
-    fn test_extract_point_path_custom_prefix() {
-        let topic = "custom/prefix/some/point/path/Value";
-        assert_eq!(
-            extract_point_path(topic, "custom/prefix/"),
-            Some("some/point/path")
-        );
-    }
-
-    #[test]
-    fn test_extract_point_path_wrong_prefix() {
-        let topic = "BMS/v1/some/point/path/Value";
-        assert_eq!(extract_point_path(topic, "wrong/prefix/"), None);
     }
 
     #[test]

--- a/crates/dsx-exchange-consumer/src/messages.rs
+++ b/crates/dsx-exchange-consumer/src/messages.rs
@@ -202,62 +202,65 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_value_message_active_int() {
-        let json = r#"{"value": 1, "timestamp": 1706284800}"#;
-        let value: ValueMessage = serde_json::from_str(json).unwrap();
-        assert_eq!(value.value, FaultValue::Faulting);
-    }
+    fn parses_value_message_binary_value() {
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::scenarios;
 
-    #[test]
-    fn test_parse_value_message_active_float() {
-        let json = r#"{"value": 1.0, "timestamp": 1706284800}"#;
-        let value: ValueMessage = serde_json::from_str(json).unwrap();
-        assert_eq!(value.value, FaultValue::Faulting);
-        // 1706284800 = 2024-01-26T12:00:00Z
-        assert_eq!(value.timestamp.timestamp(), 1706284800);
-        assert_eq!(
-            value.timestamp,
-            DateTime::from_timestamp(1706284800, 0).unwrap()
+        // Every fixture carries the same timestamp; 1706284800 = 2024-01-26T12:00:00Z.
+        // Each success row asserts both the decoded fault value and that the
+        // timestamp round-trips through `ts_seconds`.
+        scenarios!(
+            run = |json: &str| {
+                serde_json::from_str::<ValueMessage>(json)
+                    .map(|m| (m.value, m.timestamp))
+                    // The error type isn't PartialEq; these rows assert only that
+                    // an out-of-range value fails, so carry the message as a String.
+                    .map_err(|e| e.to_string())
+            };
+            "0 or 1 decode to Clear / Faulting, as int or float" {
+                r#"{"value": 1, "timestamp": 1706284800}"#
+                    => Yields((FaultValue::Faulting, DateTime::from_timestamp(1706284800, 0).unwrap())),
+                r#"{"value": 1.0, "timestamp": 1706284800}"#
+                    => Yields((FaultValue::Faulting, DateTime::from_timestamp(1706284800, 0).unwrap())),
+                r#"{"value": 0, "timestamp": 1706284800}"#
+                    => Yields((FaultValue::Clear, DateTime::from_timestamp(1706284800, 0).unwrap())),
+                r#"{"value": 0.0, "timestamp": 1706284800}"#
+                    => Yields((FaultValue::Clear, DateTime::from_timestamp(1706284800, 0).unwrap())),
+            }
+            "anything other than 0 or 1 is rejected, as int or float" {
+                r#"{"value": 2, "timestamp": 1706284800}"# => Fails,
+                r#"{"value": 0.5, "timestamp": 1706284800}"# => Fails,
+            }
         );
     }
 
     #[test]
-    fn test_parse_value_message_clear_int() {
-        let json = r#"{"value": 0, "timestamp": 1706284800}"#;
-        let value: ValueMessage = serde_json::from_str(json).unwrap();
-        assert_eq!(value.value, FaultValue::Clear);
-    }
+    fn leak_point_type_probe_id() {
+        use carbide_test_support::value_scenarios;
 
-    #[test]
-    fn test_parse_value_message_clear_float() {
-        let json = r#"{"value": 0.0, "timestamp": 1706284800}"#;
-        let value: ValueMessage = serde_json::from_str(json).unwrap();
-        assert_eq!(value.value, FaultValue::Clear);
-    }
-
-    #[test]
-    fn test_parse_value_message_invalid_int() {
-        let json = r#"{"value": 2, "timestamp": 1706284800}"#;
-        let result: Result<ValueMessage, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("invalid binary value")
+        // The probe id is part of the contract with the health pipeline; pin each
+        // variant's exact id.
+        value_scenarios!(
+            run = |leak_type: LeakPointType| leak_type.probe_id();
+            "each leak type maps to its health probe id" {
+                LeakPointType::LeakDetectRack => "BmsLeakDetectRack".parse().unwrap(),
+                LeakPointType::LeakSensorFaultRack => "BmsLeakSensorFaultRack".parse().unwrap(),
+                LeakPointType::LeakDetectRackTray => "BmsLeakDetectRackTray".parse().unwrap(),
+            }
         );
     }
 
     #[test]
-    fn test_parse_value_message_invalid_float() {
-        let json = r#"{"value": 0.5, "timestamp": 1706284800}"#;
-        let result: Result<ValueMessage, _> = serde_json::from_str(json);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("invalid binary value")
+    fn leak_point_type_description() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |leak_type: LeakPointType| leak_type.description();
+            "each leak type carries a human-readable alert description" {
+                LeakPointType::LeakDetectRack => "Leak detected",
+                LeakPointType::LeakSensorFaultRack => "Leak sensor fault",
+                LeakPointType::LeakDetectRackTray => "Rack tray leak detected",
+            }
         );
     }
 

--- a/crates/kms-provider/Cargo.toml
+++ b/crates/kms-provider/Cargo.toml
@@ -39,6 +39,7 @@ vaultrs = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/kms-provider/src/providers/integrated.rs
+++ b/crates/kms-provider/src/providers/integrated.rs
@@ -229,8 +229,46 @@ mod tests {
         assert_eq!(*dek, *unwrapped);
     }
 
-    // Verifies that from_config loads keys from
-    // env vars.
+    // Verifies that from_config loads a key from each KeySource variant and
+    // rejects sources whose key material is malformed. Loading a key under a
+    // kek_id is observable through can_decrypt_kek, so each success row yields
+    // whether the configured key is present.
+    #[test]
+    fn from_config_loads_each_key_source_and_rejects_bad_material() {
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::scenarios;
+
+        // A key read from a file: write valid base64 to a temp path the File
+        // source then points at. The tempdir lives for the whole table.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("test-key");
+        std::fs::write(&file_path, encode_key(&make_test_key(2))).expect("write");
+
+        scenarios!(
+            run = |source: KeySource| {
+                let key_map = HashMap::from([("key".to_string(), source)]);
+                IntegratedKmsProvider::from_config(&key_map)
+                    .map(|p| p.can_decrypt_kek("key"))
+                    // KmsError isn't PartialEq; the failing rows assert only that
+                    // malformed material is rejected, so carry the message as a String.
+                    .map_err(|e| e.to_string())
+            };
+            "a valid key loads from any source" {
+                KeySource::File { file: file_path } => Yields(true),
+                KeySource::Value { value: encode_key(&make_test_key(3)) } => Yields(true),
+            }
+            "malformed key material is rejected" {
+                // Not valid base64.
+                KeySource::Value { value: "not-valid-base64!!!".to_string() } => Fails,
+                // Valid base64, but only 16 bytes — not a 256-bit key.
+                KeySource::Value { value: BASE64.encode([0u8; 16]) } => Fails,
+            }
+        );
+    }
+
+    // Verifies that from_config loads keys from env vars. Kept separate from the
+    // key-source table because it mutates process-wide environment and so must
+    // run serially.
     #[test]
     #[serial]
     fn from_config_env_source() {
@@ -251,73 +289,12 @@ mod tests {
         unsafe { std::env::remove_var("TEST_KMS_KEY_1") };
     }
 
-    // Verifies that from_config loads keys from files.
-    #[test]
-    fn from_config_file_source() {
-        let key = make_test_key(2);
-        let dir = tempfile::tempdir().expect("tempdir");
-        let file_path = dir.path().join("test-key");
-        std::fs::write(&file_path, encode_key(&key)).expect("write");
-
-        let mut key_map = HashMap::new();
-        key_map.insert("file-key".to_string(), KeySource::File { file: file_path });
-
-        let provider = IntegratedKmsProvider::from_config(&key_map).expect("from_config");
-        assert!(provider.can_decrypt_kek("file-key"));
-    }
-
-    // Verifies that from_config loads inline base64 values.
-    #[test]
-    fn from_config_value_source() {
-        let key = make_test_key(3);
-        let mut key_map = HashMap::new();
-        key_map.insert(
-            "inline-key".to_string(),
-            KeySource::Value {
-                value: encode_key(&key),
-            },
-        );
-
-        let provider = IntegratedKmsProvider::from_config(&key_map).expect("from_config");
-        assert!(provider.can_decrypt_kek("inline-key"));
-    }
-
-    // Verifies that from_config errors when no keys
-    // are provided.
+    // Verifies that from_config errors when no keys are provided. Kept separate
+    // from the key-source table: this exercises an empty map rather than a single
+    // source variant.
     #[test]
     fn from_config_empty_errors() {
         let result = IntegratedKmsProvider::from_config(&HashMap::new());
-        assert!(result.is_err());
-    }
-
-    // Verifies that from_config errors on invalid base64.
-    #[test]
-    fn from_config_invalid_base64_errors() {
-        let mut key_map = HashMap::new();
-        key_map.insert(
-            "bad-key".to_string(),
-            KeySource::Value {
-                value: "not-valid-base64!!!".to_string(),
-            },
-        );
-
-        let result = IntegratedKmsProvider::from_config(&key_map);
-        assert!(result.is_err());
-    }
-
-    // Verifies that from_config errors when a key
-    // is not 32 bytes.
-    #[test]
-    fn from_config_wrong_key_length_errors() {
-        let mut key_map = HashMap::new();
-        key_map.insert(
-            "short-key".to_string(),
-            KeySource::Value {
-                value: BASE64.encode([0u8; 16]),
-            },
-        );
-
-        let result = IntegratedKmsProvider::from_config(&key_map);
         assert!(result.is_err());
     }
 }

--- a/crates/rvs/Cargo.toml
+++ b/crates/rvs/Cargo.toml
@@ -54,5 +54,8 @@ tower-http = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/rvs/src/scenario/resolver.rs
+++ b/crates/rvs/src/scenario/resolver.rs
@@ -94,6 +94,8 @@ fn eval_sotpath<'a>(sot: &'a RackFirmwareData, sotpath: &str) -> Result<&'a str,
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
     use serde_json::json;
 
     use super::*;
@@ -121,87 +123,125 @@ mod tests {
         }
     }
 
-    // --- eval_sotpath ---
-
     #[test]
-    fn eval_sotpath_returns_first_string_match() {
-        let sot = make_sot(json!({ "firmware": { "url": "https://cdn.example.com/fw.bin" } }));
-        let url = eval_sotpath(&sot, "$.firmware.url").unwrap();
-        assert_eq!(url, "https://cdn.example.com/fw.bin");
-    }
+    fn eval_sotpath_resolves_to_the_first_matching_string() {
+        /// A SOT config paired with the JSONPath to evaluate against it.
+        struct Query {
+            config: serde_json::Value,
+            sotpath: &'static str,
+        }
 
-    #[test]
-    fn eval_sotpath_no_match_is_error() {
-        let sot = make_sot(json!({ "firmware": {} }));
-        let err = eval_sotpath(&sot, "$.firmware.url").unwrap_err();
-        assert!(err.to_string().contains("matched nothing"), "got: {err}");
-    }
-
-    #[test]
-    fn eval_sotpath_non_string_match_is_error() {
-        let sot = make_sot(json!({ "firmware": { "version": 42 } }));
-        let err = eval_sotpath(&sot, "$.firmware.version").unwrap_err();
-        assert!(
-            err.to_string().contains("did not resolve to a string"),
-            "got: {err}"
+        scenarios!(
+            run = |Query { config, sotpath }: Query| {
+                // The match borrows `sot`, so resolve it to an owned String here.
+                // RvsError isn't PartialEq; the failing rows assert only that the
+                // path does not resolve, so carry the message as a String too.
+                eval_sotpath(&make_sot(config), sotpath)
+                    .map(str::to_string)
+                    .map_err(|e| e.to_string())
+            };
+            "a string match resolves to its value" {
+                Query {
+                    config: json!({ "firmware": { "url": "https://cdn.example.com/fw.bin" } }),
+                    sotpath: "$.firmware.url",
+                } => Yields("https://cdn.example.com/fw.bin".to_string()),
+            }
+            "a path matching nothing is an error" {
+                Query { config: json!({ "firmware": {} }), sotpath: "$.firmware.url" } => Fails,
+            }
+            "a non-string match is an error" {
+                Query {
+                    config: json!({ "firmware": { "version": 42 } }),
+                    sotpath: "$.firmware.version",
+                } => Fails,
+            }
         );
     }
 
-    // --- resolve_for_scenario ---
-
     #[test]
-    fn resolve_for_scenario_os_image_only() {
-        let sot = make_sot(json!({}));
-        let scenario = make_scenario("gb200nvl", "1.2.5");
-        let downloads = resolve_for_scenario(&sot, &scenario, "/cache").unwrap();
-        assert_eq!(downloads.len(), 1);
-        assert_eq!(downloads[0].output_path, "/cache/gb200nvl/1.2.5/os");
-        assert_eq!(downloads[0].url, "https://example.com/os.img");
-    }
+    fn resolve_for_scenario_collects_os_image_and_artifacts() {
+        /// A SOT config and the single artifact (if any) to resolve alongside the
+        /// always-present OS image.
+        struct Case {
+            config: serde_json::Value,
+            artifact: Option<super::super::Artifact>,
+        }
 
-    #[test]
-    fn resolve_for_scenario_direct_uri_artifact() {
-        let sot = make_sot(json!({}));
-        let mut scenario = make_scenario("gb200nvl", "1.2.5");
-        scenario.artifacts.push(super::super::Artifact {
-            name: "diag".to_string(),
-            output: "diag.bin".parse().unwrap(),
-            uri: Some("https://example.com/diag.bin".to_string()),
-            sotpath: None,
-        });
-        let downloads = resolve_for_scenario(&sot, &scenario, "/cache").unwrap();
-        assert_eq!(downloads.len(), 2);
-        assert_eq!(downloads[1].output_path, "/cache/gb200nvl/1.2.5/diag.bin");
-        assert_eq!(downloads[1].url, "https://example.com/diag.bin");
-    }
-
-    #[test]
-    fn resolve_for_scenario_sotpath_artifact() {
-        let sot = make_sot(json!({ "packages": { "diag": "https://cdn.example.com/diag.bin" } }));
-        let mut scenario = make_scenario("gb200nvl", "1.2.5");
-        scenario.artifacts.push(super::super::Artifact {
-            name: "diag".to_string(),
-            output: "diag.bin".parse().unwrap(),
-            uri: None,
-            sotpath: Some("$.packages.diag".to_string()),
-        });
-        let downloads = resolve_for_scenario(&sot, &scenario, "/cache").unwrap();
-        assert_eq!(downloads.len(), 2);
-        assert_eq!(downloads[1].output_path, "/cache/gb200nvl/1.2.5/diag.bin");
-        assert_eq!(downloads[1].url, "https://cdn.example.com/diag.bin");
-    }
-
-    #[test]
-    fn resolve_for_scenario_sotpath_missing_is_error() {
-        let sot = make_sot(json!({}));
-        let mut scenario = make_scenario("gb200nvl", "1.2.5");
-        scenario.artifacts.push(super::super::Artifact {
-            name: "diag".to_string(),
-            output: "diag.bin".parse().unwrap(),
-            uri: None,
-            sotpath: Some("$.packages.diag".to_string()),
-        });
-        let err = resolve_for_scenario(&sot, &scenario, "/cache").unwrap_err();
-        assert!(err.to_string().contains("matched nothing"), "got: {err}");
+        // The OS image is always the first download; any artifact follows. Each
+        // success row pins the full (output_path, url) list the resolution yields.
+        scenarios!(
+            run = |Case { config, artifact }: Case| {
+                let sot = make_sot(config);
+                let mut scenario = make_scenario("gb200nvl", "1.2.5");
+                scenario.artifacts.extend(artifact);
+                resolve_for_scenario(&sot, &scenario, "/cache")
+                    .map(|downloads| {
+                        downloads
+                            .into_iter()
+                            .map(|d| (d.output_path, d.url.to_string()))
+                            .collect::<Vec<_>>()
+                    })
+                    // RvsError isn't PartialEq; the failing row asserts only that
+                    // an unresolvable sotpath fails, so carry the message as a String.
+                    .map_err(|e| e.to_string())
+            };
+            "the OS image alone is resolved when there are no artifacts" {
+                Case { config: json!({}), artifact: None } => Yields(vec![(
+                    "/cache/gb200nvl/1.2.5/os".to_string(),
+                    "https://example.com/os.img".to_string(),
+                )]),
+            }
+            "a direct-URI artifact follows the OS image" {
+                Case {
+                    config: json!({}),
+                    artifact: Some(super::super::Artifact {
+                        name: "diag".to_string(),
+                        output: "diag.bin".parse().unwrap(),
+                        uri: Some("https://example.com/diag.bin".to_string()),
+                        sotpath: None,
+                    }),
+                } => Yields(vec![
+                    (
+                        "/cache/gb200nvl/1.2.5/os".to_string(),
+                        "https://example.com/os.img".to_string(),
+                    ),
+                    (
+                        "/cache/gb200nvl/1.2.5/diag.bin".to_string(),
+                        "https://example.com/diag.bin".to_string(),
+                    ),
+                ]),
+            }
+            "a SOT-resolved artifact follows the OS image" {
+                Case {
+                    config: json!({ "packages": { "diag": "https://cdn.example.com/diag.bin" } }),
+                    artifact: Some(super::super::Artifact {
+                        name: "diag".to_string(),
+                        output: "diag.bin".parse().unwrap(),
+                        uri: None,
+                        sotpath: Some("$.packages.diag".to_string()),
+                    }),
+                } => Yields(vec![
+                    (
+                        "/cache/gb200nvl/1.2.5/os".to_string(),
+                        "https://example.com/os.img".to_string(),
+                    ),
+                    (
+                        "/cache/gb200nvl/1.2.5/diag.bin".to_string(),
+                        "https://cdn.example.com/diag.bin".to_string(),
+                    ),
+                ]),
+            }
+            "a SOT-resolved artifact whose path matches nothing is an error" {
+                Case {
+                    config: json!({}),
+                    artifact: Some(super::super::Artifact {
+                        name: "diag".to_string(),
+                        output: "diag.bin".parse().unwrap(),
+                        uri: None,
+                        sotpath: Some("$.packages.diag".to_string()),
+                    }),
+                } => Fails,
+            }
+        );
     }
 }


### PR DESCRIPTION
Wave 2 of the carbide-test-support integration (#2692) -- the small-crate bundle.

Five crates each proved a single parser/serde mapping one `#[test]` per case; each folds into one table over a named row:
- `carbide-dns`: gRPC-code → DNS-response-code classifier, extended to the full 17-variant `tonic::Code` set.
- `bms-dsx-exchange`: metadata-topic parsing over a `Message { topic, payload }` row.
- `carbide-dsx-exchange-consumer`: point-path extraction + `FaultValue` serde, plus new `LeakPointType` probe-id/description tables.
- `carbide-kms-provider`: config-file key-source loader over a `KeySource` row.
- `carbide-rvs`: `eval_sotpath` + `resolve_for_scenario` (now asserting the full `(output_path, url)` vec).

Errors compare as `Fails` (these error types aren't `PartialEq`); env-mutating and different-shape tests stay separate. Adds the dev-dep to the four crates that lacked it. No production change. Verified: `--lib` tests pass in all five, `clippy --locked --all-targets --all-features` clean, nightly rustfmt clean.

Addresses #2731.
