### PR TITLE
fix(ssh-console): fall back for Lenovo SOL activation

### DIFF
--- a/crates/machine-a-tron/src/mock_ssh_server.rs
+++ b/crates/machine-a-tron/src/mock_ssh_server.rs
@@ -45,6 +45,7 @@ pub struct Credentials {
 pub enum PromptBehavior {
     Dell,
     Dpu,
+    LenovoSr650,
 }
 
 pub async fn spawn(
@@ -202,9 +203,10 @@ impl MockSshHandler {
                     format!("\r\nroot@{} # ", self.prompt_hostname.get_hostname()),
                 )?;
             }
-            ConsoleState::Bmc => {
-                session.data(channel, "\nracadm>>")?;
-            }
+            ConsoleState::Bmc => match self.prompt_behavior {
+                PromptBehavior::LenovoSr650 => session.data(channel, "\nsystem>")?,
+                _ => session.data(channel, "\nracadm>>")?,
+            },
             ConsoleState::NoShell => {
                 // Do nothing
             }
@@ -256,7 +258,7 @@ impl server::Handler for MockSshHandler {
     ) -> StdResult<(), Self::Error> {
         tracing::debug!("shell_request");
         match self.prompt_behavior {
-            PromptBehavior::Dell => {
+            PromptBehavior::Dell | PromptBehavior::LenovoSr650 => {
                 self.console_state = ConsoleState::Bmc;
             }
             PromptBehavior::Dpu => {
@@ -314,11 +316,33 @@ impl server::Handler for MockSshHandler {
             ConsoleState::Bmc => {
                 if data == b"\n" || data == b"\r\n" || data == b"\r" {
                     let command = std::mem::take(&mut self.buffer);
-                    if command.starts_with(b"connect com2") {
-                        tracing::info!(
-                            "Got `connect com2` in bmc propmt, simulating system console"
-                        );
-                        self.console_state = ConsoleState::SystemConsole;
+                    match self.prompt_behavior {
+                        PromptBehavior::Dell if command.starts_with(b"connect com2") => {
+                            tracing::info!(
+                                "Got `connect com2` in bmc prompt, simulating system console"
+                            );
+                            self.console_state = ConsoleState::SystemConsole;
+                        }
+                        PromptBehavior::LenovoSr650 if command.starts_with(b"console kill 1") => {
+                            tracing::info!(
+                                "Got unsupported Lenovo `console kill 1`, simulating BMC error"
+                            );
+                            session.data(
+                                channel,
+                                "\r\nThe command line contains extraneous arguments\r\n",
+                            )?;
+                        }
+                        PromptBehavior::LenovoSr650 if command.starts_with(b"console kill") => {
+                            tracing::info!(
+                                "Got Lenovo `console kill`, simulating terminated SOL session"
+                            );
+                            session.data(channel, "\r\nSession on channel 1 is terminated\r\n")?;
+                        }
+                        PromptBehavior::LenovoSr650 if command.starts_with(b"console start") => {
+                            tracing::info!("Got Lenovo `console start`, simulating system console");
+                            self.console_state = ConsoleState::SystemConsole;
+                        }
+                        _ => {}
                     }
                     self.print_prompt(session, channel)?;
                 } else {

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -45,6 +45,8 @@ use crate::bmc::vendor::SshBmcVendor;
 
 static RUSSH_CLIENT_CONFIG: LazyLock<Arc<russh::client::Config>> =
     LazyLock::new(russh_client_config);
+const LENOVO_SOL_PRIMARY_FAILURE: &[u8] = b"The command line contains extraneous arguments";
+const LENOVO_SOL_FALLBACK_ACTIVATE_COMMAND: &[u8] = b"console kill\nconsole start";
 
 /// Connect to a BMC one time, returning a [`Handle`]. Will not retry on connection errors.
 pub async fn spawn(
@@ -392,8 +394,8 @@ async fn make_authenticated_client(
 }
 
 // Interact with the serial-on-lan console within the BMC ssh session, calling the vendor's serial
-// activation command (`connect com1`, etc) and ensuring we're in the serial console before
-// continuing.
+// activation command (`connect com1`, etc), falling back when needed, and ensuring we're in the
+// serial console before continuing.
 async fn trigger_and_await_sol_console(
     machine_id: MachineId,
     ssh_client_channel: &mut Channel<russh::client::Msg>,
@@ -439,12 +441,14 @@ async fn trigger_and_await_sol_console(
         })?;
 
     let mut prompt_buf: Vec<u8> = Vec::with_capacity(1024);
-    let timeout = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+    let mut timeout = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
     // After sending the activate command, wait for this much data to be read back (the command
     // itself echoing back, plus the prompt length) before continuing. (If we let the client use the
     // console before this, we get false positives about seeing a bmc prompt while we're supposed to
     // be in the console.)
-    let skip_data_read_len = bmc_prompt.len() + activate_command.len();
+    let mut activate_command = activate_command;
+    let mut skip_data_read_len = bmc_prompt.len() + activate_command.len();
+    let mut lenovo_fallback_sent = false;
 
     let mut activation_step = SerialConsoleActivationStep::WaitingForBmcPrompt;
     loop {
@@ -463,7 +467,7 @@ async fn trigger_and_await_sol_console(
 
                         if matches!(activation_step, SerialConsoleActivationStep::WaitingForBmcPrompt) {
                             // Do we see the bmc prompt?
-                            if prompt_buf.windows(bmc_prompt.len()).any(|window| window == bmc_prompt) {
+                            if bytes_contains(&prompt_buf, bmc_prompt) {
                                 // We saw the prompt, send the serial activate command (`connect com1`,
                                 // etc) one byte at a time: This seems to work better with some
                                 // consoles.
@@ -486,7 +490,36 @@ async fn trigger_and_await_sol_console(
                         // get false positives about seeing a bmc prompt while we're supposed to be
                         // in the console.)
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
-                            && prompt_buf.len() > skip_data_read_len {
+                            && bmc_vendor == SshBmcVendor::Lenovo
+                            && !lenovo_fallback_sent
+                            && should_run_lenovo_sol_fallback(&prompt_buf, bmc_prompt)
+                        {
+                            tracing::info!(
+                                %machine_id,
+                                "Lenovo primary SOL activation failed, trying console start fallback"
+                            );
+                            activate_command = LENOVO_SOL_FALLBACK_ACTIVATE_COMMAND;
+                            skip_data_read_len = bmc_prompt.len() + activate_command.len();
+                            timeout = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+                            for byte in activate_command {
+                                ssh_client_channel
+                                    .data([*byte].as_slice())
+                                    .await
+                                .map_err(|error| ConsoleActivateError::Request { phase: "sending serial activate command to BMC", error })?;
+                            }
+                            ssh_client_channel.data(b"\n".as_slice()).await
+                                .map_err(|error| ConsoleActivateError::Request { phase: "sending data to BMC", error })?;
+                            lenovo_fallback_sent = true;
+                            prompt_buf.clear();
+                        }
+
+                        if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
+                            && should_accept_sol_activation_output(
+                                bmc_vendor,
+                                lenovo_fallback_sent,
+                                &prompt_buf,
+                                skip_data_read_len,
+                            ) {
                             tracing::debug!(%machine_id, "confirmed serial activate command sent, letting client use console");
                             break;
                         }
@@ -535,6 +568,26 @@ fn russh_client_config() -> Arc<russh::client::Config> {
 enum SerialConsoleActivationStep {
     WaitingForBmcPrompt,
     ActivateSent,
+}
+
+fn should_run_lenovo_sol_fallback(prompt_buf: &[u8], bmc_prompt: &[u8]) -> bool {
+    bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE) && bytes_contains(prompt_buf, bmc_prompt)
+}
+
+fn should_accept_sol_activation_output(
+    bmc_vendor: SshBmcVendor,
+    lenovo_fallback_sent: bool,
+    prompt_buf: &[u8],
+    skip_data_read_len: usize,
+) -> bool {
+    let lenovo_primary_failure_pending = bmc_vendor == SshBmcVendor::Lenovo
+        && !lenovo_fallback_sent
+        && bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE);
+    !lenovo_primary_failure_pending && prompt_buf.len() > skip_data_read_len
+}
+
+fn bytes_contains(buf: &[u8], pat: &[u8]) -> bool {
+    !pat.is_empty() && buf.windows(pat.len()).any(|window| window == pat)
 }
 
 /// Returns `true` if `buf` contains the byte sequence `pat` anywhere
@@ -600,6 +653,56 @@ fn test_ringbuf_contains() {
     assert!(ringbuf_contains(&rb, b"")); // empty always true
     assert!(!ringbuf_contains(&rb, b"rustacean")); // longer than buf
     assert!(!ringbuf_contains(&rb, b"aean")); // non-contiguous
+}
+
+#[test]
+fn lenovo_primary_failure_without_prompt_waits_instead_of_succeeding() {
+    let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
+    let activate_command = SshBmcVendor::Lenovo.serial_activate_command().unwrap();
+    let skip_data_read_len = bmc_prompt.len() + activate_command.len();
+    let output = b"console kill 1\r\nThe command line contains extraneous arguments\r\n";
+
+    assert!(output.len() > skip_data_read_len);
+    assert!(!should_run_lenovo_sol_fallback(output, bmc_prompt));
+    assert!(!should_accept_sol_activation_output(
+        SshBmcVendor::Lenovo,
+        false,
+        output,
+        skip_data_read_len,
+    ));
+}
+
+#[test]
+fn lenovo_primary_failure_with_prompt_runs_fallback() {
+    let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
+    let output = b"console kill 1\r\nThe command line contains extraneous arguments\r\nsystem>";
+
+    assert!(should_run_lenovo_sol_fallback(output, bmc_prompt));
+}
+
+#[test]
+fn lenovo_fallback_output_succeeds_by_byte_count() {
+    let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
+    let skip_data_read_len = bmc_prompt.len() + LENOVO_SOL_FALLBACK_ACTIVATE_COMMAND.len();
+    let output = b"console kill\r\nSession on channel 1 is terminated\r\nsystem> console start\r\n";
+
+    assert!(output.len() > skip_data_read_len);
+    assert!(should_accept_sol_activation_output(
+        SshBmcVendor::Lenovo,
+        true,
+        output,
+        skip_data_read_len,
+    ));
+}
+
+#[test]
+fn non_lenovo_activation_still_succeeds_by_byte_count() {
+    assert!(should_accept_sol_activation_output(
+        SshBmcVendor::Dell,
+        false,
+        b"connect com2\r\nready",
+        b"connect com2".len(),
+    ));
 }
 
 #[derive(Clone)]

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -532,6 +532,15 @@ async fn trigger_and_await_sol_console(
                             prompt_buf.clear();
                         }
 
+                        if fallback_activate_commands
+                            .is_some_and(|commands| next_fallback_command_index == commands.len())
+                            && let Some(prompt_offset) = prompt_buf
+                                .windows(bmc_prompt.len())
+                                .rposition(|window| window == bmc_prompt)
+                        {
+                            prompt_buf.drain(..prompt_offset + bmc_prompt.len());
+                        }
+
                         let waiting_for_fallback_prompt = fallback_activate_commands
                             .is_some_and(|commands| next_fallback_command_index < commands.len());
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -516,6 +516,7 @@ async fn trigger_and_await_sol_console(
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
                             && let Some(fallback_commands) = fallback_activate_commands
                             && next_fallback_command_index < fallback_commands.len()
+                            && prompt_buf.len() > skip_data_read_len
                             && prompt_buf.windows(bmc_prompt.len()).any(|window| window == bmc_prompt)
                         {
                             let fallback_command = fallback_commands[next_fallback_command_index];

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -532,21 +532,30 @@ async fn trigger_and_await_sol_console(
                             prompt_buf.clear();
                         }
 
-                        if fallback_activate_commands
-                            .is_some_and(|commands| next_fallback_command_index == commands.len())
-                            && let Some(prompt_offset) = prompt_buf
-                                .windows(bmc_prompt.len())
-                                .rposition(|window| window == bmc_prompt)
-                        {
-                            prompt_buf.drain(..prompt_offset + bmc_prompt.len());
-                        }
-
                         let waiting_for_fallback_prompt = fallback_activate_commands
                             .is_some_and(|commands| next_fallback_command_index < commands.len());
+                        let fallback_sequence_complete = fallback_activate_commands
+                            .is_some_and(|commands| next_fallback_command_index == commands.len());
+                        let activation_output = if fallback_sequence_complete
+                            && let Some(fallback_commands) = fallback_activate_commands
+                        {
+                            let final_fallback_command = fallback_commands[fallback_commands.len() - 1];
+                            prompt_buf
+                                .windows(final_fallback_command.len())
+                                .rposition(|window| window == final_fallback_command)
+                                .map(|command_offset| &prompt_buf[command_offset..])
+                        } else {
+                            Some(prompt_buf.as_slice())
+                        };
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
                             && !waiting_for_fallback_prompt
+                            && let Some(activation_output) = activation_output
+                            && !(fallback_sequence_complete
+                                && activation_output
+                                    .windows(bmc_prompt.len())
+                                    .any(|window| window == bmc_prompt))
                             && bmc_vendor.should_accept_sol_activation_output(
-                                &prompt_buf,
+                                activation_output,
                                 skip_data_read_len,
                             ) {
                             tracing::debug!(%machine_id, "confirmed serial activate command sent, letting client use console");

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -45,8 +45,6 @@ use crate::bmc::vendor::SshBmcVendor;
 
 static RUSSH_CLIENT_CONFIG: LazyLock<Arc<russh::client::Config>> =
     LazyLock::new(russh_client_config);
-const LENOVO_SOL_PRIMARY_FAILURE: &[u8] = b"The command line contains extraneous arguments";
-const LENOVO_SOL_FALLBACK_ACTIVATE_COMMAND: &[u8] = b"console kill\nconsole start";
 
 /// Connect to a BMC one time, returning a [`Handle`]. Will not retry on connection errors.
 pub async fn spawn(
@@ -446,9 +444,10 @@ async fn trigger_and_await_sol_console(
     // itself echoing back, plus the prompt length) before continuing. (If we let the client use the
     // console before this, we get false positives about seeing a bmc prompt while we're supposed to
     // be in the console.)
-    let mut activate_command = activate_command;
     let mut skip_data_read_len = bmc_prompt.len() + activate_command.len();
-    let mut lenovo_fallback_sent = false;
+    let mut fallback_activate_sent = false;
+    let mut fallback_activate_commands: Option<&'static [&'static [u8]]> = None;
+    let mut next_fallback_command_index = 0;
 
     let mut activation_step = SerialConsoleActivationStep::WaitingForBmcPrompt;
     loop {
@@ -467,18 +466,16 @@ async fn trigger_and_await_sol_console(
 
                         if matches!(activation_step, SerialConsoleActivationStep::WaitingForBmcPrompt) {
                             // Do we see the bmc prompt?
-                            if bytes_contains(&prompt_buf, bmc_prompt) {
+                            if prompt_buf.windows(bmc_prompt.len()).any(|window| window == bmc_prompt) {
                                 // We saw the prompt, send the serial activate command (`connect com1`,
                                 // etc) one byte at a time: This seems to work better with some
                                 // consoles.
-                                for byte in activate_command {
-                                    ssh_client_channel
-                                        .data([*byte].as_slice())
-                                        .await
-                                    .map_err(|error| ConsoleActivateError::Request { phase: "sending serial activate command to BMC", error })?;
-                                }
-                                ssh_client_channel.data(b"\n".as_slice()).await
-                                    .map_err(|error| ConsoleActivateError::Request { phase: "sending data to BMC", error })?;
+                                send_command_bytewise(
+                                    ssh_client_channel,
+                                    activate_command,
+                                    "sending serial activate command to BMC",
+                                )
+                                .await?;
                                 activation_step = SerialConsoleActivationStep::ActivateSent;
                                 // Clear the prompt
                                 prompt_buf.clear();
@@ -490,33 +487,55 @@ async fn trigger_and_await_sol_console(
                         // get false positives about seeing a bmc prompt while we're supposed to be
                         // in the console.)
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
-                            && bmc_vendor == SshBmcVendor::Lenovo
-                            && !lenovo_fallback_sent
-                            && should_run_lenovo_sol_fallback(&prompt_buf, bmc_prompt)
+                            && let Some(fallback_commands) = bmc_vendor
+                                .fallback_serial_activate_commands_if_needed(
+                                    &prompt_buf,
+                                    fallback_activate_sent,
+                                )
                         {
                             tracing::info!(
                                 %machine_id,
-                                "Lenovo primary SOL activation failed, trying console start fallback"
+                                "Primary SOL activation failed, trying fallback"
                             );
-                            activate_command = LENOVO_SOL_FALLBACK_ACTIVATE_COMMAND;
-                            skip_data_read_len = bmc_prompt.len() + activate_command.len();
+                            fallback_activate_sent = true;
+                            fallback_activate_commands = Some(fallback_commands);
+                            next_fallback_command_index = 0;
+                            let fallback_command = fallback_commands[next_fallback_command_index];
+                            next_fallback_command_index += 1;
+                            skip_data_read_len = bmc_prompt.len() + fallback_command.len();
                             timeout = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
-                            for byte in activate_command {
-                                ssh_client_channel
-                                    .data([*byte].as_slice())
-                                    .await
-                                .map_err(|error| ConsoleActivateError::Request { phase: "sending serial activate command to BMC", error })?;
-                            }
-                            ssh_client_channel.data(b"\n".as_slice()).await
-                                .map_err(|error| ConsoleActivateError::Request { phase: "sending data to BMC", error })?;
-                            lenovo_fallback_sent = true;
+                            send_command_bytewise(
+                                ssh_client_channel,
+                                fallback_command,
+                                "sending fallback serial activate command to BMC",
+                            )
+                            .await?;
                             prompt_buf.clear();
                         }
 
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
-                            && should_accept_sol_activation_output(
-                                bmc_vendor,
-                                lenovo_fallback_sent,
+                            && let Some(fallback_commands) = fallback_activate_commands
+                            && next_fallback_command_index < fallback_commands.len()
+                            && prompt_buf.windows(bmc_prompt.len()).any(|window| window == bmc_prompt)
+                        {
+                            let fallback_command = fallback_commands[next_fallback_command_index];
+                            next_fallback_command_index += 1;
+                            skip_data_read_len = bmc_prompt.len() + fallback_command.len();
+                            timeout = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
+                            send_command_bytewise(
+                                ssh_client_channel,
+                                fallback_command,
+                                "sending fallback serial activate command to BMC",
+                            )
+                            .await?;
+                            prompt_buf.clear();
+                        }
+
+                        let waiting_for_fallback_prompt = fallback_activate_commands
+                            .is_some_and(|commands| next_fallback_command_index < commands.len());
+                        if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
+                            && !waiting_for_fallback_prompt
+                            && bmc_vendor.should_accept_sol_activation_output(
                                 &prompt_buf,
                                 skip_data_read_len,
                             ) {
@@ -570,24 +589,25 @@ enum SerialConsoleActivationStep {
     ActivateSent,
 }
 
-fn should_run_lenovo_sol_fallback(prompt_buf: &[u8], bmc_prompt: &[u8]) -> bool {
-    bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE) && bytes_contains(prompt_buf, bmc_prompt)
-}
-
-fn should_accept_sol_activation_output(
-    bmc_vendor: SshBmcVendor,
-    lenovo_fallback_sent: bool,
-    prompt_buf: &[u8],
-    skip_data_read_len: usize,
-) -> bool {
-    let lenovo_primary_failure_pending = bmc_vendor == SshBmcVendor::Lenovo
-        && !lenovo_fallback_sent
-        && bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE);
-    !lenovo_primary_failure_pending && prompt_buf.len() > skip_data_read_len
-}
-
-fn bytes_contains(buf: &[u8], pat: &[u8]) -> bool {
-    !pat.is_empty() && buf.windows(pat.len()).any(|window| window == pat)
+async fn send_command_bytewise(
+    ssh_client_channel: &mut Channel<russh::client::Msg>,
+    command: &[u8],
+    phase: &'static str,
+) -> Result<(), ConsoleActivateError> {
+    for byte in command {
+        ssh_client_channel
+            .data([*byte].as_slice())
+            .await
+            .map_err(|error| ConsoleActivateError::Request { phase, error })?;
+    }
+    ssh_client_channel
+        .data(b"\n".as_slice())
+        .await
+        .map_err(|error| ConsoleActivateError::Request {
+            phase: "sending data to BMC",
+            error,
+        })?;
+    Ok(())
 }
 
 /// Returns `true` if `buf` contains the byte sequence `pat` anywhere
@@ -653,56 +673,6 @@ fn test_ringbuf_contains() {
     assert!(ringbuf_contains(&rb, b"")); // empty always true
     assert!(!ringbuf_contains(&rb, b"rustacean")); // longer than buf
     assert!(!ringbuf_contains(&rb, b"aean")); // non-contiguous
-}
-
-#[test]
-fn lenovo_primary_failure_without_prompt_waits_instead_of_succeeding() {
-    let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
-    let activate_command = SshBmcVendor::Lenovo.serial_activate_command().unwrap();
-    let skip_data_read_len = bmc_prompt.len() + activate_command.len();
-    let output = b"console kill 1\r\nThe command line contains extraneous arguments\r\n";
-
-    assert!(output.len() > skip_data_read_len);
-    assert!(!should_run_lenovo_sol_fallback(output, bmc_prompt));
-    assert!(!should_accept_sol_activation_output(
-        SshBmcVendor::Lenovo,
-        false,
-        output,
-        skip_data_read_len,
-    ));
-}
-
-#[test]
-fn lenovo_primary_failure_with_prompt_runs_fallback() {
-    let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
-    let output = b"console kill 1\r\nThe command line contains extraneous arguments\r\nsystem>";
-
-    assert!(should_run_lenovo_sol_fallback(output, bmc_prompt));
-}
-
-#[test]
-fn lenovo_fallback_output_succeeds_by_byte_count() {
-    let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
-    let skip_data_read_len = bmc_prompt.len() + LENOVO_SOL_FALLBACK_ACTIVATE_COMMAND.len();
-    let output = b"console kill\r\nSession on channel 1 is terminated\r\nsystem> console start\r\n";
-
-    assert!(output.len() > skip_data_read_len);
-    assert!(should_accept_sol_activation_output(
-        SshBmcVendor::Lenovo,
-        true,
-        output,
-        skip_data_read_len,
-    ));
-}
-
-#[test]
-fn non_lenovo_activation_still_succeeds_by_byte_count() {
-    assert!(should_accept_sol_activation_output(
-        SshBmcVendor::Dell,
-        false,
-        b"connect com2\r\nready",
-        b"connect com2".len(),
-    ));
 }
 
 #[derive(Clone)]

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -24,6 +24,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// The escape sequence for IPMI is vendor-independent since it's specific to ipmitool.
 pub static IPMITOOL_ESCAPE_SEQUENCE: EscapeSequence =
     EscapeSequence::Pair((b'~', &[b'.', b'B', b'?', 0x1a, 0x18]));
+const LENOVO_SOL_PRIMARY_FAILURE: &[u8] = b"The command line contains extraneous arguments";
+const LENOVO_SOL_FALLBACK_ACTIVATE_COMMANDS: &[&[u8]] = &[b"console kill", b"console start"];
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BmcVendor {
@@ -171,6 +173,35 @@ impl SshBmcVendor {
         }
     }
 
+    pub fn fallback_serial_activate_commands_if_needed(
+        &self,
+        prompt_buf: &[u8],
+        fallback_sent: bool,
+    ) -> Option<&'static [&'static [u8]]> {
+        match self {
+            SshBmcVendor::Lenovo
+                if !fallback_sent
+                    && bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE)
+                    && self
+                        .bmc_prompt()
+                        .is_some_and(|prompt| bytes_contains(prompt_buf, prompt)) =>
+            {
+                Some(LENOVO_SOL_FALLBACK_ACTIVATE_COMMANDS)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn should_accept_sol_activation_output(
+        &self,
+        prompt_buf: &[u8],
+        skip_data_read_len: usize,
+    ) -> bool {
+        let lenovo_failure_pending = matches!(self, SshBmcVendor::Lenovo)
+            && bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE);
+        !lenovo_failure_pending && prompt_buf.len() > skip_data_read_len
+    }
+
     pub fn filter_escape_sequences<'a>(
         &self,
         input: &'a [u8],
@@ -200,6 +231,10 @@ impl SshBmcVendor {
             SshBmcVendor::Dpu => "dpu",
         }
     }
+}
+
+fn bytes_contains(buf: &[u8], pat: &[u8]) -> bool {
+    !pat.is_empty() && buf.windows(pat.len()).any(|window| window == pat)
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -330,6 +365,18 @@ mod tests {
         escape: EscapeSequence,
         input: &'static [u8],
         prev_pending: bool,
+    }
+
+    struct FallbackCase {
+        vendor: SshBmcVendor,
+        output: &'static [u8],
+        fallback_sent: bool,
+    }
+
+    struct AcceptActivationCase {
+        vendor: SshBmcVendor,
+        output: &'static [u8],
+        skip_data_read_len: usize,
     }
 
     /// The Lenovo/HPE two-byte escape (`ESC (`), used by most filtering rows.
@@ -493,6 +540,75 @@ mod tests {
             let deserialized: Wrap = toml::from_str(&serialized).expect("deserialize");
             assert_eq!(deserialized, wrap, "{label}");
         }
+    }
+
+    #[test]
+    fn fallback_serial_activate_commands_if_needed_detects_lenovo_failure() {
+        let lenovo_primary_failure =
+            b"console kill 1\r\nThe command line contains extraneous arguments\r\nsystem>";
+
+        value_scenarios!(
+            run = |case: FallbackCase| case.vendor
+                .fallback_serial_activate_commands_if_needed(case.output, case.fallback_sent)
+                .is_some();
+
+            "Lenovo SR650 v4 fallback" {
+                FallbackCase { vendor: SshBmcVendor::Lenovo, output: lenovo_primary_failure, fallback_sent: false } => true,
+                FallbackCase { vendor: SshBmcVendor::Lenovo, output: b"console kill 1\r\nThe command line contains extraneous arguments\r\n", fallback_sent: false } => false,
+                FallbackCase { vendor: SshBmcVendor::Lenovo, output: lenovo_primary_failure, fallback_sent: true } => false,
+                FallbackCase { vendor: SshBmcVendor::Dell, output: lenovo_primary_failure, fallback_sent: false } => false,
+            }
+        );
+
+        let commands = SshBmcVendor::Lenovo
+            .fallback_serial_activate_commands_if_needed(lenovo_primary_failure, false)
+            .expect("Lenovo failure should provide fallback commands");
+        assert_eq!(
+            commands,
+            &[b"console kill".as_slice(), b"console start".as_slice()]
+        );
+    }
+
+    #[test]
+    fn should_accept_sol_activation_output_handles_fallback_cases() {
+        let bmc_prompt = SshBmcVendor::Lenovo.bmc_prompt().unwrap();
+        let lenovo_primary_skip_len = bmc_prompt.len()
+            + SshBmcVendor::Lenovo
+                .serial_activate_command()
+                .unwrap()
+                .len();
+        let lenovo_start_skip_len = bmc_prompt.len() + b"console start".len();
+
+        value_scenarios!(
+            run = |case: AcceptActivationCase| case.vendor.should_accept_sol_activation_output(
+                case.output,
+                case.skip_data_read_len,
+            );
+
+            "Lenovo primary failure waits for fallback" {
+                AcceptActivationCase {
+                    vendor: SshBmcVendor::Lenovo,
+                    output: b"console kill 1\r\nThe command line contains extraneous arguments\r\n",
+                    skip_data_read_len: lenovo_primary_skip_len,
+                } => false,
+            }
+
+            "Lenovo fallback start succeeds by byte count" {
+                AcceptActivationCase {
+                    vendor: SshBmcVendor::Lenovo,
+                    output: b"console start\r\nroot@host # ",
+                    skip_data_read_len: lenovo_start_skip_len,
+                } => true,
+            }
+
+            "non-Lenovo activation still succeeds by byte count" {
+                AcceptActivationCase {
+                    vendor: SshBmcVendor::Dell,
+                    output: b"connect com2\r\nready",
+                    skip_data_read_len: b"connect com2".len(),
+                } => true,
+            }
+        );
     }
 
     #[test]

--- a/crates/ssh-console/tests/main.rs
+++ b/crates/ssh-console/tests/main.rs
@@ -161,6 +161,32 @@ async fn test_ssh_console() -> eyre::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_ssh_console_lenovo_sr650_sol_fallback() -> eyre::Result<()> {
+    if std::env::var("REPO_ROOT").is_err() {
+        tracing::info!("Skipping running ssh-console integration tests, as REPO_ROOT is not set");
+        return Ok(());
+    }
+    let Some(env) = run_baseline_test_environment(vec![MockBmcType::LenovoSr650Ssh]).await? else {
+        return Ok(());
+    };
+
+    let handle = ssh_console_test_helper::spawn(env.mock_api_server.addr.port(), None).await?;
+
+    env.run_baseline_assertions(
+        handle.addr,
+        "new-ssh-console Lenovo SR650",
+        &[BaselineTestAssertion::ConnectAsMachineId],
+        || None,
+        false,
+    )
+    .await?;
+
+    handle.spawn_handle.shutdown_and_wait().await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ssh_console_reconnect() -> eyre::Result<()> {
     if std::env::var("REPO_ROOT").is_err() {
         tracing::info!("Skipping running ssh-console integration tests, as REPO_ROOT is not set");

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -112,21 +112,25 @@ pub fn log_stdout_and_stderr(process: &mut tokio::process::Child, prefix: &str) 
 pub async fn run_baseline_test_environment(
     machines: Vec<MockBmcType>,
 ) -> eyre::Result<Option<BaselineTestEnvironment>> {
-    let mock_bmc_handles: Vec<(MockBmcHandle, MachineId)> =
+    let mock_bmc_handles: Vec<(MockBmcHandle, MachineId, MockBmcType)> =
         join_all(machines.iter().map(|bmc_type| {
             // Generate random machine ID's for each mocked host
             let machine_id = carbide_uuid::machine::MachineId::new(
                 MachineIdSource::Tpm,
                 rand::random(),
                 match bmc_type {
-                    MockBmcType::Ssh | MockBmcType::Ipmi => MachineType::Host,
+                    MockBmcType::Ssh | MockBmcType::LenovoSr650Ssh | MockBmcType::Ipmi => {
+                        MachineType::Host
+                    }
                     MockBmcType::DpuSsh => MachineType::Dpu,
                 },
             );
 
             async move {
                 let bmc_handle = match bmc_type {
-                    ssh_type @ MockBmcType::Ssh | ssh_type @ MockBmcType::DpuSsh => {
+                    ssh_type @ MockBmcType::Ssh
+                    | ssh_type @ MockBmcType::LenovoSr650Ssh
+                    | ssh_type @ MockBmcType::DpuSsh => {
                         Ok::<MockBmcHandle, eyre::Error>(MockBmcHandle::Ssh(
                             machine_a_tron::spawn_mock_ssh_server(
                                 IpAddr::from_str("127.0.0.1").unwrap(),
@@ -138,6 +142,7 @@ pub async fn run_baseline_test_environment(
                                 }),
                                 match ssh_type {
                                     MockBmcType::Ssh => PromptBehavior::Dell,
+                                    MockBmcType::LenovoSr650Ssh => PromptBehavior::LenovoSr650,
                                     MockBmcType::DpuSsh => PromptBehavior::Dpu,
                                     MockBmcType::Ipmi => unreachable!(),
                                 },
@@ -150,7 +155,7 @@ pub async fn run_baseline_test_environment(
                     )),
                 }?;
 
-                Ok::<_, eyre::Error>((bmc_handle, machine_id))
+                Ok::<_, eyre::Error>((bmc_handle, machine_id, *bmc_type))
             }
         }))
         .await
@@ -161,12 +166,15 @@ pub async fn run_baseline_test_environment(
     let mock_hosts: Arc<Vec<MockHost>> = Arc::new(
         mock_bmc_handles
             .iter()
-            .map(|(bmc_handle, machine_id)| MockHost {
+            .map(|(bmc_handle, machine_id, bmc_type)| MockHost {
                 machine_id: *machine_id,
                 instance_id: Uuid::new_v4(),
                 tenant_public_key: TENANT_SSH_PUBKEY.to_string(),
                 sys_vendor: match &bmc_handle {
-                    MockBmcHandle::Ssh(_) => "Dell",
+                    MockBmcHandle::Ssh(_) => match bmc_type {
+                        MockBmcType::LenovoSr650Ssh => "Lenovo",
+                        _ => "Dell",
+                    },
                     MockBmcHandle::Ipmi(_) => "Supermicro",
                 },
                 bmc_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -197,7 +205,7 @@ pub async fn run_baseline_test_environment(
         mock_api_server: api_server_handle,
         _mock_bmc_handles: mock_bmc_handles
             .into_iter()
-            .map(|(handle, _machine_id)| handle)
+            .map(|(handle, _machine_id, _bmc_type)| handle)
             .collect(),
         mock_hosts,
     }))
@@ -206,6 +214,7 @@ pub async fn run_baseline_test_environment(
 #[derive(Debug, Clone, Copy)]
 pub enum MockBmcType {
     Ssh,
+    LenovoSr650Ssh,
     DpuSsh,
     Ipmi,
 }


### PR DESCRIPTION
## Summary
- keep the existing Lenovo SOL activation command as the primary path
- detect the SR650 v4 Lenovo `extraneous arguments` response and fall back to `console kill` / `console start`
- add focused unit tests for the Lenovo fallback decision and existing non-Lenovo activation behavior

Fixes #2919

## Test plan
- cargo +nightly-2026-06-16 fmt --all -- --check
- git diff --check fork/main..HEAD
- cargo test -p carbide-ssh-console --lib lenovo_primary_failure
- cargo test -p carbide-ssh-console --lib non_lenovo_activation
- cargo test -p carbide-ssh-console --lib

Note: William ran the cargo tests on Linux. Local macOS test execution is blocked by existing Linux-specific `io_util.rs` termios compile errors.