### PR TITLE
feat(health): forward Redfish diagnostic payloads from health logs

### DIFF
--- a/crates/health/benches/collector_pipeline.rs
+++ b/crates/health/benches/collector_pipeline.rs
@@ -122,6 +122,7 @@ fn build_log_event(idx: usize) -> CollectorEvent {
                 (Cow::Borrowed("entry_id"), idx.to_string()),
                 (Cow::Borrowed("service_id"), "logservice-1".to_string()),
             ],
+            diagnostic_record: None,
         }
         .into(),
     )

--- a/crates/health/benches/sink_pipeline.rs
+++ b/crates/health/benches/sink_pipeline.rs
@@ -345,6 +345,7 @@ fn log_events_with_attrs(count: usize, unique_sensors: usize) -> Vec<CollectorEv
                         format!(r#"["{sensor}","3.96","-0.05"]"#),
                     ),
                 ],
+                diagnostic_record: None,
             }))
         })
         .collect()

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -99,8 +99,8 @@ endpoint = "http://localhost:4317"
 
 # Include Redfish diagnostic payload fields in OTLP logs.
 # If every diagnostic-capable sink leaves diagnostics off, collectors do not
-# attach them. Diagnostic fields are emitted with their parent log record and
-# use the same latest-wins queue replacement.
+# attach them. OTLP exports parent logs normally and emits diagnostics as a
+# separate bounded latest-wins log per endpoint.
 include_diagnostics = false
 
 batch_size = 512

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -99,9 +99,8 @@ endpoint = "http://localhost:4317"
 
 # Include Redfish diagnostic payload fields in OTLP logs.
 # If every diagnostic-capable sink leaves diagnostics off, collectors do not
