### PR TITLE
Fix: backport 2593, 2618, and 2619 to 0.10

### DIFF
--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -888,6 +888,28 @@ pub async fn update_nvlink_status_observation(
     Ok(())
 }
 
+/// Clears `machines.nvlink_status_observation` for the given machine IDs.
+///
+/// Used when NMX-C is unreachable so instance state does not retain stale partition observations.
+pub async fn clear_nvlink_status_observations(
+    txn: &mut PgConnection,
+    machine_ids: &[MachineId],
+) -> Result<(), DatabaseError> {
+    if machine_ids.is_empty() {
+        return Ok(());
+    }
+
+    let query = "UPDATE machines SET nvlink_status_observation = NULL WHERE id = ANY($1)";
+    let machine_id_strings: Vec<String> = machine_ids.iter().map(|id| id.to_string()).collect();
+    sqlx::query(query)
+        .bind(machine_id_strings)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 async fn debug_failed_machine_status_update(
     txn: &mut PgConnection,

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -22,11 +22,13 @@ use carbide_uuid::switch::SwitchId;
 use chrono::prelude::*;
 use config_version::{ConfigVersion, Versioned};
 use health_report::{HealthReport, HealthReportApplyMode};
+use mac_address::MacAddress;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::metadata::Metadata;
 use model::rack::RackFirmwareUpgradeStatus;
 use model::switch::{
-    FabricManagerStatus, NewSwitch, Switch, SwitchControllerState, SwitchReprovisionRequest,
+    CONTROL_PLANE_STATE_CONFIGURED, FabricManagerState, FabricManagerStatus, NewSwitch,
+    SWITCH_CONTROLLER_STATE_READY, Switch, SwitchControllerState, SwitchReprovisionRequest,
 };
 use sqlx::PgConnection;
 
@@ -241,6 +243,41 @@ pub async fn find_ids(
         .fetch_all(txn)
         .await
         .map_err(|e| DatabaseError::new("switch::find_ids", e))
+}
+
+/// Returns non-deleted switches in `rack_id` whose controller state is Ready and whose
+/// Fabric Manager status reports `fabric_manager_state = ok` with
+/// `addition_info = CONTROL_PLANE_STATE_CONFIGURED`.
+pub async fn find_ready_control_plane_configured_switch_ids_in_rack<DB>(
+    txn: &mut DB,
+    rack_id: &RackId,
+) -> DatabaseResult<Vec<SwitchId>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    let query = r#"
+        SELECT s.id
+        FROM switches s
+        WHERE s.rack_id = $1
+          AND s.deleted IS NULL
+          AND s.controller_state->>'state' = $2
+          AND s.fabric_manager_status->>'fabric_manager_state' = $3
+          AND s.fabric_manager_status->>'addition_info' = $4
+    "#;
+
+    sqlx::query_as::<_, SwitchId>(query)
+        .bind(rack_id)
+        .bind(SWITCH_CONTROLLER_STATE_READY)
+        .bind(FabricManagerState::Ok.as_str())
+        .bind(CONTROL_PLANE_STATE_CONFIGURED)
+        .fetch_all(&mut *txn)
+        .await
+        .map_err(|e| {
+            DatabaseError::new(
+                "switch::find_ready_control_plane_configured_switch_ids_in_rack",
+                e,
+            )
+        })
 }
 
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Switch>>(
@@ -458,8 +495,6 @@ pub async fn update(switch: &Switch, txn: &mut PgConnection) -> Result<Switch, D
 
     Ok(switch.clone())
 }
-
-use mac_address::MacAddress;
 
 #[derive(Debug, sqlx::FromRow)]
 pub struct SwitchBmcInfoRow {

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -84,12 +84,29 @@ pub use crate::rack::{
     SwitchNvosUpdateStatus,
 };
 
+/// Controller state value for a switch in [`SwitchControllerState::Ready`].
+pub const SWITCH_CONTROLLER_STATE_READY: &str = "ready";
+
+/// `addition_info` value reported by Fabric Manager when the NMX-C control plane is configured.
+pub const CONTROL_PLANE_STATE_CONFIGURED: &str = "CONTROL_PLANE_STATE_CONFIGURED";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FabricManagerState {
     Ok,
     NotOk,
     Unknown,
+}
+
+impl FabricManagerState {
+    /// JSON representation stored in the `fabric_manager_status` column.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ok => "ok",
+            Self::NotOk => "not_ok",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -101,10 +118,13 @@ pub struct FabricManagerStatus {
 }
 
 impl FabricManagerStatus {
+    pub fn is_control_plane_configured(&self) -> bool {
+        self.fabric_manager_state == FabricManagerState::Ok
+            && self.addition_info.as_deref() == Some(CONTROL_PLANE_STATE_CONFIGURED)
+    }
+
     pub fn display_status(&self) -> &'static str {
-        if self.fabric_manager_state == FabricManagerState::Ok
-            && self.addition_info.as_deref() == Some("CONTROL_PLANE_STATE_CONFIGURED")
-        {
+        if self.is_control_plane_configured() {
             "running"
         } else {
             "not_running"

--- a/crates/api/src/handlers/machine_discovery.rs
+++ b/crates/api/src/handlers/machine_discovery.rs
@@ -25,7 +25,6 @@ use carbide_uuid::machine::MachineIdSource;
 use carbide_uuid::nvlink::NvLinkDomainId;
 use db::WithTransaction;
 use futures_util::FutureExt;
-use libnmxc::{Endpoint, NMX_C_GATEWAY_ID};
 use model::hardware_info::{GpuPlatformInfo, HardwareInfo, MachineNvLinkInfo, NvLinkGpu};
 use model::machine::machine_id::{from_hardware_info, host_id_from_dpu_hardware_info};
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -34,7 +33,7 @@ use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_machine_id, log_request_data};
 use crate::handlers::utils::convert_and_log_machine_id;
-use crate::{CarbideError, CarbideResult, attestation as attest};
+use crate::{CarbideError, attestation as attest};
 
 pub(crate) async fn discover_machine(
     api: &Api,
@@ -94,8 +93,8 @@ pub(crate) async fn discover_machine(
         })?;
     log_machine_id(&stable_machine_id);
 
-    // Before opening a database transaction, get information from nvlink if we need it.
-    // Discover NVLink info if this is a GBX00 machine and we have platform info for any GPU.
+    // Build NVLink info from scout GPU platform info. domain_uuid is backfilled by the
+    // NVLink partition monitor from NMX-C hello.
     let gpu_platform_infos: Vec<&GpuPlatformInfo> = hardware_info
         .gpus
         .iter()
@@ -104,16 +103,13 @@ pub(crate) async fn discover_machine(
 
     let nvlink_info = if hardware_info.is_gbx00()
         && !gpu_platform_infos.is_empty()
-        && let Some(nvlink_config) = api.runtime_config.nvlink_config.as_ref()
-        && nvlink_config.enabled
+        && api
+            .runtime_config
+            .nvlink_config
+            .as_ref()
+            .is_some_and(|config| config.enabled)
     {
-        get_nvlink_info_from_nmx_c(api, &gpu_platform_infos)
-            .await
-            .map_err(|e| {
-                tracing::warn!("Failed to get NVLink info from NMX-C: {e}");
-                e
-            })
-            .ok()
+        nvlink_info_from_gpu_platform_infos(&gpu_platform_infos)
     } else {
         None
     };
@@ -498,56 +494,16 @@ pub(crate) async fn discovery_completed(
 }
 
 /// Builds NVLink discovery info from scout `GpuPlatformInfo` for every GPU that reported it.
-/// Resolves `domain_uuid` from NMX-C `Hello` (`server_header.domain_uuid`).
-async fn get_nvlink_info_from_nmx_c(
-    api: &Api,
+fn nvlink_info_from_gpu_platform_infos(
     platform_infos: &[&GpuPlatformInfo],
-) -> CarbideResult<MachineNvLinkInfo> {
+) -> Option<MachineNvLinkInfo> {
     let chassis_serial = platform_infos
         .first()
         .map(|p| p.chassis_serial.clone())
         .unwrap_or_default();
     if chassis_serial.trim().is_empty() {
-        return Err(CarbideError::internal(
-            "Missing chassis_serial in GpuPlatformInfo for NMX-C hello".to_string(),
-        ));
+        return None;
     }
-
-    let mut txn = api.txn_begin().await?;
-    let endpoint =
-        db::nvlink_nmxc_endpoints::find_by_chassis_serial(&mut txn, chassis_serial.trim())
-            .await?
-            .map(|row| row.endpoint)
-            .ok_or_else(|| {
-                CarbideError::internal(format!(
-                    "No NMX-C endpoint configured for chassis serial {}",
-                    chassis_serial.trim()
-                ))
-            })?;
-    txn.commit().await?;
-
-    let mut nmx_c_client = api
-        .nmxc_client_pool
-        .create_client(Endpoint::new(&endpoint).map_err(|e| CarbideError::internal(e.to_string()))?)
-        .await
-        .map_err(|e| CarbideError::internal(format!("Failed to create NMX-C client: {e}")))?;
-
-    let hello = nmx_c_client
-        .hello(NMX_C_GATEWAY_ID)
-        .await
-        .map_err(|e| CarbideError::internal(format!("Failed to call NMX-C hello: {e}")))?;
-
-    let domain_uuid = hello
-        .server_header
-        .as_ref()
-        .and_then(|header| uuid::Uuid::parse_str(&header.domain_uuid).ok())
-        .ok_or_else(|| {
-            CarbideError::internal(format!(
-                "Failed to parse domain UUID from NMX-C hello response: {hello:?}"
-            ))
-        })?;
-
-    let domain_uuid = NvLinkDomainId::from(domain_uuid);
 
     let gpus = platform_infos
         .iter()
@@ -569,8 +525,8 @@ async fn get_nvlink_info_from_nmx_c(
         })
         .collect();
 
-    Ok(MachineNvLinkInfo {
-        domain_uuid,
+    Some(MachineNvLinkInfo {
+        domain_uuid: NvLinkDomainId::nil(),
         chassis_serial,
         gpus,
     })

--- a/crates/api/src/handlers/nmxc_browse.rs
+++ b/crates/api/src/handlers/nmxc_browse.rs
@@ -18,7 +18,10 @@
 use std::collections::HashMap;
 
 use ::rpc::forge as rpc;
-use libnmxc::nmxc_model::{GetComputeNodeInfoListRequest, GetGpuInfoListRequest, GpuAttr};
+use libnmxc::nmxc_model::{
+    GetComputeNodeInfoListRequest, GetGpuInfoListRequest, GetPartitionInfoListRequest,
+    GetSwitchNodeInfoListRequest, GpuAttr,
+};
 use libnmxc::{Endpoint, NMX_C_GATEWAY_ID, Nmxc};
 use tonic::{Request, Response, Status};
 
@@ -38,6 +41,24 @@ async fn compute_node_info_list_json(
 
     let body = serde_json::to_string(&resp).map_err(|e| {
         CarbideError::internal(format!("serialize GetComputeNodeInfoListResponse: {e}"))
+    })?;
+    Ok((body, 200, HashMap::new()))
+}
+
+/// Calls NMX-C `GetSwitchNodeInfoList` and returns the JSON response for the NMX-C browser.
+async fn switch_node_info_list_json(
+    nmxc: &mut dyn Nmxc,
+) -> Result<(String, i32, HashMap<String, String>), CarbideError> {
+    let resp = nmxc
+        .get_switch_node_info_list(GetSwitchNodeInfoListRequest {
+            context: Some(Default::default()),
+            loc_list: vec![],
+            gateway_id: NMX_C_GATEWAY_ID.to_string(),
+        })
+        .await?;
+
+    let body = serde_json::to_string(&resp).map_err(|e| {
+        CarbideError::internal(format!("serialize GetSwitchNodeInfoListResponse: {e}"))
     })?;
     Ok((body, 200, HashMap::new()))
 }
@@ -67,6 +88,38 @@ async fn gpu_info_json(
 
     let body = serde_json::to_string(gpu)
         .map_err(|e| CarbideError::internal(format!("serialize GpuInfo: {e}")))?;
+    Ok((body, 200, HashMap::new()))
+}
+
+/// Calls NMX-C `GetPartitionInfoList` and returns the JSON response for the NMX-C browser.
+async fn partition_info_list_json(
+    nmxc: &mut dyn Nmxc,
+) -> Result<(String, i32, HashMap<String, String>), CarbideError> {
+    let resp = nmxc
+        .get_partition_info_list(GetPartitionInfoListRequest {
+            context: Some(Default::default()),
+            partition_id_list: vec![],
+            partition_name_list: vec![],
+            gateway_id: NMX_C_GATEWAY_ID.into(),
+        })
+        .await?;
+
+    let body = serde_json::to_string(&resp).map_err(|e| {
+        CarbideError::internal(format!("serialize GetPartitionInfoListResponse: {e}"))
+    })?;
+    Ok((body, 200, HashMap::new()))
+}
+
+/// Calls NMX-C `GetDomainProperties` and returns the JSON response for the NMX-C browser.
+async fn get_domain_properties_json(
+    nmxc: &mut dyn Nmxc,
+) -> Result<(String, i32, HashMap<String, String>), CarbideError> {
+    let resp = nmxc
+        .get_domain_properties(Some(Default::default()), NMX_C_GATEWAY_ID)
+        .await?;
+
+    let body = serde_json::to_string(&resp)
+        .map_err(|e| CarbideError::internal(format!("serialize DomainProperties: {e}")))?;
     Ok((body, 200, HashMap::new()))
 }
 
@@ -140,6 +193,9 @@ pub(crate) async fn nmxc_browse(
             rpc::NmxcBrowseOperation::ComputeNodeInfoList => {
                 compute_node_info_list_json(nmxc.as_mut()).await
             }
+            rpc::NmxcBrowseOperation::SwitchNodeInfoList => {
+                switch_node_info_list_json(nmxc.as_mut()).await
+            }
             rpc::NmxcBrowseOperation::GpuInfo => {
                 if request.gpu_uid == 0 {
                     Err(CarbideError::InvalidArgument(
@@ -150,6 +206,12 @@ pub(crate) async fn nmxc_browse(
                 }
             }
             rpc::NmxcBrowseOperation::GpuInfoList => gpu_info_list_json(nmxc.as_mut()).await,
+            rpc::NmxcBrowseOperation::PartitionInfoList => {
+                partition_info_list_json(nmxc.as_mut()).await
+            }
+            rpc::NmxcBrowseOperation::GetDomainProperties => {
+                get_domain_properties_json(nmxc.as_mut()).await
+            }
         };
 
         match result {

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -101,7 +101,13 @@ impl EndpointExplorer for MockEndpointExplorer {
             .unwrap()
             .push(bmc_ip_address.ip());
         let guard = self.reports.lock().unwrap();
-        let res = guard.get(&bmc_ip_address.ip()).unwrap();
+        let res = guard.get(&bmc_ip_address.ip()).unwrap_or_else(|| {
+            panic!(
+                "MockEndpointExplorer has no report for {}; registered: {:?}",
+                bmc_ip_address.ip(),
+                guard.keys().collect::<Vec<_>>()
+            )
+        });
         res.clone()
     }
 

--- a/crates/api/src/tests/common/api_fixtures/managed_host.rs
+++ b/crates/api/src/tests/common/api_fixtures/managed_host.rs
@@ -60,6 +60,9 @@ pub struct ManagedHostConfig {
     /// Default: true (maintains backward compatibility)
     pub auto_assign_sku_in_fixture: bool,
     pub hardware_info_template: HardwareInfoTemplate,
+    /// When set, DPU-backed hosts try ADMIN then ADMIN2 admin-segment DHCP during fixture
+    /// ingestion. Used by NVLink rack-switch tests that provision a second admin segment.
+    pub admin_dhcp_fallback: bool,
     /// The contents of this will be used as ExpectedMachine entry
     /// However not all fields need to be filled
     /// - bmc username/password are not required
@@ -140,6 +143,7 @@ impl Default for ManagedHostConfig {
                 .collect(),
             auto_assign_sku_in_fixture: true,
             hardware_info_template: HardwareInfoTemplate::Default,
+            admin_dhcp_fallback: false,
             expected_machine_data: None,
         }
     }

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -45,7 +45,7 @@ use model::machine::{
 use model::power_shelf::power_shelf_id::from_hardware_info;
 use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
 use model::rack::RackConfig;
-use model::site_explorer::EndpointExplorationReport;
+use model::site_explorer::{Chassis, EndpointExplorationReport, EndpointType};
 use model::switch::{NewSwitch, SwitchConfig};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self, HealthReportEntry, InsertMachineHealthReportRequest};
@@ -64,7 +64,7 @@ use crate::tests::common::api_fixtures::host::host_uefi_setup;
 use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY,
+    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2, FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY,
 };
 use crate::tests::common::api_fixtures::{
     TestEnv, TestManagedHost, forge_agent_control, get_machine_validation_runs,
@@ -73,6 +73,21 @@ use crate::tests::common::api_fixtures::{
 };
 use crate::tests::common::mac_address_pool::EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL;
 use crate::tests::common::rpc_builder::DhcpDiscovery;
+
+async fn ensure_admin_interface_primary(
+    env: &TestEnv,
+    mac: mac_address::MacAddress,
+) -> eyre::Result<()> {
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(txn.as_mut(), mac).await?;
+    if let Some(interface) = interfaces.first()
+        && !interface.primary_interface
+    {
+        db::machine_interface::set_primary_interface(&interface.id, true, txn.as_mut()).await?;
+    }
+    txn.commit().await?;
+    Ok(())
+}
 
 async fn current_host_state_and_cleanup_needed(
     env: &TestEnv,
@@ -321,23 +336,66 @@ impl<'a> MockExploredHost<'a> {
         mut self,
         f: F,
     ) -> eyre::Result<Self> {
-        // Run dhcp from primary interface
-        let relay_address = if self.managed_host.dpus.is_empty() {
-            // zero-DPU machines DHCP from a HostInband segment
-            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.ip().to_string()
+        let result = if self.managed_host.admin_dhcp_fallback && !self.managed_host.dpus.is_empty()
+        {
+            let mac = self.managed_host.dhcp_mac_address();
+            let env = self.test_env;
+            let dhcp_result = Box::pin(async move {
+                let primary_result = env
+                    .api
+                    .discover_dhcp(
+                        DhcpDiscovery::builder(mac, FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.ip())
+                            .vendor_string("Bluefield")
+                            .tonic_request(),
+                    )
+                    .await;
+
+                match primary_result {
+                    Ok(response) => Ok(response),
+                    Err(_) => env
+                        .api
+                        .discover_dhcp(
+                            DhcpDiscovery::builder(
+                                mac,
+                                FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2.ip(),
+                            )
+                            .vendor_string("Bluefield")
+                            .tonic_request(),
+                        )
+                        .await
+                        .map_err(|status| {
+                            tonic::Status::internal(format!("admin-segment DHCP failed: {status}"))
+                        }),
+                }
+            })
+            .await;
+
+            match dhcp_result {
+                Ok(response) => {
+                    ensure_admin_interface_primary(self.test_env, mac)
+                        .await
+                        .ok();
+                    Ok(response)
+                }
+                Err(status) => Err(status),
+            }
         } else {
-            FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.ip().to_string()
+            let relay_address = if self.managed_host.dpus.is_empty() {
+                FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.ip().to_string()
+            } else {
+                FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.ip().to_string()
+            };
+
+            self.test_env
+                .api
+                .discover_dhcp(
+                    DhcpDiscovery::builder(self.managed_host.dhcp_mac_address(), relay_address)
+                        .vendor_string("Bluefield")
+                        .tonic_request(),
+                )
+                .await
         };
 
-        let result = self
-            .test_env
-            .api
-            .discover_dhcp(
-                DhcpDiscovery::builder(self.managed_host.dhcp_mac_address(), relay_address)
-                    .vendor_string("Bluefield")
-                    .tonic_request(),
-            )
-            .await;
         if let Ok(ref response) = result {
             self.host_dhcp_response = Some(response.get_ref().clone());
         }
@@ -1293,6 +1351,93 @@ impl<'a> MockExploredHost<'a> {
             state
         }
     }
+
+    /// Site-explorer ingestion steps shared by [`new_mock_host`].
+    ///
+    /// Each step is awaited separately so the async state machine does not accumulate the full
+    /// chain on the stack (see comment in [`new_mock_host`]).
+    async fn finish_standard_ingestion_flow(mut self) -> eyre::Result<Self> {
+        self = self.discover_dhcp_host_bmc(|_, _| Ok(())).boxed().await?;
+        self = self.insert_site_exploration_results()?;
+        self = self.run_site_explorer_iteration().boxed().await;
+        self = self.mark_preingestion_complete().boxed().await?;
+        self = self.run_site_explorer_iteration().boxed().await;
+        self = self
+            .discover_dhcp_host_primary_iface(|_, _| Ok(()))
+            .boxed()
+            .await?;
+        self = self.dpu_state_controller_iterations().boxed().await;
+        self = self.discover_machine(|_, _| Ok(())).boxed().await?;
+        self = self.run_site_explorer_iteration().boxed().await;
+        self = self.host_state_controller_iterations().boxed().await;
+        Ok(self)
+    }
+}
+
+fn expected_switch_exploration_report() -> EndpointExplorationReport {
+    EndpointExplorationReport {
+        endpoint_type: EndpointType::Bmc,
+        vendor: Some(bmc_vendor::BMCVendor::Nvidia),
+        model: Some("Switch".to_string()),
+        chassis: vec![Chassis {
+            id: "mgx_nvswitch_0".to_string(),
+            manufacturer: Some("NVIDIA".to_string()),
+            model: Some("Switch".to_string()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+async fn switch_interface_ip(
+    txn: &mut sqlx::PgConnection,
+    mac: mac_address::MacAddress,
+) -> eyre::Result<Option<IpAddr>> {
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
+    let Some(interface) = interfaces.first() else {
+        return Ok(None);
+    };
+    let addresses =
+        db::machine_interface_address::find_for_interface(&mut *txn, interface.id).await?;
+    Ok(addresses.first().map(|address| address.address))
+}
+
+/// Registers mock endpoint-exploration results for every expected switch BMC and NVOS IP.
+///
+/// Required when switches (and their static interfaces) exist before `new_mock_host` runs,
+/// e.g. rack-switch NMX-C simulator tests that create the switch before host discovery.
+/// NVOS static IPs live on the `static-assignments` segment, which is typed as underlay,
+/// so site-explorer will attempt to explore them too.
+pub async fn register_expected_switch_exploration_results(env: &TestEnv) -> eyre::Result<()> {
+    let mut txn = env.pool.begin().await?;
+    let expected_switches = db::expected_switch::find_all(&mut txn).await?;
+    let mut endpoints = Vec::new();
+    for expected_switch in expected_switches {
+        let report = expected_switch_exploration_report();
+        let bmc_ip = if let Some(ip) = expected_switch.bmc_ip_address {
+            ip
+        } else if let Some(ip) =
+            switch_interface_ip(txn.as_mut(), expected_switch.bmc_mac_address).await?
+        {
+            ip
+        } else {
+            continue;
+        };
+        endpoints.push((bmc_ip, report.clone()));
+
+        if let Some(nvos_ip) = expected_switch.nvos_ip_address {
+            endpoints.push((nvos_ip, report));
+        } else if let [nvos_mac] = expected_switch.nvos_mac_addresses.as_slice()
+            && let Some(nvos_ip) = switch_interface_ip(txn.as_mut(), *nvos_mac).await?
+        {
+            endpoints.push((nvos_ip, report));
+        }
+    }
+    txn.commit().await?;
+    if !endpoints.is_empty() {
+        env.endpoint_explorer.insert_endpoints(endpoints);
+    }
+    Ok(())
 }
 
 pub async fn register_expected_machine(
@@ -1392,41 +1537,10 @@ pub async fn new_mock_host(
             .await;
     }
 
-    // Run through site explorer iterations to get it ready.
-    // NOTE: Calling `.boxed()` on each future here decreases the amount of stack space used by
-    // these futures. Prior to this we were hitting stack space limits (going over 2MB in stack) in
-    // unit tests. This buys us some savings so that we don't have to fiddle with adjusting the
-    // default stack size.
-    Ok(mock_explored_host
-        // ...Then run host BMC's DHCP
-        .discover_dhcp_host_bmc(|_, _| Ok(()))
-        .boxed()
-        .await?
-        .insert_site_exploration_results()?
-        .run_site_explorer_iteration()
-        .boxed()
-        .await
-        .mark_preingestion_complete()
-        .boxed()
-        .await?
-        .run_site_explorer_iteration()
-        .boxed()
-        .await
-        .discover_dhcp_host_primary_iface(|_, _| Ok(()))
-        .boxed()
-        .await?
-        .dpu_state_controller_iterations()
-        .boxed()
-        .await
-        .discover_machine(|_, _| Ok(()))
-        .boxed()
-        .await?
-        .run_site_explorer_iteration()
-        .boxed()
-        .await
-        .host_state_controller_iterations()
-        .boxed()
-        .await)
+    // NOTE: Calling `.boxed()` on each future in `finish_standard_ingestion_flow` decreases the
+    // amount of stack space used by these futures. Prior to this we were hitting stack space
+    // limits (going over 2MB in stack) in unit tests.
+    mock_explored_host.finish_standard_ingestion_flow().await
 }
 
 /// Use this function to make a new managed host with a given number of DPUs, using site-explorer
@@ -1842,29 +1956,28 @@ pub async fn new_mock_host_with_dpf(
             .await;
     }
 
-    // Run through site explorer iterations to get it ready.
-    // NOTE: Calling `.boxed()` on each future here decreases the amount of stack space used by
-    // these futures. Prior to this we were hitting stack space limits (going over 2MB in stack) in
-    // unit tests. This buys us some savings so that we don't have to fiddle with adjusting the
-    // default stack size.
     mock_explored_host = mock_explored_host
-        // ...Then run host BMC's DHCP
         .discover_dhcp_host_bmc(|_, _| Ok(()))
         .boxed()
-        .await?
-        .insert_site_exploration_results()?
+        .await?;
+    mock_explored_host = mock_explored_host.insert_site_exploration_results()?;
+    mock_explored_host = mock_explored_host
         .run_site_explorer_iteration()
         .boxed()
-        .await
+        .await;
+    mock_explored_host = mock_explored_host
         .mark_preingestion_complete()
         .boxed()
-        .await?
+        .await?;
+    mock_explored_host = mock_explored_host
         .run_site_explorer_iteration()
         .boxed()
-        .await
+        .await;
+    mock_explored_host = mock_explored_host
         .discover_dhcp_host_primary_iface(|_, _| Ok(()))
         .boxed()
-        .await?
+        .await?;
+    mock_explored_host = mock_explored_host
         .dpu_state_controller_iterations_with_dpf()
         .boxed()
         .await;
@@ -1876,16 +1989,20 @@ pub async fn new_mock_host_with_dpf(
         .collect();
     network_configured(env, &dpu_ids).await;
 
-    mock_explored_host
+    mock_explored_host = mock_explored_host
         .discover_machine(|_, _| Ok(()))
         .boxed()
-        .await?
+        .await?;
+    mock_explored_host = mock_explored_host
         .run_site_explorer_iteration()
         .boxed()
-        .await
+        .await;
+    mock_explored_host = mock_explored_host
         .host_state_controller_iterations()
         .boxed()
-        .await
+        .await;
+
+    mock_explored_host
         .finish(|mock| async move {
             let machine_id = mock.machine_discovery_response.unwrap().machine_id.unwrap();
             Ok(db::managed_host::load_snapshot(
@@ -1902,82 +2019,92 @@ pub async fn new_mock_host_with_dpf(
         .await
 }
 
-/// create_expected_switches seeds 6 expected switches into the database,
-/// replacing the create_expected_switch.sql fixture.
-pub async fn create_expected_switches(
+/// Seeds one expected switch (plus BMC/NVOS machine interfaces) into the database.
+pub async fn create_expected_switch(
     txn: &mut sqlx::PgConnection,
-) -> Vec<model::expected_switch::ExpectedSwitch> {
+    index: u32,
+) -> model::expected_switch::ExpectedSwitch {
     use model::expected_switch::ExpectedSwitch;
     use model::metadata::Metadata;
 
     use crate::tests::common::mac_address_pool::EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL;
 
-    let mut created = Vec::new();
-    for i in 0..6 {
-        let switch = ExpectedSwitch {
-            expected_switch_id: None,
-            bmc_mac_address: EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL.allocate(),
-            nvos_mac_addresses: vec![EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL.allocate()],
-            serial_number: format!("SW-SN-{:03}", i + 1),
-            bmc_username: "ADMIN".into(),
-            bmc_password: "Pwd2023x0x0x0x7".into(),
-            nvos_username: if (3..=4).contains(&i) {
-                Some(format!("nvos_admin{}", i - 2))
-            } else {
-                None
-            },
-            nvos_password: if (3..=4).contains(&i) {
-                Some(format!("nvos_pass{}", i - 2))
-            } else {
-                None
-            },
-            bmc_ip_address: None,
-            nvos_ip_address: None,
-            metadata: Metadata {
-                name: format!("Switch{}", i + 1),
-                description: format!("Test Switch {}", i + 1),
-                labels: HashMap::new(),
-            },
-            rack_id: None,
-            bmc_retain_credentials: None,
-        };
-        let result = db::expected_switch::create(txn, switch)
-            .await
-            .expect("unable to create expected switch");
+    let i = index as usize;
+    let switch = ExpectedSwitch {
+        expected_switch_id: None,
+        bmc_mac_address: EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL.allocate(),
+        nvos_mac_addresses: vec![EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL.allocate()],
+        serial_number: format!("SW-SN-{:03}", index + 1),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "Pwd2023x0x0x0x7".into(),
+        nvos_username: if (3..=4).contains(&i) {
+            Some(format!("nvos_admin{}", i - 2))
+        } else {
+            None
+        },
+        nvos_password: if (3..=4).contains(&i) {
+            Some(format!("nvos_pass{}", i - 2))
+        } else {
+            None
+        },
+        bmc_ip_address: None,
+        nvos_ip_address: None,
+        metadata: Metadata {
+            name: format!("Switch{}", index + 1),
+            description: format!("Test Switch {}", index + 1),
+            labels: HashMap::new(),
+        },
+        rack_id: None,
+        bmc_retain_credentials: None,
+    };
+    let result = db::expected_switch::create(txn, switch)
+        .await
+        .expect("unable to create expected switch");
 
-        let network_segments = db::network_segment::admin(txn)
-            .await
-            .map_err(|e| eyre::eyre!("Failed to get admin network segment: {:?}", e))
-            .unwrap();
+    let network_segments = db::network_segment::admin(txn)
+        .await
+        .map_err(|e| eyre::eyre!("Failed to get admin network segment: {:?}", e))
+        .unwrap();
 
-        for nvos_mac in &result.nvos_mac_addresses.clone() {
-            db::machine_interface::create(
-                txn,
-                &network_segments,
-                nvos_mac,
-                false,
-                AddressSelectionStrategy::NextAvailableIp,
-            )
-            .await
-            .map_err(|e| eyre::eyre!("Failed to create NVOS machine interface: {:?}", e))
-            .unwrap();
-        }
-        let overlay_network_segment = db::network_segment::find_by_name(txn, "UNDERLAY")
-            .await
-            .map_err(|e| eyre::eyre!("Failed to get overlay network segment: {:?}", e))
-            .unwrap();
-
+    for nvos_mac in &result.nvos_mac_addresses.clone() {
         db::machine_interface::create(
             txn,
-            std::slice::from_ref(&overlay_network_segment),
-            &result.bmc_mac_address.clone(),
+            &network_segments,
+            nvos_mac,
             false,
             AddressSelectionStrategy::NextAvailableIp,
         )
         .await
-        .map_err(|e| eyre::eyre!("Failed to create BMC machine interface: {:?}", e))
+        .map_err(|e| eyre::eyre!("Failed to create NVOS machine interface: {:?}", e))
         .unwrap();
-        created.push(result);
+    }
+    let overlay_network_segment = db::network_segment::find_by_name(txn, "UNDERLAY")
+        .await
+        .map_err(|e| eyre::eyre!("Failed to get overlay network segment: {:?}", e))
+        .unwrap();
+
+    db::machine_interface::create(
+        txn,
+        std::slice::from_ref(&overlay_network_segment),
+        &result.bmc_mac_address.clone(),
+        false,
+        AddressSelectionStrategy::NextAvailableIp,
+    )
+    .await
+    .map_err(|e| eyre::eyre!("Failed to create BMC machine interface: {:?}", e))
+    .unwrap();
+
+    result
+}
+
+/// create_expected_switches seeds 6 expected switches into the database,
+/// replacing the create_expected_switch.sql fixture.
+pub async fn create_expected_switches(
+    txn: &mut sqlx::PgConnection,
+) -> Vec<model::expected_switch::ExpectedSwitch> {
+    let mut created = Vec::new();
+    for i in 0..6 {
+        created.push(create_expected_switch(txn, i).await);
     }
     created
 }

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -2056,6 +2056,70 @@ fn nmxc_simulator_tests_enabled() -> bool {
     std::env::var_os(RUN_NMXC_SIMULATOR_TESTS).is_some()
 }
 
+const GB200_TRAY_4_CHASSIS_SERIAL: &str = "27XYX27000001";
+
+/// Removes the `nvlink_nmxc_endpoints` row for `chassis_serial` so NMX-C resolution fails in tests.
+async fn delete_nvlink_nmxc_endpoint(pool: &sqlx::PgPool, chassis_serial: &str) {
+    let mut txn = pool
+        .begin()
+        .await
+        .expect("begin txn for nvlink_nmxc_endpoint delete");
+    assert!(
+        db::nvlink_nmxc_endpoints::delete(txn.as_mut(), chassis_serial)
+            .await
+            .expect("delete nvlink_nmxc_endpoint"),
+        "nvlink_nmxc_endpoint row missing for {chassis_serial}"
+    );
+    txn.commit()
+        .await
+        .expect("commit nvlink_nmxc_endpoint delete");
+}
+
+/// Asserts the machine has a populated NVLink status observation with partition assignments.
+async fn assert_machine_nvlink_observation_present(
+    mh: &TestManagedHost,
+    expected_gpu_count: usize,
+) {
+    let machine = mh.host().rpc_machine().await;
+    let observation = machine
+        .nvlink_status_observation
+        .as_ref()
+        .expect("expected nvlink_status_observation to be set");
+    assert_eq!(observation.gpu_status.len(), expected_gpu_count);
+    for gpu_obs in &observation.gpu_status {
+        assert!(
+            gpu_obs.logical_partition_id.is_some(),
+            "expected logical_partition_id on gpu observation"
+        );
+        assert!(
+            gpu_obs.partition_id.is_some(),
+            "expected partition_id on gpu observation"
+        );
+    }
+}
+
+/// Asserts `nvlink_status_observation` was cleared (null) via RPC and in the database.
+async fn assert_machine_nvlink_observation_null(mh: &TestManagedHost, pool: &sqlx::PgPool) {
+    let machine = mh.host().rpc_machine().await;
+    assert!(
+        machine.nvlink_status_observation.is_none(),
+        "expected null nvlink_status_observation via RPC, got {:?}",
+        machine.nvlink_status_observation
+    );
+
+    let mut txn = pool
+        .begin()
+        .await
+        .expect("begin txn for nvlink observation check");
+    let db_machine = mh.host().db_machine(&mut txn).await;
+    assert!(
+        db_machine.nvlink_status_observation.is_none(),
+        "expected null nvlink_status_observation in DB, got {:?}",
+        db_machine.nvlink_status_observation
+    );
+    txn.commit().await.expect("commit nvlink observation check");
+}
+
 async fn run_create_instance_with_nvl_config_nmxc_simulator_scenario(
     pool: sqlx::PgPool,
     with_mtls: bool,
@@ -2945,4 +3009,130 @@ async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulat
         .partition_info_list;
     assert_eq!(nmxc_partitions.len(), 1);
     assert_eq!(nmxc_partitions[0].name, "tray_partition_1");
+}
+
+/// Verifies null `nvlink_status_observation` is written when the NMX-C endpoint cannot be resolved.
+/// Verifies the NVLink config is not synced when NMX-C is unreachable.
+#[crate::sqlx_test]
+async fn test_null_nvlink_observation_after_nmxc_unreachable_use_nmxc_simulator(
+    pool: sqlx::PgPool,
+) {
+    if !nmxc_simulator_tests_enabled() {
+        println!(
+            "skipping test_null_nvlink_observation_after_nmxc_unreachable_use_nmxc_simulator as nmxc simulator tests are not enabled"
+        );
+        return;
+    }
+
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    let mut test_overrides = TestEnvOverrides::with_config(config);
+    test_overrides.nmxc_simulator = Some(true);
+
+    let env =
+        common::api_fixtures::create_test_env_with_overrides(pool.clone(), test_overrides).await;
+
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id,
+        logical_partition: _logical_partition,
+    } = create_nvl_logical_partition(&env, "test_partition".to_string()).await;
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_4_INFO_JSON,
+        ),
+    )
+    .await;
+    let machine = mh.host().rpc_machine().await;
+    assert_eq!(&machine.state, "Ready");
+
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+    assert_eq!(discovery_info.gpus.len(), 4);
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: discovery_info
+            .gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id - 1,
+                        logical_partition_id: Some(logical_partition_id),
+                    }
+                })
+            })
+            .collect(),
+    };
+
+    let (tinstance, instance) =
+        create_instance_with_nvlink_config(&env, &mh, nvl_config, segment_id).await;
+
+    assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
+
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let ids_all = env
+        .api
+        .find_nv_link_partition_ids(tonic::Request::new(
+            rpc::forge::NvLinkPartitionSearchFilter {
+                name: None,
+                tenant_organization_id: None,
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(ids_all.partition_ids.len(), 1);
+
+    let mut nmxc_sim_client = env
+        .nmxc_sim
+        .create_client(libnmxc::Endpoint::new("http://localhost:9601").expect("NMX-C endpoint URI"))
+        .await
+        .unwrap();
+    let nmxc_partitions = nmxc_sim_client
+        .get_partition_info_list(GetPartitionInfoListRequest {
+            context: Some(libnmxc::nmxc_model::Context {
+                context: String::new(),
+            }),
+            partition_id_list: vec![],
+            partition_name_list: vec![],
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .unwrap()
+        .partition_info_list;
+    assert_eq!(nmxc_partitions.len(), 1);
+
+    assert_machine_nvlink_observation_present(&mh, 4).await;
+
+    let instance = tinstance.rpc_instance().await;
+    let instance_status = instance.status();
+    let nvl_status = instance_status.inner().nvlink.as_ref().unwrap();
+    assert_eq!(nvl_status.configs_synced(), rpc::SyncState::Synced);
+
+    delete_nvlink_nmxc_endpoint(&pool, GB200_TRAY_4_CHASSIS_SERIAL).await;
+
+    env.run_nvl_partition_monitor_iteration().await;
+
+    assert_machine_nvlink_observation_null(&mh, &pool).await;
+
+    let instance_after_failure = tinstance.rpc_instance().await;
+    let instance_status_after_failure = instance_after_failure.status();
+    let nvlink_status_after_failure = instance_status_after_failure
+        .inner()
+        .nvlink
+        .as_ref()
+        .expect("expected nvlink status after monitor iteration");
+    assert_ne!(
+        nvlink_status_after_failure.configs_synced(),
+        rpc::SyncState::Synced,
+        "nvlink config must not remain Synced when NMX-C is unreachable"
+    );
 }

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -52,9 +52,8 @@ use rpc::forge::TenantState;
 use rpc::forge::forge_server::Forge;
 
 use crate::tests::common;
-use crate::tests::common::api_fixtures::TEST_SITE_PREFIXES;
-use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::nvl_logical_partition::NvlLogicalPartitionFixture;
+use crate::tests::common::api_fixtures::{TEST_SITE_PREFIXES, TestEnvOverrides};
 use crate::tests::common::mac_address_pool::{
     EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL, EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL,
 };

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -18,25 +18,51 @@
 //use rpc::forge::NvlPartitionSearchFilter;
 use ::rpc::machine_discovery::Gpu;
 use carbide_uuid::nvlink::NvLinkPartitionId;
-use common::api_fixtures::create_managed_host_with_hardware_info_template;
+use carbide_uuid::rack::RackId;
+use carbide_uuid::switch::SwitchId;
 use common::api_fixtures::instance::{
     create_instance_with_nvlink_config, update_instance_nvlink_config,
 };
-use common::api_fixtures::managed_host::HardwareInfoTemplate;
+use common::api_fixtures::managed_host::{HardwareInfoTemplate, ManagedHostConfig};
+use common::api_fixtures::network_segment::{
+    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2, create_network_segment,
+};
 use common::api_fixtures::nvl_logical_partition::create_nvl_logical_partition;
-use db::{self, nvl_partition as db_nvl_partition};
+use common::api_fixtures::site_explorer::{
+    TestRackDbBuilder, new_host, register_expected_switch_exploration_results,
+};
+use common::api_fixtures::{
+    TestEnv, TestManagedHost, create_managed_host_with_hardware_info_template,
+    insert_nvlink_nmxc_endpoint_from_managed_host,
+};
+use db::{self, nvl_partition as db_nvl_partition, switch as db_switch};
+use ipnetwork::IpNetwork;
 use libnmxc::nmxc_model::{
     CreatePartitionRequest, GetPartitionInfoListRequest, UpdatePartitionRequest,
 };
+use model::expected_switch::ExpectedSwitch;
 use model::instance::config::nvlink::InstanceNvLinkConfig;
+use model::metadata::Metadata;
 use model::nvl_partition::{NewNvlPartition, NvlPartitionName};
+use model::switch::{
+    CONTROL_PLANE_STATE_CONFIGURED, FabricManagerState, FabricManagerStatus, NewSwitch,
+    SwitchConfig, SwitchControllerState,
+};
 use rpc::forge::TenantState;
 use rpc::forge::forge_server::Forge;
 
-// model::instance::config::nvlink::{InstanceNvLinkConfig, InstanceNvLinkGpuConfig},
 use crate::tests::common;
+use crate::tests::common::api_fixtures::TEST_SITE_PREFIXES;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::nvl_logical_partition::NvlLogicalPartitionFixture;
+use crate::tests::common::mac_address_pool::{
+    EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL, EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL,
+};
+
+const SWITCH_BMC_STATIC_IP: std::net::IpAddr =
+    std::net::IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 1, 50));
+const SWITCH_NVOS_STATIC_IP: std::net::IpAddr =
+    std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
 
 #[crate::sqlx_test]
 async fn test_nmx_c_partition_id_migration_deletes_legacy_nmx_m_rows(pool: sqlx::PgPool) {
@@ -1617,7 +1643,6 @@ async fn test_create_instance_add_to_existing_partition(pool: sqlx::PgPool) {
         .unwrap()
         .partition_info_list;
 
-    println!("\n\n\n nmxc_partitions {:?}", nmxc_partitions);
     assert_eq!(nmxc_partitions.len(), 1);
     assert_eq!(nmxc_partitions[0].gpu_uid_list.len(), 4);
 
@@ -1635,7 +1660,6 @@ async fn test_create_instance_add_to_existing_partition(pool: sqlx::PgPool) {
     assert_eq!(discovery_info2.gpus.len(), 4);
 
     let gpus2: Vec<Gpu> = discovery_info2.gpus.to_vec();
-    println!("{gpus2:?}");
 
     let nvl_config2 = rpc::forge::InstanceNvLinkConfig {
         gpu_configs: gpus2
@@ -1935,7 +1959,6 @@ async fn test_create_instance_gpu_in_unknown_partition(pool: sqlx::PgPool) {
         .unwrap()
         .partition_info_list;
     assert_eq!(nmxc_partitions.len(), 1);
-    println!("\n\n\nnmxc_partitions: {:?}", nmxc_partitions);
 
     let mh1 = create_managed_host_with_hardware_info_template(
         &env,
@@ -1951,7 +1974,6 @@ async fn test_create_instance_gpu_in_unknown_partition(pool: sqlx::PgPool) {
     assert_eq!(discovery_info1.gpus.len(), 4);
 
     let gpus: Vec<Gpu> = discovery_info1.gpus.to_vec();
-    println!("{gpus:?}");
 
     let nvl_config = rpc::forge::InstanceNvLinkConfig {
         gpu_configs: gpus
@@ -2090,8 +2112,6 @@ async fn run_create_instance_with_nvl_config_nmxc_simulator_scenario(
 
     let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
 
-    println!("{gpus:?}");
-
     let mut nvl_config = rpc::forge::InstanceNvLinkConfig {
         gpu_configs: gpus
             .iter()
@@ -2214,6 +2234,266 @@ async fn test_create_instance_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgP
         return;
     }
     run_create_instance_with_nvl_config_nmxc_simulator_scenario(pool, false).await;
+}
+
+async fn seed_switch_endpoint_records(
+    txn: &mut sqlx::PgConnection,
+    bmc_mac: mac_address::MacAddress,
+    nvos_mac: mac_address::MacAddress,
+    serial_number: &str,
+    switch_name: &str,
+    rack_id: &RackId,
+) {
+    db::expected_switch::create(
+        txn,
+        ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac,
+            nvos_mac_addresses: vec![nvos_mac],
+            serial_number: serial_number.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "Pwd2023x0x0x0x7".into(),
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: Some(SWITCH_BMC_STATIC_IP),
+            nvos_ip_address: Some(SWITCH_NVOS_STATIC_IP),
+            metadata: Metadata {
+                name: switch_name.to_string(),
+                description: "Test switch for NMX-C simulator".to_string(),
+                labels: Default::default(),
+            },
+            rack_id: Some(rack_id.clone()),
+            bmc_retain_credentials: None,
+        },
+    )
+    .await
+    .expect("create expected switch");
+
+    db::machine_interface::preallocate_bmc_machine_interface(txn, bmc_mac, SWITCH_BMC_STATIC_IP)
+        .await
+        .expect("BMC machine interface");
+    db::machine_interface::preallocate_machine_interface(txn, nvos_mac, SWITCH_NVOS_STATIC_IP)
+        .await
+        .expect("NVOS machine interface");
+}
+
+async fn create_rack_switch_for_nmxc_simulator(env: &TestEnv, rack_id: &RackId) -> SwitchId {
+    const SWITCH_SERIAL: &str = "SW-SN-001";
+    let bmc_mac = EXPECTED_SWITCH_BMC_MAC_ADDRESS_POOL.allocate();
+    let nvos_mac = EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL.allocate();
+    let switch_id = model::switch::switch_id::from_hardware_info(
+        SWITCH_SERIAL,
+        "NVIDIA",
+        "Switch",
+        carbide_uuid::switch::SwitchIdSource::ProductBoardChassisSerial,
+        carbide_uuid::switch::SwitchType::NvLink,
+    )
+    .expect("switch id");
+
+    let mut txn = env.pool.begin().await.expect("begin txn");
+    seed_switch_endpoint_records(
+        txn.as_mut(),
+        bmc_mac,
+        nvos_mac,
+        SWITCH_SERIAL,
+        "Switch1",
+        rack_id,
+    )
+    .await;
+    db_switch::create(
+        txn.as_mut(),
+        &NewSwitch {
+            id: switch_id,
+            config: SwitchConfig {
+                name: "Switch1".to_string(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            bmc_mac_address: Some(bmc_mac),
+            metadata: None,
+            rack_id: Some(rack_id.clone()),
+            slot_number: Some(0),
+            tray_index: Some(0),
+        },
+    )
+    .await
+    .expect("create switch");
+
+    let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+        .await
+        .expect("load switch")
+        .expect("switch");
+    db_switch::try_update_controller_state(
+        txn.as_mut(),
+        switch_id,
+        switch.controller_state.version,
+        switch.controller_state.version.increment(),
+        &SwitchControllerState::Ready,
+    )
+    .await
+    .expect("set switch ready");
+    db_switch::update_fabric_manager_status(
+        txn.as_mut(),
+        switch_id,
+        Some(&FabricManagerStatus {
+            fabric_manager_state: FabricManagerState::Ok,
+            addition_info: Some(CONTROL_PLANE_STATE_CONFIGURED.to_string()),
+            reason: None,
+            error_message: None,
+        }),
+    )
+    .await
+    .expect("set fabric manager status");
+    db_switch::set_primary_switch_for_rack(txn.as_mut(), rack_id, &switch_id)
+        .await
+        .expect("set primary switch");
+    txn.commit().await.expect("commit switch");
+    switch_id
+}
+
+#[crate::sqlx_test]
+async fn test_rack_switch_create_instance_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgPool) {
+    if !nmxc_simulator_tests_enabled() {
+        println!(
+            "skipping test_rack_switch_create_nvl_config_use_nmxc_simulator as nmxc simulator tests are not enabled"
+        );
+        return;
+    }
+
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+        nvlink_config.allow_insecure = true;
+    }
+
+    let mut overrides = TestEnvOverrides::with_config(config);
+    overrides.nmxc_simulator = Some(true);
+    let mut site_prefixes = TEST_SITE_PREFIXES.clone();
+    site_prefixes.push(*FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2);
+    overrides.site_prefixes = Some(site_prefixes);
+
+    let env = common::api_fixtures::create_test_env_with_overrides(pool.clone(), overrides).await;
+
+    create_network_segment(
+        &env.api,
+        "ADMIN2",
+        &IpNetwork::new(
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2.network(),
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2.prefix(),
+        )
+        .unwrap()
+        .to_string(),
+        &FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2
+            .ip()
+            .to_string(),
+        rpc::forge::NetworkSegmentType::Admin,
+        None,
+        true,
+    )
+    .await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let rack_id: RackId = "rack_1".parse().expect("rack id");
+    let mut txn = pool.begin().await.expect("begin txn");
+    TestRackDbBuilder::new()
+        .with_rack_id(rack_id.clone())
+        .persist(&mut txn)
+        .await
+        .expect("create rack");
+    txn.commit().await.expect("commit rack");
+
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id,
+        logical_partition: _logical_partition,
+    } = create_nvl_logical_partition(&env, "test_partition".to_string()).await;
+
+    // Switch must exist before host discovery so NMX-C endpoint resolution can use rack NVOS IP.
+    let _switch_id = create_rack_switch_for_nmxc_simulator(&env, &rack_id).await;
+
+    register_expected_switch_exploration_results(&env)
+        .await
+        .expect("register switch endpoint exploration mocks");
+
+    let hardware_info_template = HardwareInfoTemplate::Custom(
+        crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_4_INFO_JSON,
+    );
+    insert_nvlink_nmxc_endpoint_from_managed_host(&env, &hardware_info_template).await;
+    let mut managed_host_config =
+        ManagedHostConfig::with_hardware_info_template(hardware_info_template);
+    managed_host_config.admin_dhcp_fallback = true;
+    let mh_snapshot = new_host(&env, managed_host_config)
+        .await
+        .expect("create managed host");
+    let mh = TestManagedHost {
+        id: mh_snapshot.host_snapshot.id,
+        dpu_ids: mh_snapshot
+            .dpu_snapshots
+            .into_iter()
+            .map(|snapshot| snapshot.id)
+            .collect(),
+        api: env.api.clone(),
+    };
+
+    let mut txn = pool.begin().await.expect("begin txn");
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .expect("set machine rack_id");
+    txn.commit().await.expect("commit machine rack_id");
+
+    let machine = mh.host().rpc_machine().await;
+    assert_eq!(machine.rack_id.as_ref(), Some(&rack_id));
+    assert_eq!(&machine.state, "Ready");
+
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+    assert_eq!(discovery_info.gpus.len(), 4);
+
+    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id - 1,
+                        logical_partition_id: Some(logical_partition_id),
+                    }
+                })
+            })
+            .collect(),
+    };
+
+    let (tinstance, instance) =
+        create_instance_with_nvlink_config(&env, &mh, nvl_config, segment_id).await;
+
+    let machine = mh.host().rpc_machine().await;
+    assert_eq!(&machine.state, "Assigned/Ready");
+
+    let check_instance = tinstance.rpc_instance().await;
+    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
+    assert_eq!(instance, check_instance);
+
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let ids_all = env
+        .api
+        .find_nv_link_partition_ids(tonic::Request::new(
+            rpc::forge::NvLinkPartitionSearchFilter {
+                name: None,
+                tenant_organization_id: None,
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(ids_all.partition_ids.len(), 1);
 }
 
 // mTLS scenario. For this test, the simulator needs to be configured with mTLS.
@@ -2597,4 +2877,72 @@ async fn test_instance_delete_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgP
         .map(|response| response.into_inner())
         .unwrap();
     assert_eq!(ids_all.partition_ids.len(), 0);
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulator(
+    pool: sqlx::PgPool,
+) {
+    if !nmxc_simulator_tests_enabled() {
+        println!(
+            "skipping test_instance_delete_with_nvl_config_use_nmxc_simulator as nmxc simulator tests are not enabled"
+        );
+        return;
+    }
+
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    let mut test_overrides = TestEnvOverrides::with_config(config);
+    test_overrides.nmxc_simulator = Some(true);
+
+    let env =
+        common::api_fixtures::create_test_env_with_overrides(pool.clone(), test_overrides).await;
+
+    let _segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_4_INFO_JSON,
+        ),
+    )
+    .await;
+    let machine = mh.host().rpc_machine().await;
+
+    assert_eq!(&machine.state, "Ready");
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+
+    assert_eq!(discovery_info.gpus.len(), 4);
+
+    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
+
+    println!("{gpus:?}");
+
+    // Run twice to record observation.
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let mut nmxc_sim_client = env
+        .nmxc_sim
+        .create_client(libnmxc::Endpoint::new("http://localhost:9601").expect("NMX-C endpoint URI"))
+        .await
+        .unwrap();
+    let nmxc_partitions = nmxc_sim_client
+        .get_partition_info_list(GetPartitionInfoListRequest {
+            context: Some(libnmxc::nmxc_model::Context {
+                context: String::new(),
+            }),
+            partition_id_list: vec![],
+            partition_name_list: vec![],
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .unwrap()
+        .partition_info_list;
+    assert_eq!(nmxc_partitions.len(), 1);
+    assert_eq!(nmxc_partitions[0].name, "tray_partition_1");
 }

--- a/crates/api/src/tests/switch_find.rs
+++ b/crates/api/src/tests/switch_find.rs
@@ -262,3 +262,88 @@ async fn test_find_switches_by_ids_response_fields(
 
     Ok(())
 }
+
+#[crate::sqlx_test]
+async fn test_find_ready_control_plane_configured_switch_ids_in_rack(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use carbide_uuid::rack::RackId;
+    use db::switch as db_switch;
+    use model::switch::{
+        CONTROL_PLANE_STATE_CONFIGURED, FabricManagerState, FabricManagerStatus,
+        SwitchControllerState,
+    };
+
+    use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
+
+    let env = create_test_env(pool).await;
+    let mut txn = env.pool.begin().await?;
+
+    let rack_id: RackId = "rack-sw-find".parse().unwrap();
+    let other_rack_id: RackId = "rack-other".parse().unwrap();
+    TestRackDbBuilder::new()
+        .with_rack_id(rack_id.clone())
+        .persist(&mut txn)
+        .await?;
+    TestRackDbBuilder::new()
+        .with_rack_id(other_rack_id.clone())
+        .persist(&mut txn)
+        .await?;
+    txn.commit().await?;
+
+    let matching_switch = new_switch(&env, Some("Switch1".to_string()), None).await?;
+    let wrong_fm_switch = new_switch(&env, Some("Switch2".to_string()), None).await?;
+    let other_rack_switch = new_switch(&env, Some("Switch4".to_string()), None).await?;
+
+    let configured_status = FabricManagerStatus {
+        fabric_manager_state: FabricManagerState::Ok,
+        addition_info: Some(CONTROL_PLANE_STATE_CONFIGURED.to_string()),
+        reason: None,
+        error_message: None,
+    };
+
+    let mut txn = env.pool.begin().await?;
+    for (switch_id, rack, fm_status) in [
+        (matching_switch, &rack_id, Some(&configured_status)),
+        (wrong_fm_switch, &rack_id, None),
+        (other_rack_switch, &other_rack_id, Some(&configured_status)),
+    ] {
+        sqlx::query("UPDATE switches SET rack_id = $1 WHERE id = $2")
+            .bind(rack)
+            .bind(switch_id)
+            .execute(txn.as_mut())
+            .await?;
+
+        let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+            .await?
+            .expect("switch should exist");
+        db_switch::try_update_controller_state(
+            txn.as_mut(),
+            switch_id,
+            switch.controller_state.version,
+            switch.controller_state.version.increment(),
+            &SwitchControllerState::Ready,
+        )
+        .await?;
+
+        if let Some(status) = fm_status {
+            db_switch::update_fabric_manager_status(txn.as_mut(), switch_id, Some(status)).await?;
+        }
+    }
+    txn.commit().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let found =
+        db_switch::find_ready_control_plane_configured_switch_ids_in_rack(txn.as_mut(), &rack_id)
+            .await?;
+    assert_eq!(found, vec![matching_switch]);
+
+    let found_other = db_switch::find_ready_control_plane_configured_switch_ids_in_rack(
+        txn.as_mut(),
+        &other_rack_id,
+    )
+    .await?;
+    assert_eq!(found_other, vec![other_rack_switch]);
+
+    Ok(())
+}

--- a/crates/api/src/web/nmxc_browser.rs
+++ b/crates/api/src/web/nmxc_browser.rs
@@ -55,8 +55,11 @@ pub struct QueryParams {
 fn browse_operation_from_query(s: &str) -> i32 {
     match s.trim() {
         "compute_node_info_list" => rpc::forge::NmxcBrowseOperation::ComputeNodeInfoList as i32,
+        "switch_node_info_list" => rpc::forge::NmxcBrowseOperation::SwitchNodeInfoList as i32,
         "gpu_info" => rpc::forge::NmxcBrowseOperation::GpuInfo as i32,
         "gpu_info_list" => rpc::forge::NmxcBrowseOperation::GpuInfoList as i32,
+        "partition_info_list" => rpc::forge::NmxcBrowseOperation::PartitionInfoList as i32,
+        "get_domain_properties" => rpc::forge::NmxcBrowseOperation::GetDomainProperties as i32,
         _ => rpc::forge::NmxcBrowseOperation::Unspecified as i32,
     }
 }

--- a/crates/api/templates/nmxc_browser.html
+++ b/crates/api/templates/nmxc_browser.html
@@ -20,8 +20,11 @@ See the <a href="https://docs.nvidia.com/networking/display/nmxcv11/grpc+api+doc
 		<select id="operation_input" name="operation">
 			<option value="" {% if operation.is_empty() %}selected{% endif %}>— choose —</option>
 			<option value="compute_node_info_list" {% if operation == "compute_node_info_list" %}selected{% endif %}>Compute node info list</option>
+			<option value="switch_node_info_list" {% if operation == "switch_node_info_list" %}selected{% endif %}>Switch node info list</option>
 			<option value="gpu_info" {% if operation == "gpu_info" %}selected{% endif %}>GPU info (by UID)</option>
 			<option value="gpu_info_list" {% if operation == "gpu_info_list" %}selected{% endif %}>GPU info list (domain)</option>
+			<option value="partition_info_list" {% if operation == "partition_info_list" %}selected{% endif %}>Partition info list</option>
+			<option value="get_domain_properties" {% if operation == "get_domain_properties" %}selected{% endif %}>Get domain properties</option>
 		</select>
 	</div>
 	<div>

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -42,7 +42,10 @@ use db::{self, ObjectColumnFilter, TransactionVending, machine};
 use errors::{NvLinkManagerError, NvLinkManagerResult};
 use libnmxc::nmxc_model::{GetPartitionInfoListRequest, PartitionInfo};
 use libnmxc::{Endpoint, NMX_C_GATEWAY_ID, Nmxc, NmxcPool};
-use metrics::{AppliedChange, NmxcMetricOperationStatus, NvlPartitionMonitorMetrics};
+use metrics::{
+    AppliedChange, ChassisNmxCUnreachableReason, NmxcMetricOperationStatus,
+    NvlPartitionMonitorMetrics,
+};
 use model::hardware_info::{HardwareInfo, MachineNvLinkInfo, NvLinkGpu};
 use model::instance::status::SyncState;
 use model::instance::status::nvlink::InstanceNvLinkStatus;
@@ -771,6 +774,16 @@ struct CheckPartitionsInput {
     nvlink_info_db_updates: Vec<(MachineId, MachineNvLinkInfo)>,
 }
 
+/// Work queued when NMX-C cannot be used for a chassis and observations must be cleared.
+struct PendingNullNvlinkObservation {
+    /// Chassis serial for the machines whose observations will be cleared.
+    chassis_serial: String,
+    /// Failure reason recorded in partition-monitor metrics.
+    reason: ChassisNmxCUnreachableReason,
+    /// Host machines on the chassis that will receive a null `nvlink_status_observation`.
+    machine_ids: Vec<MachineId>,
+}
+
 impl NvlPartitionMonitor {
     const ITERATION_WORK_KEY: &'static str = "NvlPartitionMonitor::run_single_iteration";
 
@@ -943,12 +956,19 @@ impl NvlPartitionMonitor {
         metrics.num_physical_partitions = db_nvl_partitions.len();
 
         let mut total_completed_operations = 0;
+        let mut pending_null_nvlink_observations = Vec::new();
 
         for (chassis_serial, chassis_snapshots) in &managed_host_snapshots_by_chassis_serial {
             let Some(endpoint_url) = chassis_serial_to_resolved_endpoint.get(chassis_serial) else {
-                tracing::debug!(
+                tracing::warn!(
                     %chassis_serial,
                     "No NMX-C endpoint for chassis (switch NVOS IP or nvlink_nmxc_endpoints mapping); skipping partition monitor work"
+                );
+                Self::queue_null_nvlink_status_observation(
+                    &mut pending_null_nvlink_observations,
+                    chassis_serial,
+                    chassis_snapshots,
+                    ChassisNmxCUnreachableReason::NoEndpoint,
                 );
                 continue;
             };
@@ -961,6 +981,12 @@ impl NvlPartitionMonitor {
                         endpoint = %endpoint_url,
                         error = %e,
                         "Invalid NMX-C endpoint URI; skipping partition monitor work for this chassis"
+                    );
+                    Self::queue_null_nvlink_status_observation(
+                        &mut pending_null_nvlink_observations,
+                        chassis_serial,
+                        chassis_snapshots,
+                        ChassisNmxCUnreachableReason::InvalidEndpointUri,
                     );
                     continue;
                 }
@@ -975,6 +1001,12 @@ impl NvlPartitionMonitor {
                         error = %e,
                         "Failed to create NMX-C client; skipping partition monitor work for this chassis"
                     );
+                    Self::queue_null_nvlink_status_observation(
+                        &mut pending_null_nvlink_observations,
+                        chassis_serial,
+                        chassis_snapshots,
+                        ChassisNmxCUnreachableReason::ClientCreateFailed,
+                    );
                     continue;
                 }
             };
@@ -987,6 +1019,12 @@ impl NvlPartitionMonitor {
                         error = %e,
                         "NMX-C hello failed; skipping partition monitor work for this chassis"
                     );
+                    Self::queue_null_nvlink_status_observation(
+                        &mut pending_null_nvlink_observations,
+                        chassis_serial,
+                        chassis_snapshots,
+                        ChassisNmxCUnreachableReason::HelloFailed,
+                    );
                     continue;
                 }
             };
@@ -998,6 +1036,12 @@ impl NvlPartitionMonitor {
                         endpoint = %endpoint_url,
                         error = %e,
                         "Failed to parse domain UUID from NMX-C hello; skipping partition monitor work for this chassis"
+                    );
+                    Self::queue_null_nvlink_status_observation(
+                        &mut pending_null_nvlink_observations,
+                        chassis_serial,
+                        chassis_snapshots,
+                        ChassisNmxCUnreachableReason::DomainUuidParseFailed,
                     );
                     continue;
                 }
@@ -1047,7 +1091,7 @@ impl NvlPartitionMonitor {
                 .cloned()
                 .collect();
 
-            let num_completed = self
+            let num_completed = match self
                 .check_partitions_and_apply_nmx_c_operations(
                     nmxc_client.as_mut(),
                     metrics,
@@ -1059,9 +1103,29 @@ impl NvlPartitionMonitor {
                         nvlink_info_db_updates,
                     },
                 )
-                .await?;
+                .await
+            {
+                Ok(num_completed) => num_completed,
+                Err(e) => {
+                    tracing::warn!(
+                        %chassis_serial,
+                        error = %e,
+                        "Partition monitor work failed for chassis; queuing null nvlink status observations"
+                    );
+                    Self::queue_null_nvlink_status_observation(
+                        &mut pending_null_nvlink_observations,
+                        chassis_serial,
+                        chassis_snapshots,
+                        ChassisNmxCUnreachableReason::PartitionMonitorWorkFailed,
+                    );
+                    0
+                }
+            };
             total_completed_operations += num_completed;
         }
+
+        self.record_null_nvlink_status_observations(&pending_null_nvlink_observations, metrics)
+            .await?;
 
         metrics.num_completed_operations = total_completed_operations;
 
@@ -1644,6 +1708,76 @@ impl NvlPartitionMonitor {
                 );
                 partition_ctx.handle_gpu_removal(&gpu_ctx, gpus_to_keep)?;
             }
+        }
+        Ok(())
+    }
+
+    /// Queues machines on `chassis_serial` for a batched null `nvlink_status_observation` write.
+    ///
+    /// Entries are flushed in one transaction by [`Self::record_null_nvlink_status_observations`].
+    fn queue_null_nvlink_status_observation(
+        pending: &mut Vec<PendingNullNvlinkObservation>,
+        chassis_serial: &str,
+        chassis_snapshots: &[&ManagedHostStateSnapshot],
+        reason: ChassisNmxCUnreachableReason,
+    ) {
+        let machine_ids: Vec<MachineId> = chassis_snapshots
+            .iter()
+            .map(|snapshot| snapshot.host_snapshot.id)
+            .collect();
+        if machine_ids.is_empty() {
+            return;
+        }
+        pending.push(PendingNullNvlinkObservation {
+            chassis_serial: chassis_serial.to_string(),
+            reason,
+            machine_ids,
+        });
+    }
+
+    /// Clears `nvlink_status_observation` for all queued chassis in one transaction and updates metrics.
+    async fn record_null_nvlink_status_observations(
+        &self,
+        pending: &[PendingNullNvlinkObservation],
+        metrics: &mut NvlPartitionMonitorMetrics,
+    ) -> NvLinkManagerResult<()> {
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        for entry in pending {
+            *metrics
+                .num_nmx_c_unreachable_chassis
+                .entry(entry.reason)
+                .or_insert(0) += 1;
+        }
+
+        let machine_ids: Vec<MachineId> = pending
+            .iter()
+            .flat_map(|entry| entry.machine_ids.iter().copied())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let mut obs_txn = self.db_pool.begin().await.map_err(|e| {
+            NvLinkManagerError::internal(format!(
+                "Failed to create transaction for clearing nvlink status observations: {e}"
+            ))
+        })?;
+        machine::clear_nvlink_status_observations(&mut obs_txn, &machine_ids).await?;
+        obs_txn.commit().await.map_err(|e| {
+            NvLinkManagerError::internal(format!(
+                "Failed to commit transaction for clearing nvlink status observations: {e}"
+            ))
+        })?;
+
+        for entry in pending {
+            tracing::info!(
+                chassis_serial = %entry.chassis_serial,
+                reason = ?entry.reason,
+                machine_ids = ?entry.machine_ids,
+                "Posted null nvlink status observations because NMX-C is unreachable for chassis"
+            );
         }
         Ok(())
     }

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -62,9 +62,10 @@ use tracing::Instrument;
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
 
-/// Multicast groups limit for new NMX-C partitions. Assuming at most 2 partitions per tray and
-// 18 tray default partitions, this is set to floor(1024 / (36+18)).
-const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / (36 + 18);
+/// Multicast groups limit for new NMX-C partitions. Must be a multiple of 4. Assuming at most 2
+/// partitions per tray and 18 tray default partitions, this is floor(1024 / (36+18)) rounded down
+/// to the nearest multiple of 4.
+const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 16;
 
 fn rack_id_from_chassis_snapshots(
     chassis_snapshots: &[&ManagedHostStateSnapshot],

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -19,6 +19,7 @@ use std::collections::{HashMap, HashSet};
 pub mod config;
 mod errors;
 mod metrics;
+pub mod nmx_c_endpoint;
 pub mod nvlink;
 
 use std::io;
@@ -28,6 +29,7 @@ use std::time::Duration;
 use carbide_utils::periodic_timer::PeriodicTimer;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
+use carbide_uuid::rack::RackId;
 use chrono::Utc;
 use config::NvLinkConfig;
 use config_version::Versioned;
@@ -41,7 +43,7 @@ use errors::{NvLinkManagerError, NvLinkManagerResult};
 use libnmxc::nmxc_model::{GetPartitionInfoListRequest, PartitionInfo};
 use libnmxc::{Endpoint, NMX_C_GATEWAY_ID, Nmxc, NmxcPool};
 use metrics::{AppliedChange, NmxcMetricOperationStatus, NvlPartitionMonitorMetrics};
-use model::hardware_info::MachineNvLinkInfo;
+use model::hardware_info::{HardwareInfo, MachineNvLinkInfo, NvLinkGpu};
 use model::instance::status::SyncState;
 use model::instance::status::nvlink::InstanceNvLinkStatus;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -56,6 +58,162 @@ use tracing::Instrument;
 
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
+
+/// Multicast groups limit for new NMX-C partitions. Assuming at most 2 partitions per tray and
+// 18 tray default partitions, this is set to floor(1024 / (36+18)).
+const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / (36 + 18);
+
+fn rack_id_from_chassis_snapshots(
+    chassis_snapshots: &[&ManagedHostStateSnapshot],
+) -> Option<RackId> {
+    chassis_snapshots
+        .iter()
+        .find_map(|snapshot| snapshot.host_snapshot.rack_id.clone())
+}
+
+fn domain_uuid_from_nmx_c_hello(
+    hello: &libnmxc::nmxc_model::ServerHello,
+) -> NvLinkManagerResult<NvLinkDomainId> {
+    hello
+        .server_header
+        .as_ref()
+        .and_then(|header| uuid::Uuid::parse_str(&header.domain_uuid).ok())
+        .map(NvLinkDomainId::from)
+        .ok_or_else(|| {
+            NvLinkManagerError::internal(format!(
+                "Failed to parse domain UUID from NMX-C hello response: {hello:?}"
+            ))
+        })
+}
+
+fn parse_nvlink_gpu_fabric_guid(fabric_guid: &str) -> u64 {
+    let s = fabric_guid.trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16).unwrap_or(0)
+    } else {
+        s.parse::<u64>().unwrap_or(0)
+    }
+}
+
+fn nvlink_gpus_from_hardware_info(hardware_info: &HardwareInfo) -> Vec<NvLinkGpu> {
+    hardware_info
+        .gpus
+        .iter()
+        .filter_map(|gpu| gpu.platform_info.as_ref())
+        .map(|platform_info| NvLinkGpu {
+            tray_index: platform_info.tray_index as i32,
+            slot_id: platform_info.slot_number as i32,
+            device_id: platform_info.module_id as i32,
+            guid: parse_nvlink_gpu_fabric_guid(&platform_info.fabric_guid),
+        })
+        .collect()
+}
+
+fn build_machine_nvlink_info_from_nmx_c_hello(
+    existing: Option<&MachineNvLinkInfo>,
+    snapshot: Option<&ManagedHostStateSnapshot>,
+    chassis_serial: &str,
+    domain_uuid: NvLinkDomainId,
+) -> MachineNvLinkInfo {
+    if let Some(existing) = existing {
+        let mut info = existing.clone();
+        if info.domain_uuid == NvLinkDomainId::nil() {
+            info.domain_uuid = domain_uuid;
+        }
+        if info.chassis_serial.trim().is_empty() {
+            info.chassis_serial = chassis_serial.to_string();
+        }
+        return info;
+    }
+
+    if let Some(snapshot_info) =
+        snapshot.and_then(|snapshot| snapshot.host_snapshot.nvlink_info.as_ref())
+    {
+        return MachineNvLinkInfo {
+            domain_uuid,
+            chassis_serial: if snapshot_info.chassis_serial.trim().is_empty() {
+                chassis_serial.to_string()
+            } else {
+                snapshot_info.chassis_serial.clone()
+            },
+            gpus: snapshot_info.gpus.clone(),
+        };
+    }
+
+    let gpus = snapshot
+        .and_then(|snapshot| snapshot.host_snapshot.hardware_info.as_ref())
+        .map(nvlink_gpus_from_hardware_info)
+        .unwrap_or_default();
+
+    MachineNvLinkInfo {
+        domain_uuid,
+        chassis_serial: chassis_serial.to_string(),
+        gpus,
+    }
+}
+
+/// Populates missing `machines.nvlink_info` entries (or nil `domain_uuid`) using NMX-C hello.
+fn populate_machine_nvlink_info_if_needed(
+    machine_nvlink_info: &mut HashMap<MachineId, Option<MachineNvLinkInfo>>,
+    managed_host_snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+    chassis_serial: &str,
+    machine_ids: &[MachineId],
+    domain_uuid: NvLinkDomainId,
+) -> Vec<(MachineId, MachineNvLinkInfo)> {
+    let mut updates = Vec::new();
+    for machine_id in machine_ids {
+        let existing = machine_nvlink_info
+            .get(machine_id)
+            .and_then(|info| info.as_ref());
+        if existing.is_some_and(|info| info.domain_uuid != NvLinkDomainId::nil()) {
+            continue;
+        }
+
+        let snapshot = managed_host_snapshots.get(machine_id);
+        let updated = build_machine_nvlink_info_from_nmx_c_hello(
+            existing,
+            snapshot,
+            chassis_serial,
+            domain_uuid,
+        );
+        machine_nvlink_info.insert(*machine_id, Some(updated.clone()));
+        updates.push((*machine_id, updated));
+    }
+    updates
+}
+
+fn nmx_c_partition_create_attr_with_multicast_groups_limit(
+    multicast_groups_limit: u32,
+) -> libnmxc::nmxc_model::PartitionAttr {
+    libnmxc::nmxc_model::PartitionAttr {
+        resiliency_mode: libnmxc::nmxc_model::ResiliencyMode::NmxResiliencyModeUndefined as i32,
+        multicast_groups_limit,
+    }
+}
+
+fn nmx_c_create_partition_request(
+    name: String,
+    gpu_uids: &[u64],
+    multicast_groups_limit: u32,
+) -> libnmxc::nmxc_model::CreatePartitionRequest {
+    libnmxc::nmxc_model::CreatePartitionRequest {
+        context: None,
+        name,
+        gpu_resource_id: gpu_uids
+            .iter()
+            .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
+                resource_id: Some(libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
+                    uid,
+                )),
+            })
+            .collect(),
+        attr: Some(nmx_c_partition_create_attr_with_multicast_groups_limit(
+            multicast_groups_limit,
+        )),
+        partition_id: None,
+        gateway_id: NMX_C_GATEWAY_ID.into(),
+    }
+}
 
 #[derive(Debug, Clone)]
 struct NmxcPartitionOperation {
@@ -605,6 +763,14 @@ pub struct NvlPartitionMonitor {
     work_lock_manager_handle: WorkLockManagerHandle,
 }
 
+struct CheckPartitionsInput {
+    db_nvl_logical_partitions: Vec<LogicalPartition>,
+    db_nvl_partitions: Vec<NvlPartition>,
+    machine_nvlink_info: HashMap<MachineId, Option<MachineNvLinkInfo>>,
+    managed_host_snapshots: HashMap<MachineId, ManagedHostStateSnapshot>,
+    nvlink_info_db_updates: Vec<(MachineId, MachineNvLinkInfo)>,
+}
+
 impl NvlPartitionMonitor {
     const ITERATION_WORK_KEY: &'static str = "NvlPartitionMonitor::run_single_iteration";
 
@@ -725,7 +891,7 @@ impl NvlPartitionMonitor {
 
         let mut txn = self.db_pool.txn_begin().await?;
         let managed_host_snapshots = self.load_mnnvl_managed_host_snapshots(txn.as_mut()).await?;
-        let machine_nvlink_info = machine::find_nvlink_info_by_machine_ids(
+        let mut machine_nvlink_info = machine::find_nvlink_info_by_machine_ids(
             &mut txn,
             &managed_host_snapshots.keys().copied().collect::<Vec<_>>(),
         )
@@ -754,12 +920,21 @@ impl NvlPartitionMonitor {
             db::nvl_logical_partition::find_by(&mut txn, ObjectColumnFilter::<LpIdColumn>::All)
                 .await?;
 
-        let chassis_serial_to_endpoint: HashMap<String, String> =
-            db::nvlink_nmxc_endpoints::find_all(&mut txn)
-                .await?
-                .into_iter()
-                .map(|r| (r.chassis_serial, r.endpoint))
-                .collect();
+        let mut chassis_serial_to_resolved_endpoint = HashMap::new();
+        for (chassis_serial, chassis_snapshots) in &managed_host_snapshots_by_chassis_serial {
+            let rack_id = rack_id_from_chassis_snapshots(chassis_snapshots);
+            if let Some(endpoint_url) = nmx_c_endpoint::resolve_nmx_c_endpoint_url(
+                &mut txn,
+                rack_id.as_ref(),
+                chassis_serial,
+                &self.config,
+            )
+            .await
+            .map_err(NvLinkManagerError::from)?
+            {
+                chassis_serial_to_resolved_endpoint.insert(chassis_serial.clone(), endpoint_url);
+            }
+        }
 
         // Don't hold the transaction across unrelated awaits
         txn.commit().await?;
@@ -770,10 +945,10 @@ impl NvlPartitionMonitor {
         let mut total_completed_operations = 0;
 
         for (chassis_serial, chassis_snapshots) in &managed_host_snapshots_by_chassis_serial {
-            let Some(endpoint_url) = chassis_serial_to_endpoint.get(chassis_serial) else {
+            let Some(endpoint_url) = chassis_serial_to_resolved_endpoint.get(chassis_serial) else {
                 tracing::debug!(
                     %chassis_serial,
-                    "No nvlink_nmxc_endpoints mapping for chassis; skipping partition monitor work"
+                    "No NMX-C endpoint for chassis (switch NVOS IP or nvlink_nmxc_endpoints mapping); skipping partition monitor work"
                 );
                 continue;
             };
@@ -803,33 +978,68 @@ impl NvlPartitionMonitor {
                     continue;
                 }
             };
-            if let Err(e) = nmxc_client.hello(NMX_C_GATEWAY_ID).await {
-                tracing::warn!(
-                    %chassis_serial,
-                    endpoint = %endpoint_url,
-                    error = %e,
-                    "NMX-C hello failed; skipping partition monitor work for this chassis"
-                );
-                continue;
-            }
+            let hello = match nmxc_client.hello(NMX_C_GATEWAY_ID).await {
+                Ok(hello) => hello,
+                Err(e) => {
+                    tracing::warn!(
+                        %chassis_serial,
+                        endpoint = %endpoint_url,
+                        error = %e,
+                        "NMX-C hello failed; skipping partition monitor work for this chassis"
+                    );
+                    continue;
+                }
+            };
+            let domain_uuid = match domain_uuid_from_nmx_c_hello(&hello) {
+                Ok(domain_uuid) => domain_uuid,
+                Err(e) => {
+                    tracing::warn!(
+                        %chassis_serial,
+                        endpoint = %endpoint_url,
+                        error = %e,
+                        "Failed to parse domain UUID from NMX-C hello; skipping partition monitor work for this chassis"
+                    );
+                    continue;
+                }
+            };
 
             // Filter managed host snapshots, nvlink info, and DB partitions for this chassis.
-            let managed_host_snapshots_domain: HashMap<MachineId, ManagedHostStateSnapshot> =
+            let mut managed_host_snapshots_domain: HashMap<MachineId, ManagedHostStateSnapshot> =
                 chassis_snapshots
                     .iter()
                     .map(|s| (s.host_snapshot.id, (*s).clone()))
                     .collect();
             let machine_ids_in_domain: Vec<MachineId> =
                 managed_host_snapshots_domain.keys().copied().collect();
+            let nvlink_info_db_updates = populate_machine_nvlink_info_if_needed(
+                &mut machine_nvlink_info,
+                &managed_host_snapshots,
+                chassis_serial,
+                &machine_ids_in_domain,
+                domain_uuid,
+            );
+            if !nvlink_info_db_updates.is_empty() {
+                tracing::info!(
+                    %chassis_serial,
+                    %domain_uuid,
+                    machine_ids = ?nvlink_info_db_updates.iter().map(|(id, _)| id).collect::<Vec<_>>(),
+                    "Populated machine nvlink_info from NMX-C hello"
+                );
+                for (machine_id, nvlink_info) in &nvlink_info_db_updates {
+                    if let Some(snapshot) = managed_host_snapshots_domain.get_mut(machine_id) {
+                        snapshot.host_snapshot.nvlink_info = Some(nvlink_info.clone());
+                    }
+                }
+            }
             let machine_nvlink_info_domain: HashMap<MachineId, Option<MachineNvLinkInfo>> =
                 machine_nvlink_info
                     .iter()
                     .filter(|(id, _)| machine_ids_in_domain.contains(id))
                     .map(|(k, v)| (*k, v.clone()))
                     .collect();
-            let domain_uuids: HashSet<NvLinkDomainId> = chassis_snapshots
-                .iter()
-                .filter_map(|s| s.host_snapshot.nvlink_info.as_ref().map(|n| n.domain_uuid))
+            let domain_uuids: HashSet<NvLinkDomainId> = machine_nvlink_info_domain
+                .values()
+                .filter_map(|info| info.as_ref().map(|info| info.domain_uuid))
                 .collect();
             let db_nvl_partitions_domain: Vec<NvlPartition> = db_nvl_partitions
                 .iter()
@@ -841,10 +1051,13 @@ impl NvlPartitionMonitor {
                 .check_partitions_and_apply_nmx_c_operations(
                     nmxc_client.as_mut(),
                     metrics,
-                    db_nvl_logical_partitions.clone(),
-                    db_nvl_partitions_domain,
-                    machine_nvlink_info_domain,
-                    managed_host_snapshots_domain,
+                    CheckPartitionsInput {
+                        db_nvl_logical_partitions: db_nvl_logical_partitions.clone(),
+                        db_nvl_partitions: db_nvl_partitions_domain,
+                        machine_nvlink_info: machine_nvlink_info_domain,
+                        managed_host_snapshots: managed_host_snapshots_domain,
+                        nvlink_info_db_updates,
+                    },
                 )
                 .await?;
             total_completed_operations += num_completed;
@@ -861,11 +1074,15 @@ impl NvlPartitionMonitor {
         &self,
         nmxc_client: &mut dyn Nmxc,
         metrics: &mut NvlPartitionMonitorMetrics,
-        db_nvl_logical_partitions: Vec<LogicalPartition>,
-        db_nvl_partitions: Vec<NvlPartition>,
-        machine_nvlink_info: HashMap<MachineId, Option<MachineNvLinkInfo>>,
-        managed_host_snapshots: HashMap<MachineId, ManagedHostStateSnapshot>,
+        input: CheckPartitionsInput,
     ) -> NvLinkManagerResult<usize> {
+        let CheckPartitionsInput {
+            db_nvl_logical_partitions,
+            db_nvl_partitions,
+            machine_nvlink_info,
+            managed_host_snapshots,
+            nvlink_info_db_updates,
+        } = input;
         let partition_info_list = nmxc_client
             .get_partition_info_list(GetPartitionInfoListRequest {
                 context: Some(libnmxc::nmxc_model::Context {
@@ -951,6 +1168,9 @@ impl NvlPartitionMonitor {
 
         // Update db with the operations that completed successfully.
         let mut txn = self.db_pool.txn_begin().await?;
+        for (machine_id, nvlink_info) in nvlink_info_db_updates {
+            machine::update_nvlink_info(&mut txn, &machine_id, nvlink_info).await?;
+        }
         self.update_db_with_nmx_c_operations(
             &mut txn,
             completed_nmx_c_operations,
@@ -1477,24 +1697,11 @@ impl NvlPartitionMonitor {
                                 .join(",")
                         );
                         let name: String = name.chars().take(240).collect();
-                        let request = libnmxc::nmxc_model::CreatePartitionRequest {
-                            context: None,
+                        let request = nmx_c_create_partition_request(
                             name,
-                            gpu_resource_id: operation
-                                .gpu_uids
-                                .iter()
-                                .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
-                                    resource_id: Some(
-                                        libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
-                                            uid,
-                                        ),
-                                    ),
-                                })
-                                .collect(),
-                            attr: None,
-                            partition_id: None,
-                            gateway_id: NMX_C_GATEWAY_ID.into(),
-                        };
+                            &operation.gpu_uids,
+                            NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT,
+                        );
                         match nmxc_client.create_partition(request).await {
                             Ok(_) => true,
                             Err(e) => {

--- a/crates/nvlink-manager/src/metrics.rs
+++ b/crates/nvlink-manager/src/metrics.rs
@@ -52,6 +52,25 @@ pub struct NvlPartitionMonitorMetrics {
     pub operation_latencies: HashMap<AppliedChange, Vec<Duration>>,
     /// Time from nvlink_config_version for instances currently in Pending (time spent in Pending), in milliseconds
     pub nvlink_config_apply_durations_ms: Vec<f64>,
+    /// Chassis-level NMX-C connectivity failures that caused null nvlink status observations
+    pub num_nmx_c_unreachable_chassis: HashMap<ChassisNmxCUnreachableReason, usize>,
+}
+
+/// Why the partition monitor could not use NMX-C for a chassis during an iteration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChassisNmxCUnreachableReason {
+    /// No rack-switch NVOS IP or `nvlink_nmxc_endpoints` row resolved an endpoint URL.
+    NoEndpoint,
+    /// The resolved endpoint URL could not be parsed as a valid NMX-C client URI.
+    InvalidEndpointUri,
+    /// The NMX-C client pool failed to create a client for the resolved endpoint.
+    ClientCreateFailed,
+    /// NMX-C `hello` failed after the client was created.
+    HelloFailed,
+    /// NMX-C `hello` succeeded but the domain UUID in the response could not be parsed.
+    DomainUuidParseFailed,
+    /// Partition monitor work failed after NMX-C connectivity was established (for example, partition list fetch).
+    PartitionMonitorWorkFailed,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -109,6 +128,7 @@ impl NvlPartitionMonitorMetrics {
             applied_changes: HashMap::new(),
             operation_latencies: HashMap::new(),
             nvlink_config_apply_durations_ms: Vec::new(),
+            num_nmx_c_unreachable_chassis: HashMap::new(),
             nmxc: NmxcMetrics {
                 endpoint: String::new(),
                 connect_error: String::new(),
@@ -124,7 +144,7 @@ impl Display for NvlPartitionMonitorMetrics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{ machines_scanned: {}, instances_scanned: {}, nvl_status_updates: {}, num_logical_partitions: {}, num_physical_partitions:{}, num_gpus_scanned: {}, nvlink_info_mismatches: {}, stale_partitions_deleted: {}, applied_changes: {}, nmxc_connect_err: {}, nmxc_num_partitions: {}, nmxc_num_gpus: {}, completed_operations: {}, duration: {} }}",
+            "{{ machines_scanned: {}, instances_scanned: {}, nvl_status_updates: {}, num_logical_partitions: {}, num_physical_partitions:{}, num_gpus_scanned: {}, nvlink_info_mismatches: {}, stale_partitions_deleted: {}, nmx_c_unreachable_chassis: {:?}, applied_changes: {}, nmxc_connect_err: {}, nmxc_num_partitions: {}, nmxc_num_gpus: {}, completed_operations: {}, duration: {} }}",
             self.num_machines_scanned,
             self.num_instances_scanned,
             self.num_machine_nvl_status_updates,
@@ -133,6 +153,7 @@ impl Display for NvlPartitionMonitorMetrics {
             self.num_gpus_scanned,
             self.num_nvlink_info_mismatches,
             self.num_stale_partitions_deleted,
+            self.num_nmx_c_unreachable_chassis,
             self.applied_changes.len(),
             self.nmxc.connect_error,
             self.nmxc.num_partitions,
@@ -289,6 +310,28 @@ impl NvlPartitionMonitorInstruments {
         }
 
         {
+            let metrics = shared_metrics.clone();
+            meter
+                .u64_observable_gauge(
+                    "carbide_nvlink_partition_monitor_nmx_c_unreachable_chassis_count",
+                )
+                .with_description(
+                    "Number of chassis where NMX-C was unreachable during partition monitor iteration",
+                )
+                .with_callback(move |o| {
+                    metrics.if_available(|metrics, attrs| {
+                        for (reason, &count) in &metrics.num_nmx_c_unreachable_chassis {
+                            o.observe(
+                                count as u64,
+                                &[attrs, &[KeyValue::new("reason", *reason)]].concat(),
+                            );
+                        }
+                    })
+                })
+                .build();
+        }
+
+        {
             let metrics = shared_metrics;
             meter
                 .u64_observable_gauge("carbide_nvlink_partition_monitor_stale_partitions_deleted")
@@ -366,6 +409,23 @@ impl NmxcMetricOperation {
             Self::RemoveDefaultPartition,
         ]
         .into_iter()
+    }
+}
+
+impl From<ChassisNmxCUnreachableReason> for opentelemetry::Value {
+    fn from(value: ChassisNmxCUnreachableReason) -> Self {
+        let str_value = match value {
+            ChassisNmxCUnreachableReason::NoEndpoint => "no_endpoint",
+            ChassisNmxCUnreachableReason::InvalidEndpointUri => "invalid_endpoint_uri",
+            ChassisNmxCUnreachableReason::ClientCreateFailed => "client_create_failed",
+            ChassisNmxCUnreachableReason::HelloFailed => "hello_failed",
+            ChassisNmxCUnreachableReason::DomainUuidParseFailed => "domain_uuid_parse_failed",
+            ChassisNmxCUnreachableReason::PartitionMonitorWorkFailed => {
+                "partition_monitor_work_failed"
+            }
+        };
+
+        Self::from(str_value)
     }
 }
 

--- a/crates/nvlink-manager/src/nmx_c_endpoint.rs
+++ b/crates/nvlink-manager/src/nmx_c_endpoint.rs
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use carbide_uuid::rack::RackId;
+use db::db_read::DbReader;
+use db::{self, DatabaseResult};
+
+use crate::config::NvLinkConfig;
+
+/// Default NMX-C gRPC port when switch NVOS info does not specify one.
+pub const NMX_C_DEFAULT_GRPC_PORT: u16 = 9601;
+
+fn nmx_c_endpoint_uses_tls(config: &NvLinkConfig) -> bool {
+    config.nmx_c_tls_client_cert_path.is_some() && config.nmx_c_tls_client_key_path.is_some()
+}
+
+fn nmx_c_endpoint_scheme(config: &NvLinkConfig) -> &'static str {
+    if config.allow_insecure && !nmx_c_endpoint_uses_tls(config) {
+        "http"
+    } else {
+        "https"
+    }
+}
+
+/// Builds an NMX-C gRPC URL from a switch NVOS IP (same data as RPC `SwitchNvosInfo`).
+pub fn nmx_c_endpoint_url_from_nvos_ip(
+    ip: &IpAddr,
+    port: Option<u16>,
+    config: &NvLinkConfig,
+) -> String {
+    format!(
+        "{}://{}:{}",
+        nmx_c_endpoint_scheme(config),
+        ip,
+        port.unwrap_or(NMX_C_DEFAULT_GRPC_PORT)
+    )
+}
+
+/// Resolves the NMX-C gRPC endpoint URL for a chassis.
+///
+/// When `rack_id` is set and the rack has a ready switch with Fabric Manager control plane
+/// configured, uses the first matching switch's NVOS IP. Otherwise falls back to
+/// `nvlink_nmxc_endpoints` for `chassis_serial`.
+pub async fn resolve_nmx_c_endpoint_url<DB>(
+    db: &mut DB,
+    rack_id: Option<&RackId>,
+    chassis_serial: &str,
+    nvlink_config: &NvLinkConfig,
+) -> DatabaseResult<Option<String>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    if let Some(rack_id) = rack_id {
+        let switch_ids =
+            db::switch::find_ready_control_plane_configured_switch_ids_in_rack(&mut *db, rack_id)
+                .await?;
+
+        if let Some(switch_id) = switch_ids.first() {
+            let endpoint_rows =
+                db::switch::find_switch_endpoints_by_ids(&mut *db, &[*switch_id]).await?;
+
+            if let Some(nvos_ip) = endpoint_rows.first().and_then(|row| row.nvos_ip.as_ref()) {
+                return Ok(Some(nmx_c_endpoint_url_from_nvos_ip(
+                    nvos_ip,
+                    None,
+                    nvlink_config,
+                )));
+            }
+
+            tracing::debug!(
+                %rack_id,
+                %switch_id,
+                %chassis_serial,
+                "Ready configured switch has no NVOS IP; falling back to nvlink_nmxc_endpoints"
+            );
+        }
+    }
+
+    Ok(
+        db::nvlink_nmxc_endpoints::find_by_chassis_serial(&mut *db, chassis_serial.trim())
+            .await?
+            .map(|row| row.endpoint),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    #[test]
+    fn endpoint_url_uses_http_when_allow_insecure() {
+        let config = NvLinkConfig {
+            allow_insecure: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            nmx_c_endpoint_url_from_nvos_ip(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None, &config),
+            "http://10.0.0.1:9601"
+        );
+    }
+
+    #[test]
+    fn endpoint_url_uses_https_by_default() {
+        let config = NvLinkConfig::default();
+        assert_eq!(
+            nmx_c_endpoint_url_from_nvos_ip(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None, &config),
+            "https://10.0.0.1:9601"
+        );
+    }
+}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -7117,6 +7117,9 @@ enum NmxcBrowseOperation {
   NMXC_BROWSE_OPERATION_GPU_INFO = 2;
   // Calls NMX-C GetGpuInfoList (all GPUs in the domain); response includes domain UUID from the RPC header.
   NMXC_BROWSE_OPERATION_GPU_INFO_LIST = 3;
+  NMXC_BROWSE_OPERATION_PARTITION_INFO_LIST = 4;
+  NMXC_BROWSE_OPERATION_SWITCH_NODE_INFO_LIST = 5;
+  NMXC_BROWSE_OPERATION_GET_DOMAIN_PROPERTIES = 6;
 }
 
 message NmxcBrowseRequest {


### PR DESCRIPTION
<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->
From 2593 - https://github.com/NVIDIA/infra-controller/issues/2296
From 2618 - https://github.com/NVIDIA/infra-controller/issues/2001
From 2619 - https://github.com/NVIDIA/infra-controller/issues/2614

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

