### PR TITLE
refactor(machine-a-tron): remove persisted DHCP IDs

### DIFF
--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -333,8 +333,6 @@ pub struct PersistedHostMachine {
     pub observed_machine_id: Option<MachineId>,
     pub installed_os: OsImage,
     pub tpm_ek_certificate: Option<Vec<u8>>,
-    pub machine_dhcp_id: Uuid,
-    pub bmc_dhcp_id: Uuid,
 }
 
 impl From<PersistedHostMachine> for HostMachineInfo {
@@ -361,8 +359,6 @@ pub struct PersistedDpuMachine {
     pub serial: String,
     pub installed_os: OsImage,
     pub dpu_index: u8,
-    pub machine_dhcp_id: Uuid,
-    pub bmc_dhcp_id: Uuid,
     #[serde(flatten)]
     pub settings: DpuSettings,
 }

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -171,8 +171,6 @@ impl DpuMachine {
         let mat_id = self.mat_id;
         let dpu_info = self.dpu_info.clone();
         let dpu_index = self.dpu_index;
-        let bmc_dhcp_id = self.state_machine.bmc_dhcp_id;
-        let machine_dhcp_id = self.state_machine.machine_dhcp_id;
         let live_state = self.state_machine.live_state.clone();
         let join_handle = tokio::task::Builder::new()
             .name(&format!("DPU {}", self.mat_id))
@@ -196,8 +194,6 @@ impl DpuMachine {
             mat_id,
             dpu_info,
             dpu_index,
-            bmc_dhcp_id,
-            machine_dhcp_id,
             join_handle: Mutex::new(Some(join_handle)),
         }))
     }
@@ -340,8 +336,6 @@ struct DpuMachineActor {
     mat_id: Uuid,
     dpu_info: DpuMachineInfo,
     dpu_index: u8,
-    bmc_dhcp_id: Uuid,
-    machine_dhcp_id: Uuid,
     join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -425,8 +419,6 @@ impl DpuMachineHandle {
             settings: self.0.dpu_info.settings.clone(),
             installed_os: self.0.live_state.read().unwrap().installed_os,
             dpu_index: self.0.dpu_index,
-            bmc_dhcp_id: self.0.bmc_dhcp_id,
-            machine_dhcp_id: self.0.machine_dhcp_id,
         }
     }
 

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -228,8 +228,6 @@ impl HostMachine {
         let host_info = self.host_info.clone();
         let dpus = self.dpus.clone();
         let machine_config_section = self.machine_config_section.clone();
-        let bmc_dhcp_id = self.state_machine.bmc_dhcp_id;
-        let machine_dhcp_id = self.state_machine.machine_dhcp_id;
 
         if !paused {
             self.resume_dpus();
@@ -256,8 +254,6 @@ impl HostMachine {
             host_info,
             dpus,
             machine_config_section,
-            bmc_dhcp_id,
-            machine_dhcp_id,
 
             join_handle: Mutex::new(Some(join_handle)),
         }))
@@ -503,8 +499,6 @@ struct HostMachineActor {
     host_info: HostMachineInfo,
     dpus: Vec<DpuMachineHandle>,
     machine_config_section: String,
-    bmc_dhcp_id: Uuid,
-    machine_dhcp_id: Uuid,
 }
 
 #[derive(Debug, Clone)]
@@ -594,8 +588,6 @@ impl HostMachineHandle {
             observed_machine_id: live_state.observed_machine_id,
             installed_os: live_state.installed_os,
             tpm_ek_certificate: live_state.tpm_ek_certificate.clone(),
-            machine_dhcp_id: self.0.machine_dhcp_id,
-            bmc_dhcp_id: self.0.bmc_dhcp_id,
         }
     }
 

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -57,8 +57,6 @@ pub type DpuDhcpRelayHandle = oneshot::Sender<()>;
 /// receive PXE instructions, etc.)
 pub struct MachineStateMachine {
     pub live_state: Arc<RwLock<LiveState>>,
-    pub machine_dhcp_id: Uuid,
-    pub bmc_dhcp_id: Uuid,
     pub mat_host_id: Uuid,
     pub installed_os: OsImage,
 
@@ -217,31 +215,22 @@ impl MachineStateMachine {
         dpu_dhcp_relay: Option<DpuDhcpRelay>,
         mat_host_id: Uuid,
     ) -> MachineStateMachine {
-        let (initial_os_image, tpm_ek_certificate, bmc_dhcp_id, machine_dhcp_id, machine_info) =
-            match persisted_machine {
-                PersistedMachine::Host(h) => (
-                    h.installed_os,
-                    h.tpm_ek_certificate,
-                    h.bmc_dhcp_id,
-                    h.machine_dhcp_id,
-                    MachineInfo::Host(HostMachineInfo {
-                        hw_type: h.hw_type.unwrap_or_default(),
-                        bmc_mac_address: h.bmc_mac_address,
-                        serial: h.serial,
-                        dpus: h.dpus.into_iter().map(Into::into).collect(),
-                        non_dpu_mac_address: h.non_dpu_mac_address,
-                        nvos_mac_addresses: h.nvos_mac_addresses,
-                        switch_serial_number: h.switch_serial_number,
-                    }),
-                ),
-                PersistedMachine::Dpu(d) => (
-                    d.installed_os,
-                    None,
-                    d.bmc_dhcp_id,
-                    d.machine_dhcp_id,
-                    MachineInfo::Dpu(d.into()),
-                ),
-            };
+        let (initial_os_image, tpm_ek_certificate, machine_info) = match persisted_machine {
+            PersistedMachine::Host(h) => (
+                h.installed_os,
+                h.tpm_ek_certificate,
+                MachineInfo::Host(HostMachineInfo {
+                    hw_type: h.hw_type.unwrap_or_default(),
+                    bmc_mac_address: h.bmc_mac_address,
+                    serial: h.serial,
+                    dpus: h.dpus.into_iter().map(Into::into).collect(),
+                    non_dpu_mac_address: h.non_dpu_mac_address,
+                    nvos_mac_addresses: h.nvos_mac_addresses,
+                    switch_serial_number: h.switch_serial_number,
+                }),
+            ),
+            PersistedMachine::Dpu(d) => (d.installed_os, None, MachineInfo::Dpu(d.into())),
+        };
         let (fsm, actions) = MachineFsm::init(true, Self::is_bmc_only(&machine_info, &config));
         MachineStateMachine {
             fsm,
@@ -260,10 +249,8 @@ impl MachineStateMachine {
                 tpm_ek_certificate,
                 ..Default::default()
             })),
-            bmc_dhcp_id,
             machine_info,
             bmc_command_channel,
-            machine_dhcp_id,
             config,
             app_context,
             dpu_dhcp_relay,
@@ -298,11 +285,9 @@ impl MachineStateMachine {
             machine_on_deadline: None,
             agent_polling_deadline: None,
             power_cycle_deadline: None,
-            bmc_dhcp_id: Uuid::new_v4(),
             installed_os: OsImage::default(),
             machine_info,
             bmc_command_channel,
-            machine_dhcp_id: Uuid::new_v4(),
             config,
             app_context,
             dpu_dhcp_relay,


### PR DESCRIPTION
DHCP ids were used long time ago but not used anymore.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

