### PR TITLE
feat(bmc-mock): add Dell R760 BF4 hardware scaffolding

### DIFF
--- a/crates/bmc-mock/src/hw/bluefield4.rs
+++ b/crates/bmc-mock/src/hw/bluefield4.rs
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use mac_address::MacAddress;
+use rpc::machine_discovery::DiscoveryInfo;
+use serde_json::json;
+
+use crate::{Callbacks, LogService, LogServices, hw, redfish};
+
+pub struct Bluefield4<'a> {
+    pub product_serial_number: Cow<'a, str>,
+    pub host_mac_address: MacAddress,
+    pub bmc_mac_address: MacAddress,
+}
+
+impl Bluefield4<'_> {
+    fn sensor_layout() -> redfish::sensor::Layout {
+        // BF4 Card1 dump contains 96 sensors total. The generic mock
+        // layout currently models Temperature, Fan, Power, Current,
+        // and Voltage.  Missing BF4 ReadingType counts: Percent=64,
+        // Frequency=2, EnergyJoules=1.
+        redfish::sensor::Layout {
+            temperature: 5,
+            fan: 0,
+            power: 6,
+            current: 0,
+            voltage: 18,
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        redfish::chassis::ChassisConfig {
+            chassis: vec![
+                redfish::chassis::SingleChassisConfig {
+                    id: "Bluefield_BMC".into(),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some("Nvidia".into()),
+                    model: Some("B4240".into()),
+                    part_number: Some(self.part_number().into()),
+                    pcie_devices: Some(vec![]),
+                    sensors: Some(vec![]),
+                    serial_number: Some(self.product_serial_number.to_string().into()),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "Bluefield_BMC_ERoT".into(),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some(Cow::Borrowed("NVIDIA")),
+                    serial_number: Some("".into()),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "Bluefield_CPU_ERoT".into(),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some(Cow::Borrowed("NVIDIA")),
+                    serial_number: Some("".into()),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "Bluefield_NIC".into(),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some(Cow::Borrowed("NVIDIA")),
+                    serial_number: Some("".into()),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "Card1".into(),
+                    chassis_type: "Card".into(),
+                    pcie_devices: Some(vec![]),
+                    sensors: Some(redfish::sensor::generate_chassis_sensors(
+                        "Card1",
+                        Self::sensor_layout(),
+                    )),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "MCTP_SPI_DEV".into(),
+                    chassis_type: "".into(),
+                    pcie_devices: Some(vec![]),
+                    sensors: Some(vec![]),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+            ],
+        }
+    }
+
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+        let system_id = "Bluefield";
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed("Bluefield"),
+                manufacturer: None,
+                model: None,
+                eth_interfaces: Some(vec![]),
+                chassis: vec!["Bluefield_BMC".into()],
+                serial_number: None,
+                boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
+                callbacks: Some(callbacks),
+                boot_options: Some(vec![]),
+                bios_mode: redfish::computer_system::BiosMode::Generic,
+                oem: redfish::computer_system::Oem::NvidiaBluefield,
+                base_bios: Some(
+                    redfish::bios::builder(&redfish::bios::resource(system_id))
+                        .attributes(json!({}))
+                        .build(),
+                ),
+                log_services: Some(Arc::new(Bf4LogServices {
+                    event_log: DpuEventLog { entries: vec![] },
+                })),
+                storage: Some(vec![]),
+                processors: Some(vec![]),
+                secure_boot_available: true,
+            }],
+        }
+    }
+
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: "Bluefield_BMC",
+                eth_interfaces: Some(vec![
+                    redfish::ethernet_interface::builder(
+                        &redfish::ethernet_interface::manager_resource("Bluefield_BMC", "eth0"),
+                    )
+                    .mac_address(self.bmc_mac_address)
+                    .interface_enabled(true)
+                    .build(),
+                ]),
+                host_interfaces: None,
+                firmware_version: Some("BF4-26.01-2"),
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+
+    pub fn host_nic(&self) -> hw::nic::Nic<'static> {
+        hw::nic::Nic {
+            mac_address: self.host_mac_address,
+            serial_number: Some(format!("{}", self.product_serial_number).into()),
+            manufacturer: Some("Mellanox Technologies".into()),
+            model: Some("B4240".into()),
+            description: Some("CX9 Family [ConnectX-9]".into()),
+            part_number: Some(self.part_number().into()),
+            firmware_version: Some("82.48.0802".into()),
+            is_mat_dpu: true,
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo::default()
+    }
+
+    fn part_number(&self) -> &'static str {
+        "900-9D4B4-CWAA-TSA"
+    }
+}
+
+struct DpuEventLog {
+    entries: Vec<String>,
+}
+
+impl LogService for DpuEventLog {
+    fn id(&self) -> &str {
+        "EventLog"
+    }
+
+    fn entries(&self, collection: &redfish::Collection<'_>) -> Vec<serde_json::Value> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| {
+                redfish::log_service::event_entry(collection, &idx.to_string())
+                    .message(entry)
+                    // These are not required by specification but
+                    // required by libredfish. Making it happy. However, in future
+                    // we may want to simulate these fields as well.
+                    .severity("OK")
+                    .created("2026-02-12T02:06:58+00:00")
+                    .build()
+            })
+            .collect()
+    }
+}
+
+struct Bf4LogServices {
+    event_log: DpuEventLog,
+}
+
+impl LogServices for Bf4LogServices {
+    fn services(&self) -> Vec<&(dyn LogService + '_)> {
+        vec![&self.event_log as &dyn LogService]
+    }
+}

