### PR TITLE
fix(pxe): scout-loader honors static_pxe_url override instead of hardcoding carbide-static-pxe.forge

### DIFF
--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -207,7 +207,10 @@ impl PxeInstructions {
                 if machine_type == MachineType::Host || machine_type == MachineType::PredictedHost {
                     InstructionGenerator {
                         kernel: "${base-url}/internal/aarch64/scout.efi".to_string(),
-                        command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url]"),
+                        // static_pxe_url passes the (already iPXE-expanded) static-pxe
+                        // base to the scout-loader so it fetches scout.squashfs from the
+                        // configured static-pxe server instead of hardcoding a hostname.
+                        command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url] static_pxe_url=${{base-url}}"),
                         initrd: None,
                     }
                 }
@@ -223,7 +226,10 @@ impl PxeInstructions {
             rpc::MachineArchitecture::X86 => {
                 InstructionGenerator {
                     kernel: "${base-url}/internal/x86_64/scout.efi".to_string(),
-                    command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url]"),
+                    // static_pxe_url passes the (already iPXE-expanded) static-pxe
+                    // base to the scout-loader so it fetches scout.squashfs from the
+                    // configured static-pxe server instead of hardcoding a hostname.
+                    command_line: format!("mac={mac_address} console=tty0 console={console},115200 pci=realloc=off iommu=off cli_cmd=auto-detect machine_id={machine_interface_id} server_uri=[api_url] pxe_uri=[pxe_url] static_pxe_url=${{base-url}}"),
                     initrd: None,
                 }
             }

--- a/pxe/common_files/scout-loader-rclocal
+++ b/pxe/common_files/scout-loader-rclocal
@@ -39,13 +39,26 @@ send_msg() {
 	done
 }
 
-# Default image will be scout, from the nginx container
+# Default image will be scout, from the nginx container.
+# Resolution order for the rootfs URL:
+#   1. newrootfs=<full-url> on the kernel cmdline (explicit override).
+#   2. static_pxe_url=<base> on the kernel cmdline, populated by NICo Core from
+#      the configured static-pxe URL (honors external_static_pxe_url overrides).
+#   3. Backward-compatible fallback to the carbide-static-pxe.forge hostname.
 if [ "$(grep -c 'newrootfs=' /proc/cmdline)" -eq 1 ]
 then
     newrootfsurl=$(cat /proc/cmdline | sed -e 's/.*newrootfs=//' -e 's/ .*//')
 else
     arch=$(uname -m)
-    newrootfsurl="http://carbide-static-pxe.forge/public/blobs/internal/${arch}/scout.squashfs"
+    if [ "$(grep -c 'static_pxe_url=' /proc/cmdline)" -eq 1 ]
+    then
+        # static_pxe_url already points at .../public/blobs (NICo Core base-url);
+        # strip any trailing slash before appending the rootfs path.
+        static_pxe_url=$(cat /proc/cmdline | sed -e 's/.*static_pxe_url=//' -e 's/ .*//' -e 's:/*$::')
+        newrootfsurl="${static_pxe_url}/internal/${arch}/scout.squashfs"
+    else
+        newrootfsurl="http://carbide-static-pxe.forge/public/blobs/internal/${arch}/scout.squashfs"
+    fi
 fi
 
 # Respect the console info from the kernel command line


### PR DESCRIPTION
## The bug

The scout-loader hardcodes the rootfs (`scout.squashfs`) download host to `carbide-static-pxe.forge` and ignores the configurable static-pxe URL that the rest of the PXE flow already honors:

- `crates/api-core/src/cfg/file.rs`: `external_static_pxe_url: Option<String>`
- `crates/api-core/src/handlers/pxe.rs`: resolves `static_pxe_url_override`
- `crates/pxe/src/routes/ipxe.rs`: templates `static_pxe_url` into the iPXE wrapper
- `pxe/templates/pxe`: `set base-url {{ static_pxe_url }}/public/blobs/`

The scout-loader is the most critical early-boot fetch, yet it was the **one place** that did not respect the override. Before this change, `pxe/common_files/scout-loader-rclocal` did:

```sh
newrootfsurl="http://carbide-static-pxe.forge/public/blobs/internal/${arch}/scout.squashfs"
```

## Verified repro (dpu-mode / unresolvable DNS)

On a BlueField dpu-mode host, when the DPU's local resolver (dnsmasq/HBN) is down or the site uses IP-only / custom DNS, the scout-loader fails with:

```
LOADER: Failed to gather root filesystem information:
curl: (6) Could not resolve host: carbide-static-pxe.forge
```

so the host never finishes discovery — even though the static-pxe server is reachable by IP and a `static_pxe_url` override is configured.

## The fix

1. **`crates/api-core/src/ipxe.rs`** — append `static_pxe_url=${base-url}` to the `scout.efi` kernel command line (x86_64 and aarch64 host). `${base-url}` is already set by the wrapping `pxe` template to the resolved `{{ static_pxe_url }}/public/blobs/` (which honors `external_static_pxe_url` / `static_pxe_url_override`), and iPXE expands it before booting, so the scout kernel receives the resolved static-pxe base. This reuses the value the override system already computes; no new plumbing.

2. **`pxe/common_files/scout-loader-rclocal`** — parse `static_pxe_url=` from `/proc/cmdline` and build the rootfs URL from it; fall back to the existing `http://carbide-static-pxe.forge` host when it is unset. This mirrors the existing idiom in `pxe/common_files/check-scout-updates.sh`, which already derives its base from a kernel cmdline arg with the same hostname fallback.

Resolution order in the loader:
1. `newrootfs=<full-url>` on the cmdline (explicit override) — unchanged, still highest priority.
2. `static_pxe_url=<base>` on the cmdline (new) — the configured static-pxe URL.
3. Hardcoded `carbide-static-pxe.forge` (fallback).

Note: in current `main` the per-arch `etc/rc.local` files are generated at build time by the `stage-scout-loader-rclocal` Make task from the single `pxe/common_files/scout-loader-rclocal` source, so editing the one source file covers both profiles.

## Backward compatibility

When no override is configured the loader falls back to the original `http://carbide-static-pxe.forge/public/blobs/internal/${arch}/scout.squashfs` URL, so behavior is unchanged for existing deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)