### PR TITLE
fix(site-explorer): recover a host's boot interface from retained_boot_interfaces

### DIFF
--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -435,12 +435,38 @@ impl MachineCreator {
         // choice authoritative regardless of DHCP arrival order, and keeps exactly
         // one primary per machine -- so adopting several NICs that leased before
         // ingestion never trips the `one_primary_interface_per_machine` index.
+        // The host's primary (boot) interface is a declared `ExpectedHostNic.primary`
+        // when set, otherwise the boot interface preserved across `--delete-interfaces`
+        // in `retained_boot_interfaces`. The retained fallback lets a host with no
+        // declared primary -- a DPU flipped to NIC mode is the common case -- re-ingest
+        // with a settled boot interface, so the controller has a boot target to
+        // provision from instead of parking with no primary at all.
         let declared_primary = machine_data.and_then(|data| data.declared_primary_mac());
+        let primary_mac = match declared_primary {
+            Some(declared) => Some(declared),
+            None => {
+                let mut recovered = None;
+                for mac_address in &mac_addresses {
+                    if db::retained_boot_interface::find_by_mac(
+                        &mut *txn,
+                        *mac_address,
+                        self.config.retained_boot_interface_window,
+                    )
+                    .await?
+                    .is_some()
+                    {
+                        recovered = Some(*mac_address);
+                        break;
+                    }
+                }
+                recovered
+            }
+        };
 
         // Create and attach a non-DPU machine_interface to the host for every MAC address we see in
         // the exploration report
         for mac_address in mac_addresses {
-            let is_declared_primary = declared_primary == Some(mac_address);
+            let is_primary = primary_mac == Some(mac_address);
             if let Some(machine_interface) =
                 db::machine_interface::find_by_mac_address(&mut *txn, mac_address)
                     .await?
@@ -467,10 +493,10 @@ impl MachineCreator {
                     // Reconcile its primary flag to the declaration before adopting it: an anonymous
                     // DHCP row defaults to primary=true, so without this two pre-ingestion leases
                     // would both arrive primary and collide on association.
-                    if machine_interface.primary_interface != is_declared_primary {
+                    if machine_interface.primary_interface != is_primary {
                         db::machine_interface::set_primary_interface(
                             &machine_interface.id,
-                            is_declared_primary,
+                            is_primary,
                             txn,
                         )
                         .await?;
@@ -502,7 +528,7 @@ impl MachineCreator {
                         mac_address,
                         expected_network_segment_type: NetworkSegmentType::HostInband,
                         boot_interface_id,
-                        primary_interface: is_declared_primary,
+                        primary_interface: is_primary,
                     },
                     txn,
                 )

--- a/crates/site-explorer/tests/zero_dpu.rs
+++ b/crates/site-explorer/tests/zero_dpu.rs
@@ -359,6 +359,80 @@ async fn test_predicted_live_boot_interface_id_outranks_retained_at_promotion(
     Ok(())
 }
 
+/// A zero-DPU host with no declared primary recovers its primary (boot)
+/// interface from the boot pair preserved across `--delete-interfaces` in
+/// `retained_boot_interfaces`. This is the DPU->NIC flip re-registration case:
+/// the operator patches `dpu_mode = nic_mode` and force-deletes, declaring no
+/// primary, and the host comes back with no managed DPU -- so neither the
+/// declared-primary nor the DPU-host-PF path names a primary. Without the
+/// retained fallback the re-ingested host would come up with no primary at all,
+/// leaving the machine-controller no boot target to set a boot order from.
+#[sqlx_test]
+async fn test_zero_dpu_recovers_primary_from_retained_boot_interface(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = init(pool).await;
+    let mock_host = zero_dpu_host();
+    let inband_mac = *mock_host.non_dpu_macs.first().unwrap();
+    register_zero_dpu_expected_machine(&env, &mock_host).await?;
+
+    // The host's boot interface was retained by a prior `--delete-interfaces`,
+    // keyed by its MAC. Assert the precondition this test turns on: the
+    // registered machine declares no primary, so the retained fallback -- not
+    // the declared-primary path -- is what settles the boot interface below.
+    let mut txn = env.pool.begin().await?;
+    let registered =
+        db::expected_machine::find_by_bmc_mac_address(&mut *txn, mock_host.bmc_mac_address)
+            .await?
+            .expect("registered zero-DPU expected machine");
+    assert!(
+        registered.data.declared_primary_mac().is_none(),
+        "test precondition: no declared primary, so the retained fallback is the path under test",
+    );
+    db::retained_boot_interface::upsert(txn.as_mut(), inband_mac, "NIC.Embedded.1-1-1").await?;
+    txn.commit().await?;
+
+    let host_bmc_response = env
+        .api()
+        .discover_dhcp(
+            rpc::forge::DhcpDiscovery::builder(
+                mock_host.bmc_mac_address,
+                env.underlay_segment.relay_address,
+            )
+            .vendor_string("SomeVendor")
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let host_bmc_ip = host_bmc_response.address.parse()?;
+
+    env.site_explorer.insert_endpoints(
+        mock_host
+            .exploration_results(Some(host_bmc_ip), &[])?
+            .into_endpoints(),
+    );
+    env.site_explorer.run_single_iteration().await?;
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(host_bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    env.site_explorer.run_single_iteration().await?;
+
+    // The predicted interface for the retained boot MAC is flagged primary, so
+    // the controller has a boot target before the host's first DHCP.
+    let mut txn = env.pool.begin().await?;
+    let predicted = db::predicted_machine_interface::find_by_mac_address(&mut txn, inband_mac)
+        .await?
+        .expect("zero-DPU ingest should mint a predicted interface for the host NIC");
+    assert!(
+        predicted.primary_interface,
+        "a zero-DPU host with no declared primary should recover its primary from \
+         retained_boot_interfaces, so the controller has a boot target",
+    );
+    txn.rollback().await?;
+
+    Ok(())
+}
+
 /// If a static preallocation creates the machine_interfaces row while a
 /// prediction is still pending (an ExpectedMachine `fixed_ip` recorded in
 /// between), the prediction's live-report id still outranks the retained


### PR DESCRIPTION
We keep a host's boot interface in `retained_boot_interfaces` when its interfaces are deleted, so a later registration can put its boot device back. This change uses it for the one path that wasn't already consulting it: a host that re-registers with no DPU and no declared primary.

That's the DPU→NIC flip. An operator sets a host's `dpu_mode` to NIC and force-deletes it with `--delete-interfaces`, and it re-registers with no managed DPU and nothing declaring which interface it boots from. With neither a declared primary nor a DPU to take the boot interface from, the host used to register with no primary interface at all — so the `machine-controller` had no boot device to set a boot order from, and the host sat stuck in setup. The boot interface was in `retained_boot_interfaces` the whole time, keyed by MAC; now it's recovered from there when nothing else names one.

Tests: a new `zero_dpu.rs` case covers the recovery — it fails without this change — and the existing zero-DPU tests still pass.

Supports #2633.

_Surfaced while building the machine-a-tron end-to-end test for #2632; that full e2e additionally needs machine-a-tron to simulate the runtime flip (a reusable harness change), so it's tracked separately._


Closes #2633
