### PR TITLE
fix(rest-api): Use capital case for BMC credential kind

### DIFF
--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -113,6 +113,9 @@ jobs:
           base: 'origin/main:rest-api/openapi/spec.yaml'
           revision: ':rest-api/openapi/spec.yaml'
           fail-on: ERR
+          # Allowlist the intentional one-time rename of the BMC credential
+          # `kind` enum values to CapitalCase; see the referenced ignore file.
+          err-ignore: 'rest-api/openapi/oasdiff-breaking-changes-ignore.txt'
 
   check-generated-files:
     name: Check Generated Files

--- a/rest-api/AGENTS.md
+++ b/rest-api/AGENTS.md
@@ -191,6 +191,8 @@ verification expectations.
   passwords and other credentials are never returned. Keep OpenAPI
   descriptions focused on the REST contract rather than internal gRPC
   implementation details.
+- API-layer enum-like request constants exposed through JSON use CapitalCase
+  values, for example `SiteWideRoot` and `BMCRoot`.
 
 ### Prefer range-based iteration over C-style `for` loops
 

--- a/rest-api/api/pkg/api/model/bmccredential.go
+++ b/rest-api/api/pkg/api/model/bmccredential.go
@@ -16,23 +16,23 @@ import (
 const (
 	// BMCCredentialKindSiteWideRoot stores the site-wide BMC root credential
 	// (empty username). Maps to CredentialType_SiteWideBmcRoot.
-	BMCCredentialKindSiteWideRoot = "site-wide-root"
+	BMCCredentialKindSiteWideRoot = "SiteWideRoot"
 	// BMCCredentialKindBMCRoot stores a per-BMC root credential keyed by MAC
 	// address. Maps to CredentialType_RootBmcByMacAddress.
-	BMCCredentialKindBMCRoot = "bmc-root"
+	BMCCredentialKindBMCRoot = "BMCRoot"
 )
 
 // APIBMCCredentialRequest sets (creates or overwrites) a BMC credential.
 type APIBMCCredentialRequest struct {
 	// SiteID is the ID of the Site where the credential is stored.
 	SiteID string `json:"siteId"`
-	// Kind selects which BMC credential to store: "site-wide-root" or "bmc-root".
+	// Kind selects which BMC credential to store: "SiteWideRoot" or "BMCRoot".
 	Kind string `json:"kind"`
 	// Password is the credential password (required).
 	Password string `json:"password"`
-	// Username is optional; Core defaults to "root" when omitted for bmc-root.
+	// Username is optional; Core defaults to "root" when omitted for BMCRoot.
 	Username *string `json:"username,omitempty"`
-	// MacAddress is required for kind "bmc-root" and ignored for "site-wide-root".
+	// MacAddress is required for kind "BMCRoot" and ignored for "SiteWideRoot".
 	MacAddress *string `json:"macAddress,omitempty"`
 }
 
@@ -40,11 +40,11 @@ type APIBMCCredentialRequest struct {
 type APIBMCCredential struct {
 	// SiteID is the ID of the Site where the credential is stored.
 	SiteID string `json:"siteId"`
-	// Kind selects which BMC credential was stored: "site-wide-root" or "bmc-root".
+	// Kind selects which BMC credential was stored: "SiteWideRoot" or "BMCRoot".
 	Kind string `json:"kind"`
-	// Username is optional; Core defaults to "root" when omitted for bmc-root.
+	// Username is optional; Core defaults to "root" when omitted for BMCRoot.
 	Username *string `json:"username,omitempty"`
-	// MacAddress is required for kind "bmc-root" and ignored for "site-wide-root".
+	// MacAddress is required for kind "BMCRoot" and ignored for "SiteWideRoot".
 	MacAddress *string `json:"macAddress,omitempty"`
 }
 

--- a/rest-api/api/pkg/api/model/bmccredential_test.go
+++ b/rest-api/api/pkg/api/model/bmccredential_test.go
@@ -24,11 +24,11 @@ func TestAPIBMCCredentialRequestValidate(t *testing.T) {
 		req     APIBMCCredentialRequest
 		wantErr bool
 	}{
-		{"site-wide-root ok", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindSiteWideRoot, Password: "pw"}, false},
-		{"bmc-root ok", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindBMCRoot, Password: "pw", MacAddress: mac}, false},
+		{"SiteWideRoot ok", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindSiteWideRoot, Password: "pw"}, false},
+		{"BMCRoot ok", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindBMCRoot, Password: "pw", MacAddress: mac}, false},
 		{"missing siteId", APIBMCCredentialRequest{Kind: BMCCredentialKindSiteWideRoot, Password: "pw"}, true},
 		{"invalid siteId", APIBMCCredentialRequest{SiteID: "bad-site-id", Kind: BMCCredentialKindSiteWideRoot, Password: "pw"}, true},
