### PR TITLE
perf(nico-admin-cli): fetch paged list details concurrently

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -471,7 +471,8 @@ pub fn domain_for_command(name: &str) -> Option<CliDomain> {
 mod tests {
     use std::collections::HashSet;
 
-    use clap::{CommandFactory, Parser, error::ErrorKind};
+    use clap::error::ErrorKind;
+    use clap::{CommandFactory, Parser};
 
     use super::{COMMAND_DOMAINS, CliOptions, domain_for_command};
 
@@ -522,6 +523,14 @@ mod tests {
     fn internal_page_size_rejects_zero() {
         let err = CliOptions::try_parse_from(["nico-admin-cli", "--internal-page-size", "0"])
             .expect_err("zero page size should be rejected");
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn internal_page_size_rejects_values_above_max() {
+        let err = CliOptions::try_parse_from(["nico-admin-cli", "--internal-page-size", "101"])
+            .expect_err("page sizes above max should be rejected");
 
         assert_eq!(err.kind(), ErrorKind::ValueValidation);
     }

--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -30,6 +30,22 @@ use crate::{
     version, vpc, vpc_peering, vpc_prefix,
 };
 
+const MAX_INTERNAL_PAGE_SIZE: usize = 100;
+
+fn parse_internal_page_size(value: &str) -> Result<usize, String> {
+    let page_size = value
+        .parse::<usize>()
+        .map_err(|err| format!("invalid internal page size: {err}"))?;
+
+    if (1..=MAX_INTERNAL_PAGE_SIZE).contains(&page_size) {
+        Ok(page_size)
+    } else {
+        Err(format!(
+            "internal page size must be between 1 and {MAX_INTERNAL_PAGE_SIZE}"
+        ))
+    }
+}
+
 #[derive(Parser, Debug)]
 #[clap(name = "nico-admin-cli")]
 #[clap(author = "https://github.com/NVIDIA/ncx-infra-controller-core")]
@@ -111,7 +127,12 @@ pub struct CliOptions {
     #[clap(subcommand)]
     pub commands: Option<CliCommand>,
 
-    #[clap(short = 'p', long, default_value_t = 100)]
+    #[clap(
+        short = 'p',
+        long,
+        default_value_t = 100,
+        value_parser = parse_internal_page_size
+    )]
     #[clap(help = "For commands that internally retrieve data with paging, use this page size.")]
     pub internal_page_size: usize,
 
@@ -450,7 +471,7 @@ pub fn domain_for_command(name: &str) -> Option<CliDomain> {
 mod tests {
     use std::collections::HashSet;
 
-    use clap::CommandFactory;
+    use clap::{CommandFactory, Parser, error::ErrorKind};
 
     use super::{COMMAND_DOMAINS, CliOptions, domain_for_command};
 
@@ -495,5 +516,21 @@ mod tests {
             "cli_domains.yaml lists commands that are not real top-level \
              commands; rename or remove them: {stale:?}"
         );
+    }
+
+    #[test]
+    fn internal_page_size_rejects_zero() {
+        let err = CliOptions::try_parse_from(["nico-admin-cli", "--internal-page-size", "0"])
+            .expect_err("zero page size should be rejected");
+
+        assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn internal_page_size_accepts_valid_values() {
+        let opts = CliOptions::try_parse_from(["nico-admin-cli", "--internal-page-size", "100"])
+            .expect("valid page size should parse");
+
+        assert_eq!(opts.internal_page_size, 100);
     }
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -116,15 +116,14 @@ impl ApiClient {
             machines: Vec::with_capacity(all_machine_ids.machine_ids.len()),
         };
 
-        let machine_pages = stream::iter(all_machine_ids.machine_ids.chunks(page_size))
+        stream::iter(all_machine_ids.machine_ids.chunks(page_size))
             .map(|machine_ids| self.get_machines_by_ids(machine_ids))
             .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_collect::<Vec<_>>()
+            .try_for_each(|machines| {
+                all_machines.machines.extend(machines.machines);
+                futures::future::ok(())
+            })
             .await?;
-
-        for machines in machine_pages {
-            all_machines.machines.extend(machines.machines);
-        }
 
         Ok(all_machines)
     }
@@ -242,15 +241,14 @@ impl ApiClient {
             instances: Vec::with_capacity(all_ids.instance_ids.len()),
         };
 
-        let instance_pages = stream::iter(all_ids.instance_ids.chunks(page_size))
+        stream::iter(all_ids.instance_ids.chunks(page_size))
             .map(|ids| self.0.find_instances_by_ids(ids.to_vec()))
             .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_collect::<Vec<_>>()
+            .try_for_each(|list| {
+                all_list.instances.extend(list.instances);
+                futures::future::ok(())
+            })
             .await?;
-
-        for list in instance_pages {
-            all_list.instances.extend(list.instances);
-        }
 
         Ok(all_list)
     }
@@ -600,15 +598,14 @@ impl ApiClient {
             endpoints: Vec::with_capacity(endpoint_ids.endpoint_ids.len()),
         };
 
-        let endpoint_pages = stream::iter(endpoint_ids.endpoint_ids.chunks(page_size))
+        stream::iter(endpoint_ids.endpoint_ids.chunks(page_size))
             .map(|ids| self.get_explored_endpoints_by_ids(ids))
             .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_collect::<Vec<_>>()
+            .try_for_each(|list| {
+                all_endpoints.endpoints.extend(list.endpoints);
+                futures::future::ok(())
+            })
             .await?;
-
-        for list in endpoint_pages {
-            all_endpoints.endpoints.extend(list.endpoints);
-        }
 
         // grab managed hosts
         let all_hosts = self.get_all_explored_managed_hosts(page_size).await?;
@@ -645,15 +642,14 @@ impl ApiClient {
             managed_hosts: Vec::with_capacity(host_ids.host_ids.len()),
         };
 
-        let host_pages = stream::iter(host_ids.host_ids.chunks(page_size))
+        stream::iter(host_ids.host_ids.chunks(page_size))
             .map(|ids| self.0.find_explored_managed_hosts_by_ids(ids))
             .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_collect::<Vec<_>>()
+            .try_for_each(|list| {
+                all_hosts.managed_hosts.extend(list.managed_hosts);
+                futures::future::ok(())
+            })
             .await?;
-
-        for list in host_pages {
-            all_hosts.managed_hosts.extend(list.managed_hosts);
-        }
 
         Ok(all_hosts.managed_hosts)
     }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -116,19 +116,13 @@ impl ApiClient {
             machines: Vec::with_capacity(all_machine_ids.machine_ids.len()),
         };
 
-        let mut machine_pages =
-            stream::iter(all_machine_ids.machine_ids.chunks(page_size).enumerate())
-                .map(|(index, machine_ids)| async move {
-                    self.get_machines_by_ids(machine_ids)
-                        .await
-                        .map(|machines| (index, machines))
-                })
-                .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
-                .try_collect::<Vec<_>>()
-                .await?;
+        let machine_pages = stream::iter(all_machine_ids.machine_ids.chunks(page_size))
+            .map(|machine_ids| self.get_machines_by_ids(machine_ids))
+            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
 
-        machine_pages.sort_by_key(|(index, _)| *index);
-        for (_, machines) in machine_pages {
+        for machines in machine_pages {
             all_machines.machines.extend(machines.machines);
         }
 
@@ -248,19 +242,13 @@ impl ApiClient {
             instances: Vec::with_capacity(all_ids.instance_ids.len()),
         };
 
-        let mut instance_pages = stream::iter(all_ids.instance_ids.chunks(page_size).enumerate())
-            .map(|(index, ids)| async move {
-                self.0
-                    .find_instances_by_ids(ids.to_vec())
-                    .await
-                    .map(|list| (index, list))
-            })
-            .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
+        let instance_pages = stream::iter(all_ids.instance_ids.chunks(page_size))
+            .map(|ids| self.0.find_instances_by_ids(ids.to_vec()))
+            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
             .try_collect::<Vec<_>>()
             .await?;
 
-        instance_pages.sort_by_key(|(index, _)| *index);
-        for (_, list) in instance_pages {
+        for list in instance_pages {
             all_list.instances.extend(list.instances);
         }
 
@@ -612,19 +600,13 @@ impl ApiClient {
             endpoints: Vec::with_capacity(endpoint_ids.endpoint_ids.len()),
         };
 
-        let mut endpoint_pages =
-            stream::iter(endpoint_ids.endpoint_ids.chunks(page_size).enumerate())
-                .map(|(index, ids)| async move {
-                    self.get_explored_endpoints_by_ids(ids)
-                        .await
-                        .map(|list| (index, list))
-                })
-                .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
-                .try_collect::<Vec<_>>()
-                .await?;
+        let endpoint_pages = stream::iter(endpoint_ids.endpoint_ids.chunks(page_size))
+            .map(|ids| self.get_explored_endpoints_by_ids(ids))
+            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
 
-        endpoint_pages.sort_by_key(|(index, _)| *index);
-        for (_, list) in endpoint_pages {
+        for list in endpoint_pages {
             all_endpoints.endpoints.extend(list.endpoints);
         }
 
@@ -663,19 +645,13 @@ impl ApiClient {
             managed_hosts: Vec::with_capacity(host_ids.host_ids.len()),
         };
 
-        let mut host_pages = stream::iter(host_ids.host_ids.chunks(page_size).enumerate())
-            .map(|(index, ids)| async move {
-                self.0
-                    .find_explored_managed_hosts_by_ids(ids)
-                    .await
-                    .map(|list| (index, list))
-            })
-            .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
+        let host_pages = stream::iter(host_ids.host_ids.chunks(page_size))
+            .map(|ids| self.0.find_explored_managed_hosts_by_ids(ids))
+            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
             .try_collect::<Vec<_>>()
             .await?;
 
-        host_pages.sort_by_key(|(index, _)| *index);
-        for (_, list) in host_pages {
+        for list in host_pages {
             all_hosts.managed_hosts.extend(list.managed_hosts);
         }
 

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -44,6 +44,7 @@ use carbide_uuid::rack::RackId;
 use carbide_uuid::spx::SpxPartitionId;
 use carbide_uuid::switch::SwitchId;
 use carbide_uuid::vpc::{VpcId, VpcPrefixId};
+use futures::{StreamExt, TryStreamExt, stream};
 use mac_address::MacAddress;
 
 use crate::IntoOnlyOne;
@@ -73,6 +74,8 @@ fn maybe_unimplemented(status: &tonic::Status) -> bool {
         tonic::Code::Unimplemented | tonic::Code::PermissionDenied
     )
 }
+
+const MACHINE_LIST_FETCH_CONCURRENCY: usize = 8;
 
 // Note: You do *not* need to add every gRPC method to this wrapper. Callers can use `.0` to get
 // access to the underlying ForgeApiClient, if they want to simply call the gRPC methods themselves.
@@ -112,8 +115,19 @@ impl ApiClient {
             machines: Vec::with_capacity(all_machine_ids.machine_ids.len()),
         };
 
-        for machine_ids in all_machine_ids.machine_ids.chunks(page_size) {
-            let machines = self.get_machines_by_ids(machine_ids).await?;
+        let mut machine_pages =
+            stream::iter(all_machine_ids.machine_ids.chunks(page_size).enumerate())
+                .map(|(index, machine_ids)| async move {
+                    self.get_machines_by_ids(machine_ids)
+                        .await
+                        .map(|machines| (index, machines))
+                })
+                .buffer_unordered(MACHINE_LIST_FETCH_CONCURRENCY)
+                .try_collect::<Vec<_>>()
+                .await?;
+
+        machine_pages.sort_by_key(|(index, _)| *index);
+        for (_, machines) in machine_pages {
             all_machines.machines.extend(machines.machines);
         }
 

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -75,7 +75,8 @@ fn maybe_unimplemented(status: &tonic::Status) -> bool {
     )
 }
 
-const MACHINE_LIST_FETCH_CONCURRENCY: usize = 8;
+// Benchmarks showed 4 had better overall performance while still overlapping page fetch latency.
+const PAGED_LIST_FETCH_CONCURRENCY: usize = 4;
 
 // Note: You do *not* need to add every gRPC method to this wrapper. Callers can use `.0` to get
 // access to the underlying ForgeApiClient, if they want to simply call the gRPC methods themselves.
@@ -122,7 +123,7 @@ impl ApiClient {
                         .await
                         .map(|machines| (index, machines))
                 })
-                .buffer_unordered(MACHINE_LIST_FETCH_CONCURRENCY)
+                .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
                 .try_collect::<Vec<_>>()
                 .await?;
 
@@ -247,8 +248,19 @@ impl ApiClient {
             instances: Vec::with_capacity(all_ids.instance_ids.len()),
         };
 
-        for ids in all_ids.instance_ids.chunks(page_size) {
-            let list = self.0.find_instances_by_ids(ids.to_vec()).await?;
+        let mut instance_pages = stream::iter(all_ids.instance_ids.chunks(page_size).enumerate())
+            .map(|(index, ids)| async move {
+                self.0
+                    .find_instances_by_ids(ids.to_vec())
+                    .await
+                    .map(|list| (index, list))
+            })
+            .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        instance_pages.sort_by_key(|(index, _)| *index);
+        for (_, list) in instance_pages {
             all_list.instances.extend(list.instances);
         }
 
@@ -599,8 +611,20 @@ impl ApiClient {
         let mut all_endpoints = ::rpc::site_explorer::ExploredEndpointList {
             endpoints: Vec::with_capacity(endpoint_ids.endpoint_ids.len()),
         };
-        for ids in endpoint_ids.endpoint_ids.chunks(page_size) {
-            let list = self.get_explored_endpoints_by_ids(ids).await?;
+
+        let mut endpoint_pages =
+            stream::iter(endpoint_ids.endpoint_ids.chunks(page_size).enumerate())
+                .map(|(index, ids)| async move {
+                    self.get_explored_endpoints_by_ids(ids)
+                        .await
+                        .map(|list| (index, list))
+                })
+                .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
+                .try_collect::<Vec<_>>()
+                .await?;
+
+        endpoint_pages.sort_by_key(|(index, _)| *index);
+        for (_, list) in endpoint_pages {
             all_endpoints.endpoints.extend(list.endpoints);
         }
 
@@ -638,10 +662,23 @@ impl ApiClient {
         let mut all_hosts = ::rpc::site_explorer::ExploredManagedHostList {
             managed_hosts: Vec::with_capacity(host_ids.host_ids.len()),
         };
-        for ids in host_ids.host_ids.chunks(page_size) {
-            let list = self.0.find_explored_managed_hosts_by_ids(ids).await?;
+
+        let mut host_pages = stream::iter(host_ids.host_ids.chunks(page_size).enumerate())
+            .map(|(index, ids)| async move {
+                self.0
+                    .find_explored_managed_hosts_by_ids(ids)
+                    .await
+                    .map(|list| (index, list))
+            })
+            .buffer_unordered(PAGED_LIST_FETCH_CONCURRENCY)
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        host_pages.sort_by_key(|(index, _)| *index);
+        for (_, list) in host_pages {
             all_hosts.managed_hosts.extend(list.managed_hosts);
         }
+
         Ok(all_hosts.managed_hosts)
     }
 
@@ -2242,7 +2279,6 @@ impl ApiClient {
     ) -> CarbideCliResult<RemediationList> {
         let all_remediation_ids = self.0.find_remediation_ids().await?;
 
-        use futures::{StreamExt, TryStreamExt, stream};
         let remediations = stream::iter(all_remediation_ids.remediation_ids.chunks(page_size))
             .then(|remediation_ids| async move {
                 self.0


### PR DESCRIPTION
## Summary

- Fetch paged nico-admin-cli detail records with bounded concurrency instead of one page at a time.
- Preserve output ordering by collecting page indexes and sorting after concurrent fetches complete.
- Apply the same pattern to machine, instance, site-explorer endpoint, and explored managed-host list hydration.
- Use `PAGED_LIST_FETCH_CONCURRENCY = 4`; benchmark runs showed this value had the best overall performance.

## Benchmark Summary

All 52 benchmark runs completed successfully against our largest env. Representative p50 results:

| Command | p50 |
| --- | ---: |
| `machine show` | 6.69s |
| `machine show --hosts` | 4.00s |
| `machine show --dpus` | 5.36s |
| `managed-host show` | 7.50s |
| `managed-host show --more` | 6.86s |
| `managed-host show --ips` | 6.80s |
| `instance show` | 4.88s |
| `site-explorer get-report all` | 6.45s |
| `site-explorer get-report managed-host` | 6.53s |
| `site-explorer get-report endpoint` | 6.45s |

## Validation

- `cargo fmt --all -- --check`
- `gitleaks detect --source /Users/williamp/git/ncx-infra-controller-core --log-opts origin/main..HEAD --verbose --redact`
- `git diff --no-ext-diff --unified=0 origin/main...HEAD | rg ...`
- `cargo test -p nico-admin-cli`
- Linux host validation reported passing before the rebase: full tests and `cargo make --no-workspace clippy-flow`

Post-rebase local `cargo make --no-workspace clippy-flow` was attempted on macOS but is blocked by `libudev-sys` requiring `pkg-config --libs --cflags libudev`. Please rerun on Linux:

```bash
cargo make --no-workspace clippy-flow
```
