### PR TITLE
feat(machine-validation): Implement M2 machine validation heartbeat recovery

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -2292,6 +2292,13 @@ impl Forge for Api {
         crate::handlers::machine_validation::get_machine_validation_attempt(self, request).await
     }
 
+    async fn heartbeat_machine_validation_run(
+        &self,
+        request: Request<rpc::MachineValidationHeartbeatRequest>,
+    ) -> Result<Response<rpc::MachineValidationHeartbeatResponse>, Status> {
+        crate::handlers::machine_validation::heartbeat_machine_validation_run(self, request).await
+    }
+
     async fn admin_power_control(
         &self,
         request: Request<rpc::AdminPowerControlRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -497,6 +497,7 @@ impl InternalRBACRules {
             "GetMachineValidationAttempt",
             vec![ForgeAdminCLI, SiteAgent],
         );
+        x.perm("HeartbeatMachineValidationRun", vec![Scout, SiteAgent]);
         x.perm("AdminBmcReset", vec![ForgeAdminCLI]);
         x.perm("AdminPowerControl", vec![ForgeAdminCLI, Flow]);
         x.perm("DisableSecureBoot", vec![ForgeAdminCLI]);

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -544,6 +544,51 @@ pub(crate) async fn get_machine_validation_attempt(
     )))
 }
 
