### PR TITLE
test(api-db): cover the retained_boot_interfaces store

### DIFF
--- a/crates/api-db/src/retained_boot_interface.rs
+++ b/crates/api-db/src/retained_boot_interface.rs
@@ -159,3 +159,194 @@ pub async fn delete_expired(
         .map_err(|e| DatabaseError::query(query, e))?;
     Ok(result.rows_affected())
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Duration;
+    use mac_address::MacAddress;
+    use sqlx::PgConnection;
+
+    use super::{delete_expired, find_by_mac, find_records_by_macs, take_by_mac, upsert};
+
+    fn mac(last: u8) -> MacAddress {
+        MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, last])
+    }
+
+    /// Backdate a record's `recorded_at` so the window / expiry paths have a
+    /// stale row to act on -- production only ever writes `recorded_at = NOW()`.
+    async fn age_record(txn: &mut PgConnection, mac: MacAddress, seconds_ago: i64) {
+        sqlx::query(
+            "UPDATE retained_boot_interfaces \
+             SET recorded_at = NOW() - ($2::bigint * INTERVAL '1 second') \
+             WHERE mac_address = $1",
+        )
+        .bind(mac)
+        .bind(seconds_ago)
+        .execute(txn)
+        .await
+        .unwrap();
+    }
+
+    #[crate::sqlx_test]
+    async fn upsert_then_find_by_mac_returns_the_retained_id(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.7-1-1")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            find_by_mac(txn.as_mut(), mac(1), None)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("NIC.Slot.7-1-1"),
+        );
+        // A MAC with nothing on file resolves to None.
+        assert_eq!(find_by_mac(txn.as_mut(), mac(2), None).await.unwrap(), None);
+    }
+
+    #[crate::sqlx_test]
+    async fn upsert_keeps_the_newest_id_for_a_mac(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.1-1").await.unwrap();
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.7-1-1")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            find_by_mac(txn.as_mut(), mac(1), None)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("NIC.Slot.7-1-1"),
+            "the newest observation wins on conflict",
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn take_by_mac_returns_the_id_and_consumes_the_row(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.7-1-1")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            take_by_mac(txn.as_mut(), mac(1), None)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("NIC.Slot.7-1-1"),
+        );
+        // The row is gone after a take...
+        assert_eq!(find_by_mac(txn.as_mut(), mac(1), None).await.unwrap(), None);
+        // ...so a second take finds nothing.
+        assert_eq!(take_by_mac(txn.as_mut(), mac(1), None).await.unwrap(), None);
+    }
+
+    #[crate::sqlx_test]
+    async fn find_by_mac_filters_records_aged_past_the_window(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.7-1-1")
+            .await
+            .unwrap();
+        age_record(txn.as_mut(), mac(1), 3600).await; // an hour old
+
+        // Inside a generous window the pair still applies.
+        assert_eq!(
+            find_by_mac(txn.as_mut(), mac(1), Some(Duration::hours(2)))
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("NIC.Slot.7-1-1"),
+        );
+        // Aged past a tight window, it is filtered out.
+        assert_eq!(
+            find_by_mac(txn.as_mut(), mac(1), Some(Duration::seconds(60)))
+                .await
+                .unwrap(),
+            None,
+        );
+        // No window means forever, so it applies again.
+        assert_eq!(
+            find_by_mac(txn.as_mut(), mac(1), None)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("NIC.Slot.7-1-1"),
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn take_by_mac_withholds_a_stale_id_but_still_consumes_the_row(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.7-1-1")
+            .await
+            .unwrap();
+        age_record(txn.as_mut(), mac(1), 3600).await; // an hour old
+
+        // Past the window the id is withheld -- a recycled MAC must not inherit it...
+        assert_eq!(
+            take_by_mac(txn.as_mut(), mac(1), Some(Duration::seconds(60)))
+                .await
+                .unwrap(),
+            None,
+        );
+        // ...but the row is consumed regardless, so a stale record can't linger.
+        assert_eq!(find_by_mac(txn.as_mut(), mac(1), None).await.unwrap(), None);
+    }
+
+    #[crate::sqlx_test]
+    async fn delete_expired_sweeps_only_aged_rows_and_noops_without_a_window(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.1-1").await.unwrap(); // fresh
+        upsert(txn.as_mut(), mac(2), "NIC.Slot.2-1").await.unwrap();
+        age_record(txn.as_mut(), mac(2), 3600).await; // stale
+
+        // Without a window nothing ever expires, so the sweep is a no-op.
+        assert_eq!(delete_expired(txn.as_mut(), None).await.unwrap(), 0);
+
+        // A window removes only the aged row.
+        assert_eq!(
+            delete_expired(txn.as_mut(), Some(Duration::seconds(60)))
+                .await
+                .unwrap(),
+            1,
+        );
+        assert_eq!(find_by_mac(txn.as_mut(), mac(2), None).await.unwrap(), None);
+        assert_eq!(
+            find_by_mac(txn.as_mut(), mac(1), None)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("NIC.Slot.1-1"),
+            "fresh records survive the sweep",
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn find_records_by_macs_returns_every_match_including_stale(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+
+        upsert(txn.as_mut(), mac(1), "NIC.Slot.1-1").await.unwrap();
+        upsert(txn.as_mut(), mac(2), "NIC.Slot.2-1").await.unwrap();
+        age_record(txn.as_mut(), mac(1), 3600).await; // stale, but still surfaced
+
+        let records = find_records_by_macs(txn.as_mut(), &[mac(1), mac(2)])
+            .await
+            .unwrap();
+
+        // The troubleshooting read is unfiltered and ordered by MAC: both rows come
+        // back, the stale one included.
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].mac_address, mac(1));
+        assert_eq!(records[0].boot_interface_id, "NIC.Slot.1-1");
+        assert_eq!(records[1].mac_address, mac(2));
+        assert_eq!(records[1].boot_interface_id, "NIC.Slot.2-1");
+    }
+}


### PR DESCRIPTION
## Summary

`retained_boot_interfaces` is the store that lets a re-ingested machine recover its boot interface id after the live MAC is gone -- the piece that keeps the boot NIC resolvable by its interface id even when a DPU/NIC-mode flip (or an iDRAC partition, #2821) drops the MAC from Redfish. It had **no direct tests**; this adds deterministic, DB-backed coverage of its round-trip and retention-window behavior.

### Tests (all via the `#[crate::sqlx_test]` harness against Postgres)

- **Round-trip:** `upsert` then `find_by_mac` / `take_by_mac` recover the id; `upsert` keeps the newest id on conflict; `take_by_mac` consumes the row.
- **Retention window:** `find_by_mac` filters records aged past the window; `take_by_mac` withholds a stale id but **still removes the row** (so a recycled MAC can't inherit it); `delete_expired` sweeps only aged rows and no-ops without a window.
- **Troubleshooting read:** `find_records_by_macs` returns every match unfiltered (stale included).

Test-only -- no production code changes.

This supports https://github.com/NVIDIA/infra-controller/issues/2821