### PR TITLE
fix: report a machine's live BMC IP, not a stale topology copy

### DIFF
--- a/crates/api-core/src/handlers/machine_interface.rs
+++ b/crates/api-core/src/handlers/machine_interface.rs
@@ -183,30 +183,39 @@ pub(crate) async fn find_bmc_ips(
                 return Ok(Response::new(rpc::BmcIpList::default()));
             };
 
-            // Get the machine topology for this machine
-            let Some(machine_topology) = api
+            // Resolve the BMC IP from the live interface, not the discovery topology
+            // snapshot, so a released or changed lease can't surface a stale IP.
+            let Some(bmc_ip) = api
                 .with_txn(|txn| {
                     async move {
-                        db::machine_topology::find_latest_by_machine_ids(txn, &[machine_id]).await
+                        db::machine_topology::find_machine_bmc_pairs_by_machine_id(
+                            txn,
+                            vec![machine_id],
+                        )
+                        .await
                     }
                     .boxed()
                 })
                 .await??
-                .into_values()
-                .next()
+                .into_iter()
+                .find_map(|(_, ip)| ip)
             else {
                 return Ok(Response::new(rpc::BmcIpList::default()));
             };
 
-            // Get the BMC IP out of the machine topology
-            let bmc_ip = match machine_topology.topology.bmc_info.ip {
-                Some(ip) => ip,
-                None => {
+            // The address comes from a Postgres `inet` column, so it parses today --
+            // but don't silently swallow the error if that ever changes: warn and skip.
+            match bmc_ip.parse::<IpAddr>() {
+                Ok(ip) => vec![ip],
+                Err(e) => {
+                    tracing::warn!(
+                        %bmc_ip,
+                        error = %e,
+                        "BMC IP from machine_interfaces did not parse; skipping"
+                    );
                     return Ok(Response::new(rpc::BmcIpList::default()));
                 }
-            };
-
-            vec![bmc_ip]
+            }
         }
         None => return Err(CarbideError::MissingArgument("lookup_by").into()),
     };

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -2727,11 +2727,122 @@ pub fn count_healthy_unhealthy_host_machines(
 
 #[cfg(test)]
 mod test {
+    use std::net::IpAddr;
     use std::str::FromStr;
 
-    use carbide_uuid::machine::MachineId;
+    use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+    use carbide_uuid::network::NetworkSegmentId;
+    use model::allocation_type::AllocationType;
+    use model::bmc_info::BmcInfo;
+    use model::hardware_info::HardwareInfo;
     use model::machine::ManagedHostState;
     use model::machine::machine_search_config::MachineSearchConfig;
+    use model::machine::topology::{DiscoveryData, TopologyData};
+
+    /// The machine snapshot reports the BMC IP from the *live* `machine_interface_addresses`
+    /// row, and reports `None` once that address is gone -- it must never fall back to the
+    /// stale copy cached in `machine_topologies.topology.bmc_info.ip`.
+    ///
+    /// Exercises the BMC subquery in `machine_snapshots.sql.template`, which now reads
+    /// `host(bmc_addr.address)` directly instead of coalescing onto the topology copy.
+    #[crate::sqlx_test]
+    async fn test_snapshot_bmc_ip_follows_live_interface_not_stale_topology(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+
+        let live_bmc_ip: IpAddr = "10.1.2.3".parse()?;
+        // A different value in the topology copy makes a fallback observable: if the
+        // snapshot ever read the stale copy we'd see this instead of the live address.
+        let stale_topology_ip: IpAddr = "10.9.9.9".parse()?;
+
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
+        super::create(
+            txn.as_mut(),
+            None,
+            &machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+
+        // A BMC interface attached to the machine, plus its live address (a DHCP lease).
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version) VALUES ($1, 'V1-T0') RETURNING id",
+        )
+        .bind("bmc-live-vs-stale")
+        .fetch_one(txn.as_mut())
+        .await?;
+        let bmc_interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (machine_id, association_type, segment_id, mac_address,
+                  primary_interface, hostname, interface_type)
+             VALUES ($1, 'Machine', $2, $3::macaddr, false, 'bmc-live-vs-stale', 'Bmc')
+             RETURNING id",
+        )
+        .bind(machine_id)
+        .bind(segment_id)
+        .bind("02:00:00:00:00:01")
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            bmc_interface_id,
+            live_bmc_ip,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        // A topology row that *also* carries a (stale) BMC IP -- the removed fallback.
+        let topology = TopologyData {
+            discovery_data: DiscoveryData {
+                info: HardwareInfo::default(),
+            },
+            bmc_info: BmcInfo {
+                ip: Some(stale_topology_ip),
+                ..Default::default()
+            },
+        };
+        sqlx::query("INSERT INTO machine_topologies (machine_id, topology) VALUES ($1, $2::jsonb)")
+            .bind(machine_id)
+            .bind(sqlx::types::Json(&topology))
+            .execute(txn.as_mut())
+            .await?;
+
+        // With a live address present, the snapshot reports it.
+        let machine = super::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("machine snapshot should load");
+        assert_eq!(machine.bmc_info.ip, Some(live_bmc_ip));
+
+        // Release the lease: drop the live address but keep the interface and the topology
+        // row (with its stale bmc_info.ip) intact.
+        crate::machine_interface_address::delete(txn.as_mut(), &bmc_interface_id).await?;
+
+        // The key assertion: with no live address, the snapshot reports None rather than
+        // falling back to the stale topology copy.
+        let machine = super::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("machine snapshot should load");
+        assert_eq!(machine.bmc_info.ip, None);
+
+        // Now drop the BMC interface row entirely; the topology row (with its stale
+        // bmc_info.ip) stays. Even with no live BMC interface at all, the snapshot must
+        // still report None -- it must not fall back to the stale copy via the outer COALESCE.
+        sqlx::query("DELETE FROM machine_interfaces WHERE id = $1")
+            .bind(bmc_interface_id)
+            .execute(txn.as_mut())
+            .await?;
+        let machine = super::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+            .await?
+            .expect("machine snapshot should load");
+        assert_eq!(machine.bmc_info.ip, None);
+
+        txn.rollback().await?;
+        Ok(())
+    }
 
     #[crate::sqlx_test]
 

