### PR TITLE
test(api-test-helper): make vault dev startup robust to port races

### DIFF
--- a/crates/api-integration-tests/tests/secrets_import.rs
+++ b/crates/api-integration-tests/tests/secrets_import.rs
@@ -19,7 +19,6 @@
 //! These tests start a real Vault dev server and connect to a real Postgres instance.
 //! Requires: `vault` binary in PATH, `DATABASE_URL` env var set.
 
-use std::net::{SocketAddr, TcpListener};
 use std::str::FromStr;
 
 use carbide_secrets::credentials::{
@@ -29,12 +28,6 @@ use carbide_secrets::credentials::{
 use carbide_secrets::{VaultConfig, create_vault_client};
 use sqlx::PgPool;
 use sqlx::postgres::PgConnectOptions;
-
-/// allocate_port picks a free port by binding to port 0.
-fn allocate_port() -> SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to free port");
-    listener.local_addr().expect("local addr")
-}
 
 /// make_test_key creates a deterministic 32-byte key from a seed byte.
 fn make_test_key(seed: u8) -> [u8; 32] {
@@ -241,10 +234,9 @@ async fn vault_to_postgres_import() -> eyre::Result<()> {
 /// round-trips, re-import as a noop, and check the completion marker.
 async fn exercise_import(test_pool: &PgPool) -> eyre::Result<()> {
     // --- Start Vault ---
-    let vault_addr = allocate_port();
-    let vault = api_test_helper::vault::start(vault_addr).await?;
+    let vault = api_test_helper::vault::start().await?;
     let vault_config = VaultConfig {
-        address: Some(format!("https://{vault_addr}")),
+        address: Some(format!("https://{}", vault.addr)),
         kv_mount_location: Some("secret".to_string()),
         pki_mount_location: Some("forgeca".to_string()),
         pki_role_name: Some("forge-cluster".to_string()),

--- a/crates/api-integration-tests/tests/vault_catalogue.rs
+++ b/crates/api-integration-tests/tests/vault_catalogue.rs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-use std::net::TcpListener;
-
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialPrefix, CredentialWriter, Credentials,
     MqttCredentialType,
@@ -24,11 +22,6 @@ use carbide_secrets::credentials::{
 use carbide_secrets::{ForgeVaultClient, VaultConfig, create_vault_client};
 use mac_address::MacAddress;
 use serial_test::serial;
-
-fn allocate_port() -> std::net::SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to free port");
-    listener.local_addr().expect("local addr")
-}
 
 fn cred(user: &str, pass: &str) -> Credentials {
     Credentials::UsernamePassword {
@@ -53,13 +46,10 @@ async fn setup_vault_with_secrets() -> Option<(
         })
         .next()?;
 
-    let addr = allocate_port();
-    let vault = api_test_helper::vault::start(addr)
-        .await
-        .expect("start vault");
+    let vault = api_test_helper::vault::start().await.expect("start vault");
 
     let config = VaultConfig {
-        address: Some(format!("https://{addr}")),
+        address: Some(format!("https://{}", vault.addr)),
         kv_mount_location: Some("secret".to_string()),
         pki_mount_location: Some("forgeca".to_string()),
         pki_role_name: Some("forge-cluster".to_string()),

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -88,7 +88,7 @@ impl IntegrationTestEnvironment {
         // Pick free ports for addresses we need. This is still racy, as it's not guaranteed that
         // the ports will still be available when we start the servers, but it's better than
         // hardcoding them.
-        let (carbide_api_addrs, carbide_metrics_addrs, vault_addr) = {
+        let (carbide_api_addrs, carbide_metrics_addrs) = {
             let mut listeners = vec![]; // hold the listeners so that we don't get the same port twice
             let mut api_addrs = vec![];
             let mut metrics_addrs = vec![];
@@ -107,22 +107,16 @@ impl IntegrationTestEnvironment {
                 });
             }
 
-            // Pick an address for vault too
-            let vault_addr = {
-                let l = TcpListener::bind("127.0.0.1:0")?;
-                let addr = l.local_addr()?;
-                listeners.push(l);
-                addr
-            };
-
-            (api_addrs, metrics_addrs, vault_addr)
+            (api_addrs, metrics_addrs)
         };
 
-        let vault = vault::start(vault_addr).await?;
+        // vault picks its own free port (retrying past races) and reports it
+        // back on the handle, so we don't reserve one here.
+        let vault = vault::start().await?;
 
         let credential_config = CredentialConfig {
             vault: VaultConfig {
-                address: Some(format!("https://{vault_addr}")),
+                address: Some(format!("https://{}", vault.addr)),
                 kv_mount_location: Some("secret".to_string()),
                 pki_mount_location: Some("forgeca".to_string()),
                 pki_role_name: Some("forge-cluster".to_string()),

--- a/crates/api-test-helper/src/vault.rs
+++ b/crates/api-test-helper/src/vault.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::SocketAddr;
+use std::net::{SocketAddr, TcpListener};
 use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
@@ -27,14 +27,67 @@ use tokio::sync::oneshot;
 const ROOT_TOKEN: &str = "Root Token";
 const VAULT_CACERT_ENV_STRING: &str = "$ export VAULT_CACERT";
 
+// A port can be claimed by another process between allocate_port releasing it
+// and vault binding it, so a failed start just means "try another port". Give
+// it a handful of fresh ports before treating the failure as real.
+const MAX_START_ATTEMPTS: usize = 5;
+
+// Bounds a single attempt. A vault that loses the port race exits well before
+// this (surfacing as an error right away); the timeout only stops a genuine
+// hang from stalling the retry loop.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
+
 #[derive(Debug)]
 pub struct Vault {
+    /// The address vault bound. [`start`] chooses it -- retrying across ports
+    /// until one sticks -- so callers read it back here instead of picking it.
+    pub addr: SocketAddr,
     pub process: process::Child,
     pub token: String,
     pub ca_cert: String,
 }
 
-pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
+/// Start a vault dev server on a free local port and wait until it is ready.
+///
+/// vault binds the listen port itself but cannot be asked to pick a free one
+/// and report it back, so we allocate a port and hand it over. The port can be
+/// claimed in the gap between allocate_port releasing it and vault binding it,
+/// so a failed attempt retries on a fresh port. The bound address is returned
+/// on the [`Vault`].
+pub async fn start() -> Result<Vault, eyre::Report> {
+    let mut last_err = None;
+    for attempt in 1..=MAX_START_ATTEMPTS {
+        let addr = allocate_port();
+        match try_start(addr).await {
+            Ok(vault) => return Ok(vault),
+            Err(e) => {
+                // No logger here. A lost port race is expected occasionally, so
+                // keep per-attempt noise low and let the final error speak.
+                eprintln!(
+                    "vault failed to start on {addr} (attempt {attempt}/{MAX_START_ATTEMPTS}): {e:#}"
+                );
+                last_err = Some(e);
+            }
+        }
+    }
+    let err = last_err.unwrap_or_else(|| eyre::eyre!("vault never started"));
+    Err(err.wrap_err(format!(
+        "vault did not start after {MAX_START_ATTEMPTS} attempts"
+    )))
+}
+
+/// Pick a free local port by binding to port 0 and releasing it immediately.
+/// The port is free when this returns, so the caller must claim it promptly;
+/// [`start`] retries if it loses the race.
+fn allocate_port() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind to free port");
+    listener.local_addr().expect("local addr")
+}
+
+/// Spawn vault on `addr` and wait for it to report a token and CA cert. Errors
+/// if vault exits (e.g. the port was taken) or does not report readiness within
+/// [`STARTUP_TIMEOUT`], so [`start`] can retry on a fresh port.
+async fn try_start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
     let bins = crate::utils::find_prerequisites()?;
 
     let mut process =
@@ -98,9 +151,17 @@ pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
         Ok::<(), eyre::Error>(())
     });
 
-    // Vault dev prints the token immediately on startup, so block and wait for it
-    let token = token_rx.await.context("waiting for vault token")?;
-    let ca_cert = ca_rx.await.context("waiting for vault CA cert")?;
+    // Vault dev prints the token and CA cert on startup. If it loses the port
+    // race it exits instead, dropping these senders -- which surfaces here as an
+    // error so start() retries. The timeout only guards a genuine hang.
+    let ready = async {
+        let token = token_rx.await.context("waiting for vault token")?;
+        let ca_cert = ca_rx.await.context("waiting for vault CA cert")?;
+        Ok::<(String, String), eyre::Report>((token, ca_cert))
+    };
+    let (token, ca_cert) = tokio::time::timeout(STARTUP_TIMEOUT, ready)
+        .await
+        .context("timed out waiting for vault to report readiness")??;
 
     // Vault announces the cert path in its stdout log before it finishes writing the
     // file to disk. Poll until the file is present so callers can use it immediately.
@@ -116,6 +177,7 @@ pub async fn start(addr: SocketAddr) -> Result<Vault, eyre::Report> {
     }
 
     Ok(Vault {
+        addr,
         process,
         token,
         ca_cert,


### PR DESCRIPTION
Our integration tests pick a port for the vault dev server by binding to `:0`, dropping the listener, then handing the freed port to vault. That leaves a window where another process can grab the port first and vault fails to bind -- a classic source of intermittent CI failures.

`vault::start` now owns the whole reservation: it allocates a port, starts vault, and if vault loses the race and exits, retries on a fresh port. A few attempts is plenty, since the race is rare.

- `start()` drops its address argument and returns the bound addr on the `Vault`, so every caller reads `vault.addr` instead of the port it picked and handed in.
- A per-attempt timeout bounds a true startup hang; a lost port race surfaces right away when vault exits.
- The three callers -- the import and catalogue tests and the api-server test harness -- drop their own port-picking and lean on this.

Tests updated!

This supports https://github.com/NVIDIA/infra-controller/issues/2777
