### PR TITLE
chore: bump libredfish to v0.44.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6561,7 +6561,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.15#539221bcc0b16603e16bc2ee3d9632ce8576e330"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.16#211f6e8dcdf4fa59500e3308246a6bc21a24276e"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.15" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.16" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-rc1" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
chore: bump libredfish to v0.44.16

```
fix(dell): resolve boot NIC by interface id on the BIOS verify path by @chet in https://github.com/NVIDIA/libredfish/pull/96

feat: gracefully handle PATCH-ing settings on Dells that do not create a config job by @spydaNVIDIA in https://github.com/NVIDIA/libredfish/pull/97
```

## Related issues

https://github.com/NVIDIA/infra-controller/issues/2506

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

