### PR TITLE
feat(machine-a-tron): simulate a runtime DPU-to-NIC-mode flip

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -174,6 +174,14 @@ async fn test_integration() -> eyre::Result<()> {
             Ipv4Addr::new(10, 10, 11, 2),
         )
         .boxed(),
+        test_machine_a_tron_dpu_to_nic_mode_reregistration(
+            HostHardwareType::DellPowerEdgeR750,
+            &test_env,
+            &bmc_address_registry,
+            // Relay IP in host-inband net
+            Ipv4Addr::new(10, 10, 11, 2),
+        )
+        .boxed(),
         test_machine_a_tron_dual_stack(
             HostHardwareType::DellPowerEdgeR750,
             &test_env,
@@ -731,6 +739,182 @@ async fn test_machine_a_tron_singledpu_nic_mode(
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!("Machine {machine_id} has made it to Ready again, all done");
+                Ok::<(), eyre::Report>(())
+            }
+        },
+    )
+    .await
+}
+
+/// DPU-mode -> NIC-mode flip + zero-DPU re-ingestion (machine-a-tron harness,
+/// #2661 / #2632). A host boots as a managed-DPU machine, an operator declares
+/// NIC mode and force-deletes it with `--delete-interfaces`, and the host
+/// re-ingests with no managed DPUs -- exercising the simulated BlueField flip
+/// (`Mode.Set` staged, applied on power-cycle), the host converging off its DPU
+/// DHCP relay and dropping the DPU from its inventory, and site-explorer
+/// re-registering the host with zero managed DPUs.
+///
+/// Asserts the re-ingest milestone directly against the database -- the host's
+/// (stable, TPM-derived) machine row returns with its data-plane NIC and no
+/// managed DPU -- then drives the re-ingested NIC-mode host all the way to Ready.
+async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
+    hw_type: HostHardwareType,
+    test_env: &IntegrationTestEnvironment,
+    bmc_mock_registry: &BmcMockRegistry,
+    admin_dhcp_relay_address: Ipv4Addr,
+) -> eyre::Result<()> {
+    run_machine_a_tron_test(
+        hw_type,
+        1,
+        1,
+        // Start in DPU mode: the host comes up as a managed-DPU machine, and we
+        // flip it to NIC mode below.
+        false,
+        test_env,
+        bmc_mock_registry,
+        admin_dhcp_relay_address,
+        |machine_handle| {
+            let carbide_api_addrs = &test_env.carbide_api_addrs;
+            async move {
+                // 1. Host reaches Ready as a managed-DPU machine.
+                machine_handle
+                    .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
+                    .await?;
+                let bmc_mac = machine_handle.host_info().bmc_mac_address.to_string();
+                let initial_machine_id = machine_handle
+                    .observed_machine_id()
+                    .expect("Machine ID should be set if host is ready");
+                tracing::info!(
+                    "Machine {initial_machine_id} (bmc_mac {bmc_mac}) is Ready in DPU mode; flipping to NIC mode"
+                );
+
+                // 2. Flip the ExpectedMachine to NIC mode. Get the current record,
+                //    set `dpu_mode`, and round-trip the full message back through
+                //    UpdateExpectedMachine (the same get-mutate-update the admin CLI
+                //    `patch_expected_machine` uses, so we preserve every other field).
+                let get_req = serde_json::json!({ "bmc_mac_address": bmc_mac });
+                let expected_machine_json =
+                    api_test_helper::grpcurl::grpcurl(carbide_api_addrs, "GetExpectedMachine", Some(&get_req))
+                        .await?;
+                let mut expected_machine: serde_json::Value =
+                    serde_json::from_str(&expected_machine_json)?;
+                expected_machine["dpu_mode"] = serde_json::json!("NIC_MODE");
+                api_test_helper::grpcurl::grpcurl(
+                    carbide_api_addrs,
+                    "UpdateExpectedMachine",
+                    Some(&expected_machine),
+                )
+                .await?;
+                tracing::info!("ExpectedMachine for {bmc_mac} now declares NIC mode");
+
+                // 3. Force-delete the managed-DPU machine so site-explorer
+                //    re-ingests the host under the new declared mode. This is the
+                //    issue's `force-delete --delete-interfaces`: it removes the host
+                //    + DPU machine rows, their interfaces, and their explored-endpoint
+                //    records, so site-explorer rediscovers and re-ingests from scratch.
+                //
+                //    Query by the host's MachineId: `host_query` resolves a
+                //    data-plane MAC or a machine id, but not a BMC MAC
+                //    (`find_by_mac_address` excludes BMC interfaces), so the BMC MAC
+                //    used for the ExpectedMachine lookups above would not match here.
+                let force_delete_req = serde_json::json!({
+                    "host_query": initial_machine_id,
+                    "delete_interfaces": true,
+                });
+                api_test_helper::grpcurl::grpcurl(
+                    carbide_api_addrs,
+                    "AdminForceDeleteMachine",
+                    Some(&force_delete_req),
+                )
+                .await?;
+                tracing::info!("Force-deleted machine {initial_machine_id}; awaiting re-ingestion as NicMode");
+
+                // 4. Wait for the host to re-ingest as a zero-managed-DPU machine,
+                //    asserted directly against the database. The host's TPM-derived
+                //    MachineId is deterministic (a hash of its EK cert), so the
+                //    re-ingested host resurrects under the SAME id captured before
+                //    the flip -- the machine-a-tron handle's observed id is cleared
+                //    by the force-delete, so we key off the captured id. First
+                //    confirm the re-ingest milestone (the host row is back with its
+                //    NIC and no managed DPU); step 5 then drives it all the way to
+                //    Ready. Allow generous time for the rate-limited flip
+                //    power-cycle plus full rediscovery.
+                let host_id = initial_machine_id.to_string();
+                let pool = &test_env.db_pool;
+                let reingest_deadline = time::Instant::now() + Duration::from_secs(180);
+                loop {
+                    // The host row is back under its stable TPM-derived id.
+                    let host_exists: bool =
+                        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM machines WHERE id = $1)")
+                            .bind(&host_id)
+                            .fetch_one(pool)
+                            .await?;
+                    // It re-ingested with at least one data-plane (non-BMC) NIC.
+                    let nic_count: i64 = sqlx::query_scalar(
+                        "SELECT COUNT(*) FROM machine_interfaces \
+                         WHERE machine_id = $1 AND interface_type != 'Bmc'",
+                    )
+                    .bind(&host_id)
+                    .fetch_one(pool)
+                    .await?;
+                    // Zero managed DPUs: no data-plane interface still points at a
+                    // DPU (any non-null `attached_dpu_machine_id`), so the BlueField
+                    // flipped to NIC mode and is no longer managed. Count attachments
+                    // directly instead of joining `machines`, so a stale attachment
+                    // pointing at an already-deleted DPU row still counts.
+                    let managed_dpu_count: i64 = sqlx::query_scalar(
+                        "SELECT COUNT(*) FROM machine_interfaces \
+                         WHERE machine_id = $1 \
+                         AND interface_type != 'Bmc' \
+                         AND attached_dpu_machine_id IS NOT NULL",
+                    )
+                    .bind(&host_id)
+                    .fetch_one(pool)
+                    .await?;
+
+                    if host_exists && nic_count >= 1 && managed_dpu_count == 0 {
+                        tracing::info!(
+                            "Host re-ingested as zero-managed-DPU machine {host_id} \
+                             (nic_count={nic_count}); DPU->NIC flip applied"
+                        );
+                        break;
+                    }
+                    if time::Instant::now() >= reingest_deadline {
+                        panic!(
+                            "host {host_id} did not re-ingest as a zero-managed-DPU NicMode machine \
+                             within the timeout (host_exists={host_exists}, nic_count={nic_count}, \
+                             managed_dpu_count={managed_dpu_count})"
+                        );
+                    }
+                    sleep(Duration::from_secs(2)).await;
+                }
+
+                // 5. Drive the re-ingested NicMode host all the way to Ready --
+                //    the host BMC now serves an event log so the controller's
+                //    restart verification can confirm reboots, and the zero-DPU
+                //    lockdown short-circuit lets it skip the DPU-down wait.
+                tracing::info!("Waiting for re-ingested NicMode host {host_id} to reach Ready");
+                let ready_deadline = time::Instant::now() + Duration::from_secs(240);
+                loop {
+                    let resp = api_test_helper::grpcurl::grpcurl(
+                        carbide_api_addrs,
+                        "FindMachinesByIds",
+                        Some(&serde_json::json!({ "machine_ids": [{"id": host_id}] })),
+                    )
+                    .await?;
+                    let resp: serde_json::Value = serde_json::from_str(&resp)?;
+                    let state = resp["machines"][0]["state"].as_str().unwrap_or("");
+                    if state == "Ready" {
+                        tracing::info!("Re-ingested NicMode host {host_id} reached Ready ({state})");
+                        break;
+                    }
+                    if time::Instant::now() >= ready_deadline {
+                        panic!(
+                            "re-ingested NicMode host {host_id} did not reach Ready within the timeout (last state: {state})"
+                        );
+                    }
+                    sleep(Duration::from_secs(2)).await;
+                }
                 Ok::<(), eyre::Report>(())
             }
         },

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -74,4 +74,14 @@ impl BmcState {
             v.apply_pending_mode();
         }
     }
