### PR TITLE
feat(bmc-mock): add configurable MAC address pools

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -27,6 +27,7 @@ use api_test_helper::{
     IntegrationTestEnvironment, domain, instance, machine, metrics, subnet, tenant, utils, vpc,
     vpc_prefix,
 };
+use bmc_mock::test_support::TEST_MAC_POOL;
 use bmc_mock::{HostHardwareType, ListenerOrAddress};
 use eyre::ContextCompat;
 use futures::FutureExt;
@@ -914,6 +915,8 @@ where
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
         mock_bmc_ssh_port: None,
+        hw_mac_address_ranges: None,
+        mac_address_pool: None,
     };
 
     let (machine_handles, _mat_handle) = api_test_helper::machine_a_tron::run_local(
@@ -921,6 +924,7 @@ where
         additional_api_urls,
         &test_env.root_dir,
         Some(bmc_mock_registry.clone()),
+        TEST_MAC_POOL.clone(),
     )
     .await
     .unwrap();

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use bmc_mock::mac_address_pool::MacAddressPool;
 use forge_tls::client_config::get_root_ca_path;
 use futures::future::try_join_all;
 use machine_a_tron::{
@@ -41,6 +42,7 @@ pub async fn run_local(
     additional_api_urls: Vec<String>,
     repo_root: &Path,
     bmc_address_registry: Option<BmcMockRegistry>,
+    mac_address_pool: Arc<Mutex<MacAddressPool>>,
 ) -> eyre::Result<(Vec<HostMachineHandle>, MachineATronHandle)> {
     let forge_root_ca_path = get_root_ca_path(None, None); // Will get it from the local repo
     let forge_client_config = ForgeClientConfig::new(forge_root_ca_path.clone(), None);
@@ -87,6 +89,7 @@ pub async fn run_local(
         api_throttler,
         desired_firmware_versions: desired_firmware,
         forge_api_client,
+        mac_address_pool,
     });
 
     let mat = MachineATron::new(app_context.clone());

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -30,6 +30,7 @@ mod http;
 mod hw;
 pub mod injection;
 mod json;
+pub mod mac_address_pool;
 mod machine_info;
 mod middleware_router;
 mod mock_machine_router;

--- a/crates/bmc-mock/src/mac_address_pool.rs
+++ b/crates/bmc-mock/src/mac_address_pool.rs
@@ -1,0 +1,773 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashSet;
+
+use mac_address::MacAddress;
+
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    pub ranges: Option<RangesConfig>,
+    pub pool: Option<PoolConfig>,
+}
+
+impl Config {
+    fn in_any_range(&self, v: MacAddress) -> bool {
+        self.ranges.is_some_and(|r| r.in_any_range(v))
+    }
+
+    fn in_pool(&self, v: MacAddress) -> bool {
+        self.pool.is_some_and(|p| {
+            let base = p.base;
+            let host_bits = p.host_bits;
+            v.clear_mask_bits(host_bits) == base
+        })
+    }
+
+    fn in_pool_or_ranges(&self, v: MacAddress) -> bool {
+        self.in_pool(v) || self.in_any_range(v)
+    }
+
+    fn range_base_for(&self, v: MacAddress) -> Option<MacAddress> {
+        if self.in_any_range(v) {
+            self.ranges.map(|r| r.range_base_for(v))
+        } else {
+            None
+        }
+    }
+
+    /// Number of addresses in row to be skipped to advance to first
+    /// address outside of configured ranges.
+    fn skip_to_next_outside_ranges(&self, v: MacAddress) -> Option<u64> {
+        if self.in_any_range(v) {
+            self.ranges
+                .map(|r| r.base.to_u64() + (1_u64 << r.host_bits) - v.to_u64())
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RangesConfig {
+    // MAC address ranges base.
+    base: MacAddress,
+    // Number of lower bits covered by the whole ranges area.
+    host_bits: usize,
+    // Number of lower bits covered by each individual range.
+    range_host_bits: usize,
+}
+
+impl RangesConfig {
+    pub fn new(base: MacAddress, host_bits: usize, range_host_bits: usize) -> Result<Self, Error> {
+        if host_bits > 48 {
+            return Err(Error::InvalidHostBits(host_bits));
+        }
+        if range_host_bits > host_bits {
+            return Err(Error::InvalidRangeHostBits {
+                range_host_bits,
+                host_bits,
+            });
+        }
+        Ok(Self {
+            base: base.bit_and(MacAddress::host_mask(host_bits).bit_not()),
+            host_bits,
+            range_host_bits,
+        })
+    }
+
+    fn in_any_range(&self, v: MacAddress) -> bool {
+        v.clear_mask_bits(self.host_bits) == self.base
+    }
+
+    fn range_base_for(&self, v: MacAddress) -> MacAddress {
+        v.clear_mask_bits(self.range_host_bits)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PoolConfig {
+    // Individual MAC address pool base.
+    base: MacAddress,
+    // Number of lower bits that identify a MAC address inside the pool.
+    host_bits: usize,
+}
+
+impl PoolConfig {
+    pub fn new(base: MacAddress, host_bits: usize) -> Result<Self, Error> {
+        if host_bits > 48 {
+            return Err(Error::InvalidHostBits(host_bits));
+        }
+        Ok(Self {
+            base: base.bit_and(MacAddress::host_mask(host_bits).bit_not()),
+            host_bits,
+        })
+    }
+    pub fn base(&self) -> MacAddress {
+        self.base
+    }
+    pub fn host_bits(&self) -> usize {
+        self.host_bits
+    }
+    pub fn contains(&self, address: MacAddress) -> bool {
+        address.clear_mask_bits(self.host_bits) == self.base
+    }
+}
+
+/// Defines data structure that is able to allocate unique
+/// MacAddresses.
+pub struct MacAddressPool {
+    config: Config,
+    allocated: HashSet<MacAddress>,
+    allocated_ranges: HashSet<MacAddress>,
+    pool_next_addr: u64,
+    ranges_next_range: u64,
+}
+
+impl MacAddressPool {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            allocated: HashSet::new(),
+            allocated_ranges: HashSet::new(),
+            pool_next_addr: 1,
+            ranges_next_range: 1,
+        }
+    }
+
+    pub fn new_pool(config: PoolConfig) -> Self {
+        Self::new(Config {
+            pool: Some(config),
+            ranges: None,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("MAC address {0} is already allocated")]
+    AlreadyAllocated(MacAddress),
+    #[error("Trying to reserve MAC address {mac} is within allocated range {range}")]
+    ReservationWithinAllocatedRange { mac: MacAddress, range: MacAddress },
+    #[error("MAC address pool exhausted")]
+    Exhausted,
+    #[error("MAC address pool not configured")]
+    PoolNotConfigured,
+    #[error("MAC address ranges are not configured")]
+    RangesNotConfigured,
+    #[error("Invalid host bits length: {0} (must be up to 48)")]
+    InvalidHostBits(usize),
+    #[error("Invalid range host bits length: {range_host_bits} > {host_bits}")]
+    InvalidRangeHostBits {
+        range_host_bits: usize,
+        host_bits: usize,
+    },
+    #[error("MAC address range {base}/{host_bits} is outside configured ranges")]
+    RangeOutsideConfiguredRanges { base: MacAddress, host_bits: usize },
+}
+
+impl MacAddressPool {
+    /// Reserve MacAddress (prevent from further allocation).
+    pub fn reserve(&mut self, address: MacAddress) -> Result<(), Error> {
+        if !self.config.in_pool_or_ranges(address) {
+            return Ok(());
+        }
+        if let Some(range_base) = self.config.range_base_for(address)
+            && self.allocated_ranges.contains(&range_base)
+        {
+            return Err(Error::ReservationWithinAllocatedRange {
+                mac: address,
+                range: range_base,
+            });
+        }
+
+        if self.allocated.insert(address) {
+            // If address within ranges pool => block whole
+            // corresponding subrange.
+            self.maybe_reserve_range(address);
+            Ok(())
+        } else {
+            Err(Error::AlreadyAllocated(address))
+        }
+    }
+
+    /// Allocate standalone address from common MAC address pool.
+    pub fn allocate(&mut self) -> Result<MacAddress, Error> {
+        let Some(pool_config) = self.config.pool else {
+            return Err(Error::PoolNotConfigured);
+        };
+
+        let base = pool_config.base;
+        let host_bits = pool_config.host_bits;
+        let mut left_tries = 1_u64 << host_bits;
+        loop {
+            if left_tries == 0 {
+                break Err(Error::Exhausted);
+            }
+            let cur = self.pool_next_addr;
+            self.pool_next_addr = self.pool_next_addr.wrapping_add(1);
+            left_tries -= 1;
+            let addr = MacAddress::from_u64(cur)
+                .bit_and(MacAddress::host_mask(host_bits))
+                .bit_or(base);
+            if let Some(skip) = self.config.skip_to_next_outside_ranges(addr) {
+                let skip = skip - 1; // Adjust to already incremented pool_next_addr / decremented left_tries.
+                self.pool_next_addr = self.pool_next_addr.wrapping_add(skip);
+                if left_tries > skip {
+                    left_tries -= skip;
+                    continue;
+                } else {
+                    break Err(Error::Exhausted);
+                }
+            }
+            if self.allocated.insert(addr) {
+                self.maybe_reserve_range(addr);
+                break Ok(addr);
+            }
+        }
+    }
+
+    pub fn allocate_range_config(&mut self) -> Result<PoolConfig, Error> {
+        let Some(ranges_config) = self.config.ranges else {
+            return Err(Error::RangesNotConfigured);
+        };
+        let ranges_count = 1_u64 << (ranges_config.host_bits - ranges_config.range_host_bits);
+        let mut left_tries = ranges_count;
+
+        loop {
+            if left_tries == 0 {
+                break Err(Error::Exhausted);
+            }
+            left_tries -= 1;
+
+            let cur = self.ranges_next_range;
+            self.ranges_next_range = self.ranges_next_range.wrapping_add(1);
+
+            let range_base = MacAddress::from_u64(cur << ranges_config.range_host_bits)
+                .bit_and(MacAddress::host_mask(ranges_config.host_bits))
+                .bit_or(ranges_config.base);
+
+            if self.allocated_ranges.insert(range_base) {
+                break Ok(PoolConfig {
+                    base: range_base,
+                    host_bits: ranges_config.range_host_bits,
+                });
+            }
+        }
+    }
+
+    pub fn reserve_range_config(&mut self, pool: PoolConfig) -> Result<(), Error> {
+        let Some(ranges_config) = self.config.ranges else {
+            return Err(Error::RangesNotConfigured);
+        };
+
+        if pool.host_bits != ranges_config.range_host_bits
+            || !ranges_config.in_any_range(pool.base)
+            || ranges_config.range_base_for(pool.base) != pool.base
+        {
+            return Err(Error::RangeOutsideConfiguredRanges {
+                base: pool.base,
+                host_bits: pool.host_bits,
+            });
+        }
+
+        self.allocated_ranges.insert(pool.base);
+        Ok(())
+    }
+
+    /// Allocate MAC address subrange from ranges pool.
+    pub fn allocate_range(&mut self) -> Result<Self, Error> {
+        self.allocate_range_config().map(|pool| {
+            Self::new(Config {
+                // Returned pool should not have subranges.
+                ranges: None,
+                pool: Some(pool),
+            })
+        })
+    }
+
+    fn maybe_reserve_range(&mut self, addr: MacAddress) {
+        if let Some(range_base) = self.config.range_base_for(addr) {
+            self.allocated_ranges.insert(range_base);
+        }
+    }
+}
+
+trait MacAddressExt: Sized + Copy {
+    fn host_mask(len: usize) -> Self;
+    fn from_u64(v: u64) -> Self;
+    fn to_u64(&self) -> u64;
+    fn bit_or(&self, other: Self) -> Self {
+        Self::from_u64(self.to_u64() | other.to_u64())
+    }
+    fn bit_not(&self) -> Self {
+        Self::from_u64(!self.to_u64())
+    }
+    fn bit_and(&self, other: Self) -> Self {
+        Self::from_u64(self.to_u64() & other.to_u64())
+    }
+    fn clear_mask_bits(&self, host_bits: usize) -> Self {
+        Self::host_mask(host_bits).bit_not().bit_and(*self)
+    }
+}
+
+impl MacAddressExt for MacAddress {
+    fn host_mask(len: usize) -> Self {
+        Self::from_u64((1_u64 << len) - 1)
+    }
+
+    fn from_u64(v: u64) -> Self {
+        MacAddress::new([
+            ((v >> 40) & 0xFF) as u8,
+            ((v >> 32) & 0xFF) as u8,
+            ((v >> 24) & 0xFF) as u8,
+            ((v >> 16) & 0xFF) as u8,
+            ((v >> 8) & 0xFF) as u8,
+            (v & 0xFF) as u8,
+        ])
+    }
+
+    fn to_u64(&self) -> u64 {
+        let bytes = self.bytes();
+        ((bytes[0] as u64) << 40)
+            | ((bytes[1] as u64) << 32)
+            | ((bytes[2] as u64) << 24)
+            | ((bytes[3] as u64) << 16)
+            | ((bytes[4] as u64) << 8)
+            | (bytes[5] as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mac(v: u64) -> MacAddress {
+        MacAddress::from_u64(v)
+    }
+
+    #[test]
+    fn allocate_pool_overlapping_ranges_still_finds_free_address_after_range() {
+        let config = Config {
+            // Ranges occupy MACs 0..=1.
+            ranges: Some(RangesConfig {
+                base: mac(0),
+                host_bits: 1,
+                range_host_bits: 1,
+            }),
+            // Pool occupies MACs 0..=3, so MACs 2 and 3 are valid standalone
+            // allocation candidates.
+            pool: Some(PoolConfig {
+                base: mac(0),
+                host_bits: 2,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        let addr = pool
+            .allocate()
+            .expect("pool has free addresses outside the overlapping ranges");
+
+        assert!(
+            !pool.config.in_any_range(addr),
+            "allocated address {addr} must not be inside ranges"
+        );
+    }
+
+    #[test]
+    fn allocate_range_skips_subrange_reserved_by_address() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x100),
+                host_bits: 3,
+                range_host_bits: 1,
+            }),
+            pool: Some(PoolConfig {
+                base: mac(0x1000),
+                host_bits: 4,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        // Address 0x102 belongs to subrange base 0x102, so that whole
+        // subrange must become unavailable for allocate_range().
+        pool.reserve(mac(0x102)).unwrap();
+
+        let child = pool
+            .allocate_range()
+            .expect("there are other free subranges");
+
+        assert_ne!(
+            child.config.pool.unwrap().base,
+            mac(0x102),
+            "allocate_range() must not allocate a subrange reserved by address"
+        );
+    }
+
+    #[test]
+    fn allocate_range_exhausts_after_all_subranges_are_allocated() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x200),
+                host_bits: 2,
+                range_host_bits: 1,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        pool.allocate_range().unwrap();
+        pool.allocate_range().unwrap();
+
+        assert!(matches!(pool.allocate_range(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn allocate_range_returns_pool_without_subranges() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x300),
+                host_bits: 3,
+                range_host_bits: 2,
+            }),
+
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+        let child = pool.allocate_range().unwrap();
+
+        assert!(child.config.ranges.is_none());
+        assert_eq!(child.config.pool.unwrap().host_bits, 2);
+    }
+
+    #[test]
+    fn child_pool_returned_by_allocate_range_cannot_allocate_nested_ranges() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x400),
+                host_bits: 3,
+                range_host_bits: 2,
+            }),
+
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+        let mut child = pool.allocate_range().unwrap();
+
+        assert!(
+            matches!(child.allocate_range(), Err(Error::RangesNotConfigured)),
+            "child pool has ranges == None, so it must not allocate nested ranges"
+        );
+    }
+
+    #[test]
+    fn child_pool_can_allocate_entire_allocated_range() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x500),
+                host_bits: 2,
+                range_host_bits: 1,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+        let mut child = pool.allocate_range().unwrap();
+
+        let first = child.allocate().unwrap();
+        let second = child
+            .allocate()
+            .expect("range_host_bits == 1 means child range contains 2 addresses");
+
+        assert_ne!(first, second);
+        assert!(matches!(child.allocate(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn allocate_does_not_skip_free_address_immediately_after_overlapping_ranges() {
+        let config = Config {
+            // Ranges occupy MACs 0..=1.
+            ranges: Some(RangesConfig {
+                base: mac(0),
+                host_bits: 1,
+                range_host_bits: 1,
+            }),
+
+            // Pool occupies MACs 0..=3.
+            pool: Some(PoolConfig {
+                base: mac(0),
+                host_bits: 2,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        // MAC 3 is allocated, MAC 2 is still free.
+        pool.reserve(mac(3)).unwrap();
+
+        let addr = pool
+            .allocate()
+            .expect("MAC 2 is free and immediately after the overlapping ranges");
+
+        assert_eq!(addr, mac(2));
+    }
+
+    #[test]
+    fn allocate_with_zero_host_bits_allocates_only_pool_base_once() {
+        let config = Config {
+            ranges: None,
+
+            pool: Some(PoolConfig {
+                base: mac(0xabc),
+                host_bits: 0,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        assert_eq!(pool.allocate().unwrap(), mac(0xabc));
+        assert!(matches!(pool.allocate(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn allocate_skips_reserved_address_and_wraps_to_pool_base() {
+        let config = Config {
+            ranges: None,
+
+            pool: Some(PoolConfig {
+                base: mac(0x100),
+                host_bits: 2,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        // Allocation order starts at offset 1, then 2, 3, 0.
+        pool.reserve(mac(0x101)).unwrap();
+
+        assert_eq!(pool.allocate().unwrap(), mac(0x102));
+        assert_eq!(pool.allocate().unwrap(), mac(0x103));
+        assert_eq!(pool.allocate().unwrap(), mac(0x100));
+        assert!(matches!(pool.allocate(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn allocate_exhausts_when_all_pool_addresses_are_reserved() {
+        let config = Config {
+            ranges: None,
+
+            pool: Some(PoolConfig {
+                base: mac(0x200),
+                host_bits: 2,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        pool.reserve(mac(0x200)).unwrap();
+        pool.reserve(mac(0x201)).unwrap();
+        pool.reserve(mac(0x202)).unwrap();
+        pool.reserve(mac(0x203)).unwrap();
+
+        assert!(matches!(pool.allocate(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn reserve_allocated_standalone_address_fails() {
+        let config = Config {
+            ranges: None,
+
+            pool: Some(PoolConfig {
+                base: mac(0x300),
+                host_bits: 1,
+            }),
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        let addr = pool.allocate().unwrap();
+
+        assert!(matches!(
+            pool.reserve(addr),
+            Err(Error::AlreadyAllocated(a)) if a == addr
+        ));
+    }
+
+    #[test]
+    fn allocate_range_with_zero_host_bits_allocates_only_ranges_base_once() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x400),
+                host_bits: 0,
+                range_host_bits: 0,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        assert_eq!(
+            pool.allocate_range().unwrap().config.pool.unwrap().base,
+            mac(0x400)
+        );
+        assert!(matches!(pool.allocate_range(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn allocate_range_when_range_size_equals_ranges_size_allocates_single_range() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x500),
+                host_bits: 3,
+                range_host_bits: 3,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        let child = pool.allocate_range().unwrap();
+
+        assert_eq!(child.config.pool.unwrap().base, mac(0x500));
+        assert_eq!(child.config.pool.unwrap().host_bits, 3);
+        assert!(matches!(pool.allocate_range(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn allocate_range_eventually_returns_every_subrange_once() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x600),
+                host_bits: 3,
+                range_host_bits: 1,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+
+        let mut bases = std::collections::HashSet::new();
+
+        for _ in 0..4 {
+            let child = pool.allocate_range().unwrap();
+            assert!(
+                bases.insert(child.config.pool.unwrap().base),
+                "subrange base must be unique"
+            );
+        }
+
+        assert_eq!(
+            bases,
+            std::collections::HashSet::from([mac(0x600), mac(0x602), mac(0x604), mac(0x606)])
+        );
+
+        assert!(matches!(pool.allocate_range(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn reserving_one_address_in_each_subrange_exhausts_ranges() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x700),
+                host_bits: 3,
+                range_host_bits: 1,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+        pool.reserve(mac(0x700)).unwrap();
+        pool.reserve(mac(0x702)).unwrap();
+        pool.reserve(mac(0x704)).unwrap();
+        pool.reserve(mac(0x706)).unwrap();
+        assert!(matches!(pool.allocate_range(), Err(Error::Exhausted)));
+    }
+
+    #[test]
+    fn reserving_address_inside_allocated_range_should_fail() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x800),
+                host_bits: 2,
+                range_host_bits: 1,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+        let child = pool.allocate_range().unwrap();
+        let addr_inside_child_range = child.config.pool.unwrap().base;
+        assert!(
+            matches!(
+                pool.reserve(addr_inside_child_range),
+                Err(Error::ReservationWithinAllocatedRange { mac, .. }) if mac == addr_inside_child_range
+            ),
+            "parent must not reserve an address inside an already allocated range"
+        );
+    }
+
+    #[test]
+    fn reserve_range_config_marks_subrange_allocated_without_allocating_member_addresses() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x900),
+                host_bits: 3,
+                range_host_bits: 1,
+            }),
+            pool: None,
+        };
+
+        let mut pool = MacAddressPool::new(config);
+        pool.reserve_range_config(PoolConfig {
+            base: mac(0x902),
+            host_bits: 1,
+        })
+        .unwrap();
+
+        let expected = mac(0x902);
+        assert!(matches!(
+            pool.reserve(expected),
+            Err(Error::ReservationWithinAllocatedRange { mac, range })
+                if mac == expected && range == expected
+        ));
+    }
+
+    #[test]
+    fn reserve_silently_accepts_address_outside_pool_and_ranges() {
+        let config = Config {
+            ranges: Some(RangesConfig {
+                base: mac(0x1000),
+                host_bits: 4,
+                range_host_bits: 2,
+            }),
+            pool: Some(PoolConfig {
+                base: mac(0x2000),
+                host_bits: 4,
+            }),
+        };
+        let mut pool = MacAddressPool::new(config);
+        let outside = mac(0x3000);
+        pool.reserve(outside).unwrap();
+        assert!(!pool.allocated.contains(&outside));
+        pool.reserve(outside).unwrap();
+    }
+}

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -16,16 +16,15 @@
  */
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
+use crate::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use crate::redfish::update_service::UpdateServiceConfig;
-use crate::{hw, redfish};
-static NEXT_MAC_ADDRESS: AtomicU32 = AtomicU32::new(1);
 use crate::{
     DUMMY_FACTORY_DPU_PASSWORD, DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostHardwareType,
+    hw, redfish,
 };
 
 /// Represents static information we know ahead of time about a host or DPU (independent of any
@@ -46,6 +45,7 @@ pub struct HostMachineInfo {
     pub non_dpu_mac_address: Option<MacAddress>,
     pub nvos_mac_addresses: Vec<MacAddress>,
     pub switch_serial_number: Option<String>,
+    pub hw_mac_addr_pool: MacAddressPoolConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -88,14 +88,13 @@ impl Default for DpuSettings {
     }
 }
 
-impl Default for DpuMachineInfo {
-    fn default() -> Self {
-        Self::new(HostHardwareType::DellPowerEdgeR750, DpuSettings::default())
-    }
-}
-
 impl DpuMachineInfo {
-    pub fn new(hw_type: HostHardwareType, settings: DpuSettings) -> Self {
+    pub fn new(
+        hw_type: HostHardwareType,
+        pool: &mut MacAddressPool,
+        settings: DpuSettings,
+    ) -> Self {
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         let bmc_mac_address = next_mac();
         let host_mac_address = next_mac();
         let oob_mac_address = next_mac();
@@ -145,7 +144,13 @@ impl DpuMachineInfo {
 }
 
 impl HostMachineInfo {
-    pub fn new(hw_type: HostHardwareType, dpus: Vec<DpuMachineInfo>) -> Self {
+    pub fn new(
+        hw_type: HostHardwareType,
+        dpus: Vec<DpuMachineInfo>,
+        pool: &mut MacAddressPool,
+        hw_mac_addr_pool: MacAddressPoolConfig,
+    ) -> Self {
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         let bmc_mac_address = next_mac();
         let nvos_mac_addresses = if matches!(hw_type, HostHardwareType::NvidiaSwitchNd5200Ld) {
             vec![next_mac()]
@@ -171,6 +176,7 @@ impl HostMachineInfo {
             nvos_mac_addresses,
             switch_serial_number,
             dpus,
+            hw_mac_addr_pool,
         }
     }
 
@@ -377,6 +383,8 @@ impl HostMachineInfo {
                 .map(|(index, dpu)| (index + 1, dpu.bluefield3().host_nic()))
                 .collect()
         };
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         hw::dell_poweredge_r750::DellPowerEdgeR750 {
             bmc_mac_address: self.bmc_mac_address,
             product_serial_number: Cow::Borrowed(&self.serial),
@@ -448,6 +456,8 @@ impl HostMachineInfo {
             [superchip_a_sn, "1642225000086"],
             ["MT2521XZ0GJM", "MT2521XZ0GJM-SYNTH"],
         );
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         hw::dgx_gb300_nvl::DgxGB300Nvl {
             system_0_serial_number: "1332425360072".into(),
             chassis_0_serial_number: "1332425360072".into(),
@@ -489,6 +499,8 @@ impl HostMachineInfo {
             [superchip_a_sn, "1764625800673"],
             ["MT2609603LCN", "MT2609603LQ2"],
         );
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         hw::supermicro_gb300_nvl::SupermicroGB300Nvl {
             system_0_serial_number: "A978250X6404492".into(),
             chassis_0_serial_number: "HA261S056572".into(),
@@ -524,6 +536,8 @@ impl HostMachineInfo {
         let superchip_b_sn = "165300000002";
         let io_board0_sn = "MT2524000001";
         let io_board1_sn = "MT2524000002";
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         hw::lenovo_gb300_nvl::LenovoGB300Nvl {
             system_0_serial_number: "012345678901234567890123".into(),
             chassis_0_serial_number: Cow::Borrowed(&self.serial),
@@ -586,6 +600,8 @@ impl HostMachineInfo {
     }
 
     fn nvidia_switch_nd5200_ld(&self) -> hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld<'_> {
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld {
             bmc_mac_address_eth0: self.bmc_mac_address,
             bmc_mac_address_eth1: next_mac(),
@@ -600,6 +616,8 @@ impl HostMachineInfo {
     }
 
     fn nvidia_dgx_h100(&self) -> hw::nvidia_dgx_h100::NvidiaDgxH100<'_> {
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         let storage_nic0_p0_mac = next_mac();
         let storage_nic0_serial = format!("MT{}", storage_nic0_p0_mac.to_string().replace(":", ""));
         hw::nvidia_dgx_h100::NvidiaDgxH100 {
@@ -782,19 +800,6 @@ impl MachineInfo {
             ),
         }
     }
-}
-
-fn next_mac() -> MacAddress {
-    let next_mac_num = NEXT_MAC_ADDRESS.fetch_add(1, Ordering::Acquire);
-
-    let bytes: Vec<u8> = [0x02u8, 0x01]
-        .into_iter()
-        .chain(next_mac_num.to_be_bytes())
-        .collect();
-
-    let mac_bytes = <[u8; 6]>::try_from(bytes).unwrap();
-
-    MacAddress::from(mac_bytes)
 }
 
 /// CPU / GPU / IO-board chassis common to every GB300 tray: NVIDIA HGX reference

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -24,10 +24,15 @@ use std::process::Command;
 use std::sync::Arc;
 
 use axum::Router;
-use bmc_mock::{
-    BmcCommand, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, ListenerOrAddress,
-    MachineInfo, MockPowerState, SetSystemPowerError, SystemPowerControl,
+use bmc_mock::mac_address_pool::{
+    Config as MacAddressConfig, MacAddressPool, PoolConfig as MacAddressPoolConfig,
+    RangesConfig as MacAddressRangesConfig,
 };
+use bmc_mock::{
+    BmcCommand, Callbacks, DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo,
+    ListenerOrAddress, MachineInfo, MockPowerState, SetSystemPowerError, SystemPowerControl,
+};
+use mac_address::MacAddress;
 use tar_router::TarGzOption;
 use tokio::sync::{RwLock, mpsc};
 use tracing::info;
@@ -155,16 +160,31 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
 fn default_host_mock() -> Router {
     let command_channel = spawn_qemu_reboot_handler();
     let callbacks = Arc::new(ChannelCallbacks::new(command_channel));
-    bmc_mock::machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::WiwynnGB200Nvl,
-            vec![DpuMachineInfo::default(), DpuMachineInfo::default()],
-        )),
-        callbacks,
-        String::default(),
-        false,
-    )
-    .0
+    let mut pool = MacAddressPool::new(MacAddressConfig {
+        pool: Some(
+            MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16)
+                .expect("Must be constructed with these parameters"),
+        ),
+        ranges: Some(
+            MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16, 8)
+                .expect("Must be constructed with these parameters"),
+        ),
+    });
+
+    let hw_type = HostHardwareType::WiwynnGB200Nvl;
+    let ndpu = hw_type.fixed_number_of_dpu().unwrap_or(1);
+    let mac_range = pool
+        .allocate_range_config()
+        .expect("MAC address pool should be allocated");
+    let machine_info = MachineInfo::Host(HostMachineInfo::new(
+        HostHardwareType::WiwynnGB200Nvl,
+        (0..ndpu)
+            .map(|_| DpuMachineInfo::new(hw_type, &mut pool, DpuSettings::default()))
+            .collect(),
+        &mut pool,
+        mac_range,
+    ));
+    bmc_mock::machine_router(&machine_info, callbacks, String::default(), false).0
 }
 
 #[derive(Debug)]

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -239,6 +239,7 @@ mod tests {
     use serde_json::Value;
     use tower::Service;
 
+    use crate::test_support::TEST_MAC_POOL;
     use crate::*;
 
     #[derive(Debug)]
@@ -256,10 +257,19 @@ mod tests {
 
     fn test_host_mock() -> Router {
         let callbacks = Arc::new(TestCallbacks {});
+        let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
+        let hw_type = HostHardwareType::DellPowerEdgeR750;
+        let ranges_config = mac_pool.allocate_range_config().unwrap();
         crate::machine_router(
             &MachineInfo::Host(HostMachineInfo::new(
-                HostHardwareType::DellPowerEdgeR750,
-                vec![DpuMachineInfo::default()],
+                hw_type,
+                vec![DpuMachineInfo::new(
+                    hw_type,
+                    &mut mac_pool,
+                    DpuSettings::default(),
+                )],
+                &mut mac_pool,
+                ranges_config,
             )),
             callbacks,
             String::default(),
@@ -308,7 +318,6 @@ mod tests {
             else {
                 panic!("Network adapter must contain @odata.id");
             };
-            println!("{odata_id}");
             let upstream_network_adapter_body = subject
                 .call(
                     Request::builder()

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -15,19 +15,24 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use axum_http_client::AxumRouterHttpClient;
+use mac_address::MacAddress;
 use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
 use url::Url;
 
+use crate::mac_address_pool::{
+    Config as MacAddressConfig, MacAddressPool, PoolConfig as MacAddressPoolConfig,
+    RangesConfig as MacAddressRangesConfig,
+};
 use crate::machine_info::DpuSettings;
 use crate::{
     BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
     MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
 };
-pub mod axum_http_client;
 
-use axum_http_client::AxumRouterHttpClient;
+pub mod axum_http_client;
 
 #[derive(Debug)]
 struct NoopCallbacks;
@@ -48,6 +53,17 @@ impl Callbacks for NoopCallbacks {
 }
 
 pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
+
+lazy_static::lazy_static! {
+    pub static ref TEST_HW_MAC_POOL_CONFIG: MacAddressPoolConfig =
+        MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).unwrap();
+
+    pub static ref TEST_MAC_POOL: Arc<Mutex<MacAddressPool>> =
+        Arc::new(Mutex::new(MacAddressPool::new(MacAddressConfig {
+            pool: Some(MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 32).unwrap()),
+            ranges: Some(MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 32, 8).unwrap()),
+        })));
+}
 
 #[derive(Clone)]
 pub struct TestBmcHandle {
@@ -71,15 +87,23 @@ async fn test_bmc((router, state): (axum::Router, BmcState)) -> TestBmcHandle {
     }
 }
 
+fn host_info(hw_type: HostHardwareType) -> MachineInfo {
+    let ndpu = hw_type.fixed_number_of_dpu().unwrap_or(0);
+    let mut pool = TEST_MAC_POOL.lock().unwrap();
+    let ranges_config = pool.allocate_range_config().unwrap();
+    MachineInfo::Host(HostMachineInfo::new(
+        hw_type,
+        (0..ndpu)
+            .map(|_| DpuMachineInfo::new(hw_type, &mut pool, DpuSettings::default()))
+            .collect(),
+        &mut pool,
+        ranges_config,
+    ))
+}
+
 pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::WiwynnGB200Nvl,
-            vec![
-                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-                DpuMachineInfo::new(HostHardwareType::WiwynnGB200Nvl, DpuSettings::default()),
-            ],
-        )),
+        &host_info(HostHardwareType::WiwynnGB200Nvl),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -89,13 +113,7 @@ pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
 
 pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::LenovoGB300Nvl,
-            vec![DpuMachineInfo::new(
-                HostHardwareType::LenovoGB300Nvl,
-                DpuSettings::default(),
-            )],
-        )),
+        &host_info(HostHardwareType::LenovoGB300Nvl),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -105,13 +123,7 @@ pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
 
 pub async fn dgx_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::NvidiaDgxGb300,
-            vec![DpuMachineInfo::new(
-                HostHardwareType::NvidiaDgxGb300,
-                DpuSettings::default(),
-            )],
-        )),
+        &host_info(HostHardwareType::NvidiaDgxGb300),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -121,13 +133,7 @@ pub async fn dgx_gb300_bmc() -> TestBmcHandle {
 
 pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::SupermicroGb300Nvl,
-            vec![DpuMachineInfo::new(
-                HostHardwareType::SupermicroGb300Nvl,
-                DpuSettings::default(),
-            )],
-        )),
+        &host_info(HostHardwareType::SupermicroGb300Nvl),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -137,10 +143,7 @@ pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
 
 pub async fn generic_supermicro_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::GenericSupermicro,
-            vec![],
-        )),
+        &host_info(HostHardwareType::GenericSupermicro),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -150,10 +153,7 @@ pub async fn generic_supermicro_bmc() -> TestBmcHandle {
 
 pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::LiteOnPowerShelf,
-            vec![],
-        )),
+        &host_info(HostHardwareType::LiteOnPowerShelf),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -163,10 +163,7 @@ pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
 
 pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::NvidiaSwitchNd5200Ld,
-            vec![],
-        )),
+        &host_info(HostHardwareType::NvidiaSwitchNd5200Ld),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -176,10 +173,7 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
 
 pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::DellPowerEdgeR750,
-            vec![],
-        )),
+        &host_info(HostHardwareType::DellPowerEdgeR750),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -188,11 +182,16 @@ pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
 }
 
 pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBmcHandle {
-    test_bmc(machine_router(
-        &MachineInfo::Dpu(DpuMachineInfo::new(
+    let machine_info = {
+        let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
+        MachineInfo::Dpu(DpuMachineInfo::new(
             HostHardwareType::DellPowerEdgeR750,
+            &mut mac_pool,
             settings,
-        )),
+        ))
+    };
+    test_bmc(machine_router(
+        &machine_info,
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
         false,
@@ -202,7 +201,7 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
 
 pub async fn generic_ami_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &MachineInfo::Host(HostMachineInfo::new(HostHardwareType::GenericAmi, vec![])),
+        &host_info(HostHardwareType::GenericAmi),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -219,15 +218,13 @@ mod test {
 
     use super::*;
     use crate::test_support::axum_http_client::Error;
+    use crate::test_support::host_info;
 
     #[tokio::test]
     async fn transport_supports_expand_query_through_mock_expander() {
         let client = AxumRouterHttpClient::new(
             machine_router(
-                &MachineInfo::Host(HostMachineInfo::new(
-                    HostHardwareType::DellPowerEdgeR750,
-                    vec![],
-                )),
+                &host_info(HostHardwareType::DellPowerEdgeR750),
                 Arc::new(NoopCallbacks),
                 "test-host-id".to_string(),
                 false,

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -17,10 +17,11 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo};
+use bmc_mock::mac_address_pool::MacAddressPool;
+use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType};
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
 use duration_str::deserialize_duration;
@@ -247,6 +248,16 @@ pub struct MachineATronConfig {
         serialize_with = "as_std_duration"
     )]
     pub api_refresh_interval: Duration,
+
+    /// Pool to allocate regular MAC addresses for the machines.
+    #[serde(default)]
+    pub mac_address_pool: Option<MacAddressPoolConfig>,
+    /// Pool to allocate ranges of HW MAC addresses for the machines.
+    /// Ranges are needed for deterministic and unique addresses but
+    /// that do not participate in any associations (allocated using
+    /// just "next_mac()" manner).
+    #[serde(default)]
+    pub hw_mac_address_ranges: Option<MacAddressRangesConfig>,
 }
 
 impl MachineATronConfig {
@@ -333,19 +344,16 @@ pub struct PersistedHostMachine {
     pub observed_machine_id: Option<MachineId>,
     pub installed_os: OsImage,
     pub tpm_ek_certificate: Option<Vec<u8>>,
+    #[serde(default)]
+    pub hw_mac_addr_pool: Option<MacAddressPoolConfig>,
 }
 
-impl From<PersistedHostMachine> for HostMachineInfo {
-    fn from(value: PersistedHostMachine) -> Self {
-        Self {
-            hw_type: value.hw_type.unwrap_or_default(),
-            bmc_mac_address: value.bmc_mac_address,
-            serial: value.serial,
-            dpus: value.dpus.into_iter().map(Into::into).collect(),
-            non_dpu_mac_address: value.non_dpu_mac_address,
-            nvos_mac_addresses: value.nvos_mac_addresses,
-            switch_serial_number: value.switch_serial_number,
-        }
+impl PersistedHostMachine {
+    pub fn mac_addresses(&self) -> impl Iterator<Item = MacAddress> {
+        std::iter::once(self.bmc_mac_address)
+            .chain(self.dpus.iter().flat_map(|d| d.mac_addresses()))
+            .chain(self.non_dpu_mac_address.iter().copied())
+            .chain(self.nvos_mac_addresses.iter().copied())
     }
 }
 
@@ -361,6 +369,17 @@ pub struct PersistedDpuMachine {
     pub dpu_index: u8,
     #[serde(flatten)]
     pub settings: DpuSettings,
+}
+
+impl PersistedDpuMachine {
+    pub fn mac_addresses(&self) -> impl Iterator<Item = MacAddress> {
+        [
+            self.bmc_mac_address,
+            self.host_mac_address,
+            self.oob_mac_address,
+        ]
+        .into_iter()
+    }
 }
 
 impl From<PersistedDpuMachine> for DpuMachineInfo {
@@ -416,9 +435,21 @@ fn default_true() -> bool {
     true
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct MacAddressPoolConfig {
+    pub base: MacAddress,
+    pub host_bits: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct MacAddressRangesConfig {
+    pub base: MacAddress,
+    pub host_bits: usize,
+    pub range_host_bits: usize,
+}
+
 // Lots of types keep an owned reference to MachineATronContext, making an Arc keeps this cheap.
 
-#[derive(Debug)]
 pub struct MachineATronContext {
     pub app_config: MachineATronConfig,
     pub forge_client_config: ForgeClientConfig,
@@ -429,6 +460,7 @@ pub struct MachineATronContext {
     /// firmware, DPU's can mock that they already have this installed.
     pub desired_firmware_versions: Vec<DesiredFirmwareVersionEntry>,
     pub forge_api_client: ForgeApiClient,
+    pub mac_address_pool: Arc<Mutex<MacAddressPool>>,
 }
 
 impl MachineATronContext {

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use bmc_mock::mac_address_pool::MacAddressPool;
 use bmc_mock::{
     BmcCommand, DpuMachineInfo, DpuSettings, HostHardwareType, MachineInfo, SetSystemPowerResult,
     SystemPowerControl,
@@ -80,6 +81,7 @@ impl DpuMachine {
         };
         let state_machine = MachineStateMachine::from_persisted(
             PersistedMachine::Dpu(persisted_dpu_machine),
+            MachineInfo::Dpu(dpu_info.clone()),
             config,
             app_context.clone(),
             bmc_control_tx,
@@ -112,6 +114,7 @@ impl DpuMachine {
         dpu_index: u8,
         app_context: Arc<MachineATronContext>,
         config: Arc<MachineConfig>,
+        mac_addr_pool: &mut MacAddressPool,
         host_dhcp_request_rx: Option<
             mpsc::UnboundedReceiver<oneshot::Sender<DhcpRelayResult<DhcpResponseInfo>>>,
         >,
@@ -129,6 +132,7 @@ impl DpuMachine {
 
         let dpu_info = DpuMachineInfo::new(
             hw_type,
+            mac_addr_pool,
             DpuSettings {
                 nic_mode: config.dpus_in_nic_mode,
                 firmware_versions: firmware_versions.into(),

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -19,6 +19,7 @@ use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use bmc_mock::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use bmc_mock::{
     BmcCommand, HostMachineInfo, MachineInfo, SetSystemPowerResult, SystemPowerControl,
 };
@@ -32,7 +33,7 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::api_client::ApiClient;
-use crate::config::{MachineATronContext, MachineConfig, PersistedHostMachine};
+use crate::config::{self, MachineATronContext, MachineConfig, PersistedHostMachine};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
 use crate::machine_state_machine::{LiveState, MachineStateMachine, PersistedMachine};
@@ -65,6 +66,7 @@ impl HostMachine {
         machine_config_section: String,
         app_context: Arc<MachineATronContext>,
         config: Arc<MachineConfig>,
+        hw_mac_addr_pool: MacAddressPoolConfig,
     ) -> Self {
         let mat_id = persisted_host_machine.mat_id;
         let (bmc_control_tx, bmc_control_rx) = mpsc::unbounded_channel();
@@ -103,6 +105,7 @@ impl HostMachine {
             non_dpu_mac_address: persisted_host_machine.non_dpu_mac_address,
             nvos_mac_addresses: persisted_host_machine.nvos_mac_addresses.clone(),
             switch_serial_number: persisted_host_machine.switch_serial_number.clone(),
+            hw_mac_addr_pool,
         };
         let dpus = dpu_machines
             .into_iter()
@@ -111,6 +114,7 @@ impl HostMachine {
 
         let state_machine = MachineStateMachine::from_persisted(
             PersistedMachine::Host(persisted_host_machine),
+            MachineInfo::Host(host_info.clone()),
             config,
             app_context.clone(),
             bmc_control_tx,
@@ -147,6 +151,8 @@ impl HostMachine {
         app_context: Arc<MachineATronContext>,
         machine_config_section: String,
         config: Arc<MachineConfig>,
+        mac_pool: &mut MacAddressPool,
+        hw_pool_config: MacAddressPoolConfig,
     ) -> Self {
         let mat_id = Uuid::new_v4();
         let (bmc_control_tx, bmc_control_rx) = mpsc::unbounded_channel();
@@ -167,6 +173,7 @@ impl HostMachine {
                     index,
                     app_context.clone(),
                     config.clone(),
+                    mac_pool,
                     if dpus_in_nic_mode {
                         None
                     } else {
@@ -178,6 +185,8 @@ impl HostMachine {
         let host_info = HostMachineInfo::new(
             config.hw_type,
             dpu_machines.iter().map(|d| d.dpu_info().clone()).collect(),
+            mac_pool,
+            hw_pool_config,
         );
         let dpus = dpu_machines
             .into_iter()
@@ -588,6 +597,10 @@ impl HostMachineHandle {
             observed_machine_id: live_state.observed_machine_id,
             installed_os: live_state.installed_os,
             tpm_ek_certificate: live_state.tpm_ek_certificate.clone(),
+            hw_mac_addr_pool: Some(config::MacAddressPoolConfig {
+                base: self.0.host_info.hw_mac_addr_pool.base(),
+                host_bits: self.0.host_info.hw_mac_addr_pool.host_bits(),
+            }),
         }
     }
 

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -18,6 +18,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use bmc_mock::HostHardwareType;
+use bmc_mock::mac_address_pool::PoolConfig as MacAddressPoolConfig;
 use futures::future::try_join_all;
 use rpc::forge::{DpuMode, VpcVirtualizationType};
 use tokio::sync::mpsc;
@@ -56,47 +57,83 @@ impl MachineATron {
             })
             .unwrap_or_default();
 
-        // If we've persisted the machine info on a previous run, use that
-        let machines: Vec<HostMachineHandle> = self
-            .app_context
-            .app_config
-            .machines
-            .iter()
-            .flat_map(|(config_name, config)| {
-                if let Some(persisted_machines) = persisted_machines
-                    .as_mut()
-                    .and_then(|m| m.remove(config_name.as_str()))
-                {
-                    tracing::info!("Recovering persisted machines for config {}", config_name);
-                    persisted_machines
-                        .into_iter()
-                        .map(|persisted| {
-                            let host_machine = HostMachine::from_persisted(
-                                persisted,
-                                config_name.clone(),
-                                self.app_context.clone(),
-                                config.clone(),
-                            );
+        // If we've persisted the machine info on a previous run, use that.
+        // Reserve all persisted MACs before allocating anything new, so recovery
+        // is independent of config iteration order.
+        let machines = {
+            let mut mac_address_pool = self.app_context.mac_address_pool.lock().unwrap();
 
-                            host_machine.start(paused)
+            if let Some(persisted_machines) = persisted_machines.as_ref() {
+                for persisted in persisted_machines.values().flatten() {
+                    let hw_mac_address_ranges = persisted
+                        .hw_mac_addr_pool
+                        .as_ref()
+                        .map(|pool| MacAddressPoolConfig::new(pool.base, pool.host_bits))
+                        .transpose()?;
+                    if let Some(hw_mac_address_ranges) = hw_mac_address_ranges {
+                        mac_address_pool.reserve_range_config(hw_mac_address_ranges)?;
+                    }
+                    persisted
+                        .mac_addresses()
+                        .filter(|addr| {
+                            !hw_mac_address_ranges.is_some_and(|range| range.contains(*addr))
                         })
-                        .collect::<Vec<_>>()
-                } else {
-                    tracing::info!("Constructing machines for config {}", config_name);
-                    (0..config.host_count)
-                        .map(move |_| {
-                            let host_machine = HostMachine::new(
-                                self.app_context.clone(),
-                                config_name.clone(),
-                                config.clone(),
-                            );
-
-                            host_machine.start(paused)
-                        })
-                        .collect::<Vec<_>>()
+                        .map(|addr| mac_address_pool.reserve(addr))
+                        .collect::<Result<Vec<_>, _>>()?;
                 }
-            })
-            .collect();
+            }
+
+            self.app_context
+                .app_config
+                .machines
+                .iter()
+                .flat_map(|(config_name, config)| {
+                    if let Some(persisted_machines) = persisted_machines
+                        .as_mut()
+                        .and_then(|m| m.remove(config_name.as_str()))
+                    {
+                        tracing::info!("Recovering persisted machines for config {}", config_name);
+                        persisted_machines
+                            .into_iter()
+                            .map(|persisted| -> eyre::Result<HostMachineHandle> {
+                                let hw_mac_address_ranges = persisted
+                                    .hw_mac_addr_pool
+                                    .as_ref()
+                                    .map(|pool| {
+                                        MacAddressPoolConfig::new(pool.base, pool.host_bits)
+                                    })
+                                    .unwrap_or_else(|| mac_address_pool.allocate_range_config())?;
+                                let host_machine = HostMachine::from_persisted(
+                                    persisted,
+                                    config_name.clone(),
+                                    self.app_context.clone(),
+                                    config.clone(),
+                                    hw_mac_address_ranges,
+                                );
+
+                                Ok(host_machine.start(paused))
+                            })
+                            .collect::<Vec<_>>()
+                    } else {
+                        tracing::info!("Constructing machines for config {}", config_name);
+                        (0..config.host_count)
+                            .map(|_| {
+                                let mac_range = mac_address_pool.allocate_range_config()?;
+                                let host_machine = HostMachine::new(
+                                    self.app_context.clone(),
+                                    config_name.clone(),
+                                    config.clone(),
+                                    &mut mac_address_pool,
+                                    mac_range,
+                                );
+
+                                Ok(host_machine.start(paused))
+                            })
+                            .collect::<Vec<_>>()
+                    }
+                })
+                .collect::<Result<Vec<_>, _>>()?
+        };
 
         if self.app_context.app_config.register_expected_machines {
             for machine in &machines {

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -23,9 +23,9 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::{
-    BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostMachineInfo,
-    HostnameQuerying, MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError,
-    SetSystemPowerResult, SystemPowerControl,
+    BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostnameQuerying,
+    MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
+    SystemPowerControl,
 };
 use carbide_network::virtualization::build_dual_stack_list;
 use carbide_uuid::machine::MachineId;
@@ -209,27 +209,16 @@ pub enum PersistedMachine {
 impl MachineStateMachine {
     pub fn from_persisted(
         persisted_machine: PersistedMachine,
+        machine_info: MachineInfo,
         config: Arc<MachineConfig>,
         app_context: Arc<MachineATronContext>,
         bmc_command_channel: mpsc::UnboundedSender<BmcCommand>,
         dpu_dhcp_relay: Option<DpuDhcpRelay>,
         mat_host_id: Uuid,
     ) -> MachineStateMachine {
-        let (initial_os_image, tpm_ek_certificate, machine_info) = match persisted_machine {
-            PersistedMachine::Host(h) => (
-                h.installed_os,
-                h.tpm_ek_certificate,
-                MachineInfo::Host(HostMachineInfo {
-                    hw_type: h.hw_type.unwrap_or_default(),
-                    bmc_mac_address: h.bmc_mac_address,
-                    serial: h.serial,
-                    dpus: h.dpus.into_iter().map(Into::into).collect(),
-                    non_dpu_mac_address: h.non_dpu_mac_address,
-                    nvos_mac_addresses: h.nvos_mac_addresses,
-                    switch_serial_number: h.switch_serial_number,
-                }),
-            ),
-            PersistedMachine::Dpu(d) => (d.installed_os, None, MachineInfo::Dpu(d.into())),
+        let (initial_os_image, tpm_ek_certificate) = match persisted_machine {
+            PersistedMachine::Host(h) => (h.installed_os, h.tpm_ek_certificate),
+            PersistedMachine::Dpu(d) => (d.installed_os, None),
         };
         let (fsm, actions) = MachineFsm::init(true, Self::is_bmc_only(&machine_info, &config));
         MachineStateMachine {

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -17,9 +17,13 @@
 use std::borrow::Cow;
 use std::error::Error;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use bmc_mock::mac_address_pool::{
+    Config as MacAddressConfig, MacAddressPool, PoolConfig as MacAddressPoolConfig,
+    RangesConfig as MacAddressRangesConfig,
+};
 use bmc_mock::{CombinedServer, HostnameQuerying, ListenerOrAddress};
 use clap::Parser;
 use figment::Figment;
@@ -27,6 +31,7 @@ use figment::providers::{Format, Toml};
 use forge_tls::client_config::{
     get_client_cert_info, get_config_from_file, get_proxy_info, get_root_ca_path,
 };
+use mac_address::MacAddress;
 use machine_a_tron::{
     AppEvent, BmcMockRegistry, BmcRegistrationMode, MachineATron, MachineATronArgs,
     MachineATronConfig, MachineATronContext, MockSshServerHandle, PromptBehavior, Tui, TuiHostLogs,
@@ -137,6 +142,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let bmc_mock_port = app_config.bmc_mock_port;
     let tui_enabled = app_config.tui_enabled;
 
+    let mac_address_pool = MacAddressPool::new(MacAddressConfig {
+        pool: Some(
+            app_config
+                .mac_address_pool
+                .as_ref()
+                .map(|pool| MacAddressPoolConfig::new(pool.base, pool.host_bits))
+                .unwrap_or_else(|| {
+                    MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 24)
+                })?,
+        ),
+        ranges: Some(
+            app_config
+                .hw_mac_address_ranges
+                .as_ref()
+                .map(|config| {
+                    MacAddressRangesConfig::new(
+                        config.base,
+                        config.host_bits,
+                        config.range_host_bits,
+                    )
+                })
+                .unwrap_or_else(|| {
+                    MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 32, 8)
+                })?,
+        ),
+    });
+
     let app_context = Arc::new(MachineATronContext {
         app_config,
         forge_client_config,
@@ -145,6 +177,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         api_throttler,
         desired_firmware_versions,
         forge_api_client,
+        mac_address_pool: Mutex::new(mac_address_pool).into(),
     });
 
     let info = app_context.forge_api_client.version(false).await?;

--- a/crates/machine-a-tron/src/vpc.rs
+++ b/crates/machine-a-tron/src/vpc.rs
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use ::rpc::Timestamp;
@@ -24,7 +23,7 @@ use carbide_uuid::vpc::VpcId;
 use crate::config::MachineATronContext;
 use crate::tui::{UiUpdate, VpcDetails};
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Vpc {
     pub vpc_id: VpcId,
     pub app_context: Arc<MachineATronContext>,


### PR DESCRIPTION
Replace the global mock MAC counter with configurable MAC address pool and hardware range allocation. Thread pools through host/DPU construction, persist allocated hardware ranges, and reserve persisted MACs on recovery to avoid collisions.

Update machine-a-tron config and test support to use the new allocation flow.

## Related issues

#1864 

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

