### PR TITLE
fixi(nvlink): safe handling of legacy/missing chassis_serial field in…

### DIFF
--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -362,6 +362,7 @@ impl Display for MachineInventorySoftwareComponent {
 pub struct MachineNvLinkInfo {
     pub domain_uuid: NvLinkDomainId,
     /// Chassis serial from the first GPU `GpuPlatformInfo` at discovery (or operator RPC).
+    #[serde(default)]
     pub chassis_serial: String,
     pub gpus: Vec<NvLinkGpu>,
 }
@@ -414,6 +415,36 @@ mod tests {
     const DPU_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_info.json");
     const DPU_BF3_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_bf3_info.json");
     const X86_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/x86_info.json");
+
+    /// Pre-NMX-C rows stored `nvlink_info` without `chassis_serial` (and GPUs carried `nmx_m_id`).
+    #[test]
+    fn machine_nvlink_info_deserializes_legacy_json_without_chassis_serial() {
+        let domain_uuid: NvLinkDomainId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".parse().unwrap();
+        let legacy_json = r#"{
+            "domain_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "gpus": [{
+                "nmx_m_id": "legacy-partition-id",
+                "tray_index": 0,
+                "slot_id": 1,
+                "device_id": 1,
+                "guid": 12345
+            }]
+        }"#;
+
+        let info: MachineNvLinkInfo = serde_json::from_str(legacy_json).unwrap();
+
+        assert_eq!(info.domain_uuid, domain_uuid);
+        assert_eq!(info.chassis_serial, "");
+        assert_eq!(
+            info.gpus,
+            vec![NvLinkGpu {
+                tray_index: 0,
+                slot_id: 1,
+                device_id: 1,
+                guid: 12345,
+            }]
+        );
+    }
 
     #[test]
     fn test_machine_inventory_json_representation() {

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -159,7 +159,8 @@ fn build_machine_nvlink_info_from_nmx_c_hello(
     }
 }
 
-/// Populates missing `machines.nvlink_info` entries (or nil `domain_uuid`) using NMX-C hello.
+/// Populates missing `machines.nvlink_info` entries, nil `domain_uuid`, or empty `chassis_serial`
+/// using NMX-C hello.
 fn populate_machine_nvlink_info_if_needed(
     machine_nvlink_info: &mut HashMap<MachineId, Option<MachineNvLinkInfo>>,
     managed_host_snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
@@ -172,7 +173,13 @@ fn populate_machine_nvlink_info_if_needed(
         let existing = machine_nvlink_info
             .get(machine_id)
             .and_then(|info| info.as_ref());
-        if existing.is_some_and(|info| info.domain_uuid != NvLinkDomainId::nil()) {
+        let needs_update = match existing {
+            None => true,
+            Some(info) => {
+                info.domain_uuid == NvLinkDomainId::nil() || info.chassis_serial.trim().is_empty()
+            }
+        };
+        if !needs_update {
             continue;
         }
 


### PR DESCRIPTION
… persisted nvlink_info

<!-- Describe what this PR does -->
Make sure that nvlink_info can be safely deserialized even if chassis_serial field in persisted json blob is missing or empty. Also, make partition monitor backfill chassis_serial in nvlink_info when the field is empty
## Related issues
https://github.com/NVIDIA/infra-controller/issues/2857

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