-# attach them. Diagnostic occurrences use the same OTLP export retry path as
-# other log records, but are queued as distinct occurrences instead of using
-# latest-wins replacement.
+# attach them. Diagnostic fields are emitted with their parent log record and
+# use the same latest-wins queue replacement.
 include_diagnostics = false
 
 batch_size = 512

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -73,11 +73,22 @@ power_shelf = { id = "fps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1
 [sinks.tracing]
 enabled = false
 
+# Include Redfish diagnostic payload fields in tracing output.
+# Payload bodies are forwarded opaquely and may be large. If every
+# diagnostic-capable sink leaves diagnostics off, collectors do not attach them.
+include_diagnostics = false
+
 [sinks.prometheus]
 enabled = true
 
 [sinks.log_file]
 enabled = false
+
+# Include Redfish diagnostic payload fields in JSONL output.
+# If every diagnostic-capable sink leaves diagnostics off, collectors do not
+# attach them.
+include_diagnostics = false
+
 output_dir = "/tmp/logs"
 max_file_size = 104857600 # 100MB
 max_backups = 5
@@ -85,6 +96,14 @@ max_backups = 5
 [sinks.otlp]
 enabled = false
 endpoint = "http://localhost:4317"
+
+# Include Redfish diagnostic payload fields in OTLP logs.
+# If every diagnostic-capable sink leaves diagnostics off, collectors do not
+# attach them. Diagnostic occurrences use the same OTLP export retry path as
+# other log records, but are queued as distinct occurrences instead of using
+# latest-wins replacement.
+include_diagnostics = false
+
 batch_size = 512
 flush_interval = "2s"
 

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -99,8 +99,8 @@ endpoint = "http://localhost:4317"
 
 # Include Redfish diagnostic payload fields in OTLP logs.
 # If every diagnostic-capable sink leaves diagnostics off, collectors do not
-# attach them. OTLP exports parent logs normally and emits diagnostics as a
-# separate bounded latest-wins log per endpoint.
+# attach them. OTLP exports parent logs normally and keeps diagnostics as
+# latest-wins per endpoint while the drain is backed up.
 include_diagnostics = false
 
 batch_size = 512

--- a/crates/health/src/collectors/logs/diagnostic.rs
+++ b/crates/health/src/collectors/logs/diagnostic.rs
@@ -139,6 +139,9 @@ pub(crate) fn make_diagnostic_record(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::Yields;
+    use carbide_test_support::scenarios;
+
     use super::*;
 
     #[derive(Serialize)]
@@ -147,75 +150,142 @@ mod tests {
         CperSection,
     }
 
-    fn attr_value<'a>(record: &'a DiagnosticLogRecord, key: &str) -> Option<&'a str> {
-        record
-            .attributes
-            .iter()
-            .find(|(k, _)| k.as_ref() == key)
-            .map(|(_, v)| v.as_str())
+    enum DiagnosticInput {
+        EnumWireSpelling,
+        Record(DiagnosticRecordInput),
     }
 
-    #[test]
-    fn redfish_enum_string_uses_serde_wire_spelling() {
-        assert_eq!(
-            redfish_enum_string(&TestDiagnosticDataType::CperSection),
-            Some("CPERSection".to_string())
-        );
+    struct DiagnosticRecordInput {
+        diagnostic_data: Option<&'static str>,
+        diagnostic_data_type: Option<String>,
+        oem_diagnostic_data_type: Option<&'static str>,
+        additional_data_uri: Option<&'static str>,
+        additional_data_size_bytes: Option<i64>,
+        message_id: Option<&'static str>,
+        event_id: Option<&'static str>,
+        log_entry_id: Option<&'static str>,
     }
 
-    #[test]
-    fn diagnostic_payload_fields_preserve_opaque_payload() {
-        let Some(record) = make_diagnostic_record(DiagnosticPayload {
-            diagnostic_data: Some("base64-payload"),
-            diagnostic_data_type: Some("CPER".to_string()),
+    #[derive(Debug, PartialEq)]
+    enum DiagnosticOutput {
+        EnumWireSpelling(Option<String>),
+        Record(Option<DiagnosticRecordOutput>),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct DiagnosticRecordOutput {
+        body: String,
+        attributes: Vec<(String, String)>,
+    }
+
+    /// Runs one diagnostic helper scenario and normalizes owned output.
+    fn run_diagnostic_case(input: DiagnosticInput) -> Result<DiagnosticOutput, ()> {
+        let output = match input {
+            DiagnosticInput::EnumWireSpelling => DiagnosticOutput::EnumWireSpelling(
+                redfish_enum_string(&TestDiagnosticDataType::CperSection),
+            ),
+            DiagnosticInput::Record(input) => {
+                let record = make_diagnostic_record(DiagnosticPayload {
+                    diagnostic_data: input.diagnostic_data,
+                    diagnostic_data_type: input.diagnostic_data_type,
+                    oem_diagnostic_data_type: input.oem_diagnostic_data_type,
+                    additional_data_uri: input.additional_data_uri,
+                    additional_data_size_bytes: input.additional_data_size_bytes,
+                    message_id: input.message_id,
+                    event_id: input.event_id,
+                    log_entry_id: input.log_entry_id,
+                })
+                .map(|record| DiagnosticRecordOutput {
+                    body: record.body,
+                    attributes: record
+                        .attributes
+                        .into_iter()
+                        .map(|(key, value)| (key.into_owned(), value))
+                        .collect(),
+                });
+
+                DiagnosticOutput::Record(record)
+            }
+        };
+
+        Ok(output)
+    }
+
+    /// Builds a complete diagnostic payload input with common parent metadata.
+    fn record_input(
+        diagnostic_data: Option<&'static str>,
+        diagnostic_data_type: Option<&'static str>,
+        additional_data_uri: Option<&'static str>,
+    ) -> DiagnosticInput {
+        DiagnosticInput::Record(DiagnosticRecordInput {
+            diagnostic_data,
+            diagnostic_data_type: diagnostic_data_type.map(str::to_string),
             oem_diagnostic_data_type: None,
-            additional_data_uri: Some("/redfish/v1/Log/1/data"),
+            additional_data_uri,
             additional_data_size_bytes: Some(2048),
             message_id: Some("ResourceEvent.1.0.ResourceErrorsDetected"),
             event_id: Some("ev-1"),
             log_entry_id: Some("42"),
-        }) else {
-            panic!("diagnostic payload should produce diagnostic fields");
-        };
-
-        assert_eq!(record.body, "base64-payload");
-
-        assert_eq!(
-            attr_value(&record, "redfish.diagnostic_data.type"),
-            Some("CPER")
-        );
-
-        assert_eq!(
-            attr_value(&record, "redfish.diagnostic_data.additional_uri"),
-            Some("/redfish/v1/Log/1/data")
-        );
-
-        assert_eq!(
-            attr_value(&record, "redfish.diagnostic_data.size_bytes"),
-            Some("2048")
-        );
-
-        assert_eq!(attr_value(&record, "redfish.parent.event_id"), Some("ev-1"));
-
-        assert_eq!(
-            attr_value(&record, "redfish.parent.log_entry_id"),
-            Some("42")
-        );
+        })
     }
 
-    #[test]
-    fn diagnostic_payload_fields_skip_absent_payload_and_uri() {
-        let event = make_diagnostic_record(DiagnosticPayload {
-            diagnostic_data: None,
-            diagnostic_data_type: Some("CPER".to_string()),
-            oem_diagnostic_data_type: None,
-            additional_data_uri: None,
-            additional_data_size_bytes: None,
-            message_id: None,
-            event_id: None,
-            log_entry_id: None,
-        });
+    /// Builds the expected record output with owned attribute strings.
+    fn expected_record(body: &str, attributes: &[(&str, &str)]) -> DiagnosticOutput {
+        DiagnosticOutput::Record(Some(DiagnosticRecordOutput {
+            body: body.to_string(),
+            attributes: attributes
+                .iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+        }))
+    }
 
-        assert!(event.is_none());
+    /// Verifies diagnostic payload conversion cases.
+    #[test]
+    fn diagnostic_payload_fields() {
+        scenarios!(run_diagnostic_case:
+            "enum wire spelling" {
+                DiagnosticInput::EnumWireSpelling => Yields(
+                    DiagnosticOutput::EnumWireSpelling(Some("CPERSection".to_string()))
+                ),
+            }
+
+            "opaque diagnostic payload" {
+                record_input(
+                    Some("base64-payload"),
+                    Some("CPER"),
+                    Some("/redfish/v1/Log/1/data"),
+                ) => Yields(expected_record(
+                    "base64-payload",
+                    &[
+                        ("redfish.diagnostic_data.type", "CPER"),
+                        (
+                            "redfish.diagnostic_data.additional_uri",
+                            "/redfish/v1/Log/1/data",
+                        ),
+                        (
+                            "redfish.parent.message_id",
+                            "ResourceEvent.1.0.ResourceErrorsDetected",
+                        ),
+                        ("redfish.parent.event_id", "ev-1"),
+                        ("redfish.parent.log_entry_id", "42"),
+                        ("redfish.diagnostic_data.size_bytes", "2048"),
+                    ],
+                )),
+            }
+
+            "absent payload and uri" {
+                DiagnosticInput::Record(DiagnosticRecordInput {
+                    diagnostic_data: None,
+                    diagnostic_data_type: Some("CPER".to_string()),
+                    oem_diagnostic_data_type: None,
+                    additional_data_uri: None,
+                    additional_data_size_bytes: None,
+                    message_id: None,
+                    event_id: None,
+                    log_entry_id: None,
+                }) => Yields(DiagnosticOutput::Record(None)),
+            }
+        );
     }
 }

--- a/crates/health/src/collectors/logs/diagnostic.rs
+++ b/crates/health/src/collectors/logs/diagnostic.rs
@@ -1,0 +1,221 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Helpers for carrying Redfish diagnostic payload fields into log sinks.
+//!
+//! Redfish exposes these fields as part of the event or log-entry schema.
+//! The health crate intentionally does not parse CPER or other diagnostic
+//! formats. It preserves the payload and related Redfish metadata so each sink,
+//! or its downstream consumer, can decide how to handle the opaque body.
+
+use std::borrow::Cow;
+
+use serde::Serialize;
+
+use crate::metrics::MetricLabel;
+use crate::sink::DiagnosticLogRecord;
+
+const DIAGNOSTIC_DATA_TYPE_ATTR: &str = "redfish.diagnostic_data.type";
+const DIAGNOSTIC_DATA_OEM_TYPE_ATTR: &str = "redfish.diagnostic_data.oem_type";
+const DIAGNOSTIC_DATA_ADDITIONAL_URI_ATTR: &str = "redfish.diagnostic_data.additional_uri";
+const DIAGNOSTIC_DATA_SIZE_BYTES_ATTR: &str = "redfish.diagnostic_data.size_bytes";
+const PARENT_MESSAGE_ID_ATTR: &str = "redfish.parent.message_id";
+const PARENT_EVENT_ID_ATTR: &str = "redfish.parent.event_id";
+const PARENT_LOG_ENTRY_ID_ATTR: &str = "redfish.parent.log_entry_id";
+
+/// Borrowed diagnostic fields extracted from one Redfish event or log entry.
+pub(crate) struct DiagnosticPayload<'a> {
+    /// Opaque Redfish `DiagnosticData` payload, commonly base64 text for CPER.
+    pub diagnostic_data: Option<&'a str>,
+
+    /// Redfish `DiagnosticDataType`, serialized with the schema wire spelling.
+    pub diagnostic_data_type: Option<String>,
+
+    /// Vendor-specific diagnostic data type when Redfish provides one.
+    pub oem_diagnostic_data_type: Option<&'a str>,
+
+    /// Redfish `AdditionalDataURI`; this module forwards the URI but does not
+    /// fetch it.
+    pub additional_data_uri: Option<&'a str>,
+
+    /// Optional Redfish size metadata for `AdditionalDataURI`.
+    pub additional_data_size_bytes: Option<i64>,
+
+    /// Parent Redfish message id for correlating the diagnostic fields.
+    pub message_id: Option<&'a str>,
+
+    /// Parent Redfish event id for correlating the diagnostic fields.
+    pub event_id: Option<&'a str>,
+
+    /// Parent Redfish log entry id for correlating the diagnostic fields.
+    pub log_entry_id: Option<&'a str>,
+}
+
+/// Flattens generated Redfish nullable option fields.
+///
+/// Redfish generated models use `Option<Option<T>>` to distinguish an absent
+/// property from an explicit JSON null. Diagnostic export treats both as absent.
+pub(crate) fn nullable_ref<T>(value: &Option<Option<T>>) -> Option<&T> {
+    value.as_ref().and_then(Option::as_ref)
+}
+
+/// Flattens generated Redfish nullable string fields.
+///
+/// See [`nullable_ref`] for why explicit null and missing values are handled the
+/// same way in diagnostic fields.
+pub(crate) fn nullable_str(value: &Option<Option<String>>) -> Option<&str> {
+    nullable_ref(value).map(String::as_str)
+}
+
+/// Serializes generated Redfish enums through serde to preserve wire spelling.
+pub(crate) fn redfish_enum_string<T: Serialize>(value: &T) -> Option<String> {
+    serde_json::to_string(value)
+        .ok()
+        .and_then(|value| serde_json::from_str::<String>(&value).ok())
+}
+
+/// Builds diagnostic fields from Redfish payload fields.
+///
+/// URI-only diagnostics are still forwarded because the URI and size metadata
+/// may be enough for a downstream collector to fetch or correlate the payload.
+pub(crate) fn make_diagnostic_record(
+    payload: DiagnosticPayload<'_>,
+) -> Option<DiagnosticLogRecord> {
+    if payload.diagnostic_data.is_none() && payload.additional_data_uri.is_none() {
+        return None;
+    }
+
+    // These attributes leave health through generic sinks, so keep Redfish
+    // schema fields namespaced instead of competing with sink-level keys.
+    let mut attributes: Vec<MetricLabel> = [
+        (
+            DIAGNOSTIC_DATA_TYPE_ATTR,
+            payload.diagnostic_data_type.as_deref(),
+        ),
+        (
+            DIAGNOSTIC_DATA_OEM_TYPE_ATTR,
+            payload.oem_diagnostic_data_type,
+        ),
+        (
+            DIAGNOSTIC_DATA_ADDITIONAL_URI_ATTR,
+            payload.additional_data_uri,
+        ),
+        (PARENT_MESSAGE_ID_ATTR, payload.message_id),
+        (PARENT_EVENT_ID_ATTR, payload.event_id),
+        (PARENT_LOG_ENTRY_ID_ATTR, payload.log_entry_id),
+    ]
+    .into_iter()
+    .filter_map(|(key, value)| value.map(|value| (Cow::Borrowed(key), value.to_string())))
+    .collect();
+
+    if let Some(size_bytes) = payload.additional_data_size_bytes {
+        attributes.push((
+            Cow::Borrowed(DIAGNOSTIC_DATA_SIZE_BYTES_ATTR),
+            size_bytes.to_string(),
+        ));
+    }
+
+    // Keep the diagnostic body opaque. CPER and vendor formats are parsed by
+    // downstream consumers that understand their schema.
+    Some(DiagnosticLogRecord {
+        body: payload.diagnostic_data.unwrap_or_default().to_string(),
+        attributes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Serialize)]
+    enum TestDiagnosticDataType {
+        #[serde(rename = "CPERSection")]
+        CperSection,
+    }
+
+    fn attr_value<'a>(record: &'a DiagnosticLogRecord, key: &str) -> Option<&'a str> {
+        record
+            .attributes
+            .iter()
+            .find(|(k, _)| k.as_ref() == key)
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn redfish_enum_string_uses_serde_wire_spelling() {
+        assert_eq!(
+            redfish_enum_string(&TestDiagnosticDataType::CperSection),
+            Some("CPERSection".to_string())
+        );
+    }
+
+    #[test]
+    fn diagnostic_payload_fields_preserve_opaque_payload() {
+        let Some(record) = make_diagnostic_record(DiagnosticPayload {
+            diagnostic_data: Some("base64-payload"),
+            diagnostic_data_type: Some("CPER".to_string()),
+            oem_diagnostic_data_type: None,
+            additional_data_uri: Some("/redfish/v1/Log/1/data"),
+            additional_data_size_bytes: Some(2048),
+            message_id: Some("ResourceEvent.1.0.ResourceErrorsDetected"),
+            event_id: Some("ev-1"),
+            log_entry_id: Some("42"),
+        }) else {
+            panic!("diagnostic payload should produce diagnostic fields");
+        };
+
+        assert_eq!(record.body, "base64-payload");
+
+        assert_eq!(
+            attr_value(&record, "redfish.diagnostic_data.type"),
+            Some("CPER")
+        );
+
+        assert_eq!(
+            attr_value(&record, "redfish.diagnostic_data.additional_uri"),
+            Some("/redfish/v1/Log/1/data")
+        );
+
+        assert_eq!(
+            attr_value(&record, "redfish.diagnostic_data.size_bytes"),
+            Some("2048")
+        );
+
+        assert_eq!(attr_value(&record, "redfish.parent.event_id"), Some("ev-1"));
+
+        assert_eq!(
+            attr_value(&record, "redfish.parent.log_entry_id"),
+            Some("42")
+        );
+    }
+
+    #[test]
+    fn diagnostic_payload_fields_skip_absent_payload_and_uri() {
+        let event = make_diagnostic_record(DiagnosticPayload {
+            diagnostic_data: None,
+            diagnostic_data_type: Some("CPER".to_string()),
+            oem_diagnostic_data_type: None,
+            additional_data_uri: None,
+            additional_data_size_bytes: None,
+            message_id: None,
+            event_id: None,
+            log_entry_id: None,
+        });
+
+        assert!(event.is_none());
+    }
+}

--- a/crates/health/src/collectors/logs/diagnostic.rs
+++ b/crates/health/src/collectors/logs/diagnostic.rs
@@ -144,17 +144,20 @@ mod tests {
 
     use super::*;
 
+    /// Minimal generated-enum stand-in used to verify serde wire spelling.
     #[derive(Serialize)]
     enum TestDiagnosticDataType {
         #[serde(rename = "CPERSection")]
         CperSection,
     }
 
+    /// Input variants exercised by the table-driven diagnostic tests.
     enum DiagnosticInput {
         EnumWireSpelling,
         Record(DiagnosticRecordInput),
     }
 
+    /// Owned test input mirroring the borrowed production payload fields.
     struct DiagnosticRecordInput {
         diagnostic_data: Option<&'static str>,
         diagnostic_data_type: Option<String>,
@@ -166,12 +169,14 @@ mod tests {
         log_entry_id: Option<&'static str>,
     }
 
+    /// Expected output variants from diagnostic helper scenarios.
     #[derive(Debug, PartialEq)]
     enum DiagnosticOutput {
         EnumWireSpelling(Option<String>),
         Record(Option<DiagnosticRecordOutput>),
     }
 
+    /// Owned diagnostic record output used for scenario comparisons.
     #[derive(Debug, PartialEq)]
     struct DiagnosticRecordOutput {
         body: String,

--- a/crates/health/src/collectors/logs/mod.rs
+++ b/crates/health/src/collectors/logs/mod.rs
@@ -16,6 +16,8 @@
  */
 
 pub(crate) mod auto;
+
+mod diagnostic;
 mod downgrade;
 mod periodic;
 mod sse;

--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -39,6 +39,8 @@ pub struct LogsCollectorConfig {
     pub state_file_path: PathBuf,
     pub service_refresh_interval: Duration,
     pub data_sink: Option<Arc<dyn DataSink>>,
+
+    /// Attach Redfish diagnostic payloads to emitted log records.
     pub include_diagnostics: bool,
 }
 

--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -26,6 +26,9 @@ use nv_redfish::log_service::LogService;
 use nv_redfish::{Resource, ServiceRoot};
 use serde::{Deserialize, Serialize};
 
+use super::diagnostic::{
+    DiagnosticPayload, make_diagnostic_record, nullable_ref, nullable_str, redfish_enum_string,
+};
 use crate::HealthError;
 use crate::collectors::{IterationResult, PeriodicCollector};
 use crate::endpoint::{BmcEndpoint, EndpointMetadata};
@@ -36,6 +39,7 @@ pub struct LogsCollectorConfig {
     pub state_file_path: PathBuf,
     pub service_refresh_interval: Duration,
     pub data_sink: Option<Arc<dyn DataSink>>,
+    pub include_diagnostics: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -63,6 +67,7 @@ pub struct LogsCollector<B: Bmc> {
     state: Option<LogsCollectorState<B>>,
     service_refresh_interval: Duration,
     data_sink: Option<Arc<dyn DataSink>>,
+    include_diagnostics: bool,
 }
 
 impl<B: Bmc + 'static> PeriodicCollector<B> for LogsCollector<B> {
@@ -82,6 +87,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for LogsCollector<B> {
             state: None,
             service_refresh_interval: config.service_refresh_interval,
             data_sink: config.data_sink,
+            include_diagnostics: config.include_diagnostics,
         })
     }
 
@@ -278,7 +284,8 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                         }
                     };
 
-                    // We apply manual filter in either case, if BMC is returns all entries even with filter applied
+                    // We apply manual filter in either case, if BMC is returns all entries even
+                    // with filter applied
                     entries
                         .into_iter()
                         .filter(|entry| {
@@ -334,6 +341,26 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                     String::new()
                 };
 
+                let diagnostic_record = self
+                    .include_diagnostics
+                    .then(|| {
+                        make_diagnostic_record(DiagnosticPayload {
+                            diagnostic_data: nullable_str(&entry.diagnostic_data),
+                            diagnostic_data_type: nullable_ref(&entry.diagnostic_data_type)
+                                .and_then(redfish_enum_string),
+                            oem_diagnostic_data_type: nullable_str(&entry.oem_diagnostic_data_type),
+                            additional_data_uri: nullable_str(&entry.additional_data_uri),
+                            additional_data_size_bytes: nullable_ref(
+                                &entry.additional_data_size_bytes,
+                            )
+                            .copied(),
+                            message_id: entry.message_id.as_deref(),
+                            event_id: entry.event_id.as_deref(),
+                            log_entry_id: Some(entry.base.id.as_str()),
+                        })
+                    })
+                    .flatten();
+
                 let log_event = CollectorEvent::Log(
                     LogRecord {
                         body,
@@ -343,6 +370,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                             (Cow::Borrowed("entry_id"), entry.base.id.clone()),
                             (Cow::Borrowed("service_id"), service_id.clone()),
                         ],
+                        diagnostic_record,
                     }
                     .into(),
                 );

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -32,7 +32,9 @@ use crate::collectors::runtime::{EventStream, StreamingCollector, open_sse_strea
 use crate::endpoint::BmcEndpoint;
 use crate::sink::{CollectorEvent, LogRecord};
 
+/// Configuration for the Redfish SSE log collector.
 pub struct SseLogCollectorConfig {
+    /// Attach Redfish diagnostic payloads to emitted log records.
     pub include_diagnostics: bool,
 }
 

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -97,6 +97,7 @@ fn map_payload<B: Bmc>(
     }
 }
 
+/// Converts one Redfish SSE event into collector log events.
 fn event_to_logs<B: Bmc>(
     event: &Event,
     bmc: &B,

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -24,15 +24,21 @@ use nv_redfish::core::{Bmc, EntityTypeRef};
 use nv_redfish::event_service::{Event, EventStreamPayload};
 use nv_redfish::resource::Health;
 
+use super::diagnostic::{
+    DiagnosticPayload, make_diagnostic_record, nullable_ref, nullable_str, redfish_enum_string,
+};
 use crate::HealthError;
 use crate::collectors::runtime::{EventStream, StreamingCollector, open_sse_stream};
 use crate::endpoint::BmcEndpoint;
 use crate::sink::{CollectorEvent, LogRecord};
 
-pub struct SseLogCollectorConfig;
+pub struct SseLogCollectorConfig {
+    pub include_diagnostics: bool,
+}
 
 pub struct SseLogCollector<B: Bmc> {
     bmc: Arc<B>,
+    include_diagnostics: bool,
 }
 
 #[async_trait]
@@ -42,18 +48,22 @@ impl<B: Bmc + 'static> StreamingCollector<B> for SseLogCollector<B> {
     fn new_runner(
         bmc: Arc<B>,
         _endpoint: Arc<BmcEndpoint>,
-        _config: Self::Config,
+        config: Self::Config,
     ) -> Result<Self, HealthError> {
-        Ok(Self { bmc })
+        Ok(Self {
+            bmc,
+            include_diagnostics: config.include_diagnostics,
+        })
     }
 
     async fn connect(&mut self) -> Result<EventStream<'_>, HealthError> {
         let sse_stream = open_sse_stream(Arc::clone(&self.bmc)).await?;
 
         let bmc = Arc::clone(&self.bmc);
+        let include_diagnostics = self.include_diagnostics;
         let event_stream: EventStream<'_> = sse_stream
             .flat_map(move |result| {
-                let events = map_payload(result, bmc.as_ref());
+                let events = map_payload(result, bmc.as_ref(), include_diagnostics);
                 futures::stream::iter(events)
             })
             .boxed();
@@ -78,15 +88,20 @@ fn health_to_severity(h: &Health) -> &'static str {
 fn map_payload<B: Bmc>(
     result: Result<EventStreamPayload, HealthError>,
     bmc: &B,
+    include_diagnostics: bool,
 ) -> Vec<Result<CollectorEvent, HealthError>> {
     match result {
-        Ok(EventStreamPayload::Event(event)) => event_to_logs(&event, bmc),
+        Ok(EventStreamPayload::Event(event)) => event_to_logs(&event, bmc, include_diagnostics),
         Ok(EventStreamPayload::MetricReport(_)) => Vec::new(),
         Err(e) => vec![Err(e)],
     }
 }
 
-fn event_to_logs<B: Bmc>(event: &Event, bmc: &B) -> Vec<Result<CollectorEvent, HealthError>> {
+fn event_to_logs<B: Bmc>(
+    event: &Event,
+    bmc: &B,
+    include_diagnostics: bool,
+) -> Vec<Result<CollectorEvent, HealthError>> {
     event
         .events
         .iter()
@@ -117,6 +132,13 @@ fn event_to_logs<B: Bmc>(event: &Event, bmc: &B) -> Vec<Result<CollectorEvent, H
                 .or(record.severity.as_deref())
                 .unwrap_or("Unknown")
                 .to_string();
+
+            // Reuse the same Redfish log-entry reference for the parent log
+            // attribute and the diagnostic correlation attribute.
+            let log_entry_id = record
+                .log_entry
+                .as_ref()
+                .map(|log_entry_ref| log_entry_ref.odata_id().to_string());
 
             let mut attributes = vec![
                 (Cow::Borrowed("message_id"), record.message_id.clone()),
@@ -149,11 +171,8 @@ fn event_to_logs<B: Bmc>(event: &Event, bmc: &B) -> Vec<Result<CollectorEvent, H
                     origin.odata_id.to_string(),
                 ));
             }
-            if let Some(log_entry_ref) = &record.log_entry {
-                attributes.push((
-                    Cow::Borrowed("log_entry_id"),
-                    log_entry_ref.odata_id().to_string(),
-                ));
+            if let Some(log_entry_id) = &log_entry_id {
+                attributes.push((Cow::Borrowed("log_entry_id"), log_entry_id.clone()));
             }
             if let Some(group_id) = record.event_group_id {
                 attributes.push((Cow::Borrowed("event_group_id"), group_id.to_string()));
@@ -162,10 +181,28 @@ fn event_to_logs<B: Bmc>(event: &Event, bmc: &B) -> Vec<Result<CollectorEvent, H
                 attributes.push((Cow::Borrowed("resolution"), resolution.clone()));
             }
 
+            let diagnostic_record = if include_diagnostics {
+                make_diagnostic_record(DiagnosticPayload {
+                    diagnostic_data: nullable_str(&record.diagnostic_data),
+                    diagnostic_data_type: nullable_ref(&record.diagnostic_data_type)
+                        .and_then(redfish_enum_string),
+                    oem_diagnostic_data_type: nullable_str(&record.oem_diagnostic_data_type),
+                    additional_data_uri: nullable_str(&record.additional_data_uri),
+                    additional_data_size_bytes: nullable_ref(&record.additional_data_size_bytes)
+                        .copied(),
+                    message_id: Some(record.message_id.as_str()),
+                    event_id: record.event_id.as_deref(),
+                    log_entry_id: log_entry_id.as_deref(),
+                })
+            } else {
+                None
+            };
+
             Ok(CollectorEvent::Log(Box::new(LogRecord {
                 body,
                 severity,
                 attributes,
+                diagnostic_record,
             })))
         })
         .collect()

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -275,6 +275,7 @@ impl SinksConfig {
     }
 }
 
+/// Configuration for the tracing sink.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct TracingSinkConfig {
@@ -290,11 +291,17 @@ pub struct TracingSinkConfig {
 #[serde(default)]
 pub struct PrometheusSinkConfig {}
 
+/// Configuration for the JSONL log file sink.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LogFileSinkConfig {
+    /// Directory where rotated health log files are written.
     pub output_dir: String,
+
+    /// Maximum bytes per active log file before rotation.
     pub max_file_size: u64,
+
+    /// Number of rotated backup files to retain.
     pub max_backups: usize,
 
     /// Write Redfish diagnostic payload fields.
@@ -335,7 +342,8 @@ pub struct OtlpSinkConfig {
     /// Disabled by default because payload bodies are opaque and may be large or
     /// sensitive. If no diagnostic-capable sink enables diagnostics, collectors
     /// do not attach diagnostic fields. OTLP exports parent logs normally and
-    /// emits diagnostics as a separate bounded latest-wins log per endpoint.
+    /// keeps diagnostics as latest-wins per endpoint while the drain is backed
+    /// up.
     pub include_diagnostics: bool,
 }
 
@@ -1164,14 +1172,6 @@ impl Config {
         if let Configurable::Enabled(ref otlp) = self.sinks.otlp {
             tonic::transport::Channel::from_shared(otlp.endpoint.clone())
                 .map_err(|_| format!("invalid sinks.otlp.endpoint: {}", otlp.endpoint))?;
-
-            if otlp.batch_size == 0 {
-                return Err("sinks.otlp.batch_size must be greater than 0".to_string());
-            }
-
-            if otlp.flush_interval.is_zero() {
-                return Err("sinks.otlp.flush_interval must be greater than 0".to_string());
-            }
         }
 
         self.metrics_addr()?;
@@ -1570,18 +1570,6 @@ username = "root"
 
         config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
             endpoint: "not a valid uri\n".to_string(),
-            ..OtlpSinkConfig::default()
-        });
-        assert!(config.validate().is_err());
-
-        config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
-            batch_size: 0,
-            ..OtlpSinkConfig::default()
-        });
-        assert!(config.validate().is_err());
-
-        config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
-            flush_interval: Duration::from_secs(0),
             ..OtlpSinkConfig::default()
         });
         assert!(config.validate().is_err());

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -268,6 +268,10 @@ impl SinksConfig {
                 .log_file
                 .as_option()
                 .is_some_and(|config| config.include_diagnostics)
+            || self
+                .otlp
+                .as_option()
+                .is_some_and(|config| config.include_diagnostics)
     }
 }
 