+pub(crate) async fn heartbeat_machine_validation_run(
+    api: &Api,
+    request: tonic::Request<rpc::MachineValidationHeartbeatRequest>,
+) -> Result<tonic::Response<rpc::MachineValidationHeartbeatResponse>, Status> {
+    log_request_data(&request);
+    let req = request.into_inner();
+    let validation_id = req
+        .validation_id
+        .as_ref()
+        .ok_or(CarbideError::MissingArgument("validation id"))?;
+    let run_item_id = req
+        .run_item_id
+        .as_ref()
+        .map(|id| {
+            uuid::Uuid::try_from(id)
+                .map(MachineValidationRunItemId::from)
+                .map_err(CarbideError::from)
+        })
+        .transpose()?;
+    let attempt_id = req
+        .attempt_id
+        .as_ref()
+        .map(|id| {
+            uuid::Uuid::try_from(id)
+                .map(MachineValidationAttemptId::from)
+                .map_err(CarbideError::from)
+        })
+        .transpose()?;
+    let mut txn = api.txn_begin().await?;
+    let accepted = db::machine_validation_execution::record_heartbeat(
+        &mut txn,
+        validation_id,
+        run_item_id.as_ref(),
+        attempt_id.as_ref(),
+        req.test_id.as_deref(),
+        chrono::Utc::now(),
+    )
+    .await?;
+    txn.commit().await?;
+
+    Ok(tonic::Response::new(
+        rpc::MachineValidationHeartbeatResponse { accepted },
+    ))
+}
+
 pub(crate) async fn on_demand_machine_validation(
     api: &Api,
     request: tonic::Request<rpc::MachineValidationOnDemandRequest>,

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -554,35 +554,45 @@ pub(crate) async fn heartbeat_machine_validation_run(
         .validation_id
         .as_ref()
         .ok_or(CarbideError::MissingArgument("validation id"))?;
-    let run_item_id = req
-        .run_item_id
-        .as_ref()
-        .map(|id| {
-            uuid::Uuid::try_from(id)
-                .map(MachineValidationRunItemId::from)
-                .map_err(CarbideError::from)
-        })
-        .transpose()?;
-    let attempt_id = req
-        .attempt_id
-        .as_ref()
-        .map(|id| {
-            uuid::Uuid::try_from(id)
-                .map(MachineValidationAttemptId::from)
-                .map_err(CarbideError::from)
-        })
-        .transpose()?;
+    let mut test_id = None;
+    let mut run_item_id = None;
+    let mut attempt_id = None;
+    match req.target {
+        Some(rpc::machine_validation_heartbeat_request::Target::RunItemId(id)) => {
+            run_item_id = Some(
+                uuid::Uuid::try_from(&id)
+                    .map(MachineValidationRunItemId::from)
+                    .map_err(CarbideError::from)?,
+            );
+        }
+        Some(rpc::machine_validation_heartbeat_request::Target::AttemptId(id)) => {
+            attempt_id = Some(
+                uuid::Uuid::try_from(&id)
+                    .map(MachineValidationAttemptId::from)
+                    .map_err(CarbideError::from)?,
+            );
+        }
+        Some(rpc::machine_validation_heartbeat_request::Target::TestId(value)) => {
+            test_id = Some(value);
+        }
+        None => {}
+    }
+
     let mut txn = api.txn_begin().await?;
     let accepted = db::machine_validation_execution::record_heartbeat(
         &mut txn,
         validation_id,
         run_item_id.as_ref(),
         attempt_id.as_ref(),
-        req.test_id.as_deref(),
+        test_id.as_deref(),
         chrono::Utc::now(),
     )
     .await?;
-    txn.commit().await?;
+    if accepted {
+        txn.commit().await?;
+    } else {
+        txn.rollback().await?;
+    }
 
     Ok(tonic::Response::new(
         rpc::MachineValidationHeartbeatResponse { accepted },

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -36,6 +36,10 @@ use tokio_util::sync::CancellationToken;
 use self::metrics::MachineValidationMetrics;
 use crate::CarbideResult;
 
+// The Scout heartbeat interval is 30 seconds. Keep heartbeat-based stale reconciliation above that
+// cadence so a low configured stale timeout does not fail healthy active runs between heartbeats.
+const MIN_HEARTBEAT_STALE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
 pub struct MachineValidationManager {
     database_connection: sqlx::PgPool,
     config: MachineValidationConfig,
@@ -99,6 +103,7 @@ impl MachineValidationManager {
 
         let mut txn = db::Transaction::begin(&self.database_connection).await?;
         let now = chrono::Utc::now();
+        let heartbeat_stale_timeout = heartbeat_stale_timeout(self.config.stale_run_timeout);
 
         for validation in db::machine_validation::find_active(&mut txn).await? {
             reconcile_terminal_run_items(txn.as_pgconn(), validation).await?;
@@ -106,12 +111,15 @@ impl MachineValidationManager {
 
         let stale_attempts = db::machine_validation_execution::find_stale_active_attempts(
             &mut txn,
-            self.config.stale_run_timeout,
+            heartbeat_stale_timeout,
             now,
         )
         .await?;
 
-        for stale_attempt in stale_attempts {
+        for stale_attempt in stale_attempts
+            .into_iter()
+            .filter(|attempt| attempt.last_heartbeat_at.is_some())
+        {
             if reconcile_stale_attempt(txn.as_pgconn(), stale_attempt, now).await? {
                 metrics.stale_validation += 1;
             }
@@ -120,6 +128,7 @@ impl MachineValidationManager {
         let stale_validations = stale_validations(
             db::machine_validation::find_active(&mut txn).await?,
             self.config.stale_run_timeout,
+            heartbeat_stale_timeout,
             now,
         );
 
@@ -193,17 +202,23 @@ fn active_validation_age_seconds(
         .map(|age| age.as_secs())
 }
 
+fn heartbeat_stale_timeout(configured_timeout: std::time::Duration) -> std::time::Duration {
+    configured_timeout.max(MIN_HEARTBEAT_STALE_TIMEOUT)
+}
+
 fn stale_validations(
     validations: Vec<MachineValidation>,
     stale_run_timeout: std::time::Duration,
+    heartbeat_stale_timeout: std::time::Duration,
     now: chrono::DateTime<chrono::Utc>,
 ) -> Vec<MachineValidation> {
     validations
         .into_iter()
         .filter(|validation| {
             let stale_run_timeout = chrono::Duration::from_std(stale_run_timeout).ok();
+            let heartbeat_stale_timeout = chrono::Duration::from_std(heartbeat_stale_timeout).ok();
             if let (Some(last_heartbeat_at), Some(stale_run_timeout)) =
-                (validation.last_heartbeat_at, stale_run_timeout)
+                (validation.last_heartbeat_at, heartbeat_stale_timeout)
             {
                 return last_heartbeat_at + stale_run_timeout < now;
             }
@@ -473,7 +488,12 @@ mod tests {
         let stale = validation_started_at(now - chrono::Duration::seconds(11), 5);
         let active = validation_started_at(now - chrono::Duration::seconds(9), 5);
 
-        let stale = stale_validations(vec![stale, active], std::time::Duration::from_secs(5), now);
+        let stale = stale_validations(
+            vec![stale, active],
+            std::time::Duration::from_secs(5),
+            std::time::Duration::from_secs(90),
+            now,
+        );
 
         assert_eq!(stale.len(), 1);
     }

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -27,7 +27,8 @@ use db::ObjectColumnFilter;
 use db::machine_validation::StateColumn;
 use model::machine::{FailureCause, FailureDetails, FailureSource};
 use model::machine_validation::{
-    MachineValidation, MachineValidationState, MachineValidationStatus,
+    MachineValidation, MachineValidationRunItem, MachineValidationRunItemState,
+    MachineValidationState, MachineValidationStatus,
 };
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -98,6 +99,23 @@ impl MachineValidationManager {
 
         let mut txn = db::Transaction::begin(&self.database_connection).await?;
         let now = chrono::Utc::now();
+
+        for validation in db::machine_validation::find_active(&mut txn).await? {
+            reconcile_terminal_run_items(txn.as_pgconn(), validation).await?;
+        }
+
+        let stale_attempts = db::machine_validation_execution::find_stale_active_attempts(
+            &mut txn,
+            self.config.stale_run_timeout,
+            now,
+        )
+        .await?;
+
+        for stale_attempt in stale_attempts {
+            if reconcile_stale_attempt(txn.as_pgconn(), stale_attempt, now).await? {
+                metrics.stale_validation += 1;
+            }
+        }
 
         let stale_validations = stale_validations(
             db::machine_validation::find_active(&mut txn).await?,
@@ -183,17 +201,143 @@ fn stale_validations(
     validations
         .into_iter()
         .filter(|validation| {
+            let stale_run_timeout = chrono::Duration::from_std(stale_run_timeout).ok();
+            if let (Some(last_heartbeat_at), Some(stale_run_timeout)) =
+                (validation.last_heartbeat_at, stale_run_timeout)
+            {
+                return last_heartbeat_at + stale_run_timeout < now;
+            }
+
             validation
                 .start_time
                 .and_then(|start_time| {
                     let expected_duration =
                         chrono::Duration::seconds(validation.duration_to_complete.max(0));
-                    let stale_run_timeout = chrono::Duration::from_std(stale_run_timeout).ok()?;
+                    let stale_run_timeout = stale_run_timeout?;
                     Some(start_time + expected_duration + stale_run_timeout)
                 })
                 .is_some_and(|stale_after| stale_after < now)
         })
         .collect()
+}
+
+async fn reconcile_terminal_run_items(
+    txn: &mut sqlx::PgConnection,
+    validation: MachineValidation,
+) -> CarbideResult<bool> {
+    let run_items =
+        db::machine_validation_execution::find_run_items_by_run_id(&mut *txn, &validation.id)
+            .await?;
+
+    if run_items.is_empty() || !run_items.iter().all(run_item_is_terminal) {
+        return Ok(false);
+    }
+
+    if run_items
+        .iter()
+        .any(|item| item.state == MachineValidationRunItemState::Failed)
+    {
+        let failed_items = run_items
+            .iter()
+            .filter(|item| item.state == MachineValidationRunItemState::Failed)
+            .map(|item| item.display_name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let error_message = format!(
+            "Machine validation run {} completed with failed run item(s): {}",
+            validation.id, failed_items
+        );
+        return complete_active_validation_as_failed(
+            txn,
+            &validation.id,
+            error_message,
+            "FailedValidationRunItems",
+        )
+        .await;
+    }
+
+    let status = MachineValidationStatus {
+        state: MachineValidationState::Success,
+        ..MachineValidationStatus::default()
+    };
+    let completed = db::machine_validation::mark_machine_validation_complete(
+        txn,
+        &validation.machine_id,
+        &validation.id,
+        status,
+    )
+    .await?;
+    Ok(completed)
+}
+
+fn run_item_is_terminal(run_item: &MachineValidationRunItem) -> bool {
+    matches!(
+        run_item.state,
+        MachineValidationRunItemState::Success
+            | MachineValidationRunItemState::Skipped
+            | MachineValidationRunItemState::Failed
+    )
+}
+
+async fn reconcile_stale_attempt(
+    txn: &mut sqlx::PgConnection,
+    stale_attempt: db::machine_validation_execution::StaleMachineValidationAttempt,
+    now: chrono::DateTime<chrono::Utc>,
+) -> CarbideResult<bool> {
+    let error_message = format!(
+        "Machine validation attempt {} for test {} in run {} stopped heartbeating or exceeded its timeout",
+        stale_attempt.attempt_id, stale_attempt.test_id, stale_attempt.validation_id
+    );
+
+    let Some(validation_id) = db::machine_validation_execution::mark_attempt_stale_if_active(
+        txn,
+        &stale_attempt.attempt_id,
+        now,
+        &error_message,
+    )
+    .await?
+    else {
+        tracing::debug!(
+            attempt_id = %stale_attempt.attempt_id,
+            "skipping stale machine validation attempt because it is no longer active"
+        );
+        return Ok(false);
+    };
+
+    complete_active_validation_as_failed(
+        txn,
+        &validation_id,
+        error_message,
+        "StaleMachineValidationAttempt",
+    )
+    .await
+}
+
+async fn complete_active_validation_as_failed(
+    txn: &mut sqlx::PgConnection,
+    validation_id: &carbide_uuid::machine_validation::MachineValidationId,
+    error_message: String,
+    alert_id: &str,
+) -> CarbideResult<bool> {
+    let validation = db::machine_validation::find_by_id(&mut *txn, validation_id).await?;
+    let status = MachineValidationStatus {
+        state: MachineValidationState::Failed,
+        ..MachineValidationStatus::default()
+    };
+
+    let completed = db::machine_validation::mark_machine_validation_complete(
+        txn,
+        &validation.machine_id,
+        &validation.id,
+        status,
+    )
+    .await?;
+
+    if completed {
+        record_failed_validation_side_effects(txn, &validation, error_message, alert_id).await?;
+    }
+
+    Ok(completed)
 }
 
 async fn reconcile_stale_validation(
@@ -230,13 +374,36 @@ async fn reconcile_stale_validation(
         return Ok(false);
     };
 
+    record_failed_validation_side_effects(
+        txn,
+        &validation,
+        error_message,
+        "StaleMachineValidationRun",
+    )
+    .await?;
+
+    tracing::warn!(
+        validation_id = %validation.id,
+        machine_id = %validation.machine_id,
+        "reconciled stale machine validation run"
+    );
+
+    Ok(true)
+}
+
+async fn record_failed_validation_side_effects(
+    txn: &mut sqlx::PgConnection,
+    validation: &MachineValidation,
+    error_message: String,
+    alert_id: &str,
+) -> CarbideResult<()> {
     let Some(machine) = db::machine::find_by_validation_id(txn, &validation.id).await? else {
         tracing::warn!(
             validation_id = %validation.id,
             machine_id = %validation.machine_id,
-            "stale machine validation has no owning machine"
+            "failed machine validation has no owning machine"
         );
-        return Ok(true);
+        return Ok(());
     };
 
     db::machine::update_failure_details_by_machine_id(
@@ -255,7 +422,7 @@ async fn reconcile_stale_validation(
     let mut health_report = machine.machine_validation_health_report();
     health_report.observed_at = Some(chrono::Utc::now());
     health_report.alerts.push(health_report::HealthProbeAlert {
-        id: "StaleMachineValidationRun".parse().unwrap(),
+        id: alert_id.parse().unwrap(),
         target: None,
         in_alert_since: Some(chrono::Utc::now()),
         message: error_message.clone(),
@@ -267,13 +434,7 @@ async fn reconcile_stale_validation(
     db::machine::set_machine_validation_request(txn, &machine.id, false).await?;
     db::machine::update_machine_validation_time(&machine.id, txn).await?;
 
-    tracing::warn!(
-        validation_id = %validation.id,
-        machine_id = %machine.id,
-        "reconciled stale machine validation run"
-    );
-
-    Ok(true)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -302,6 +463,7 @@ mod tests {
             context: Some("OnDemand".to_string()),
             status: None,
             duration_to_complete,
+            last_heartbeat_at: None,
         }
     }
 

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -36,8 +36,9 @@ use tokio_util::sync::CancellationToken;
 use self::metrics::MachineValidationMetrics;
 use crate::CarbideResult;
 
-// The Scout heartbeat interval is 30 seconds. Keep heartbeat-based stale reconciliation above that
-// cadence so a low configured stale timeout does not fail healthy active runs between heartbeats.
+// The Scout heartbeat interval is 30 seconds. Keep heartbeat-based stale reconciliation above three
+// missed beats so a low configured stale timeout does not fail healthy active runs between
+// heartbeats.
 const MIN_HEARTBEAT_STALE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
 
 pub struct MachineValidationManager {
@@ -496,5 +497,21 @@ mod tests {
         );
 
         assert_eq!(stale.len(), 1);
+    }
+
+    #[test]
+    fn stale_validations_clamps_heartbeat_timeout_above_scout_cadence() {
+        let now = chrono::Utc::now();
+        let mut active = validation_started_at(now - chrono::Duration::seconds(30), 0);
+        active.last_heartbeat_at = Some(now - chrono::Duration::seconds(30));
+
+        let stale = stale_validations(
+            vec![active],
+            std::time::Duration::from_secs(1),
+            heartbeat_stale_timeout(std::time::Duration::from_secs(1)),
+            now,
+        );
+
+        assert!(stale.is_empty());
     }
 }

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -36,11 +36,6 @@ use tokio_util::sync::CancellationToken;
 use self::metrics::MachineValidationMetrics;
 use crate::CarbideResult;
 
-// The Scout heartbeat interval is 30 seconds. Keep heartbeat-based stale reconciliation above three
-// missed beats so a low configured stale timeout does not fail healthy active runs between
-// heartbeats.
-const MIN_HEARTBEAT_STALE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
-
 pub struct MachineValidationManager {
     database_connection: sqlx::PgPool,
     config: MachineValidationConfig,
@@ -53,6 +48,17 @@ impl MachineValidationManager {
         config: MachineValidationConfig,
         meter: opentelemetry::metrics::Meter,
     ) -> Self {
+        let configured_stale_run_timeout = config.stale_run_timeout;
+        let config = config.with_minimum_stale_run_timeout();
+        if config.stale_run_timeout != configured_stale_run_timeout {
+            tracing::warn!(
+                configured_stale_run_timeout_seconds = configured_stale_run_timeout.as_secs(),
+                minimum_stale_run_timeout_seconds =
+                    MachineValidationConfig::MIN_STALE_RUN_TIMEOUT.as_secs(),
+                "machine validation stale_run_timeout is below minimum; using minimum"
+            );
+        }
+
         let hold_period = config
             .run_interval
             .saturating_add(std::time::Duration::from_secs(60));
@@ -204,7 +210,7 @@ fn active_validation_age_seconds(
 }
 
 fn heartbeat_stale_timeout(configured_timeout: std::time::Duration) -> std::time::Duration {
-    configured_timeout.max(MIN_HEARTBEAT_STALE_TIMEOUT)
+    configured_timeout.max(MachineValidationConfig::MIN_STALE_RUN_TIMEOUT)
 }
 
 fn stale_validations(

--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -1607,9 +1607,11 @@ async fn test_machine_validation_m1_persists_selected_test_and_idempotent_result
         .heartbeat_machine_validation_run(tonic::Request::new(
             rpc::forge::MachineValidationHeartbeatRequest {
                 validation_id: Some(validation_id),
-                run_item_id: None,
-                attempt_id: None,
-                test_id: Some("unknown_machine_validation_test".to_string()),
+                target: Some(
+                    rpc::forge::machine_validation_heartbeat_request::Target::TestId(
+                        "unknown_machine_validation_test".to_string(),
+                    ),
+                ),
             },
         ))
         .await?
@@ -1621,9 +1623,11 @@ async fn test_machine_validation_m1_persists_selected_test_and_idempotent_result
         .heartbeat_machine_validation_run(tonic::Request::new(
             rpc::forge::MachineValidationHeartbeatRequest {
                 validation_id: Some(validation_id),
-                run_item_id: None,
-                attempt_id: None,
-                test_id: Some(selected_test.test_id.clone()),
+                target: Some(
+                    rpc::forge::machine_validation_heartbeat_request::Target::TestId(
+                        selected_test.test_id.clone(),
+                    ),
+                ),
             },
         ))
         .await?
@@ -1670,6 +1674,30 @@ async fn test_machine_validation_m1_persists_selected_test_and_idempotent_result
             },
         ))
         .await?;
+
+    let previous_run_heartbeat =
+        db::machine_validation::find_by_id(&env.pool, &validation_id).await?;
+    let rejected_heartbeat = env
+        .api
+        .heartbeat_machine_validation_run(tonic::Request::new(
+            rpc::forge::MachineValidationHeartbeatRequest {
+                validation_id: Some(validation_id),
+                target: Some(
+                    rpc::forge::machine_validation_heartbeat_request::Target::TestId(
+                        selected_test.test_id.clone(),
+                    ),
+                ),
+            },
+        ))
+        .await?
+        .into_inner();
+    assert!(!rejected_heartbeat.accepted);
+    let run_after_rejected_heartbeat =
+        db::machine_validation::find_by_id(&env.pool, &validation_id).await?;
+    assert_eq!(
+        run_after_rejected_heartbeat.last_heartbeat_at,
+        previous_run_heartbeat.last_heartbeat_at
+    );
 
     let replayed_result = rpc::forge::MachineValidationResult {
         name: "changed replay name".to_string(),
@@ -1875,9 +1903,11 @@ async fn test_machine_validation_manager_reconciles_stale_active_attempt(
         .heartbeat_machine_validation_run(tonic::Request::new(
             rpc::forge::MachineValidationHeartbeatRequest {
                 validation_id: Some(validation_id),
-                run_item_id: None,
-                attempt_id: None,
-                test_id: Some(selected_test.test_id.clone()),
+                target: Some(
+                    rpc::forge::machine_validation_heartbeat_request::Target::TestId(
+                        selected_test.test_id.clone(),
+                    ),
+                ),
             },
         ))
         .await?

--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -1602,6 +1602,53 @@ async fn test_machine_validation_m1_persists_selected_test_and_idempotent_result
     })
     .await;
 
+    let invalid_heartbeat = env
+        .api
+        .heartbeat_machine_validation_run(tonic::Request::new(
+            rpc::forge::MachineValidationHeartbeatRequest {
+                validation_id: Some(validation_id),
+                run_item_id: None,
+                attempt_id: None,
+                test_id: Some("unknown_machine_validation_test".to_string()),
+            },
+        ))
+        .await?
+        .into_inner();
+    assert!(!invalid_heartbeat.accepted);
+
+    let heartbeat = env
+        .api
+        .heartbeat_machine_validation_run(tonic::Request::new(
+            rpc::forge::MachineValidationHeartbeatRequest {
+                validation_id: Some(validation_id),
+                run_item_id: None,
+                attempt_id: None,
+                test_id: Some(selected_test.test_id.clone()),
+            },
+        ))
+        .await?
+        .into_inner();
+    assert!(heartbeat.accepted);
+
+    let running_run_items = env
+        .api
+        .find_machine_validation_run_items_by_ids(tonic::Request::new(
+            rpc::forge::MachineValidationRunItemsByIdsRequest {
+                run_item_ids: vec![run_items[0].run_item_id.clone().unwrap()],
+            },
+        ))
+        .await?
+        .into_inner()
+        .run_items;
+    assert_eq!(running_run_items[0].state, "Running");
+    assert!(running_run_items[0].last_heartbeat_at.is_some());
+
+    let running_attempts =
+        db::machine_validation_execution::find_attempts_by_run_item_id(&env.pool, &run_item_id)
+            .await?;
+    assert_eq!(running_attempts[0].state.to_string(), "Running");
+    assert!(running_attempts[0].last_heartbeat_at.is_some());
+
     let terminal_result = rpc::forge::MachineValidationResult {
         validation_id: Some(validation_id),
         name: selected_test.name.clone(),
@@ -1688,7 +1735,286 @@ async fn test_machine_validation_m1_persists_selected_test_and_idempotent_result
         .into_iter()
         .find(|run| run.validation_id == Some(validation_id))
         .expect("on-demand validation run should be listed");
-    assert_eq!(run.status.unwrap().completed_tests, 1);
+    assert_eq!(run.status.as_ref().unwrap().completed_tests, 1);
+    assert!(run.last_heartbeat_at.is_some());
+
+    let mut config = env.config.machine_validation_config.clone();
+    config.stale_run_timeout = std::time::Duration::from_secs(1);
+    crate::machine_validation::MachineValidationManager::new(
+        env.pool.clone(),
+        config,
+        opentelemetry::global::meter(
+            "test_machine_validation_m1_persists_selected_test_and_idempotent_result",
+        ),
+    )
+    .run_single_iteration()
+    .await?;
+
+    let runs = get_machine_validation_runs(&env, &mh.host().id, true).await;
+    let success_state_int =
+        rpc::forge::machine_validation_status::MachineValidationState::Completed(
+            rpc::forge::machine_validation_status::MachineValidationCompleted::Success.into(),
+        );
+    let run = runs
+        .runs
+        .into_iter()
+        .find(|run| run.validation_id == Some(validation_id))
+        .expect("on-demand validation run should be listed");
+    assert_eq!(
+        run.status
+            .unwrap_or_default()
+            .machine_validation_state
+            .unwrap_or(success_state_int),
+        success_state_int
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test(fixtures("create_machine_validation_tests",))]
+async fn test_machine_validation_manager_reconciles_stale_active_attempt(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let initial_result = rpc::forge::MachineValidationResult {
+        validation_id: None,
+        name: "test1".to_string(),
+        description: "desc".to_string(),
+        command: "echo".to_string(),
+        args: "test".to_string(),
+        std_out: "".to_string(),
+        std_err: "".to_string(),
+        context: "Discovery".to_string(),
+        exit_code: 0,
+        start_time: Some(Timestamp::from(SystemTime::now())),
+        end_time: Some(Timestamp::from(SystemTime::now())),
+        test_id: Some("test1".to_string()),
+    };
+    let mh = create_host_with_machine_validation(&env, Some(initial_result), None).await;
+    let machine = mh.host().rpc_machine().await;
+
+    let selected_test = env
+        .api
+        .get_machine_validation_tests(tonic::Request::new(
+            rpc::forge::MachineValidationTestsGetRequest {
+                test_id: Some("forge_dcgm_long_test".to_string()),
+                ..rpc::forge::MachineValidationTestsGetRequest::default()
+            },
+        ))
+        .await?
+        .into_inner()
+        .tests
+        .into_iter()
+        .next()
+        .expect("machine validation fixture should include forge_dcgm_long_test");
+
+    let on_demand_response = on_demand_machine_validation(
+        &env,
+        machine.id.unwrap_or_default(),
+        Vec::new(),
+        vec![selected_test.test_id.clone()],
+        true,
+        vec!["OnDemand".to_string()],
+    )
+    .await;
+    let validation_id = on_demand_response.validation_id.unwrap();
+
+    env.api
+        .update_machine_validation_run(tonic::Request::new(
+            rpc::forge::MachineValidationRunRequest {
+                validation_id: Some(validation_id),
+                duration_to_complete: Some(rpc::Duration::from(std::time::Duration::from_secs(
+                    selected_test.timeout.unwrap_or(7200).try_into().unwrap(),
+                ))),
+                total: 1,
+                selected_tests: vec![selected_test.clone()],
+            },
+        ))
+        .await?;
+
+    let run_item_ids = env
+        .api
+        .find_machine_validation_run_item_ids(tonic::Request::new(
+            rpc::forge::MachineValidationRunItemSearchFilter {
+                validation_id: Some(validation_id),
+            },
+        ))
+        .await?
+        .into_inner()
+        .run_item_ids;
+    assert_eq!(run_item_ids.len(), 1);
+    let run_item_id = MachineValidationRunItemId::from(uuid::Uuid::try_from(&run_item_ids[0])?);
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Validation {
+            validation_state: ValidationState::MachineValidation {
+                machine_validation: MachineValidatingState::RebootHost { validation_id },
+            },
+        },
+    )
+    .await;
+    let _ = mh.host().reboot_completed().await;
+    env.run_machine_state_controller_iteration_until_state_condition(&mh.host().id, 1, |machine| {
+        match machine.current_state() {
+            ManagedHostState::Validation {
+                validation_state:
+                    ValidationState::MachineValidation {
+                        machine_validation: MachineValidatingState::MachineValidating { id, .. },
+                    },
+            } => *id == validation_id,
+            _ => false,
+        }
+    })
+    .await;
+
+    let heartbeat = env
+        .api
+        .heartbeat_machine_validation_run(tonic::Request::new(
+            rpc::forge::MachineValidationHeartbeatRequest {
+                validation_id: Some(validation_id),
+                run_item_id: None,
+                attempt_id: None,
+                test_id: Some(selected_test.test_id.clone()),
+            },
+        ))
+        .await?
+        .into_inner();
+    assert!(heartbeat.accepted);
+
+    let running_attempts =
+        db::machine_validation_execution::find_attempts_by_run_item_id(&env.pool, &run_item_id)
+            .await?;
+    let attempt_id = running_attempts[0].id;
+    assert_eq!(running_attempts[0].state.to_string(), "Running");
+
+    sqlx::query(
+        "UPDATE machine_validation SET last_heartbeat_at = NOW() - INTERVAL '2 days' WHERE id = $1",
+    )
+    .bind(validation_id)
+    .execute(&env.pool)
+    .await?;
+    sqlx::query(
+        "UPDATE machine_validation_run_items SET started_at = NOW() - INTERVAL '2 days', last_heartbeat_at = NOW() - INTERVAL '2 days' WHERE id = $1",
+    )
+    .bind(run_item_id)
+    .execute(&env.pool)
+    .await?;
+    sqlx::query(
+        "UPDATE machine_validation_attempts SET started_at = NOW() - INTERVAL '2 days', last_heartbeat_at = NOW() - INTERVAL '2 days' WHERE id = $1",
+    )
+    .bind(attempt_id)
+    .execute(&env.pool)
+    .await?;
+
+    let mut config = env.config.machine_validation_config.clone();
+    config.stale_run_timeout = std::time::Duration::from_secs(1);
+    crate::machine_validation::MachineValidationManager::new(
+        env.pool.clone(),
+        config,
+        opentelemetry::global::meter(
+            "test_machine_validation_manager_reconciles_stale_active_attempt",
+        ),
+    )
+    .run_single_iteration()
+    .await?;
+
+    let stale_attempts =
+        db::machine_validation_execution::find_attempts_by_run_item_id(&env.pool, &run_item_id)
+            .await?;
+    assert_eq!(stale_attempts[0].state.to_string(), "Failed");
+    assert_eq!(
+        stale_attempts[0].failure_classification.as_deref(),
+        Some("StaleHeartbeat")
+    );
+    assert!(
+        stale_attempts[0]
+            .stderr_summary
+            .as_deref()
+            .unwrap_or_default()
+            .contains("stopped heartbeating")
+    );
+
+    let run_items = env
+        .api
+        .find_machine_validation_run_items_by_ids(tonic::Request::new(
+            rpc::forge::MachineValidationRunItemsByIdsRequest { run_item_ids },
+        ))
+        .await?
+        .into_inner()
+        .run_items;
+    assert_eq!(run_items[0].state, "Failed");
+    assert!(
+        run_items[0]
+            .failure_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("stopped heartbeating")
+    );
+
+    env.api
+        .persist_validation_result(tonic::Request::new(
+            rpc::forge::MachineValidationResultPostRequest {
+                result: Some(rpc::forge::MachineValidationResult {
+                    validation_id: Some(validation_id),
+                    name: selected_test.name.clone(),
+                    description: selected_test.description.clone().unwrap_or_default(),
+                    command: selected_test.command.clone(),
+                    args: selected_test.args.clone(),
+                    std_out: "late ok".to_string(),
+                    std_err: String::new(),
+                    context: "OnDemand".to_string(),
+                    exit_code: 0,
+                    start_time: Some(Timestamp::from(SystemTime::now())),
+                    end_time: Some(Timestamp::from(SystemTime::now())),
+                    test_id: Some(selected_test.test_id.clone()),
+                }),
+            },
+        ))
+        .await?;
+    let legacy_results =
+        db::machine_validation_result::find_by_validation_id(&env.pool, &validation_id).await?;
+    assert!(
+        !legacy_results
+            .iter()
+            .any(|result| result.test_id == Some(selected_test.test_id.clone()))
+    );
+
+    let runs = get_machine_validation_runs(&env, &mh.host().id, true).await;
+    let failed_state_int = rpc::forge::machine_validation_status::MachineValidationState::Completed(
+        rpc::forge::machine_validation_status::MachineValidationCompleted::Failed.into(),
+    );
+    let stale_run = runs
+        .runs
+        .into_iter()
+        .find(|run| run.validation_id == Some(validation_id))
+        .expect("stale attempt run should be listed");
+    assert_eq!(
+        stale_run
+            .status
+            .unwrap_or_default()
+            .machine_validation_state
+            .unwrap_or(failed_state_int),
+        failed_state_int
+    );
+
+    env.run_machine_state_controller_iteration_until_state_condition(&mh.host().id, 1, |machine| {
+        matches!(
+            machine.current_state(),
+            ManagedHostState::Failed {
+                retry_count: 0,
+                details: FailureDetails {
+                    cause: FailureCause::MachineValidation { err },
+                    source: FailureSource::Scout,
+                    ..
+                },
+                ..
+            } if err.contains("stopped heartbeating")
+        )
+    })
+    .await;
 
     Ok(())
 }

--- a/crates/api-db/migrations/20260624120000_machine_validation_heartbeat_recovery.sql
+++ b/crates/api-db/migrations/20260624120000_machine_validation_heartbeat_recovery.sql
@@ -1,0 +1,14 @@
+ALTER TABLE machine_validation
+ADD COLUMN last_heartbeat_at TIMESTAMPTZ;
+
+CREATE INDEX machine_validation_active_heartbeat_idx
+    ON machine_validation (last_heartbeat_at)
+    WHERE end_time IS NULL AND state IN ('Started', 'InProgress');
+
+CREATE INDEX machine_validation_run_items_active_heartbeat_idx
+    ON machine_validation_run_items (last_heartbeat_at)
+    WHERE state IN ('Pending', 'Running');
+
+CREATE INDEX machine_validation_attempts_active_heartbeat_idx
+    ON machine_validation_attempts (last_heartbeat_at)
+    WHERE state IN ('Pending', 'Running');

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -150,9 +150,18 @@ pub async fn mark_stale_if_active(
         WHERE id=$1
         AND end_time IS NULL
         AND state IN ('Started', 'InProgress')
-        AND start_time
-            + (GREATEST(duration_to_complete, 0) * INTERVAL '1 second')
-            + ($3::bigint * INTERVAL '1 second') < $4
+        AND (
+            (
+                last_heartbeat_at IS NOT NULL
+                AND last_heartbeat_at + ($3::bigint * INTERVAL '1 second') < $4
+            )
+            OR (
+                last_heartbeat_at IS NULL
+                AND start_time
+                    + (GREATEST(duration_to_complete, 0) * INTERVAL '1 second')
+                    + ($3::bigint * INTERVAL '1 second') < $4
+            )
+        )
         RETURNING *";
     sqlx::query_as::<_, MachineValidation>(query)
         .bind(id)

--- a/crates/api-db/src/machine_validation_execution.rs
+++ b/crates/api-db/src/machine_validation_execution.rs
@@ -18,6 +18,7 @@
 use carbide_uuid::machine_validation::{
     MachineValidationAttemptId, MachineValidationId, MachineValidationRunItemId,
 };
+use chrono::{DateTime, Utc};
 use model::machine_validation::{
     MachineValidationAttempt, MachineValidationAttemptState, MachineValidationResult,
     MachineValidationRunItem, MachineValidationRunItemState, MachineValidationTest,
@@ -32,6 +33,18 @@ const DEFAULT_TIMEOUT_SECONDS: i64 = 7200;
 // Retry-aware events will need to carry attempt identity before this can vary.
 const INITIAL_ATTEMPT_NUMBER: i32 = 1;
 const SUMMARY_LIMIT: usize = 4096;
+
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct StaleMachineValidationAttempt {
+    pub validation_id: MachineValidationId,
+    pub run_item_id: MachineValidationRunItemId,
+    pub attempt_id: MachineValidationAttemptId,
+    pub test_id: String,
+    pub display_name: String,
+    pub timeout_seconds: i64,
+    pub started_at: Option<DateTime<Utc>>,
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
+}
 
 pub async fn materialize_run_plan(
     txn: &mut PgConnection,
@@ -209,6 +222,304 @@ pub async fn record_result(
     }
 
     Ok(first_terminal)
+}
+
+pub async fn record_heartbeat(
+    txn: &mut PgConnection,
+    validation_id: &MachineValidationId,
+    run_item_id: Option<&MachineValidationRunItemId>,
+    attempt_id: Option<&MachineValidationAttemptId>,
+    test_id: Option<&str>,
+    observed_at: DateTime<Utc>,
+) -> DatabaseResult<bool> {
+    let targets_run_item = run_item_id.is_some() || attempt_id.is_some() || test_id.is_some();
+    let Some(run_item_id) =
+        resolve_run_item_for_heartbeat(txn, validation_id, run_item_id, attempt_id, test_id)
+            .await?
+    else {
+        return if targets_run_item {
+            Ok(false)
+        } else {
+            update_run_heartbeat(txn, validation_id, observed_at).await
+        };
+    };
+
+    if !update_run_heartbeat(txn, validation_id, observed_at).await? {
+        return Ok(false);
+    }
+
+    if !update_run_item_heartbeat(txn, validation_id, &run_item_id, observed_at).await? {
+        return Ok(false);
+    }
+
+    update_attempt_heartbeat(txn, &run_item_id, attempt_id, observed_at).await
+}
+
+pub async fn find_stale_active_attempts(
+    txn: impl DbReader<'_>,
+    stale_run_timeout: std::time::Duration,
+    now: DateTime<Utc>,
+) -> DatabaseResult<Vec<StaleMachineValidationAttempt>> {
+    let stale_run_timeout_seconds = i64::try_from(stale_run_timeout.as_secs()).unwrap_or(i64::MAX);
+    const QUERY: &str = "
+        WITH active_attempts AS (
+            SELECT
+                run_item.run_id AS validation_id,
+                run_item.id AS run_item_id,
+                attempt.id AS attempt_id,
+                run_item.test_id,
+                run_item.display_name,
+                run_item.timeout_seconds,
+                attempt.started_at,
+                attempt.last_heartbeat_at,
+                COALESCE(
+                    attempt.last_heartbeat_at,
+                    attempt.started_at,
+                    run_item.last_heartbeat_at
+                ) AS heartbeat_reference
+            FROM machine_validation_attempts attempt
+            JOIN machine_validation_run_items run_item
+                ON run_item.id=attempt.run_item_id
+            JOIN machine_validation validation
+                ON validation.id=run_item.run_id
+            WHERE validation.end_time IS NULL
+                AND validation.state IN ('Started', 'InProgress')
+                AND run_item.state='Running'
+                AND attempt.state='Running'
+        )
+        SELECT
+            validation_id,
+            run_item_id,
+            attempt_id,
+            test_id,
+            display_name,
+            timeout_seconds,
+            started_at,
+            last_heartbeat_at
+        FROM active_attempts
+        WHERE (
+            heartbeat_reference IS NOT NULL
+            AND heartbeat_reference + ($1::bigint * INTERVAL '1 second') < $2
+        ) OR (
+            started_at IS NOT NULL
+            AND started_at
+                + (GREATEST(timeout_seconds, 0) * INTERVAL '1 second')
+                + ($1::bigint * INTERVAL '1 second') < $2
+        )
+        ORDER BY validation_id, run_item_id";
+
+    sqlx::query_as::<_, StaleMachineValidationAttempt>(QUERY)
+        .bind(stale_run_timeout_seconds)
+        .bind(now)
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+pub async fn mark_attempt_stale_if_active(
+    txn: &mut PgConnection,
+    attempt_id: &MachineValidationAttemptId,
+    now: DateTime<Utc>,
+    failure_reason: &str,
+) -> DatabaseResult<Option<MachineValidationId>> {
+    const QUERY: &str = "
+        WITH updated_attempt AS (
+            UPDATE machine_validation_attempts
+            SET
+                state='Failed',
+                failure_classification='StaleHeartbeat',
+                ended_at=$2,
+                stderr_summary=COALESCE(stderr_summary, $3)
+            WHERE id=$1
+                AND state='Running'
+            RETURNING run_item_id
+        ),
+        updated_run_item AS (
+            UPDATE machine_validation_run_items
+            SET
+                state='Failed',
+                ended_at=$2,
+                failure_reason=$3
+            WHERE id=(SELECT run_item_id FROM updated_attempt)
+                AND state='Running'
+            RETURNING run_id
+        )
+        SELECT run_id FROM updated_run_item";
+
+    sqlx::query_scalar::<_, MachineValidationId>(QUERY)
+        .bind(attempt_id)
+        .bind(now)
+        .bind(truncate_summary(failure_reason).unwrap_or_default())
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))
+}
+
+async fn update_run_heartbeat(
+    txn: &mut PgConnection,
+    validation_id: &MachineValidationId,
+    observed_at: DateTime<Utc>,
+) -> DatabaseResult<bool> {
+    const QUERY: &str = "
+        UPDATE machine_validation
+        SET
+            last_heartbeat_at=$2,
+            state='InProgress'
+        WHERE id=$1
+            AND end_time IS NULL
+            AND state IN ('Started', 'InProgress')
+        RETURNING id";
+
+    let updated = sqlx::query_scalar::<_, MachineValidationId>(QUERY)
+        .bind(validation_id)
+        .bind(observed_at)
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))?;
+    Ok(updated.is_some())
+}
+
+async fn resolve_run_item_for_heartbeat(
+    txn: &mut PgConnection,
+    validation_id: &MachineValidationId,
+    run_item_id: Option<&MachineValidationRunItemId>,
+    attempt_id: Option<&MachineValidationAttemptId>,
+    test_id: Option<&str>,
+) -> DatabaseResult<Option<MachineValidationRunItemId>> {
+    if let Some(attempt_id) = attempt_id {
+        const QUERY: &str = "
+            SELECT run_item.id
+            FROM machine_validation_run_items run_item
+            JOIN machine_validation_attempts attempt
+                ON attempt.run_item_id=run_item.id
+            WHERE run_item.run_id=$1
+                AND attempt.id=$2";
+
+        return sqlx::query_scalar::<_, MachineValidationRunItemId>(QUERY)
+            .bind(validation_id)
+            .bind(attempt_id)
+            .fetch_optional(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::query(QUERY, e));
+    }
+
+    if let Some(run_item_id) = run_item_id {
+        const QUERY: &str = "
+            SELECT id
+            FROM machine_validation_run_items
+            WHERE run_id=$1
+                AND id=$2";
+
+        return sqlx::query_scalar::<_, MachineValidationRunItemId>(QUERY)
+            .bind(validation_id)
+            .bind(run_item_id)
+            .fetch_optional(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::query(QUERY, e));
+    }
+
+    if let Some(test_id) = test_id {
+        const QUERY: &str = "
+            SELECT id
+            FROM machine_validation_run_items
+            WHERE run_id=$1
+                AND test_id=$2";
+
+        return sqlx::query_scalar::<_, MachineValidationRunItemId>(QUERY)
+            .bind(validation_id)
+            .bind(test_id)
+            .fetch_optional(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::query(QUERY, e));
+    }
+
+    Ok(None)
+}
+
+async fn update_run_item_heartbeat(
+    txn: &mut PgConnection,
+    validation_id: &MachineValidationId,
+    run_item_id: &MachineValidationRunItemId,
+    observed_at: DateTime<Utc>,
+) -> DatabaseResult<bool> {
+    const QUERY: &str = "
+        UPDATE machine_validation_run_items
+        SET
+            state='Running',
+            attempt=GREATEST(attempt, $3),
+            started_at=COALESCE(started_at, $4),
+            last_heartbeat_at=$4
+        WHERE id=$1
+            AND run_id=$2
+            AND state IN ('Pending', 'Running')
+        RETURNING id";
+
+    let updated = sqlx::query_scalar::<_, MachineValidationRunItemId>(QUERY)
+        .bind(run_item_id)
+        .bind(validation_id)
+        .bind(INITIAL_ATTEMPT_NUMBER)
+        .bind(observed_at)
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(QUERY, e))?;
+    Ok(updated.is_some())
+}
+
+async fn update_attempt_heartbeat(
+    txn: &mut PgConnection,
+    run_item_id: &MachineValidationRunItemId,
+    attempt_id: Option<&MachineValidationAttemptId>,
+    observed_at: DateTime<Utc>,
+) -> DatabaseResult<bool> {
+    let updated = match attempt_id {
+        Some(attempt_id) => {
+            const QUERY: &str = "
+                UPDATE machine_validation_attempts
+                SET
+                    state='Running',
+                    started_at=COALESCE(started_at, $3),
+                    last_heartbeat_at=$3
+                WHERE run_item_id=$1
+                    AND id=$2
+                    AND state IN ('Pending', 'Running')
+                RETURNING id";
+
+            sqlx::query_scalar::<_, MachineValidationAttemptId>(QUERY)
+                .bind(run_item_id)
+                .bind(attempt_id)
+                .bind(observed_at)
+                .fetch_optional(&mut *txn)
+                .await
+                .map_err(|e| DatabaseError::query(QUERY, e))?
+        }
+        None => {
+            const QUERY: &str = "
+                WITH selected_attempt AS (
+                    SELECT id
+                    FROM machine_validation_attempts
+                    WHERE run_item_id=$1
+                    ORDER BY attempt_number DESC
+                    LIMIT 1
+                )
+                UPDATE machine_validation_attempts
+                SET
+                    state='Running',
+                    started_at=COALESCE(started_at, $2),
+                    last_heartbeat_at=$2
+                WHERE id=(SELECT id FROM selected_attempt)
+                    AND state IN ('Pending', 'Running')
+                RETURNING id";
+
+            sqlx::query_scalar::<_, MachineValidationAttemptId>(QUERY)
+                .bind(run_item_id)
+                .bind(observed_at)
+                .fetch_optional(&mut *txn)
+                .await
+                .map_err(|e| DatabaseError::query(QUERY, e))?
+        }
+    };
+
+    Ok(updated.is_some())
 }
 
 async fn upsert_run_item_from_test(

--- a/crates/api-model/src/machine_validation.rs
+++ b/crates/api-model/src/machine_validation.rs
@@ -172,6 +172,7 @@ pub struct MachineValidation {
     pub context: Option<String>,
     pub status: Option<MachineValidationStatus>,
     pub duration_to_complete: i64,
+    pub last_heartbeat_at: Option<DateTime<Utc>>,
     // Columns for these exist, but are unused in rust code
     // pub description: Option<String>,
 }
@@ -198,6 +199,7 @@ impl<'r> FromRow<'r, PgRow> for MachineValidation {
             filter: filter.map(|x| x.0),
             status: Some(status),
             duration_to_complete: row.try_get("duration_to_complete")?,
+            last_heartbeat_at: row.try_get("last_heartbeat_at")?,
             // description: row.try_get("description")?, // unused
         })
     }

--- a/crates/machine-controller/src/config/machine_validation.rs
+++ b/crates/machine-controller/src/config/machine_validation.rs
@@ -87,12 +87,25 @@ pub struct MachineValidationTestConfig {
 }
 
 impl MachineValidationConfig {
+    /// Minimum allowed stale timeout.
+    ///
+    /// Scout sends machine validation heartbeats every 30 seconds. Keep the timeout above three
+    /// missed beats so a low configured value cannot fail healthy active runs between heartbeats.
+    pub const MIN_STALE_RUN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
     const fn default_run_interval() -> std::time::Duration {
         std::time::Duration::from_secs(60)
     }
 
     const fn default_stale_run_timeout() -> std::time::Duration {
         std::time::Duration::from_secs(24 * 60 * 60)
+    }
+
+    pub fn with_minimum_stale_run_timeout(mut self) -> Self {
+        self.stale_run_timeout = self
+            .stale_run_timeout
+            .max(MachineValidationConfig::MIN_STALE_RUN_TIMEOUT);
+        self
     }
 }
 
@@ -105,5 +118,37 @@ impl Default for MachineValidationConfig {
             stale_run_timeout: Self::default_stale_run_timeout(),
             tests: Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_minimum_stale_run_timeout_clamps_low_configured_values() {
+        let config = MachineValidationConfig {
+            stale_run_timeout: std::time::Duration::from_secs(1),
+            ..MachineValidationConfig::default()
+        }
+        .with_minimum_stale_run_timeout();
+
+        assert_eq!(
+            config.stale_run_timeout,
+            MachineValidationConfig::MIN_STALE_RUN_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn with_minimum_stale_run_timeout_preserves_safe_configured_values() {
+        let configured_timeout = MachineValidationConfig::MIN_STALE_RUN_TIMEOUT
+            .saturating_add(std::time::Duration::from_secs(1));
+        let config = MachineValidationConfig {
+            stale_run_timeout: configured_timeout,
+            ..MachineValidationConfig::default()
+        }
+        .with_minimum_stale_run_timeout();
+
+        assert_eq!(config.stale_run_timeout, configured_timeout);
     }
 }

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -27,6 +27,7 @@ use forge_tls::client_config::ClientCert;
 use rpc::forge_tls_client;
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
 use tracing::{error, info, trace};
 
 use crate::{
@@ -40,9 +41,60 @@ pub const DEFAULT_TIMEOUT: u64 = 3600;
 const MACHINE_VALIDATION_HEARTBEAT_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(30);
 
-async fn stop_machine_validation_heartbeat(heartbeat_task: tokio::task::JoinHandle<()>) {
-    heartbeat_task.abort();
-    let _ = heartbeat_task.await;
+struct MachineValidationExecution {
+    result: rpc::forge::MachineValidationResult,
+    heartbeat: Option<MachineValidationHeartbeatGuard>,
+}
+
+impl MachineValidationExecution {
+    fn without_heartbeat(result: rpc::forge::MachineValidationResult) -> Self {
+        Self {
+            result,
+            heartbeat: None,
+        }
+    }
+
+    fn with_heartbeat(
+        result: rpc::forge::MachineValidationResult,
+        heartbeat: MachineValidationHeartbeatGuard,
+    ) -> Self {
+        Self {
+            result,
+            heartbeat: Some(heartbeat),
+        }
+    }
+}
+
+struct MachineValidationHeartbeatGuard {
+    task: Option<JoinHandle<()>>,
+}
+
+impl MachineValidationHeartbeatGuard {
+    fn new(task: JoinHandle<()>) -> Self {
+        Self { task: Some(task) }
+    }
+
+    async fn stop(mut self) {
+        let Some(task) = self.task.take() else {
+            return;
+        };
+
+        task.abort();
+        match task.await {
+            Ok(()) => {}
+            Err(e) if e.is_cancelled() => {}
+            Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
+            Err(e) => error!(error = %e, "machine validation heartbeat task failed"),
+        }
+    }
+}
+
+impl Drop for MachineValidationHeartbeatGuard {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
 }
 
 impl MachineValidation {
@@ -172,14 +224,20 @@ impl MachineValidation {
                     .heartbeat_machine_validation_run(validation_id, Some(test_id.clone()))
                     .await
                 {
-                    Ok(true) => trace!("sent machine validation heartbeat"),
+                    Ok(true) => {
+                        trace!(%validation_id, test_id = %test_id, "sent machine validation heartbeat")
+                    }
                     Ok(false) => {
                         error!(
+                            %validation_id,
+                            test_id = %test_id,
                             "machine validation heartbeat was rejected because run or attempt is no longer active"
                         );
                         return;
                     }
-                    Err(e) => error!("failed to send machine validation heartbeat: {}", e),
+                    Err(e) => {
+                        error!(%validation_id, test_id = %test_id, error = %e, "failed to send machine validation heartbeat")
+                    }
                 }
             }
         })
@@ -287,7 +345,7 @@ impl MachineValidation {
         test: &rpc::forge::MachineValidationTest,
         in_context: String,
         validation_id: MachineValidationId,
-    ) -> Option<rpc::forge::MachineValidationResult> {
+    ) -> MachineValidationExecution {
         let mut mc_result = rpc::forge::MachineValidationResult {
             test_id: Some(test.test_id.clone()),
             name: test.name.clone(),
@@ -303,22 +361,36 @@ impl MachineValidation {
             .heartbeat_machine_validation_run(validation_id, Some(test.test_id.clone()))
             .await
         {
-            Ok(true) => trace!("sent initial machine validation heartbeat"),
+            Ok(true) => trace!(
+                %validation_id,
+                test_id = %test.test_id,
+                "sent initial machine validation heartbeat"
+            ),
             Ok(false) => {
                 let now = Utc::now();
-                error!("initial machine validation heartbeat was rejected");
+                error!(
+                    %validation_id,
+                    test_id = %test.test_id,
+                    "initial machine validation heartbeat was rejected"
+                );
                 mc_result.start_time = Some(now.into());
                 mc_result.end_time = Some(now.into());
                 mc_result.std_err = "Machine validation heartbeat was rejected because run or attempt is no longer active".to_owned();
                 mc_result.std_out = "Skipped: Machine validation heartbeat was rejected".to_owned();
                 mc_result.exit_code = 0;
-                return Some(mc_result);
+                return MachineValidationExecution::without_heartbeat(mc_result);
             }
-            Err(e) => error!("failed to send initial machine validation heartbeat: {}", e),
+            Err(e) => error!(
+                %validation_id,
+                test_id = %test.test_id,
+                error = %e,
+                "failed to send initial machine validation heartbeat"
+            ),
         }
-        let heartbeat_task = self
-            .clone()
-            .spawn_machine_validation_heartbeat(validation_id, test.test_id.clone());
+        let heartbeat = MachineValidationHeartbeatGuard::new(
+            self.clone()
+                .spawn_machine_validation_heartbeat(validation_id, test.test_id.clone()),
+        );
         if test.external_config_file.is_some() {
             let file_name = test.external_config_file.clone().unwrap_or_default();
             match self
@@ -333,8 +405,7 @@ impl MachineValidation {
                     mc_result.std_err = format!("Error {e}");
                     mc_result.std_out = format!("Skipped: Error {e}");
                     mc_result.exit_code = 0;
-                    stop_machine_validation_heartbeat(heartbeat_task).await;
-                    return Some(mc_result);
+                    return MachineValidationExecution::with_heartbeat(mc_result, heartbeat);
                 }
             }
         }
@@ -360,8 +431,7 @@ impl MachineValidation {
                         mc_result.std_err = result.stderr;
                         mc_result.std_out = "Skipped : Pre condition failed".to_owned();
                         mc_result.exit_code = 0;
-                        stop_machine_validation_heartbeat(heartbeat_task).await;
-                        return Some(mc_result);
+                        return MachineValidationExecution::with_heartbeat(mc_result, heartbeat);
                     }
                 }
                 Err(e) => {
@@ -370,8 +440,7 @@ impl MachineValidation {
                     mc_result.std_err = e.to_string();
                     mc_result.std_out = "Skipped : Pre condition failed".to_owned();
                     mc_result.exit_code = 0;
-                    stop_machine_validation_heartbeat(heartbeat_task).await;
-                    return Some(mc_result);
+                    return MachineValidationExecution::with_heartbeat(mc_result, heartbeat);
                 }
             }
         }
@@ -427,9 +496,8 @@ impl MachineValidation {
             .env("MACHINE_ID".to_owned(), machine_id.to_string())
             .output_with_timeout()
             .await;
-        stop_machine_validation_heartbeat(heartbeat_task).await;
 
-        match command_result {
+        let result = match command_result {
             Ok(result) => {
                 let mut stdout_str = result.stdout;
                 let mut stderr_str = result.stderr;
@@ -469,7 +537,7 @@ impl MachineValidation {
                     stdout_str
                 };
                 mc_result.exit_code = result.exit_code;
-                Some(mc_result)
+                mc_result
             }
             Err(e) => {
                 mc_result.start_time = Some(Utc::now().into());
@@ -477,9 +545,11 @@ impl MachineValidation {
                 mc_result.std_err = e.to_string();
                 mc_result.std_out = e.to_string();
                 mc_result.exit_code = -1;
-                Some(mc_result)
+                mc_result
             }
-        }
+        };
+
+        MachineValidationExecution::with_heartbeat(result, heartbeat)
     }
 
     pub(crate) async fn update_machine_validation_run(
@@ -524,7 +594,7 @@ impl MachineValidation {
                 {
                     continue;
                 }
-                let result = self
+                let execution = self
                     .clone()
                     .execute_machinevalidation_command(
                         machine_id,
@@ -533,7 +603,12 @@ impl MachineValidation {
                         validation_id,
                     )
                     .await;
-                match self.clone().persist(result).await {
+                let MachineValidationExecution { result, heartbeat } = execution;
+                let persist_result = self.clone().persist(Some(result)).await;
+                if let Some(heartbeat) = heartbeat {
+                    heartbeat.stop().await;
+                }
+                match persist_result {
                     Ok(_) => info!("Successfully sent to api server - {}", test.name),
                     Err(e) => error!("{}", e.to_string()),
                 }

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -37,6 +37,8 @@ use crate::{
 };
 pub const MAX_STRING_STD_SIZE: usize = 1024 * 1024; // 1MB in bytes;
 pub const DEFAULT_TIMEOUT: u64 = 3600;
+const MACHINE_VALIDATION_HEARTBEAT_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(30);
 
 impl MachineValidation {
     pub(crate) async fn get_container_auth_config(self) -> Result<(), MachineValidationError> {
@@ -124,6 +126,59 @@ impl MachineValidation {
                 )
             })?;
         Ok(())
+    }
+
+    pub(crate) async fn heartbeat_machine_validation_run(
+        self,
+        validation_id: MachineValidationId,
+        test_id: Option<String>,
+    ) -> Result<bool, MachineValidationError> {
+        let mut client = self.create_forge_client().await?;
+        let response = client
+            .heartbeat_machine_validation_run(tonic::Request::new(
+                rpc::forge::MachineValidationHeartbeatRequest {
+                    validation_id: Some(validation_id),
+                    run_item_id: None,
+                    attempt_id: None,
+                    test_id,
+                },
+            ))
+            .await
+            .map_err(|e| {
+                MachineValidationError::ApiClient(
+                    "heartbeat_machine_validation_run".to_owned(),
+                    e.to_string(),
+                )
+            })?
+            .into_inner();
+        Ok(response.accepted)
+    }
+
+    fn spawn_machine_validation_heartbeat(
+        self,
+        validation_id: MachineValidationId,
+        test_id: String,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(MACHINE_VALIDATION_HEARTBEAT_INTERVAL);
+            loop {
+                interval.tick().await;
+                match self
+                    .clone()
+                    .heartbeat_machine_validation_run(validation_id, Some(test_id.clone()))
+                    .await
+                {
+                    Ok(true) => trace!("sent machine validation heartbeat"),
+                    Ok(false) => {
+                        error!(
+                            "machine validation heartbeat was rejected because run or attempt is no longer active"
+                        );
+                        return;
+                    }
+                    Err(e) => error!("failed to send machine validation heartbeat: {}", e),
+                }
+            }
+        })
     }
 
     pub(crate) async fn get_machine_validation_tests(
@@ -239,9 +294,22 @@ impl MachineValidation {
             validation_id: Some(validation_id),
             ..rpc::forge::MachineValidationResult::default()
         };
+        match self
+            .clone()
+            .heartbeat_machine_validation_run(validation_id, Some(test.test_id.clone()))
+            .await
+        {
+            Ok(true) => trace!("sent initial machine validation heartbeat"),
+            Ok(false) => error!("initial machine validation heartbeat was rejected"),
+            Err(e) => error!("failed to send initial machine validation heartbeat: {}", e),
+        }
         if test.external_config_file.is_some() {
             let file_name = test.external_config_file.clone().unwrap_or_default();
-            match self.get_external_config(file_name.clone(), None).await {
+            match self
+                .clone()
+                .get_external_config(file_name.clone(), None)
+                .await
+            {
                 Ok(()) => trace!("Fetched {} config", file_name),
                 Err(e) => {
                     mc_result.start_time = Some(Utc::now().into());
@@ -329,7 +397,10 @@ impl MachineValidation {
             Err(_) => error!("Failed to create file"),
         }
 
-        match TokioCmd::new("sh")
+        let heartbeat_task = self
+            .clone()
+            .spawn_machine_validation_heartbeat(validation_id, test.test_id.clone());
+        let command_result = TokioCmd::new("sh")
             .args(vec!["-c".to_string(), command_string])
             .timeout(test.timeout.unwrap_or(7200).try_into().unwrap())
             .env("CONTEXT".to_owned(), in_context.clone())
@@ -339,8 +410,11 @@ impl MachineValidation {
             )
             .env("MACHINE_ID".to_owned(), machine_id.to_string())
             .output_with_timeout()
-            .await
-        {
+            .await;
+        heartbeat_task.abort();
+        let _ = heartbeat_task.await;
+
+        match command_result {
             Ok(result) => {
                 let mut stdout_str = result.stdout;
                 let mut stderr_str = result.stderr;

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -40,6 +40,11 @@ pub const DEFAULT_TIMEOUT: u64 = 3600;
 const MACHINE_VALIDATION_HEARTBEAT_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(30);
 
+async fn stop_machine_validation_heartbeat(heartbeat_task: tokio::task::JoinHandle<()>) {
+    heartbeat_task.abort();
+    let _ = heartbeat_task.await;
+}
+
 impl MachineValidation {
     pub(crate) async fn get_container_auth_config(self) -> Result<(), MachineValidationError> {
         let file_name = "/root/.docker/config.json".to_string();
@@ -138,9 +143,8 @@ impl MachineValidation {
             .heartbeat_machine_validation_run(tonic::Request::new(
                 rpc::forge::MachineValidationHeartbeatRequest {
                     validation_id: Some(validation_id),
-                    run_item_id: None,
-                    attempt_id: None,
-                    test_id,
+                    target: test_id
+                        .map(rpc::forge::machine_validation_heartbeat_request::Target::TestId),
                 },
             ))
             .await
@@ -300,9 +304,21 @@ impl MachineValidation {
             .await
         {
             Ok(true) => trace!("sent initial machine validation heartbeat"),
-            Ok(false) => error!("initial machine validation heartbeat was rejected"),
+            Ok(false) => {
+                let now = Utc::now();
+                error!("initial machine validation heartbeat was rejected");
+                mc_result.start_time = Some(now.into());
+                mc_result.end_time = Some(now.into());
+                mc_result.std_err = "Machine validation heartbeat was rejected because run or attempt is no longer active".to_owned();
+                mc_result.std_out = "Skipped: Machine validation heartbeat was rejected".to_owned();
+                mc_result.exit_code = 0;
+                return Some(mc_result);
+            }
             Err(e) => error!("failed to send initial machine validation heartbeat: {}", e),
         }
+        let heartbeat_task = self
+            .clone()
+            .spawn_machine_validation_heartbeat(validation_id, test.test_id.clone());
         if test.external_config_file.is_some() {
             let file_name = test.external_config_file.clone().unwrap_or_default();
             match self
@@ -317,6 +333,7 @@ impl MachineValidation {
                     mc_result.std_err = format!("Error {e}");
                     mc_result.std_out = format!("Skipped: Error {e}");
                     mc_result.exit_code = 0;
+                    stop_machine_validation_heartbeat(heartbeat_task).await;
                     return Some(mc_result);
                 }
             }
@@ -343,6 +360,7 @@ impl MachineValidation {
                         mc_result.std_err = result.stderr;
                         mc_result.std_out = "Skipped : Pre condition failed".to_owned();
                         mc_result.exit_code = 0;
+                        stop_machine_validation_heartbeat(heartbeat_task).await;
                         return Some(mc_result);
                     }
                 }
@@ -352,6 +370,7 @@ impl MachineValidation {
                     mc_result.std_err = e.to_string();
                     mc_result.std_out = "Skipped : Pre condition failed".to_owned();
                     mc_result.exit_code = 0;
+                    stop_machine_validation_heartbeat(heartbeat_task).await;
                     return Some(mc_result);
                 }
             }
@@ -397,9 +416,6 @@ impl MachineValidation {
             Err(_) => error!("Failed to create file"),
         }
 
-        let heartbeat_task = self
-            .clone()
-            .spawn_machine_validation_heartbeat(validation_id, test.test_id.clone());
         let command_result = TokioCmd::new("sh")
             .args(vec!["-c".to_string(), command_string])
             .timeout(test.timeout.unwrap_or(7200).try_into().unwrap())
@@ -411,8 +427,7 @@ impl MachineValidation {
             .env("MACHINE_ID".to_owned(), machine_id.to_string())
             .output_with_timeout()
             .await;
-        heartbeat_task.abort();
-        let _ = heartbeat_task.await;
+        stop_machine_validation_heartbeat(heartbeat_task).await;
 
         match command_result {
             Ok(result) => {

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -38,6 +38,9 @@ use crate::{
 };
 pub const MAX_STRING_STD_SIZE: usize = 1024 * 1024; // 1MB in bytes;
 pub const DEFAULT_TIMEOUT: u64 = 3600;
+
+// The API manager clamps heartbeat-based stale reconciliation to at least three missed beats, so
+// low stale_run_timeout config values cannot fail healthy runs between these heartbeat updates.
 const MACHINE_VALIDATION_HEARTBEAT_INTERVAL: std::time::Duration =
     std::time::Duration::from_secs(30);
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6325,9 +6325,11 @@ message MachineValidationAttempt {
 
 message MachineValidationHeartbeatRequest {
   common.MachineValidationId validation_id = 1;
-  optional common.UUID run_item_id = 2;
-  optional common.UUID attempt_id = 3;
-  optional string test_id = 4;
+  oneof target {
+    common.UUID run_item_id = 2;
+    common.UUID attempt_id = 3;
+    string test_id = 4;
+  }
 }
 
 message MachineValidationHeartbeatResponse {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -617,6 +617,9 @@ service Forge {
   // Machine-Validation attempt detail
   rpc GetMachineValidationAttempt(MachineValidationAttemptGetRequest) returns (MachineValidationAttempt);
 
+  // Machine-Validation run and active attempt heartbeat
+  rpc HeartbeatMachineValidationRun(MachineValidationHeartbeatRequest) returns (MachineValidationHeartbeatResponse);
+
   // Remove ExternalConfig
   rpc RemoveMachineValidationExternalConfig(RemoveMachineValidationExternalConfigRequest) returns (google.protobuf.Empty);
   // Machine-Validation test list
@@ -6077,6 +6080,7 @@ message MachineValidationRun {
   optional string context = 6;
   MachineValidationStatus status = 7;
   google.protobuf.Duration duration_to_complete = 8;
+  google.protobuf.Timestamp last_heartbeat_at = 9;
 
 }
 
@@ -6317,6 +6321,17 @@ message MachineValidationAttempt {
   google.protobuf.Timestamp last_heartbeat_at = 13;
   optional string stdout_summary = 14;
   optional string stderr_summary = 15;
+}
+
+message MachineValidationHeartbeatRequest {
+  common.MachineValidationId validation_id = 1;
+  optional common.UUID run_item_id = 2;
+  optional common.UUID attempt_id = 3;
+  optional string test_id = 4;
+}
+
+message MachineValidationHeartbeatResponse {
+  bool accepted = 1;
 }
 
 message IsBmcInManagedHostResponse {

--- a/crates/rpc/src/model/machine_validation.rs
+++ b/crates/rpc/src/model/machine_validation.rs
@@ -161,6 +161,7 @@ impl From<MachineValidation> for rpc::forge::MachineValidationRun {
             duration_to_complete: Some(rpc::Duration::from(std::time::Duration::from_secs(
                 value.duration_to_complete.try_into().unwrap_or(0),
             ))),
+            last_heartbeat_at: value.last_heartbeat_at.map(Into::into),
         }
     }
 }


### PR DESCRIPTION
## Summary
This change makes machine validation more reliable when Scout or a validation test gets stuck, crashes, or stops reporting back.

  Before this, the system mostly knew: “validation started” and later “validation finished.” If Scout died in the middle, or a test stopped running but never sent a final result, the API could be left waiting until a broader timeout path cleaned it up.

  Now we added a “heartbeat” mechanism:

  - Scout tells the API periodically: “I am still running this validation test.”
  - The API stores the latest heartbeat time.
  - If heartbeats stop for too long, the API marks that specific validation attempt as failed.
  - The machine is then unblocked and moved to the correct failed state instead of hanging indefinitely.
  - If Scout already sent all test results but missed the final “run completed” call, the API can now complete the run by looking at the test item states.

  Why you should care:

  - Machines should not get stuck in validation forever.
  - Failures become clearer: “this validation attempt stopped heartbeating.”
  - Operators can tell whether validation is active, stale, failed, or completed.
  - The system becomes safer for production workflows because it can recover from Scout crashes and missed completion events.
  - Old behavior still works for older Scouts, so this is not a risky all-or-nothing rollout.

## Description
  Implements the M2 machine validation reliability work from the design in NVIDIA/infra-controller#2070, covering run/attempt heartbeats and stale validation recovery.

  This PR adds:
  - Run-level and active-attempt heartbeat support from Scout to API.
  - Heartbeat persistence on machine validation runs, run items, and attempts.
  - Reconciliation for stale active attempts when Scout stops heartbeating.
  - Reconciliation for runs where run items reached terminal state but final run completion was missed.
  - Compatibility fallback for older Scouts that do not send heartbeats, using the existing duration-based stale-run timeout path.
  - Tests for heartbeat acceptance, invalid heartbeat rejection, stale attempt recovery, stale run recovery, and missed completion reconciliation.

  ## DB Changes

  Adds migration:

  - `crates/api-db/migrations/20260624120000_machine_validation_heartbeat_recovery.sql`

  Schema changes:
  - Adds nullable `machine_validation.last_heartbeat_at`.
  - Adds partial heartbeat indexes for active validation runs, run items, and attempts.

  ## Compatibility

  - Proto changes are additive.
  - Old Scout + new API is supported.
  - New Scout + old API will log heartbeat RPC failures but still continues validation execution/result persistence.
  - Existing duration-based stale-run reconciliation remains as fallback.


## Related issues
Fixes https://github.com/NVIDIA/infra-controller/issues/454

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
  Refs NVIDIA/infra-controller#454
  Design: NVIDIA/infra-controller#2070

Deployment note:
  - Apply the DB migration before rolling out the new API/Scout binaries.
  - The new column is nullable, so existing data and older Scout behavior remain compatible.
  - Older Scouts will continue using the existing result/completion flow; they simply will not emit heartbeats.