### PR TITLE
fix(admin-cli): cap paged chunk size to the server's max_find_by_ids

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -75,6 +75,17 @@ fn maybe_unimplemented(status: &tonic::Status) -> bool {
     )
 }
 
+/// Caps `page_size` to a non-zero server `cap` (the `*ByIds` per-request limit).
+/// A zero cap means the server enforces no limit, so `page_size` is used as-is --
+/// chunking by zero would panic.
+fn cap_chunk_size(page_size: usize, cap: usize) -> usize {
+    if cap == 0 {
+        page_size
+    } else {
+        page_size.min(cap)
+    }
+}
+
 // Benchmarks showed 4 had better overall performance while still overlapping page fetch latency.
 const PAGED_LIST_FETCH_CONCURRENCY: usize = 4;
 
@@ -88,6 +99,22 @@ const PAGED_LIST_FETCH_CONCURRENCY: usize = 4;
 // other conveniences. 90% of these methods no longer justify their existence... we probably don't
 // need to add more.)
 impl ApiClient {
+    /// Caps a CLI `page_size` to the server's `max_find_by_ids`, so a page of ids
+    /// never exceeds what the `*ByIds` RPCs accept (they reject larger requests
+    /// with `InvalidArgument`). The cap is read from `RuntimeConfig`, the same
+    /// source `version` already exposes. A zero/unset cap means the server
+    /// enforces no limit, so we fall back to `page_size` -- `chunks(0)` panics.
+    async fn effective_chunk_size(&self, page_size: usize) -> CarbideCliResult<usize> {
+        let cap = self
+            .0
+            .version(true)
+            .await?
+            .runtime_config
+            .unwrap_or_default()
+            .max_find_by_ids as usize;
+        Ok(cap_chunk_size(page_size, cap))
+    }
+
     pub async fn get_machine(&self, id: MachineId) -> CarbideCliResult<rpc::Machine> {
         let mut machines = self
             .0
@@ -116,14 +143,18 @@ impl ApiClient {
             machines: Vec::with_capacity(all_machine_ids.machine_ids.len()),
         };
 
-        stream::iter(all_machine_ids.machine_ids.chunks(page_size))
-            .map(|machine_ids| self.get_machines_by_ids(machine_ids))
-            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_for_each(|machines| {
-                all_machines.machines.extend(machines.machines);
-                futures::future::ok(())
-            })
-            .await?;
+        stream::iter(
+            all_machine_ids
+                .machine_ids
+                .chunks(self.effective_chunk_size(page_size).await?),
+        )
+        .map(|machine_ids| self.get_machines_by_ids(machine_ids))
+        .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+        .try_for_each(|machines| {
+            all_machines.machines.extend(machines.machines);
+            futures::future::ok(())
+        })
+        .await?;
 
         Ok(all_machines)
     }
@@ -241,14 +272,18 @@ impl ApiClient {
             instances: Vec::with_capacity(all_ids.instance_ids.len()),
         };
 
-        stream::iter(all_ids.instance_ids.chunks(page_size))
-            .map(|ids| self.0.find_instances_by_ids(ids.to_vec()))
-            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_for_each(|list| {
-                all_list.instances.extend(list.instances);
-                futures::future::ok(())
-            })
-            .await?;
+        stream::iter(
+            all_ids
+                .instance_ids
+                .chunks(self.effective_chunk_size(page_size).await?),
+        )
+        .map(|ids| self.0.find_instances_by_ids(ids.to_vec()))
+        .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+        .try_for_each(|list| {
+            all_list.instances.extend(list.instances);
+            futures::future::ok(())
+        })
+        .await?;
 
         Ok(all_list)
     }
@@ -292,7 +327,10 @@ impl ApiClient {
             racks: Vec::with_capacity(all_ids.rack_ids.len()),
         };
 
