### PR TITLE
fix(site-explorer): Derive DPU base MAC from BMC eth0 offset fallback

### DIFF
--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -174,6 +174,20 @@ impl<B: Bmc> ExploredManager<B> {
                     }
                 })?;
 
+            // Warn if the manager eth0 MAC is locally-administered: a real BMC MAC is
+            // globally unique, so this signals transient pre-sync data (seen briefly
+            // after a BMC reboot) that would poison anything keyed on the BMC MAC.
+            if iface.id().inner().eq_ignore_ascii_case("eth0")
+                && let Some(mac) = mac_address
+                && is_locally_administered_mac(mac)
+            {
+                tracing::warn!(
+                    manager_id = %self.manager.id().inner(),
+                    eth0_mac = %mac,
+                    "manager eth0 MAC is locally-administered (transient pre-sync data?)",
+                );
+            }
+
             let uefi_device_path = iface
                 .uefi_device_path()
                 .map(|v| v.into_inner())
@@ -196,4 +210,11 @@ impl<B: Bmc> ExploredManager<B> {
             ethernet_interfaces,
         })
     }
+}
+
+/// Whether `mac` has the locally-administered bit set (bit 0x02 of the first
+/// octet). NVIDIA BMC/NIC MACs are globally unique, so a locally-administered
+/// value indicates transient pre-sync data rather than the burned-in address.
+fn is_locally_administered_mac(mac: mac_address::MacAddress) -> bool {
+    mac.bytes()[0] & 0x02 != 0
 }

--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -17,7 +17,7 @@
 
 use std::str::FromStr;
 
-use carbide_network::deserialize_input_mac_to_address;
+use carbide_network::{deserialize_input_mac_to_address, is_locally_administered_mac};
 use model::site_explorer::{
     EthernetInterface as ModelEthernetInterface, Manager as ModelManager, UefiDevicePath,
 };
@@ -210,11 +210,4 @@ impl<B: Bmc> ExploredManager<B> {
             ethernet_interfaces,
         })
     }
-}
-
-/// Whether `mac` has the locally-administered bit set (bit 0x02 of the first
-/// octet). NVIDIA BMC/NIC MACs are globally unique, so a locally-administered
-/// value indicates transient pre-sync data rather than the burned-in address.
-fn is_locally_administered_mac(mac: mac_address::MacAddress) -> bool {
-    mac.bytes()[0] & 0x02 != 0
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -167,6 +167,14 @@ pub fn deserialize_input_mac_to_address(input_value: &str) -> Result<MacAddress,
     let mac_address: MacAddress = mac_string.parse()?;
     Ok(mac_address)
 }
+
+/// Whether `mac` has the locally-administered bit set (bit 0x02 of the first
+/// octet). NVIDIA BMC/NIC MACs are globally unique, so a locally-administered
+/// value indicates transient pre-sync data rather than the burned-in address.
+pub fn is_locally_administered_mac(mac: MacAddress) -> bool {
+    mac.bytes()[0] & 0x02 != 0
+}
+
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -357,4 +357,48 @@ mod tests {
             },
         );
     }
+
+    // The locally-administered bit is 0x02 of the first octet. Drives the table
+    // off the parsed MAC's first octet so the bit math is exercised directly.
+    #[test]
+    fn is_locally_administered_mac_reads_the_u_l_bit() {
+        check_cases(
+            [
+                Case {
+                    scenario: "globally-unique NVIDIA-style mac (U/L bit clear)",
+                    input: "A0:88:C2:46:0C:68",
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "all zeros (U/L bit clear)",
+                    input: "00:00:00:00:00:00",
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "locally-administered bit set (0x02)",
+                    input: "02:00:00:00:00:00",
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "locally-administered among other first-octet bits (0x06)",
+                    input: "06:11:22:33:44:55",
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "multicast bit set but U/L bit clear (0x01)",
+                    input: "01:00:00:00:00:00",
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "all f's — every bit set, U/L included",
+                    input: "FF:FF:FF:FF:FF:FF",
+                    expect: Yields(true),
+                },
+            ],
+            |input| {
+                let mac = deserialize_input_mac_to_address(input).expect("valid test mac");
+                Ok::<_, ()>(is_locally_administered_mac(mac))
+            },
+        );
+    }
 }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -3237,7 +3237,7 @@ fn derive_base_mac_from_bmc_eth0(report: &EndpointExplorationReport) -> Option<M
         .flat_map(|m| m.ethernet_interfaces.iter())
         .find(|e| {
             e.id.as_deref()
-                .is_some_and(|id| id.to_lowercase().contains("eth0"))
+                .is_some_and(|id| id.eq_ignore_ascii_case("eth0"))
         })
         .and_then(|e| e.mac_address)?;
 

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -78,6 +78,7 @@ mod managed_host;
 use db::ObjectColumnFilter;
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 pub use managed_host::is_endpoint_in_managed_host;
+use model::DpuModel;
 use model::expected_machine::DpuMode;
 use model::firmware::FirmwareComponentType;
 use model::machine_interface_address::MachineInterfaceAssociation;
