### PR TITLE
fix(rest): build arm64 images natively per-arch + merge manifest

### DIFF
--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
     inputs:
       runner:
-        description: 'Runner type for the build job'
+        description: 'Runner type for the build job (amd64; arm64 leg uses a fixed arm64 runner)'
         required: false
         default: 'linux-amd64-cpu4'
         type: string
@@ -70,9 +70,25 @@ on:
         required: false
 
 jobs:
+  # Build each architecture natively on its own runner. A single multi-platform
+  # build does NOT work here: the Dockerfile builder is `FROM --platform=$BUILDPLATFORM`,
+  # so BuildKit builds it once on the build host (amd64) and BOTH final stages
+  # `COPY --from=builder`, shipping the amd64 binary inside the arm64 image. Building
+  # each arch on its own runner (separate, single-platform builds) is the only way to
+  # guarantee the arm64 image contains an arm64 binary; the manifest is stitched in `merge`.
   build:
-    name: Build ${{ inputs.service_name }}
-    runs-on: ${{ inputs.runner }}
+    name: Build ${{ inputs.service_name }} (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: linux-amd64-cpu4
+          - arch: arm64
+            platform: linux/arm64
+            runner: linux-arm64-cpu4
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -80,11 +96,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -101,71 +112,37 @@ jobs:
           username: ${{ secrets.NVCR_USERNAME }}
           password: ${{ secrets.NVCR_TOKEN }}
 
-      - name: Build amd64 image for Grype scan (load to daemon)
-        id: scan-build
-        continue-on-error: true
-        uses: docker/build-push-action@v5
-        with:
-          context: ./rest-api
-          file: ${{ inputs.dockerfile }}
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: localbuild/scan-${{ inputs.service_name }}:${{ github.run_id }}-${{ github.run_attempt }}
-          cache-from: type=gha,scope=${{ inputs.service_name }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}
-
-      - name: Grype vulnerability scan
-        if: steps.scan-build.outcome == 'success'
-        continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
-        with:
-          image: localbuild/scan-${{ inputs.service_name }}:${{ github.run_id }}-${{ github.run_attempt }}
-          fail-on: critical
-          fail-build: 'false'
-          write-summary: 'false'
-          upload-sarif: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
-          sarif-category: grype-${{ inputs.service_name }}
-          artifact-name: grype-${{ inputs.service_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-          sbom-artifact-name: sbom-${{ inputs.service_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-
       - name: Determine Docker tags
         id: docker-tags
         run: |
-          TAGS=""
-          PRIMARY_TAG=""
           # semantic_version comes from `git describe --long` and already ends in `-g<short_sha>`,
           # so appending short_sha again would produce a duplicated SHA suffix.
           ARTIFACT_VERSION="${{ inputs.semantic_version }}"
-
           if [ "${{ inputs.is_main_branch }}" == "true" ]; then
             PRIMARY_TAG="${{ inputs.semantic_version }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${PRIMARY_TAG}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:latest"
           elif [ "${{ inputs.release_tag }}" != "" ]; then
             PRIMARY_TAG="${{ inputs.release_tag }}"
             ARTIFACT_VERSION="${{ inputs.release_tag }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${PRIMARY_TAG}"
           else
             PRIMARY_TAG="${{ inputs.branch_sha_tag }}"
-            TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${PRIMARY_TAG}"
           fi
-
-          TAGS="${TAGS#,}"
-          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          # Per-arch tag; the bare manifest tag is assembled by the merge job.
+          ARCH_TAG="${{ inputs.target_registry }}/${{ inputs.service_name }}:${PRIMARY_TAG}-${{ matrix.arch }}"
           echo "primary_tag=$PRIMARY_TAG" >> $GITHUB_OUTPUT
+          echo "arch_tag=$ARCH_TAG" >> $GITHUB_OUTPUT
           echo "artifact_version=$ARTIFACT_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Build and push ${{ inputs.service_name }} (multi-arch)
+      - name: Build ${{ inputs.service_name }} (${{ matrix.arch }})
         uses: docker/build-push-action@v5
         with:
           context: ./rest-api
           file: ${{ inputs.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ inputs.push_enabled }}
-          tags: ${{ steps.docker-tags.outputs.tags }}
-          cache-from: type=gha,scope=${{ inputs.service_name }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: true
+          tags: ${{ steps.docker-tags.outputs.arch_tag }}
+          cache-from: type=gha,scope=${{ inputs.service_name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}-${{ matrix.arch }}
           labels: |
             org.opencontainers.image.title=${{ inputs.service_name }}
             org.opencontainers.image.version=${{ inputs.semantic_version }}
@@ -174,39 +151,52 @@ jobs:
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.url=${{ github.repositoryUrl }}
 
-      - name: Extract amd64 binary from image
+      - name: Grype vulnerability scan
+        if: matrix.arch == 'amd64'
+        continue-on-error: true
+        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
+        with:
+          image: ${{ steps.docker-tags.outputs.arch_tag }}
+          fail-on: critical
+          fail-build: 'false'
+          write-summary: 'false'
+          upload-sarif: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
+          sarif-category: grype-${{ inputs.service_name }}
+          artifact-name: grype-${{ inputs.service_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          sbom-artifact-name: sbom-${{ inputs.service_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Extract ${{ matrix.arch }} binary and verify architecture
         if: inputs.push_enabled == true
         run: |
+          set -euo pipefail
           mkdir -p artifacts
-          docker pull --platform linux/amd64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }}
-          docker create --name temp-container --platform linux/amd64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }}
-          docker cp temp-container:${{ inputs.binary_path }} artifacts/${{ inputs.binary_name }}-amd64
-          docker rm temp-container
-          chmod +x artifacts/${{ inputs.binary_name }}-amd64
+          cid=$(docker create "${{ steps.docker-tags.outputs.arch_tag }}")
+          docker cp "${cid}:${{ inputs.binary_path }}" "artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}"
+          docker rm "${cid}"
+          chmod +x "artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}"
+          # Guard: the binary must match this leg's target arch (amd64=x86-64, arm64=aarch64).
+          case "${{ matrix.arch }}" in
+            amd64) want='x86-64' ;;
+            arm64) want='aarch64' ;;
+            *) echo "::error::unknown arch ${{ matrix.arch }}"; exit 1 ;;
+          esac
+          got="$(file -b "artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}")"
+          echo "${got}" | grep -q "${want}" \
+            || { echo "::error::${{ matrix.arch }} ${{ inputs.binary_name }} is not ${want}: ${got}"; exit 1; }
 
-      - name: Extract arm64 binary from image
+      - name: Push ${{ matrix.arch }} image
         if: inputs.push_enabled == true
-        run: |
-          docker pull --platform linux/arm64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }}
-          docker create --name temp-container-arm --platform linux/arm64 ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }}
-          docker cp temp-container-arm:${{ inputs.binary_path }} artifacts/${{ inputs.binary_name }}-arm64
-          docker rm temp-container-arm
-          chmod +x artifacts/${{ inputs.binary_name }}-arm64
-
-      - name: Export Docker image
-        if: inputs.push_enabled == true
-        run: |
-          docker save ${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }} | gzip > artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
+        run: docker push "${{ steps.docker-tags.outputs.arch_tag }}"
 
       - name: Upload binary artifact with semantic version
         if: inputs.push_enabled == true
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
         with:
