### PR TITLE
feat(dns): derive reverse-DNS zones from network prefixes

### DIFF
--- a/crates/api-core/src/handlers/network_segment.rs
+++ b/crates/api-core/src/handlers/network_segment.rs
@@ -367,6 +367,13 @@ pub(crate) async fn save(
         }
     };
 
+    // A network's reverse-DNS zone is derived from its prefix and created with
+    // it, so PTR lookups for the network's addresses resolve without anyone
+    // hand-authoring the zone.
+    for network_prefix in &network_segment.prefixes {
+        db::dns::ensure_reverse_zone(network_prefix.prefix, txn.as_mut()).await?;
+    }
+
     if allocate_svi_ip {
         db::network_segment::allocate_svi_ip(&network_segment, txn).await?;
         let network_segments = db::network_segment::find_by(

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -21,6 +21,12 @@ pub mod resource_record;
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use ipnetwork::IpNetwork;
+use model::dns::NewDomain;
+use sqlx::PgConnection;
+
+use crate::DatabaseResult;
+
 pub fn normalize_domain(name: &str) -> String {
     let normalized_domain = name.trim_end_matches('.').to_ascii_lowercase();
     tracing::debug!(input = %name, normalized = %normalized_domain, "normalized domain name");
@@ -69,8 +75,121 @@ pub fn arpa_qname_to_ip(qname: &str) -> Option<IpAddr> {
     }
 }
 
+/// Build the reverse-DNS zone name for a network prefix: the network octets
+/// (IPv4) or nibbles (IPv6) the prefix covers, in reverse, under `in-addr.arpa`
+/// / `ip6.arpa`. The forward inverse of [`arpa_qname_to_ip`].
+///
+/// Returns `None` for a prefix that is not octet-aligned (IPv4: /8, /16, /24,
+/// /32) or nibble-aligned (IPv6: a multiple of 4) -- RFC 2317 classless
+/// delegation is out of scope.
+pub fn cidr_to_reverse_zone(prefix: IpNetwork) -> Option<String> {
+    match prefix {
+        IpNetwork::V4(net) => {
+            let bits = net.prefix();
+            if bits == 0 || bits % 8 != 0 {
+                return None;
+            }
+            let octets = net.network().octets();
+            let labels = (bits / 8) as usize;
+            let mut parts: Vec<String> = octets[..labels].iter().rev().map(u8::to_string).collect();
+            parts.push("in-addr.arpa".to_string());
+            Some(parts.join("."))
+        }
+        IpNetwork::V6(net) => {
+            let bits = net.prefix();
+            if bits == 0 || bits % 4 != 0 {
+                return None;
+            }
+            let octets = net.network().octets();
+            let nibbles = (bits / 4) as usize;
+            let mut parts: Vec<String> = (0..nibbles)
+                .map(|i| {
+                    let byte = octets[i / 2];
+                    let nibble = if i % 2 == 0 { byte >> 4 } else { byte & 0x0f };
+                    format!("{nibble:x}")
+                })
+                .collect();
+            parts.reverse();
+            parts.push("ip6.arpa".to_string());
+            Some(parts.join("."))
+        }
+    }
+}
+
+/// Ensure the reverse-DNS zone for a network prefix exists, deriving its name
+/// from the prefix and creating the domain only if it is not already present.
+/// A network's reverse zone is a consequence of the network existing, so this is
+/// called wherever a network segment is created; non-aligned prefixes are skipped
+/// (see [`cidr_to_reverse_zone`]).
+///
+/// The find-then-create avoids duplicating a zone an earlier same-prefix segment
+/// already created (domain names are not unique). It does not need to guard
+/// concurrent creation: network prefixes are globally non-overlapping
+/// (`network_prefixes_prefix_excl`), so two segments never map to the same zone,
+/// and a duplicate prefix fails in `network_segment::save` before this runs.
+pub async fn ensure_reverse_zone(prefix: IpNetwork, txn: &mut PgConnection) -> DatabaseResult<()> {
+    let Some(zone) = cidr_to_reverse_zone(prefix) else {
+        tracing::debug!(%prefix, "no reverse zone: prefix is not octet/nibble aligned");
+        return Ok(());
+    };
+    if domain::find_by_name(&mut *txn, &zone).await?.is_empty() {
+        tracing::info!(zone = %zone, %prefix, "creating reverse-DNS zone for network prefix");
+        domain::persist(NewDomain::new(zone), txn).await?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn cidr_to_reverse_zone_derives_aligned_prefixes() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |cidr: &str| super::cidr_to_reverse_zone(cidr.parse().unwrap());
+            "ipv4 octet-aligned" {
+                "10.0.0.0/8" => Some("10.in-addr.arpa".to_string()),
+                "192.168.0.0/16" => Some("168.192.in-addr.arpa".to_string()),
+                "192.0.2.0/24" => Some("2.0.192.in-addr.arpa".to_string()),
+                "192.0.2.1/32" => Some("1.2.0.192.in-addr.arpa".to_string()),
+            }
+            "ipv6 nibble-aligned" {
+                "fd00::/16" => Some("0.0.d.f.ip6.arpa".to_string()),
+                "2001:db8::/32" => Some("8.b.d.0.1.0.0.2.ip6.arpa".to_string()),
+            }
+            "rejects prefixes that are not octet- or nibble-aligned" {
+                "192.168.0.0/25" => None,
+                "fd00::/17" => None,
+                "0.0.0.0/0" => None,
+            }
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn ensure_reverse_zone_creates_idempotently(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let prefix: ipnetwork::IpNetwork = "10.0.0.0/16".parse().unwrap();
+
+        // First call creates the zone; the second is a no-op.
+        super::ensure_reverse_zone(prefix, txn.as_mut())
+            .await
+            .unwrap();
+        super::ensure_reverse_zone(prefix, txn.as_mut())
+            .await
+            .unwrap();
+        let zones = super::domain::find_by_name(txn.as_mut(), "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert_eq!(zones.len(), 1, "reverse zone created exactly once");
+
+        // A non-aligned prefix derives no zone, so nothing is created.
+        let unaligned: ipnetwork::IpNetwork = "10.1.0.0/25".parse().unwrap();
+        super::ensure_reverse_zone(unaligned, txn.as_mut())
+            .await
+            .unwrap();
+        assert!(super::cidr_to_reverse_zone(unaligned).is_none());
+    }
 
     #[test]
     fn test_normalize_domain_name() {


### PR DESCRIPTION
## Summary

A network's reverse-DNS zone is a pure function of its prefix (`10.0.0.0/16` → `0.10.in-addr.arpa`), and every network already carries its prefix. So this derives each reverse zone from the network and creates it in the same transaction the network is created — at config init and at runtime — rather than having anyone author it by hand. Reverse zones track networks (static and dynamic) automatically.

- `cidr_to_reverse_zone(prefix)` (api-db `dns`) — the forward inverse of `arpa_qname_to_ip`; `None` for prefixes that are not octet/nibble aligned (RFC 2317 classless is out of scope).
- `ensure_reverse_zone(prefix, txn)` — creates the arpa domain idempotently (several segments can share one zone), skips non-aligned prefixes.
- Hook in `network_segment::save` — the chokepoint both `create_initial_networks` (config seed) and the runtime create handler route through. The arpa domain registers the zone; PTR records within it resolve via the existing address-keyed lookup (the merged PTR train).

Tests: a `cidr_to_reverse_zone` table (IPv4/IPv6 aligned + rejected non-aligned), and a DB test that `ensure_reverse_zone` is idempotent and skips non-aligned prefixes.

**Follow-ups (out of scope here):** the internal linknet-allocation path (`network_segment/allocate.rs`) bypasses `save`, so its segments don't get reverse zones — linknets are point-to-point internals that likely don't want reverse DNS, but worth a deliberate call; and dropping a reverse zone on network deletion when nothing else maps to it.

Implements #2766. Part of the #2630 reverse-DNS epic.