@@ -312,19 +316,35 @@ impl Default for LogFileSinkConfig {
     }
 }
 
+/// OTLP gRPC sink configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct OtlpSinkConfig {
+    /// OTLP gRPC target.
     pub endpoint: String,
+
+    /// Maximum number of events or samples exported per request.
     pub batch_size: usize,
+
+    /// Maximum time to wait before flushing a non-empty batch.
     #[serde(with = "humantime_serde")]
     pub flush_interval: std::time::Duration,
+
+    /// Export Redfish diagnostic payload fields.
+    ///
+    /// Disabled by default because payload bodies are opaque and may be large or
+    /// sensitive. If no diagnostic-capable sink enables diagnostics, collectors
+    /// do not attach diagnostic fields. Diagnostic occurrences use the same
+    /// OTLP export retry path as other log records, but are queued as distinct
+    /// occurrences instead of using latest-wins replacement.
+    pub include_diagnostics: bool,
 }
 
 impl Default for OtlpSinkConfig {
     fn default() -> Self {
         Self {
             endpoint: "http://localhost:4317".to_string(),
+            include_diagnostics: false,
             batch_size: 512,
             flush_interval: std::time::Duration::from_secs(2),
         }
@@ -1561,11 +1581,17 @@ username = "root"
             .merge(Toml::string("include_diagnostics = true"))
             .extract()
             .expect("log file config should parse");
+        let otlp: OtlpSinkConfig = Figment::new()
+            .merge(Toml::string("include_diagnostics = true"))
+            .extract()
+            .expect("otlp config should parse");
 
         assert!(tracing.include_diagnostics);
         assert!(log_file.include_diagnostics);
+        assert!(otlp.include_diagnostics);
         assert!(!TracingSinkConfig::default().include_diagnostics);
         assert!(!LogFileSinkConfig::default().include_diagnostics);
+        assert!(!OtlpSinkConfig::default().include_diagnostics);
     }
 
     #[test]
@@ -1577,6 +1603,7 @@ username = "root"
                 SinksConfig {
                     tracing: Configurable::Enabled(TracingSinkConfig::default()),
                     log_file: Configurable::Enabled(LogFileSinkConfig::default()),
+                    otlp: Configurable::Enabled(OtlpSinkConfig::default()),
                     ..SinksConfig::default()
                 },
                 false,
@@ -1597,6 +1624,17 @@ username = "root"
                     log_file: Configurable::Enabled(LogFileSinkConfig {
                         include_diagnostics: true,
                         ..LogFileSinkConfig::default()
+                    }),
+                    ..SinksConfig::default()
+                },
+                true,
+            ),
+            (
+                "otlp-diagnostics",
+                SinksConfig {
+                    otlp: Configurable::Enabled(OtlpSinkConfig {
+                        include_diagnostics: true,
+                        ..OtlpSinkConfig::default()
                     }),
                     ..SinksConfig::default()
                 },

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -334,8 +334,8 @@ pub struct OtlpSinkConfig {
     ///
     /// Disabled by default because payload bodies are opaque and may be large or
     /// sensitive. If no diagnostic-capable sink enables diagnostics, collectors
-    /// do not attach diagnostic fields. Diagnostic fields are emitted with
-    /// their parent log record and use the same latest-wins queue replacement.
+    /// do not attach diagnostic fields. OTLP exports parent logs normally and
+    /// emits diagnostics as a separate bounded latest-wins log per endpoint.
     pub include_diagnostics: bool,
 }
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -334,9 +334,8 @@ pub struct OtlpSinkConfig {
     ///
     /// Disabled by default because payload bodies are opaque and may be large or
     /// sensitive. If no diagnostic-capable sink enables diagnostics, collectors
-    /// do not attach diagnostic fields. Diagnostic occurrences use the same
-    /// OTLP export retry path as other log records, but are queued as distinct
-    /// occurrences instead of using latest-wins replacement.
+    /// do not attach diagnostic fields. Diagnostic fields are emitted with
+    /// their parent log record and use the same latest-wins queue replacement.
     pub include_diagnostics: bool,
 }
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1590,6 +1590,7 @@ username = "root"
         assert!(config.validate().is_ok());
     }
 