+
+    /// The BlueField's current NIC-mode flag, or `None` for a BMC that does not
+    /// mock a BlueField (e.g. the host iDRAC). Lets machine-a-tron observe a DPU
+    /// that flipped to NIC mode on a power cycle and converge to NIC behavior.
+    pub fn bluefield_nic_mode(&self) -> Option<bool> {
+        match &self.oem_state {
+            redfish::oem::State::NvidiaBluefield(v) => Some(v.nic_mode()),
+            _ => None,
+        }
+    }
 }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -24,7 +24,7 @@ use mac_address::MacAddress;
 use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, MemoryDevice};
 use serde_json::json;
 
-use crate::{BootOptionKind, Callbacks, hw, redfish};
+use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
 
 pub struct DellPowerEdgeR750<'a> {
     pub bmc_mac_address: MacAddress,
@@ -36,6 +36,42 @@ pub struct DellPowerEdgeR750<'a> {
 pub struct EmbeddedNic {
     pub port_1: MacAddress,
     pub port_2: MacAddress,
+}
+
+struct DellEventLog {
+    entries: Vec<String>,
+}
+
+impl LogService for DellEventLog {
+    fn id(&self) -> &str {
+        "EventLog"
+    }
+
+    fn entries(&self, collection: &redfish::Collection<'_>) -> Vec<serde_json::Value> {
+        self.entries
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| {
+                redfish::log_service::event_entry(collection, &idx.to_string())
+                    .message(entry)
+                    // Severity + Created are not required by the Redfish spec but
+                    // libredfish expects them (mirrors the BlueField event log).
+                    .severity("OK")
+                    .created("2026-02-12T02:06:58+00:00")
+                    .build()
+            })
+            .collect()
+    }
+}
+
+struct DellLogServices {
+    event_log: DellEventLog,
+}
+
+impl LogServices for DellLogServices {
+    fn services(&self) -> Vec<&(dyn LogService + '_)> {
+        vec![&self.event_log as &dyn LogService]
+    }
 }
 
 impl DellPowerEdgeR750<'_> {
