### PR TITLE
fix(api-web): show managed host health alert details

### DIFF
--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -14,10 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::str::FromStr as _;
+
 use axum::body::Body;
 use carbide_rpc_utils::ManagedHostOutput;
 use carbide_test_harness::TestMachine as _;
 use db::{machine, managed_host};
+use health_report::{
+    HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthReport, HealthReportApplyMode,
+};
 use http_body_util::BodyExt;
 use hyper::http::StatusCode;
 use model::machine::{InstanceState, LoadSnapshotOptions, ManagedHostState, RetryInfo};
@@ -210,6 +215,72 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert_eq!(row.dpus[1].bmc_mac, dpu_2.bmc_mac.to_string());
     assert_eq!(row.dpus[1].oob_mac, dpu_2.oob_mac().to_string());
     assert!(!row.dpus[1].oob_ip.is_empty(), "dpu should show an oob ip");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_html_includes_health_alert_details(
+    pool: sqlx::PgPool,
+) -> eyre::Result<()> {
+    let env = TestEnv::new(pool).await;
+    let mh = env.create_ready_managed_host(1).await.0;
+
+    let report = HealthReport {
+        source: "mock-bmc-intrusion".to_string(),
+        triggered_by: None,
+        observed_at: None,
+        successes: vec![],
+        alerts: vec![HealthProbeAlert {
+            id: HealthProbeId::from_str("IntrusionSensorTriggered")?,
+            target: Some("HostBMC".to_string()),
+            in_alert_since: None,
+            message: "Physical Chassis Intrusion Alert".to_string(),
+            tenant_message: None,
+            classifications: vec![
+                HealthAlertClassification::hardware(),
+                HealthAlertClassification::sensor_critical(),
+                HealthAlertClassification::prevent_allocations(),
+            ],
+        }],
+    };
+
+    let mut txn = env.test_harness.db_txn().await;
+    db::machine::insert_health_report(
+        &mut txn,
+        &mh.host.id,
+        HealthReportApplyMode::Merge,
+        &report,
+        false,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let app = make_test_app(&env.test_harness);
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/managed-host")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("Empty response body?")
+        .to_bytes();
+    let body_str = std::str::from_utf8(&body_bytes).expect("Invalid UTF-8 in body");
+
+    assert!(
+        body_str.contains(
+            "IntrusionSensorTriggered [Target: HostBMC]: Physical Chassis Intrusion Alert"
+        )
+    );
 
     Ok(())
 }

--- a/crates/api-web/templates/managed_host_individual_table.html
+++ b/crates/api-web/templates/managed_host_individual_table.html
@@ -43,7 +43,7 @@
 			</td>
 			<td>
 				<a href="/admin/machine/{{ host.machine_id }}/health">
-					{{ host.health_probe_alerts|health_alerts_fmt(false, false)|safe }}
+					{{ host.health_probe_alerts|health_alerts_fmt(true, true)|safe }}
 				</a>
 			</td>
 			<td><a href="/admin/machine/{{ host.machine_id }}/health">{{ host.health_sources.len() }}</a></td>


### PR DESCRIPTION
## Summary
- show health alert target and message directly in the managed-host list health-alert column
- add a regression test covering an intrusion-style host BMC alert on `/admin/managed-host`

Addresses the UI surfacing requested in #2671.

## Validation
- `rustup run nightly-2026-06-16 rustfmt --check crates/api-web/src/tests/managed_host.rs`
- `git diff --check`
- `DATABASE_URL='postgresql://postgres:admin@host.docker.internal' CARGO_HOME="$HOME/.cargo" /opt/homebrew/bin/makers test-docker-postgres-smoke`
- local DevSpace UI check: `/admin/managed-host` renders `IntrusionSensorTriggered [Target: HostBMC]: Physical Chassis Intrusion Alert`

## Not run
- `cargo test -p carbide-api-web test_managed_host_html_includes_health_alert_details` on macOS: blocked by `tss-esapi-sys` unsupported `(aarch64, darwin)` target
- same focused test through `cargo-docker-minimal`: blocked by missing `tss2-sys` pkg-config dependency in the minimal Docker image