--- a/crates/bmc-mock/src/hw/dell_poweredge_r760_bf4.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r760_bf4.rs
@@ -1,0 +1,276 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use bmc_vendor::BMCVendor;
+use carbide_utils::arch::CpuArchitecture;
+use mac_address::MacAddress;
+use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, MemoryDevice};
+use serde_json::json;
+
+use crate::{BootOptionKind, Callbacks, hw, redfish};
+
+pub struct DellPowerEdgeR760Bf4<'a> {
+    pub bmc_mac_address: MacAddress,
+    pub product_serial_number: Cow<'a, str>,
+    pub bf4: hw::nic::Nic<'a>,
+}
+
+const BF4_SLOT: hw::nic::SlotNumber = 2;
+
+impl DellPowerEdgeR760Bf4<'_> {
+    fn sensor_layout() -> redfish::sensor::Layout {
+        // R760 BF4 System.Embedded.1 dump contains 38 sensors total. The
+        // generic mock layout currently models Temperature, Fan, Power,
+        // Current, and Voltage. Missing R760 BF4 ReadingType counts:
+        // Percent=4, Frequency=2.
+        redfish::sensor::Layout {
+            temperature: 5,
+            fan: 12,
+            power: 5,
+            current: 2,
+            voltage: 8,
+        }
+    }
+
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: "iDRAC.Embedded.1",
+                eth_interfaces: Some(vec![
+                    redfish::ethernet_interface::builder(
+                        &redfish::ethernet_interface::manager_resource("iDRAC.Embedded.1", "NIC.1"),
+                    )
+                    .mac_address(self.bmc_mac_address)
+                    .interface_enabled(true)
+                    .build(),
+                ]),
+                host_interfaces: Some(vec![
+                    redfish::host_interface::builder(&redfish::host_interface::manager_resource(
+                        "iDRAC.Embedded.1",
+                        "Host.1",
+                    ))
+                    .interface_enabled(false)
+                    .build(),
+                ]),
+                firmware_version: Some("7.10.50.00"),
+                oem: Some(redfish::manager::Oem::Dell),
+            }],
+        }
+    }
+
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+        let callbacks = Some(callbacks);
+        let serial_number = Some(self.product_serial_number.to_string().into());
+        let system_id = "System.Embedded.1";
+
+        let eth_id = format!("NIC.Slot.{BF4_SLOT}-1");
+        let eth_interfaces = vec![
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::system_resource(
+                system_id, &eth_id,
+            ))
+            .description(&format!("NIC in Slot {BF4_SLOT} Port 1"))
+            .mac_address(self.bf4.mac_address)
+            .interface_enabled(true)
+            .build(),
+        ];
+
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
+                .boot_option_reference(id)
+        };
+        let boot_options = vec![
+            boot_opt_builder("Boot0000", BootOptionKind::Network)
+                .display_name(&format!("HTTP Device 1: NIC in Slot {BF4_SLOT} Port 1"))
+                .build(),
+            boot_opt_builder("Boot0001", BootOptionKind::Disk)
+                .display_name("Unavailable: Ubuntu")
+                .uefi_device_path("HD(1,GPT,2D26D4C6-A7B5-4F71-93D4-7F6DF36BC8A8,0x800,0x219800)/\\EFI\\ubuntu\\shimx64.efi")
+                .build(),
+        ];
+
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed(system_id),
+                manufacturer: Some("Dell Inc.".into()),
+                model: Some("PowerEdge R760".into()),
+                eth_interfaces: Some(eth_interfaces),
+                serial_number,
+                boot_order_mode: redfish::computer_system::BootOrderMode::DellOem,
+                callbacks,
+                chassis: vec!["System.Embedded.1".into()],
+                boot_options: Some(boot_options),
+                bios_mode: redfish::computer_system::BiosMode::DellOem,
+                oem: redfish::computer_system::Oem::Generic,
+                log_services: None,
+                // Today carbide need for any Dell to have storage
+                // collection. It tries to find BOSS controller
+                // there. So we provide empty collection to avoid 404
+                // failure.
+                storage: Some(vec![]),
+                processors: None,
+                secure_boot_available: true,
+                base_bios: Some(redfish::bios::builder(&redfish::bios::resource(system_id))
+                    .attributes(json!({
+                        "BootSeqRetry": "Disabled",
+                        "SetBootOrderEn": "NIC.HttpDevice.1-1,Disk.Bay.2:Enclosure.Internal.0-1",
+                        "InBandManageabilityInterface": "Enabled",
+                        "UefiVariableAccess": "Standard",
+                        "SerialComm": "OnConRedir",
+                        "SerialPortAddress": "Com1",
+                        "FailSafeBaud": "115200",
+                        "ConTermType": "Vt100Vt220",
+                        "RedirAfterBoot": "Enabled",
+                        "SriovGlobalEnable": "Enabled",
+                        "TpmSecurity": "On",
+                        "Tpm2Algorithm": "SHA256",
+                        "Tpm2Hierarchy": "Enabled",
+                        "HttpDev1EnDis": "Enabled",
+                        "PxeDev1EnDis": "Disabled",
+                        "HttpDev1Interface": eth_id,
+                        "SystemBiosVersion": "2.2.7",
+                        "SystemManufacturer": "Dell Inc.",
+                        "SystemModelName": "PowerEdge R760",
+                    })).build()),
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let chassis_id = "System.Embedded.1";
+        let network_adapter_id = format!("NIC.Slot.{BF4_SLOT}");
+        let function_id = format!("NIC.Slot.{BF4_SLOT}-1");
+        let function = redfish::network_device_function::builder(
+            &redfish::network_device_function::chassis_resource(
+                chassis_id,
+                &network_adapter_id,
+                &function_id,
+            ),
+        )
+        .ethernet(json!({"MACAddress": &self.bf4.mac_address}))
+        .oem(redfish::oem::dell::network_device_function::dell_nic_info(
+            &function_id,
+            BF4_SLOT,
+            self.bf4
+                .serial_number
+                .as_ref()
+                .unwrap_or(&Cow::Borrowed("unknown")),
+        ))
+        .build();
+        let network_adapters = vec![
+            redfish::network_adapter::builder_from_nic(
+                &redfish::network_adapter::chassis_resource(chassis_id, &network_adapter_id),
+                &self.bf4,
+            )
+            .network_device_functions(
+                &redfish::network_device_function::chassis_collection(
+                    chassis_id,
+                    &network_adapter_id,
+                ),
+                vec![function],
+            )
+            .status(redfish::resource::Status::Ok)
+            .build(),
+        ];
+
+        let pcie_device_id = format!("mat_{BF4_SLOT}");
+        let pcie_devices = vec![
+            redfish::pcie_device::builder_from_nic(
+                &redfish::pcie_device::chassis_resource(chassis_id, &pcie_device_id),
+                &self.bf4,
+            )
+            .status(redfish::resource::Status::Ok)
+            .build(),
+        ];
+
+        redfish::chassis::ChassisConfig {
+            chassis: vec![redfish::chassis::SingleChassisConfig {
+                id: Cow::Borrowed(chassis_id),
+                chassis_type: "RackMount".into(),
+                manufacturer: Some("Dell Inc.".into()),
+                part_number: Some("0C9W19A01".into()),
+                model: Some("PowerEdge R760".into()),
+                serial_number: Some(self.product_serial_number.to_string().into()),
+                network_adapters: Some(network_adapters),
+                pcie_devices: Some(pcie_devices),
+                sensors: Some(redfish::sensor::generate_chassis_sensors(
+                    chassis_id,
+                    Self::sensor_layout(),
+                )),
+                ..redfish::chassis::SingleChassisConfig::defaults()
+            }],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo {
+            network_interfaces: vec![self.bf4.discovery_info(BF4_SLOT)],
+            infiniband_interfaces: vec![],
+            cpu_info: vec![CpuInfo {
+                model: "Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz".into(),
+                vendor: "GenuineIntel".into(),
+                sockets: 2,
+                cores: 18,
+                threads: 36,
+            }],
+            block_devices: (0..2)
+                .map(|n| BlockDevice {
+                    model: "Dell Ent NVMe v2 AGN RI U.2 1.92TB".into(),
+                    revision: "2.3.0".into(),
+                    serial: format!("FAKESERNUM{n}"),
+                    device_type: "".into(),
+                })
+                .collect(),
+            machine_type: CpuArchitecture::X86_64.to_string(),
+            machine_arch: Some(rpc::utils::cpu_architecture_to_rpc(CpuArchitecture::X86_64)),
+            nvme_devices: vec![],
+            dmi_data: Some(DmiData {
+                board_name: "01J4WF".into(),
+                board_version: "A05".into(),
+                bios_version: "2.2.7".into(),
+                bios_date: "12/19/2023".into(),
+                product_serial: self.product_serial_number.to_string(),
+                board_serial: format!(".{}.FAKESERNUM2.", self.product_serial_number),
+                chassis_serial: self.product_serial_number.to_string(),
+                product_name: "PowerEdge R760".into(),
+                // Logic of machine state handler depends on BMC
+                // vendor that is calculated from dmi_data.sys_vendor
+                // value.
+                sys_vendor: hw::bmc_vendor_to_udev_dmi(BMCVendor::Dell).into(),
+            }),
+            dpu_info: None,
+            gpus: vec![],
+            memory_devices: (0..8)
+                .map(|_| MemoryDevice {
+                    size_mb: Some(16384),
+                    mem_type: Some("DDR4".into()),
+                })
+                .collect(),
+            tpm_ek_certificate: None,
+            tpm_description: None,
+            ..Default::default()
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -24,11 +24,17 @@ pub mod nic;
 /// Support of NVIDIA Bluefield3 DPU.
 pub mod bluefield3;
 
+/// Support of NVIDIA Bluefield4 DPU.
+pub mod bluefield4;
+
 /// Generic AMI server.
 pub mod generic_ami;
 
 /// Support of Dell PowerEdge R750 servers.
 pub mod dell_poweredge_r750;
+
+/// Support of Dell PowerEdge R760 server with Bluefield4 installed.
+pub mod dell_poweredge_r760_bf4;
 
 /// Support of Wiwynn GB200 NVL servers.
 pub mod wiwynn_gb200_nvl;

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -56,6 +56,8 @@ pub enum HostHardwareType {
     #[serde(rename = "dell_poweredge_r750")]
     #[default]
     DellPowerEdgeR750,
+    #[serde(rename = "dell_poweredge_r760_bf4")]
+    DellPowerEdgeR760Bf4,
     #[serde(rename = "wiwynn_gb200_nvl")]
     WiwynnGB200Nvl,
     #[serde(rename = "lenovo_gb300_nvl")]
@@ -83,6 +85,7 @@ impl fmt::Display for HostHardwareType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::DellPowerEdgeR750 => "Dell PowerEdge R750".fmt(f),
+            Self::DellPowerEdgeR760Bf4 => "Dell PowerEdge R760 Bluefield-4".fmt(f),
             Self::WiwynnGB200Nvl => "WIWYNN GB200 NVL".fmt(f),
             Self::LenovoGB300Nvl => "Lenovo GB300 NVL".fmt(f),
             Self::NvidiaDgxGb300 => "NVIDIA DGX GB300 NVL".fmt(f),
@@ -103,6 +106,7 @@ impl HostHardwareType {
     pub fn fixed_number_of_dpu(&self) -> Option<u8> {
         match self {
             Self::DellPowerEdgeR750 => None,
+            Self::DellPowerEdgeR760Bf4 => Some(1),
             Self::WiwynnGB200Nvl => Some(2),
             Self::LenovoGB300Nvl => Some(1),
             Self::NvidiaDgxGb300 => Some(1),

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -78,6 +78,11 @@ fn default_true() -> bool {
     true
 }
 
+enum DpuType {
+    Bluefield3,
+    Bluefield4,
+}
+
 impl Default for DpuSettings {
     fn default() -> Self {
         Self {
@@ -122,7 +127,9 @@ impl DpuMachineInfo {
             | HostHardwareType::LenovoGB300Nvl
             | HostHardwareType::NvidiaDgxGb300
             | HostHardwareType::SupermicroGb300Nvl => hw::bluefield3::Mode::B3240ColdAisle,
-            HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld => {
+            HostHardwareType::LiteOnPowerShelf
+            | HostHardwareType::NvidiaSwitchNd5200Ld
+            | HostHardwareType::DellPowerEdgeR760Bf4 => {
                 panic!("Bluefield3 DPU is defined for {}", self.hw_type)
             }
         };
@@ -139,6 +146,75 @@ impl DpuMachineInfo {
                 erot: settings.firmware_versions.cec.clone().unwrap_or_default(),
                 dpu_nic: settings.firmware_versions.nic.clone().unwrap_or_default(),
             },
+        }
+    }
+
+    fn bluefield4(&self) -> hw::bluefield4::Bluefield4<'_> {
+        hw::bluefield4::Bluefield4 {
+            host_mac_address: self.host_mac_address,
+            bmc_mac_address: self.bmc_mac_address,
+            product_serial_number: Cow::Borrowed(&self.serial),
+        }
+    }
+
+    fn dpu_type(&self) -> DpuType {
+        match self.hw_type {
+            HostHardwareType::DellPowerEdgeR750
+            | HostHardwareType::NvidiaDgxH100
+            | HostHardwareType::GenericAmi
+            | HostHardwareType::GenericSupermicro
+            | HostHardwareType::WiwynnGB200Nvl
+            | HostHardwareType::LenovoGB300Nvl
+            | HostHardwareType::NvidiaDgxGb300
+            | HostHardwareType::SupermicroGb300Nvl
+            | HostHardwareType::LiteOnPowerShelf
+            | HostHardwareType::NvidiaSwitchNd5200Ld => DpuType::Bluefield3,
+            HostHardwareType::DellPowerEdgeR760Bf4 => DpuType::Bluefield4,
+        }
+    }
+
+    pub fn bmc_product(&self) -> Option<&'static str> {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => Some("BlueField-3 DPU"),
+            DpuType::Bluefield4 => Some("B4240"),
+        }
+    }
+
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => self.bluefield3().manager_config(),
+            DpuType::Bluefield4 => self.bluefield4().manager_config(),
+        }
+    }
+
+    pub fn system_config(
+        &self,
+        callbacks: Arc<dyn crate::Callbacks>,
+    ) -> redfish::computer_system::Config {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => self.bluefield3().system_config(callbacks),
+            DpuType::Bluefield4 => self.bluefield4().system_config(callbacks),
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => self.bluefield3().chassis_config(),
+            DpuType::Bluefield4 => self.bluefield4().chassis_config(),
+        }
+    }
+
+    pub fn update_service_config(&self) -> UpdateServiceConfig {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => self.bluefield3().update_service_config(),
+            DpuType::Bluefield4 => self.bluefield4().update_service_config(),
+        }
+    }
+
+    pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => self.bluefield3().discovery_info(),
+            DpuType::Bluefield4 => self.bluefield4().discovery_info(),
         }
     }
 }