--- a/crates/api-db/src/sql/machine_snapshots.sql.template
+++ b/crates/api-db/src/sql/machine_snapshots.sql.template
@@ -9,7 +9,7 @@ m.*,
 sku.device_type as hw_sku_device_type,
 COALESCE(i.json, '[]') AS interfaces,
 COALESCE(t.json, '[]') AS topology,
-COALESCE(bmc.json, t.bmc_info, '{}'::jsonb) AS bmc_info
+COALESCE(bmc.json, t.bmc_info - 'ip' - 'mac', '{}'::jsonb) AS bmc_info
 __HISTORY_SELECT__
 FROM machines m
 LEFT JOIN machine_skus sku on  m.hw_sku = sku.id
@@ -37,8 +37,8 @@ LEFT JOIN LATERAL (
         COALESCE(t.bmc_info, '{}'::jsonb) ||
         jsonb_build_object(
             'machine_interface_id', bmc_i.id,
-            'ip', COALESCE(host(bmc_addr.address), t.bmc_info->>'ip'),
-            'mac', COALESCE(bmc_i.mac_address::text, t.bmc_info->>'mac')
+            'ip', host(bmc_addr.address),
+            'mac', bmc_i.mac_address::text
         )
     ) AS json
     FROM machine_interfaces bmc_i