@@ -143,7 +179,14 @@ impl DellPowerEdgeR750<'_> {
                 boot_options: Some(boot_options),
                 bios_mode: redfish::computer_system::BiosMode::DellOem,
                 oem: redfish::computer_system::Oem::Generic,
-                log_services: None,
+                log_services: Some(Arc::new(DellLogServices {
+                    event_log: DellEventLog {
+                        // Always report a completed reboot so the controller's
+                        // restart verification (which reads the host BMC event
+                        // log) can confirm reboots for this host.
+                        entries: vec!["Server reset.".to_string()],
+                    },
+                })),
                 // Today carbide need for any Dell to have storage
                 // collection. It tries to find BOSS controller
                 // there. So we provide empty collection to avoid 404

--- a/crates/bmc-mock/src/redfish/oem/nvidia/bluefield.rs
+++ b/crates/bmc-mock/src/redfish/oem/nvidia/bluefield.rs
@@ -55,7 +55,7 @@ impl BluefieldState {
     }
 
     /// Whether the BlueField currently reports NIC mode.
-    fn nic_mode(&self) -> bool {
+    pub fn nic_mode(&self) -> bool {
         self.mode.lock().unwrap().nic_mode
     }
 

--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -89,8 +89,6 @@ pub enum DhcpRelayError {
     ClientApiError(#[from] ClientApiError),
     #[error("Invalid DHCP record: {0}")]
     InvalidDhcpRecord(String),
-    #[error("Cannot send host DHCP from DPU as relay: {0}")]
-    DpuRelayError(String),
 }
 
 impl From<tonic::Status> for DhcpRelayError {

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -363,6 +363,13 @@ impl DpuMachineHandle {
                 || matches!(live_state.booted_os.0, Some(OsImage::DpuAgent)))
     }
 
+    /// Whether this DPU's BlueField has flipped to NIC mode (a `Mode.Set` applied
+    /// on a power cycle). The owning host polls this to converge -- detaching its
+    /// DPU DHCP relay -- once a managed DPU becomes a plain NIC.
+    pub fn flipped_to_nic_mode(&self) -> bool {
+        self.0.live_state.read().unwrap().dpu_flipped_to_nic_mode
+    }
+
     pub async fn wait_until_machine_up_with_api_state(
         &self,
         state: &str,

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -339,9 +339,29 @@ impl HostMachine {
             return Duration::MAX;
         }
 
+        self.maybe_converge_after_dpu_flip();
+
         let sleep_duration = self.state_machine.advance().await;
         tracing::trace!("state_machine.advance end");
         sleep_duration
+    }
+
+    /// When a managed DPU flips to NIC mode it becomes a plain NIC, so this host
+    /// must stop relaying its data-plane DHCP through the DPU and instead DHCP
+    /// directly (on the same former-DPU host MAC, so a retained boot interface
+    /// still matches). Detect the flip through the DPU handle and detach the
+    /// relay once; the host then re-ingests as a zero-managed-DPU NIC-mode
+    /// machine on its next power cycle.
+    fn maybe_converge_after_dpu_flip(&mut self) {
+        if self.state_machine.has_dpu_dhcp_relay()
+            && self.dpus.iter().any(|dpu| dpu.flipped_to_nic_mode())
+        {
+            tracing::info!(
+                "a managed DPU flipped to NIC mode; converging the host to zero managed DPUs (detaching its DPU DHCP relay and dropping the DPU from its reported inventory) so it re-ingests as a NIC-mode host"
+            );
+            self.state_machine.detach_dpu_dhcp_relay();
+            self.state_machine.drop_managed_dpus();
+        }
     }
 
     async fn handle_actor_message(&mut self, message: HostMachineMessage) -> HandleMessageResult {

--- a/crates/machine-a-tron/src/machine_fsm.rs
+++ b/crates/machine-a-tron/src/machine_fsm.rs
@@ -41,6 +41,18 @@ impl MachineFsm {
     }
 
     pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+        // A managed DPU that applied a staged NIC-mode flip is now a plain NIC,
+        // not a DPU: converge it to the dormant BMC-only track from any active
+        // state. Producing this transition here (rather than assigning the state
+        // in the driver) keeps every FSM transition flowing through `event()`.
+        if matches!(event, Event::DpuFlippedToNicMode) {
+            return match self {
+                Self::BmcOnlyMachineUp | Self::BmcOnlyMachineDown => (self, vec![]),
+                // Clean up as the DPU parks: drop its relay handle and cached
+                // discovery state so the flipped NIC stops serving host DHCP.
+                _ => (Self::BmcOnlyMachineUp, vec![Action::CleanupOnPowerOff]),
+            };
+        }
         match self {
             Self::BmcInit { power_on, bmc_only } => self.fsm_bmc_init(event, power_on, bmc_only),
             Self::Init => self.fsm_init(event),
@@ -201,6 +213,13 @@ impl MachineFsm {
         match event {
             Event::PowerCycle => self.machine_down_on_power_cycle(),
             Event::PowerOff => self.machine_down_on_power_off(),
+            // A host whose OS failed and is parked waiting for a reboot -- e.g.
+            // its machine was force-deleted, so its agent hit `MachineNotFound`
+            // -- reboots when the controller powers it back on, so it re-PXEs and
+            // re-ingests. A real host always boots on power-on; a normally serving
+            // host treats a redundant `PowerOn` as a no-op (the `os_fsm`
+            // fall-through below), so scope the reboot to the failed-waiting case.
+            Event::PowerOn if os_fsm.is_awaiting_reboot() => self.machine_down_on_power_cycle(),
             _ => {
                 let (os_fsm, actions) = os_fsm.event(event);
                 (Self::MachineUp { os_fsm }, actions)
@@ -265,6 +284,7 @@ pub enum Event {
     AgentControlCompleted,
     MachineNotFound,
     NetworkObservationCompleted,
+    DpuFlippedToNicMode,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -322,6 +342,17 @@ impl OsFsm {
                 (Self::DpuAgent(dpu_agent_fsm), actions)
             }
         }
+    }
+
+    /// A failed OS parked waiting to be rebooted -- e.g. its machine was
+    /// force-deleted and its agent hit `MachineNotFound`. The host must reboot
+    /// on the next power-on to re-PXE and re-ingest.
+    pub fn is_awaiting_reboot(&self) -> bool {
+        matches!(
+            self,
+            Self::Scout(ScoutFsm::FailedAndWaitForReboot)
+                | Self::DpuAgent(DpuAgentFsm::FailedAndWaitForReboot)
+        )
     }
 }
 

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -16,7 +16,6 @@
  */
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::convert::identity;
 use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, RwLock};
@@ -152,6 +151,10 @@ pub struct LiveState {
     pub api_state: String,
     pub tpm_ek_certificate: Option<Vec<u8>>,
     pub ssh_host_key: Option<String>,
+    /// For a DPU machine, whether its BlueField has flipped to NIC mode. Lets the
+    /// owning host observe the flip through the DPU handle and converge (detach
+    /// its DPU DHCP relay). Always false for a host machine.
+    pub dpu_flipped_to_nic_mode: bool,
 }
 
 impl Default for LiveState {
@@ -170,6 +173,7 @@ impl Default for LiveState {
             api_state: "Unknown".to_string(),
             tpm_ek_certificate: None,
             ssh_host_key: None,
+            dpu_flipped_to_nic_mode: false,
         }
     }
 }
@@ -392,6 +396,33 @@ impl MachineStateMachine {
                         bmc_state.on_event(event)
                     }
                     self.actions.pop_front();
+                    // A BlueField that just applied a staged NIC-mode flip on this
+                    // power-on is now a plain NIC, not a managed DPU. Converge to the
+                    // dormant BMC-only track: drop the queued boot actions and stop,
+                    // so it no longer PXE-boots or is re-discovered as a DPU, matching
+                    // a host configured `dpus_in_nic_mode` from the start.
+                    let flipped_to_nic = matches!(&self.machine_info, MachineInfo::Dpu(_))
+                        && self
+                            .bmc_state
+                            .as_ref()
+                            .and_then(|bmc_state| bmc_state.bluefield_nic_mode())
+                            .unwrap_or(false);
+                    let already_dormant = matches!(
+                        self.fsm,
+                        MachineFsm::BmcOnlyMachineUp | MachineFsm::BmcOnlyMachineDown
+                    );
+                    if flipped_to_nic && !already_dormant {
+                        // Stop the converged DPU completely: drop queued boot actions
+                        // and the pending timers, so `advance()` can't re-enqueue work
+                        // after the FSM converges to the dormant BMC-only track.
+                        self.actions.clear();
+                        self.machine_on_deadline = None;
+                        self.power_cycle_deadline = None;
+                        self.agent_polling_deadline = None;
+                        // Let the FSM own the transition: it is returned by `event()`,
+                        // not assigned here.
+                        self.fsm_event(Event::DpuFlippedToNicMode);
+                    }
                 }
                 FsmAction::InitialDiscoveryRequest(os_image) => {
                     match self.initial_discovery_request(*os_image).await {
@@ -502,22 +533,45 @@ impl MachineStateMachine {
 
         tracing::debug!("Sending Admin DHCP Request for {}", primary_mac);
         let start = Instant::now();
+        // Bound the relay wait so a vanished DPU (one mid-flip to NIC mode, its
+        // relay server gone) can't block the host actor indefinitely.
+        const DPU_DHCP_RELAY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
         let machine_dhcp_info_result = if let Some(DpuDhcpRelay::HostEnd(relay_tx)) =
             &self.dpu_dhcp_relay
         {
+            // Relay this host's data-plane DHCP through its managed DPU, but fall
+            // back to a direct request on the host's own MAC if the relay does not
+            // answer promptly -- e.g. the DPU just flipped to NIC mode, so its relay
+            // server is gone. The same MAC is used either way, so a retained boot
+            // interface still matches on re-ingestion.
             let (reply_tx, reply_rx) = oneshot::channel();
-            match relay_tx.send(reply_tx).map_err(|_| {
-                DhcpRelayError::DpuRelayError("Error sending request, channel closed".to_string())
-            }) {
-                Ok(_) => reply_rx
+            let relayed = match relay_tx.send(reply_tx) {
+                Ok(()) => match tokio::time::timeout(DPU_DHCP_RELAY_TIMEOUT, reply_rx).await {
+                    // The relay answered -- use its result (success OR a real
+                    // DHCP/API error). Only fall back to a direct request when the
+                    // relay is genuinely gone: send failed, channel canceled, or
+                    // timed out.
+                    Ok(Ok(result)) => Some(result),
+                    Ok(Err(_)) | Err(_) => None,
+                },
+                Err(_) => None,
+            };
+            match relayed {
+                Some(result) => result,
+                None => {
+                    tracing::warn!(
+                        "DPU DHCP relay did not answer for {primary_mac}; falling back to a direct request (the DPU likely flipped to NIC mode)"
+                    );
+                    dhcp_wrapper::request_ip(
+                        self.app_context.api_client(),
+                        DhcpRequestInfo {
+                            mac_address: primary_mac,
+                            relay_address: self.config.admin_dhcp_relay_address,
+                            template_dir: self.config.template_dir.clone(),
+                        },
+                    )
                     .await
-                    .map_err(|_| {
-                        DhcpRelayError::DpuRelayError(
-                            "Error reading reply, channel closed".to_string(),
-                        )
-                    })
-                    .and_then(identity),
-                Err(err) => Err(err),
+                }
             }
         } else {
             dhcp_wrapper::request_ip(
@@ -755,6 +809,57 @@ impl MachineStateMachine {
             .bmc_state
             .as_ref()
             .and_then(|state| state.system_state.resolve_current_boot_selection());
+        live_state.dpu_flipped_to_nic_mode = matches!(&self.machine_info, MachineInfo::Dpu(_))
+            && self
+                .bmc_state
+                .as_ref()
+                .and_then(|state| state.bluefield_nic_mode())
+                .unwrap_or(false);
+    }
+
+    /// Whether this machine still relays its data-plane DHCP through a managed
+    /// DPU. False once the relay is detached (see `detach_dpu_dhcp_relay`) or for
+    /// a host that never had a managed DPU.
+    pub fn has_dpu_dhcp_relay(&self) -> bool {
+        self.dpu_dhcp_relay.is_some()
+    }
+
+    /// Stop relaying data-plane DHCP through the DPU. Once a DPU flips to NIC
+    /// mode it is a plain NIC, so the host DHCPs directly on its own (former-DPU
+    /// host) MAC -- the same MAC, so a retained boot interface still matches on
+    /// re-ingestion. Idempotent.
+    pub fn detach_dpu_dhcp_relay(&mut self) {
+        self.dpu_dhcp_relay = None;
+        self.dpu_dhcp_relay_handle = None;
+    }
+
+    /// Drop this host's managed DPUs from its reported inventory once they have
+    /// flipped to NIC mode, so the host BMC enumerates zero managed DPUs and the
+    /// host re-ingests (and rediscovers) as a zero-DPU NIC-mode machine -- the
+    /// PCIe/identity signal a real flipped host would present. The flipped DPU's
+    /// host-facing MAC becomes the host's own plain-NIC MAC, so the host keeps
+    /// DHCPing on the same MAC and a retained boot interface still matches.
+    /// No-op for a non-host machine or a host that already has no DPUs.
+    pub fn drop_managed_dpus(&mut self) {
+        if let MachineInfo::Host(host) = &mut self.machine_info {
+            if host.dpus.is_empty() {
+                return;
+            }
+            // `non_dpu_mac_address` holds a single MAC, so this faithfully models a
+            // single-DPU flip (the case this harness exercises): the former-DPU
+            // host-facing MAC becomes the host's plain-NIC MAC. Preserving every NIC
+            // of a multi-DPU host would need the host info to carry multiple NIC MACs
+            // -- a follow-up.
+            debug_assert!(
+                host.dpus.len() == 1,
+                "drop_managed_dpus preserves only the first former-DPU MAC; \
+                 multi-DPU flip preservation is a follow-up",
+            );
+            if host.non_dpu_mac_address.is_none() {
+                host.non_dpu_mac_address = host.dpus.first().map(|dpu| dpu.host_mac_address);
+            }
+            host.dpus.clear();
+        }
     }
 
     async fn run_machine_discovery(

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -121,8 +121,10 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it took to perform create_machines inside site-explorer</td></tr>
 <tr><td>carbide_site_explorer_created_machines_count</td><td>gauge</td><td>The amount of Machine pairs that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
+<tr><td>carbide_site_explorer_dpu_migration_signals_count</td><td>gauge</td><td>Count of DPU NIC-mode migration signals by kind -- mode-mismatch found, set_nic_mode issued, reset requested, and zero-DPU registered for a NicMode host.</td></tr>
 <tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
 <tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
+<tr><td>carbide_site_explorer_last_run_status</td><td>gauge</td><td>The status of the latest Site Explorer run</td></tr>
 <tr><td>carbide_site_explorer_phase_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration phase</td></tr>
 <tr><td>carbide_site_explorer_update_explored_endpoints_count</td><td>gauge</td><td>Counts from the last update_explored_endpoints phase by kind</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>


### PR DESCRIPTION
machine-a-tron and `bmc-mock` can now simulate a BlueField converting from DPU
mode to plain NIC mode mid-run, so integration tests can drive the operator's
DPU-to-NIC re-registration flow end to end. A host boots with a managed DPU, an
operator sets `dpu_mode` to `nic_mode`, and after the force-delete and
power-cycle the simulated BlueField re-reports as a NIC, the host re-ingests
with no managed DPU, and it provisions through to **Ready**.

A new `test_integration` case proves the whole flow: it drives the flip,
verifies against the database that the host re-ingests as a single
zero-managed-DPU machine, and then drives that machine all the way to Ready.

## Highlights
- machine-a-tron converges a flipped DPU to its NIC-mode (BMC-only) behavior on
  the applying power-cycle; the owning host detaches its DPU DHCP relay and
  drops the DPU from its inventory so it re-reports as zero-DPU.
- Fixes a real simulator bug found while building this: a host whose DPU
  vanished mid-flip would hang forever on its DHCP relay. The relay now bounds
  that wait and falls back to direct DHCP.
- A host parked after an OS failure (for example, a force-delete) now reboots on
  the next power-on, re-PXEs, and re-ingests the way real hardware does.
- `bmc-mock` exposes the BlueField's live NIC-mode flag, and its Dell host BMC
  now serves a system event log so the controller can confirm reboots during
  provisioning.

## Testing
The new `test_integration` case passes, driving a `DellPowerEdgeR750` host
through the full flip and re-registration to Ready (~150s). All existing
`test_integration` sub-tests stay green. Test-infra only -- no product code.

## Deferred follow-ups
- The bmc-mock event logs (both BlueField and the new Dell one) are statically
  pre-seeded; making them causal -- appending a reset entry on the actual reboot
  -- is a broader bmc-mock change worth a separate pass.
- After convergence the host still holds its (now-dormant) DPU handles; retiring
  them for a single source of truth is a follow-up (it cannot be done here
  without aborting the DPU mock, which re-ingest still reads).

Supports #2661.
Supports #2632.


Closes #2632

Closes #2661
