### PR TITLE
fix(api): verify caller machine ID against instance when phone home

### DIFF
--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -800,6 +800,29 @@ pub(crate) async fn update_phone_home_last_contact(
     request: Request<rpc::InstancePhoneHomeLastContactRequest>,
 ) -> Result<Response<rpc::InstancePhoneHomeLastContactResponse>, Status> {
     log_request_data(&request);
+
+    // Extract the calling machine's ID from the SPIFFE certificate before consuming the request.
+    // When bypass_rbac is enabled (integration tests), the cert check is skipped: test tooling
+    // uses a generic TLS client cert that carries no SPIFFE identity.
+    let caller_machine_id = if api.runtime_config.bypass_rbac {
+        None
+    } else {
+        let id_str = request
+            .extensions()
+            .get::<crate::auth::AuthContext>()
+            .and_then(|ctx| ctx.get_spiffe_machine_id())
+            .ok_or_else(|| {
+                CarbideError::ClientCertificateMissingInformation(
+                    "phone-home request must include a valid machine SPIFFE certificate".into(),
+                )
+            })?;
+        Some(MachineId::from_str(id_str).map_err(|_| {
+            CarbideError::ClientCertificateMissingInformation(
+                "machine ID in SPIFFE certificate is invalid".into(),
+            )
+        })?)
+    };
+
     let request = request.into_inner();
     let instance_id = request
         .instance_id
@@ -809,13 +832,49 @@ pub(crate) async fn update_phone_home_last_contact(
 
     let instance = db::instance::find_by_id(&mut txn, instance_id)
         .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "instance",
-            id: instance_id.to_string(),
+        .ok_or_else(|| {
+            // Return PermissionDenied (not NotFound) so callers cannot probe instance existence
+            // by observing which error they receive.
+            match &caller_machine_id {
+                Some(mid) => CarbideError::PermissionDeniedError(format!(
+                    "machine {mid} is not authorized to update phone-home for instance {instance_id}"
+                )),
+                None => CarbideError::NotFoundError {
+                    kind: "instance",
+                    id: instance_id.to_string(),
+                },
+            }
         })?;
 
     log_machine_id(&instance.machine_id);
     log_tenant_organization_id(instance.config.tenant.tenant_organization_id.as_str());
+
+    // Verify the caller is authorized: either the instance's host machine itself, or a DPU
+    // attached to that host. Phone-home calls originate from the DPU agent on the host.
+    // Skipped when bypass_rbac is enabled (caller_machine_id is None).
+    if let Some(ref caller_machine_id) = caller_machine_id {
+        let caller_is_host = *caller_machine_id == instance.machine_id;
+        let caller_is_attached_dpu = if caller_is_host {
+            false
+        } else {
+            db::machine::find_host_by_dpu_machine_id(&mut txn, caller_machine_id)
+                .await?
+                .is_some_and(|host| host.id == instance.machine_id)
+        };
+
+        if !caller_is_host && !caller_is_attached_dpu {
+            tracing::warn!(
+                %caller_machine_id,
+                instance_machine_id = %instance.machine_id,
+                %instance_id,
+                "phone-home denied: caller is not the instance host or an attached DPU",
+            );
+            return Err(CarbideError::PermissionDeniedError(format!(
+                "machine {caller_machine_id} is not authorized to update phone-home for instance {instance_id}"
+            ))
+            .into());
+        }
+    }
 
     let res = db::instance::update_phone_home_last_contact(&mut txn, instance.id).await?;
 

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -2100,12 +2100,16 @@ async fn test_instance_phone_home(_: PgPoolOptions, options: PgConnectOptions) {
     assert_eq!(instance.status().tenant(), rpc::TenantState::Provisioning);
 
     // Phone home to transition to the ready state
+    let mut phone_home_req = tonic::Request::new(rpc::forge::InstancePhoneHomeLastContactRequest {
+        instance_id: Some(tinstance.id),
+    });
+    let mut auth_context = crate::auth::AuthContext::default();
+    auth_context
+        .principals
+        .push(carbide_authn::middleware::Principal::SpiffeMachineIdentifier(mh.id.to_string()));
+    phone_home_req.extensions_mut().insert(auth_context);
     env.api
-        .update_instance_phone_home_last_contact(tonic::Request::new(
-            rpc::forge::InstancePhoneHomeLastContactRequest {
-                instance_id: Some(tinstance.id),
-            },
-        ))
+        .update_instance_phone_home_last_contact(phone_home_req)
         .await
         .unwrap();
 

--- a/crates/api-core/src/tests/instance_config_update.rs
+++ b/crates/api-core/src/tests/instance_config_update.rs
@@ -191,12 +191,16 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
     );
 
     // Phone home to transition from provisioning to configuring state
+    let mut phone_home_req = tonic::Request::new(rpc::forge::InstancePhoneHomeLastContactRequest {
+        instance_id: Some(tinstance.id),
+    });
+    let mut auth_context = crate::auth::AuthContext::default();
+    auth_context
+        .principals
+        .push(carbide_authn::middleware::Principal::SpiffeMachineIdentifier(mh.id.to_string()));
+    phone_home_req.extensions_mut().insert(auth_context);
     env.api
-        .update_instance_phone_home_last_contact(tonic::Request::new(
-            rpc::forge::InstancePhoneHomeLastContactRequest {
-                instance_id: Some(tinstance.id),
-            },
-        ))
+        .update_instance_phone_home_last_contact(phone_home_req)
         .await
         .unwrap();
 

--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -104,7 +104,7 @@ pub async fn create(
         let before_phone = get_instance_state(addrs, &instance_id).await?;
         assert_eq!(before_phone, "PROVISIONING");
         // Phone home to transition to the ready state
-        phone_home(addrs, &instance_id).await?;
+        phone_home(addrs, &instance_id, host_machine_id).await?;
         wait_for_instance_state(addrs, &instance_id, "READY").await?;
         let after_phone = get_instance_state(addrs, &instance_id).await?;
         assert_eq!(after_phone, "READY");
@@ -230,12 +230,16 @@ pub async fn release(
     Ok(())
 }
 
-pub async fn phone_home(addrs: &[SocketAddr], instance_id: &str) -> eyre::Result<()> {
+pub async fn phone_home(
+    addrs: &[SocketAddr],
+    instance_id: &str,
+    host_machine_id: &MachineId,
+) -> eyre::Result<()> {
     let data = serde_json::json!({
         "instance_id": {"value": instance_id},
     });
 
-    tracing::info!("Phoning home with data: {data}");
+    tracing::info!(%host_machine_id, "Phoning home for instance {instance_id}");
 
     grpcurl(addrs, "UpdateInstancePhoneHomeLastContact", Some(&data)).await?;
 


### PR DESCRIPTION
The phone-home endpoint used mTLS to authenticate the caller but blindly trusted the `instance_id` in the request body, allowing any machine with a valid certificate to update phone-home timestamps for arbitrary instances.

Extract the caller's machine ID from the SPIFFE certificate and require it to match either the instance's host machine or a DPU attached to that host via `find_host_by_dpu_machine_id`. Callers that pass mTLS but fail this check receive `PERMISSION_DENIED`.

Rather than generating machine certs in integration tests, gate the entire SPIFFE identity check on `api.runtime_config.bypass_rbac`.  When `bypass_rbac = true` (set in the integration test server config), `caller_machine_id` is `None` and both the cert extraction and the host/DPU authorization check are skipped.  When `bypass_rbac = false` (production), the full check still runs.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [X] Integration tests added/updated
- [ ] Manual testing performed
- [] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

