### PR TITLE
fix(helm): correct boot-artifacts mount path and remove readOnly

### DIFF
--- a/deploy/components/boot-artifacts-containers/patch-boot-artifacts.yaml
+++ b/deploy/components/boot-artifacts-containers/patch-boot-artifacts.yaml
@@ -23,7 +23,7 @@
   path: /spec/template/spec/containers/0/volumeMounts/0
   value:
     name: boot-artifacts
-    mountPath: /nico-boot-artifacts/blobs/internal
+    mountPath: /forge-boot-artifacts/blobs/internal
 
 - op: add
   path: /spec/template/spec/containers/0
@@ -32,10 +32,10 @@
     image: yourdockerregistry.com/path/to/boot-artifacts-x86_64:latest
     imagePullPolicy: IfNotPresent
     command: ["/bin/sh"]
-    args: ["-c", "cp -r /x86_64 /nico-boot-artifacts/blobs/internal; trap : TERM INT; sleep 9999999999d & wait"]
+    args: ["-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal; trap : TERM INT; sleep 9999999999d & wait"]
     volumeMounts:
       - name: boot-artifacts
-        mountPath: /nico-boot-artifacts/blobs/internal
+        mountPath: /forge-boot-artifacts/blobs/internal
 - op: add
   path: /spec/template/spec/containers/0
   value:
@@ -43,10 +43,10 @@
     image: yourdockerregistry.com/path/to/boot-artifacts-aarch64:latest
     imagePullPolicy: IfNotPresent
     command: ["/bin/sh"]
-    args: ["-c", "cp -r /aarch64 /nico-boot-artifacts/blobs/internal; cp -r /apt /nico-boot-artifacts/blobs/internal; cp -r /firmware /nico-boot-artifacts/blobs/internal; trap : TERM INT; sleep 9999999999d & wait"]
+    args: ["-c", "cp -r /aarch64 /forge-boot-artifacts/blobs/internal; cp -r /apt /forge-boot-artifacts/blobs/internal; cp -r /firmware /forge-boot-artifacts/blobs/internal; trap : TERM INT; sleep 9999999999d & wait"]
     volumeMounts:
       - name: boot-artifacts
-        mountPath: /nico-boot-artifacts/blobs/internal
+        mountPath: /forge-boot-artifacts/blobs/internal
 
 # We keep this image around to still provide access to the previous
 # qcow-imager.efi/root binaries for backward compatibility, this should be
@@ -58,10 +58,10 @@
     image: yourdockerregistry.com/path/to/boot-artifacts-x86_64:v2023.11-rc1-16-gf7aebdcc
     imagePullPolicy: IfNotPresent
     command: ["/bin/sh"]
-    args: ["-c", "mkdir -vp /nico-boot-artifacts/blobs/internal/x86_64 && cp -fr /x86_64/qcow-imaging* /nico-boot-artifacts/blobs/internal/x86_64; trap : TERM INT; sleep 9999999999d & wait"]
+    args: ["-c", "mkdir -vp /forge-boot-artifacts/blobs/internal/x86_64 && cp -fr /x86_64/qcow-imaging* /forge-boot-artifacts/blobs/internal/x86_64; trap : TERM INT; sleep 9999999999d & wait"]
     volumeMounts:
       - name: boot-artifacts
-        mountPath: /nico-boot-artifacts/blobs/internal
+        mountPath: /forge-boot-artifacts/blobs/internal
 - op: add
   path: /spec/template/spec/containers/0
   value:
@@ -69,7 +69,7 @@
     image: yourdockerregistry.com/path/to/nvmetal-scout-burn-in:1.3.0
     imagePullPolicy: IfNotPresent
     command: ["/bin/sh"]
-    args: ["-c", "cp -r /machine-validation /nico-boot-artifacts/blobs/internal; trap : TERM INT; sleep 9999999999d & wait"]
+    args: ["-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal; trap : TERM INT; sleep 9999999999d & wait"]
     volumeMounts:
       - name: boot-artifacts
