### PR TITLE
refactor(site-explorer): paginate the explored Mellanox device RPC

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -654,6 +654,33 @@ impl ApiClient {
         Ok(all_hosts.managed_hosts)
     }
 
+    pub async fn get_all_explored_mlx_devices(
+        &self,
+        page_size: usize,
+        host: Option<String>,
+    ) -> CarbideCliResult<Vec<::rpc::site_explorer::ExploredMlxDevice>> {
+        // A specific host short-circuits the id listing; otherwise list every host
+        // BMC carrying BlueField devices and page through them.
+        let host_ids: Vec<String> = match host {
+            Some(host) => vec![host],
+            None => self.0.find_explored_mlx_device_host_ids().await?.host_ids,
+        };
+
+        let mut all = ::rpc::site_explorer::ExploredMlxDeviceList {
+            devices: Vec::with_capacity(host_ids.len()),
+        };
+        stream::iter(host_ids.chunks(page_size))
+            .map(|ids| self.0.find_explored_mlx_devices_by_ids(ids))
+            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+            .try_for_each(|list| {
+                all.devices.extend(list.devices);
+                futures::future::ok(())
+            })
+            .await?;
+
+        Ok(all.devices)
+    }
+
     pub async fn get_machines_by_ids(
         &self,
         machine_ids: &[MachineId],

--- a/crates/admin-cli/src/site_explorer/mlx_devices/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/mlx_devices/cmd.rs
@@ -16,9 +16,7 @@
  */
 
 use ::rpc::admin_cli::OutputFormat;
-use ::rpc::site_explorer::{
-    ExploredMlxDevice, GetExploredMlxDevicesRequest, MlxDeviceKind, NicMode,
-};
+use ::rpc::site_explorer::{ExploredMlxDevice, MlxDeviceKind, NicMode};
 use prettytable::{Row, Table};
 use serde::Serialize;
 
@@ -32,17 +30,14 @@ pub async fn mlx_devices(
     output_format: OutputFormat,
     api_client: &ApiClient,
     opts: Args,
+    page_size: usize,
 ) -> CarbideCliResult<()> {
     let nic_mode_only = opts.nic_mode_only;
     let expected_version = opts.expected_version;
 
     let devices: Vec<MlxDeviceRow> = api_client
-        .0
-        .get_explored_mlx_devices(GetExploredMlxDevicesRequest {
-            host_bmc_ip: opts.host,
-        })
+        .get_all_explored_mlx_devices(page_size, opts.host)
         .await?
-        .devices
         .into_iter()
         // Only NIC-mode DPUs, when asked.
         .filter(|d| !nic_mode_only || d.device_kind == MlxDeviceKind::Bf3NicMode as i32)

--- a/crates/admin-cli/src/site_explorer/mlx_devices/mod.rs
+++ b/crates/admin-cli/src/site_explorer/mlx_devices/mod.rs
@@ -31,6 +31,7 @@ impl Run for Args {
             ctx.config.format,
             &ctx.api_client,
             self,
+            ctx.config.page_size,
         )
         .await
     }

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -1092,11 +1092,18 @@ impl Forge for Api {
         crate::handlers::site_explorer::find_explored_managed_hosts_by_ids(self, request).await
     }
 
-    async fn get_explored_mlx_devices(
+    async fn find_explored_mlx_device_host_ids(
         &self,
-        request: Request<::rpc::site_explorer::GetExploredMlxDevicesRequest>,
+        request: Request<::rpc::site_explorer::ExploredMlxDeviceHostSearchFilter>,
+    ) -> Result<Response<::rpc::site_explorer::ExploredMlxDeviceHostIdList>, Status> {
+        crate::handlers::site_explorer::find_explored_mlx_device_host_ids(self, request).await
+    }
+
+    async fn find_explored_mlx_devices_by_ids(
+        &self,
+        request: Request<::rpc::site_explorer::ExploredMlxDevicesByIdsRequest>,
     ) -> Result<Response<::rpc::site_explorer::ExploredMlxDeviceList>, Status> {
-        crate::handlers::site_explorer::get_explored_mlx_devices(self, request).await
+        crate::handlers::site_explorer::find_explored_mlx_devices_by_ids(self, request).await
     }
 
     async fn update_machine_hardware_info(

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -281,7 +281,8 @@ impl InternalRBACRules {
         x.perm("FindExploredEndpointsByIds", vec![ForgeAdminCLI, Flow]);
         x.perm("FindExploredManagedHostIds", vec![ForgeAdminCLI, Flow]);
         x.perm("FindExploredManagedHostsByIds", vec![ForgeAdminCLI, Flow]);
-        x.perm("GetExploredMlxDevices", vec![ForgeAdminCLI]);
+        x.perm("FindExploredMlxDeviceHostIds", vec![ForgeAdminCLI]);
+        x.perm("FindExploredMlxDevicesByIds", vec![ForgeAdminCLI]);
         x.perm("AdminForceDeleteMachine", vec![ForgeAdminCLI, Machineatron]);
         x.perm("AdminForceDeleteRack", vec![ForgeAdminCLI, Machineatron]);
         x.perm("AdminForceDeleteSwitch", vec![ForgeAdminCLI, Machineatron]);

--- a/crates/api-core/src/handlers/site_explorer.rs
+++ b/crates/api-core/src/handlers/site_explorer.rs
@@ -151,26 +151,72 @@ pub(crate) async fn get_site_exploration_report(
     Ok(tonic::Response::new(report.into()))
 }
 
-pub(crate) async fn get_explored_mlx_devices(
+pub(crate) async fn find_explored_mlx_device_host_ids(
     api: &Api,
-    request: Request<::rpc::site_explorer::GetExploredMlxDevicesRequest>,
+    request: Request<::rpc::site_explorer::ExploredMlxDeviceHostSearchFilter>,
+) -> Result<Response<::rpc::site_explorer::ExploredMlxDeviceHostIdList>, Status> {
+    log_request_data(&request);
+
+    // The host BMC IPs whose Redfish PCIe inventory carries a BlueField device --
+    // the pages the client walks. DPU endpoints are excluded; they report no
+    // host-side inventory and would yield no devices.
+    let endpoints = db::explored_endpoints::find_all(&api.database_connection).await?;
+    let host_ids = endpoints
+        .iter()
+        .filter(|ep| !ep.report.is_dpu() && ep.report.has_bluefield_devices())
+        .map(|ep| ep.address.to_string())
+        .collect();
+
+    Ok(Response::new(
+        ::rpc::site_explorer::ExploredMlxDeviceHostIdList { host_ids },
+    ))
+}
+
+pub(crate) async fn find_explored_mlx_devices_by_ids(
+    api: &Api,
+    request: Request<::rpc::site_explorer::ExploredMlxDevicesByIdsRequest>,
 ) -> Result<Response<::rpc::site_explorer::ExploredMlxDeviceList>, Status> {
     log_request_data(&request);
 
-    let host_filter = request
+    let ips: Vec<IpAddr> = request
         .into_inner()
-        .host_bmc_ip
-        .map(|ip| IpAddr::from_str(&ip))
-        .transpose()
+        .host_ids
+        .iter()
+        .map(|rs| IpAddr::from_str(rs))
+        .collect::<Result<Vec<IpAddr>, _>>()
         .map_err(CarbideError::AddressParseError)?;
 
-    // Load every explored endpoint: the projection reads each host's PCIe
-    // inventory, and the serial join needs the DPU endpoints alongside them.
-    let endpoints = db::explored_endpoints::find_all(&api.database_connection).await?;
+    let max_find_by_ids = api.runtime_config.max_find_by_ids as usize;
+    if ips.len() > max_find_by_ids {
+        return Err(CarbideError::InvalidArgument(format!(
+            "no more than {max_find_by_ids} IDs can be accepted"
+        ))
+        .into());
+    } else if ips.is_empty() {
+        return Err(
+            CarbideError::InvalidArgument("at least one ID must be provided".to_string()).into(),
+        );
+    }
+
+    // Load only the requested host reports, derive the BlueField device serials
+    // they hold, then fetch just the DPU endpoints those serials match -- rather
+    // than scanning every explored endpoint per page. The serial query is
+    // constrained to DPU reports, so a host with a coincidentally matching serial
+    // is not pulled in.
+    let mut endpoints = db::explored_endpoints::find_by_ips(&api.database_connection, ips).await?;
+    let serials: Vec<String> = endpoints
+        .iter()
+        .flat_map(|ep| ep.report.bluefield_device_serials())
+        .collect();
+    if !serials.is_empty() {
+        let dpus =
+            db::explored_endpoints::find_by_dpu_serial_numbers(&api.database_connection, serials)
+                .await?;
+        endpoints.extend(dpus);
+    }
 
     let devices = model::site_explorer::collect_explored_mlx_devices(&endpoints)
         .into_iter()
-        .filter(|device| host_filter.is_none_or(|ip| device.host_bmc_ip == ip))
         .map(::rpc::site_explorer::ExploredMlxDevice::from)
         .collect();
 

--- a/crates/api-core/src/tests/explored_mlx_devices.rs
+++ b/crates/api-core/src/tests/explored_mlx_devices.rs
@@ -40,11 +40,12 @@ fn pcie(part: &str, fw: &str, serial: &str, id: &str) -> PCIeDevice {
     }
 }
 
-// Exercises the full explored-device read path: seed a host whose Redfish PCIe
-// inventory shows a NIC-mode DPU plus that DPU's own BMC endpoint, then confirm
-// the handler projects the device and joins it to its DPU BMC by serial.
+// Exercises the paginated explored-device read path: seed a host whose Redfish
+// PCIe inventory shows a NIC-mode DPU plus that DPU's own BMC endpoint, then
+// confirm the host-ids step lists the host and the by-ids step projects the
+// device and joins it to its DPU BMC by serial.
 #[crate::sqlx_test()]
-async fn test_get_explored_mlx_devices(
+async fn test_find_explored_mlx_devices(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool.clone()).await;
@@ -91,10 +92,26 @@ async fn test_get_explored_mlx_devices(
     db::explored_endpoints::insert(dpu_ip, &dpu_report, false, &mut txn).await?;
     txn.commit().await?;
 
+    // List the host BMC IPs carrying BlueField devices -- the DPU endpoint is
+    // excluded, since it reports no host-side inventory.
+    let host_ids = env
+        .api
+        .find_explored_mlx_device_host_ids(tonic::Request::new(
+            ::rpc::site_explorer::ExploredMlxDeviceHostSearchFilter {},
+        ))
+        .await
+        .map(|response| response.into_inner())
+        .unwrap()
+        .host_ids;
+    assert_eq!(host_ids, vec!["192.0.2.20".to_string()]);
+
+    // Fetch the devices for that page of hosts.
     let devices = env
         .api
-        .get_explored_mlx_devices(tonic::Request::new(
-            ::rpc::site_explorer::GetExploredMlxDevicesRequest { host_bmc_ip: None },
+        .find_explored_mlx_devices_by_ids(tonic::Request::new(
+            ::rpc::site_explorer::ExploredMlxDevicesByIdsRequest {
+                host_ids: host_ids.clone(),
+            },
         ))
         .await
         .map(|response| response.into_inner())
@@ -119,12 +136,12 @@ async fn test_get_explored_mlx_devices(
         Some(::rpc::site_explorer::NicMode::Nic as i32)
     );
 
-    // The host filter scopes the result to a single host BMC.
+    // A page naming a host with no explored devices comes back empty.
     let other_host = env
         .api
-        .get_explored_mlx_devices(tonic::Request::new(
-            ::rpc::site_explorer::GetExploredMlxDevicesRequest {
-                host_bmc_ip: Some("198.51.100.1".to_string()),
+        .find_explored_mlx_devices_by_ids(tonic::Request::new(
+            ::rpc::site_explorer::ExploredMlxDevicesByIdsRequest {
+                host_ids: vec!["198.51.100.1".to_string()],
             },
         ))
         .await

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -152,6 +152,32 @@ pub async fn find_by_ips(
         .map_err(|e| DatabaseError::new("explored_endpoints::find_by_ips", e))
 }
 
+/// Fetches explored DPU endpoints whose reported system serial number is in
+/// `serials`. Resolves the host-to-DPU serial join for a page of hosts without
+/// loading every explored endpoint. Constrained to DPU reports
+/// (`Systems[0].Id == "Bluefield"`) so a host endpoint with a coincidentally
+/// matching serial is not pulled in.
+///
+/// `exploration_report` is the constantly-rewritten site-exploration blob, so we
+/// deliberately do not index this JSON path: DPU-endpoint cardinality per site is
+/// low and this serves an occasional admin query, so a scoped scan beats taxing
+/// the exploration write path with an expression index.
+pub async fn find_by_dpu_serial_numbers(
+    db: impl DbReader<'_>,
+    serials: Vec<String>,
+) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
+    let query = "SELECT * FROM explored_endpoints \
+                 WHERE exploration_report->'Systems'->0->>'SerialNumber' = ANY($1) \
+                 AND exploration_report->'Systems'->0->>'Id' = 'Bluefield'";
+
+    sqlx::query_as::<_, DbExploredEndpoint>(query)
+        .bind(serials)
+        .fetch_all(db)
+        .await
+        .map(|endpoints| endpoints.into_iter().map(Into::into).collect())
+        .map_err(|e| DatabaseError::new("explored_endpoints::find_by_dpu_serial_numbers", e))
+}
+
 /// find_all returns all explored endpoints that site explorer has been able to probe
 pub async fn find_all(txn: impl DbReader<'_>) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
     let query = "SELECT * FROM explored_endpoints";

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1720,6 +1720,30 @@ impl EndpointExplorationReport {
             })
             .collect()
     }
+
+    /// Whether this report's Redfish PCIe inventory holds any BlueField/Mellanox
+    /// device -- i.e. whether it would yield any [`ExploredMlxDevice`].
+    pub fn has_bluefield_devices(&self) -> bool {
+        self.systems
+            .iter()
+            .flat_map(|system| system.pcie_devices.iter())
+            .any(|device| device.is_bluefield())
+    }
+
+    /// The (trimmed, non-empty) serial numbers of the BlueField devices in this
+    /// report's PCIe inventory -- the keys used to match each device to its DPU
+    /// endpoint, the same serials [`collect_explored_mlx_devices`] joins on.
+    pub fn bluefield_device_serials(&self) -> Vec<String> {
+        self.systems
+            .iter()
+            .flat_map(|system| system.pcie_devices.iter())
+            .filter(|device| device.is_bluefield())
+            .filter_map(|device| device.serial_number.as_deref())
+            .map(str::trim)
+            .filter(|serial| !serial.is_empty())
+            .map(str::to_string)
+            .collect()
+    }
 }
 
 /// Builds the [`ExploredMlxDevice`] view across a set of explored endpoints.

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -310,8 +310,11 @@ service Forge {
   rpc FindExploredManagedHostIds(site_explorer.ExploredManagedHostSearchFilter) returns (site_explorer.ExploredManagedHostIdList);
   rpc FindExploredManagedHostsByIds(site_explorer.ExploredManagedHostsByIdsRequest) returns (site_explorer.ExploredManagedHostList);
   // Mellanox/BlueField device firmware, projected from explored Redfish PCIe
-  // inventory -- surfaces NIC firmware for DPUs operating in NIC mode.
-  rpc GetExploredMlxDevices(site_explorer.GetExploredMlxDevicesRequest) returns (site_explorer.ExploredMlxDeviceList);
+  // inventory -- surfaces NIC firmware for DPUs operating in NIC mode. Paginated
+  // like the explored reads above: list the host BMC IPs carrying BlueField
+  // devices, then fetch their devices a page of hosts at a time.
+  rpc FindExploredMlxDeviceHostIds(site_explorer.ExploredMlxDeviceHostSearchFilter) returns (site_explorer.ExploredMlxDeviceHostIdList);
+  rpc FindExploredMlxDevicesByIds(site_explorer.ExploredMlxDevicesByIdsRequest) returns (site_explorer.ExploredMlxDeviceList);
   rpc UpdateMachineHardwareInfo(UpdateMachineHardwareInfoRequest) returns (google.protobuf.Empty);
 
   // Force deletes a Machine and the associated DPU from Forge databases,

--- a/crates/rpc/proto/site_explorer.proto
+++ b/crates/rpc/proto/site_explorer.proto
@@ -171,9 +171,20 @@ message ExploredMlxDeviceList {
   repeated ExploredMlxDevice devices = 1;
 }
 
-message GetExploredMlxDevicesRequest {
-  // Restrict to devices found under this host BMC IP; all hosts if unset.
-  optional string host_bmc_ip = 1;
+// Paginated like the other explored reads: list the host BMC IPs that carry
+// BlueField devices, then fetch the devices a page of hosts at a time.
+message ExploredMlxDeviceHostSearchFilter {
+    // empty now, but maybe in the future we add a way to filter
+}
+
+message ExploredMlxDeviceHostIdList {
+  // host bmc IP address is used as an ID
+  repeated string host_ids = 1;
+}
+
+message ExploredMlxDevicesByIdsRequest {
+  // host bmc IP address is used as an ID
+  repeated string host_ids = 1;
 }
 
 enum NicMode {


### PR DESCRIPTION
The explored Mellanox device report (#2365) shipped as a single RPC that loaded every explored endpoint and returned every device at once. This moves it to the same paginated two-step contract the other explored reads use, so the response stays bounded as sites grow -- list the host BMC IPs that have BlueField devices, then fetch their devices a page of hosts at a time. The serial join that attaches each device's DPU BMC IP and NIC mode is resolved server-side per page, so it stays correct across page boundaries.

- Replaced `GetExploredMlxDevices` with `FindExploredMlxDeviceHostIds` + `FindExploredMlxDevicesByIds`; the by-ids handler loads the requested host page plus the DPU endpoints the join needs.
- `admin-cli site-explorer mlx-devices` now pages the host ids through the by-ids RPC concurrently (`get_all_explored_mlx_devices`), mirroring the managed-host helper; the command's flags and output are unchanged.
- Added `EndpointExplorationReport::has_bluefield_devices` to drive the host id listing.

Tests updated!

This supports https://github.com/NVIDIA/infra-controller/issues/2765


Closes #2765