@@ -3161,26 +3162,125 @@ fn get_base_mac_from_sys_image_version(sys_image_version: &String) -> Result<Str
 /// The method should be migrated to the DPU directly providing the
 /// MAC address: https://redmine.mellanox.com/issues/3749837
 fn find_host_pf_mac_address(dpu_ep: &ExploredEndpoint) -> Result<MacAddress, String> {
-    // First, try to grab a MAC from explored Redfish data,
-    // which lives under ComputerSystem. Otherwise, just fall
-    // back to the legacy method via get_sys_image_version.
+    // Base-MAC derivation has three paths, tried in order of trust:
+    //   1. Primary  : the explored ComputerSystem base_mac (OEM Redfish BaseMAC).
+    //   2. Legacy    : derived from UpdateService/FirmwareInventory/DPU_SYS_IMAGE.Version.
+    //   3. BMC offset: derived from the BMC manager eth0 MAC minus a per-platform
+    //                  offset (fallback-only; see derive_base_mac_from_bmc_eth0).
+    // We only hard-fail if all three paths fail.
 
-    // Try the explored computer-system base_mac first
+    // Path 1: explored computer-system base_mac.
     if let Some(system_mac) = dpu_ep.report.systems.first().and_then(|s| s.base_mac) {
         return Ok(system_mac.to_mac());
     }
 
-    tracing::warn!("ComputerSystem doesn't have base_mac, falling back to legacy method");
-    let legacy_mac = get_base_mac_from_sys_image_version(get_sys_image_version(
-        dpu_ep.report.service.as_ref(),
-    )?)?;
+    // Path 2: legacy DPU_SYS_IMAGE derivation. Soft-fail so we can try path 3.
+    tracing::warn!("ComputerSystem doesn't have base_mac, falling back to DPU_SYS_IMAGE method");
+    let legacy_err = match get_sys_image_version(dpu_ep.report.service.as_ref())
+        .and_then(get_base_mac_from_sys_image_version)
+        .and_then(|legacy_mac| {
+            sanitized_mac(&legacy_mac).map_err(|e| {
+                format!("Failed to build sanitized MAC from legacy/service MAC: {e} (source_mac: {legacy_mac})")
+            })
+        }) {
+        Ok(mac) => return Ok(mac),
+        Err(e) => {
+            tracing::warn!("DPU_SYS_IMAGE derivation failed, falling back to BMC eth0 offset: {e}");
+            e
+        }
+    };
 
-    // Sanitize the legacy MAC and return it
-    sanitized_mac(&legacy_mac).map_err(|e| {
-        format!(
-            "Failed to build sanitized MAC from legacy/service MAC: {e} (source_mac: {legacy_mac})"
-        )
-    })
+    // Path 3: BMC manager eth0 MAC minus a per-platform offset. If this path is
+    // also unavailable, surface the legacy error so we still fail the old way.
+    derive_base_mac_from_bmc_eth0(&dpu_ep.report).ok_or(legacy_err)
+}
+
+// The PF0 base MAC sits a fixed offset below the DPU BMC's eth0 MAC, within the
+// contiguous MAC block allocated to the card. Per the BlueField-3 DPU Controller
+// User Manual (§10.1, "DPU Controller Board Label"):
+//   * host high-speed ports are `base + port_index`
+//   * `DPU_BMC_MAC = OOB_MAC + 1`
+// so the offset decomposes as `(OOB - base) + 1`.
+//
+// Measured on a real BF3 DPU (offset = 0x25 = 37):
+//   DPU BMC eth0                              : 5c:25:73:9e:ac:eb
+//   base (DPU_SYS_IMAGE 5c25:7303:009e:acc6)  : 5c:25:73:9e:ac:c6
+// which implies OOB = bmc - 1 = ...ea and a host-reservation gap of
+// (OOB - base) = 0x24 = 36, consistent with the manual's `BMC = OOB + 1`.
+//
+// The host-reservation gap is not published and could differ on other SKUs
+// (e.g. 1- vs 2-port); revisit if a card of a different SKU mis-derives.
+const BF3_ETH0_TO_BASE_MAC_OFFSET: u64 = 0x25; // measured: BlueField-3, see above
+
+/// The per-platform offset to subtract from the BMC manager eth0 MAC to obtain
+/// the DPU PF0 base MAC, or `None` for platforms we can't classify (we never guess).
+fn bmc_eth0_to_base_mac_offset(report: &EndpointExplorationReport) -> Option<u64> {
+    match report.identify_dpu()? {
+        DpuModel::BlueField3 => Some(BF3_ETH0_TO_BASE_MAC_OFFSET),
+        // BlueField-2 is not supported by the BMC eth0 offset fallback.
+        DpuModel::BlueField2 | DpuModel::Unknown => None,
+    }
+}
+
+/// Fallback-only (item #2 of issue #1076): derive the DPU PF0 base MAC from the
+/// BMC manager eth0 MAC minus a platform-specific offset. Returns `None` if the
+/// eth0 interface MAC is missing, locally-administered (pre-sync), the platform
+/// is unknown, or the subtraction would underflow.
+fn derive_base_mac_from_bmc_eth0(report: &EndpointExplorationReport) -> Option<MacAddress> {
+    let offset = bmc_eth0_to_base_mac_offset(report)?;
+
+    // Pick the eth0 interface specifically -- the OOB interface also lives in
+    // the manager's ethernet_interfaces list.
+    let bmc_eth0 = report
+        .managers
+        .iter()
+        .flat_map(|m| m.ethernet_interfaces.iter())
+        .find(|e| {
+            e.id.as_deref()
+                .is_some_and(|id| id.to_lowercase().contains("eth0"))
+        })
+        .and_then(|e| e.mac_address)?;
+
+    // A real NVIDIA BMC MAC is globally unique. A locally-administered MAC means
+    // the BMC hasn't synced its burned-in address yet (transient post-boot
+    // state) -- refuse to derive a base MAC from it rather than hand back a
+    // plausible-but-wrong value.
+    if is_locally_administered_mac(bmc_eth0) {
+        tracing::warn!(
+            bmc_eth0 = %bmc_eth0,
+            "BMC eth0 MAC is locally-administered (pre-sync?); skipping offset derivation",
+        );
+        return None;
+    }
+
+    let derived = mac_to_u64(bmc_eth0).checked_sub(offset)?;
+    let mac = u64_to_mac(derived);
+    tracing::warn!(
+        bmc_eth0 = %bmc_eth0,
+        derived = %mac,
+        "derived DPU base MAC from BMC eth0 via offset fallback",
+    );
+    Some(mac)
+}
+
+/// Whether `mac` has the locally-administered bit set (bit 0x02 of the first
+/// octet). NVIDIA BMC/NIC MACs are globally unique, so a locally-administered
+/// value indicates transient pre-sync data rather than the burned-in address.
+pub(crate) fn is_locally_administered_mac(mac: MacAddress) -> bool {
+    mac.bytes()[0] & 0x02 != 0
+}
+
+/// MAC address as a 48-bit big-endian integer (top two bytes of the u64 are zero).
+fn mac_to_u64(mac: MacAddress) -> u64 {
+    mac.bytes()
+        .iter()
+        .fold(0u64, |acc, &byte| (acc << 8) | u64::from(byte))
+}
+
+/// Inverse of [`mac_to_u64`]; the high 16 bits are discarded.
+fn u64_to_mac(value: u64) -> MacAddress {
+    let b = value.to_be_bytes();
+    MacAddress::new([b[2], b[3], b[4], b[5], b[6], b[7]])
 }
 
 /// Whether a discovered DPU BMC is reporting that it's running as a plain NIC.
