### PR TITLE
fix(rest-api): Add soft-deletion tag for DPU Extension Service deleted timestamp

### DIFF
--- a/rest-api/db/pkg/db/model/dpuextensionservice.go
+++ b/rest-api/db/pkg/db/model/dpuextensionservice.go
@@ -153,7 +153,7 @@ type DpuExtensionService struct {
 	IsMissingOnSite bool                            `bun:"is_missing_on_site,notnull,default:false"`
 	Created         time.Time                       `bun:"created,nullzero,notnull,default:current_timestamp"`
 	Updated         time.Time                       `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	Deleted         time.Time                       `bun:"deleted,nullzero,default:null"`
+	Deleted         *time.Time                      `bun:"deleted,soft_delete"`
 	CreatedBy       uuid.UUID                       `bun:"created_by,type:uuid,notnull"`
 }
 

--- a/rest-api/db/pkg/db/model/dpuextensionservice_test.go
+++ b/rest-api/db/pkg/db/model/dpuextensionservice_test.go
@@ -906,7 +906,7 @@ func TestDpuExtensionServiceSQLDAO_Delete(t *testing.T) {
 		{
 			desc:               "can delete existing object success",
 			desID:              dessExp[1].ID,
-			checkSoftDelete:    false,
+			checkSoftDelete:    true,
 			wantErr:            false,
 			verifyChildSpanner: true,
 		},

--- a/rest-api/db/pkg/db/model/dpuextensionservice_test.go
+++ b/rest-api/db/pkg/db/model/dpuextensionservice_test.go
@@ -899,12 +899,14 @@ func TestDpuExtensionServiceSQLDAO_Delete(t *testing.T) {
 	tests := []struct {
 		desc               string
 		desID              uuid.UUID
+		checkSoftDelete    bool
 		wantErr            bool
 		verifyChildSpanner bool
 	}{
 		{
 			desc:               "can delete existing object success",
 			desID:              dessExp[1].ID,
+			checkSoftDelete:    false,
 			wantErr:            false,
 			verifyChildSpanner: true,
 		},
@@ -927,6 +929,12 @@ func TestDpuExtensionServiceSQLDAO_Delete(t *testing.T) {
 
 			err = dbSession.DB.NewSelect().Model(&res).Where("des.id = ?", tc.desID).Scan(ctx)
 			assert.ErrorIs(t, err, sql.ErrNoRows)
+
+			if tc.checkSoftDelete {
+				err = dbSession.DB.NewSelect().Model(&res).Where("des.id = ?", tc.desID).WhereAllWithDeleted().Scan(ctx)
+				assert.NoError(t, err)
+				assert.NotNil(t, res.Deleted)
+			}
 
 			if tc.verifyChildSpanner {
 				span := otrace.SpanFromContext(ctx)


### PR DESCRIPTION
Currently DPU Extension Services are not getting deleted because the soft-deletion tag is incorrect. This PR fixes that.

## Related issues
Internal

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