-          name: ${{ inputs.service_name }}-binary-amd64
-          display-name: ${{ inputs.service_name }}-binary-amd64
-          description: ${{ inputs.service_name }} binary (amd64)
+          name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
+          display-name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
+          description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: ${{ steps.docker-tags.outputs.artifact_version }}
-          path: artifacts/${{ inputs.binary_name }}-amd64
+          path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
           ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
@@ -214,40 +204,73 @@ jobs:
         if: inputs.is_main_branch == 'true' && inputs.push_enabled == true
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
         with:
-          name: ${{ inputs.service_name }}-binary-amd64
-          display-name: ${{ inputs.service_name }}-binary-amd64
-          description: ${{ inputs.service_name }} binary (amd64)
+          name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
+          display-name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
+          description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: latest
-          path: artifacts/${{ inputs.binary_name }}-amd64
+          path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
           ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
-      - name: Upload arm64 binary artifact with semantic version
-        if: inputs.push_enabled == true
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
-        with:
-          name: ${{ inputs.service_name }}-binary-arm64
-          display-name: ${{ inputs.service_name }}-binary-arm64
-          description: ${{ inputs.service_name }} binary (arm64)
-          version: ${{ steps.docker-tags.outputs.artifact_version }}
-          path: artifacts/${{ inputs.binary_name }}-arm64
-          ngc-path: ${{ inputs.ngc_path }}
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+  # Stitch the per-arch images pushed by `build` into one multi-arch manifest at the
+  # bare tag, then export/upload the image tarball. Push refs only.
+  merge:
+    name: Merge ${{ inputs.service_name }} manifest
+    needs: build
+    if: ${{ inputs.push_enabled == true }}
+    runs-on: linux-amd64-cpu4
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Upload arm64 binary artifact with latest tag
-        if: inputs.is_main_branch == 'true' && inputs.push_enabled == true
-        uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
+      - name: Login to NVCR
+        uses: docker/login-action@v3
         with:
