### PR TITLE
Adding decline-probation-period to kea config

### DIFF
--- a/crates/dhcp/examples/kea-dhcp4-carbide.conf
+++ b/crates/dhcp/examples/kea-dhcp4-carbide.conf
@@ -22,6 +22,7 @@
 		"renew-timer": 900,
 		"rebind-timer": 1800,
 		"valid-lifetime": 3600,
+		"decline-probation-period": 900,
 
 		// Another thing possible here are hooks. Kea supports a powerful mechanism
 		// that allows loading external libraries that can extract information and

--- a/crates/dhcp/tests/common/kea.rs
+++ b/crates/dhcp/tests/common/kea.rs
@@ -361,6 +361,7 @@ impl Kea {
             "renew-timer": 900,
             "rebind-timer": 1800,
             "valid-lifetime": 3600,
+            "decline-probation-period": 900,
             "hooks-libraries": [
                 {
                         "library": hook_lib,

--- a/deploy/files/kea_config.json
+++ b/deploy/files/kea_config.json
@@ -15,6 +15,7 @@
     "renew-timer": 3600,
     "rebind-timer": 432000,
     "valid-lifetime": 604800,
+    "decline-probation-period": 900,
     "hooks-libraries": [
       {
         "library": "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so",

--- a/dev/deployment/kea-dhcp4-carbide.conf
+++ b/dev/deployment/kea-dhcp4-carbide.conf
@@ -22,6 +22,7 @@
 		"renew-timer": 900,
 		"rebind-timer": 1800,
 		"valid-lifetime": 3600,
+		"decline-probation-period": 900,
 
 		// Another thing possible here are hooks. Kea supports a powerful mechanism
 		// that allows loading external libraries that can extract information and

--- a/dev/kea-dhcp4.conf.example
+++ b/dev/kea-dhcp4.conf.example
@@ -22,6 +22,7 @@
 		"renew-timer": 900,
 		"rebind-timer": 1800,
 		"valid-lifetime": 3600,
+		"decline-probation-period": 900,
 
 		// Another thing possible here are hooks. Kea supports a powerful mechanism
 		// that allows loading external libraries that can extract information and

--- a/helm/charts/nico-dhcp/templates/_helpers.tpl
+++ b/helm/charts/nico-dhcp/templates/_helpers.tpl
@@ -157,7 +157,8 @@ controls the YAML→JSON name mapping.
     "renew-timer": {{ default 900 $k.renewTimer | toJson }},
     "rebind-timer": {{ default 1800 $k.rebindTimer | toJson }},
     "valid-lifetime": {{ default 3600 $k.validLifetime | toJson }},
-    {{- /*
+    "decline-probation-period": {{ default 900 $k.declineProbationPeriod | toJson }},
+    {{/*
       Hook parameters — write both nico-* and carbide-* keys with identical
       values so the kea hook library (crates/dhcp/src/kea/loader.cc still
       reads carbide-*) and any future nico-named build both find the value

--- a/helm/charts/nico-dhcp/templates/_helpers.tpl
+++ b/helm/charts/nico-dhcp/templates/_helpers.tpl
@@ -142,6 +142,10 @@ controls the YAML→JSON name mapping.
 {{- $ld := default (dict) $k.leaseDatabase -}}
 {{- $subnets := default (list) $k.subnet4 -}}
 {{- $loggers := default (list) $k.loggers -}}
+{{- $declineProbationPeriod := 900 -}}
+{{- if hasKey $k "declineProbationPeriod" -}}
+{{- $declineProbationPeriod = $k.declineProbationPeriod -}}
+{{- end -}}
 {
   "Dhcp4": {
     "interfaces-config": {
@@ -157,7 +161,7 @@ controls the YAML→JSON name mapping.
     "renew-timer": {{ default 900 $k.renewTimer | toJson }},
     "rebind-timer": {{ default 1800 $k.rebindTimer | toJson }},
     "valid-lifetime": {{ default 3600 $k.validLifetime | toJson }},
-    "decline-probation-period": {{ default 900 $k.declineProbationPeriod | toJson }},
+    "decline-probation-period": {{ $declineProbationPeriod | toJson }},
     {{/*
       Hook parameters — write both nico-* and carbide-* keys with identical
       values so the kea hook library (crates/dhcp/src/kea/loader.cc still

--- a/helm/charts/nico-dhcp/tests/apiservice_test.yaml
+++ b/helm/charts/nico-dhcp/tests/apiservice_test.yaml
@@ -19,3 +19,10 @@ tests:
       - matchRegex:
           path: data["kea_config.json"]
           pattern: 'https://carbide-api\.nico-system\.svc\.cluster\.local'
+  - it: preserves an explicit zero decline probation period
+    set:
+      config.kea.declineProbationPeriod: 0
+    asserts:
+      - matchRegex:
+          path: data["kea_config.json"]
+          pattern: '"decline-probation-period": 0'

--- a/helm/charts/nico-dhcp/tests/apiservice_test.yaml
+++ b/helm/charts/nico-dhcp/tests/apiservice_test.yaml
@@ -9,6 +9,9 @@ tests:
       - matchRegex:
           path: data["kea_config.json"]
           pattern: 'https://nico-api\.nico-system\.svc\.cluster\.local'
+      - matchRegex:
+          path: data["kea_config.json"]
+          pattern: '"decline-probation-period": 900'
   - it: apiServiceName overrides the Kea hook API URL host to carbide-api
     set:
       apiServiceName: carbide-api

--- a/helm/charts/nico-dhcp/values.yaml
+++ b/helm/charts/nico-dhcp/values.yaml
@@ -127,6 +127,7 @@ config:
     renewTimer: 900
     rebindTimer: 1800
     validLifetime: 3600
+    declineProbationPeriod: 900
 
     ## libdhcp hook parameters — these become the JSON object at
     ## Dhcp4.hooks-libraries[0].parameters and are read by the

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -172,6 +172,7 @@ nico-dhcp:
       # renewTimer: 900
       # rebindTimer: 1800
       # validLifetime: 3600
+      # declineProbationPeriod: 900
       # hookLibraryPath: /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so
       # additionalHooksLibraries: []
       # loggers:


### PR DESCRIPTION
In issue 2432 we noticed that a DPU was unable to get an IP address from DHCP.   We traced it to the DPU having done a DECLINE for the IP previously, and kea had marked that IP as on bad for 24 hours.
We don't know why the DECLINE was sent, as things worked fine after we restarted kea to clear the list of bad addresses.

This change is to drop the "marked as bad" timer (decline-probation-period) from 24 hours to 15 minutes.   To stop DPUs getting locked out for a day.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2432

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
The kea change has been tested in local-dev.