### PR TITLE
fix: report TYPE-line metric name in NameMismatch error

### DIFF
--- a/crates/prometheus-text-parser/src/lib.rs
+++ b/crates/prometheus-text-parser/src/lib.rs
@@ -167,7 +167,7 @@ impl UnknownMetric {
         if name != self.name {
             return Err(MetricsParsingError::NameMismatch {
                 help_name: self.name,
-                type_name: type_str.to_string(),
+                type_name: name.to_string(),
             });
         }
 
@@ -648,6 +648,22 @@ build_info{build_date="real-date",git_sha="real-sha",role="api"} 1
             "other attributes are left alone" {
                 "role" => Some("\"api\"".to_string()),
             }
+        );
+    }
+
+    #[test]
+    fn name_mismatch_error_reports_type_line_name() {
+        let error = "# HELP metric help\n# TYPE other counter\n"
+            .parse::<ParsedPrometheusMetrics>()
+            .expect_err("mismatched HELP/TYPE names should fail to parse");
+        let message = error.to_string();
+        assert!(
+            message.contains("HELP line is for metric metric"),
+            "error should name the HELP-line metric: {message}"
+        );
+        assert!(
+            message.contains("TYPE line is for other"),
+            "error should name the TYPE-line metric, not its type: {message}"
         );
     }
 }


### PR DESCRIPTION
When a metric's `# HELP` and `# TYPE` lines disagree on the metric name, `UnknownMetric::promote` returned the metric **type** (e.g. `counter`) in the error's `type_name` field instead of the metric **name** parsed from the `# TYPE` line. Because `MetricsParsingError::NameMismatch` renders as:

> `Metric name mismatch: HELP line is for metric {help_name} but TYPE line is for {type_name}`

the diagnostic named the metric *type* rather than the mismatched metric name. For input:

```
# HELP metric help
# TYPE other counter
```

it produced *"...TYPE line is for **counter**"* instead of *"...for **other**"*.

The fix passes the parsed `# TYPE`-line name into `type_name`.

## Related issues
None.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

Added `name_mismatch_error_reports_type_line_name`, which asserts the rendered error message names both the HELP-line and TYPE-line metrics. The existing `reports_parse_errors` test only asserted the error *variant* (`"name-mismatch"`), not the message contents, which is why this went unnoticed. Verified the new test fails against the original code (`...TYPE line is for counter`) and passes with the fix. `cargo test -p prometheus-text-parser` (6 passed) and `cargo clippy -p prometheus-text-parser -- -D warnings` are clean.
