### PR TITLE
change(api): add dual-stack FNN allocation and IPv6 static-assignment support

### DIFF
--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -202,9 +202,9 @@ pub async fn create_initial_vpcs(
 
 /// Create the static-assignments anchor segment if it doesn't exist.
 /// This segment holds external static IP assignments that don't fall
-/// within any managed network prefix. The 169.254.254.254/32 prefix is
-/// a link-local placeholder -- the allocator will never hand out IPs
-/// from it, it exists only because the schema requires a prefix.
+/// within any managed network prefix. The placeholder prefixes are never
+/// handed out by the allocator; they exist because the schema requires
+/// segment prefixes and because static assignments can be IPv4 or IPv6.
 pub async fn ensure_static_assignments_segment(
     api: &Api,
     txn: &mut db::Transaction<'_>,
@@ -224,12 +224,20 @@ pub async fn ensure_static_assignments_segment(
         subdomain_id,
         vpc_id: None,
         mtu: 1500,
-        prefixes: vec![NewNetworkPrefix {
-            prefix: "169.254.254.254/32".parse().unwrap(),
-            gateway: None,
-            dhcpv6_link_address: None,
-            num_reserved: 1,
-        }],
+        prefixes: vec![
+            NewNetworkPrefix {
+                prefix: "169.254.254.254/32".parse().unwrap(),
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 1,
+            },
+            NewNetworkPrefix {
+                prefix: "100::/128".parse().unwrap(),
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 1,
+            },
+        ],
         vlan_id: None,
         vni: None,
         segment_type: NetworkSegmentType::Underlay,
@@ -288,8 +296,9 @@ pub async fn update_network_segments_svi_ip(db_pool: &Pool<Postgres>) -> Result<
             continue;
         }
 
-        // Already SVI IP is allocated.
-        if segment.prefixes.iter().any(|x| x.svi_ip.is_some()) {
+        // Already SVI IP is allocated for every prefix. Prefixless segments
+        // still fall through so allocate_svi_ip reports the invalid state.
+        if !segment.prefixes.is_empty() && segment.prefixes.iter().all(|x| x.svi_ip.is_some()) {
             continue;
         }
 

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -42,7 +42,7 @@ use model::network_segment::{
 };
 use model::resource_pool::common::VLANID;
 use model::resource_pool::{ResourcePool, ResourcePoolStats, ValueType};
-use model::vpc::{UpdateVpcVirtualization, VpcDefinition};
+use model::vpc::{NewVpc, UpdateVpcVirtualization, VpcDefinition, VpcStatus};
 use prometheus_text_parser::ParsedPrometheusMetrics;
 use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
@@ -56,6 +56,70 @@ use crate::tests::common::api_fixtures::{
     get_vpc_fixture_id,
 };
 use crate::tests::common::rpc_builder::VpcCreationRequest;
+
+/// Creates a VPC with one stretchable segment for direct SVI allocation tests.
+async fn create_stretchable_segment_for_svi_test(
+    txn: &mut sqlx::PgTransaction<'_>,
+    name: &str,
+    prefixes: Vec<NewNetworkPrefix>,
+) -> Result<(VpcId, NetworkSegmentId), db::DatabaseError> {
+    create_stretchable_segment_for_svi_test_with_vpc_type(
+        txn,
+        name,
+        VpcVirtualizationType::Flat,
+        prefixes,
+    )
+    .await
+}
+
+async fn create_stretchable_segment_for_svi_test_with_vpc_type(
+    txn: &mut sqlx::PgTransaction<'_>,
+    name: &str,
+    network_virtualization_type: VpcVirtualizationType,
+    prefixes: Vec<NewNetworkPrefix>,
+) -> Result<(VpcId, NetworkSegmentId), db::DatabaseError> {
+    // Seed a VPC that can be updated through the same DB path used by handlers.
+    let vpc_id = uuid::Uuid::new_v4().into();
+    db::vpc::persist(
+        NewVpc {
+            id: vpc_id,
+            tenant_organization_id: "tenant".to_string(),
+            network_virtualization_type,
+            metadata: model::metadata::Metadata {
+                name: format!("{name}-vpc"),
+                ..Default::default()
+            },
+            network_security_group_id: None,
+            routing_profile_type: None,
+            vni: None,
+        },
+        VpcStatus { vni: None },
+        txn.as_mut(),
+    )
+    .await?;
+
+    // Attach a stretchable segment whose prefixes should receive SVI IPs.
+    let segment = db::network_segment::persist(
+        NewNetworkSegment {
+            id: uuid::Uuid::new_v4().into(),
+            name: name.to_string(),
+            subdomain_id: None,
+            vpc_id: Some(vpc_id),
+            mtu: 1500,
+            prefixes,
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::Admin,
+            can_stretch: Some(true),
+            allocation_strategy: Default::default(),
+        },
+        txn.as_mut(),
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+
+    Ok((vpc_id, segment.id))
+}
 
 #[crate::sqlx_test]
 async fn test_advance_network_prefix_state(
@@ -1152,6 +1216,194 @@ async fn test_update_svi_ip(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
             assert!(prefix.svi_ip.is_some());
         }
     }
+
+    Ok(())
+}
+
+/// Verifies that converting a VPC to FNN allocates SVI IPs for every prefix
+/// on a dual-stack segment, not just the IPv4 prefix.
+#[crate::sqlx_test]
+async fn test_update_svi_ip_dual_stack_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+    let (vpc_id, segment_id) = create_stretchable_segment_for_svi_test(
+        &mut txn,
+        "dual-stack-svi",
+        vec![
+            NewNetworkPrefix {
+                prefix: "198.18.40.0/24".parse().unwrap(),
+                gateway: Some("198.18.40.1".parse().unwrap()),
+                dhcpv6_link_address: None,
+                num_reserved: 3,
+            },
+            NewNetworkPrefix {
+                prefix: "2001:db8:4040::/64".parse().unwrap(),
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 3,
+            },
+        ],
+    )
+    .await?;
+
+    // Update virtualization through the DB path that refreshes SVI IPs.
+    let update_request = UpdateVpcVirtualization {
+        id: vpc_id,
+        if_version_match: None,
+        network_virtualization_type: VpcVirtualizationType::Fnn,
+    };
+    db::vpc::update_virtualization(&update_request, &mut txn).await?;
+    txn.commit().await?;
+
+    // Re-read the segment to verify both prefix families persisted SVI IPs.
+    let mut txn = pool.begin().await?;
+    let mut segments = db::network_segment::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
+        network_segment::NetworkSegmentSearchConfig::default(),
+    )
+    .await?;
+    let segment = segments.remove(0);
+    assert_eq!(segment.prefixes.len(), 2);
+    assert!(
+        segment
+            .prefixes
+            .iter()
+            .any(|prefix| prefix.prefix.is_ipv4() && prefix.svi_ip.is_some())
+    );
+    assert!(
+        segment
+            .prefixes
+            .iter()
+            .any(|prefix| prefix.prefix.is_ipv6() && prefix.svi_ip.is_some())
+    );
+
+    Ok(())
+}
+
+/// Verifies that startup SVI backfill repairs partially populated dual-stack
+/// segments instead of skipping them when one prefix already has an SVI IP.
+#[crate::sqlx_test]
+async fn test_update_network_segments_svi_ip_backfills_partial_dual_stack_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+    // Create the segment as FNN up front so this test covers the startup
+    // backfill path, not the VPC virtualization update path.
+    let (_vpc_id, segment_id) = create_stretchable_segment_for_svi_test_with_vpc_type(
+        &mut txn,
+        "partial-dual-stack-svi",
+        VpcVirtualizationType::Fnn,
+        vec![
+            NewNetworkPrefix {
+                prefix: "198.18.42.0/24".parse().unwrap(),
+                gateway: Some("198.18.42.1".parse().unwrap()),
+                dhcpv6_link_address: None,
+                num_reserved: 3,
+            },
+            NewNetworkPrefix {
+                prefix: "2001:db8:4042::/64".parse().unwrap(),
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 3,
+            },
+        ],
+    )
+    .await?;
+
+    let mut segments = db::network_segment::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
+        network_segment::NetworkSegmentSearchConfig::default(),
+    )
+    .await?;
+    let segment = segments.remove(0);
+    let ipv4_prefix = segment
+        .prefixes
+        .iter()
+        .find(|prefix| prefix.prefix.is_ipv4())
+        .unwrap();
+    // Seed the partial state produced by older dual-stack behavior: IPv4 has
+    // an SVI, while the IPv6 prefix still needs to be backfilled on startup.
+    let ipv4_svi_ip = "198.18.42.2".parse().unwrap();
+    db::network_prefix::set_svi_ip(txn.as_mut(), ipv4_prefix.id, &ipv4_svi_ip).await?;
+    txn.commit().await?;
+
+    // This used to skip the segment because any prefix already had an SVI.
+    // The desired behavior is to allocate SVI addresses for missing prefixes.
+    db_init::update_network_segments_svi_ip(&pool).await?;
+
+    let mut txn = pool.begin().await?;
+    let mut segments = db::network_segment::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
+        network_segment::NetworkSegmentSearchConfig::default(),
+    )
+    .await?;
+    let segment = segments.remove(0);
+    txn.rollback().await?;
+
+    let ipv4_prefix = segment
+        .prefixes
+        .iter()
+        .find(|prefix| prefix.prefix.is_ipv4())
+        .unwrap();
+    let ipv6_prefix = segment
+        .prefixes
+        .iter()
+        .find(|prefix| prefix.prefix.is_ipv6())
+        .unwrap();
+    assert_eq!(ipv4_prefix.svi_ip, Some(ipv4_svi_ip));
+    // The IPv6 SVI is the third address in the IPv6 prefix, matching the
+    // normal SVI allocation rule used for both address families.
+    assert_eq!(ipv6_prefix.svi_ip.unwrap().to_string(), "2001:db8:4042::2");
+
+    Ok(())
+}
+
+/// Verifies that the FNN SVI allocation path supports IPv6-only segments.
+///
+/// This protects against reintroducing the old requirement that every
+/// stretchable segment must have an IPv4 prefix before SVI allocation.
+#[crate::sqlx_test]
+async fn test_update_svi_ip_ipv6_only_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+    let (vpc_id, segment_id) = create_stretchable_segment_for_svi_test(
+        &mut txn,
+        "ipv6-only-svi",
+        vec![NewNetworkPrefix {
+            prefix: "2001:db8:4041::/64".parse().unwrap(),
+            gateway: None,
+            dhcpv6_link_address: None,
+            num_reserved: 3,
+        }],
+    )
+    .await?;
+
+    // Update virtualization; the old IPv4 precheck rejected this segment.
+    let update_request = UpdateVpcVirtualization {
+        id: vpc_id,
+        if_version_match: None,
+        network_virtualization_type: VpcVirtualizationType::Fnn,
+    };
+    db::vpc::update_virtualization(&update_request, &mut txn).await?;
+    txn.commit().await?;
+
+    // Re-read the segment to verify the IPv6 SVI IP persisted.
+    let mut txn = pool.begin().await?;
+    let mut segments = db::network_segment::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::network_segment::IdColumn, &segment_id),
+        network_segment::NetworkSegmentSearchConfig::default(),
+    )
+    .await?;
+    let segment = segments.remove(0);
+    assert_eq!(segment.prefixes.len(), 1);
+    assert!(segment.prefixes[0].prefix.is_ipv6());
+    assert!(segment.prefixes[0].svi_ip.is_some());
 
     Ok(())
 }