-        for ids in all_ids.rack_ids.chunks(page_size) {
+        for ids in all_ids
+            .rack_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.0.find_racks_by_ids(ids.to_vec()).await?;
             all_list.racks.extend(list.racks);
         }
@@ -335,7 +373,10 @@ impl ApiClient {
             switches: Vec::with_capacity(all_ids.ids.len()),
         };
 
-        for ids in all_ids.ids.chunks(page_size) {
+        for ids in all_ids
+            .ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self
                 .0
                 .find_switches_by_ids(rpc::SwitchesByIdsRequest {
@@ -367,7 +408,10 @@ impl ApiClient {
             power_shelves: Vec::with_capacity(all_ids.ids.len()),
         };
 
-        for ids in all_ids.ids.chunks(page_size) {
+        for ids in all_ids
+            .ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self
                 .0
                 .find_power_shelves_by_ids(rpc::PowerShelvesByIdsRequest {
@@ -403,7 +447,10 @@ impl ApiClient {
             network_segments: Vec::with_capacity(all_ids.network_segments_ids.len()),
         };
 
-        for ids in all_ids.network_segments_ids.chunks(page_size) {
+        for ids in all_ids
+            .network_segments_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.get_segments_by_ids(ids).await?;
             all_list.network_segments.extend(list.network_segments);
         }
@@ -616,14 +663,18 @@ impl ApiClient {
             endpoints: Vec::with_capacity(endpoint_ids.endpoint_ids.len()),
         };
 
-        stream::iter(endpoint_ids.endpoint_ids.chunks(page_size))
-            .map(|ids| self.get_explored_endpoints_by_ids(ids))
-            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_for_each(|list| {
-                all_endpoints.endpoints.extend(list.endpoints);
-                futures::future::ok(())
-            })
-            .await?;
+        stream::iter(
+            endpoint_ids
+                .endpoint_ids
+                .chunks(self.effective_chunk_size(page_size).await?),
+        )
+        .map(|ids| self.get_explored_endpoints_by_ids(ids))
+        .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+        .try_for_each(|list| {
+            all_endpoints.endpoints.extend(list.endpoints);
+            futures::future::ok(())
+        })
+        .await?;
 
         // grab managed hosts
         let all_hosts = self.get_all_explored_managed_hosts(page_size).await?;
@@ -660,14 +711,18 @@ impl ApiClient {
             managed_hosts: Vec::with_capacity(host_ids.host_ids.len()),
         };
 
-        stream::iter(host_ids.host_ids.chunks(page_size))
-            .map(|ids| self.0.find_explored_managed_hosts_by_ids(ids))
-            .buffered(PAGED_LIST_FETCH_CONCURRENCY)
-            .try_for_each(|list| {
-                all_hosts.managed_hosts.extend(list.managed_hosts);
-                futures::future::ok(())
-            })
-            .await?;
+        stream::iter(
+            host_ids
+                .host_ids
+                .chunks(self.effective_chunk_size(page_size).await?),
+        )
+        .map(|ids| self.0.find_explored_managed_hosts_by_ids(ids))
+        .buffered(PAGED_LIST_FETCH_CONCURRENCY)
+        .try_for_each(|list| {
+            all_hosts.managed_hosts.extend(list.managed_hosts);
+            futures::future::ok(())
+        })
+        .await?;
 
         Ok(all_hosts.managed_hosts)
     }
@@ -687,7 +742,7 @@ impl ApiClient {
         let mut all = ::rpc::site_explorer::ExploredMlxDeviceList {
             devices: Vec::with_capacity(host_ids.len()),
         };
-        stream::iter(host_ids.chunks(page_size))
+        stream::iter(host_ids.chunks(self.effective_chunk_size(page_size).await?))
             .map(|ids| self.0.find_explored_mlx_devices_by_ids(ids))
             .buffered(PAGED_LIST_FETCH_CONCURRENCY)
             .try_for_each(|list| {
@@ -959,7 +1014,10 @@ impl ApiClient {
             vpcs: Vec::with_capacity(all_ids.vpc_ids.len()),
         };
 
-        for ids in all_ids.vpc_ids.chunks(page_size) {
+        for ids in all_ids
+            .vpc_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.0.find_vpcs_by_ids(ids).await?;
             all_list.vpcs.extend(list.vpcs);
         }
@@ -976,7 +1034,10 @@ impl ApiClient {
 
         let include_history = all_ids.ids.len() == 1;
 
-        for ids in all_ids.ids.chunks(page_size) {
+        for ids in all_ids
+            .ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let request = rpc::DpaInterfacesByIdsRequest {
                 ids: ids.to_vec(),
                 include_history,
@@ -1136,7 +1197,10 @@ impl ApiClient {
             ib_partitions: Vec::with_capacity(all_ids.ib_partition_ids.len()),
         };
 
-        for ids in all_ids.ib_partition_ids.chunks(page_size) {
+        for ids in all_ids
+            .ib_partition_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.get_ib_partitions_by_ids(ids).await?;
             all_list.ib_partitions.extend(list.ib_partitions);
         }
@@ -1155,7 +1219,10 @@ impl ApiClient {
             spx_partitions: Vec::with_capacity(all_ids.spx_partition_ids.len()),
         };
 
-        for ids in all_ids.spx_partition_ids.chunks(page_size) {
+        for ids in all_ids
+            .spx_partition_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.get_spx_partitions_by_ids(ids).await?;
             all_list.spx_partitions.extend(list.spx_partitions);
         }
@@ -1236,7 +1303,10 @@ impl ApiClient {
             keyset: Vec::with_capacity(all_ids.keyset_ids.len()),
         };
 
-        for ids in all_ids.keyset_ids.chunks(page_size) {
+        for ids in all_ids
+            .keyset_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.get_keysets_by_ids(ids).await?;
             all_list.keyset.extend(list.keyset);
         }
@@ -2070,7 +2140,7 @@ impl ApiClient {
 
         let mut all_nsgs = Vec::with_capacity(all_nsg_ids.len());
 
-        for nsg_ids in all_nsg_ids.chunks(page_size) {
+        for nsg_ids in all_nsg_ids.chunks(self.effective_chunk_size(page_size).await?) {
             let nsgs = self
                 .0
                 .find_network_security_groups_by_ids(FindNetworkSecurityGroupsByIdsRequest {
@@ -2152,7 +2222,7 @@ impl ApiClient {
 
         let mut all_itypes = Vec::with_capacity(all_ids.len());
 
-        for ids in all_ids.chunks(page_size) {
+        for ids in all_ids.chunks(self.effective_chunk_size(page_size).await?) {
             let itypes = self
                 .0
                 .find_instance_types_by_ids(FindInstanceTypesByIdsRequest {
@@ -2192,7 +2262,10 @@ impl ApiClient {
             partitions: Vec::with_capacity(all_ids.partition_ids.len()),
         };
 
-        for ids in all_ids.partition_ids.chunks(page_size) {
+        for ids in all_ids
+            .partition_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.get_nv_link_partitions_by_ids(ids).await?;
             all_list.partitions.extend(list.partitions);
         }
@@ -2252,7 +2325,10 @@ impl ApiClient {
             partitions: Vec::with_capacity(all_ids.partition_ids.len()),
         };
 
-        for ids in all_ids.partition_ids.chunks(page_size) {
+        for ids in all_ids
+            .partition_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let list = self.get_logical_partitions_by_ids(ids).await?;
             all_list.partitions.extend(list.partitions);
         }
@@ -2349,18 +2425,22 @@ impl ApiClient {
     ) -> CarbideCliResult<RemediationList> {
         let all_remediation_ids = self.0.find_remediation_ids().await?;
 
-        let remediations = stream::iter(all_remediation_ids.remediation_ids.chunks(page_size))
-            .then(|remediation_ids| async move {
-                self.0
-                    .find_remediations_by_ids(remediation_ids)
-                    .await
-                    .map_err(CarbideCliError::ApiInvocationError)
-            })
-            .try_fold(vec![], |mut accum, remediations| async move {
-                accum.extend(remediations.remediations);
-                Ok(accum)
-            })
-            .await?;
+        let remediations = stream::iter(
+            all_remediation_ids
+                .remediation_ids
+                .chunks(self.effective_chunk_size(page_size).await?),
+        )
+        .then(|remediation_ids| async move {
+            self.0
+                .find_remediations_by_ids(remediation_ids)
+                .await
+                .map_err(CarbideCliError::ApiInvocationError)
+        })
+        .try_fold(vec![], |mut accum, remediations| async move {
+            accum.extend(remediations.remediations);
+            Ok(accum)
+        })
+        .await?;
         Ok(RemediationList { remediations })
     }
 
@@ -2382,7 +2462,10 @@ impl ApiClient {
             services: Vec::with_capacity(ids_response.service_ids.len()),
         };
 
-        for ids in ids_response.service_ids.chunks(page_size) {
+        for ids in ids_response
+            .service_ids
+            .chunks(self.effective_chunk_size(page_size).await?)
+        {
             let request = rpc::DpuExtensionServicesByIdsRequest {
                 service_ids: ids.to_vec(),
             };
@@ -2434,7 +2517,7 @@ impl ApiClient {
     ) -> CarbideCliResult<Vec<rpc::dpf_state_response::DpfState>> {
         let mut all_dpf_states = Vec::with_capacity(machine_ids.len());
 
-        for machine_ids in machine_ids.chunks(page_size) {
+        for machine_ids in machine_ids.chunks(self.effective_chunk_size(page_size).await?) {
             let request = GetDpfStateRequest {
                 machine_ids: machine_ids.to_vec(),
             };
@@ -2464,7 +2547,7 @@ impl ApiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::maybe_unimplemented;
+    use super::{cap_chunk_size, maybe_unimplemented};
 
     /// `PermissionDenied` must trigger the deprecated-alias fallback: servers
     /// that predate a renamed RPC reject its unknown method name with a bare
@@ -2492,5 +2575,17 @@ mod tests {
                 status.code()
             );
         }
+    }
+
+    #[test]
+    fn cap_chunk_size_respects_server_limit() {
+        // A zero/unset cap means no server limit -- use page_size as-is.
+        assert_eq!(cap_chunk_size(100, 0), 100);
+        // A smaller cap wins, so a page never exceeds what the *ByIds RPCs accept.
+        assert_eq!(cap_chunk_size(100, 40), 40);
+        // A larger cap leaves page_size untouched.
+        assert_eq!(cap_chunk_size(100, 500), 100);
+        // Equal is a no-op.
+        assert_eq!(cap_chunk_size(100, 100), 100);
     }
 }


### PR DESCRIPTION
The admin-cli's paged `get_all_*` wrappers chunk ids by the CLI's `page_size`, but the server's `*ByIds` RPCs reject any request whose id count exceeds `runtime_config.max_find_by_ids`. Since the two limits are configured independently, a deployment with `page_size` above the server cap would fail every paged list command with `InvalidArgument`. This routes all the wrappers through one cap, so a page never exceeds what the server accepts.

- A new `ApiClient::effective_chunk_size` reads `max_find_by_ids` from the `RuntimeConfig` the `version` RPC already exposes and returns `min(page_size, cap)`; a zero/unset cap falls back to `page_size`, since chunking by zero would panic.
- All 21 paged `.chunks(page_size)` sites (machines, instances, racks, switches, power-shelves, segments, VPCs, DPAs, partitions, keysets, NSGs, explored hosts/devices, ...) now chunk by the capped size.
- The cap arithmetic is a pure `cap_chunk_size` helper with a unit test.

Surfaced by CodeRabbit on PR #2833.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/2872
