### PR TITLE
fix(ci): Make breaking changes checks compare against the merge-base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -994,7 +994,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Required: Buf needs the history to compare against main
+          fetch-depth: 0 # Required to compute the merge-base against main
 
       - name: Install Buf CLI
         run: |
@@ -1004,8 +1004,18 @@ jobs:
 
       - name: Check for Breaking Changes
         run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          MERGE_BASE="$(git merge-base HEAD origin/main)"
+          BASE_PROTO_DIR="$(mktemp -d)"
+          trap 'rm -rf "${BASE_PROTO_DIR}"' EXIT
+
+          echo "Comparing protobuf changes against merge-base ${MERGE_BASE}"
+          git archive "${MERGE_BASE}" crates/rpc/proto | tar -x -C "${BASE_PROTO_DIR}"
+
           buf breaking crates/rpc/proto \
-            --against 'https://github.com/${{ github.repository }}.git#branch=main,subdir=crates/rpc/proto' \
+            --against "${BASE_PROTO_DIR}/crates/rpc/proto" \
             --error-format=github-actions
 
   lint-police:

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -107,10 +107,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve OpenAPI comparison base
+        id: openapi-base
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          MERGE_BASE="$(git merge-base HEAD origin/main)"
+
+          echo "merge_base=${MERGE_BASE}" >> "${GITHUB_OUTPUT}"
+          echo "Comparing OpenAPI changes against merge-base ${MERGE_BASE}"
+
       - name: Check OpenAPI breaking changes
         uses: oasdiff/oasdiff-action/breaking@a8c7f0e5649d20d623edb5b38446d3ab3d82d43c
         with:
-          base: 'origin/main:rest-api/openapi/spec.yaml'
+          base: '${{ steps.openapi-base.outputs.merge_base }}:rest-api/openapi/spec.yaml'
           revision: ':rest-api/openapi/spec.yaml'
           fail-on: ERR
           # Allowlist the intentional one-time rename of the BMC credential


### PR DESCRIPTION
For both the proto-breaking-changes and openapi-breaking-changes checks, they currently compare against main for breaking changes, but that means if new fields/etc were added to main since the branch was created, they incorrectly show them as being removed in the PR branch. This updates it to check against $(git merge-base HEAD origin/main) so that it only sees the actual diffs introduced in this branch since it started.

## Related issues
#2923 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