--- a/crates/api-core/src/tests/static_address_management.rs
+++ b/crates/api-core/src/tests/static_address_management.rs
@@ -513,6 +513,71 @@ async fn test_assign_external_ip_moves_to_static_assignments(
     Ok(())
 }
 
+/// Verifies that an external static IPv6 assignment moves the interface to the
+/// static-assignments segment and that the anchor segment is dual-stack.
+///
+/// This covers the IPv6 counterpart to external static IPv4 assignment: static
+/// addresses outside managed prefixes must still land on the durable
+/// static-assignment topology.
+#[crate::sqlx_test]
+async fn test_assign_external_ipv6_moves_to_dual_stack_static_assignments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let relay: IpAddr = FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap();
+
+    // Create an addressless interface that can safely receive a static IPv6 assignment.
+    let mut txn = env.pool.begin().await?;
+    let interface = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:2a").unwrap(),
+        std::slice::from_ref(&relay),
+        None,
+        None,
+    )
+    .await?;
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    txn.commit().await?;
+
+    // Assign an external IPv6 address that is outside managed network prefixes.
+    let requested_ipv6_address: IpAddr = "2001:db8:ffff::100".parse().unwrap();
+    env.api
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface.id),
+            ip_address: requested_ipv6_address.to_string(),
+        }))
+        .await?;
+
+    // Re-read the interface and static segment to verify the durable topology.
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(&mut *txn, interface.id).await?;
+    let static_seg = db::network_segment::static_assignments(&mut txn).await?;
+    assert_eq!(
+        updated.segment_id, static_seg.id,
+        "interface should have moved to the static-assignments segment"
+    );
+    assert!(
+        updated.addresses.contains(&requested_ipv6_address),
+        "interface should carry the assigned IPv6 address"
+    );
+    assert!(
+        static_seg
+            .prefixes
+            .iter()
+            .any(|prefix| prefix.prefix.is_ipv4()),
+        "static-assignments should keep its IPv4 placeholder"
+    );
+    assert!(
+        static_seg
+            .prefixes
+            .iter()
+            .any(|prefix| prefix.prefix.is_ipv6()),
+        "static-assignments should include an IPv6 placeholder"
+    );
+
+    Ok(())
+}
+
 /// When assigning a static IP within the interface's current segment,
 /// the segment_id should not change.
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -693,6 +693,55 @@ async fn test_vpc_prefix_rpc_status_includes_lifecycle_and_counters(
     Ok(())
 }
 
