### PR TITLE
docs(helm): document required resource pools in site config

### DIFF
--- a/helm/PREREQUISITES.md
+++ b/helm/PREREQUISITES.md
@@ -218,7 +218,43 @@ global:
 
 ---
 
-## 6. Network Requirements
+## 6. Site Configuration
+
+`nico-api` **exits at startup** if resource pools are not defined. You must set `nico-api.siteConfig.enabled: true` and provide a `nicoApiSiteConfig` TOML value that includes at minimum the four required pool definitions.
+
+```yaml
+nico-api:
+  siteConfig:
+    enabled: true
+    nicoApiSiteConfig: |
+      dhcp_servers = ["nico-dhcp.nico-system.svc.cluster.local:67"]
+      enable_route_servers = true
+      initial_domain_name = "site.example.com"
+      sitename = "site"
+
+      # All four pools are required.
+      [pools.lo-ip]
+      type = "ipv4"
+      ranges = [{ start = "10.0.0.0", end = "10.0.1.0" }]
+
+      [pools.vlan-id]
+      type = "integer"
+      ranges = [{ start = "100", end = "501" }]
+
+      [pools.vni]
+      type = "integer"
+      ranges = [{ start = "1024500", end = "1024800" }]
+
+      [pools.vpc-vni]
+      type = "integer"
+      ranges = [{ start = "0", end = "100" }]
+```
+
+Adjust pool ranges to match your site's address plan. A fully annotated example with all available options is at [`deploy/files/nico-api/nico-api-site-config.toml`](../deploy/files/nico-api/nico-api-site-config.toml).
+
+---
+
+## 7. Network Requirements
 
 Several NICo services require direct network connectivity to bare metal hosts. Ensure the following network conditions are met before installation:
 
@@ -242,7 +278,7 @@ Ensure that firewall rules and network policies allow traffic between NICo servi
 
 ---
 
-## 7. Loki (Optional — for SSH Console Log Shipping)
+## 8. Loki (Optional — for SSH Console Log Shipping)
 
 The `nico-ssh-console-rs` subchart includes an optional OpenTelemetry Collector Contrib sidecar that ships SSH console logs to Loki. This sidecar is **disabled by default** (`lokiLogCollector.enabled: false`).
 

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -197,9 +197,13 @@ configFiles:
   casbinPolicy: ""      # If empty, uses the default from files/
 
 ## Site-specific config (nico-api-site-config-files ConfigMap)
+## nicoApiSiteConfig is REQUIRED: nico-api exits at startup if the four
+## resource pool definitions (lo-ip, vlan-id, vni, vpc-vni) are absent.
+## See PREREQUISITES.md § "Site Configuration" and
+## deploy/files/nico-api/nico-api-site-config.toml for a full example.
 siteConfig:
   enabled: true
-  nicoApiSiteConfig: ""  # Override per environment
+  nicoApiSiteConfig: ""  # Must include [pools.lo-ip], [pools.vlan-id], [pools.vni], [pools.vpc-vni]
 
 ## NICo Web UI hostname (always created as ConfigMap)
 hostname: "nico.local"

--- a/helm/examples/values-minimal.yaml
+++ b/helm/examples/values-minimal.yaml
@@ -25,9 +25,31 @@ nico-api:
   siteConfig:
     enabled: true
     nicoApiSiteConfig: |
-      # Site-specific overrides for nico-api-config.toml
-      # At minimum, configure DHCP servers and route servers for your site:
-      # dhcp_servers=["nico-dhcp.nico-system.svc.cluster.local:67"]
+      dhcp_servers = ["nico-dhcp.nico-system.svc.cluster.local:67"]
+      # route_servers = ["FRR_ROUTING_0_EXTERNAL_IP"]
+      enable_route_servers = true
+      initial_domain_name = "site.example.com"
+      sitename = "site"
+      attestation_enabled = false
+      bypass_rbac = true  # set false in production
+
+      # Resource pools are required — nico-api exits at startup without them.
+      # Adjust ranges to match your site's address plan.
+      [pools.lo-ip]
+      type = "ipv4"
+      ranges = [{ start = "10.0.0.0", end = "10.0.1.0" }]
+
+      [pools.vlan-id]
+      type = "integer"
+      ranges = [{ start = "100", end = "501" }]
+
+      [pools.vni]
+      type = "integer"
+      ranges = [{ start = "1024500", end = "1024800" }]
+
+      [pools.vpc-vni]
+      type = "integer"
+      ranges = [{ start = "0", end = "100" }]
 
 ## nico-dhcp: Configure subnets and IPs for your environment
 nico-dhcp:


### PR DESCRIPTION
<!-- Describe what this PR does -->
nico-api exits at startup when pools are absent. Adds a Site Configuration section to PREREQUISITES.md, clarifies the values.yaml comment on nicoApiSiteConfig, and adds working pool definitions to values-minimal.yaml. References deploy/files/nico-api/nico-api-site-config.toml as the full annotated example.

## Related issues

https://github.com/NVIDIA/infra-controller/issues/494

## Type of Change

<!-- Check one that best describes this PR -->

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->

- [ ] **This PR contains breaking changes**

## Testing

<!-- How was this tested? Check all that apply -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Addresses the undocumented hard requirement that `nico-api` will exit immediately at startup if the four resource pool definitions (`lo-ip`, `vlan-id`, `vni`, `vpc-vni`) are absent from the site config. Three files changed:

- **`helm/PREREQUISITES.md`** — new §6 "Site Configuration" with a minimum working `nicoApiSiteConfig` example and a link to the full annotated reference at `deploy/files/nico-api/nico-api-site-config.toml`.
- **`helm/charts/nico-api/values.yaml`** — comment on `nicoApiSiteConfig` updated from "Override per environment" to explicitly state it is REQUIRED and list the four expected pool keys.
- **`helm/examples/values-minimal.yaml`** — replaces the placeholder comment with a working TOML block including all four pools, `dhcp_servers`, `attestation_enabled`, and `bypass_rbac` so the example is actually deployable out of the box.