-          name: ${{ inputs.service_name }}-binary-arm64
-          display-name: ${{ inputs.service_name }}-binary-arm64
-          description: ${{ inputs.service_name }} binary (arm64)
-          version: latest
-          path: artifacts/${{ inputs.binary_name }}-arm64
-          ngc-path: ${{ inputs.ngc_path }}
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          registry: nvcr.io
+          username: ${{ secrets.NVCR_USERNAME }}
+          password: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Determine Docker tags
+        id: docker-tags
+        run: |
+          ARTIFACT_VERSION="${{ inputs.semantic_version }}"
+          if [ "${{ inputs.is_main_branch }}" == "true" ]; then
+            PRIMARY_TAG="${{ inputs.semantic_version }}"
+          elif [ "${{ inputs.release_tag }}" != "" ]; then
+            PRIMARY_TAG="${{ inputs.release_tag }}"
+            ARTIFACT_VERSION="${{ inputs.release_tag }}"
+          else
+            PRIMARY_TAG="${{ inputs.branch_sha_tag }}"
+          fi
+          echo "primary_tag=$PRIMARY_TAG" >> $GITHUB_OUTPUT
+          echo "artifact_version=$ARTIFACT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push multi-arch manifest
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          retry_wait_seconds: 20
+          command: |
+            REG="${{ inputs.target_registry }}/${{ inputs.service_name }}"
+            TAG="${{ steps.docker-tags.outputs.primary_tag }}"
+            docker buildx imagetools create -t "${REG}:${TAG}" "${REG}:${TAG}-amd64" "${REG}:${TAG}-arm64"
+            if [ "${{ inputs.is_main_branch }}" == "true" ]; then
+              docker buildx imagetools create -t "${REG}:latest" "${REG}:${TAG}-amd64" "${REG}:${TAG}-arm64"
+            fi
+
+      - name: Export Docker image
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          docker pull "${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }}"
+          docker save "${{ inputs.target_registry }}/${{ inputs.service_name }}:${{ steps.docker-tags.outputs.primary_tag }}" \
+            | gzip > "artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz"
 
       - name: Upload Docker image artifact with semantic version
-        if: inputs.push_enabled == true
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
         with:
           name: ${{ inputs.service_name }}-image
@@ -259,7 +282,7 @@ jobs:
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch == 'true' && inputs.push_enabled == true
+        if: inputs.is_main_branch == 'true'
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@47c68bf27edde19d1acece9b7721b4a1a0044dfa
         with:
           name: ${{ inputs.service_name }}-image


### PR DESCRIPTION
## Problem

The arm64 variants of the `nico-rest-*` images contain **amd64 binaries** → they CrashLoop with `exec format error` on arm64 nodes.

Proof (`carbide-dev/nico-rest-db`): `:v1.5.1` and `:latest` arm64 `/app/migrations` are `ELF … x86-64`; for `:latest` the amd64 and arm64 variants are **byte-identical** (same `sha256`). Every service built via this workflow is affected.

## Root cause

A single multi-platform build cannot produce a correct arm64 image here. The Dockerfile builder is `FROM --platform=$BUILDPLATFORM`, so BuildKit builds it **once** on the build host (amd64) and **both** final stages `COPY --from=builder` → the amd64 binary ends up in the arm64 image.

Confirmed in PR build logs that this is structural, not a caching issue — neither inlining `GOARCH=$TARGETARCH` nor `no-cache-filters: builder` fixed it: only `[linux/amd64 builder] … go build` ever runs, and `[linux/arm64 final] COPY --from=builder …` copies that amd64 binary.

## Fix — native per-arch build + manifest merge

Restructure `rest-build-push-service.yml` (reusable workflow; the `workflow_call` interface is unchanged, so callers are untouched):

- **`build`** runs as a matrix over `amd64` / `arm64`, each on its **own native runner**, single-platform → pushes `…:<tag>-<arch>`. No shared builder is possible, so each image gets a real per-arch binary. Cache is scoped per arch (`<service>-<arch>`).
- **`merge`** stitches the two per-arch images into the bare multi-arch manifest with `docker buildx imagetools create` (+ `:latest` on `main`).
- **Arch guard**: each leg extracts its binary and asserts `file` matches the target (amd64 → `x86-64`, arm64 → `aarch64`) **before** pushing — fails loudly if it's ever wrong again.

No Dockerfile change. The fix is workflow-only (not in the `rest-api/` subtree, so a subtree sync won't revert it).

## Cost

Per service: 1 job → 2 native build jobs + 1 merge job (the arm64 leg uses an arm64 runner). Each build is native — no QEMU.

## Verify

A native arm64 build inherently produces an arm64 binary, and the guard fails the build if any arch is wrong. PR builds don't push (`push_enabled=false`), so the merge/extract/guard steps are skipped there — they run on `main`/push builds, where the guard is the definitive check.
