### PR TITLE
fix: Allow extension service reuse after soft delete

### DIFF
--- a/crates/api-core/src/tests/extension_service.rs
+++ b/crates/api-core/src/tests/extension_service.rs
@@ -970,6 +970,46 @@ async fn test_extension_service_creation_with_same_name(
 }
 
 #[crate::sqlx_test]
+async fn test_extension_service_recreate_same_name_after_delete(
+    db_pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env = create_test_env(db_pool).await;
+
+    create_test_tenants(&env).await?;
+
+    let service_name = "test-service";
+    let extension_service = create_test_extension_service(&env.api, service_name, None).await?;
+    let service_id = extension_service.service_id.clone();
+
+    let delete_resp = env
+        .api
+        .delete_dpu_extension_service(Request::new(rpc::DeleteDpuExtensionServiceRequest {
+            service_id: service_id.clone(),
+            versions: vec![],
+        }))
+        .await;
+    assert!(delete_resp.is_ok());
+
+    let find_resp = env
+        .api
+        .find_dpu_extension_services_by_ids(Request::new(rpc::DpuExtensionServicesByIdsRequest {
+            service_ids: vec![service_id],
+        }))
+        .await;
+    assert!(find_resp.is_ok());
+    assert!(find_resp.unwrap().into_inner().services.is_empty());
+
+    let recreate_resp = create_test_extension_service(&env.api, service_name, None).await;
+    assert!(recreate_resp.is_ok());
+
+    let recreated_service = recreate_resp.unwrap();
+    assert_eq!(recreated_service.service_name, service_name);
+    assert_ne!(recreated_service.service_id, extension_service.service_id);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_extension_service_update(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
     let env = create_test_env(db_pool).await;
     let service_version = create_test_extension_service_and_tenants(&env).await?;

--- a/crates/api-db/migrations/20260622165000_extension_services_unique_active_name.sql
+++ b/crates/api-db/migrations/20260622165000_extension_services_unique_active_name.sql
@@ -1,0 +1,11 @@
+-- The old unique index includes soft-deleted extesnion service rows, which
+-- prevents a tenant from reusing a service name after the original service
+-- is deleted. 
+-- Replace the old index with a partial unique index so uniqueness constraint
+-- only applies to non-deleted extension services to allow recreate using same
+-- name after deletion.
+DROP INDEX IF EXISTS extension_services_tenant_lowername_unique;
+
+CREATE UNIQUE INDEX extension_services_tenant_lowername_unique
+  ON extension_services (tenant_organization_id, lower(name))
+  WHERE deleted IS NULL;


### PR DESCRIPTION
Updates the extension service name uniqueness constraint to apply only to non-deleted services.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

