### PR TITLE
ci: build arm64 multi-arch images (nvmetal-carbide, boot-artifacts, machine_validation)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -509,6 +509,43 @@ jobs:
       tag_latest: false
     secrets: inherit
 
+  # Combine the per-arch nvmetal-carbide images into a single multi-arch manifest
+  # at the bare tag, so the carbide control plane can be scheduled on both amd64
+  # and arm64 nodes. The per-arch images are still pushed individually
+  # (nvmetal-carbide = amd64, nvmetal-carbide-aarch64 = arm64). Sources are
+  # referenced by digest so re-runs are idempotent. Push refs only.
+  merge-manifests-nvmetal-carbide:
+    needs:
+      - prepare
+      - build-release-container-x86_64
+      - build-release-container-aarch64
+    if: ${{ !cancelled() && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') && needs.build-release-container-x86_64.result == 'success' && needs.build-release-container-aarch64.result == 'success' }}
+    runs-on: linux-amd64-cpu4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to NVCR
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 20
+          command: |
+            docker buildx imagetools create -t \
+              nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide:${{ needs.prepare.outputs.version }} \
+              nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide@${{ needs.build-release-container-x86_64.outputs.image_digest }} \
+              nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide-aarch64@${{ needs.build-release-container-aarch64.outputs.image_digest }}
+
   test-release-container-services:
     if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     needs:
@@ -733,7 +770,12 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
       image_name: nvcr.io/0837451325059433/carbide-dev/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
-      platforms: linux/amd64
+      # Multi-arch on push so this x86_64 boot-artifacts carrier can run as an
+      # init container on both amd64 and arm64 control-plane nodes; the payload
+      # it ships is unchanged (x86_64 boot blobs). The Dockerfile has no RUN
+      # steps (FROM alpine + COPY only), so no QEMU is needed. Single-arch on PR
+      # so the image loads to the daemon for the Grype scan.
+      platforms: ${{ !contains(github.ref, 'pull-request/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       runner: linux-amd64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
       load: true
@@ -759,7 +801,12 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
       image_name: nvcr.io/0837451325059433/carbide-dev/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
-      platforms: linux/amd64  # Note: aarch64 artifacts packaged in x86_64 image
+      # Container arch is independent of the payload: this carrier always ships
+      # the aarch64 boot blobs as files. Build it multi-arch on push so it can
+      # run as an init container on both amd64 and arm64 control-plane nodes. The
+      # Dockerfile has no RUN steps (FROM alpine + COPY only), so no QEMU is
+      # needed. Single-arch on PR so the image loads to the daemon for Grype.
+      platforms: ${{ !contains(github.ref, 'pull-request/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       runner: linux-amd64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
       load: true
@@ -866,6 +913,65 @@ jobs:
       load: true  # load to daemon so the Grype scan can read it on PR builds
       scan: true
     secrets: inherit
+
+  # arm64 container build of the machine-validation config carrier, so it can run
+  # as an init container on arm64 control-plane nodes. FROM the aarch64 runtime
+  # base; pushed as machine_validation-aarch64 and merged into the bare
+  # machine_validation tag below. (The bundled validation runner payload staying
+  # arm64-capable is tracked separately — this only makes the carrier runnable on
+  # arm64 nodes.)
+  build-release-machine-validation-artifacts-arm-host:
+    needs:
+      - prepare
+      - build-runtime-container-aarch64
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-runtime-container-aarch64.result) }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: dev/docker/Dockerfile.machine-validation-config-aarch64
+      image_name: nvcr.io/0837451325059433/carbide-dev/machine_validation-aarch64
+      image_tag: ${{ needs.prepare.outputs.version }}
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_AARCH64":"nvcr.io/0837451325059433/carbide-dev/runtime-container-aarch64:${{ needs.prepare.outputs.runtime_container_aarch64_version }}"}'
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: true  # load to daemon so the Grype scan can read it on PR builds
+      scan: true
+    secrets: inherit
+
+  # Combine machine_validation (amd64) and machine_validation-aarch64 into a
+  # single multi-arch manifest at the bare machine_validation tag. Sources are
+  # referenced by digest so re-runs are idempotent. Push refs only.
+  merge-manifests-machine-validation:
+    needs:
+      - prepare
+      - build-release-machine-validation-artifacts-x86-host
+      - build-release-machine-validation-artifacts-arm-host
+    if: ${{ !cancelled() && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') && needs.build-release-machine-validation-artifacts-x86-host.result == 'success' && needs.build-release-machine-validation-artifacts-arm-host.result == 'success' }}
+    runs-on: linux-amd64-cpu4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to NVCR
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 20
+          command: |
+            docker buildx imagetools create -t \
+              nvcr.io/0837451325059433/carbide-dev/machine_validation:${{ needs.prepare.outputs.version }} \
+              nvcr.io/0837451325059433/carbide-dev/machine_validation@${{ needs.build-release-machine-validation-artifacts-x86-host.outputs.image_digest }} \
+              nvcr.io/0837451325059433/carbide-dev/machine_validation-aarch64@${{ needs.build-release-machine-validation-artifacts-arm-host.outputs.image_digest }}
 
   proto-police:
     needs:

--- a/dev/docker/Dockerfile.machine-validation-config-aarch64
+++ b/dev/docker/Dockerfile.machine-validation-config-aarch64
@@ -1,0 +1,26 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ARG CONTAINER_RUNTIME_AARCH64
+
+FROM $CONTAINER_RUNTIME_AARCH64
+
+WORKDIR /
+COPY crates/machine-validation/config /machine-validation/config
+RUN cd /machine-validation/config && tar -cvf /tmp/config.tar . && cp /tmp/config.tar /machine-validation/config/
+COPY crates/machine-validation/images /machine-validation/images
+
+CMD exec /bin/sh -c "trap : TERM INT; sleep 9999999999d & wait"


### PR DESCRIPTION
## What

Make the carbide control-plane container images multi-arch (amd64 + arm64) so the control plane can be scheduled on arm64 nodes.

- **nvmetal-carbide**: new `merge-manifests-nvmetal-carbide` job combines the existing per-arch images (`nvmetal-carbide` amd64 + `nvmetal-carbide-aarch64`) into a multi-arch manifest at the bare tag (digest-based merge, push refs only). The per-arch images are still pushed individually.
- **boot-artifacts-x86_64 / boot-artifacts-aarch64**: build multi-arch on push; single `linux/amd64` on PR so the image still loads to the daemon for the Grype scan. Their Dockerfiles are `FROM alpine` + `COPY` only (no `RUN`), so the amd64 runner cross-builds arm64 with no QEMU.
- **machine_validation**: new aarch64 config carrier (`Dockerfile.machine-validation-config-aarch64`, FROM the aarch64 runtime base) built on a native arm64 runner, plus `merge-manifests-machine-validation` to publish a multi-arch manifest at the bare tag.

## Why

The control plane (nico-pxe / nico-api) runs these as the main container and as init-container file-carriers. To schedule those pods on arm64 nodes, every image they run must have an arm64 variant.

## Validation

- `ci.yaml` parses as valid YAML; the new jobs mirror the existing `merge-manifests-forge-cli` pattern.
- PR CI exercises the amd64 path plus the arm64 **builds** for nvmetal-carbide and machine_validation.
- Note: boot-artifacts arm64 and all three manifest-merge steps are **push-only** (merges need the per-arch images to already be pushed), so they first run on the post-merge `main` build.

## Out of scope (intentional)

- Promotion (`promotion.yaml`) is left unchanged.
- The machine-validation **runner payload** for arm targets (as opposed to the config carrier made runnable on arm64 here) is not included.
