### PR TITLE
fix(health): report BMC intrusion events

### DIFF
--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -44,8 +44,8 @@ use crate::endpoint::{CompositeEndpointSource, EndpointSource, StaticEndpointSou
 use crate::limiter::{BucketLimiter, NoopLimiter, RateLimiter};
 use crate::metrics::{MetricsManager, run_metrics_server};
 use crate::processor::{
-    EventProcessingPipeline, EventProcessor, HealthReportProcessor, LeakEventProcessor,
-    RackLeakProcessor,
+    BmcIntrusionEventProcessor, EventProcessingPipeline, EventProcessor, HealthReportProcessor,
+    LeakEventProcessor, RackLeakProcessor,
 };
 use crate::sharding::ShardManager;
 use crate::sink::event_mapper::{OpenBmcEventMapper, RedfishEventMapper};
@@ -185,6 +185,10 @@ fn build_data_sink(
         || config.processors.leak_detection.is_enabled()
     {
         processors.push(Arc::new(HealthReportProcessor::new()));
+    }
+
+    if config.sinks.health_report.is_enabled() {
+        processors.push(Arc::new(BmcIntrusionEventProcessor::new()));
     }
 
     if let Configurable::Enabled(ref leak_detection_cfg) = config.processors.leak_detection {

--- a/crates/health/src/processor/intrusion_events.rs
+++ b/crates/health/src/processor/intrusion_events.rs
@@ -1,0 +1,273 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use super::{CollectorEvent, EventContext, EventProcessor};
+use crate::sink::{
+    Classification, HealthReport, HealthReportAlert, HealthReportSuccess, HealthReportTarget,
+    LogRecord, Probe, ReportSource,
+};
+
+const HOST_BMC_TARGET: &str = "HostBMC";
+const INTRUSION_ALERT_MESSAGE: &str = "Physical Chassis Intrusion Alert";
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum IntrusionEventState {
+    Alert,
+    Clear,
+}
+
+pub struct BmcIntrusionEventProcessor;
+
+impl BmcIntrusionEventProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn attr<'a>(attributes: &'a [(Cow<'static, str>, String)], key: &str) -> Option<&'a str> {
+        attributes
+            .iter()
+            .find(|(name, _)| name.as_ref() == key)
+            .map(|(_, value)| value.as_str())
+    }
+
+    fn message_args(record: &LogRecord) -> Vec<String> {
+        Self::attr(&record.attributes, "message_args")
+            .and_then(|args| serde_json::from_str::<Vec<String>>(args).ok())
+            .unwrap_or_default()
+    }
+
+    fn intrusion_event_state(record: &LogRecord) -> Option<IntrusionEventState> {
+        let mut text = record.body.clone();
+        text.push(' ');
+        text.push_str(&record.severity);
+        text.push(' ');
+        for arg in Self::message_args(record) {
+            text.push_str(&arg);
+            text.push(' ');
+        }
+
+        let text = text.to_ascii_lowercase();
+        let mentions_intrusion = text.contains("chassis intrusion")
+            || text.contains("intrusion sensor")
+            || text.contains("physical chassis intrusion")
+            || text.contains("reset intrusion");
+
+        if !mentions_intrusion {
+            return None;
+        }
+
+        if text.contains("clear")
+            || text.contains("cleared")
+            || text.contains("deassert")
+            || text.contains("normal")
+            || text.contains("reset")
+        {
+            return Some(IntrusionEventState::Clear);
+        }
+
+        if text.contains("physical chassis intrusion alert")
+            || text.contains("trigger")
+            || text.contains("triggered")
+            || text.contains("assert")
+            || text.contains("alert")
+            || text.contains("critical")
+            || text.contains("warning")
+        {
+            return Some(IntrusionEventState::Alert);
+        }
+
+        None
+    }
+}
+
+impl EventProcessor for BmcIntrusionEventProcessor {
+    fn processor_type(&self) -> &'static str {
+        "bmc_intrusion_event_processor"
+    }
+
+    fn process_event(
+        &self,
+        _context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Vec<CollectorEvent> {
+        let CollectorEvent::Log(record) = event else {
+            return Vec::new();
+        };
+
+        let Some(state) = Self::intrusion_event_state(record) else {
+            return Vec::new();
+        };
+
+        let (successes, alerts) = match state {
+            IntrusionEventState::Alert => (
+                Vec::new(),
+                vec![HealthReportAlert {
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                    message: INTRUSION_ALERT_MESSAGE.to_string(),
+                    classifications: vec![
+                        Classification::SensorCritical,
+                        Classification::PreventAllocations,
+                    ],
+                }],
+            ),
+            IntrusionEventState::Clear => (
+                vec![HealthReportSuccess {
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                }],
+                Vec::new(),
+            ),
+        };
+
+        let report = HealthReport {
+            source: ReportSource::BmcEvents,
+            target: Some(HealthReportTarget::Machine),
+            observed_at: Some(chrono::Utc::now()),
+            successes,
+            alerts,
+        };
+
+        vec![CollectorEvent::HealthReport(Arc::new(report))]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
+
+    use mac_address::MacAddress;
+
+    use super::*;
+    use crate::endpoint::BmcAddr;
+
+    fn context() -> EventContext {
+        EventContext {
+            endpoint_key: "42:9e:b1:bd:9d:dd".to_string(),
+            addr: BmcAddr {
+                ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                port: Some(443),
+                mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
+            },
+            collector_type: "logs_collector",
+            metadata: None,
+            rack_id: None,
+        }
+    }
+
+    fn log(body: &str, severity: &str, message_args: Option<&str>) -> CollectorEvent {
+        let mut attributes = Vec::new();
+        if let Some(message_args) = message_args {
+            attributes.push((Cow::Borrowed("message_args"), message_args.to_string()));
+        }
+
+        CollectorEvent::Log(Box::new(LogRecord {
+            body: body.to_string(),
+            severity: severity.to_string(),
+            attributes,
+        }))
+    }
+
+    fn emitted_report(event: CollectorEvent) -> Arc<HealthReport> {
+        let processor = BmcIntrusionEventProcessor::new();
+        let emitted = processor.process_event(&context(), &event);
+        assert_eq!(emitted.len(), 1);
+
+        let CollectorEvent::HealthReport(report) = &emitted[0] else {
+            panic!("expected health report");
+        };
+
+        Arc::clone(report)
+    }
+
+    #[test]
+    fn emits_alert_for_physical_chassis_intrusion_log_body() {
+        let report = emitted_report(log("Physical Chassis Intrusion Alert", "Critical", None));
+
+        assert_eq!(report.source, ReportSource::BmcEvents);
+        assert_eq!(report.target, Some(HealthReportTarget::Machine));
+        assert!(report.successes.is_empty());
+        assert_eq!(report.alerts.len(), 1);
+
+        let alert = &report.alerts[0];
+        assert_eq!(alert.probe_id, Probe::IntrusionSensorTriggered);
+        assert_eq!(alert.target.as_deref(), Some(HOST_BMC_TARGET));
+        assert_eq!(alert.message, INTRUSION_ALERT_MESSAGE);
+        assert!(
+            alert
+                .classifications
+                .contains(&Classification::SensorCritical)
+        );
+        assert!(
+            alert
+                .classifications
+                .contains(&Classification::PreventAllocations)
+        );
+    }
+
+    #[test]
+    fn emits_alert_for_intrusion_message_args() {
+        let report = emitted_report(log(
+            "",
+            "Warning",
+            Some(r#"["Physical Chassis Intrusion Alert"]"#),
+        ));
+
+        assert_eq!(report.alerts.len(), 1);
+        assert_eq!(report.alerts[0].probe_id, Probe::IntrusionSensorTriggered);
+    }
+
+    #[test]
+    fn emits_success_for_cleared_intrusion_event() {
+        let report = emitted_report(log("Physical Chassis Intrusion cleared", "OK", None));
+
+        assert!(report.alerts.is_empty());
+        assert_eq!(report.successes.len(), 1);
+        assert_eq!(
+            report.successes[0].probe_id,
+            Probe::IntrusionSensorTriggered
+        );
+        assert_eq!(report.successes[0].target.as_deref(), Some(HOST_BMC_TARGET));
+    }
+
+    #[test]
+    fn emits_success_for_reset_intrusion_event() {
+        let report = emitted_report(log("Reset Intrusion", "OK", None));
+
+        assert!(report.alerts.is_empty());
+        assert_eq!(report.successes.len(), 1);
+        assert_eq!(
+            report.successes[0].probe_id,
+            Probe::IntrusionSensorTriggered
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_logs() {
+        let processor = BmcIntrusionEventProcessor::new();
+        let emitted = processor.process_event(
+            &context(),
+            &log("CPU temperature threshold warning", "Warning", None),
+        );
+
+        assert!(emitted.is_empty());
+    }
+}

--- a/crates/health/src/processor/intrusion_events.rs
+++ b/crates/health/src/processor/intrusion_events.rs
@@ -33,6 +33,7 @@ enum IntrusionEventState {
     Clear,
 }
 
+#[derive(Default)]
 pub struct BmcIntrusionEventProcessor;
 
 impl BmcIntrusionEventProcessor {
@@ -73,15 +74,6 @@ impl BmcIntrusionEventProcessor {
             return None;
         }
 
-        if text.contains("clear")
-            || text.contains("cleared")
-            || text.contains("deassert")
-            || text.contains("normal")
-            || text.contains("reset")
-        {
-            return Some(IntrusionEventState::Clear);
-        }
-
         if text.contains("physical chassis intrusion alert")
             || text.contains("trigger")
             || text.contains("triggered")
@@ -91,6 +83,15 @@ impl BmcIntrusionEventProcessor {
             || text.contains("warning")
         {
             return Some(IntrusionEventState::Alert);
+        }
+
+        if text.contains("clear")
+            || text.contains("cleared")
+            || text.contains("deassert")
+            || text.contains("normal")
+            || text.contains("reset")
+        {
+            return Some(IntrusionEventState::Clear);
         }
 
         None
@@ -154,10 +155,28 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
 
+    use carbide_test_support::value_scenarios;
     use mac_address::MacAddress;
 
     use super::*;
     use crate::endpoint::BmcAddr;
+
+    #[derive(Clone, Copy)]
+    struct IntrusionLogCase {
+        body: &'static str,
+        severity: &'static str,
+        message_args: Option<&'static str>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct IntrusionReportSummary {
+        alert_count: usize,
+        success_count: usize,
+        probe_id: Probe,
+        target: Option<String>,
+        message: Option<String>,
+        classifications: Vec<Classification>,
+    }
 
     fn context() -> EventContext {
         EventContext {
@@ -198,65 +217,121 @@ mod tests {
         Arc::clone(report)
     }
 
-    #[test]
-    fn emits_alert_for_physical_chassis_intrusion_log_body() {
-        let report = emitted_report(log("Physical Chassis Intrusion Alert", "Critical", None));
+    fn summarize_report(case: IntrusionLogCase) -> IntrusionReportSummary {
+        let report = emitted_report(log(case.body, case.severity, case.message_args));
 
         assert_eq!(report.source, ReportSource::BmcEvents);
         assert_eq!(report.target, Some(HealthReportTarget::Machine));
-        assert!(report.successes.is_empty());
-        assert_eq!(report.alerts.len(), 1);
 
-        let alert = &report.alerts[0];
-        assert_eq!(alert.probe_id, Probe::IntrusionSensorTriggered);
-        assert_eq!(alert.target.as_deref(), Some(HOST_BMC_TARGET));
-        assert_eq!(alert.message, INTRUSION_ALERT_MESSAGE);
-        assert!(
-            alert
-                .classifications
-                .contains(&Classification::SensorCritical)
-        );
-        assert!(
-            alert
-                .classifications
-                .contains(&Classification::PreventAllocations)
-        );
+        if let Some(alert) = report.alerts.first() {
+            return IntrusionReportSummary {
+                alert_count: report.alerts.len(),
+                success_count: report.successes.len(),
+                probe_id: alert.probe_id,
+                target: alert.target.clone(),
+                message: Some(alert.message.clone()),
+                classifications: alert.classifications.clone(),
+            };
+        }
+
+        let success = report.successes.first().expect("success report");
+        IntrusionReportSummary {
+            alert_count: report.alerts.len(),
+            success_count: report.successes.len(),
+            probe_id: success.probe_id,
+            target: success.target.clone(),
+            message: None,
+            classifications: Vec::new(),
+        }
     }
 
     #[test]
-    fn emits_alert_for_intrusion_message_args() {
-        let report = emitted_report(log(
-            "",
-            "Warning",
-            Some(r#"["Physical Chassis Intrusion Alert"]"#),
-        ));
+    fn intrusion_report_cases() {
+        value_scenarios!(
+            run = summarize_report;
+            "physical chassis intrusion log body" {
+                IntrusionLogCase {
+                    body: "Physical Chassis Intrusion Alert",
+                    severity: "Critical",
+                    message_args: None,
+                } => IntrusionReportSummary {
+                    alert_count: 1,
+                    success_count: 0,
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                    message: Some(INTRUSION_ALERT_MESSAGE.to_string()),
+                    classifications: vec![
+                        Classification::SensorCritical,
+                        Classification::PreventAllocations,
+                    ],
+                },
+            }
 
-        assert_eq!(report.alerts.len(), 1);
-        assert_eq!(report.alerts[0].probe_id, Probe::IntrusionSensorTriggered);
-    }
+            "intrusion message args" {
+                IntrusionLogCase {
+                    body: "",
+                    severity: "Warning",
+                    message_args: Some(r#"["Physical Chassis Intrusion Alert"]"#),
+                } => IntrusionReportSummary {
+                    alert_count: 1,
+                    success_count: 0,
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                    message: Some(INTRUSION_ALERT_MESSAGE.to_string()),
+                    classifications: vec![
+                        Classification::SensorCritical,
+                        Classification::PreventAllocations,
+                    ],
+                },
+            }
 
-    #[test]
-    fn emits_success_for_cleared_intrusion_event() {
-        let report = emitted_report(log("Physical Chassis Intrusion cleared", "OK", None));
+            "normal to critical intrusion event" {
+                IntrusionLogCase {
+                    body: "Physical Chassis Intrusion changed from Normal to Critical",
+                    severity: "Critical",
+                    message_args: None,
+                } => IntrusionReportSummary {
+                    alert_count: 1,
+                    success_count: 0,
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                    message: Some(INTRUSION_ALERT_MESSAGE.to_string()),
+                    classifications: vec![
+                        Classification::SensorCritical,
+                        Classification::PreventAllocations,
+                    ],
+                },
+            }
 
-        assert!(report.alerts.is_empty());
-        assert_eq!(report.successes.len(), 1);
-        assert_eq!(
-            report.successes[0].probe_id,
-            Probe::IntrusionSensorTriggered
-        );
-        assert_eq!(report.successes[0].target.as_deref(), Some(HOST_BMC_TARGET));
-    }
+            "cleared intrusion event" {
+                IntrusionLogCase {
+                    body: "Physical Chassis Intrusion cleared",
+                    severity: "OK",
+                    message_args: None,
+                } => IntrusionReportSummary {
+                    alert_count: 0,
+                    success_count: 1,
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                    message: None,
+                    classifications: vec![],
+                },
+            }
 
-    #[test]
-    fn emits_success_for_reset_intrusion_event() {
-        let report = emitted_report(log("Reset Intrusion", "OK", None));
-
-        assert!(report.alerts.is_empty());
-        assert_eq!(report.successes.len(), 1);
-        assert_eq!(
-            report.successes[0].probe_id,
-            Probe::IntrusionSensorTriggered
+            "reset intrusion event" {
+                IntrusionLogCase {
+                    body: "Reset Intrusion",
+                    severity: "OK",
+                    message_args: None,
+                } => IntrusionReportSummary {
+                    alert_count: 0,
+                    success_count: 1,
+                    probe_id: Probe::IntrusionSensorTriggered,
+                    target: Some(HOST_BMC_TARGET.to_string()),
+                    message: None,
+                    classifications: vec![],
+                },
+            }
         );
     }
 

--- a/crates/health/src/processor/mod.rs
+++ b/crates/health/src/processor/mod.rs
@@ -21,9 +21,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 mod health_report;
+mod intrusion_events;
 mod leak_events;
 mod rack_leak;
 pub use health_report::HealthReportProcessor;
+pub use intrusion_events::BmcIntrusionEventProcessor;
 pub use leak_events::LeakEventProcessor;
 pub use rack_leak::RackLeakProcessor;
 

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -243,6 +243,7 @@ pub enum CollectorEvent {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum ReportSource {
     BmcSensors,
+    BmcEvents,
     BmcLeakDetectors,
     TrayLeakDetection,
     RackLeakDetection,
@@ -252,6 +253,7 @@ impl ReportSource {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::BmcSensors => "bmc-sensors",
+            Self::BmcEvents => "bmc-events",
             Self::BmcLeakDetectors => "bmc-leak-detectors",
             Self::TrayLeakDetection => "tray-leak-detection",
             Self::RackLeakDetection => "rack-leak-detection",
@@ -262,6 +264,7 @@ impl ReportSource {
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Probe {
     Sensor,
+    IntrusionSensorTriggered,
     LeakDetection,
 }
 
@@ -269,6 +272,7 @@ impl Probe {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Sensor => "BmcSensor",
+            Self::IntrusionSensorTriggered => "IntrusionSensorTriggered",
             Self::LeakDetection => "BmcLeakDetection",
         }
     }
@@ -281,6 +285,7 @@ pub enum Classification {
     SensorCritical,
     SensorFatal,
     SensorFailure,
+    PreventAllocations,
     Leak,
     LeakDetector,
 }
@@ -293,6 +298,7 @@ impl Classification {
             Self::SensorCritical => "SensorCritical",
             Self::SensorFatal => "SensorFatal",
             Self::SensorFailure => "SensorFailure",
+            Self::PreventAllocations => "PreventAllocations",
             Self::Leak => "Leak",
             Self::LeakDetector => "LeakDetector",
         }
@@ -433,6 +439,7 @@ mod tests {
     #[derive(Clone, Copy)]
     enum AlertCase {
         WithTarget,
+        Intrusion,
         WithoutClassifications,
     }
 
@@ -566,6 +573,15 @@ mod tests {
                 message: "fan warning".to_string(),
                 classifications: vec![Classification::SensorWarning, Classification::SensorFailure],
             },
+            AlertCase::Intrusion => HealthReportAlert {
+                probe_id: Probe::IntrusionSensorTriggered,
+                target: Some("HostBMC".to_string()),
+                message: "Physical Chassis Intrusion Alert".to_string(),
+                classifications: vec![
+                    Classification::SensorCritical,
+                    Classification::PreventAllocations,
+                ],
+            },
             AlertCase::WithoutClassifications => HealthReportAlert {
                 probe_id: Probe::LeakDetection,
                 target: None,
@@ -640,6 +656,10 @@ mod tests {
                 ReportSource::BmcSensors => "bmc-sensors",
             }
 
+            "BMC events" {
+                ReportSource::BmcEvents => "bmc-events",
+            }
+
             "BMC leak detectors" {
                 ReportSource::BmcLeakDetectors => "bmc-leak-detectors",
             }
@@ -668,6 +688,13 @@ mod tests {
                 Probe::Sensor => ProbeSummary {
                     as_str: "BmcSensor",
                     health_report_id: "BmcSensor".to_string(),
+                },
+            }
+
+            "intrusion sensor triggered" {
+                Probe::IntrusionSensorTriggered => ProbeSummary {
+                    as_str: "IntrusionSensorTriggered",
+                    health_report_id: "IntrusionSensorTriggered".to_string(),
                 },
             }
 
@@ -723,6 +750,13 @@ mod tests {
                 Classification::SensorFailure => ClassificationSummary {
                     as_str: "SensorFailure",
                     health_report_classification: "SensorFailure".to_string(),
+                },
+            }
+
+            "prevent allocations" {
+                Classification::PreventAllocations => ClassificationSummary {
+                    as_str: "PreventAllocations",
+                    health_report_classification: "PreventAllocations".to_string(),
                 },
             }
 
@@ -823,6 +857,21 @@ mod tests {
                     classifications: vec![
                         "SensorWarning".to_string(),
                         "SensorFailure".to_string(),
+                        "Hardware".to_string(),
+                    ],
+                },
+            }
+
+            "intrusion alert" {
+                AlertCase::Intrusion => AlertSummary {
+                    id: "IntrusionSensorTriggered".to_string(),
+                    target: Some("HostBMC".to_string()),
+                    message: "Physical Chassis Intrusion Alert".to_string(),
+                    tenant_message: None,
+                    in_alert_since: false,
+                    classifications: vec![
+                        "SensorCritical".to_string(),
+                        "PreventAllocations".to_string(),
                         "Hardware".to_string(),
                     ],
                 },

--- a/deploy/nico-base/hardware-health/deployment.yaml
+++ b/deploy/nico-base/hardware-health/deployment.yaml
@@ -47,6 +47,8 @@ spec:
               value: "full"
             - name: RUST_LIB_BACKTRACE # See https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
               value: "0"
+            - name: NICO_HEALTH__COLLECTORS__LOGS__ENABLED
+              value: "true"
           ports:
             - name: metrics
               containerPort: 9009

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -46,7 +46,7 @@ certificate:
 env:
   RUST_BACKTRACE: "full"
   RUST_LIB_BACKTRACE: "0"
-  NICO_HEALTH__COLLECTORS__LOGS__ENABLED: "false"
+  NICO_HEALTH__COLLECTORS__LOGS__ENABLED: "true"
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
## Summary
- detect BMC log events for physical chassis intrusion and emit `IntrusionSensorTriggered` machine health reports
- add `hardware-health.bmc-events` source plus `PreventAllocations`/`SensorCritical` classifications for the generated alert
- enable hardware-health BMC log collection in Helm and deploy manifests so the detector receives intrusion events

## Validation
- `PATH="$HOME/.rustup/toolchains/1.96.0-aarch64-apple-darwin/bin:$PATH" cargo test -p carbide-health intrusion --lib`
- `PATH="$HOME/.rustup/toolchains/1.96.0-aarch64-apple-darwin/bin:$PATH" cargo test -p carbide-health sink::events --lib`
- `PATH="$HOME/.rustup/toolchains/1.96.0-aarch64-apple-darwin/bin:$PATH" cargo test -p carbide-health --lib`
- `rustup run nightly-2026-06-16 rustfmt --check crates/health/src/processor/intrusion_events.rs crates/health/src/processor/mod.rs crates/health/src/lib.rs crates/health/src/sink/events.rs`
- `git diff --check`
- `helm lint helm/charts/nico-hardware-health`
- `helm template nico-hardware-health helm/charts/nico-hardware-health`
- `kubectl kustomize deploy/nico-base/hardware-health`

Backend follow-up for #2671; complements #2772, which surfaces the resulting alert details on `/admin/managed-host`.
