### PR TITLE
docs: fix relative links to existing doc pages

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -43,7 +43,7 @@ NICo deploys a set of binaries on these hosts during various points of their lif
 [dpu-agent](https://github.com/NVIDIA/infra-controller/blob/main/crates/agent) is an agent that NICo runs exclusively on DPUS managed by NICo as a daemon.
 
 DPU agent performs the following tasks:
-- Configuring the DPU as required at any state during the hosts lifecycle. This process is described more in depth in [DPU configuration](dpu_configuration.md).
+- Configuring the DPU as required at any state during the hosts lifecycle. This process is described more in depth in [DPU configuration](../dpu-management/dpu_configuration.md).
 - Executing periodic health-checks on the DPU
 - Running the NICo metadata service (FMDS), which provides the users on the bare metal instance a HTTP based API to retrieve information about their running instance. Users can e.g. use FMDS to determine their Machine ID or certain Boot/OS information.
 - Enabling auto-updates of the dpu-agent itself

--- a/docs/development.md
+++ b/docs/development.md
@@ -219,4 +219,4 @@ Remember to `strip` before you scp so that scp goes faster. scp to DPU example (
 Set up a QEMU host for your docker-compose services to manage:
 
 1. [Build iPXE and bootable artifacts image](bootable_artifacts.md)
-1. [Start QEMU server](vm_pxe_client.md)
+1. [Start QEMU server](development/vm_pxe_client.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -159,7 +159,7 @@ SLAs are defined per Machine lifecycle state. When a Machine remains in a given 
 
 **What validation is performed after an Instance reports `Ready`?**
 
-NICo runs both in-band validation tests (executed on the host while it is not leased to a tenant) and out-of-band validation tests (executed against the BMC). The in-band tests ("machine-validation tests") are configurable by the site administrator and are implemented as shell scripts; NICo evaluates the exit code to determine pass or fail. The results of all health checks are aggregated into the `health` property of the `Machine` object. Refer to the [health aggregation architecture documentation](../architecture/health_aggregation.md) for a full list of checks.
+NICo runs both in-band validation tests (executed on the host while it is not leased to a tenant) and out-of-band validation tests (executed against the BMC). The in-band tests ("machine-validation tests") are configurable by the site administrator and are implemented as shell scripts; NICo evaluates the exit code to determine pass or fail. The results of all health checks are aggregated into the `health` property of the `Machine` object. Refer to the [health aggregation architecture documentation](architecture/health_aggregation.md) for a full list of checks.
 
 **How can network security group (NSG) and SSH key sync status be verified after Instance creation?**
 
@@ -218,6 +218,6 @@ Deletion is accepted immediately but the Instance must run through all defined d
 
 **What metrics and dashboards are available for monitoring NICo deployments?**
 
-A subset of NICo metrics is documented in the [Core Metrics reference](../observability/core_metrics.md). Key metrics for operational monitoring include per-state machine counts and `nico_machines_per_state_above_sla`.
+A subset of NICo metrics is documented in the [Core Metrics reference](observability/core_metrics.md). Key metrics for operational monitoring include per-state machine counts and `nico_machines_per_state_above_sla`.
 
 Grafana dashboard definitions for NICo deployments are maintained separately from the open-source package. A dashboard JSON for deployment on a site-local Grafana Instance is available in the NICo Helm chart distribution.

--- a/docs/operations/tenant-lifecycle-cleanup.md
+++ b/docs/operations/tenant-lifecycle-cleanup.md
@@ -13,7 +13,7 @@ For reference, see:
 - [Managed Host State Diagrams](../architecture/state_machines/managedhost.md)
 - [Repair Workflows](../manuals/repair/overview.md)
 - [Measured Boot Ingest Guidance](../provisioning/ingesting-hosts.md#measured-boot)
-- [Core Metrics](../manuals/metrics/core_metrics.md)
+- [Core Metrics](../observability/core_metrics.md)
 
 ## Release an Instance
 


### PR DESCRIPTION
Several documentation pages link to other pages using relative paths that overshoot their directory, so the links resolve to non-existent files even though the target pages exist in the tree. This corrects the relative paths to point at the existing files.

| File | Link | Fix |
|---|---|---|
| `docs/faq.md` | `../architecture/health_aggregation.md` | `architecture/health_aggregation.md` |
| `docs/faq.md` | `../observability/core_metrics.md` | `observability/core_metrics.md` |
| `docs/development.md` | `vm_pxe_client.md` | `development/vm_pxe_client.md` |
| `docs/architecture/overview.md` | `dpu_configuration.md` | `../dpu-management/dpu_configuration.md` |
| `docs/operations/tenant-lifecycle-cleanup.md` | `../manuals/metrics/core_metrics.md` | `../observability/core_metrics.md` |

Each corrected link was verified to resolve to an existing file.

## Related issues
None.

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

Verified each new relative path resolves to a file that exists in the repository.

## Additional Notes
Scope is intentionally limited to broken links whose intended target unambiguously exists. Links to pages that no longer exist anywhere in the tree (e.g. `day_one_operations.md`, `nico_admin_cli.md`) are deliberately left out, since their correct targets are ambiguous. Auto-generated CLI reference docs are also out of scope.