+    /// Verifies each diagnostic-capable sink parses the opt-in flag.
     #[test]
     fn test_sink_include_diagnostics_configs_parse() {
         let tracing: TracingSinkConfig = Figment::new()
@@ -1613,6 +1614,7 @@ username = "root"
         assert!(!OtlpSinkConfig::default().include_diagnostics);
     }
 
+    /// Verifies collectors attach diagnostics only when a capable sink opts in.
     #[test]
     fn test_sinks_config_includes_log_diagnostics() {
         let cases = [

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1165,6 +1165,14 @@ impl Config {
         if let Configurable::Enabled(ref otlp) = self.sinks.otlp {
             tonic::transport::Channel::from_shared(otlp.endpoint.clone())
                 .map_err(|_| format!("invalid sinks.otlp.endpoint: {}", otlp.endpoint))?;
+
+            if otlp.batch_size == 0 {
+                return Err("sinks.otlp.batch_size must be greater than 0".to_string());
+            }
+
+            if otlp.flush_interval.is_zero() {
+                return Err("sinks.otlp.flush_interval must be greater than 0".to_string());
+            }
         }
 
         self.metrics_addr()?;
@@ -1563,6 +1571,18 @@ username = "root"
 
         config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
             endpoint: "not a valid uri\n".to_string(),
+            ..OtlpSinkConfig::default()
+        });
+        assert!(config.validate().is_err());
+
+        config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
+            batch_size: 0,
+            ..OtlpSinkConfig::default()
+        });
+        assert!(config.validate().is_err());
+
+        config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
+            flush_interval: Duration::from_secs(0),
             ..OtlpSinkConfig::default()
         });
         assert!(config.validate().is_err());

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -258,9 +258,29 @@ impl Default for SinksConfig {
     }
 }
 
