### PR TITLE
chore(site-explorer): switch to nv-redfish exploration by default

### DIFF
--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -295,7 +295,7 @@ impl SiteExplorerConfig {
     }
 
     pub const fn default_explore_mode() -> SiteExplorerExploreMode {
-        SiteExplorerExploreMode::LibRedfish
+        SiteExplorerExploreMode::NvRedfish
     }
 }
 


### PR DESCRIPTION
nv-redfish exploration mode is faster and battle tested now. Switch to use it by default for all further releases.
libredfish exploration mode is still available as backup possibility. 

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

