### PR TITLE
fix(health): avoid duplicate OTLP log records when diagnostics are enabled

### DIFF
--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -144,34 +144,17 @@ impl OtlpSink {
         })
     }
 
-    /// Enqueues a parent log and, when enabled, a bounded diagnostic log.
+    /// Enqueues the emitted log record using the parent event identity.
     fn enqueue_log_event(&self, context: &EventContext, record: &LogRecord) {
-        let parent_key = self
+        let key = self
             .mapper
             .queue_key(&context.endpoint_key, &record.attributes);
-        let parent_record = record.emitted_log_record(false).into_owned();
-        let parent_event = CollectorEvent::Log(Box::new(parent_record));
+        let record = record
+            .emitted_log_record(self.include_diagnostics)
+            .into_owned();
+        let event = CollectorEvent::Log(Box::new(record));
 
-        if self
-            .queue
-            .save_latest(parent_key, (context.clone(), parent_event))
-        {
-            self.replaced_total.inc();
-        }
-
-        if !self.include_diagnostics || record.diagnostic_record.is_none() {
-            return;
-        }
-
-        let diagnostic_record = record.emitted_log_record(true).into_owned();
-        // Follow the existing OTLP queue policy: diagnostics are latest-wins
-        // per endpoint while the drain is backed up.
-        let diagnostic_key = format!("{}|diagnostic", context.endpoint_key);
-        let diagnostic_event = CollectorEvent::Log(Box::new(diagnostic_record));
-        if self
-            .queue
-            .save_latest(diagnostic_key, (context.clone(), diagnostic_event))
-        {
+        if self.queue.save_latest(key, (context.clone(), event)) {
             self.replaced_total.inc();
         }
     }
@@ -532,7 +515,7 @@ mod tests {
         assert_eq!(sink.replaced_total.get() as u64, 0);
     }
 
-    /// Verifies parent logs keep mapper dedup while diagnostics stay bounded.
+    /// Verifies diagnostics are folded into the single latest parent log.
     #[test]
     fn diagnostic_log_record_uses_latest_wins_by_endpoint() {
         let sink = OtlpSink::new_for_bench_with_diagnostics(Arc::new(OpenBmcEventMapper), true);
@@ -568,22 +551,22 @@ mod tests {
             records.push(record);
         }
 
-        assert_eq!(records.len(), 2);
-        assert_eq!(records[0].body, "test");
+        assert_eq!(records.len(), 1);
 
         let diagnostic_body: serde_json::Value =
-            serde_json::from_str(&records[1].body).expect("valid diagnostic body");
+            serde_json::from_str(&records[0].body).expect("valid diagnostic body");
+        assert_eq!(diagnostic_body["message"].as_str(), Some("test"));
         assert_eq!(
             diagnostic_body["diagnostic_data"].as_str(),
             Some("payload-c")
         );
-        assert_eq!(sink.replaced_total.get() as u64, 4);
+        assert_eq!(sink.replaced_total.get() as u64, 2);
 
         assert!(
             records[0]
                 .attributes
                 .iter()
-                .all(|(key, _)| key.as_ref() != "redfish.diagnostic_data")
+                .any(|(key, _)| key.as_ref() == "redfish.parent.log_entry_id")
         );
     }
 


### PR DESCRIPTION
Update the health OTLP sink to emit exactly one OTLP log record per source log event.

When diagnostics are enabled, diagnostic payload and diagnostic attributes should be folded into the same emitted log record, matching the log-file sink behavior. The OTLP queue key should continue to use the parent log attributes so existing dedup/replacement semantics remain stable.

## Related issues
Closes #2893

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)