+impl SinksConfig {
+    /// Returns true when at least one diagnostic-capable sink opts in.
+    pub fn includes_log_diagnostics(&self) -> bool {
+        self.tracing
+            .as_option()
+            .is_some_and(|config| config.include_diagnostics)
+            || self
+                .log_file
+                .as_option()
+                .is_some_and(|config| config.include_diagnostics)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
-pub struct TracingSinkConfig {}
+pub struct TracingSinkConfig {
+    /// Emit Redfish diagnostic payload fields.
+    ///
+    /// Disabled by default because payload bodies are opaque and may be large or
+    /// sensitive. If no diagnostic-capable sink enables this, collectors do not
+    /// attach diagnostic fields.
+    pub include_diagnostics: bool,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
@@ -272,11 +292,19 @@ pub struct LogFileSinkConfig {
     pub output_dir: String,
     pub max_file_size: u64,
     pub max_backups: usize,
+
+    /// Write Redfish diagnostic payload fields.
+    ///
+    /// Disabled by default because payload bodies are opaque and may be large or
+    /// sensitive. If no diagnostic-capable sink enables this, collectors do not
+    /// attach diagnostic fields.
+    pub include_diagnostics: bool,
 }
 
 impl Default for LogFileSinkConfig {
     fn default() -> Self {
         Self {
+            include_diagnostics: false,
             output_dir: "/tmp/logs".to_string(),
             max_file_size: 104_857_600, // 100MB
             max_backups: 5,
@@ -1521,6 +1549,64 @@ username = "root"
 
         config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig::default());
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_sink_include_diagnostics_configs_parse() {
+        let tracing: TracingSinkConfig = Figment::new()
+            .merge(Toml::string("include_diagnostics = true"))
+            .extract()
+            .expect("tracing config should parse");
+        let log_file: LogFileSinkConfig = Figment::new()
+            .merge(Toml::string("include_diagnostics = true"))
+            .extract()
+            .expect("log file config should parse");
+
+        assert!(tracing.include_diagnostics);
+        assert!(log_file.include_diagnostics);
+        assert!(!TracingSinkConfig::default().include_diagnostics);
+        assert!(!LogFileSinkConfig::default().include_diagnostics);
+    }
+
+    #[test]
+    fn test_sinks_config_includes_log_diagnostics() {
+        let cases = [
+            ("default", SinksConfig::default(), false),
+            (
+                "diagnostic-capable-sinks-enabled-without-diagnostics",
+                SinksConfig {
+                    tracing: Configurable::Enabled(TracingSinkConfig::default()),
+                    log_file: Configurable::Enabled(LogFileSinkConfig::default()),
+                    ..SinksConfig::default()
+                },
+                false,
+            ),
+            (
+                "tracing-diagnostics",
+                SinksConfig {
+                    tracing: Configurable::Enabled(TracingSinkConfig {
+                        include_diagnostics: true,
+                    }),
+                    ..SinksConfig::default()
+                },
+                true,
+            ),
+            (
+                "log-file-diagnostics",
+                SinksConfig {
+                    log_file: Configurable::Enabled(LogFileSinkConfig {
+                        include_diagnostics: true,
+                        ..LogFileSinkConfig::default()
+                    }),
+                    ..SinksConfig::default()
+                },
+                true,
+            ),
+        ];
+
+        for (name, sinks, expected) in cases {
+            assert_eq!(sinks.includes_log_diagnostics(), expected, "{name}");
+        }
     }
 
     #[test]

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -223,6 +223,7 @@ pub struct DiscoveryLoopContext {
     pub(crate) nmxt_config: Configurable<NmxtCollectorOptions>,
     pub(crate) nvue_config: Configurable<NvueCollectorOptions>,
     pub(crate) log_downgrade_registry: Arc<LogDowngradeRegistry>,
+    /// Whether log collectors should attach diagnostic payload carriers.
     pub(crate) logs_include_diagnostics: bool,
 }
 

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -223,6 +223,7 @@ pub struct DiscoveryLoopContext {
     pub(crate) nmxt_config: Configurable<NmxtCollectorOptions>,
     pub(crate) nvue_config: Configurable<NvueCollectorOptions>,
     pub(crate) log_downgrade_registry: Arc<LogDowngradeRegistry>,
+    pub(crate) logs_include_diagnostics: bool,
 }
 
 impl DiscoveryLoopContext {
@@ -268,6 +269,7 @@ impl DiscoveryLoopContext {
             nmxt_config: config.collectors.nmxt.clone(),
             nvue_config: config.collectors.nvue.clone(),
             log_downgrade_registry: Arc::new(LogDowngradeRegistry::new()),
+            logs_include_diagnostics: config.sinks.includes_log_diagnostics(),
         })
     }
 }

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -223,6 +223,7 @@ fn spawn_generic_redfish_collectors(
                     state_file_path,
                     service_refresh_interval: pcfg.state_refresh_interval,
                     data_sink,
+                    include_diagnostics: ctx.logs_include_diagnostics,
                 },
                 CollectorStartContext {
                     limiter: ctx.limiter.clone(),
@@ -239,7 +240,9 @@ fn spawn_generic_redfish_collectors(
                     Some(Collector::start_streaming::<SseLogCollector<BmcClient>, _>(
                         endpoint_arc.clone(),
                         bmc.clone(),
-                        SseLogCollectorConfig,
+                        SseLogCollectorConfig {
+                            include_diagnostics: ctx.logs_include_diagnostics,
+                        },
                         data_sink,
                         StreamingCollectorStartContext {
                             backoff_config: sse_backoff_config(),
@@ -273,7 +276,9 @@ fn spawn_generic_redfish_collectors(
                     Some(Collector::start_streaming::<SseLogCollector<BmcClient>, _>(
                         endpoint_arc.clone(),
                         bmc.clone(),
-                        SseLogCollectorConfig,
+                        SseLogCollectorConfig {
+                            include_diagnostics: ctx.logs_include_diagnostics,
+                        },
                         data_sink,
                         StreamingCollectorStartContext {
                             backoff_config: sse_backoff_config(),

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -167,8 +167,8 @@ fn build_data_sink(
     let mut sinks: Vec<Arc<dyn DataSink>> = Vec::new();
     let mut processors: Vec<Arc<dyn EventProcessor>> = Vec::new();
 
-    if let Configurable::Enabled(_) = &config.sinks.tracing {
-        sinks.push(Arc::new(TracingSink));
+    if let Configurable::Enabled(sink_cfg) = &config.sinks.tracing {
+        sinks.push(Arc::new(TracingSink::new(sink_cfg)));
     }
 
     if let Configurable::Enabled(_) = &config.sinks.prometheus {

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -192,7 +192,7 @@ fn convert_event(event: &CollectorEvent, observed_nanos: u64) -> Option<OtlpLogR
     }
 }
 
-/// groups a batch of events by endpoint and builds an ExportLogsServiceRequest with only logs
+/// Builds an OTLP log export request grouped by endpoint.
 pub fn build_export_request(batch: &[(EventContext, CollectorEvent)]) -> ExportLogsServiceRequest {
     let observed_nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -231,8 +231,10 @@ pub fn build_export_request(batch: &[(EventContext, CollectorEvent)]) -> ExportL
     ExportLogsServiceRequest { resource_logs }
 }
 
-/// group metric samples by endpoint and build an ExportMetricsServiceRequest.
-/// every sample maps to an OTLP `Gauge` point; Sum/Histogram is a follow-up.
+/// Builds an OTLP metric export request grouped by endpoint.
+///
+/// Every sample maps to an OTLP `Gauge` point; Sum and Histogram mapping can
+/// be added when the health metric model exposes those temporality choices.
 pub fn build_metrics_export_request(
     batch: &[(EventContext, MetricSample)],
 ) -> ExportMetricsServiceRequest {
@@ -541,6 +543,52 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].severity_text, "WARNING");
         assert_eq!(records[0].severity_number, SeverityNumber::Warn as i32);
+    }
+
+    #[test]
+    fn diagnostic_log_event_preserves_diagnostic_body_and_attributes() {
+        let ctx = test_context();
+        let body = concat!(
+            r#"{"message":"parent message","#,
+            r#""diagnostic_data":"opaque-base64-payload","#,
+            r#""diagnostic_attributes":["#,
+            r#"{"key":"redfish.diagnostic_data.type","value":"cper"},"#,
+            r#"{"key":"redfish.parent.log_entry_id","value":"42"}]}"#
+        );
+
+        let log = CollectorEvent::Log(Box::new(LogRecord {
+            body: body.to_string(),
+            severity: "WARN".to_string(),
+            attributes: vec![
+                (
+                    Cow::Borrowed("redfish.diagnostic_data.type"),
+                    "cper".to_string(),
+                ),
+                (
+                    Cow::Borrowed("redfish.parent.log_entry_id"),
+                    "42".to_string(),
+                ),
+            ],
+            diagnostic_record: None,
+        }));
+
+        let request = build_export_request(&[(ctx, log)]);
+
+        let records = &request.resource_logs[0].scope_logs[0].log_records;
+        let record = &records[0];
+
+        assert_eq!(
+            record.body.as_ref().and_then(|body| body.value.as_ref()),
+            Some(&any_value::Value::StringValue(body.to_string()))
+        );
+        assert_eq!(
+            attr_value(&record.attributes, "redfish.diagnostic_data.type"),
+            Some("cper")
+        );
+        assert_eq!(
+            attr_value(&record.attributes, "redfish.parent.log_entry_id"),
+            Some("42")
+        );
     }
 
     #[test]

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -531,6 +531,7 @@ mod tests {
             body: "something happened".to_string(),
             severity: "WARNING".to_string(),
             attributes: vec![(Cow::Borrowed("entry_id"), "42".to_string())],
+            diagnostic_record: None,
         }));
 
         let request = build_export_request(&[(ctx, log)]);
@@ -602,6 +603,7 @@ mod tests {
                     body: "x".to_string(),
                     severity: "INFO".to_string(),
                     attributes: vec![],
+                    diagnostic_record: None,
                 })),
             )
         };

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -545,6 +545,7 @@ mod tests {
         assert_eq!(records[0].severity_number, SeverityNumber::Warn as i32);
     }
 
+    /// Verifies OTLP conversion preserves an already-emitted diagnostic log.
     #[test]
     fn diagnostic_log_event_preserves_diagnostic_body_and_attributes() {
         let ctx = test_context();

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -188,11 +188,19 @@ pub struct MetricSample {
     pub context: Option<SensorThresholdContext>,
 }
 
+/// Log event emitted by collectors and consumed by sinks.
 #[derive(Clone, Debug)]
 pub struct LogRecord {
+    /// Human-readable log message or emitted structured body.
     pub body: String,
+
+    /// Source-provided severity text.
     pub severity: String,
+
+    /// Sink-visible metadata used for filtering, grouping, and correlation.
     pub attributes: Vec<MetricLabel>,
+
+    /// Optional diagnostic payload carrier kept separate until a sink opts in.
     pub diagnostic_record: Option<DiagnosticLogRecord>,
 }
 
@@ -265,10 +273,14 @@ impl LogRecord {
 /// as attributes for filtering and correlation.
 #[derive(Clone, Debug)]
 pub struct DiagnosticLogRecord {
+    /// Opaque diagnostic payload body, such as base64-encoded CPER text.
     pub body: String,
+
+    /// Redfish diagnostic metadata and parent correlation attributes.
     pub attributes: Vec<MetricLabel>,
 }
 
+/// JSON body emitted when a sink folds diagnostics into a parent log record.
 #[derive(Serialize)]
 struct DiagnosticLogBody<'a> {
     message: &'a str,
@@ -280,6 +292,7 @@ struct DiagnosticLogBody<'a> {
     diagnostic_attributes: Vec<DiagnosticLogBodyAttribute<'a>>,
 }
 
+/// Diagnostic metadata entry embedded in an emitted diagnostic log body.
 #[derive(Serialize)]
 struct DiagnosticLogBodyAttribute<'a> {
     key: &'a str,

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -209,6 +209,7 @@ impl LogRecord {
             return Cow::Borrowed(self);
         };
 
+        /// Serializes parent and diagnostic fields into an emitted log body.
         fn diagnostic_body(
             message: &str,
             diagnostic_record: &DiagnosticLogRecord,

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use carbide_uuid::machine::MachineId;
@@ -27,6 +28,7 @@ use health_report::{
     HealthReport as CarbideHealthReport, HealthReportConversionError,
 };
 use nv_redfish::resource::Health as BmcHealth;
+use serde::Serialize;
 
 use crate::endpoint::{BmcAddr, BmcEndpoint, EndpointMetadata, SwitchEndpointRole};
 use crate::metrics::MetricLabel;
@@ -191,6 +193,96 @@ pub struct LogRecord {
     pub body: String,
     pub severity: String,
     pub attributes: Vec<MetricLabel>,
+    pub diagnostic_record: Option<DiagnosticLogRecord>,
+}
+
+impl LogRecord {
+    /// Converts the collector-internal log record into the record a sink emits.
+    ///
+    /// Diagnostic payloads stay in a separate carrier until this boundary so
+    /// sinks can drop them by default. When diagnostics are enabled, the
+    /// opaque payload is embedded in the log body and diagnostic metadata is
+    /// retained as attributes for filtering and correlation.
+    /// Records without a diagnostic carrier are borrowed unchanged.
+    pub(crate) fn emitted_log_record(&self, include_diagnostics: bool) -> Cow<'_, Self> {
+        let Some(diagnostic_record) = &self.diagnostic_record else {
+            return Cow::Borrowed(self);
+        };
+
+        fn diagnostic_body(
+            message: &str,
+            diagnostic_record: &DiagnosticLogRecord,
+        ) -> Option<String> {
+            let diagnostic_data = if diagnostic_record.body.is_empty() {
+                None
+            } else {
+                Some(diagnostic_record.body.as_str())
+            };
+
+            let diagnostic_attributes = diagnostic_record
+                .attributes
+                .iter()
+                .map(|(key, value)| DiagnosticLogBodyAttribute {
+                    key: key.as_ref(),
+                    value: value.as_str(),
+                })
+                .collect();
+
+            let body = DiagnosticLogBody {
+                message,
+                diagnostic_data,
+                diagnostic_attributes,
+            };
+
+            serde_json::to_string(&body).ok()
+        }
+
+        let mut body = self.body.clone();
+        let mut attributes = self.attributes.clone();
+
+        if include_diagnostics {
+            if let Some(diagnostic_body) = diagnostic_body(self.body.as_str(), diagnostic_record) {
+                body = diagnostic_body;
+            }
+
+            attributes.extend_from_slice(&diagnostic_record.attributes);
+        }
+
+        Cow::Owned(Self {
+            body,
+            severity: self.severity.clone(),
+            attributes,
+            diagnostic_record: None,
+        })
+    }
+}
+
+/// Diagnostic payload attached to a primary log record.
+///
+/// The payload body stays opaque. Sinks that opt in encode the parent message
+/// and diagnostic payload together in the parent log body, while retaining
+/// Redfish metadata as attributes for filtering and correlation.
+#[derive(Clone, Debug)]
+pub struct DiagnosticLogRecord {
+    pub body: String,
+    pub attributes: Vec<MetricLabel>,
+}
+
+#[derive(Serialize)]
+struct DiagnosticLogBody<'a> {
+    message: &'a str,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diagnostic_data: Option<&'a str>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    diagnostic_attributes: Vec<DiagnosticLogBodyAttribute<'a>>,
+}
+
+#[derive(Serialize)]
+struct DiagnosticLogBodyAttribute<'a> {
+    key: &'a str,
+    value: &'a str,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -260,9 +260,9 @@ impl LogRecord {
 
 /// Diagnostic payload attached to a primary log record.
 ///
-/// The payload body stays opaque. Sinks that opt in encode the parent message
-/// and diagnostic payload together in the parent log body, while retaining
-/// Redfish metadata as attributes for filtering and correlation.
+/// The payload body stays opaque. Sinks that opt in fold the parent message and
+/// diagnostic payload into emitted log bodies, while retaining Redfish metadata
+/// as attributes for filtering and correlation.
 #[derive(Clone, Debug)]
 pub struct DiagnosticLogRecord {
     pub body: String,

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -92,6 +92,7 @@ struct JsonLogRecord<'a> {
 }
 
 impl<'a> JsonLogRecord<'a> {
+    /// Builds the JSONL representation for one emitted log record.
     fn from_log_record(context: &'a EventContext, record: &'a LogRecord) -> Self {
         Self {
             endpoint: context.endpoint_key(),
@@ -298,6 +299,7 @@ mod tests {
         assert_eq!(parsed["endpoint"], "aa:bb:cc:dd:ee:ff");
     }
 
+    /// Verifies log files embed diagnostics in the parent log body when enabled.
     #[test]
     fn test_writes_diagnostic_fields_in_parent_log_body() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -347,6 +349,7 @@ mod tests {
         assert_eq!(parsed["attributes"][1][1], "CPER");
     }
 
+    /// Verifies log files omit diagnostic payloads by default.
     #[test]
     fn test_skips_diagnostic_log_record_by_default() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -29,6 +29,7 @@ use crate::config::LogFileSinkConfig;
 /// files using sync I/O, safe to call from DataSink::handle_event.
 pub struct LogFileSink {
     writer: Mutex<SyncLogFileWriter>,
+    include_diagnostics: bool,
 }
 
 impl LogFileSink {
@@ -40,6 +41,7 @@ impl LogFileSink {
         )?;
         Ok(Self {
             writer: Mutex::new(writer),
+            include_diagnostics: config.include_diagnostics,
         })
     }
 }
@@ -54,7 +56,11 @@ impl DataSink for LogFileSink {
             return;
         };
 
-        let json_record = JsonLogRecord::from_event(context, record);
+        // Diagnostics are opt-in for log files. When enabled, fold the
+        // collector-only diagnostic carrier into the emitted body and
+        // attributes before JSONL serialization.
+        let record = record.emitted_log_record(self.include_diagnostics);
+        let json_record = JsonLogRecord::from_log_record(context, record.as_ref());
 
         let line = match serde_json::to_string(&json_record) {
             Ok(json) => json,
@@ -86,7 +92,7 @@ struct JsonLogRecord<'a> {
 }
 
 impl<'a> JsonLogRecord<'a> {
-    fn from_event(context: &'a EventContext, record: &'a LogRecord) -> Self {
+    fn from_log_record(context: &'a EventContext, record: &'a LogRecord) -> Self {
         Self {
             endpoint: context.endpoint_key(),
             collector: context.collector_type,
@@ -222,6 +228,7 @@ mod tests {
 
     use super::*;
     use crate::endpoint::BmcAddr;
+    use crate::sink::DiagnosticLogRecord;
 
     fn test_context() -> EventContext {
         EventContext {
@@ -241,6 +248,7 @@ mod tests {
     fn test_ignores_non_log_events() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config = LogFileSinkConfig {
+            include_diagnostics: false,
             output_dir: dir.path().to_string_lossy().into_owned(),
             max_file_size: 1024,
             max_backups: 2,
@@ -260,6 +268,7 @@ mod tests {
     fn test_writes_log_events_as_jsonl() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config = LogFileSinkConfig {
+            include_diagnostics: false,
             output_dir: dir.path().to_string_lossy().into_owned(),
             max_file_size: 1024 * 1024,
             max_backups: 2,
@@ -272,6 +281,7 @@ mod tests {
                 body: "something happened".to_string(),
                 severity: "INFO".to_string(),
                 attributes: vec![(Cow::Borrowed("entry_id"), "42".to_string())],
+                diagnostic_record: None,
             }
             .into(),
         );
@@ -289,9 +299,94 @@ mod tests {
     }
 
     #[test]
+    fn test_writes_diagnostic_fields_in_parent_log_body() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = LogFileSinkConfig {
+            include_diagnostics: true,
+            output_dir: dir.path().to_string_lossy().into_owned(),
+            max_file_size: 1024 * 1024,
+            max_backups: 2,
+        };
+        let sink = LogFileSink::new(&config).expect("sink");
+        let ctx = test_context();
+
+        let event = CollectorEvent::Log(
+            LogRecord {
+                body: "parent log".to_string(),
+                severity: "INFO".to_string(),
+                attributes: vec![(Cow::Borrowed("entry_id"), "42".to_string())],
+                diagnostic_record: Some(DiagnosticLogRecord {
+                    body: "opaque-cper".to_string(),
+                    attributes: vec![(
+                        Cow::Borrowed("redfish.diagnostic_data.type"),
+                        "CPER".to_string(),
+                    )],
+                }),
+            }
+            .into(),
+        );
+        sink.handle_event(&ctx, &event);
+
+        let log_path = dir.path().join("health_logs.jsonl");
+        let contents = fs::read_to_string(log_path).expect("read log");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1);
+
+        let parsed: serde_json::Value = serde_json::from_str(lines[0]).expect("valid json");
+        let body = parsed["body"].as_str().expect("body string");
+        let body: serde_json::Value = serde_json::from_str(body).expect("valid body json");
+
+        assert_eq!(body["message"], "parent log");
+        assert_eq!(body["diagnostic_data"], "opaque-cper");
+        assert_eq!(
+            body["diagnostic_attributes"][0]["key"],
+            "redfish.diagnostic_data.type"
+        );
+        assert_eq!(body["diagnostic_attributes"][0]["value"], "CPER");
+        assert_eq!(parsed["attributes"][1][0], "redfish.diagnostic_data.type");
+        assert_eq!(parsed["attributes"][1][1], "CPER");
+    }
+
+    #[test]
+    fn test_skips_diagnostic_log_record_by_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = LogFileSinkConfig {
+            include_diagnostics: false,
+            output_dir: dir.path().to_string_lossy().into_owned(),
+            max_file_size: 1024 * 1024,
+            max_backups: 2,
+        };
+        let sink = LogFileSink::new(&config).expect("sink");
+        let ctx = test_context();
+
+        let event = CollectorEvent::Log(
+            LogRecord {
+                body: "parent log".to_string(),
+                severity: "INFO".to_string(),
+                attributes: Vec::new(),
+                diagnostic_record: Some(DiagnosticLogRecord {
+                    body: "opaque-cper".to_string(),
+                    attributes: Vec::new(),
+                }),
+            }
+            .into(),
+        );
+        sink.handle_event(&ctx, &event);
+
+        let log_path = dir.path().join("health_logs.jsonl");
+        let contents = fs::read_to_string(log_path).expect("read log");
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 1);
+
+        let parent: serde_json::Value = serde_json::from_str(lines[0]).expect("valid parent json");
+        assert_eq!(parent["body"], "parent log");
+    }
+
+    #[test]
     fn test_rotation_creates_backups() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config = LogFileSinkConfig {
+            include_diagnostics: false,
             output_dir: dir.path().to_string_lossy().into_owned(),
             // tiny limit to force rotation quickly
             max_file_size: 50,
@@ -306,6 +401,7 @@ mod tests {
                     body: format!("log entry {i}"),
                     severity: "INFO".to_string(),
                     attributes: Vec::new(),
+                    diagnostic_record: None,
                 }
                 .into(),
             );
@@ -323,6 +419,7 @@ mod tests {
     fn test_rotation_zero_backups_truncates() {
         let dir = tempfile::tempdir().expect("tempdir");
         let config = LogFileSinkConfig {
+            include_diagnostics: false,
             output_dir: dir.path().to_string_lossy().into_owned(),
             max_file_size: 50,
             max_backups: 0,
@@ -336,6 +433,7 @@ mod tests {
                     body: format!("entry {i}"),
                     severity: "WARN".to_string(),
                     attributes: Vec::new(),
+                    diagnostic_record: None,
                 }
                 .into(),
             );

--- a/crates/health/src/sink/mod.rs
+++ b/crates/health/src/sink/mod.rs
@@ -33,9 +33,9 @@ mod tracing;
 
 pub use composite::CompositeDataSink;
 pub use events::{
-    Classification, CollectorEvent, EventContext, FirmwareInfo, HealthReport, HealthReportAlert,
-    HealthReportSuccess, HealthReportTarget, LogRecord, MetricSample, Probe, ReportSource,
-    SensorThresholdContext,
+    Classification, CollectorEvent, DiagnosticLogRecord, EventContext, FirmwareInfo, HealthReport,
+    HealthReportAlert, HealthReportSuccess, HealthReportTarget, LogRecord, MetricSample, Probe,
+    ReportSource, SensorThresholdContext,
 };
 pub use health_report::HealthReportSink;
 pub use log_file::LogFileSink;
@@ -65,8 +65,8 @@ mod tests {
     use mac_address::MacAddress;
 
     use super::{
-        CollectorEvent, CompositeDataSink, DataSink, EventContext, LogRecord, MetricSample,
-        PrometheusSink,
+        CollectorEvent, CompositeDataSink, DataSink, DiagnosticLogRecord, EventContext, LogRecord,
+        MetricSample, PrometheusSink,
     };
     use crate::endpoint::{BmcAddr, EndpointMetadata, MachineData};
     use crate::metrics::MetricsManager;
@@ -173,6 +173,10 @@ mod tests {
                 body: "ignored by prometheus sink".to_string(),
                 severity: "INFO".to_string(),
                 attributes: Vec::new(),
+                diagnostic_record: Some(DiagnosticLogRecord {
+                    body: "also ignored by prometheus sink".to_string(),
+                    attributes: Vec::new(),
+                }),
             }
             .into(),
         );

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -243,6 +243,7 @@ mod tests {
                 (Cow::Borrowed("message_id"), message_id.to_string()),
                 (Cow::Borrowed("message_args"), message_args.to_string()),
             ],
+            diagnostic_record: None,
         }))
     }
 

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -21,7 +21,7 @@ use prometheus::Counter;
 
 use super::dedup_queue::DedupQueue;
 use super::event_mapper::RedfishEventMapper;
-use super::{CollectorEvent, DataSink, EventContext, MetricSample};
+use super::{CollectorEvent, DataSink, EventContext, LogRecord, MetricSample};
 use crate::HealthError;
 use crate::config::OtlpSinkConfig;
 use crate::metrics::MetricsManager;
@@ -143,6 +143,38 @@ impl OtlpSink {
             include_diagnostics: config.include_diagnostics,
         })
     }
+
+    /// Enqueues a parent log and, when enabled, a bounded diagnostic log.
+    fn enqueue_log_event(&self, context: &EventContext, record: &LogRecord) {
+        let parent_key = self
+            .mapper
+            .queue_key(&context.endpoint_key, &record.attributes);
+        let parent_record = record.emitted_log_record(false).into_owned();
+        let parent_event = CollectorEvent::Log(Box::new(parent_record));
+
+        if self
+            .queue
+            .save_latest(parent_key, (context.clone(), parent_event))
+        {
+            self.replaced_total.inc();
+        }
+
+        if !self.include_diagnostics || record.diagnostic_record.is_none() {
+            return;
+        }
+
+        // Keep diagnostics on the same latest-wins queue policy as other logs.
+        // This bounds memory if OTLP export slows down.
+        let diagnostic_key = format!("{}|diagnostic", context.endpoint_key);
+        let diagnostic_record = record.emitted_log_record(true).into_owned();
+        let diagnostic_event = CollectorEvent::Log(Box::new(diagnostic_record));
+        if self
+            .queue
+            .save_latest(diagnostic_key, (context.clone(), diagnostic_event))
+        {
+            self.replaced_total.inc();
+        }
+    }
 }
 
 #[cfg(any(test, feature = "bench-hooks"))]
@@ -201,17 +233,10 @@ impl DataSink for OtlpSink {
             return;
         }
 
-        let (key, event, count_replacements) = match event {
+        let (key, event) = match event {
             CollectorEvent::Log(record) => {
-                let key = self
-                    .mapper
-                    .queue_key(&context.endpoint_key, &record.attributes);
-
-                let log_record = record
-                    .emitted_log_record(self.include_diagnostics)
-                    .into_owned();
-
-                (key, CollectorEvent::Log(Box::new(log_record)), true)
+                self.enqueue_log_event(context, record);
+                return;
             }
             CollectorEvent::HealthReport(report) => {
                 let key = format!(
@@ -220,16 +245,16 @@ impl DataSink for OtlpSink {
                     report.source.as_str()
                 );
 
-                (key, event.clone(), true)
+                (key, event.clone())
             }
             CollectorEvent::Firmware(info) => {
                 let key = format!("{}|firmware|{}", context.endpoint_key, info.component);
-                (key, event.clone(), true)
+                (key, event.clone())
             }
             _ => return,
         };
 
-        if self.queue.save_latest(key, (context.clone(), event)) && count_replacements {
+        if self.queue.save_latest(key, (context.clone(), event)) {
             self.replaced_total.inc();
         }
     }
@@ -507,9 +532,9 @@ mod tests {
         assert_eq!(sink.replaced_total.get() as u64, 0);
     }
 
-    /// Verifies diagnostic log bodies still use parent-event deduplication.
+    /// Verifies diagnostic log bodies use bounded latest-wins deduplication.
     #[test]
-    fn diagnostic_log_record_deduplicates_parent_events_with_payload_body() {
+    fn diagnostic_log_records_deduplicate_by_endpoint() {
         let sink = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);
         let ctx = test_context();
 
@@ -530,22 +555,21 @@ mod tests {
             ),
         );
 
-        let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() else {
-            panic!("expected queued diagnostic log");
-        };
+        let mut records = Vec::new();
+        while let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() {
+            records.push(record);
+        }
+
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].body, "test");
 
         let body: serde_json::Value =
-            serde_json::from_str(&record.body).expect("valid diagnostic body");
-        let message = body["message"].as_str().map(str::to_string);
-        let diagnostic_data = body["diagnostic_data"].as_str().map(str::to_string);
-
-        assert!(sink.queue.pop().is_none());
-        assert_eq!(message, Some("test".to_string()));
-        assert_eq!(diagnostic_data, Some("payload-b".to_string()));
-        assert_eq!(sink.replaced_total.get() as u64, 1);
+            serde_json::from_str(&records[1].body).expect("valid diagnostic body");
+        assert_eq!(body["diagnostic_data"].as_str(), Some("payload-b"));
+        assert_eq!(sink.replaced_total.get() as u64, 2);
 
         assert!(
-            record
+            records[0]
                 .attributes
                 .iter()
                 .all(|(key, _)| key.as_ref() != "redfish.diagnostic_data")

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -163,10 +163,10 @@ impl OtlpSink {
             return;
         }
 
-        // Keep diagnostics on the same latest-wins queue policy as other logs.
-        // This bounds memory if OTLP export slows down.
-        let diagnostic_key = format!("{}|diagnostic", context.endpoint_key);
         let diagnostic_record = record.emitted_log_record(true).into_owned();
+        // Follow the existing OTLP queue policy: diagnostics are latest-wins
+        // per endpoint while the drain is backed up.
+        let diagnostic_key = format!("{}|diagnostic", context.endpoint_key);
         let diagnostic_event = CollectorEvent::Log(Box::new(diagnostic_record));
         if self
             .queue
@@ -532,9 +532,9 @@ mod tests {
         assert_eq!(sink.replaced_total.get() as u64, 0);
     }
 
-    /// Verifies diagnostic log bodies use bounded latest-wins deduplication.
+    /// Verifies parent logs keep mapper dedup while diagnostics stay bounded.
     #[test]
-    fn diagnostic_log_records_deduplicate_by_endpoint() {
+    fn diagnostic_log_record_uses_latest_wins_by_endpoint() {
         let sink = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);
         let ctx = test_context();
 
@@ -554,6 +554,14 @@ mod tests {
                 Some(diagnostic_log_record("payload-b")),
             ),
         );
+        sink.handle_event(
+            &ctx,
+            &log_event_with_diagnostic_record(
+                "OpenBMC.0.1.Test",
+                "[]",
+                Some(diagnostic_log_record("payload-c")),
+            ),
+        );
 
         let mut records = Vec::new();
         while let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() {
@@ -563,10 +571,13 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].body, "test");
 
-        let body: serde_json::Value =
+        let diagnostic_body: serde_json::Value =
             serde_json::from_str(&records[1].body).expect("valid diagnostic body");
-        assert_eq!(body["diagnostic_data"].as_str(), Some("payload-b"));
-        assert_eq!(sink.replaced_total.get() as u64, 2);
+        assert_eq!(
+            diagnostic_body["diagnostic_data"].as_str(),
+            Some("payload-c")
+        );
+        assert_eq!(sink.replaced_total.get() as u64, 4);
 
         assert!(
             records[0]

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -16,7 +16,6 @@
  */
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use prometheus::Counter;
 
@@ -50,7 +49,6 @@ pub(crate) struct OtlpSink {
     metrics_replaced_total: Counter,
     mapper: Arc<dyn RedfishEventMapper>,
     include_diagnostics: bool,
-    diagnostic_sequence: AtomicU64,
 }
 
 #[cfg(feature = "bench-hooks")]
@@ -61,7 +59,6 @@ pub struct OtlpSink {
     metrics_replaced_total: Counter,
     mapper: Arc<dyn RedfishEventMapper>,
     include_diagnostics: bool,
-    diagnostic_sequence: AtomicU64,
 }
 
 /// Returns whether an event belongs in the logs drain.
@@ -144,7 +141,6 @@ impl OtlpSink {
             metrics_replaced_total,
             mapper,
             include_diagnostics: config.include_diagnostics,
-            diagnostic_sequence: AtomicU64::new(0),
         })
     }
 }
@@ -166,7 +162,6 @@ impl OtlpSink {
             metrics_replaced_total: Counter::new("bench_metrics_replaced", "bench").unwrap(),
             mapper,
             include_diagnostics,
-            diagnostic_sequence: AtomicU64::new(0),
         }
     }
 }
@@ -207,26 +202,15 @@ impl DataSink for OtlpSink {
 
         let (key, event, count_replacements) = match event {
             CollectorEvent::Log(record) => {
-                let has_included_diagnostics =
-                    self.include_diagnostics && record.diagnostic_record.is_some();
+                let key = self
+                    .mapper
+                    .queue_key(&context.endpoint_key, &record.attributes);
 
                 let log_record = record
                     .emitted_log_record(self.include_diagnostics)
                     .into_owned();
 
-                let key = if has_included_diagnostics {
-                    let sequence = self.diagnostic_sequence.fetch_add(1, Ordering::Relaxed);
-                    format!("{}|diagnostic|{sequence}", context.endpoint_key)
-                } else {
-                    self.mapper
-                        .queue_key(&context.endpoint_key, &record.attributes)
-                };
-
-                (
-                    key,
-                    CollectorEvent::Log(Box::new(log_record)),
-                    !has_included_diagnostics,
-                )
+                (key, CollectorEvent::Log(Box::new(log_record)), true)
             }
             CollectorEvent::HealthReport(report) => {
                 let key = format!(
@@ -520,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    fn diagnostic_log_record_preserves_parent_occurrences_with_payload_body() {
+    fn diagnostic_log_record_deduplicates_parent_events_with_payload_body() {
         let sink = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);
         let ctx = test_context();
 
@@ -541,31 +525,26 @@ mod tests {
             ),
         );
 
-        let mut records = Vec::new();
-        while let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() {
-            let body: serde_json::Value =
-                serde_json::from_str(&record.body).expect("valid diagnostic body");
-            let message = body["message"].as_str().map(str::to_string);
-            let diagnostic_data = body["diagnostic_data"].as_str().map(str::to_string);
+        let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() else {
+            panic!("expected queued diagnostic log");
+        };
 
-            assert!(
-                record
-                    .attributes
-                    .iter()
-                    .all(|(key, _)| key.as_ref() != "redfish.diagnostic_data")
-            );
+        let body: serde_json::Value =
+            serde_json::from_str(&record.body).expect("valid diagnostic body");
+        let message = body["message"].as_str().map(str::to_string);
+        let diagnostic_data = body["diagnostic_data"].as_str().map(str::to_string);
 
-            records.push((message, diagnostic_data));
-        }
+        assert!(sink.queue.pop().is_none());
+        assert_eq!(message, Some("test".to_string()));
+        assert_eq!(diagnostic_data, Some("payload-b".to_string()));
+        assert_eq!(sink.replaced_total.get() as u64, 1);
 
-        assert_eq!(
-            records,
-            vec![
-                (Some("test".to_string()), Some("payload-a".to_string())),
-                (Some("test".to_string()), Some("payload-b".to_string())),
-            ]
+        assert!(
+            record
+                .attributes
+                .iter()
+                .all(|(key, _)| key.as_ref() != "redfish.diagnostic_data")
         );
-        assert_eq!(sink.replaced_total.get() as u64, 0);
     }
 
     #[test]

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -16,6 +16,7 @@
  */
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use prometheus::Counter;
 
@@ -48,6 +49,8 @@ pub(crate) struct OtlpSink {
     replaced_total: Counter,
     metrics_replaced_total: Counter,
     mapper: Arc<dyn RedfishEventMapper>,
+    include_diagnostics: bool,
+    diagnostic_sequence: AtomicU64,
 }
 
 #[cfg(feature = "bench-hooks")]
@@ -57,9 +60,11 @@ pub struct OtlpSink {
     replaced_total: Counter,
     metrics_replaced_total: Counter,
     mapper: Arc<dyn RedfishEventMapper>,
+    include_diagnostics: bool,
+    diagnostic_sequence: AtomicU64,
 }
 
-/// true for events that belong in the logs drain; metrics and collection sentinels are not.
+/// Returns whether an event belongs in the logs drain.
 pub(crate) fn is_otlp_log_relevant(event: &CollectorEvent) -> bool {
     !matches!(
         event,
@@ -99,6 +104,7 @@ impl OtlpSink {
             format!("{prefix}_otlp_sink_replaced_total"),
             "total log events replaced in the otlp queue before drain could process them",
         )?;
+
         metrics_manager
             .global_registry()
             .register(Box::new(replaced_total.clone()))?;
@@ -107,6 +113,7 @@ impl OtlpSink {
             format!("{prefix}_otlp_sink_metrics_replaced_total"),
             "total metric samples replaced in the otlp queue before drain could process them",
         )?;
+
         metrics_manager
             .global_registry()
             .register(Box::new(metrics_replaced_total.clone()))?;
@@ -119,13 +126,15 @@ impl OtlpSink {
         );
         handle.spawn(drain.run());
 
-        // separate drain task so metrics don't head-of-line-block the logs export and vice versa
+        // Metrics use a separate drain so either signal type can make progress
+        // when the other collector is slow or temporarily failing.
         let metrics_drain = OtlpMetricsDrainTask::new(
             metrics_queue.clone(),
             config.endpoint.clone(),
             config.batch_size,
             config.flush_interval,
         );
+
         handle.spawn(metrics_drain.run());
 
         Ok(Self {
@@ -134,6 +143,8 @@ impl OtlpSink {
             replaced_total,
             metrics_replaced_total,
             mapper,
+            include_diagnostics: config.include_diagnostics,
+            diagnostic_sequence: AtomicU64::new(0),
         })
     }
 }
@@ -141,12 +152,21 @@ impl OtlpSink {
 #[cfg(any(test, feature = "bench-hooks"))]
 impl OtlpSink {
     pub fn new_for_bench(mapper: Arc<dyn RedfishEventMapper>) -> Self {
+        Self::new_for_bench_with_diagnostics(mapper, false)
+    }
+
+    fn new_for_bench_with_diagnostics(
+        mapper: Arc<dyn RedfishEventMapper>,
+        include_diagnostics: bool,
+    ) -> Self {
         Self {
             queue: Arc::new(DedupQueue::new()),
             metrics_queue: Arc::new(DedupQueue::new()),
             replaced_total: Counter::new("bench_replaced", "bench").unwrap(),
             metrics_replaced_total: Counter::new("bench_metrics_replaced", "bench").unwrap(),
             mapper,
+            include_diagnostics,
+            diagnostic_sequence: AtomicU64::new(0),
         }
     }
 }
@@ -170,12 +190,14 @@ impl DataSink for OtlpSink {
     fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
         if let CollectorEvent::Metric(sample) = event {
             let key = metric_queue_key(context, sample);
+
             if self
                 .metrics_queue
                 .save_latest(key, (context.clone(), (**sample).clone()))
             {
                 self.metrics_replaced_total.inc();
             }
+
             return;
         }
 
@@ -183,27 +205,46 @@ impl DataSink for OtlpSink {
             return;
         }
 
-        let key = match event {
-            CollectorEvent::Log(record) => self
-                .mapper
-                .queue_key(&context.endpoint_key, &record.attributes),
+        let (key, event, count_replacements) = match event {
+            CollectorEvent::Log(record) => {
+                let has_included_diagnostics =
+                    self.include_diagnostics && record.diagnostic_record.is_some();
+
+                let log_record = record
+                    .emitted_log_record(self.include_diagnostics)
+                    .into_owned();
+
+                let key = if has_included_diagnostics {
+                    let sequence = self.diagnostic_sequence.fetch_add(1, Ordering::Relaxed);
+                    format!("{}|diagnostic|{sequence}", context.endpoint_key)
+                } else {
+                    self.mapper
+                        .queue_key(&context.endpoint_key, &record.attributes)
+                };
+
+                (
+                    key,
+                    CollectorEvent::Log(Box::new(log_record)),
+                    !has_included_diagnostics,
+                )
+            }
             CollectorEvent::HealthReport(report) => {
-                format!(
+                let key = format!(
                     "{}|health_report|{}",
                     context.endpoint_key,
                     report.source.as_str()
-                )
+                );
+
+                (key, event.clone(), true)
             }
             CollectorEvent::Firmware(info) => {
-                format!("{}|firmware|{}", context.endpoint_key, info.component)
+                let key = format!("{}|firmware|{}", context.endpoint_key, info.component);
+                (key, event.clone(), true)
             }
             _ => return,
         };
 
-        if self
-            .queue
-            .save_latest(key, (context.clone(), event.clone()))
-        {
+        if self.queue.save_latest(key, (context.clone(), event)) && count_replacements {
             self.replaced_total.inc();
         }
     }
@@ -213,13 +254,12 @@ impl DataSink for OtlpSink {
 mod tests {
     use std::borrow::Cow;
     use std::str::FromStr;
-    use std::sync::Arc;
 
     use mac_address::MacAddress;
 
     use super::*;
     use crate::sink::event_mapper::OpenBmcEventMapper;
-    use crate::sink::{LogRecord, MetricSample};
+    use crate::sink::{DiagnosticLogRecord, LogRecord, MetricSample};
 
     fn test_context() -> EventContext {
         EventContext {
@@ -236,6 +276,14 @@ mod tests {
     }
 
     fn log_event(message_id: &str, message_args: &str) -> CollectorEvent {
+        log_event_with_diagnostic_record(message_id, message_args, None)
+    }
+
+    fn log_event_with_diagnostic_record(
+        message_id: &str,
+        message_args: &str,
+        diagnostic_record: Option<DiagnosticLogRecord>,
+    ) -> CollectorEvent {
         CollectorEvent::Log(Box::new(LogRecord {
             body: "test".to_string(),
             severity: "OK".to_string(),
@@ -243,8 +291,18 @@ mod tests {
                 (Cow::Borrowed("message_id"), message_id.to_string()),
                 (Cow::Borrowed("message_args"), message_args.to_string()),
             ],
-            diagnostic_record: None,
+            diagnostic_record,
         }))
+    }
+
+    fn diagnostic_log_record(body: &str) -> DiagnosticLogRecord {
+        DiagnosticLogRecord {
+            body: body.to_string(),
+            attributes: vec![(
+                Cow::Borrowed("redfish.parent.log_entry_id"),
+                "42".to_string(),
+            )],
+        }
     }
 
     fn metric_event() -> CollectorEvent {
@@ -436,6 +494,78 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 1, "same sensor should dedup to one entry");
+    }
+
+    #[test]
+    fn diagnostic_log_record_is_skipped_by_default() {
+        let sink = test_sink();
+        let ctx = test_context();
+
+        sink.handle_event(
+            &ctx,
+            &log_event_with_diagnostic_record(
+                "OpenBMC.0.1.Test",
+                "[]",
+                Some(diagnostic_log_record("payload-a")),
+            ),
+        );
+
+        let mut bodies = Vec::new();
+        while let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() {
+            bodies.push(record.body);
+        }
+
+        assert_eq!(bodies, vec!["test"]);
+        assert_eq!(sink.replaced_total.get() as u64, 0);
+    }
+
+    #[test]
+    fn diagnostic_log_record_preserves_parent_occurrences_with_payload_body() {
+        let sink = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);
+        let ctx = test_context();
+
+        sink.handle_event(
+            &ctx,
+            &log_event_with_diagnostic_record(
+                "OpenBMC.0.1.Test",
+                "[]",
+                Some(diagnostic_log_record("payload-a")),
+            ),
+        );
+        sink.handle_event(
+            &ctx,
+            &log_event_with_diagnostic_record(
+                "OpenBMC.0.1.Test",
+                "[]",
+                Some(diagnostic_log_record("payload-b")),
+            ),
+        );
+
+        let mut records = Vec::new();
+        while let Some((_key, (_context, CollectorEvent::Log(record)))) = sink.queue.pop() {
+            let body: serde_json::Value =
+                serde_json::from_str(&record.body).expect("valid diagnostic body");
+            let message = body["message"].as_str().map(str::to_string);
+            let diagnostic_data = body["diagnostic_data"].as_str().map(str::to_string);
+
+            assert!(
+                record
+                    .attributes
+                    .iter()
+                    .all(|(key, _)| key.as_ref() != "redfish.diagnostic_data")
+            );
+
+            records.push((message, diagnostic_data));
+        }
+
+        assert_eq!(
+            records,
+            vec![
+                (Some("test".to_string()), Some("payload-a".to_string())),
+                (Some("test".to_string()), Some("payload-b".to_string())),
+            ]
+        );
+        assert_eq!(sink.replaced_total.get() as u64, 0);
     }
 
     #[test]

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -151,6 +151,7 @@ impl OtlpSink {
         Self::new_for_bench_with_diagnostics(mapper, false)
     }
 
+    /// Builds a bench sink with diagnostic emission explicitly configured.
     fn new_for_bench_with_diagnostics(
         mapper: Arc<dyn RedfishEventMapper>,
         include_diagnostics: bool,
@@ -263,6 +264,7 @@ mod tests {
         log_event_with_diagnostic_record(message_id, message_args, None)
     }
 
+    /// Builds a log event with an optional diagnostic carrier.
     fn log_event_with_diagnostic_record(
         message_id: &str,
         message_args: &str,
@@ -279,6 +281,7 @@ mod tests {
         }))
     }
 
+    /// Builds a diagnostic carrier with stable parent metadata.
     fn diagnostic_log_record(body: &str) -> DiagnosticLogRecord {
         DiagnosticLogRecord {
             body: body.to_string(),
@@ -480,6 +483,7 @@ mod tests {
         assert_eq!(count, 1, "same sensor should dedup to one entry");
     }
 
+    /// Verifies OTLP logs omit diagnostic payloads by default.
     #[test]
     fn diagnostic_log_record_is_skipped_by_default() {
         let sink = test_sink();
@@ -503,6 +507,7 @@ mod tests {
         assert_eq!(sink.replaced_total.get() as u64, 0);
     }
 
+    /// Verifies diagnostic log bodies still use parent-event deduplication.
     #[test]
     fn diagnostic_log_record_deduplicates_parent_events_with_payload_body() {
         let sink = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -16,8 +16,19 @@
  */
 
 use super::{CollectorEvent, DataSink, EventContext};
+use crate::config::TracingSinkConfig;
 
-pub struct TracingSink;
+pub struct TracingSink {
+    include_diagnostics: bool,
+}
+
+impl TracingSink {
+    pub fn new(config: &TracingSinkConfig) -> Self {
+        Self {
+            include_diagnostics: config.include_diagnostics,
+        }
+    }
+}
 
 impl DataSink for TracingSink {
     fn sink_type(&self) -> &'static str {
@@ -60,13 +71,29 @@ impl DataSink for TracingSink {
                 );
             }
             CollectorEvent::Log(record) => {
-                tracing::info!(
-                    endpoint = %context.endpoint_key(),
-                    collector = %context.collector_type,
-                    severity = %record.severity,
-                    body = %record.body,
-                    "Log event"
-                );
+                let has_included_diagnostics =
+                    self.include_diagnostics && record.diagnostic_record.is_some();
+
+                let record = record.emitted_log_record(self.include_diagnostics);
+
+                if has_included_diagnostics {
+                    tracing::info!(
+                        endpoint = %context.endpoint_key(),
+                        collector = %context.collector_type,
+                        severity = %record.severity,
+                        body = %record.body,
+                        attributes = ?record.attributes,
+                        "Log event"
+                    );
+                } else {
+                    tracing::info!(
+                        endpoint = %context.endpoint_key(),
+                        collector = %context.collector_type,
+                        severity = %record.severity,
+                        body = %record.body,
+                        "Log event"
+                    );
+                }
             }
             CollectorEvent::Firmware(info) => {
                 tracing::info!(

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -18,6 +18,7 @@
 use super::{CollectorEvent, DataSink, EventContext};
 use crate::config::TracingSinkConfig;
 
+/// Sink that writes health events through the process tracing subscriber.
 pub struct TracingSink {
     include_diagnostics: bool,
 }

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -23,6 +23,7 @@ pub struct TracingSink {
 }
 
 impl TracingSink {
+    /// Builds a tracing sink from configuration.
     pub fn new(config: &TracingSinkConfig) -> Self {
         Self {
             include_diagnostics: config.include_diagnostics,


### PR DESCRIPTION
Added opt-in support to include Redfish diagnostic payloads in selected log sinks. When enabled, `health` carries CPER/diagnostic data through as opaque log data. Parsing and interpretation are intentionally kept outside this crate.

Implementation:
- Collects Redfish `DiagnosticData`, `DiagnosticDataType`, OEM type, `AdditionalDataURI`, size metadata, and parent correlation fields from SSE and periodic log records.
- Added a `DiagnosticLogRecord` field to `LogRecord`.
- Added `include_diagnostics = false` config for tracing, log file, and OTLP sinks.
- Keeps diagnostic payloads disabled by default; collectors only attach diagnostics when at least one diagnostic-capable sink opts in.
- Leaves non-log sinks, including Prometheus and health-report sinks, unchanged.

## Related issues
Closes #2817

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

No emitted behavior change when diagnostic payloads are disabled.

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)