+/// Verifies that large IPv6 VPC prefixes report saturated linknet counters.
+///
+/// A /48 contains 2^79 /127 linknets, which does not fit in the u64 RPC/status
+/// fields. The DB layer should cap these display counters at u64::MAX and
+/// persist that value through the public API instead of overflowing or
+/// attempting to enumerate the linknets.
+#[crate::sqlx_test]
+async fn test_ipv6_vpc_prefix_linknet_counters_cap_large_prefix(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Extend the test fabric with IPv6 so the VPC-prefix validator accepts the /48.
+    let mut site_prefixes = TEST_SITE_PREFIXES.clone();
+    site_prefixes.push("2001:db8::/32".parse().unwrap());
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            site_prefixes: Some(site_prefixes),
+            create_network_segments: Some(false),
+            ..Default::default()
+        },
+    )
+    .await;
+    let (_, vpc) = api_fixtures::vpc::create_flat_vpc(
+        &env,
+        "flat-large-v6".to_string(),
+        Some("2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string()),
+    )
+    .await;
+    let vpc_id = vpc.id.expect("flat VPC should include an id");
+
+    // Create a large IPv6 prefix whose /127 linknet count exceeds u64.
+    let created = create_vpc_prefix(&env, vpc_id, "2001:db8:1000::/48").await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    assert_status_with_lifecycle_and_linknet_counters(&created, "provisioning", u64::MAX, u64::MAX);
+
+    // Re-read through the public API to verify the capped counters persisted.
+    let persisted = find_vpc_prefix(&env, id)
+        .await
+        .expect("VPC prefix should be visible through the public get API");
+    assert_status_with_lifecycle_and_linknet_counters(
+        &persisted,
+        "provisioning",
+        u64::MAX,
+        u64::MAX,
+    );
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 async fn test_overlapping_vpc_prefixes(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;

--- a/crates/api-db/migrations/20260617120000_static_assignments_ipv6_placeholder.sql
+++ b/crates/api-db/migrations/20260617120000_static_assignments_ipv6_placeholder.sql
@@ -1,0 +1,8 @@
+-- Add an IPv6 placeholder prefix to the static-assignments anchor segment.
+-- The segment is Reserved, so the DHCP allocator never hands this address out;
+-- it only lets external static IPv6 assignments sit on a dual-family segment.
+INSERT INTO network_prefixes (segment_id, prefix, gateway, dhcpv6_link_address, num_reserved)
+SELECT id, '100::/128'::cidr, NULL::inet, NULL::inet, 1
+FROM network_segments
+WHERE name = 'static-assignments'
+ON CONFLICT DO NOTHING;

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -44,7 +44,7 @@ use sqlx::{FromRow, PgConnection, PgTransaction};
 use super::{ColumnInfo, FilterableQueryBuilder, ObjectColumnFilter};
 use crate::db_read::DbReader;
 use crate::host_naming::{self, NamingContext};
-use crate::ip_allocator::{IpAllocator, UsedIpResolver};
+use crate::ip_allocator::{DhcpError, IpAllocator, UsedIpResolver};
 use crate::machine_interface_address::{AddressAlreadyInUseError, MachineInterfaceAddressWithType};
 use crate::{DatabaseError, DatabaseResult, Transaction, network_segment as db_network_segment};
 
@@ -835,10 +835,18 @@ async fn create_fast_path(
         for _ in 0..FAST_PATH_MAX_RETRIES {
             let mut fast_txn = Transaction::begin_inner(txn).await?;
 
-            // Make sure we're mutually exclusive with the slow path: a shared lock means many fast-path
-            // allocations can happen concurrently, but the slow path will hold this exclusively
-            // (waiting on any shared locks to complete)
-            lock_network_segment_shared(&mut fast_txn, segment).await?;
+            // Keep IPv4-only allocation concurrent, but serialize any segment
+            // containing IPv6 because the Rust allocator reads used addresses
+            // without taking per-IP candidate locks.
+            if segment
+                .prefixes
+                .iter()
+                .any(|prefix| prefix.prefix.is_ipv6())
+            {
+                lock_network_segment_exclusive(&mut fast_txn, segment).await?;
+            } else {
+                lock_network_segment_shared(&mut fast_txn, segment).await?;
+            }
 
             let segment_exhausted = match try_create_fast_path(
                 &mut fast_txn,
@@ -1060,17 +1068,97 @@ async fn try_create_fast_path(
 }
 
 /// Allocate one IP address from each prefix in the segment.
-/// For dual-stack segments this means one IPv4 and one IPv6 address.
+///
+/// For dual-stack segments this means one IPv4 and one IPv6 address. Callers
+/// must already hold the segment's exclusive lock when the segment contains
+/// IPv6 prefixes.
 async fn allocate_addresses_from_segment(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
 ) -> DatabaseResult<Vec<IpAddr>> {
     let mut addresses = Vec::with_capacity(segment.prefixes.len());
     for prefix in &segment.prefixes {
-        let address = allocate_next_ip_with_retry(txn, segment, prefix).await?;
-        addresses.push(address);
+        if prefix.prefix.is_ipv6() {
+            // Use a single-prefix segment view so v6 allocation cannot consume
+            // or reason about unrelated prefixes on a dual-stack segment.
+            let single_prefix_segment = NetworkSegment {
+                prefixes: vec![prefix.clone()],
+                ..segment.clone()
+            };
+            addresses
+                .extend(allocate_v6_addresses_via_ip_allocator(txn, &single_prefix_segment).await?);
+        } else {
+            // IPv4 stays on the SQL fast path for its existing concurrency and
+            // allocation-order behavior.
+            let address = allocate_next_ip_with_retry(txn, segment, prefix).await?;
+            addresses.push(address);
+        }
     }
     Ok(addresses)
+}
+
+/// Allocates IPv6 DHCP addresses using the Rust `IpAllocator`.
+///
+/// The caller must hold the segment's exclusive advisory lock because
+/// `IpAllocator` reads the used-address set instead of taking per-IP advisory
+/// locks for each candidate.
+async fn allocate_v6_addresses_via_ip_allocator(
+    txn: &mut PgTransaction<'_>,
+    segment: &NetworkSegment,
+) -> DatabaseResult<Vec<IpAddr>> {
+    // Collect SVI IPs so the allocator treats those addresses as unavailable.
+    let reserved_ips = segment
+        .prefixes
+        .iter()
+        .filter_map(|prefix| prefix.svi_ip)
+        .collect();
+
+    let dhcp_handler: Box<dyn UsedIpResolver<PgConnection> + Send> =
+        Box::new(UsedAdminNetworkIpResolver {
+            segment_id: segment.id,
+            busy_ips: reserved_ips,
+        });
+
+    // Limit the allocator input to IPv6 prefixes; IPv4 remains on the SQL fast
+    // path even when the original segment is dual-stack.
+    let ipv6_segment = NetworkSegment {
+        prefixes: segment
+            .prefixes
+            .iter()
+            .filter(|prefix| prefix.prefix.is_ipv6())
+            .cloned()
+            .collect(),
+        ..segment.clone()
+    };
+
+    let allocator = IpAllocator::new(
+        txn.as_mut(),
+        &ipv6_segment,
+        dhcp_handler,
+        AddressSelectionStrategy::NextAvailableIp,
+    )
+    .await?;
+
+    let mut allocated_addresses = Vec::with_capacity(ipv6_segment.prefixes.len());
+    for (prefix_id, maybe_address) in allocator {
+        let address = match maybe_address {
+            Ok(address) => address,
+            Err(DatabaseError::DhcpError(DhcpError::PrefixExhausted(_))) => {
+                let prefix = ipv6_segment
+                    .prefixes
+                    .iter()
+                    .find(|prefix| prefix.id == prefix_id)
+                    .map_or_else(|| prefix_id.to_string(), |prefix| prefix.prefix.to_string());
+                return Err(DatabaseError::ResourceExhausted(format!(
+                    "No IP addresses left in prefix {prefix}"
+                )));
+            }
+            Err(err) => return Err(err),
+        };
+        allocated_addresses.push(address.ip());
+    }
+
+    Ok(allocated_addresses)
 }
 
 /// Create the actual machine interface once we know what addresses we want.
@@ -1146,16 +1234,22 @@ async fn allocate_next_ip_with_retry(
     segment: &NetworkSegment,
     prefix: &NetworkPrefix,
 ) -> DatabaseResult<IpAddr> {
+    // The SQL fast path is IPv4-only. IPv6 host-space math needs the Rust
+    // allocator's u128 arithmetic instead of PostgreSQL int4 shifts.
+    if prefix.prefix.is_ipv6() {
+        return Err(DatabaseError::internal(format!(
+            "IPv6 prefix {} cannot use the SQL fast-path allocator",
+            prefix.prefix
+        )));
+    }
+
     let reserved = if prefix.gateway.is_none() {
         prefix.num_reserved.max(2)
     } else {
         prefix.num_reserved.max(1)
     };
 
-    let network_bit_width = match prefix.prefix {
-        IpNetwork::V4(_) => 32,
-        IpNetwork::V6(_) => 128,
-    };
+    let host_bits = 32 - prefix.prefix.prefix() as i32;
 
     for _ in 0..FAST_PATH_MAX_RETRIES {
         // Grab FAST_PATH_CANDIDATE_BATCH IP's at once
@@ -1172,7 +1266,7 @@ LIMIT $6;
     "#;
         let candidates = sqlx::query_scalar::<_, IpAddr>(query)
             .bind(prefix.prefix.ip())
-            .bind(network_bit_width - prefix.prefix.prefix() as i32)
+            .bind(host_bits)
             .bind(reserved)
             .bind(prefix.gateway)
             .bind(prefix.svi_ip)
@@ -2301,23 +2395,52 @@ pub async fn allocate_address_for_family(
     family: carbide_network::ip::IpAddressFamily,
 ) -> DatabaseResult<Vec<IpAddr>> {
     let mut fast_txn = Transaction::begin_inner(txn).await?;
-    lock_network_segment_shared(&mut fast_txn, segment).await?;
+    if family == IpAddressFamily::Ipv6 {
+        lock_network_segment_exclusive(&mut fast_txn, segment).await?;
+    } else {
+        lock_network_segment_shared(&mut fast_txn, segment).await?;
+    }
 
     let mut allocated_addresses = Vec::new();
-    for prefix in segment
-        .prefixes
-        .iter()
-        .filter(|p| p.prefix.is_address_family(family))
-    {
-        let address = allocate_next_ip_with_retry(&mut fast_txn, segment, prefix).await?;
-        allocated_addresses.push(address);
-        insert_machine_interface_address(
-            fast_txn.as_pgconn(),
-            &interface_id,
-            &address,
-            AllocationType::Dhcp,
-        )
-        .await?;
+    if family == IpAddressFamily::Ipv6 {
+        // Use a family-only segment view so lease recovery allocates exactly one
+        // address from each IPv6 prefix and does not disturb IPv4 ordering.
+        let ipv6_segment = NetworkSegment {
+            prefixes: segment
+                .prefixes
+                .iter()
+                .filter(|prefix| prefix.prefix.is_ipv6())
+                .cloned()
+                .collect(),
+            ..segment.clone()
+        };
+        allocated_addresses =
+            allocate_v6_addresses_via_ip_allocator(&mut fast_txn, &ipv6_segment).await?;
+        for address in &allocated_addresses {
+            insert_machine_interface_address(
+                fast_txn.as_pgconn(),
+                &interface_id,
+                address,
+                AllocationType::Dhcp,
+            )
+            .await?;
+        }
+    } else {
+        for prefix in segment
+            .prefixes
+            .iter()
+            .filter(|p| p.prefix.is_address_family(family))
+        {
+            let address = allocate_next_ip_with_retry(&mut fast_txn, segment, prefix).await?;
+            allocated_addresses.push(address);
+            insert_machine_interface_address(
+                fast_txn.as_pgconn(),
+                &interface_id,
+                &address,
+                AllocationType::Dhcp,
+            )
+            .await?;
+        }
     }
 
     fast_txn.commit().await?;

--- a/crates/api-db/src/machine_interface/ip_allocator.rs
+++ b/crates/api-db/src/machine_interface/ip_allocator.rs
@@ -17,6 +17,7 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 
+use carbide_network::ip::IpAddressFamily;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::dns::{Domain, NewDomain};
@@ -350,6 +351,259 @@ async fn test_machine_interface_create_dual_stack(
             "address {addr} was allocated to both interfaces"
         );
     }
+
+    Ok(())
+}
+
+/// Verifies that IPv6 single-address allocation works across representative
+/// prefix widths that the old SQL fast path could not enumerate correctly.
+///
+/// This exercises both initial DHCP allocation and family-specific reallocation
+/// so shifts around /64, /96, and wider prefixes stay IPv6-safe.
+#[crate::sqlx_test]
+async fn test_machine_interface_ipv6_allocation_shift_widths(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+
+    for (index, (name, prefix)) in [
+        ("IPV6-SHIFT-64", "2001:db8:6400::/64"),
+        ("IPV6-SHIFT-65", "2001:db8:6500::/65"),
+        ("IPV6-SHIFT-80", "2001:db8:8000::/80"),
+        ("IPV6-SHIFT-96", "2001:db8:9600::/96"),
+        ("IPV6-SHIFT-97", "2001:db8:9700::/97"),
+        ("IPV6-SHIFT-112", "2001:db8:1120::/112"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        // Create an IPv6-only segment for the representative prefix width.
+        let network_segment = db::network_segment::persist(
+            NewNetworkSegment {
+                name: name.to_string(),
+                subdomain_id: None,
+                vpc_id: None,
+                mtu: 1500,
+                prefixes: vec![NewNetworkPrefix {
+                    prefix: prefix.parse().unwrap(),
+                    gateway: None,
+                    dhcpv6_link_address: None,
+                    num_reserved: 2,
+                }],
+                vlan_id: None,
+                vni: None,
+                segment_type: NetworkSegmentType::Underlay,
+                id: uuid::Uuid::new_v4().into(),
+                can_stretch: None,
+                allocation_strategy: AllocationStrategy::Dynamic,
+            },
+            &mut txn,
+            NetworkSegmentControllerState::Ready,
+        )
+        .await?;
+
+        // Initial DHCP allocation should succeed through the IPv6 allocator.
+        let interface = db::machine_interface::create(
+            &mut txn,
+            std::slice::from_ref(&network_segment),
+            &MacAddress::from_str(&format!("aa:bb:cc:dd:40:{index:02x}")).unwrap(),
+            true,
+            AddressSelectionStrategy::NextAvailableIp,
+            None,
+        )
+        .await?;
+        assert_eq!(interface.addresses.len(), 1);
+        assert!(interface.addresses[0].is_ipv6());
+        assert!(
+            network_segment.prefixes[0]
+                .prefix
+                .contains(interface.addresses[0])
+        );
+
+        // Lease reallocation for the same family should use the same IPv6-safe path.
+        db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+        let allocated = db::machine_interface::allocate_address_for_family(
+            &mut txn,
+            interface.id,
+            &network_segment,
+            IpAddressFamily::Ipv6,
+        )
+        .await?;
+        assert_eq!(allocated.len(), 1);
+        assert!(allocated[0].is_ipv6());
+        assert!(network_segment.prefixes[0].prefix.contains(allocated[0]));
+    }
+
+    Ok(())
+}
+
+/// Verifies that IPv6 exhaustion on one candidate segment falls through to the
+/// next candidate segment instead of aborting allocation.
+///
+/// This protects the fast path from treating IPv6 PrefixExhausted differently
+/// than IPv4 ResourceExhausted when later segments still have capacity.
+#[crate::sqlx_test]
+async fn test_machine_interface_ipv6_exhausted_segment_falls_through(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+
+    // Create one exhausted IPv6 segment followed by one segment with capacity.
+    let exhausted_segment = db::network_segment::persist(
+        NewNetworkSegment {
+            name: "IPV6-EXHAUSTED-FIRST".to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: vec![NewNetworkPrefix {
+                prefix: "2001:db8:7100::/127".parse().unwrap(),
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 2,
+            }],
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::Underlay,
+            id: uuid::Uuid::new_v4().into(),
+            can_stretch: None,
+            allocation_strategy: AllocationStrategy::Dynamic,
+        },
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    let available_segment = db::network_segment::persist(
+        NewNetworkSegment {
+            name: "IPV6-AVAILABLE-SECOND".to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: vec![NewNetworkPrefix {
+                prefix: "2001:db8:7200::/126".parse().unwrap(),
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 2,
+            }],
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::Underlay,
+            id: uuid::Uuid::new_v4().into(),
+            can_stretch: None,
+            allocation_strategy: AllocationStrategy::Dynamic,
+        },
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+
+    // Allocate across both candidates; the exhausted first segment should not abort the request.
+    let interface = db::machine_interface::create(
+        &mut txn,
+        &[exhausted_segment, available_segment.clone()],
+        &MacAddress::from_str("aa:bb:cc:dd:41:00").unwrap(),
+        true,
+        AddressSelectionStrategy::NextAvailableIp,
+        None,
+    )
+    .await?;
+    assert_eq!(interface.segment_id, available_segment.id);
+    assert_eq!(interface.addresses.len(), 1);
+    assert!(
+        available_segment.prefixes[0]
+            .prefix
+            .contains(interface.addresses[0])
+    );
+    let interface_id = interface.id;
+    txn.commit().await?;
+
+    // Re-read the interface to verify the fallback segment persisted.
+    let mut txn = pool.begin().await?;
+    let persisted = db::machine_interface::find_one(txn.as_mut(), interface_id).await?;
+    assert_eq!(persisted.segment_id, available_segment.id);
+    assert!(persisted.addresses.iter().any(|address| address.is_ipv6()));
+
+    Ok(())
+}
+
+/// Verifies that DHCP reallocation can restore IPv4 and IPv6 independently on
+/// a dual-stack segment.
+///
+/// This covers the family-filtered allocation wrapper used when one address
+/// family must be refreshed without disturbing the other family.
+#[crate::sqlx_test]
+async fn test_allocate_address_for_family_dual_stack_round_trip(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+
+    // Create a dual-stack admin segment and allocate both families initially.
+    let network_segment = db::network_segment::persist(
+        NewNetworkSegment {
+            name: "DUAL-STACK-REALLOCATE".to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: vec![
+                NewNetworkPrefix {
+                    prefix: "10.88.1.0/24".parse().unwrap(),
+                    gateway: Some("10.88.1.1".parse().unwrap()),
+                    dhcpv6_link_address: None,
+                    num_reserved: 1,
+                },
+                NewNetworkPrefix {
+                    prefix: "2001:db8:8801::/64".parse().unwrap(),
+                    gateway: None,
+                    dhcpv6_link_address: None,
+                    num_reserved: 2,
+                },
+            ],
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::Underlay,
+            id: uuid::Uuid::new_v4().into(),
+            can_stretch: None,
+            allocation_strategy: AllocationStrategy::Dynamic,
+        },
+        &mut txn,
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    let interface = db::machine_interface::create(
+        &mut txn,
+        std::slice::from_ref(&network_segment),
+        &MacAddress::from_str("aa:bb:cc:dd:40:ff").unwrap(),
+        true,
+        AddressSelectionStrategy::NextAvailableIp,
+        None,
+    )
+    .await?;
+    assert_eq!(interface.addresses.len(), 2);
+
+    // Remove the leases, then recover each family independently.
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    let allocated_v4 = db::machine_interface::allocate_address_for_family(
+        &mut txn,
+        interface.id,
+        &network_segment,
+        IpAddressFamily::Ipv4,
+    )
+    .await?;
+    let allocated_v6 = db::machine_interface::allocate_address_for_family(
+        &mut txn,
+        interface.id,
+        &network_segment,
+        IpAddressFamily::Ipv6,
+    )
+    .await?;
+
+    // Re-read from the database to verify both family rows persisted.
+    let persisted = db::machine_interface::find_one(txn.as_mut(), interface.id).await?;
+    assert_eq!(allocated_v4.len(), 1);
+    assert_eq!(allocated_v6.len(), 1);
+    assert!(allocated_v4[0].is_ipv4());
+    assert!(allocated_v6[0].is_ipv6());
+    assert!(persisted.addresses.iter().any(|address| address.is_ipv4()));
+    assert!(persisted.addresses.iter().any(|address| address.is_ipv6()));
 
     Ok(())
 }

--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -404,14 +404,12 @@ pub async fn update_virtualization(
             continue;
         }
 
-        let Some(prefix) = network_segment.prefixes.iter().find(|x| x.prefix.is_ipv4()) else {
-            return Err(DatabaseError::internal(format!(
-                "NetworkSegment {} does not have Ipv4 Prefix attached.",
-                network_segment.id
-            )));
-        };
-
-        if prefix.svi_ip.is_none() {
+        if network_segment.prefixes.is_empty()
+            || network_segment
+                .prefixes
+                .iter()
+                .any(|prefix| prefix.svi_ip.is_none())
+        {
             // If we can't update SVI IP in any of these segment, we have to fail whole operation.
             crate::network_segment::allocate_svi_ip(&network_segment, txn).await?;
         }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3825,22 +3825,54 @@ message DhcpDiscovery {
   optional string circuit_id = 5;
   optional string remote_id = 6;
   optional string desired_address = 7;
+  // DHCP protocol family for this request.
+  // Omit only for legacy callers; the service infers the family from relay/link
+  // addresses. If present, ADDRESS_FAMILY_UNSPECIFIED is invalid.
+  // When either address_family or message_kind is present, both must be present,
+  // specified, and compatible.
   optional AddressFamily address_family = 8;
+  // DHCP message kind for this request.
+  // Omit only for legacy callers. If present, MESSAGE_KIND_UNSPECIFIED is invalid.
+  // ADDRESS_FAMILY_V4 is valid only with MESSAGE_KIND_V4_DISCOVER.
+  // ADDRESS_FAMILY_V6 is valid only with MESSAGE_KIND_V6_SOLICIT,
+  // MESSAGE_KIND_V6_REQUEST, or MESSAGE_KIND_V6_INFO_REQUEST.
+  // Mismatched pairs, such as ADDRESS_FAMILY_V4 with MESSAGE_KIND_V6_SOLICIT,
+  // are validation errors and must not be coerced.
   optional MessageKind message_kind = 9;
+  // DHCPv6 client DUID.
+  // Must be present and non-empty for DHCPv6 requests, including all V6
+  // MessageKind values and any request with ADDRESS_FAMILY_V6.
+  // Must be absent for DHCPv4 requests.
   optional bytes duid = 10;
 }
 
+// DHCP protocol family used to validate DhcpDiscovery.message_kind and duid.
+// Field absence means legacy inference; *_UNSPECIFIED means an explicit invalid
+// value and is rejected when supplied.
 enum AddressFamily {
+  // Invalid when explicitly supplied. Omit DhcpDiscovery.address_family instead
+  // when using legacy family inference.
   ADDRESS_FAMILY_UNSPECIFIED = 0;
+  // DHCPv4. Compatible only with MESSAGE_KIND_V4_DISCOVER and no DUID.
   ADDRESS_FAMILY_V4 = 1;
+  // DHCPv6. Compatible only with V6 MessageKind values and requires a DUID.
   ADDRESS_FAMILY_V6 = 2;
 }
 
+// DHCP message type used to validate DhcpDiscovery.address_family and duid.
+// Field absence means legacy behavior; *_UNSPECIFIED means an explicit invalid
+// value and is rejected when supplied.
 enum MessageKind {
+  // Invalid when explicitly supplied. Omit DhcpDiscovery.message_kind instead
+  // when using legacy behavior.
   MESSAGE_KIND_UNSPECIFIED = 0;
+  // DHCPv4 DISCOVER. Requires ADDRESS_FAMILY_V4 and forbids duid.
   MESSAGE_KIND_V4_DISCOVER = 1;
+  // DHCPv6 SOLICIT. Requires ADDRESS_FAMILY_V6 and a non-empty duid.
   MESSAGE_KIND_V6_SOLICIT = 2;
+  // DHCPv6 REQUEST. Requires ADDRESS_FAMILY_V6 and a non-empty duid.
   MESSAGE_KIND_V6_REQUEST = 3;
+  // DHCPv6 Information-request. Requires ADDRESS_FAMILY_V6 and a non-empty duid.
   MESSAGE_KIND_V6_INFO_REQUEST = 4;
 }
 
@@ -3887,7 +3919,13 @@ message DhcpRecord {
   // Per site NTP server IPs
   repeated string ntp_servers = 13;
 
+  // DHCPv6 preferred lifetime in seconds. Set only on IPv6 DHCP responses.
+  // When present, dhcpv6_valid_lifetime_secs must also be present and must be
+  // greater than or equal to this value.
   optional uint32 dhcpv6_preferred_lifetime_secs = 14;
+  // DHCPv6 valid lifetime in seconds. Set only on IPv6 DHCP responses.
+  // When both DHCPv6 lifetime fields are present, this value must be greater
+  // than or equal to dhcpv6_preferred_lifetime_secs.
   optional uint32 dhcpv6_valid_lifetime_secs = 15;
 }
 


### PR DESCRIPTION
<!-- Describe what this PR does -->

This PR continues the foundational work for V6 support.

Implements the dual-stack allocation milestone for FNN-related database paths. Dynamic IPv6 DHCP allocation now bypasses the IPv4 SQL fast path and uses the existing u128 Rust allocator under segment-level serialization, while IPv4 allocation keeps its current fast-path behavior.

Stretchable-segment SVI refresh no longer requires an IPv4 prefix and now relies on the per-prefix SVI allocator for dual-stack and IPv6-only segments. Static external IPv6 assignments are supported by seeding the reserved static-assignments segment with an IPv6 placeholder prefix.

  - v6 DHCP allocation is routed through the u128 Rust allocator under exclusive segment locking at initial create and lease-family reallocation paths.
  - the SQL fast path now rejects IPv6 defensively instead of hitting Postgres int4 shift behavior.
  - vpc.rs no longer hard-requires an IPv4 prefix before SVI refresh.
  - static assignments now seed and migrate a v6 placeholder.
  - large IPv6 VPC-prefix counters remain capped.

I think we can do a little work to let IPv6 allocation have a "fast path" as well, but I'm going to keep that for a separate PR.

Closes #2382.

## Related issues
<!-- Refer to existing GitHub issues here -->
https://github.com/NVIDIA/infra-controller/issues/2382

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

