### PR TITLE
fix(site-agent): mount Core-gRPC certs where the binary reads them + …

### DIFF
--- a/helm/rest/nico-rest-site-agent/templates/statefulset.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/statefulset.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /etc/sitereg
               readOnly: true
             - name: nico-certs
-              mountPath: /etc/nico
+              mountPath: /etc/core-grpc
               readOnly: true
             - name: temporal-certs
               mountPath: /etc/temporal-certs

--- a/rest-api/site-agent/pkg/components/managers/coregrpc/metrics.go
+++ b/rest-api/site-agent/pkg/components/managers/coregrpc/metrics.go
@@ -4,6 +4,7 @@
 package coregrpc
 
 import (
+	"errors"
 	"time"
 
 	coregrpctypes "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/managertypes/coregrpc"
@@ -32,7 +33,20 @@ func makeGrpcClientMetrics() client.Metrics {
 			},
 			[]string{"grpc_method", "grpc_status_code"}),
 	}
-	prometheus.MustRegister(metrics.responseLatency)
+	// Use Register (not MustRegister) and tolerate a duplicate registration: the
+	// manager-level CreateGrpcClient is retried until it succeeds (e.g. on a
+	// transient cert-load failure at startup), and each attempt re-enters this
+	// function. MustRegister would panic on the second attempt and turn an
+	// otherwise-recoverable retry into a crash loop. On a duplicate, reuse the
+	// already-registered collector.
+	if err := prometheus.Register(metrics.responseLatency); err != nil {
+		are := prometheus.AlreadyRegisteredError{}
+		if errors.As(err, &are) {
+			metrics.responseLatency = are.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			panic(err)
+		}
+	}
 	return metrics
 }
 
@@ -56,7 +70,16 @@ func newWorkflowMetrics() coregrpctypes.WorkflowMetrics {
 			},
 			[]string{"activity", "status"}),
 	}
-	prometheus.MustRegister(metrics.latency)
+	// See makeGrpcClientMetrics: tolerate a duplicate registration on retry
+	// instead of panicking, reusing the already-registered collector.
+	if err := prometheus.Register(metrics.latency); err != nil {
+		are := prometheus.AlreadyRegisteredError{}
+		if errors.As(err, &are) {
+			metrics.latency = are.ExistingCollector.(*prometheus.HistogramVec)
+		} else {
+			panic(err)
+		}
+	}
 	return metrics
 }
 


### PR DESCRIPTION
…make metrics registration idempotent

The nico-rest-site-agent has two stacked bugs that cause a permanent CrashLoopBackOff.

1. Cert mount path. The chart mounts the Core-gRPC client cert secret (nico-certs) at /etc/nico, but the site-agent binary reads it from /etc/core-grpc/{ca.crt,tls.crt,tls.key} (see site-agent config DefaultCoreGrpcClientCertPath; no env override is set by the chart) and nothing ever reads /etc/nico. With the cert absent, CreateGrpcClient fails on every retry. Fix: mount the secret at /etc/core-grpc to match the binary default. The kubernetes.io/tls secret already carries ca.crt/tls.crt/tls.key.

2. Non-idempotent metrics registration. CreateGrpcClient is documented to be "retried until it succeeds", and makeGrpcClientMetrics()/newWorkflowMetrics() run on every attempt — but they use prometheus.MustRegister, which panics on the second registration. So any retry (e.g. the brief secret-volume projection lag at pod startup) turns a recoverable retry into a crash. Fix: use prometheus.Register and reuse the existing collector on AlreadyRegisteredError instead of panicking.

Fix 1 removes the permanent crashloop; fix 2 makes the retry path work as designed (and removes the residual one-restart-on-startup).

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

