### PR TITLE
docs: fix stale metal-manager repo URLs in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,8 @@ Developers must first fork the upstream [Infra Controller repository](https://gi
 ### 2. Clone Your Fork
 
 ```bash
-git clone https://github.com/<your-username>/metal-manager.git
-cd metal-manager
+git clone https://github.com/<your-username>/infra-controller.git
+cd infra-controller
 ```
 
 ### 3. Add Upstream Remote
@@ -157,7 +157,7 @@ cd metal-manager
 Add the original repository as an upstream remote to keep your fork in sync:
 
 ```bash
-git remote add upstream https://github.com/NVIDIA/metal-manager.git
+git remote add upstream https://github.com/NVIDIA/infra-controller.git
 git remote -v  # Verify remotes
 ```
 


### PR DESCRIPTION
Fixes the **Fork and Setup** instructions in `CONTRIBUTING.md`, which still referenced the old `metal-manager` repository name. Following the steps verbatim clones — and adds an upstream remote for — a repository that no longer matches this project, which is a stumbling block for first-time contributors.

All changes are in `CONTRIBUTING.md`:

| Section | Before | After |
|---|---|---|
| Clone Your Fork | `git clone .../<your-username>/metal-manager.git` | `.../infra-controller.git` |
| Clone Your Fork | `cd metal-manager` | `cd infra-controller` |
| Add Upstream Remote | `git remote add upstream .../NVIDIA/metal-manager.git` | `.../NVIDIA/infra-controller.git` |

This makes the commands consistent with the surrounding prose, which already links to the `NVIDIA/infra-controller` repository.

## Related issues
None.

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

Confirmed no remaining `metal-manager` references in `CONTRIBUTING.md`.

## Additional Notes
Scope intentionally limited to `CONTRIBUTING.md`. Other `metal-manager` / `bare-metal-manager-*` strings elsewhere in the tree refer to separate repositories (core/rest), historical `CHANGELOG` entries, or Go module paths, and are out of scope for this fix.