@@ -192,7 +268,7 @@ impl HostMachineInfo {
 
     pub fn oem_state(&self) -> redfish::oem::State {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => {
+            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4 => {
                 redfish::oem::State::DellIdrac(redfish::oem::dell::idrac::IdracState::default())
             }
             HostHardwareType::WiwynnGB200Nvl
@@ -209,7 +285,9 @@ impl HostMachineInfo {
 
     pub fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => redfish::oem::BmcVendor::Dell,
+            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4 => {
+                redfish::oem::BmcVendor::Dell
+            }
             HostHardwareType::WiwynnGB200Nvl => redfish::oem::BmcVendor::Wiwynn,
             HostHardwareType::LenovoGB300Nvl => redfish::oem::BmcVendor::Ami,
             HostHardwareType::NvidiaDgxGb300 => {
@@ -229,6 +307,9 @@ impl HostMachineInfo {
     pub fn bmc_product(&self) -> Option<&'static str> {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => None,
+            HostHardwareType::DellPowerEdgeR760Bf4 => {
+                Some("Integrated Dell Remote Access Controller")
+            }
             HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
             HostHardwareType::LenovoGB300Nvl => Some("AMI Redfish Server"),
             HostHardwareType::NvidiaDgxGb300 => Some("GB BMC"),
@@ -243,7 +324,9 @@ impl HostMachineInfo {
 
     pub fn bmc_redfish_version(&self) -> &'static str {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => "1.18.0",
+            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4 => {
+                "1.18.0"
+            }
             HostHardwareType::WiwynnGB200Nvl => "1.17.0",
             HostHardwareType::LenovoGB300Nvl => "1.21.1",
             HostHardwareType::NvidiaDgxGb300 => "1.17.0",
@@ -259,6 +342,9 @@ impl HostMachineInfo {
     pub fn manager_config(&self) -> redfish::manager::Config {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
+            HostHardwareType::DellPowerEdgeR760Bf4 => {
+                self.dell_poweredge_r760_bf4().manager_config()
+            }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().manager_config(),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().manager_config(),
@@ -282,6 +368,9 @@ impl HostMachineInfo {
             HostHardwareType::DellPowerEdgeR750 => {
                 self.dell_poweredge_r750().system_config(callbacks)
             }
+            HostHardwareType::DellPowerEdgeR760Bf4 => {
+                self.dell_poweredge_r760_bf4().system_config(callbacks)
+            }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().system_config(callbacks),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().system_config(callbacks),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().system_config(callbacks),
@@ -302,6 +391,9 @@ impl HostMachineInfo {
     pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
+            HostHardwareType::DellPowerEdgeR760Bf4 => {
+                self.dell_poweredge_r760_bf4().chassis_config()
+            }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().chassis_config(),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().chassis_config(),
@@ -321,6 +413,9 @@ impl HostMachineInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => {
                 self.dell_poweredge_r750().update_service_config()
+            }
+            HostHardwareType::DellPowerEdgeR760Bf4 => {
+                self.dell_poweredge_r760_bf4().update_service_config()
             }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().update_service_config(),
@@ -342,6 +437,9 @@ impl HostMachineInfo {
     pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
         match self.hw_type {
             HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().discovery_info(),
+            HostHardwareType::DellPowerEdgeR760Bf4 => {
+                self.dell_poweredge_r760_bf4().discovery_info()
+            }
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().discovery_info(),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().discovery_info(),
@@ -393,6 +491,19 @@ impl HostMachineInfo {
                 port_1: next_mac(),
                 port_2: next_mac(),
             },
+        }
+    }
+
+    fn dell_poweredge_r760_bf4(&self) -> hw::dell_poweredge_r760_bf4::DellPowerEdgeR760Bf4<'_> {
+        let mut dpus = self.dpus.iter();
+        hw::dell_poweredge_r760_bf4::DellPowerEdgeR760Bf4 {
+            bmc_mac_address: self.bmc_mac_address,
+            product_serial_number: Cow::Borrowed(&self.serial),
+            bf4: dpus
+                .next()
+                .expect("BF4 dpu must present")
+                .bluefield4()
+                .host_nic(),
         }
     }
 
@@ -695,7 +806,7 @@ impl MachineInfo {
     pub fn manager_config(&self) -> redfish::manager::Config {
         match self {
             MachineInfo::Host(host) => host.manager_config(),
-            MachineInfo::Dpu(dpu) => dpu.bluefield3().manager_config(),
+            MachineInfo::Dpu(dpu) => dpu.manager_config(),
         }
     }
 
@@ -718,7 +829,7 @@ impl MachineInfo {
     pub fn bmc_product(&self) -> Option<&'static str> {
         match self {
             MachineInfo::Host(h) => h.bmc_product(),
-            MachineInfo::Dpu(_) => Some("BlueField-3 DPU"),
+            MachineInfo::Dpu(d) => d.bmc_product(),
         }
     }
 
@@ -728,21 +839,21 @@ impl MachineInfo {
     ) -> redfish::computer_system::Config {
         match self {
             MachineInfo::Host(host) => host.system_config(callbacks),
-            MachineInfo::Dpu(dpu) => dpu.bluefield3().system_config(callbacks),
+            MachineInfo::Dpu(dpu) => dpu.system_config(callbacks),
         }
     }
 
     pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         match self {
             Self::Host(h) => h.chassis_config(),
-            Self::Dpu(dpu) => dpu.bluefield3().chassis_config(),
+            Self::Dpu(dpu) => dpu.chassis_config(),
         }
     }
 
     pub fn update_service_config(&self) -> UpdateServiceConfig {
         match self {
             Self::Host(h) => h.update_service_config(),
-            Self::Dpu(dpu) => dpu.bluefield3().update_service_config(),
+            Self::Dpu(dpu) => dpu.update_service_config(),
         }
     }
 
@@ -786,7 +897,7 @@ impl MachineInfo {
     pub fn discovery_info(&self) -> rpc::machine_discovery::DiscoveryInfo {
         match self {
             Self::Host(h) => h.discovery_info(),
-            Self::Dpu(dpu) => dpu.bluefield3().discovery_info(),
+            Self::Dpu(dpu) => dpu.discovery_info(),
         }
     }
 


### PR DESCRIPTION
Adds BlueField-4 DPU mock support and a Dell PowerEdge R760 configuration with BF4 installed. Wires the new hardware type through machine info, Redfish config generation, discovery info, and DPU product handling.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