-		{"bmc-root missing mac", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindBMCRoot, Password: "pw"}, true},
+		{"BMCRoot missing mac", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindBMCRoot, Password: "pw"}, true},
 		{"missing password", APIBMCCredentialRequest{SiteID: siteID, Kind: BMCCredentialKindSiteWideRoot}, true},
 		{"invalid kind", APIBMCCredentialRequest{SiteID: siteID, Kind: "nope", Password: "pw"}, true},
 	}

--- a/rest-api/openapi/oasdiff-breaking-changes-ignore.txt
+++ b/rest-api/openapi/oasdiff-breaking-changes-ignore.txt
@@ -1,0 +1,2 @@
+PUT /v2/org/{org}/nico/credential/bmc removed the enum value `bmc-root` of the request property `kind`
+PUT /v2/org/{org}/nico/credential/bmc removed the enum value `site-wide-root` of the request property `kind`

--- a/rest-api/openapi/spec.yaml
+++ b/rest-api/openapi/spec.yaml
@@ -12998,18 +12998,18 @@ components:
           type: string
           description: Which BMC credential to store.
           enum:
-            - site-wide-root
-            - bmc-root
+            - SiteWideRoot
+            - BMCRoot
         password:
           type: string
           minLength: 1
           description: Credential password.
         username:
           type: string
-          description: Optional username; Core defaults to "root" for bmc-root when omitted.
+          description: Optional username; Core defaults to "root" for BMCRoot when omitted.
         macAddress:
           type: string
-          description: BMC MAC address. Required for kind bmc-root, ignored for site-wide-root.
+          description: BMC MAC address. Required for kind BMCRoot, ignored for SiteWideRoot.
     BMCCredential:
       type: object
       title: BMCCredential
@@ -13026,14 +13026,14 @@ components:
           type: string
           description: Which BMC credential was stored.
           enum:
-            - site-wide-root
-            - bmc-root
+            - SiteWideRoot
+            - BMCRoot
         username:
           type: string
-          description: Optional username; Core defaults to "root" for bmc-root when omitted.
+          description: Optional username; Core defaults to "root" for BMCRoot when omitted.
         macAddress:
           type: string
-          description: BMC MAC address. Required for kind bmc-root, ignored for site-wide-root.
+          description: BMC MAC address. Required for kind BMCRoot, ignored for SiteWideRoot.
     InfrastructureProvider:
       description: Infrastructure providers own and manage datacenters
       type: object

--- a/rest-api/sdk/standard/model_bmc_credential.go
+++ b/rest-api/sdk/standard/model_bmc_credential.go
@@ -28,9 +28,9 @@ type BMCCredential struct {
 	SiteId string `json:"siteId"`
 	// Which BMC credential was stored.
 	Kind string `json:"kind"`
-	// Optional username; Core defaults to \"root\" for bmc-root when omitted.
+	// Optional username; Core defaults to \"root\" for BMCRoot when omitted.
 	Username *string `json:"username,omitempty"`
-	// BMC MAC address. Required for kind bmc-root, ignored for site-wide-root.
+	// BMC MAC address. Required for kind BMCRoot, ignored for SiteWideRoot.
 	MacAddress *string `json:"macAddress,omitempty"`
 }
 

--- a/rest-api/sdk/standard/model_bmc_credential_request.go
+++ b/rest-api/sdk/standard/model_bmc_credential_request.go
@@ -30,9 +30,9 @@ type BMCCredentialRequest struct {
 	Kind string `json:"kind"`
 	// Credential password.
 	Password string `json:"password"`
-	// Optional username; Core defaults to \"root\" for bmc-root when omitted.
+	// Optional username; Core defaults to \"root\" for BMCRoot when omitted.
 	Username *string `json:"username,omitempty"`
-	// BMC MAC address. Required for kind bmc-root, ignored for site-wide-root.
+	// BMC MAC address. Required for kind BMCRoot, ignored for SiteWideRoot.
 	MacAddress *string `json:"macAddress,omitempty"`
 }
 


### PR DESCRIPTION
Const values should follow established convention not introduce snake case values.