### PR TITLE
feat(secrets): config-driven certificate vending backend

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -664,9 +664,9 @@ events, so consumers handle them identically.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `address` | `String` | **required** | Vault address, e.g. `https://vault-certs.example:8200`. |
-| `pki_mount_location` | `String` | **required** | PKI secrets-engine mount path on the target Vault. |
-| `pki_role_name` | `String` | **required** | PKI role used to sign leaf certificates. |
+| `address` | `String` | **required, non-empty** | Vault address, e.g. `https://vault-certs.example:8200`. |
+| `pki_mount_location` | `String` | **required, non-empty** | PKI secrets-engine mount path on the target Vault. |
+| `pki_role_name` | `String` | **required, non-empty** | PKI role used to sign leaf certificates. |
 | `token` | `Option<String>` | — | Token for root-token auth; required only when the pod has no Kubernetes service-account token. |
 | `vault_cacert` | `Option<String>` | — | CA bundle that signs the target Vault's TLS cert. Defaults to the site root / `VAULT_CACERT`. |
 

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -117,6 +117,7 @@ applicable.
 | `tracing` | `TracingConfig` | *(default)* | `integrations` | OTLP trace export settings (see [TracingConfig](#tracingconfig)). |
 | `secrets` | `Option<SecretsConfig>` | — | `security` | Secrets backend configuration. When present, the credential reader chain and write target are operator-configured (see [SecretsConfig](#secretsconfig)). |
 | `dhcp_lease_expiry_handling` | `bool` | `false` | `networking` | Enables IP cleanup when a DHCP lease expires. |
+| `certificates` | `CertificatesConfig` | *(default)* | `security` | Certificate vending backend, selected independently of the credential store; the default shares the credential Vault (see [CertificatesConfig](#certificatesconfig)). |
 
 ---
 
@@ -651,6 +652,23 @@ events, so consumers handle them identically.
 |-------|------|---------|-------------|
 | `active` | `String` | **required** | The provider that wraps DEKs for new writes. |
 | `providers` | `HashMap<String, KmsProviderConfig>` | **required** | Named provider configurations. |
+
+### `CertificatesConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | `CertBackendKind` | `shared_vault` | Which backend issues certificates: `shared_vault` reuses the credential store's Vault client (one client, one token lease), `dedicated_vault` uses a separately-configured Vault. |
+| `dedicated_vault` | `Option<DedicatedVaultSettings>` | — | Connection settings for a dedicated certificate Vault (see [DedicatedVaultSettings](#dedicatedvaultsettings)). Required when `backend = "dedicated_vault"`, ignored otherwise. |
+
+### `DedicatedVaultSettings`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `address` | `String` | **required** | Vault address, e.g. `https://vault-certs.example:8200`. |
+| `pki_mount_location` | `String` | **required** | PKI secrets-engine mount path on the target Vault. |
+| `pki_role_name` | `String` | **required** | PKI role used to sign leaf certificates. |
+| `token` | `Option<String>` | — | Token for root-token auth; required only when the pod has no Kubernetes service-account token. |
+| `vault_cacert` | `Option<String>` | — | CA bundle that signs the target Vault's TLS cert. Defaults to the site root / `VAULT_CACERT`. |
 
 ### `RackValidationConfig`
 

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3143,88 +3143,145 @@ mod tests {
 
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/cfg/test_data");
 
+    /// Exercises the real `[certificates]` / `[certificates.dedicated_vault]`
+    /// TOML contract through Figment (the production config path), rather than
+    /// JSON serde. Each case parses a TOML fragment into `CertificatesConfig`
+    /// and asserts either the parse outcome or the `to_certificate_config`
+    /// mapping/error.
     #[test]
-    fn certificates_absent_defaults_to_shared_vault() {
-        let cfg: CertificatesConfig = serde_json::from_str("{}").unwrap();
-        assert_eq!(cfg.backend, CertBackendKind::SharedVault);
-        let runtime = cfg.to_certificate_config().unwrap();
-        assert!(matches!(
-            runtime.backend,
-            carbide_secrets::CertBackend::SharedVault
-        ));
-    }
+    fn certificates_toml_config_contract() {
+        use carbide_secrets::CertBackend;
 
-    #[test]
-    fn certificates_explicit_shared_vault() {
-        let cfg: CertificatesConfig =
-            serde_json::from_str(r#"{"backend":"shared_vault"}"#).unwrap();
-        assert!(matches!(
-            cfg.to_certificate_config().unwrap().backend,
-            carbide_secrets::CertBackend::SharedVault
-        ));
-    }
-
-    #[test]
-    fn certificates_dedicated_vault_maps_all_fields() {
-        let cfg: CertificatesConfig = serde_json::from_str(
-            r#"{
-                "backend": "dedicated_vault",
-                "dedicated_vault": {
-                    "address": "https://vault-certs.example:8200",
-                    "pki_mount_location": "pki",
-                    "pki_role_name": "machine",
-                    "token": "s.abc123"
-                }
-            }"#,
-        )
-        .unwrap();
-
-        match cfg.to_certificate_config().unwrap().backend {
-            carbide_secrets::CertBackend::DedicatedVault(dedicated) => {
-                assert_eq!(dedicated.address, "https://vault-certs.example:8200");
-                assert_eq!(dedicated.pki_mount_location, "pki");
-                assert_eq!(dedicated.pki_role_name, "machine");
-                assert_eq!(dedicated.token.as_deref(), Some("s.abc123"));
-                assert!(dedicated.vault_cacert.is_none());
-            }
-            other => panic!("expected dedicated vault backend, got {other:?}"),
+        enum Expect {
+            /// Figment/serde extraction fails (missing required field, unknown key).
+            ParseErr,
+            /// Extraction succeeds but `to_certificate_config` rejects it.
+            ConvertErr,
+            Shared,
+            Dedicated {
+                address: &'static str,
+                pki_mount_location: &'static str,
+                pki_role_name: &'static str,
+                token: Option<&'static str>,
+                vault_cacert: Option<&'static str>,
+            },
         }
-    }
 
-    #[test]
-    fn certificates_dedicated_vault_without_section_fails_fast() {
-        // backend selected but no settings -> must error rather than fall back
-        // to the credential Vault.
-        let cfg: CertificatesConfig =
-            serde_json::from_str(r#"{"backend":"dedicated_vault"}"#).unwrap();
-        let err = cfg.to_certificate_config().unwrap_err();
-        assert!(
-            err.to_string().contains("dedicated_vault"),
-            "unexpected error: {err}"
-        );
-    }
+        // The fragments extract into `CertificatesConfig` directly, so the root
+        // fields (`backend`, `[dedicated_vault]`) are the same ones that live
+        // under the `[certificates]` / `[certificates.dedicated_vault]` tables.
+        let cases: &[(&str, &str, Expect)] = &[
+            (
+                "absent section defaults to shared_vault",
+                "",
+                Expect::Shared,
+            ),
+            (
+                "explicit shared_vault",
+                r#"backend = "shared_vault""#,
+                Expect::Shared,
+            ),
+            (
+                "dedicated_vault maps all fields",
+                r#"
+                    backend = "dedicated_vault"
+                    [dedicated_vault]
+                    address = "https://vault-certs.example:8200"
+                    pki_mount_location = "pki"
+                    pki_role_name = "machine"
+                    token = "s.abc123"
+                    vault_cacert = "/etc/ssl/certs/vault-ca.pem"
+                "#,
+                Expect::Dedicated {
+                    address: "https://vault-certs.example:8200",
+                    pki_mount_location: "pki",
+                    pki_role_name: "machine",
+                    token: Some("s.abc123"),
+                    vault_cacert: Some("/etc/ssl/certs/vault-ca.pem"),
+                },
+            ),
+            (
+                "dedicated_vault selected without its section fails conversion",
+                r#"backend = "dedicated_vault""#,
+                Expect::ConvertErr,
+            ),
+            (
+                "dedicated_vault missing required address fails parse",
+                r#"
+                    backend = "dedicated_vault"
+                    [dedicated_vault]
+                    pki_mount_location = "pki"
+                    pki_role_name = "machine"
+                "#,
+                Expect::ParseErr,
+            ),
+            (
+                "unknown field rejected by deny_unknown_fields",
+                "backend = \"shared_vault\"\ntypo = true",
+                Expect::ParseErr,
+            ),
+        ];
 
-    #[test]
-    fn certificates_dedicated_vault_missing_required_field_fails_parse() {
-        // `address` is required; omitting it must fail at parse time, not vend
-        // certs from a half-specified Vault.
-        let result: Result<CertificatesConfig, _> = serde_json::from_str(
-            r#"{
-                "backend": "dedicated_vault",
-                "dedicated_vault": {
-                    "pki_mount_location": "pki",
-                    "pki_role_name": "machine"
+        for (name, toml, expect) in cases {
+            let parsed: Result<CertificatesConfig, _> =
+                Figment::new().merge(Toml::string(toml)).extract();
+
+            match expect {
+                Expect::ParseErr => {
+                    assert!(parsed.is_err(), "{name}: expected a parse error");
                 }
-            }"#,
-        );
-        assert!(result.is_err(), "expected parse error for missing address");
-    }
-
-    #[test]
-    fn certificates_unknown_field_rejected() {
-        let result: Result<CertificatesConfig, _> =
-            serde_json::from_str(r#"{"backend":"shared_vault","typo":true}"#);
-        assert!(result.is_err(), "deny_unknown_fields should reject typos");
+                Expect::ConvertErr => {
+                    let cfg = parsed
+                        .unwrap_or_else(|e| panic!("{name}: expected parse to succeed, got {e}"));
+                    let err = match cfg.to_certificate_config() {
+                        Ok(_) => panic!("{name}: expected conversion to fail"),
+                        Err(err) => err,
+                    };
+                    assert!(
+                        err.to_string().contains("dedicated_vault"),
+                        "{name}: unexpected error: {err}"
+                    );
+                }
+                Expect::Shared => {
+                    let cfg = parsed
+                        .unwrap_or_else(|e| panic!("{name}: expected parse to succeed, got {e}"));
+                    assert!(
+                        matches!(
+                            cfg.to_certificate_config().unwrap().backend,
+                            CertBackend::SharedVault
+                        ),
+                        "{name}: expected SharedVault backend"
+                    );
+                }
+                Expect::Dedicated {
+                    address,
+                    pki_mount_location,
+                    pki_role_name,
+                    token,
+                    vault_cacert,
+                } => {
+                    let cfg = parsed
+                        .unwrap_or_else(|e| panic!("{name}: expected parse to succeed, got {e}"));
+                    match cfg.to_certificate_config().unwrap().backend {
+                        CertBackend::DedicatedVault(d) => {
+                            assert_eq!(d.address, *address, "{name}: address");
+                            assert_eq!(
+                                d.pki_mount_location, *pki_mount_location,
+                                "{name}: pki_mount_location"
+                            );
+                            assert_eq!(d.pki_role_name, *pki_role_name, "{name}: pki_role_name");
+                            assert_eq!(d.token.as_deref(), *token, "{name}: token");
+                            assert_eq!(
+                                d.vault_cacert.as_deref(),
+                                *vault_cacert,
+                                "{name}: vault_cacert"
+                            );
+                        }
+                        other => panic!("{name}: expected dedicated vault backend, got {other:?}"),
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -4178,6 +4178,17 @@ mod tests {
         assert_eq!(nvl36.rack_capabilities.compute.count, 9);
         assert_eq!(nvl36.rack_capabilities.switch.count, 9);
         assert_eq!(nvl36.rack_capabilities.power_shelf.count, 2);
+
+        assert_eq!(config.certificates.backend, CertBackendKind::DedicatedVault);
+        let dedicated = config.certificates.dedicated_vault.as_ref().unwrap();
+        assert_eq!(dedicated.address, "https://vault-certs.example:8200");
+        assert_eq!(dedicated.pki_mount_location, "pki-machine");
+        assert_eq!(dedicated.pki_role_name, "machine");
+        assert_eq!(dedicated.token.as_deref(), Some("s.fulltest"));
+        assert_eq!(
+            dedicated.vault_cacert.as_deref(),
+            Some("/path/to/vault-ca.pem")
+        );
     }
 
     #[test]

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -775,6 +775,110 @@ pub struct CarbideConfig {
     /// IP cleanup on lease expiry
     #[serde(default)]
     pub dhcp_lease_expiry_handling: bool,
+
+    /// Certificate vending backend. Selected independently of the credential
+    /// store; absent means certs are issued from the credential Vault.
+    #[serde(default)]
+    pub certificates: CertificatesConfig,
+}
+
+/// `[certificates]` config section: selects the backend that vends machine and
+/// service certificates, independently of where credentials are stored.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CertificatesConfig {
+    /// Which backend issues certificates. Defaults to sharing the credential
+    /// Vault client (historical behavior).
+    #[serde(default)]
+    pub backend: CertBackendKind,
+
+    /// Connection settings for a dedicated certificate Vault. Required when
+    /// `backend = "dedicated_vault"`, ignored otherwise.
+    #[serde(default)]
+    pub dedicated_vault: Option<DedicatedVaultSettings>,
+}
+
+/// Tag selecting the certificate backend. The matching settings (if any) live
+/// in their own sub-table, so the choice is explicit rather than inferred.
+// The shared `Vault` suffix is intentional: both current backends are Vault
+// backends. The lint resolves once a non-Vault backend is added.
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CertBackendKind {
+    /// Reuse the credential store's Vault client — one client, one token lease.
+    #[default]
+    SharedVault,
+    /// Use a dedicated Vault configured under `[certificates.dedicated_vault]`.
+    DedicatedVault,
+}
+
+/// `[certificates.dedicated_vault]` settings.
+///
+/// The connection-identifying fields are required, so a partial section fails
+/// to parse rather than silently inheriting the credential Vault's process-wide
+/// `VAULT_*` environment configuration.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DedicatedVaultSettings {
+    /// Vault address, e.g. `https://vault-certs.example:8200`.
+    pub address: String,
+    /// PKI secrets-engine mount path on the target Vault.
+    pub pki_mount_location: String,
+    /// PKI role used to sign leaf certificates.
+    pub pki_role_name: String,
+    /// Token for root-token auth; required only when the pod has no Kubernetes
+    /// service-account token.
+    #[serde(default)]
+    pub token: Option<String>,
+    /// CA bundle that signs the target Vault's TLS cert. Defaults to the site
+    /// root / `VAULT_CACERT`.
+    #[serde(default)]
+    pub vault_cacert: Option<String>,
+}
+
+// Hand-rolled so the root `token` is never printed verbatim in logs or errors;
+// only its presence is shown. Serialization is handled separately by
+// `CarbideConfig::redacted()`, which clears the token before the config is
+// serialized for the admin API or config-dump paths.
+impl std::fmt::Debug for DedicatedVaultSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DedicatedVaultSettings")
+            .field("address", &self.address)
+            .field("pki_mount_location", &self.pki_mount_location)
+            .field("pki_role_name", &self.pki_role_name)
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .field("vault_cacert", &self.vault_cacert)
+            .finish()
+    }
+}
+
+impl CertificatesConfig {
+    /// Convert the parsed section into the runtime certificate config, failing
+    /// fast if a dedicated backend was selected without its settings.
+    pub fn to_certificate_config(&self) -> eyre::Result<carbide_secrets::CertificateConfig> {
+        let backend = match self.backend {
+            CertBackendKind::SharedVault => carbide_secrets::CertBackend::SharedVault,
+            CertBackendKind::DedicatedVault => {
+                let dedicated = self.dedicated_vault.as_ref().ok_or_else(|| {
+                    eyre::eyre!(
+                        "[certificates] backend = \"dedicated_vault\" requires a \
+                         [certificates.dedicated_vault] section"
+                    )
+                })?;
+                carbide_secrets::CertBackend::DedicatedVault(
+                    carbide_secrets::DedicatedVaultConfig {
+                        address: dedicated.address.clone(),
+                        pki_mount_location: dedicated.pki_mount_location.clone(),
+                        pki_role_name: dedicated.pki_role_name.clone(),
+                        token: dedicated.token.clone(),
+                        vault_cacert: dedicated.vault_cacert.clone(),
+                    },
+                )
+            }
+        };
+        Ok(carbide_secrets::CertificateConfig { backend })
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1707,6 +1811,14 @@ impl CarbideConfig {
         if let Some(host_index) = config.database_url.find('@') {
             let host = config.database_url.split_at(host_index).1;
             config.database_url = format!("postgres://redacted{host}");
+        }
+        // The dedicated certificate Vault's root token is a secret; the
+        // redacted config is serialized to JSON for the admin API and config
+        // dumps, so drop it before it leaves the process.
+        if let Some(dedicated) = config.certificates.dedicated_vault.as_mut()
+            && dedicated.token.is_some()
+        {
+            dedicated.token = Some("redacted".to_string());
         }
         config
     }
@@ -3032,6 +3144,90 @@ mod tests {
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/cfg/test_data");
 
     #[test]
+    fn certificates_absent_defaults_to_shared_vault() {
+        let cfg: CertificatesConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.backend, CertBackendKind::SharedVault);
+        let runtime = cfg.to_certificate_config().unwrap();
+        assert!(matches!(
+            runtime.backend,
+            carbide_secrets::CertBackend::SharedVault
+        ));
+    }
+
+    #[test]
+    fn certificates_explicit_shared_vault() {
+        let cfg: CertificatesConfig =
+            serde_json::from_str(r#"{"backend":"shared_vault"}"#).unwrap();
+        assert!(matches!(
+            cfg.to_certificate_config().unwrap().backend,
+            carbide_secrets::CertBackend::SharedVault
+        ));
+    }
+
+    #[test]
+    fn certificates_dedicated_vault_maps_all_fields() {
+        let cfg: CertificatesConfig = serde_json::from_str(
+            r#"{
+                "backend": "dedicated_vault",
+                "dedicated_vault": {
+                    "address": "https://vault-certs.example:8200",
+                    "pki_mount_location": "pki",
+                    "pki_role_name": "machine",
+                    "token": "s.abc123"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        match cfg.to_certificate_config().unwrap().backend {
+            carbide_secrets::CertBackend::DedicatedVault(dedicated) => {
+                assert_eq!(dedicated.address, "https://vault-certs.example:8200");
+                assert_eq!(dedicated.pki_mount_location, "pki");
+                assert_eq!(dedicated.pki_role_name, "machine");
+                assert_eq!(dedicated.token.as_deref(), Some("s.abc123"));
+                assert!(dedicated.vault_cacert.is_none());
+            }
+            other => panic!("expected dedicated vault backend, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn certificates_dedicated_vault_without_section_fails_fast() {
+        // backend selected but no settings -> must error rather than fall back
+        // to the credential Vault.
+        let cfg: CertificatesConfig =
+            serde_json::from_str(r#"{"backend":"dedicated_vault"}"#).unwrap();
+        let err = cfg.to_certificate_config().unwrap_err();
+        assert!(
+            err.to_string().contains("dedicated_vault"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn certificates_dedicated_vault_missing_required_field_fails_parse() {
+        // `address` is required; omitting it must fail at parse time, not vend
+        // certs from a half-specified Vault.
+        let result: Result<CertificatesConfig, _> = serde_json::from_str(
+            r#"{
+                "backend": "dedicated_vault",
+                "dedicated_vault": {
+                    "pki_mount_location": "pki",
+                    "pki_role_name": "machine"
+                }
+            }"#,
+        );
+        assert!(result.is_err(), "expected parse error for missing address");
+    }
+
+    #[test]
+    fn certificates_unknown_field_rejected() {
+        let result: Result<CertificatesConfig, _> =
+            serde_json::from_str(r#"{"backend":"shared_vault","typo":true}"#);
+        assert!(result.is_err(), "deny_unknown_fields should reject typos");
+    }
+
+    #[test]
     fn deserialize_serialize_machine_controller_config() {
         let input = MachineStateControllerConfig {
             controller: StateControllerConfig {
@@ -3299,6 +3495,24 @@ mod tests {
         config.database_url = "postgres://forge-system.carbide:very-very-long-password@forge-pg-cluster.postgres.svc.cluster.local:5432/forge_system_carbide".to_string();
         let redacted = config.redacted();
         assert_eq!(redacted.database_url, "postgres://redacted@forge-pg-cluster.postgres.svc.cluster.local:5432/forge_system_carbide".to_string());
+
+        // The dedicated certificate Vault's root token must not survive redaction.
+        config.certificates.dedicated_vault = Some(DedicatedVaultSettings {
+            address: "https://vault-certs.example:8200".to_string(),
+            pki_mount_location: "pki".to_string(),
+            pki_role_name: "leaf".to_string(),
+            token: Some("s.super-secret-root-token".to_string()),
+            vault_cacert: None,
+        });
+        let redacted = config.redacted();
+        assert_eq!(
+            redacted
+                .certificates
+                .dedicated_vault
+                .as_ref()
+                .and_then(|d| d.token.as_deref()),
+            Some("redacted")
+        );
     }
 
     #[test]

--- a/crates/api-core/src/cfg/test_data/full_config.toml
+++ b/crates/api-core/src/cfg/test_data/full_config.toml
@@ -253,3 +253,13 @@ description = "this is yet another test profile"
 [mlx-config-profiles.test-profile2.config]
 SRIOV_EN = false
 NUM_OF_VFS = 16
+
+[certificates]
+backend = "dedicated_vault"
+
+[certificates.dedicated_vault]
+address = "https://vault-certs.example:8200"
+pki_mount_location = "pki-machine"
+pki_role_name = "machine"
+token = "s.fulltest"
+vault_cacert = "/path/to/vault-ca.pem"

--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -23,8 +23,8 @@ use carbide_kms_provider::{
 };
 use carbide_secrets::credentials::{CredentialManager, CredentialReader, CredentialWriter};
 use carbide_secrets::{
-    CredentialConfig, ForgeVaultClient, MemoryCredentialStore, VaultConfig,
-    create_credential_manager_from, create_vault_client,
+    CredentialConfig, ForgeVaultClient, MemoryCredentialStore, SpiffeIdentity, VaultConfig,
+    create_certificate_provider, create_credential_manager_from, create_vault_client,
 };
 use carbide_utils::HostPortPair;
 use eyre::WrapErr;
@@ -213,10 +213,25 @@ pub async fn run(
 
     let vault_config = vault_config_for_site(&credential_config.vault, &carbide_config);
 
-    // One vault client serves every vault role below. PKI certificates stay
-    // on vault no matter which credential backend is configured.
+    // One vault client serves every credential vault role below.
     let vault_client = create_vault_client(&vault_config, metrics.meter.clone())?;
-    let certificate_provider = vault_client.clone();
+
+    // Certificate vending is selected independently of the credential store.
+    // SharedVault (the default) reuses `vault_client` (no second client or token
+    // lease); a dedicated cert Vault decouples PKI issuance from credentials and
+    // is fully explicit, never inheriting the credential Vault's env config. The
+    // SPIFFE identity comes from the site-resolved credential Vault config so all
+    // backends mint under the same identity namespace.
+    let cert_config = carbide_config.certificates.to_certificate_config()?;
+    let certificate_provider = create_certificate_provider(
+        &cert_config,
+        &vault_client,
+        SpiffeIdentity {
+            trust_domain: vault_config.spiffe_trust_domain(),
+            machine_base_path: vault_config.spiffe_machine_base_path(),
+        },
+        metrics.meter.clone(),
+    )?;
 
     let db_pool = setup::create_and_connect_postgres_pool(&carbide_config).await?;
 

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -290,6 +290,7 @@ pub fn get() -> CarbideConfig {
         ntp_servers: vec![],
         secrets: None,
         dhcp_lease_expiry_handling: false,
+        certificates: Default::default(),
     }
 }
 

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -1098,20 +1098,7 @@ pub fn create_vault_client(
         ForgeVaultAuthenticationType::Root(vault_config.token()?)
     };
 
-    // The attempted / succeeded / failed counters and the request-duration
-    // histogram are now `carbide-instrument` events (the `VaultRequest*` types);
-    // only the token-refresh state gauge stays a hand-rolled instrument.
-    let vault_token_time_remaining_until_refresh_gauge = meter
-        .f64_gauge("carbide-api.vault.token_time_until_refresh")
-        .with_description(
-            "The amount of time, in seconds, until the Vault token is required to be refreshed",
-        )
-        .with_unit("s")
-        .build();
-
-    let forge_vault_metrics = ForgeVaultMetrics {
-        vault_token_gauge: vault_token_time_remaining_until_refresh_gauge,
-    };
+    let forge_vault_metrics = build_vault_metrics(&meter);
 
     let vault_client_config = ForgeVaultClientConfig {
         auth_type,
@@ -1126,6 +1113,140 @@ pub fn create_vault_client(
 
     let forge_vault_client = ForgeVaultClient::new(vault_client_config, forge_vault_metrics);
     Ok(Arc::new(forge_vault_client))
+}
+
+/// Build the hand-rolled Vault instruments shared by every Vault client. The
+/// attempted / succeeded / failed counters and the request-duration histogram
+/// are now `carbide-instrument` events (the `VaultRequest*` types); only the
+/// token-refresh state gauge stays a hand-rolled instrument.
+fn build_vault_metrics(meter: &Meter) -> ForgeVaultMetrics {
+    let vault_token_time_remaining_until_refresh_gauge = meter
+        .f64_gauge("carbide-api.vault.token_time_until_refresh")
+        .with_description(
+            "The amount of time, in seconds, until the Vault token is required to be refreshed",
+        )
+        .with_unit("s")
+        .build();
+
+    ForgeVaultMetrics {
+        vault_token_gauge: vault_token_time_remaining_until_refresh_gauge,
+    }
+}
+
+/// Site-wide SPIFFE identity namespace used when minting machine certificates.
+///
+/// Certificates are issued under the same identity namespace regardless of
+/// which Vault signs them, so this is resolved once from the site's
+/// `[auth.trust]` config and shared across cert backends.
+#[derive(Debug, Clone)]
+pub struct SpiffeIdentity {
+    pub trust_domain: String,
+    pub machine_base_path: String,
+}
+
+/// Connection settings for a Vault used *only* to vend certificates, kept
+/// separate from the credential store's Vault.
+///
+/// The connection-identifying fields are required (non-optional), so a value
+/// of this type cannot be constructed without naming the target Vault, its PKI
+/// mount, and its role. None of these fields fall back to the process-global
+/// `VAULT_*` environment variables — that fallback is exactly what would
+/// silently re-point a half-configured cert Vault back at the credential Vault.
+#[derive(Clone)]
+pub struct DedicatedVaultConfig {
+    /// Vault address, e.g. `https://vault.example:8200`. Required.
+    pub address: String,
+    /// PKI secrets-engine mount path on the target Vault. Required.
+    pub pki_mount_location: String,
+    /// PKI role used to sign leaf certificates. Required.
+    pub pki_role_name: String,
+    /// Token for root-token auth. Required only when the pod has no Kubernetes
+    /// service-account token (the preferred auth path); ignored when SA auth
+    /// is available.
+    pub token: Option<String>,
+    /// Path to the CA bundle that signs the target Vault's TLS certificate.
+    /// Defaults to the standard site root (`/var/run/secrets/forge-roots/ca.crt`,
+    /// or `VAULT_CACERT`) — this is TLS trust material, not a Vault selector.
+    pub vault_cacert: Option<String>,
+}
+
+// Hand-rolled so the root `token` is never printed verbatim in logs or errors;
+// only its presence is shown.
+impl std::fmt::Debug for DedicatedVaultConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DedicatedVaultConfig")
+            .field("address", &self.address)
+            .field("pki_mount_location", &self.pki_mount_location)
+            .field("pki_role_name", &self.pki_role_name)
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .field("vault_cacert", &self.vault_cacert)
+            .finish()
+    }
+}
+
+/// Build a Vault client dedicated to certificate vending from fully explicit
+/// settings, with NO environment-variable fallback for the connection fields.
+/// A missing required setting fails here, at startup, rather than silently
+/// inheriting the credential Vault's configuration.
+pub fn create_dedicated_vault_client(
+    config: &DedicatedVaultConfig,
+    spiffe: SpiffeIdentity,
+    meter: Meter,
+) -> eyre::Result<Arc<ForgeVaultClient>> {
+    // Required fields are non-`Option`, but an empty string would still slip
+    // through serde and build a client that fails confusingly on first use.
+    for (field, value) in [
+        ("address", &config.address),
+        ("pki_mount_location", &config.pki_mount_location),
+        ("pki_role_name", &config.pki_role_name),
+    ] {
+        if value.trim().is_empty() {
+            return Err(eyre!(
+                "dedicated certificate Vault requires a non-empty `{field}`"
+            ));
+        }
+    }
+
+    let configured_ca_path = config
+        .vault_cacert
+        .clone()
+        .unwrap_or_else(|| DEFAULT_VAULT_CA_PATH.to_string());
+    let vault_root_ca_path = resolve_vault_root_ca_path(configured_ca_path.as_str())?;
+
+    let service_account_token_path =
+        Path::new("/var/run/secrets/kubernetes.io/serviceaccount/token");
+    let auth_type = if service_account_token_path.exists() {
+        ForgeVaultAuthenticationType::ServiceAccount(service_account_token_path.to_owned())
+    } else {
+        let token = config
+            .token
+            .as_ref()
+            .filter(|token| !token.trim().is_empty())
+            .cloned()
+            .ok_or_else(|| {
+                eyre!(
+                    "dedicated certificate Vault requires a non-empty explicit `token` when no Kubernetes service-account token is present"
+                )
+            })?;
+        ForgeVaultAuthenticationType::Root(token)
+    };
+
+    let vault_client_config = ForgeVaultClientConfig {
+        auth_type,
+        vault_address: config.address.clone(),
+        // Certificate vending never touches the KV engine.
+        kv_mount_location: String::new(),
+        pki_mount_location: config.pki_mount_location.clone(),
+        pki_role_name: config.pki_role_name.clone(),
+        spiffe_trust_domain: spiffe.trust_domain,
+        spiffe_machine_base_path: spiffe.machine_base_path,
+        vault_root_ca_path,
+    };
+
+    Ok(Arc::new(ForgeVaultClient::new(
+        vault_client_config,
+        build_vault_metrics(&meter),
+    )))
 }
 
 /// Build raw vaultrs client settings for a separate vault consumer (the
@@ -1163,7 +1284,48 @@ mod tests {
     use base64::Engine;
     use serde_json::json;
 
-    use super::{machine_spiffe_uri, service_account_role_name_from_jwt};
+    use super::{
+        DedicatedVaultConfig, SpiffeIdentity, create_dedicated_vault_client, machine_spiffe_uri,
+        service_account_role_name_from_jwt,
+    };
+
+    fn dedicated_config() -> DedicatedVaultConfig {
+        DedicatedVaultConfig {
+            address: "https://vault-certs.example:8200".to_string(),
+            pki_mount_location: "pki".to_string(),
+            pki_role_name: "machine".to_string(),
+            token: None,
+            vault_cacert: None,
+        }
+    }
+
+    fn test_spiffe() -> SpiffeIdentity {
+        SpiffeIdentity {
+            trust_domain: "nico.local".to_string(),
+            machine_base_path: "/forge-system/machine/".to_string(),
+        }
+    }
+
+    #[test]
+    fn dedicated_vault_rejects_empty_required_fields() {
+        let meter = opentelemetry::global::meter("test");
+        for mutate in [
+            |c: &mut DedicatedVaultConfig| c.address = "  ".to_string(),
+            |c: &mut DedicatedVaultConfig| c.pki_mount_location = String::new(),
+            |c: &mut DedicatedVaultConfig| c.pki_role_name = String::new(),
+        ] {
+            let mut config = dedicated_config();
+            mutate(&mut config);
+            let err = match create_dedicated_vault_client(&config, test_spiffe(), meter.clone()) {
+                Ok(_) => panic!("empty required field must be rejected"),
+                Err(err) => err,
+            };
+            assert!(
+                err.to_string().contains("non-empty"),
+                "unexpected error: {err}"
+            );
+        }
+    }
 
     #[test]
     fn machine_spiffe_uri_uses_trust_domain_and_base_path() {

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -1202,7 +1202,7 @@ pub fn create_dedicated_vault_client(
     ] {
         if value.trim().is_empty() {
             return Err(eyre!(
-                "dedicated certificate Vault requires a non-empty `{field}`"
+                "dedicated certificate vault requires a non-empty `{field}`"
             ));
         }
     }
@@ -1225,7 +1225,7 @@ pub fn create_dedicated_vault_client(
             .cloned()
             .ok_or_else(|| {
                 eyre!(
-                    "dedicated certificate Vault requires a non-empty explicit `token` when no Kubernetes service-account token is present"
+                    "dedicated certificate vault requires a non-empty explicit `token` when no kubernetes service-account token is present"
                 )
             })?;
         ForgeVaultAuthenticationType::Root(token)

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -25,7 +25,8 @@ pub use crate::chained_reader::ChainedCredentialReader;
 /// via `create_raw_vault_client_settings`. Credential operations should go
 /// through `create_credential_manager` instead of using the vault client directly.
 pub use crate::forge_vault::{
-    ForgeVaultClient, VaultConfig, create_raw_vault_client_settings, create_vault_client,
+    DedicatedVaultConfig, ForgeVaultClient, SpiffeIdentity, VaultConfig,
+    create_dedicated_vault_client, create_raw_vault_client_settings, create_vault_client,
 };
 pub use crate::local_credentials::{
     CredentialSnapshot, EnvCredentialsConfig, FileCredentialsConfig, MachineIdentityConfig,
@@ -49,11 +50,73 @@ use credentials::{
 use local_credentials::{EnvCredentials, FileCredentialsWatcher};
 pub use memory_credentials::MemoryCredentialStore;
 
+use crate::certificates::CertificateProvider;
+
 #[derive(Default, Debug, Clone)]
 pub struct CredentialConfig {
     pub vault: VaultConfig,
     pub env: EnvCredentialsConfig,
     pub file: FileCredentialsConfig,
+}
+
+/// Selects and configures the backend that vends machine/service certificates.
+///
+/// Certificate vending is independent of the credential store: this lets the
+/// API issue PKI certificates from a different Vault than the one backing
+/// credentials — or, in future, from a non-Vault CA — without disturbing
+/// credential storage.
+#[derive(Default, Debug, Clone)]
+pub struct CertificateConfig {
+    pub backend: CertBackend,
+}
+
+/// Backend used to issue certificates.
+///
+/// Today both variants are Vault-backed. The enum exists so additional backends
+/// (e.g. an in-process CA whose key lives in a Kubernetes Secret) can be added
+/// without touching the call sites that consume [`CertificateProvider`].
+// The shared `Vault` suffix is intentional: both current variants are Vault
+// backends, distinguished by whether the client is shared with the credential
+// store. The lint resolves once a non-Vault backend is added.
+#[allow(clippy::enum_variant_names)]
+#[derive(Default, Debug, Clone)]
+pub enum CertBackend {
+    /// Reuse the credential store's Vault client — one client, one token lease.
+    /// This is the default and matches historical behavior.
+    #[default]
+    SharedVault,
+    /// Issue certificates from a dedicated Vault, decoupled from the credential
+    /// store. [`DedicatedVaultConfig`] is fully explicit: its connection fields
+    /// never fall back to the process-global `VAULT_*` env vars, so a partial
+    /// config fails fast instead of silently re-pointing at the credential
+    /// Vault.
+    DedicatedVault(DedicatedVaultConfig),
+}
+
+/// Builds the certificate provider selected by `config`.
+///
+/// `shared_vault` is the already-constructed credential Vault client, reused
+/// for [`CertBackend::SharedVault`] so no second client or token lease is
+/// created in the common case. `spiffe` is the site's SPIFFE identity; a
+/// dedicated Vault issues certs under the same identity namespace as the rest
+/// of the deployment.
+pub fn create_certificate_provider(
+    config: &CertificateConfig,
+    shared_vault: &Arc<ForgeVaultClient>,
+    spiffe: SpiffeIdentity,
+    meter: Meter,
+) -> eyre::Result<Arc<dyn CertificateProvider>> {
+    match &config.backend {
+        CertBackend::SharedVault => {
+            let provider: Arc<dyn CertificateProvider> = shared_vault.clone();
+            Ok(provider)
+        }
+        CertBackend::DedicatedVault(dedicated) => {
+            let provider: Arc<dyn CertificateProvider> =
+                create_dedicated_vault_client(dedicated, spiffe, meter)?;
+            Ok(provider)
+        }
+    }
 }
 
 /// create_credential_manager builds the default credential chain: env -> file -> vault.


### PR DESCRIPTION
Make certificate vending a selectable, config-driven backend instead of hardcoding it to the credential store's Vault client. This decouples PKI issuance from credential storage and lays the seam for future non-Vault (e.g. k8s/local-CA) backends.

- Introduce CertBackend { SharedVault | DedicatedVault } + factory create_certificate_provider. SharedVault (the default) reuses the credential Vault client, so existing deployments are unchanged.
- DedicatedVault requires address / pki_mount_location / pki_role_name, no env fallback, and an empty-string guard, so a partial config fails fast at startup instead of silently re-pointing at the credential Vault.
- Add a [certificates] TOML section on CarbideConfig with a validating conversion; selecting dedicated_vault without its settings will error.
- Resolve SPIFFE identity once from the site config and share it across backends so certs mint under the same identity namespace.

Tests: config parse/convert (shared, dedicated, missing-section, missing-field, unknown-field) and empty-required-field rejection.

## Related issues
#2880 

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