@@ -3370,6 +3470,89 @@ mod tests {
     use model::site_explorer::PreingestionState;
 
     use super::*;
+
+    #[test]
+    fn mac_u64_roundtrip() {
+        let mac: MacAddress = "a0:88:c2:46:0c:68".parse().unwrap();
+        assert_eq!(mac_to_u64(mac), 0x0000_a088_c246_0c68);
+        assert_eq!(u64_to_mac(mac_to_u64(mac)), mac);
+    }
+
+    #[test]
+    fn u64_to_mac_discards_high_bits() {
+        // High 16 bits set must not leak into the MAC bytes.
+        assert_eq!(
+            u64_to_mac(0xffff_a088_c246_0c68),
+            "a0:88:c2:46:0c:68".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn bf3_offset_derives_measured_base_mac() {
+        // Real BF3 DPU measurement (see BF3_ETH0_TO_BASE_MAC_OFFSET):
+        // BMC eth0 - offset must yield the DPU_SYS_IMAGE-derived base MAC.
+        let bmc_eth0: MacAddress = "5c:25:73:9e:ac:eb".parse().unwrap();
+        let base: MacAddress = "5c:25:73:9e:ac:c6".parse().unwrap();
+        let derived = u64_to_mac(mac_to_u64(bmc_eth0) - BF3_ETH0_TO_BASE_MAC_OFFSET);
+        assert_eq!(derived, base);
+        // Cross-check the documented BMC = OOB + 1 relationship.
+        let oob = u64_to_mac(mac_to_u64(bmc_eth0) - 1);
+        assert_eq!(oob, "5c:25:73:9e:ac:ea".parse().unwrap());
+    }
+
+    // Minimal BlueField-3 report with a single manager eth0 interface carrying
+    // `eth0_mac`. Classifies as BF3 (system id "Bluefield" + Card1 BF3 chassis).
+    fn bf3_report_with_eth0(eth0_mac: &str) -> EndpointExplorationReport {
+        use model::site_explorer::{Chassis, ComputerSystem, EthernetInterface, Manager};
+        EndpointExplorationReport {
+            systems: vec![ComputerSystem {
+                id: "Bluefield".to_string(),
+                ..Default::default()
+            }],
+            chassis: vec![Chassis {
+                id: "Card1".to_string(),
+                model: Some("NVIDIA BlueField 3 DPU".to_string()),
+                ..Default::default()
+            }],
+            managers: vec![Manager {
+                id: "Bluefield_BMC".to_string(),
+                ethernet_interfaces: vec![EthernetInterface {
+                    id: Some("eth0".to_string()),
+                    mac_address: Some(eth0_mac.parse().unwrap()),
+                    ..Default::default()
+                }],
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn bmc_eth0_offset_skips_locally_administered_mac() {
+        // Transient pre-sync MAC (locally-administered bit set) must not derive
+        // a base MAC, even though the platform classifies and an eth0 exists.
+        let transient = bf3_report_with_eth0("9a:72:d5:07:ae:7e");
+        assert_eq!(bmc_eth0_to_base_mac_offset(&transient), Some(0x25));
+        assert!(derive_base_mac_from_bmc_eth0(&transient).is_none());
+
+        // Sanity: the same report with the real (globally-unique) eth0 derives.
+        let synced = bf3_report_with_eth0("5c:25:73:9e:ac:eb");
+        assert_eq!(
+            derive_base_mac_from_bmc_eth0(&synced),
+            Some("5c:25:73:9e:ac:c6".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn bmc_eth0_offset_fallback_unsupported_for_bf2() {
+        // BlueField-2 is intentionally not supported by the BMC eth0 offset
+        // fallback, so derivation must return None even when an eth0 MAC exists.
+        let mut report = load_bf2_ep_report();
+        for s in report.systems.iter_mut() {
+            s.base_mac = None;
+        }
+        assert!(bmc_eth0_to_base_mac_offset(&report).is_none());
+        assert!(derive_base_mac_from_bmc_eth0(&report).is_none());
+    }
 
     fn load_bf2_ep_report() -> EndpointExplorationReport {
         let path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/test_data/bf2_report.json");

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use carbide_firmware::{FirmwareConfig, FirmwareConfigSnapshot};
-use carbide_network::sanitized_mac;
+use carbide_network::{is_locally_administered_mac, sanitized_mac};
 use carbide_redfish::libredfish::conv::IntoModel;
 use carbide_secrets::credentials::CredentialManager;
 use carbide_utils::periodic_timer::PeriodicTimer;
@@ -3261,13 +3261,6 @@ fn derive_base_mac_from_bmc_eth0(report: &EndpointExplorationReport) -> Option<M
         "derived DPU base MAC from BMC eth0 via offset fallback",
     );
     Some(mac)
-}
-
-/// Whether `mac` has the locally-administered bit set (bit 0x02 of the first
-/// octet). NVIDIA BMC/NIC MACs are globally unique, so a locally-administered
-/// value indicates transient pre-sync data rather than the burned-in address.
-pub(crate) fn is_locally_administered_mac(mac: MacAddress) -> bool {
-    mac.bytes()[0] & 0x02 != 0
 }
 
 /// MAC address as a 48-bit big-endian integer (top two bytes of the u64 are zero).

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -752,16 +752,14 @@ async fn fetch_manager(client: &dyn Redfish) -> Result<Manager, RedfishError> {
     if let Some(eth0) = ethernet_interfaces.iter().find(|e| {
         e.id.as_deref()
             .is_some_and(|id| id.eq_ignore_ascii_case("eth0"))
-    }) {
-        if let Some(mac) = eth0.mac_address {
-            if crate::is_locally_administered_mac(mac) {
-                tracing::warn!(
-                    manager_id = %manager.id,
-                    eth0_mac = %mac,
-                    "manager eth0 MAC is locally-administered (transient pre-sync data?)",
-                );
-            }
-        }
+    }) && let Some(mac) = eth0.mac_address
+        && crate::is_locally_administered_mac(mac)
+    {
+        tracing::warn!(
+            manager_id = %manager.id,
+            eth0_mac = %mac,
+            "manager eth0 MAC is locally-administered (transient pre-sync data?)",
+        );
     }
 
     Ok(Manager {

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -751,7 +751,7 @@ async fn fetch_manager(client: &dyn Redfish) -> Result<Manager, RedfishError> {
     // after a BMC reboot) that would poison anything keyed on the BMC MAC.
     if let Some(eth0) = ethernet_interfaces.iter().find(|e| {
         e.id.as_deref()
-            .is_some_and(|id| id.to_lowercase().contains("eth0"))
+            .is_some_and(|id| id.eq_ignore_ascii_case("eth0"))
     }) {
         if let Some(mac) = eth0.mac_address {
             if crate::is_locally_administered_mac(mac) {

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -746,6 +746,24 @@ async fn fetch_manager(client: &dyn Redfish) -> Result<Manager, RedfishError> {
             _ => Err(err),
         })?;
 
+    // Warn if the manager eth0 MAC is locally-administered: a real BMC MAC is
+    // globally unique, so this signals transient pre-sync data (seen briefly
+    // after a BMC reboot) that would poison anything keyed on the BMC MAC.
+    if let Some(eth0) = ethernet_interfaces.iter().find(|e| {
+        e.id.as_deref()
+            .is_some_and(|id| id.to_lowercase().contains("eth0"))
+    }) {
+        if let Some(mac) = eth0.mac_address {
+            if crate::is_locally_administered_mac(mac) {
+                tracing::warn!(
+                    manager_id = %manager.id,
+                    eth0_mac = %mac,
+                    "manager eth0 MAC is locally-administered (transient pre-sync data?)",
+                );
+            }
+        }
+    }
+
     Ok(Manager {
         ethernet_interfaces,
         id: manager.id,


### PR DESCRIPTION

Item #2 of #1076: when both primary Redfish sources for the DPU PF0 base MAC are missing (Systems/Bluefield OEM BaseMAC and the DPU_SYS_IMAGE firmware version), pairing previously hard-failed. Add a third fallback that derives the base MAC from the BMC manager eth0 MAC minus a per-platform offset, only failing the old way if all paths miss.

- find_host_pf_mac_address now tries: (1) OEM BaseMAC, (2) DPU_SYS_IMAGE, (3) BMC eth0 - offset; the legacy error is surfaced if path 3 is unavailable so we still "fail the old way".
- Offset table keyed on DpuModel via identify_dpu(). BlueField-3 uses a measured offset (0x25); BlueField-2/Unknown are unsupported (return None, never guess). Offset calibrated and documented against a real BF3 DPU and cross-checked with the manual's BMC = OOB + 1 relationship.
- Guard against transient pre-sync data: a locally-administered BMC eth0 MAC is rejected for derivation, and fetch_manager logs a warning whenever it sees one (it poisons anything keyed on the BMC MAC).

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->
#1076 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

