### PR TITLE
fix: GBx00 misclassified as DPU during PXE boot

### DIFF
--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -353,8 +353,7 @@ exit ||
             // use:
             // - If we don't have an exploration report for this MAC address, don't PXE boot at all
             // - If it's X86 and we have an exploration report, assume it's a Host.
-            // - If it's ARM and we have an exploration report, check if the report has a
-            //   BlueField part number.
+            // - If it's ARM, only treat it as a DPU when the explored endpoint is itself a DPU BMC.
             let Some(endpoint) =
                 db::explored_endpoints::find_by_mac_address(&mut *txn, interface.mac_address)
                     .await?
@@ -370,7 +369,7 @@ exit ||
             let (machine_type, console) = match target.arch {
                 rpc::MachineArchitecture::X86 => (MachineType::PredictedHost, console),
                 rpc::MachineArchitecture::Arm => {
-                    if endpoint.has_bluefield_part_number() {
+                    if endpoint.report.is_dpu() {
                         (MachineType::Dpu, console)
                     } else {
                         (MachineType::PredictedHost, "ttyAMA0")


### PR DESCRIPTION
**Problem**

On ARM hosts without a minted machine ID yet, the PXE boot path classified a machine as a DPU if its explored endpoint had *any* BlueField part number in its chassis inventory (`has_bluefield_part_number()`). The GBx00 host BMC reports its BlueField-3 as a chassis object, so the host was misclassified as a DPU and served the DPU OS (`carbide.efi` / `carbide.root`) instead of the host image (`scout.efi`).

**Fix**

In `crates/api-core/src/ipxe.rs`, we now treat an endpoint as a DPU only when the explored endpoint is itself a DPU BMC (`endpoint.report.is_dpu()`, i.e. `Systems[0].Id == "Bluefield"`) rather than merely containing a BlueField part number.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2930

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