--- a/crates/api-db/src/sql/managed_hosts.sql.template
+++ b/crates/api-db/src/sql/managed_hosts.sql.template
@@ -26,7 +26,7 @@ SELECT m.* FROM (
         sku.device_type as hw_sku_device_type,
         COALESCE(i.json, '[]') AS interfaces,
         COALESCE(t.json, '[]') AS topology,
-        COALESCE(bmc.json, t.bmc_info, '{}'::jsonb) AS bmc_info,
+        COALESCE(bmc.json, t.bmc_info - 'ip' - 'mac', '{}'::jsonb) AS bmc_info,
         COALESCE(p.json, '[]') AS power_options
         __HISTORY_SELECT__
         FROM machines m2
@@ -85,8 +85,8 @@ SELECT m.* FROM (
                 COALESCE(t.bmc_info, '{}'::jsonb) ||
                 jsonb_build_object(
                     'machine_interface_id', bmc_i.id,
-                    'ip', COALESCE(host(bmc_addr.address), t.bmc_info->>'ip'),
-                    'mac', COALESCE(bmc_i.mac_address::text, t.bmc_info->>'mac')
+                    'ip', host(bmc_addr.address),
+                    'mac', bmc_i.mac_address::text
                 )
             ) AS json
             FROM machine_interfaces bmc_i
@@ -125,7 +125,7 @@ SELECT m.* FROM (
         m2.*,
         COALESCE(i.json, '[]') AS interfaces,
         COALESCE(t.json, '[]') AS topology,
-        COALESCE(bmc.json, t.bmc_info, '{}'::jsonb) AS bmc_info
+        COALESCE(bmc.json, t.bmc_info - 'ip' - 'mac', '{}'::jsonb) AS bmc_info
         __HISTORY_SELECT__
         FROM machine_interfaces mi_parent
         INNER JOIN machines m2
@@ -184,8 +184,8 @@ SELECT m.* FROM (
                 COALESCE(t.bmc_info, '{}'::jsonb) ||
                 jsonb_build_object(
                     'machine_interface_id', bmc_i.id,
-                    'ip', COALESCE(host(bmc_addr.address), t.bmc_info->>'ip'),
-                    'mac', COALESCE(bmc_i.mac_address::text, t.bmc_info->>'mac')
+                    'ip', host(bmc_addr.address),
+                    'mac', bmc_i.mac_address::text
                 )
             ) AS json
             FROM machine_interfaces bmc_i

--- a/crates/rack/src/firmware_update.rs
+++ b/crates/rack/src/firmware_update.rs
@@ -56,7 +56,7 @@ pub async fn load_rack_firmware_inventory(
     credential_manager: &dyn CredentialManager,
     rack_id: &RackId,
 ) -> Result<RackFirmwareInventory> {
-    let (machine_ids, machine_topologies) = {
+    let (machine_ids, machine_topologies, bmc_ips) = {
         let mut txn = db_pool.begin().await?;
 
         let machine_ids = db_machine::find_machine_ids(
@@ -69,9 +69,20 @@ pub async fn load_rack_firmware_inventory(
         .await?;
         let machine_topologies =
             db_machine_topology::find_latest_by_machine_ids(txn.as_mut(), &machine_ids).await?;
+        // The BMC IP is live network state -- read it from machine_interfaces, not the
+        // discovery topology snapshot, so a released or changed lease can't surface a stale IP.
+        let bmc_ips: std::collections::HashMap<_, _> =
+            db_machine_topology::find_machine_bmc_pairs_by_machine_id(
+                txn.as_mut(),
+                machine_ids.clone(),
+            )
+            .await?
+            .into_iter()
+            .filter_map(|(id, ip)| ip.map(|ip| (id, ip)))
+            .collect();
 
         txn.commit().await?;
-        (machine_ids, machine_topologies)
+        (machine_ids, machine_topologies, bmc_ips)
     };
 
     let mut machines = Vec::with_capacity(machine_ids.len());
@@ -84,11 +95,9 @@ pub async fn load_rack_firmware_inventory(
             .bmc_info
             .mac
             .ok_or_else(|| eyre!("machine {} missing BMC MAC", machine_id))?;
-        let bmc_ip = topology
-            .topology()
-            .bmc_info
-            .ip
-            .ok_or_else(|| eyre!("machine {} missing BMC IP", machine_id))?;
+        let bmc_ip = bmc_ips
+            .get(machine_id)
+            .ok_or_else(|| eyre!("machine {} has no live BMC IP", machine_id))?;
         let (bmc_username, bmc_password) =
             fetch_bmc_credentials(credential_manager, bmc_mac).await?;
         machines.push(FirmwareUpgradeDeviceInfo {

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -123,6 +123,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
 <tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
+<tr><td>carbide_site_explorer_last_run_status</td><td>gauge</td><td>The status of the latest Site Explorer run</td></tr>
 <tr><td>carbide_site_explorer_phase_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration phase</td></tr>
 <tr><td>carbide_site_explorer_update_explored_endpoints_count</td><td>gauge</td><td>Counts from the last update_explored_endpoints phase by kind</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>


### PR DESCRIPTION
A machine's BMC IP now always reflects whatever `machine_interfaces` currently holds. The snapshot used to keep a copy of it in `machine_topologies` and silently fall back to that copy once the live address was gone -- so a released or changed BMC lease left the snapshot, and everything that reads it (DPF registration, the host state machine), acting on an IP that no longer exists.

This makes the live interface the single source of truth: the snapshot reads the BMC `ip`/`mac` straight from `machine_interfaces` / `machine_interface_addresses`, or reports `None` when there is no current address, and the two readers that still pulled the IP from the topology copy now read it live. `machine_topologies` stays the hardware-inventory snapshot -- we just stop treating its BMC IP as current.

- Drop the stale `machine_topologies` BMC `ip`/`mac` fallback in the `machine_snapshots` and `managed_hosts` snapshot queries
- Repoint the rack firmware inventory and the serial->BMC-IP lookup at the live `find_machine_bmc_pairs_by_machine_id` helper
- `bmc_info.ip` is now honestly `None` after a lease release, so callers fail loudly instead of acting on a phantom IP

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/2918
