### PR TITLE
fix(helm-prereqs): Add switch_nvos vault policy paths for switch ingestion

### DIFF
--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -254,6 +254,15 @@ spec:
               path "{{ .Values.vault.kvMount }}/data/bgp/*" {
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
+              path "{{ .Values.vault.kvMount }}/data/switch_nvos/*" {
+                capabilities = ["create", "read", "patch", "list", "update", "delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/metadata/switch_nvos/*" {
+                capabilities = ["read", "list", "delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/destroy/switch_nvos/*" {
+                capabilities = ["delete"]
+              }
               POLICY
 
               # ---- K8s auth role for cert-manager ----


### PR DESCRIPTION
<!-- Describe what this PR does -->
Add switch_nvos vault policy paths for switch ingestion

Required for NVSwitch credential rotation during creds rotation flow. Grants nico-vault-policy create/read/patch/list/update/delete on data/switch_nvos/*, read/list/delete on metadata/switch_nvos/*, and delete on destroy/switch_nvos/*.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change

<!-- Check one that best describes this PR -->

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->

- [ ] **This PR contains breaking changes**

## Testing

<!-- How was this tested? Check all that apply -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Adds three new paths to `nico-vault-policy` in `helm-prereqs/templates/vault-config-job.yaml` to support NVSwitch credential rotation:

- `data/switch_nvos/*` — full CRUD + list
- `metadata/switch_nvos/*` — read, list, delete (needed to enumerate and clean up secret versions)
- `destroy/switch_nvos/*` — delete (hard-delete old secret versions)