### PR TITLE
fix(site-agent): use mTLS for Flow gRPC and protect temporal-certs secret

### DIFF
--- a/helm/rest/nico-rest-site-agent/templates/temporal-certs-secret.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/temporal-certs-secret.yaml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Temporal client TLS certs for site-agent — placeholder values populated by bootstrap
+# Temporal client TLS certs for site-agent — placeholder values populated by bootstrap.
+# resource-policy: keep prevents helm upgrade from overwriting certs written by the
+# bootstrap process; deleting and re-installing the release creates a fresh placeholder.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +11,8 @@ metadata:
   namespace: {{ include "nico-rest-site-agent.namespace" . }}
   labels:
     {{- include "nico-rest-site-agent.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 stringData:
   otp: ""

--- a/helm/rest/nico-rest-site-agent/values.yaml
+++ b/helm/rest/nico-rest-site-agent/values.yaml
@@ -82,7 +82,7 @@ envConfig:
   ENABLE_TLS: "true"
   NICO_ADDRESS: ""
   NICO_SEC_OPT: "0"
-  FLOW_GRPC_ENABLED: "false"
+  FLOW_GRPC_ENABLED: "true"
   FLOW_GRPC_SEC_OPT: "2"
   CLUSTER_ID: ""
   TEMPORAL_HOST: "temporal-frontend.temporal"

--- a/helm/rest/nico-rest-site-agent/values.yaml
+++ b/helm/rest/nico-rest-site-agent/values.yaml
@@ -82,6 +82,8 @@ envConfig:
   ENABLE_TLS: "true"
   NICO_ADDRESS: ""
   NICO_SEC_OPT: "0"
+  FLOW_GRPC_ENABLED: "false"
+  FLOW_GRPC_SEC_OPT: "2"
   CLUSTER_ID: ""
   TEMPORAL_HOST: "temporal-frontend.temporal"
   TEMPORAL_PORT: "7233"

--- a/rest-api/site-workflow/pkg/grpc/client/flow_client.go
+++ b/rest-api/site-workflow/pkg/grpc/client/flow_client.go
@@ -158,9 +158,19 @@ func NewFlowGrpcClient(config *FlowGrpcClientConfig) (client *FlowGrpcClient, er
 		if !capool.AppendCertsFromPEM(cabytes) {
 			return nil, fmt.Errorf("FlowGrpcClient: Failed to append CA cert to CA pool")
 		}
+		// Use GetClientCertificate (not Certificates) to unconditionally present
+		// the client cert. With Certificates, Go's TLS stack only selects a cert
+		// whose issuer matches the acceptable CA list from the server's
+		// CertificateRequest; when no match is found it silently sends no cert,
+		// causing the server to reject with "tls: certificate required".
+		// GetClientCertificate bypasses that matching and always returns the cert,
+		// leaving verification to the server — the same approach used in
+		// rest-api/flow/pkg/certs/certs.go TLSConfig().
 		mutualTLSConfig := &tls.Config{
-			Certificates: []tls.Certificate{clientCert},
-			RootCAs:      capool,
+			GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				return &clientCert, nil
+			},
+			RootCAs: capool,
 		}
 		creds := credentials.NewTLS(mutualTLSConfig)
 


### PR DESCRIPTION
<!-- Describe what this PR does -->
Three fixes for site-agent → Flow gRPC connectivity:
- `flow_client.go`: switch `FlowMutualTLS` from `tls.Config{Certificates}` to `GetClientCertificate` — Go silently drops the cert when the issuer doesn't match the server's CA list, causing `tls: certificate required`
- `values.yaml`: add `FLOW_GRPC_SEC_OPT: "2"` as chart default (was unset, defaulted to server-TLS only)
- `temporal-certs-secret.yaml`: add `helm.sh/resource-policy: keep` — template was overwriting bootstrap-written certs on every `helm upgrade`, causing bootstrap to retry forever and block Flow gRPC startup

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified on dev6: site-agent pods reach `1/1 Running` with 0 restarts and logs show `FlowGrpcClient: Successfully connected to server`. `helm upgrade` no longer overwrites `temporal-client-site-agent-certs`.

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->