### PR TITLE
feat(admin-cli): add rack state-history command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7211,6 +7211,7 @@ name = "nico-admin-cli"
 version = "0.0.1"
 dependencies = [
  "bmc-vendor",
+ "carbide-api-model",
  "carbide-health-report",
  "carbide-libmlx",
  "carbide-libmlx-model",

--- a/crates/admin-cli/Cargo.toml
+++ b/crates/admin-cli/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/main.rs"
 # [local-dependencies]
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 bmc-vendor = { path = "../bmc-vendor" }
+carbide-api-model = { path = "../api-model" }
 carbide-macros = { path = "../macros" }
 carbide-network = { path = "../network" }
 carbide-ssh = { path = "../ssh" }

--- a/crates/admin-cli/src/rack/mod.rs
+++ b/crates/admin-cli/src/rack/mod.rs
@@ -22,6 +22,7 @@ mod maintenance;
 pub mod metadata;
 pub mod profile;
 mod show;
+mod state_history;
 
 #[cfg(test)]
 mod tests;
@@ -46,4 +47,6 @@ pub enum Cmd {
     Profile(profile::Args),
     #[clap(subcommand, about = "On-demand rack maintenance")]
     Maintenance(maintenance::Args),
+    #[clap(about = "Show rack state history")]
+    StateHistory(state_history::Args),
 }

--- a/crates/admin-cli/src/rack/state_history/args.rs
+++ b/crates/admin-cli/src/rack/state_history/args.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::rack::RackId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show state history for a rack:
+    $ nico-admin-cli rack state-history ipp6-b03-gb-nvl-124-mini2
+
+")]
+pub struct Args {
+    #[clap(help = "Rack ID to show state history for")]
+    pub rack_id: RackId,
+}

--- a/crates/admin-cli/src/rack/state_history/cmd.rs
+++ b/crates/admin-cli/src/rack/state_history/cmd.rs
@@ -80,7 +80,10 @@ pub async fn show_state_history(
     match config.format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&output)?),
         OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&output)?),
-        _ => build_history_table(&output).printstd(),
+        OutputFormat::Csv => {
+            build_history_table(&output).to_csv(std::io::stdout()).ok();
+        }
+        OutputFormat::AsciiTable => build_history_table(&output).printstd(),
     }
 
     Ok(())

--- a/crates/admin-cli/src/rack/state_history/cmd.rs
+++ b/crates/admin-cli/src/rack/state_history/cmd.rs
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use color_eyre::Result;
+use model::rack::RackState;
+use prettytable::{Cell, Row, Table};
+use rpc::admin_cli::OutputFormat;
+use rpc::forge::StateHistoryRecord;
+use serde::Serialize;
+
+use super::args::Args;
+use crate::cfg::runtime::RuntimeConfig;
+use crate::rpc::ApiClient;
+
+#[derive(Serialize)]
+struct HistoryRecordOutput {
+    state: String,
+    version: String,
+    time: String,
+}
+
+fn format_state(state_json: &str) -> String {
+    serde_json::from_str::<RackState>(state_json)
+        .map(|state| state.to_string())
+        .unwrap_or_else(|_| state_json.to_string())
+}
+
+fn build_history_table(records: &[HistoryRecordOutput]) -> Table {
+    let mut table = Table::new();
+    table.set_titles(Row::new(vec![
+        Cell::new("State"),
+        Cell::new("Version"),
+        Cell::new("Time"),
+    ]));
+    for record in records {
+        table.add_row(prettytable::row![record.state, record.version, record.time]);
+    }
+    table
+}
+
+fn history_output(records: &[StateHistoryRecord]) -> Vec<HistoryRecordOutput> {
+    records
+        .iter()
+        .map(|record| HistoryRecordOutput {
+            state: format_state(&record.state),
+            version: record.version.clone(),
+            time: record.time.unwrap_or_default().to_string(),
+        })
+        .collect()
+}
+
+pub async fn show_state_history(
+    api_client: &ApiClient,
+    args: Args,
+    config: &RuntimeConfig,
+) -> Result<()> {
+    let rack_id = args.rack_id;
+    let history = api_client.get_rack_state_history(rack_id.clone()).await?;
+
+    if history.is_empty() {
+        println!("No state history found for rack {rack_id}");
+        return Ok(());
+    }
+
+    let output = history_output(&history);
+    match config.format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&output)?),
+        OutputFormat::Yaml => println!("{}", serde_yaml::to_string(&output)?),
+        _ => build_history_table(&output).printstd(),
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_state_parses_discovering() {
+        assert_eq!(format_state(r#"{"state":"discovering"}"#), "Discovering");
+    }
+
+    #[test]
+    fn format_state_parses_maintenance_completed() {
+        assert_eq!(
+            format_state(r#"{"state":"maintenance","rack_maintenance":"Completed"}"#),
+            "Maintenance(Completed)"
+        );
+    }
+
+    #[test]
+    fn format_state_falls_back_to_raw_json_for_legacy_values() {
+        let legacy = r#"{"state":"maintenance","rack_maintenance":{"FirmwareUpgrade":{"rack_firmware_upgrade":"Compute"}}}"#;
+        assert_eq!(format_state(legacy), legacy);
+    }
+}

--- a/crates/admin-cli/src/rack/state_history/mod.rs
+++ b/crates/admin-cli/src/rack/state_history/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::show_state_history(&ctx.api_client, self, &ctx.config).await?;
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/rack/tests.rs
+++ b/crates/admin-cli/src/rack/tests.rs
@@ -90,6 +90,20 @@ fn parse_delete() {
     }
 }
 
+// parse_state_history ensures state-history parses with rack ID.
+#[test]
+fn parse_state_history() {
+    let cmd = Cmd::try_parse_from(["rack", "state-history", "ipp6-b03-gb-nvl-124-mini2"])
+        .expect("should parse state-history");
+
+    match cmd {
+        Cmd::StateHistory(args) => {
+            assert_eq!(args.rack_id, "ipp6-b03-gb-nvl-124-mini2".parse().unwrap());
+        }
+        _ => panic!("expected StateHistory variant"),
+    }
+}
+
 // parse_profile_show ensures profile show parses with rack ID.
 #[test]
 fn parse_profile_show() {
@@ -120,6 +134,10 @@ fn invalid_invocations_are_rejected() {
 
         "profile show without a rack_id" {
             &["rack", "profile", "show"][..] => Fails,
+        }
+
+        "state-history without a rack_id" {
+            &["rack", "state-history"][..] => Fails,
         }
     );
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -446,6 +446,24 @@ impl ApiClient {
         Ok(self.0.find_network_segments_by_ids(request).await?)
     }
 
+    pub async fn get_rack_state_history(
+        &self,
+        rack_id: RackId,
+    ) -> CarbideCliResult<Vec<rpc::StateHistoryRecord>> {
+        let mut result = self
+            .0
+            .find_rack_state_histories(rpc::RackStateHistoriesRequest {
+                rack_ids: vec![rack_id.clone()],
+            })
+            .await?;
+
+        Ok(result
+            .histories
+            .remove(&rack_id.to_string())
+            .map(|h| h.records)
+            .unwrap_or_default())
+    }
+
     pub async fn get_segment_state_history(
         &self,
         segment_id: NetworkSegmentId,


### PR DESCRIPTION
Wire `nico-admin-cli rack state-history` to FindRackStateHistories so operators can inspect rack controller state transitions from the CLI. Supports table, json, and yaml output with parsed RackState display.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

