### PR TITLE
feat(site-explorer): report Mellanox firmware from explored data

### DIFF
--- a/crates/admin-cli/src/site_explorer/mlx_devices/args.rs
+++ b/crates/admin-cli/src/site_explorer/mlx_devices/args.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List Mellanox/BlueField devices across all explored hosts:
+    $ nico-admin-cli site-explorer mlx-devices
+
+List the devices found under one host BMC:
+    $ nico-admin-cli site-explorer mlx-devices --host 192.0.2.20
+
+Find DPUs in NIC mode whose NIC firmware is below the desired version:
+    $ nico-admin-cli site-explorer mlx-devices --nic-mode-only --expected-version 32.42.1000
+
+")]
+pub struct Args {
+    #[clap(long, help = "Restrict to devices found under this host BMC IP")]
+    pub host: Option<String>,
+    #[clap(
+        long,
+        help = "Only BlueField-3 devices operating in NIC mode (part number 900-9D3B4)"
+    )]
+    pub nic_mode_only: bool,
+    #[clap(
+        long,
+        help = "Only devices whose NIC firmware is below this version (e.g. 32.42.1000)"
+    )]
+    pub expected_version: Option<String>,
+}

--- a/crates/admin-cli/src/site_explorer/mlx_devices/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/mlx_devices/cmd.rs
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::OutputFormat;
+use ::rpc::site_explorer::{
+    ExploredMlxDevice, GetExploredMlxDevicesRequest, MlxDeviceKind, NicMode,
+};
+use prettytable::{Row, Table};
+use serde::Serialize;
+
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+use crate::{async_write, async_write_table_as_csv};
+
+pub async fn mlx_devices(
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+    opts: Args,
+) -> CarbideCliResult<()> {
+    let nic_mode_only = opts.nic_mode_only;
+    let expected_version = opts.expected_version;
+
+    let devices: Vec<MlxDeviceRow> = api_client
+        .0
+        .get_explored_mlx_devices(GetExploredMlxDevicesRequest {
+            host_bmc_ip: opts.host,
+        })
+        .await?
+        .devices
+        .into_iter()
+        // Only NIC-mode DPUs, when asked.
+        .filter(|d| !nic_mode_only || d.device_kind == MlxDeviceKind::Bf3NicMode as i32)
+        // Only devices whose NIC firmware is below the desired version, when given
+        // one. A device with no firmware, or a version we can't parse, is surfaced
+        // rather than hidden.
+        .filter(|d| {
+            expected_version
+                .as_deref()
+                .is_none_or(|expected| firmware_below(d.firmware_version.as_deref(), expected))
+        })
+        .map(MlxDeviceRow::from)
+        .collect();
+
+    match output_format {
+        OutputFormat::Json => {
+            async_write!(output_file, "{}", serde_json::to_string_pretty(&devices)?)?;
+        }
+        OutputFormat::Yaml => {
+            async_write!(output_file, "{}", serde_yaml::to_string(&devices)?)?;
+        }
+        OutputFormat::Csv => {
+            async_write_table_as_csv!(output_file, build_table(&devices))?;
+        }
+        _ => {
+            async_write!(output_file, "{}", build_table(&devices))?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct MlxDeviceRow {
+    host_bmc_ip: String,
+    machine_id: Option<String>,
+    kind: String,
+    part_number: Option<String>,
+    serial_number: Option<String>,
+    firmware_version: Option<String>,
+    nic_mode: Option<String>,
+    dpu_bmc_ip: Option<String>,
+    pcie_id: Option<String>,
+    description: Option<String>,
+}
+
+impl From<ExploredMlxDevice> for MlxDeviceRow {
+    fn from(device: ExploredMlxDevice) -> Self {
+        MlxDeviceRow {
+            host_bmc_ip: device.host_bmc_ip,
+            machine_id: device.machine_id,
+            kind: kind_label(device.device_kind),
+            part_number: device.part_number,
+            serial_number: device.serial_number,
+            firmware_version: device.firmware_version,
+            nic_mode: nic_mode_label(device.nic_mode),
+            dpu_bmc_ip: device.dpu_bmc_ip,
+            pcie_id: device.pcie_id,
+            description: device.description,
+        }
+    }
+}
+
+fn kind_label(device_kind: i32) -> String {
+    match MlxDeviceKind::try_from(device_kind) {
+        Ok(MlxDeviceKind::Bf3NicMode) => "BlueField-3 (NIC mode)",
+        Ok(MlxDeviceKind::Bf3DpuMode) => "BlueField-3 (DPU mode)",
+        Ok(MlxDeviceKind::Bf3SuperNic) => "BlueField-3 SuperNIC",
+        Ok(MlxDeviceKind::Bf2Dpu) => "BlueField-2 DPU",
+        Ok(MlxDeviceKind::Unknown) | Err(_) => "Unknown",
+    }
+    .to_string()
+}
+
+fn nic_mode_label(nic_mode: Option<i32>) -> Option<String> {
+    nic_mode.and_then(|mode| match NicMode::try_from(mode) {
+        Ok(NicMode::Nic) => Some("NIC".to_string()),
+        Ok(NicMode::Dpu) => Some("DPU".to_string()),
+        Err(_) => None,
+    })
+}
+
+fn build_table(devices: &[MlxDeviceRow]) -> Box<Table> {
+    let mut table = Table::new();
+    table.set_titles(Row::from(vec![
+        "Host BMC IP",
+        "Kind",
+        "Part Number",
+        "Serial",
+        "NIC FW",
+        "NIC Mode",
+        "DPU BMC IP",
+    ]));
+    for device in devices {
+        table.add_row(Row::from(vec![
+            device.host_bmc_ip.clone(),
+            device.kind.clone(),
+            device.part_number.clone().unwrap_or_default(),
+            device.serial_number.clone().unwrap_or_default(),
+            device.firmware_version.clone().unwrap_or_default(),
+            device.nic_mode.clone().unwrap_or_default(),
+            device.dpu_bmc_ip.clone().unwrap_or_default(),
+        ]));
+    }
+    Box::new(table)
+}
+
+/// Whether `actual` NIC firmware is below `expected`, comparing dotted numeric
+/// versions (e.g. `32.38.1002` is below `32.42.1000`). A device with no reported
+/// firmware -- or a version that doesn't parse as dotted numerics -- is surfaced
+/// rather than hidden: better to show a device we can't verify than to miss an
+/// outdated one.
+fn firmware_below(actual: Option<&str>, expected: &str) -> bool {
+    let Some(actual) = actual else {
+        return true;
+    };
+    match (parse_version(actual), parse_version(expected)) {
+        (Some(actual), Some(expected)) => actual < expected,
+        _ => actual != expected,
+    }
+}
+
+/// Parses a dotted numeric version (e.g. `32.42.1000`) into comparable parts,
+/// returning `None` if any component isn't a non-negative integer.
+fn parse_version(version: &str) -> Option<Vec<u64>> {
+    version
+        .split('.')
+        .map(|part| part.parse::<u64>().ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firmware_below_compares_dotted_versions() {
+        // Outdated -> below the target.
+        assert!(firmware_below(Some("32.38.1002"), "32.42.1000"));
+        // At the target -> not below.
+        assert!(!firmware_below(Some("32.42.1000"), "32.42.1000"));
+        // Newer than the target -> not below (the false positive the != filter had).
+        assert!(!firmware_below(Some("32.43.0000"), "32.42.1000"));
+        // No reported firmware -> surfaced.
+        assert!(firmware_below(None, "32.42.1000"));
+        // Unparsable versions fall back to a plain mismatch.
+        assert!(firmware_below(Some("weird-fw"), "32.42.1000"));
+        assert!(!firmware_below(Some("BF-24.07"), "BF-24.07"));
+    }
+}

--- a/crates/admin-cli/src/site_explorer/mlx_devices/mod.rs
+++ b/crates/admin-cli/src/site_explorer/mlx_devices/mod.rs
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::mlx_devices(
+            &mut ctx.output_file,
+            ctx.config.format,
+            &ctx.api_client,
+            self,
+        )
+        .await
+    }
+}

--- a/crates/admin-cli/src/site_explorer/mod.rs
+++ b/crates/admin-cli/src/site_explorer/mod.rs
@@ -23,6 +23,7 @@ mod explore;
 pub mod get_report;
 mod have_credentials;
 mod is_bmc_in_managed_host;
+mod mlx_devices;
 mod re_explore;
 mod refresh_endpoint;
 mod remediation;
@@ -41,6 +42,8 @@ use crate::cfg::dispatch::Dispatch;
 pub enum Cmd {
     #[clap(about = "Retrieves the latest site exploration report", subcommand)]
     GetReport(get_report::Args),
+    #[clap(about = "Report Mellanox/BlueField device NIC firmware from explored Redfish data.")]
+    MlxDevices(mlx_devices::Args),
     #[clap(
         about = "Asks carbide-api to explore a single host and prints the report. Does not store it."
     )]

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -1091,6 +1091,13 @@ impl Forge for Api {
         crate::handlers::site_explorer::find_explored_managed_hosts_by_ids(self, request).await
     }
 
+    async fn get_explored_mlx_devices(
+        &self,
+        request: Request<::rpc::site_explorer::GetExploredMlxDevicesRequest>,
+    ) -> Result<Response<::rpc::site_explorer::ExploredMlxDeviceList>, Status> {
+        crate::handlers::site_explorer::get_explored_mlx_devices(self, request).await
+    }
+
     async fn update_machine_hardware_info(
         &self,
         request: Request<::rpc::forge::UpdateMachineHardwareInfoRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -281,6 +281,7 @@ impl InternalRBACRules {
         x.perm("FindExploredEndpointsByIds", vec![ForgeAdminCLI, Flow]);
         x.perm("FindExploredManagedHostIds", vec![ForgeAdminCLI, Flow]);
         x.perm("FindExploredManagedHostsByIds", vec![ForgeAdminCLI, Flow]);
+        x.perm("GetExploredMlxDevices", vec![ForgeAdminCLI]);
         x.perm("AdminForceDeleteMachine", vec![ForgeAdminCLI, Machineatron]);
         x.perm("AdminForceDeleteRack", vec![ForgeAdminCLI, Machineatron]);
         x.perm("AdminForceDeleteSwitch", vec![ForgeAdminCLI, Machineatron]);

--- a/crates/api-core/src/handlers/site_explorer.rs
+++ b/crates/api-core/src/handlers/site_explorer.rs
@@ -151,6 +151,34 @@ pub(crate) async fn get_site_exploration_report(
     Ok(tonic::Response::new(report.into()))
 }
 
+pub(crate) async fn get_explored_mlx_devices(
+    api: &Api,
+    request: Request<::rpc::site_explorer::GetExploredMlxDevicesRequest>,
+) -> Result<Response<::rpc::site_explorer::ExploredMlxDeviceList>, Status> {
+    log_request_data(&request);
+
+    let host_filter = request
+        .into_inner()
+        .host_bmc_ip
+        .map(|ip| IpAddr::from_str(&ip))
+        .transpose()
+        .map_err(CarbideError::AddressParseError)?;
+
+    // Load every explored endpoint: the projection reads each host's PCIe
+    // inventory, and the serial join needs the DPU endpoints alongside them.
+    let endpoints = db::explored_endpoints::find_all(&api.database_connection).await?;
+
+    let devices = model::site_explorer::collect_explored_mlx_devices(&endpoints)
+        .into_iter()
+        .filter(|device| host_filter.is_none_or(|ip| device.host_bmc_ip == ip))
+        .map(::rpc::site_explorer::ExploredMlxDevice::from)
+        .collect();
+
+    Ok(Response::new(::rpc::site_explorer::ExploredMlxDeviceList {
+        devices,
+    }))
+}
+
 pub(crate) async fn clear_site_exploration_error(
     api: &Api,
     request: Request<rpc::ClearSiteExplorationErrorRequest>,

--- a/crates/api-core/src/tests/explored_mlx_devices.rs
+++ b/crates/api-core/src/tests/explored_mlx_devices.rs
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use ::rpc::forge as rpc;
+use model::site_explorer::{
+    Chassis, ComputerSystem, ComputerSystemAttributes, EndpointExplorationReport, EndpointType,
+    NicMode, PCIeDevice,
+};
+use rpc::forge_server::Forge;
+
+use crate::tests::common::api_fixtures::create_test_env;
+
+fn pcie(part: &str, fw: &str, serial: &str, id: &str) -> PCIeDevice {
+    PCIeDevice {
+        description: Some(format!("NVIDIA BlueField-3 {part}")),
+        firmware_version: Some(fw.to_string()),
+        gpu_vendor: None,
+        id: Some(id.to_string()),
+        manufacturer: Some("Nvidia".to_string()),
+        name: Some("Network Device".to_string()),
+        part_number: Some(part.to_string()),
+        serial_number: Some(serial.to_string()),
+        status: None,
+    }
+}
+
+// Exercises the full explored-device read path: seed a host whose Redfish PCIe
+// inventory shows a NIC-mode DPU plus that DPU's own BMC endpoint, then confirm
+// the handler projects the device and joins it to its DPU BMC by serial.
+#[crate::sqlx_test()]
+async fn test_get_explored_mlx_devices(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+
+    let host_ip = IpAddr::from_str("192.0.2.20")?;
+    let dpu_ip = IpAddr::from_str("192.0.2.50")?;
+
+    // The host BMC reports a NIC-mode DPU (900-9D3B4) running outdated NIC FW.
+    let host_report = EndpointExplorationReport {
+        endpoint_type: EndpointType::Bmc,
+        systems: vec![ComputerSystem {
+            pcie_devices: vec![pcie(
+                "900-9D3B4-00EN-EA0",
+                "32.38.1002",
+                "MT2403X00984",
+                "188-0",
+            )],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    // The DPU's own BMC endpoint, keyed by the matching serial, reporting NIC mode.
+    let dpu_report = EndpointExplorationReport {
+        endpoint_type: EndpointType::Bmc,
+        systems: vec![ComputerSystem {
+            id: "Bluefield".to_string(),
+            serial_number: Some("MT2403X00984".to_string()),
+            attributes: ComputerSystemAttributes {
+                nic_mode: Some(NicMode::Nic),
+                ..Default::default()
+            },
+            ..Default::default()
+        }],
+        chassis: vec![Chassis {
+            id: "Card1".to_string(),
+            model: Some("NVIDIA BlueField 3".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::insert(host_ip, &host_report, false, &mut txn).await?;
+    db::explored_endpoints::insert(dpu_ip, &dpu_report, false, &mut txn).await?;
+    txn.commit().await?;
+
+    let devices = env
+        .api
+        .get_explored_mlx_devices(tonic::Request::new(
+            ::rpc::site_explorer::GetExploredMlxDevicesRequest { host_bmc_ip: None },
+        ))
+        .await
+        .map(|response| response.into_inner())
+        .unwrap()
+        .devices;
+
+    // Only the host's BlueField device; the DPU endpoint contributes none.
+    assert_eq!(devices.len(), 1);
+    let device = &devices[0];
+    assert_eq!(device.host_bmc_ip, "192.0.2.20");
+    assert_eq!(device.part_number.as_deref(), Some("900-9D3B4-00EN-EA0"));
+    assert_eq!(device.firmware_version.as_deref(), Some("32.38.1002"));
+    assert_eq!(device.serial_number.as_deref(), Some("MT2403X00984"));
+    assert_eq!(
+        device.device_kind,
+        ::rpc::site_explorer::MlxDeviceKind::Bf3NicMode as i32
+    );
+    // Joined to its DPU endpoint by serial.
+    assert_eq!(device.dpu_bmc_ip.as_deref(), Some("192.0.2.50"));
+    assert_eq!(
+        device.nic_mode,
+        Some(::rpc::site_explorer::NicMode::Nic as i32)
+    );
+
+    // The host filter scopes the result to a single host BMC.
+    let other_host = env
+        .api
+        .get_explored_mlx_devices(tonic::Request::new(
+            ::rpc::site_explorer::GetExploredMlxDevicesRequest {
+                host_bmc_ip: Some("198.51.100.1".to_string()),
+            },
+        ))
+        .await
+        .map(|response| response.into_inner())
+        .unwrap()
+        .devices;
+    assert!(other_host.is_empty());
+
+    Ok(())
+}

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -39,6 +39,7 @@ mod expected_rack;
 mod expected_switch;
 mod explored_endpoint_find;
 mod explored_managed_host_find;
+mod explored_mlx_devices;
 mod extension_service;
 mod find_by_ids_guards;
 mod finder;

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::net::IpAddr;
 use std::str::FromStr;
@@ -1575,6 +1575,418 @@ pub fn is_bluefield_model(model: &str) -> bool {
         // prefix matching for BlueField-2 DPU (https://docs.nvidia.com/nvidia-bluefield-2-ethernet-dpu-user-guide.pdf)
         // TODO (sp): should we be matching on all the individual models listed ("MBF2M516C-CECOT", .. etc)
         || is_bf2_dpu(&normalized_model)
+}
+
+/// The kind of BlueField/Mellanox device, classified from its Redfish part number.
+///
+/// A BlueField-3's part number records the mode it is currently operating in:
+/// `900-9D3B4` is a card running as a NIC, `900-9D3B6` is the same generation
+/// running as a DPU, and `900-9D3D4` is a dedicated SuperNIC. That split is what
+/// lets us pick out a DPU operating in NIC mode -- whose NIC firmware is
+/// otherwise invisible while its Arm OS is down -- apart from a native SuperNIC.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum MlxDeviceKind {
+    /// BlueField-3 operating as a NIC (part number `900-9D3B4...`).
+    Bf3NicMode,
+    /// BlueField-3 operating as a DPU (part number `900-9D3B6...`).
+    Bf3DpuMode,
+    /// BlueField-3 SuperNIC (part number `900-9D3D4...`).
+    Bf3SuperNic,
+    /// BlueField-2 DPU (part number `MBF2...`).
+    Bf2Dpu,
+    /// A BlueField we recognized but could not pin to a known part-number prefix.
+    Unknown,
+}
+
+impl MlxDeviceKind {
+    /// Classifies a device by its Redfish part number, returning
+    /// [`MlxDeviceKind::Unknown`] for a BlueField whose part number matches no
+    /// known prefix (or is absent).
+    pub fn from_part_number(part_number: Option<&str>) -> Self {
+        let Some(model) = part_number else {
+            return Self::Unknown;
+        };
+        let model = model.trim().to_lowercase();
+        // `is_bf3_supernic` deliberately groups `900-9d3b4` and `900-9d3d4`; here
+        // we split them, because a NIC-mode DPU (`b4`) and a native SuperNIC
+        // (`d4`) are exactly what an operator needs told apart.
+        if model.starts_with("900-9d3b6") || model.starts_with("sn37b36732") {
+            Self::Bf3DpuMode
+        } else if model.starts_with("900-9d3b4") {
+            Self::Bf3NicMode
+        } else if model.starts_with("900-9d3d4") {
+            Self::Bf3SuperNic
+        } else if model.starts_with("mbf2") {
+            Self::Bf2Dpu
+        } else {
+            Self::Unknown
+        }
+    }
+
+    /// Whether this is a BlueField-3 operating in NIC mode -- the devices whose
+    /// NIC firmware most needs auditing, since their Arm OS can't report it.
+    pub fn is_nic_mode(&self) -> bool {
+        matches!(self, Self::Bf3NicMode)
+    }
+}
+
+impl Display for MlxDeviceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Bf3NicMode => "BlueField-3 (NIC mode)",
+            Self::Bf3DpuMode => "BlueField-3 (DPU mode)",
+            Self::Bf3SuperNic => "BlueField-3 SuperNIC",
+            Self::Bf2Dpu => "BlueField-2 DPU",
+            Self::Unknown => "Unknown",
+        };
+        write!(f, "{label}")
+    }
+}
+
+/// A Mellanox/BlueField device surfaced from site exploration.
+///
+/// This is the explored counterpart to scout's live `MlxDeviceReport`: it is
+/// derived from a host BMC's Redfish PCIe inventory -- already captured during
+/// site exploration -- so it reports a device's NIC firmware, part number and
+/// serial even for a BlueField in NIC mode, whose Arm OS is down and so cannot
+/// report any of that over its own management channel. A single host exploration
+/// report can produce several of these (a machine commonly holds one or two DPUs
+/// and up to eight SuperNICs).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ExploredMlxDevice {
+    /// The BMC IP of the host the device was found under.
+    pub host_bmc_ip: IpAddr,
+    /// The host's `MachineId`, once it has been ingested far enough to derive one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub machine_id: Option<MachineId>,
+    /// The device kind, classified from its part number.
+    pub device_kind: MlxDeviceKind,
+    /// Redfish PCIe device id / slot (e.g. `188-0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pcie_id: Option<String>,
+    /// Manufacturer part number (e.g. `900-9D3B4-00EN-EA0`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub part_number: Option<String>,
+    /// Board serial number (e.g. `MT2403X00984`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serial_number: Option<String>,
+    /// The NIC firmware version currently installed (e.g. `32.42.1000`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub firmware_version: Option<String>,
+    /// The long device description as reported by Redfish.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The BMC IP of the device's own DPU endpoint, set when the device's serial
+    /// matches a DPU we have explored. This is the address to target for a
+    /// firmware push.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dpu_bmc_ip: Option<IpAddr>,
+    /// The DPU's authoritative operating mode, read from its own Redfish endpoint
+    /// when matched -- corroborates the part-number-derived `device_kind`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nic_mode: Option<NicMode>,
+}
+
+impl EndpointExplorationReport {
+    /// Projects this report's Redfish PCIe inventory into [`ExploredMlxDevice`]s --
+    /// one per BlueField/Mellanox device, with its part number, NIC firmware and
+    /// serial. `dpu_bmc_ip`/`nic_mode` are left unset here; they are filled by
+    /// [`collect_explored_mlx_devices`] once a device is matched to its DPU endpoint.
+    pub fn explored_mlx_devices(&self, host_bmc_ip: IpAddr) -> Vec<ExploredMlxDevice> {
+        self.systems
+            .iter()
+            .flat_map(|system| system.pcie_devices.iter())
+            .filter(|device| device.is_bluefield())
+            .map(|device| ExploredMlxDevice {
+                host_bmc_ip,
+                machine_id: self.machine_id,
+                device_kind: MlxDeviceKind::from_part_number(device.part_number.as_deref()),
+                pcie_id: device.id.clone(),
+                part_number: device.part_number.clone(),
+                serial_number: device.serial_number.clone(),
+                firmware_version: device.firmware_version.clone(),
+                description: device.description.clone(),
+                dpu_bmc_ip: None,
+                nic_mode: None,
+            })
+            .collect()
+    }
+}
+
+/// Builds the [`ExploredMlxDevice`] view across a set of explored endpoints.
+///
+/// Host endpoints contribute their BlueField PCIe devices; DPU endpoints are
+/// indexed by serial so each device can be matched back to the DPU's own BMC --
+/// yielding the DPU BMC IP to target for an upgrade and the authoritative NIC
+/// mode. A device whose DPU BMC we have not (yet) explored still appears, just
+/// without those two fields. This is the same serial correlation site
+/// exploration already uses to attach DPUs to their hosts.
+pub fn collect_explored_mlx_devices(endpoints: &[ExploredEndpoint]) -> Vec<ExploredMlxDevice> {
+    // Index explored DPU endpoints by their (trimmed) system serial number, so a
+    // host-reported device can be matched to the DPU's own BMC endpoint -- the
+    // same key site exploration uses in `record_host_dpu_device`. Empty serials
+    // are skipped, and a serial reported by more than one DPU endpoint is dropped
+    // as ambiguous: better to attach nothing than to join to the wrong DPU.
+    let mut dpu_by_serial: HashMap<&str, &ExploredEndpoint> = HashMap::new();
+    let mut ambiguous: HashSet<&str> = HashSet::new();
+    for ep in endpoints.iter().filter(|ep| ep.report.is_dpu()) {
+        let Some(serial) = ep
+            .report
+            .systems
+            .first()
+            .and_then(|system| system.serial_number.as_deref())
+            .map(str::trim)
+            .filter(|serial| !serial.is_empty())
+        else {
+            continue;
+        };
+        if dpu_by_serial.insert(serial, ep).is_some() {
+            ambiguous.insert(serial);
+        }
+    }
+    for serial in ambiguous {
+        dpu_by_serial.remove(serial);
+    }
+
+    endpoints
+        .iter()
+        // Project from host endpoints; a DPU's own BMC reports no meaningful PCIe
+        // inventory, and shouldn't list itself as a host-side device.
+        .filter(|ep| !ep.report.is_dpu())
+        .flat_map(|ep| ep.report.explored_mlx_devices(ep.address))
+        .map(|mut device| {
+            if let Some(dpu_ep) = device
+                .serial_number
+                .as_deref()
+                .map(str::trim)
+                .filter(|serial| !serial.is_empty())
+                .and_then(|serial| dpu_by_serial.get(serial))
+            {
+                device.dpu_bmc_ip = Some(dpu_ep.address);
+                device.nic_mode = dpu_ep.report.nic_mode();
+            }
+            device
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod explored_mlx_device_tests {
+    use super::*;
+
+    fn endpoint(address: &str, report: EndpointExplorationReport) -> ExploredEndpoint {
+        ExploredEndpoint {
+            address: address.parse().unwrap(),
+            report,
+            report_version: ConfigVersion::new(1),
+            preingestion_state: PreingestionState::Initial,
+            waiting_for_explorer_refresh: false,
+            exploration_requested: false,
+            last_redfish_bmc_reset: None,
+            last_ipmitool_bmc_reset: None,
+            last_redfish_reboot: None,
+            last_redfish_powercycle: None,
+            pause_remediation: false,
+            boot_interface_mac: None,
+            boot_interface_id: None,
+            pause_ingestion_and_poweron: false,
+        }
+    }
+
+    fn pcie(part: &str, fw: &str, serial: &str, id: &str) -> PCIeDevice {
+        PCIeDevice {
+            description: Some(format!("NVIDIA BlueField-3 {part}")),
+            firmware_version: Some(fw.to_string()),
+            gpu_vendor: None,
+            id: Some(id.to_string()),
+            manufacturer: Some("Nvidia".to_string()),
+            name: Some("Network Device".to_string()),
+            part_number: Some(part.to_string()),
+            serial_number: Some(serial.to_string()),
+            status: None,
+        }
+    }
+
+    #[test]
+    fn classifies_bluefield_kind_by_part_number() {
+        struct Case {
+            name: &'static str,
+            part_number: Option<&'static str>,
+            expected: MlxDeviceKind,
+        }
+        let cases = [
+            Case {
+                name: "bf3 nic mode",
+                part_number: Some("900-9D3B4-00EN-EA0"),
+                expected: MlxDeviceKind::Bf3NicMode,
+            },
+            Case {
+                name: "bf3 dpu mode",
+                part_number: Some("900-9D3B6-00CV-AA0"),
+                expected: MlxDeviceKind::Bf3DpuMode,
+            },
+            Case {
+                name: "bf3 supernic",
+                part_number: Some("900-9D3D4-00EN-HA0_Ax"),
+                expected: MlxDeviceKind::Bf3SuperNic,
+            },
+            Case {
+                name: "bf2 dpu",
+                part_number: Some("MBF2H516A-CENOT"),
+                expected: MlxDeviceKind::Bf2Dpu,
+            },
+            Case {
+                name: "lenovo-branded bf3 dpu",
+                part_number: Some("SN37B36732"),
+                expected: MlxDeviceKind::Bf3DpuMode,
+            },
+            Case {
+                name: "bluefield without a known prefix",
+                part_number: Some("NVIDIA BlueField mystery board"),
+                expected: MlxDeviceKind::Unknown,
+            },
+            Case {
+                name: "absent part number",
+                part_number: None,
+                expected: MlxDeviceKind::Unknown,
+            },
+        ];
+        for case in cases {
+            assert_eq!(
+                MlxDeviceKind::from_part_number(case.part_number),
+                case.expected,
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn projects_pcie_inventory_and_joins_dpu_by_serial() {
+        // A host that reports a NIC-mode DPU (outdated FW) and a native SuperNIC.
+        let host = endpoint(
+            "192.0.2.20",
+            EndpointExplorationReport {
+                endpoint_type: EndpointType::Bmc,
+                systems: vec![ComputerSystem {
+                    pcie_devices: vec![
+                        pcie("900-9D3B4-00EN-EA0", "32.38.1002", "MT2403X00984", "188-0"),
+                        pcie(
+                            "900-9D3D4-00EN-HA0_Ax",
+                            "32.42.1000",
+                            "MT2403X09999",
+                            "204-0",
+                        ),
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+        // The NIC-mode DPU's own BMC endpoint, keyed by the matching serial.
+        let dpu = endpoint(
+            "192.0.2.50",
+            EndpointExplorationReport {
+                endpoint_type: EndpointType::Bmc,
+                systems: vec![ComputerSystem {
+                    id: "Bluefield".to_string(),
+                    serial_number: Some("MT2403X00984".to_string()),
+                    attributes: ComputerSystemAttributes {
+                        nic_mode: Some(NicMode::Nic),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }],
+                chassis: vec![Chassis {
+                    id: "Card1".to_string(),
+                    model: Some("NVIDIA BlueField 3".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+
+        let mut devices = collect_explored_mlx_devices(&[host, dpu]);
+        devices.sort_by(|a, b| a.pcie_id.cmp(&b.pcie_id));
+        assert_eq!(devices.len(), 2, "only the host's two BlueField devices");
+
+        let nic_dpu = &devices[0];
+        assert_eq!(nic_dpu.device_kind, MlxDeviceKind::Bf3NicMode);
+        assert_eq!(nic_dpu.part_number.as_deref(), Some("900-9D3B4-00EN-EA0"));
+        assert_eq!(nic_dpu.firmware_version.as_deref(), Some("32.38.1002"));
+        assert_eq!(nic_dpu.serial_number.as_deref(), Some("MT2403X00984"));
+        assert_eq!(nic_dpu.host_bmc_ip, "192.0.2.20".parse::<IpAddr>().unwrap());
+        // matched to its DPU endpoint by serial
+        assert_eq!(
+            nic_dpu.dpu_bmc_ip,
+            Some("192.0.2.50".parse::<IpAddr>().unwrap())
+        );
+        assert_eq!(nic_dpu.nic_mode, Some(NicMode::Nic));
+
+        let supernic = &devices[1];
+        assert_eq!(supernic.device_kind, MlxDeviceKind::Bf3SuperNic);
+        // no DPU endpoint matched this serial, so the join fields stay unset
+        assert_eq!(supernic.dpu_bmc_ip, None);
+        assert_eq!(supernic.nic_mode, None);
+    }
+
+    #[test]
+    fn serial_join_skips_empty_and_ambiguous_serials() {
+        let dpu = |addr: &str, serial: &str| {
+            endpoint(
+                addr,
+                EndpointExplorationReport {
+                    endpoint_type: EndpointType::Bmc,
+                    systems: vec![ComputerSystem {
+                        id: "Bluefield".to_string(),
+                        serial_number: Some(serial.to_string()),
+                        attributes: ComputerSystemAttributes {
+                            nic_mode: Some(NicMode::Nic),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }],
+                    chassis: vec![Chassis {
+                        id: "Card1".to_string(),
+                        model: Some("NVIDIA BlueField 3".to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+            )
+        };
+        // Host reports one device with an empty serial and one whose serial is
+        // claimed by two different DPU endpoints.
+        let host = endpoint(
+            "192.0.2.20",
+            EndpointExplorationReport {
+                endpoint_type: EndpointType::Bmc,
+                systems: vec![ComputerSystem {
+                    pcie_devices: vec![
+                        pcie("900-9D3B4-00EN-EA0", "32.38.1002", "", "188-0"),
+                        pcie("900-9D3B4-00EN-EA0", "32.38.1002", "DUP123", "204-0"),
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        );
+
+        let devices = collect_explored_mlx_devices(&[
+            host,
+            dpu("192.0.2.50", "DUP123"),
+            dpu("192.0.2.51", "DUP123"),
+        ]);
+
+        // Both devices project, but neither joins: the empty serial is skipped and
+        // the duplicated "DUP123" serial is ambiguous.
+        assert_eq!(devices.len(), 2);
+        for device in &devices {
+            assert_eq!(device.dpu_bmc_ip, None);
+            assert_eq!(device.nic_mode, None);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -309,6 +309,9 @@ service Forge {
   // paginated APIs to get site explorer explored managed hosts
   rpc FindExploredManagedHostIds(site_explorer.ExploredManagedHostSearchFilter) returns (site_explorer.ExploredManagedHostIdList);
   rpc FindExploredManagedHostsByIds(site_explorer.ExploredManagedHostsByIdsRequest) returns (site_explorer.ExploredManagedHostList);
+  // Mellanox/BlueField device firmware, projected from explored Redfish PCIe
+  // inventory -- surfaces NIC firmware for DPUs operating in NIC mode.
+  rpc GetExploredMlxDevices(site_explorer.GetExploredMlxDevicesRequest) returns (site_explorer.ExploredMlxDeviceList);
   rpc UpdateMachineHardwareInfo(UpdateMachineHardwareInfoRequest) returns (google.protobuf.Empty);
 
   // Force deletes a Machine and the associated DPU from Forge databases,

--- a/crates/rpc/proto/site_explorer.proto
+++ b/crates/rpc/proto/site_explorer.proto
@@ -126,6 +126,56 @@ message ExploredManagedHostList {
   repeated ExploredManagedHost managed_hosts = 1;
 }
 
+// A Mellanox/BlueField device surfaced from a host's Redfish PCIe inventory
+// during site exploration -- the explored counterpart to scout's live
+// MlxDeviceReport. Reports a device's NIC firmware, part number and serial even
+// for a BlueField in NIC mode, whose Arm OS is down and so cannot report them
+// over its own management channel.
+message ExploredMlxDevice {
+  // The BMC IP of the host the device was found under.
+  string host_bmc_ip = 1;
+  // The host's MachineId, once it has been ingested far enough to derive one.
+  optional string machine_id = 2;
+  // The device kind, classified from its part number.
+  MlxDeviceKind device_kind = 3;
+  // Redfish PCIe device id / slot (e.g. "188-0").
+  optional string pcie_id = 4;
+  // Manufacturer part number (e.g. "900-9D3B4-00EN-EA0").
+  optional string part_number = 5;
+  // Board serial number (e.g. "MT2403X00984").
+  optional string serial_number = 6;
+  // The NIC firmware version currently installed (e.g. "32.42.1000").
+  optional string firmware_version = 7;
+  // The long device description as reported by Redfish.
+  optional string description = 8;
+  // The BMC IP of the device's own DPU endpoint, set when its serial matches a
+  // DPU we have explored -- the address to target for a firmware push.
+  optional string dpu_bmc_ip = 9;
+  // The DPU's authoritative operating mode, read from its own Redfish endpoint
+  // when matched.
+  optional NicMode nic_mode = 10;
+}
+
+// The kind of BlueField/Mellanox device, classified from its part number. A
+// BlueField-3's part number records the mode it is operating in: 900-9D3B4
+// (NIC), 900-9D3B6 (DPU), 900-9D3D4 (SuperNIC).
+enum MlxDeviceKind {
+  MLX_DEVICE_KIND_UNKNOWN = 0;
+  MLX_DEVICE_KIND_BF3_NIC_MODE = 1;
+  MLX_DEVICE_KIND_BF3_DPU_MODE = 2;
+  MLX_DEVICE_KIND_BF3_SUPER_NIC = 3;
+  MLX_DEVICE_KIND_BF2_DPU = 4;
+}
+
+message ExploredMlxDeviceList {
+  repeated ExploredMlxDevice devices = 1;
+}
+
+message GetExploredMlxDevicesRequest {
+  // Restrict to devices found under this host BMC IP; all hosts if unset.
+  optional string host_bmc_ip = 1;
+}
+
 enum NicMode {
   DPU = 0;
   NIC = 1;

--- a/crates/rpc/src/model/site_explorer.rs
+++ b/crates/rpc/src/model/site_explorer.rs
@@ -19,9 +19,9 @@ use model::site_explorer::{
     BootOption, BootOrder, Chassis, ComputerSystem, ComputerSystemAttributes,
     EndpointExplorationReport, EthernetInterface, ExploredDpu, ExploredEndpoint,
     ExploredEndpointSearchFilter, ExploredManagedHost, ExploredManagedHostSearchFilter,
-    InternalLockdownStatus, Inventory, LockdownStatus, MachineSetupDiff, MachineSetupStatus,
-    Manager, NetworkAdapter, NicMode, PCIeDevice, PowerState, SecureBootStatus, Service,
-    SiteExplorationReport, SystemStatus,
+    ExploredMlxDevice, InternalLockdownStatus, Inventory, LockdownStatus, MachineSetupDiff,
+    MachineSetupStatus, Manager, MlxDeviceKind, NetworkAdapter, NicMode, PCIeDevice, PowerState,
+    SecureBootStatus, Service, SiteExplorationReport, SystemStatus,
 };
 
 use crate as rpc;
@@ -128,6 +128,38 @@ impl From<SiteExplorationReport> for rpc::site_explorer::SiteExplorationReport {
         rpc::site_explorer::SiteExplorationReport {
             endpoints: report.endpoints.into_iter().map(Into::into).collect(),
             managed_hosts: report.managed_hosts.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<MlxDeviceKind> for rpc::site_explorer::MlxDeviceKind {
+    fn from(kind: MlxDeviceKind) -> Self {
+        match kind {
+            MlxDeviceKind::Bf3NicMode => rpc::site_explorer::MlxDeviceKind::Bf3NicMode,
+            MlxDeviceKind::Bf3DpuMode => rpc::site_explorer::MlxDeviceKind::Bf3DpuMode,
+            MlxDeviceKind::Bf3SuperNic => rpc::site_explorer::MlxDeviceKind::Bf3SuperNic,
+            MlxDeviceKind::Bf2Dpu => rpc::site_explorer::MlxDeviceKind::Bf2Dpu,
+            MlxDeviceKind::Unknown => rpc::site_explorer::MlxDeviceKind::Unknown,
+        }
+    }
+}
+
+impl From<ExploredMlxDevice> for rpc::site_explorer::ExploredMlxDevice {
+    fn from(device: ExploredMlxDevice) -> Self {
+        rpc::site_explorer::ExploredMlxDevice {
+            host_bmc_ip: device.host_bmc_ip.to_string(),
+            machine_id: device.machine_id.map(|id| id.to_string()),
+            device_kind: rpc::site_explorer::MlxDeviceKind::from(device.device_kind) as i32,
+            pcie_id: device.pcie_id,
+            part_number: device.part_number,
+            serial_number: device.serial_number,
+            firmware_version: device.firmware_version,
+            description: device.description,
+            dpu_bmc_ip: device.dpu_bmc_ip.map(|ip| ip.to_string()),
+            nic_mode: device.nic_mode.map(|m| match m {
+                NicMode::Nic => rpc::site_explorer::NicMode::Nic as i32,
+                NicMode::Dpu => rpc::site_explorer::NicMode::Dpu as i32,
+            }),
         }
     }
 }


### PR DESCRIPTION
Adds an `ExploredMlxDevice` that reports every BlueField/Mellanox card's part number, NIC firmware and serial straight from the Redfish PCIe inventory site exploration already collects. A DPU running in NIC mode keeps its Arm OS down and so can't report its own NIC firmware -- but the host BMC sees it, and we already persist that, so an operator can finally spot NIC-mode DPUs on outdated firmware and target them for upgrade with no new collection.

- `ExploredMlxDevice` projects the stored exploration report, classifies each device by part number (BlueField-3 NIC mode / DPU mode / SuperNIC, BlueField-2), and joins it to its own DPU BMC by serial -- reusing the host-to-DPU correlation site exploration already does -- to attach the DPU BMC IP and authoritative NIC mode.
- A `GetExploredMlxDevices` Forge RPC serves this from persisted explored-endpoint data, so it works before ingestion and for allocated machines, where the live scout path can't reach.
- `site-explorer mlx-devices` lists the devices for operators, filterable to NIC-mode DPUs and to firmware below a desired version.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/2365


Closes #2365