-        mountPath: /nico-boot-artifacts/blobs/internal
+        mountPath: /forge-boot-artifacts/blobs/internal

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: boot-artifacts
-              mountPath: /boot-artifacts/blobs/internal
+              mountPath: /forge-boot-artifacts/blobs/internal
             {{- with .volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -187,8 +187,7 @@ spec:
               readOnly: true
             {{- if .Values.bootArtifactContainers }}
             - name: boot-artifacts
-              mountPath: /boot-artifacts/blobs/internal
-              readOnly: true
+              mountPath: /forge-boot-artifacts/blobs/internal
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/charts/nico-api/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-api/tests/boot_artifacts_test.yaml
@@ -69,7 +69,6 @@ tests:
           content:
             name: boot-artifacts
             mountPath: /forge-boot-artifacts/blobs/internal
-            readOnly: true
 
   - it: should merge bootArtifactContainers and initContainers
     set:

--- a/helm/charts/nico-api/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-api/tests/boot_artifacts_test.yaml
@@ -17,7 +17,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
             readOnly: true
 
   - it: should render boot artifact init containers with auto-injected volume mount
@@ -25,10 +25,10 @@ tests:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
         - name: boot-artifacts-aarch64
           image: registry.example.com/boot-artifacts-aarch64:latest
-          command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /forge-boot-artifacts/blobs/internal"]
     asserts:
       - exists:
           path: spec.template.spec.initContainers
@@ -45,19 +45,19 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
       - contains:
           path: spec.template.spec.initContainers[1].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
 
   - it: should add boot-artifacts volume and mount on main container
     set:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -68,7 +68,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
             readOnly: true
 
   - it: should merge bootArtifactContainers and initContainers
@@ -76,7 +76,7 @@ tests:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
       initContainers:
         - name: custom-init
           image: busybox:latest
@@ -97,7 +97,7 @@ tests:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
           volumeMounts:
             - name: extra-volume
               mountPath: /extra
@@ -109,7 +109,7 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:

--- a/helm/charts/nico-api/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-api/tests/boot_artifacts_test.yaml
@@ -18,7 +18,6 @@ tests:
           content:
             name: boot-artifacts
             mountPath: /forge-boot-artifacts/blobs/internal
-            readOnly: true
 
   - it: should render boot artifact init containers with auto-injected volume mount
     set:

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -79,19 +79,19 @@ initContainers: []
 
 ## Boot-artifact init containers
 ## Each entry is rendered as a Kubernetes init container with the boot-artifacts
-## volume automatically mounted at /boot-artifacts/blobs/internal.
+## volume automatically mounted at /forge-boot-artifacts/blobs/internal.
 bootArtifactContainers: []
 # bootArtifactContainers:
 #   - name: boot-artifacts-x86-64
 #     image: <your-registry>/boot-artifacts-x86_64:latest
-#     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+#     command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
 #   - name: boot-artifacts-aarch64
 #     image: <your-registry>/boot-artifacts-aarch64:latest
 #     # NOTE: the aarch64 image ships /aarch64 + /apt (NOT /firmware) — copying a missing dir crash-loops the init.
-#     command: ["sh", "-c", "cp -r /aarch64 /apt /boot-artifacts/blobs/internal"]
+#     command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
 #   - name: machine-validation-config
 #     image: <your-registry>/machine-validation-config:latest
-#     command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
+#     command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
 service:
   grpc:

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: boot-artifacts
-              mountPath: /boot-artifacts/blobs/internal
+              mountPath: /forge-boot-artifacts/blobs/internal
             {{- with .volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -86,8 +86,7 @@ spec:
               readOnly: true
             {{- if .Values.bootArtifactContainers }}
             - name: boot-artifacts
-              mountPath: /boot-artifacts/blobs/internal
-              readOnly: true
+              mountPath: /forge-boot-artifacts/blobs/internal
             {{- end }}
       volumes:
         - name: spiffe

--- a/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
@@ -18,7 +18,6 @@ tests:
           content:
             name: boot-artifacts
             mountPath: /forge-boot-artifacts/blobs/internal
-            readOnly: true
 
   - it: should render boot artifact init containers with auto-injected volume mount
     set:

--- a/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
@@ -66,7 +66,6 @@ tests:
           content:
             name: boot-artifacts
             mountPath: /forge-boot-artifacts/blobs/internal
-            readOnly: true
 
   - it: should use configurable serve path
     set:

--- a/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
@@ -17,7 +17,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
             readOnly: true
 
   - it: should render boot artifact init containers with auto-injected volume mount
@@ -25,10 +25,10 @@ tests:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
         - name: boot-artifacts-aarch64
           image: registry.example.com/boot-artifacts-aarch64:latest
-          command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /forge-boot-artifacts/blobs/internal"]
     asserts:
       - exists:
           path: spec.template.spec.initContainers
@@ -42,19 +42,19 @@ tests:
           path: spec.template.spec.initContainers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
       - contains:
           path: spec.template.spec.initContainers[1].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
 
   - it: should add boot-artifacts volume and mount on main container
     set:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -65,7 +65,7 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: boot-artifacts
-            mountPath: /boot-artifacts/blobs/internal
+            mountPath: /forge-boot-artifacts/blobs/internal
             readOnly: true
 
   - it: should use configurable serve path
@@ -79,18 +79,18 @@ tests:
           path: spec.template.spec.containers[0].command[2]
           pattern: '-s /custom-boot-path'
 
-  - it: should default serve path to /boot-artifacts
+  - it: should default serve path to /forge-boot-artifacts
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: '-s /boot-artifacts'
+          pattern: '-s /forge-boot-artifacts'
 
   - it: should merge bootArtifactContainers and initContainers
     set:
       bootArtifactContainers:
         - name: boot-artifacts-x86-64
           image: registry.example.com/boot-artifacts-x86_64:latest
-          command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
       initContainers:
         - name: custom-init
           image: busybox:latest

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -50,7 +50,7 @@ initContainers: []
 
 ## Boot-artifact init containers
 ## Each entry is rendered as a Kubernetes init container with the boot-artifacts
-## volume automatically mounted at /boot-artifacts/blobs/internal, then served by
+## volume automatically mounted at /forge-boot-artifacts/blobs/internal, then served by
 ## nico-pxe at /public/blobs/internal.
 ##
 ## REQUIRED for DPU and host HTTP boot: if empty, the DPU/host requests its bootloader
@@ -64,17 +64,17 @@ bootArtifactContainers: []
 # bootArtifactContainers:
 #   - name: boot-artifacts-x86-64
 #     image: <your-registry>/boot-artifacts-x86_64:<tag>
-#     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+#     command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
 #   - name: boot-artifacts-aarch64
 #     image: <your-registry>/boot-artifacts-aarch64:<tag>
-#     command: ["sh", "-c", "cp -r /aarch64 /apt /boot-artifacts/blobs/internal"]
+#     command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
 #   - name: machine-validation-config
 #     image: <your-registry>/machine-validation-config:<tag>
-#     command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
+#     command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
 ## Boot artifact serving configuration
 bootArtifacts:
-  servePath: /boot-artifacts
+  servePath: /forge-boot-artifacts
 
 annotations:
   configmap.reloader.stakater.com/reload: '{{ include "nico-pxe.name" . }}-env-config'

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -63,7 +63,7 @@ nico-api:
       command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     - name: boot-artifacts-aarch64
       image: "your-registry.example.com/boot-artifacts-aarch64:latest"
-      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /forge-boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
     - name: machine-validation-config
       image: "your-registry.example.com/machine-validation-config:latest"
       command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
@@ -248,7 +248,7 @@ nico-pxe:
       command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     - name: boot-artifacts-aarch64
       image: "your-registry.example.com/boot-artifacts-aarch64:latest"
-      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /forge-boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
     - name: machine-validation-config
       image: "your-registry.example.com/machine-validation-config:latest"
       command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -55,18 +55,18 @@ nico-api:
       cpu: 1500m
       memory: 8Gi
 
-  ## Boot-artifact init containers — volume mount at /boot-artifacts/blobs/internal
+  ## Boot-artifact init containers — volume mount at /forge-boot-artifacts/blobs/internal
   ## is auto-injected by the template.
   bootArtifactContainers:
     - name: boot-artifacts-x86-64
       image: "your-registry.example.com/boot-artifacts-x86_64:latest"
-      command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     - name: boot-artifacts-aarch64
       image: "your-registry.example.com/boot-artifacts-aarch64:latest"
-      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /forge-boot-artifacts/blobs/internal"]
     - name: machine-validation-config
       image: "your-registry.example.com/machine-validation-config:latest"
-      command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
   env:
     VAULT_PKI_ROLE_NAME: "nico-cluster"
@@ -240,18 +240,18 @@ nico-pxe:
   replicas: 1
 
   bootArtifacts:
-    servePath: /boot-artifacts
+    servePath: /forge-boot-artifacts
 
   bootArtifactContainers:
     - name: boot-artifacts-x86-64
       image: "your-registry.example.com/boot-artifacts-x86_64:latest"
-      command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     - name: boot-artifacts-aarch64
       image: "your-registry.example.com/boot-artifacts-aarch64:latest"
-      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /forge-boot-artifacts/blobs/internal"]
     - name: machine-validation-config
       image: "your-registry.example.com/machine-validation-config:latest"
-      command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
+      command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
   externalService:
     enabled: true


### PR DESCRIPTION
<!-- Describe what this PR does -->
The helm charts mounted the boot-artifacts volume at /boot-artifacts/blobs/internal
with readOnly: true on the main container. The Rust code hardcodes
/forge-boot-artifacts/blobs/internal (matching the forged kustomize overlays
which work in production), and two code paths write into the directory at runtime.
This caused DPU BFB recovery to fail on every helm-deployed site.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2490

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Two bugs fixed, both caused by the helm chart diverging from the forged kustomize overlays (the production reference implementation):

**1. Wrong mount path (`/boot-artifacts` → `/forge-boot-artifacts`)**

The Rust code hardcodes `/forge-boot-artifacts/blobs/internal` in three places:
- `crates/preingestion-manager/src/bfb_rshim_copier.rs` — `PREINGESTION_BFB_PATH` and `UNIFIED_PREINGESTION_BFB_PATH`
- `crates/machine-controller/src/handler.rs` — secure boot certificate path

The forged kustomize overlay (`components/boot-artifacts-containers/patch-boot-artifacts.yaml`) uses the same path and works correctly in production. The helm chart used `/boot-artifacts/blobs/internal`, causing a "No such file or directory" error on every BFB copy attempt in helm-deployed sites.

**2. `readOnly: true` on a directory the code writes into**

The main container mount had `readOnly: true`. Two runtime code paths write into this directory:
- BFB recovery writes `preingestion_unified_update.bfb` before streaming it to the DPU BMC rshim
- Rack firmware update uses the directory as a download cache


All 35 helm unit tests pass.