### PR TITLE
refactor(bmc-mock): avoid cloning machine info for BMC mock setup

### DIFF
--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -37,27 +37,24 @@ pub enum MachineInfo {
     Dpu(DpuMachineInfo),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct HostMachineInfo {
     pub hw_type: HostHardwareType,
     pub bmc_mac_address: MacAddress,
     pub serial: String,
     pub dpus: Vec<DpuMachineInfo>,
     pub non_dpu_mac_address: Option<MacAddress>,
-    #[serde(default)]
     pub nvos_mac_addresses: Vec<MacAddress>,
-    #[serde(default)]
     pub switch_serial_number: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct DpuMachineInfo {
     pub hw_type: HostHardwareType,
     pub bmc_mac_address: MacAddress,
     pub host_mac_address: MacAddress,
     pub oob_mac_address: MacAddress,
     pub serial: String,
-    #[serde(flatten)]
     pub settings: DpuSettings,
 }
 

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -156,7 +156,7 @@ fn default_host_mock() -> Router {
     let command_channel = spawn_qemu_reboot_handler();
     let callbacks = Arc::new(ChannelCallbacks::new(command_channel));
     bmc_mock::machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::WiwynnGB200Nvl,
             vec![DpuMachineInfo::default(), DpuMachineInfo::default()],
         )),

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -62,7 +62,7 @@ impl AddRoutes for Router<BmcState> {
 /// Return an axum::Router that mocks various redfish calls to match
 /// the provided MachineInfo.
 pub fn machine_router(
-    machine_info: MachineInfo,
+    machine_info: &MachineInfo,
     callbacks: Arc<dyn Callbacks>,
     mat_host_id: String,
     redfish_auth: bool,
@@ -86,7 +86,7 @@ pub fn machine_router(
         .add_routes(crate::redfish::session_service::add_routes)
         .add_routes(|routes| crate::redfish::computer_system::add_routes(routes, bmc_vendor))
         .add_routes(crate::ipmi::add_routes);
-    let router = match &machine_info {
+    let router = match machine_info {
         MachineInfo::Dpu(_) => {
             router.add_routes(crate::redfish::oem::nvidia::bluefield::add_routes)
         }

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -257,7 +257,7 @@ mod tests {
     fn test_host_mock() -> Router {
         let callbacks = Arc::new(TestCallbacks {});
         crate::machine_router(
-            MachineInfo::Host(HostMachineInfo::new(
+            &MachineInfo::Host(HostMachineInfo::new(
                 HostHardwareType::DellPowerEdgeR750,
                 vec![DpuMachineInfo::default()],
             )),

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -73,7 +73,7 @@ async fn test_bmc((router, state): (axum::Router, BmcState)) -> TestBmcHandle {
 
 pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::WiwynnGB200Nvl,
             vec![
                 DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
@@ -89,7 +89,7 @@ pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
 
 pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::LenovoGB300Nvl,
             vec![DpuMachineInfo::new(
                 HostHardwareType::LenovoGB300Nvl,
@@ -105,7 +105,7 @@ pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
 
 pub async fn dgx_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::NvidiaDgxGb300,
             vec![DpuMachineInfo::new(
                 HostHardwareType::NvidiaDgxGb300,
@@ -121,7 +121,7 @@ pub async fn dgx_gb300_bmc() -> TestBmcHandle {
 
 pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::SupermicroGb300Nvl,
             vec![DpuMachineInfo::new(
                 HostHardwareType::SupermicroGb300Nvl,
@@ -137,7 +137,7 @@ pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
 
 pub async fn generic_supermicro_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::GenericSupermicro,
             vec![],
         )),
@@ -150,7 +150,7 @@ pub async fn generic_supermicro_bmc() -> TestBmcHandle {
 
 pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::LiteOnPowerShelf,
             vec![],
         )),
@@ -163,7 +163,7 @@ pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
 
 pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::NvidiaSwitchNd5200Ld,
             vec![],
         )),
@@ -176,7 +176,7 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
 
 pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(
+        &MachineInfo::Host(HostMachineInfo::new(
             HostHardwareType::DellPowerEdgeR750,
             vec![],
         )),
@@ -189,7 +189,7 @@ pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
 
 pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Dpu(DpuMachineInfo::new(
+        &MachineInfo::Dpu(DpuMachineInfo::new(
             HostHardwareType::DellPowerEdgeR750,
             settings,
         )),
@@ -202,7 +202,7 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
 
 pub async fn generic_ami_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        MachineInfo::Host(HostMachineInfo::new(HostHardwareType::GenericAmi, vec![])),
+        &MachineInfo::Host(HostMachineInfo::new(HostHardwareType::GenericAmi, vec![])),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -224,7 +224,7 @@ mod test {
     async fn transport_supports_expand_query_through_mock_expander() {
         let client = AxumRouterHttpClient::new(
             machine_router(
-                MachineInfo::Host(HostMachineInfo::new(
+                &MachineInfo::Host(HostMachineInfo::new(
                     HostHardwareType::DellPowerEdgeR750,
                     vec![],
                 )),

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -36,7 +36,7 @@ use crate::mock_ssh_server::{MockSshServerHandle, PromptBehavior};
 /// either a DPU or a Host. It will rewrite certain responses to customize them for the machines
 /// machine-a-tron is mocking.
 pub struct BmcMockWrapper {
-    machine_info: MachineInfo,
+    ssh_prompt_behavior: PromptBehavior,
     app_context: Arc<MachineATronContext>,
     bmc_mock_router: Router,
     bmc_mock_state: BmcState,
@@ -45,17 +45,20 @@ pub struct BmcMockWrapper {
 
 impl BmcMockWrapper {
     pub fn new(
-        machine_info: MachineInfo,
+        machine_info: &MachineInfo,
         app_context: Arc<MachineATronContext>,
         callbacks: Arc<dyn Callbacks>,
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
     ) -> Self {
         let (bmc_mock_router, bmc_mock_state) =
-            bmc_mock::machine_router(machine_info.clone(), callbacks, host_id.to_string(), true);
+            bmc_mock::machine_router(machine_info, callbacks, host_id.to_string(), true);
 
         BmcMockWrapper {
-            machine_info,
+            ssh_prompt_behavior: match machine_info {
+                MachineInfo::Host(_) => PromptBehavior::Dell,
+                MachineInfo::Dpu(_) => PromptBehavior::Dpu,
+            },
             app_context,
             bmc_mock_router,
             bmc_mock_state,
@@ -120,10 +123,7 @@ impl BmcMockWrapper {
                         user: "root".to_string(),
                         password: "password".to_string(),
                     }),
-                    match self.machine_info {
-                        MachineInfo::Host(_) => PromptBehavior::Dell,
-                        MachineInfo::Dpu(_) => PromptBehavior::Dpu,
-                    },
+                    self.ssh_prompt_behavior,
                 )
                 .await
                 .map_err(|error| {

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -933,7 +933,7 @@ impl MachineStateMachine {
         ip_address: Ipv4Addr,
     ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
         let mut bmc_mock = BmcMockWrapper::new(
-            self.machine_info.clone(),
+            &self.machine_info,
             self.app_context.clone(),
             Arc::new(LiveStateCallbacks::new(
                 self.live_state.clone(),


### PR DESCRIPTION
Change BMC mock router construction to borrow `MachineInfo` and store only the derived SSH prompt behavior in `BmcMockWrapper`.

## Related issues

This is preliminary refactor before
#2617 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

