### PR TITLE
fix: re-assert the HTTP boot device during NIC-mode boot-order setup

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -62,9 +62,10 @@ use model::machine::{
     DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
     HostPlatformConfigurationState, HostReprovisionState, InstallDpuOsState, InstanceState,
     LockdownMode, MachineState, MachineValidatingState, ManagedHostState, MeasuringState,
-    PowerState, RetryInfo, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
-    ValidationState,
+    PowerState, RetryInfo, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
+    SpdmMeasuringState, StateMachineArea, ValidationState,
 };
+use model::network_segment::NetworkSegmentType;
 use model::site_explorer::{EndpointExplorationReport, ExploredDpu, ExploredManagedHost};
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::forge_server::Forge;
@@ -2884,6 +2885,235 @@ async fn test_polling_bios_setup_full_recovery_reruns_machine_setup_and_succeeds
             .any(|action| matches!(action, RedfishSimAction::MachineSetup { .. })),
         "expected machine_setup to be re-run after recovery, got: {actions:?}"
     );
+}
+
+/// Builds a test env wired for zero-DPU (NIC-mode) ingestion: the admin and
+/// host-inband site prefixes are routable and the host-inband segment exists,
+/// so a zero-DPU host's in-band NIC takes a real `machine_interfaces` row that
+/// the boot-order phase can resolve. Mirrors `test_dhcp_allows_zero_dpu_host`.
+async fn create_zero_dpu_test_env(pool: sqlx::PgPool) -> TestEnv {
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            ..Default::default()
+        },
+    )
+    .await;
+    create_host_inband_network_segment(&env.api, None).await;
+    env
+}
+
+/// Places a host directly in HostInit/SetBootOrder at the start of the
+/// boot-order flow, backdated so it reads as freshly entered.
+async fn set_host_stuck_in_set_boot_order(env: &TestEnv, host_id: MachineId) {
+    set_host_controller_state_stuck_in(
+        env,
+        host_id,
+        &ManagedHostState::HostInit {
+            machine_state: MachineState::SetBootOrder {
+                set_boot_order_info: Some(SetBootOrderInfo {
+                    set_boot_order_jid: None,
+                    set_boot_order_state: SetBootOrderState::SetBootOrder,
+                    retry_count: 0,
+                }),
+            },
+        },
+        1,
+    )
+    .await;
+}
+
+/// Drives the machine state controller until the host leaves HostInit/SetBootOrder
+/// for the next phase (HostInit/Measuring), returning whether it got there. A
+/// zero-DPU host whose `HttpDev1` device has de-enumerated never reaches it
+/// unless SetBootOrder re-asserts `machine_setup`, so callers assert on the
+/// result to distinguish recovery from a host wedged at CheckBootOrder.
+async fn drive_until_past_set_boot_order(
+    env: &TestEnv,
+    mh: &TestManagedHost,
+    max_iterations: usize,
+) -> bool {
+    for _ in 0..max_iterations {
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        if matches!(
+            host.current_state(),
+            ManagedHostState::HostInit {
+                machine_state: MachineState::Measuring { .. },
+            }
+        ) {
+            return true;
+        }
+    }
+    false
+}
+
+/// The MAC of the zero-DPU host's in-band NIC -- the boot interface the
+/// boot-order phase resolves and targets. Looked up by segment type (the same
+/// way the admin boot-interface resolution tests locate it), since a zero-DPU
+/// host boots from its HostInband NIC.
+async fn host_inband_nic_mac(env: &TestEnv, host_id: MachineId) -> MacAddress {
+    let mut txn = env.pool.begin().await.unwrap();
+    db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+        .await
+        .unwrap()
+        .remove(&host_id)
+        .expect("zero-DPU host should have interface rows")
+        .into_iter()
+        .find(|i| i.network_segment_type == Some(NetworkSegmentType::HostInband))
+        .expect("zero-DPU host should have a HostInband interface")
+        .mac_address
+}
+
+/// Asserts that, within the recorded boot-order actions, `machine_setup` ran
+/// before the `set_boot_order_dpu_first` reorder, and that BOTH targeted
+/// `expected_mac` -- the resolved boot NIC. This is the ordering the recovery
+/// depends on: re-enable `HttpDev1`, then reorder, both against the same NIC.
+fn assert_machine_setup_precedes_reorder_for(
+    actions: &[RedfishSimAction],
+    expected_mac: MacAddress,
+) {
+    // `MachineSetup` records the target as `Option<String>` (setup can run
+    // without one), while `SetBootOrderDpuFirst` always has a `String`.
+    let expected = expected_mac.to_string();
+
+    let machine_setup_idx = actions
+        .iter()
+        .position(|action| {
+            matches!(
+                action,
+                RedfishSimAction::MachineSetup { boot_interface_mac, .. }
+                    if boot_interface_mac.as_deref() == Some(expected.as_str())
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a machine_setup targeting the boot NIC {expected_mac}, got: {actions:?}"
+            )
+        });
+
+    let reorder_idx = actions
+        .iter()
+        .position(|action| {
+            matches!(
+                action,
+                RedfishSimAction::SetBootOrderDpuFirst { boot_interface_mac }
+                    if *boot_interface_mac == expected
+            )
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a set_boot_order_dpu_first targeting the boot NIC {expected_mac}, got: {actions:?}"
+            )
+        });
+
+    assert!(
+        machine_setup_idx < reorder_idx,
+        "machine_setup (idx {machine_setup_idx}) must re-assert HttpDev1 before the reorder \
+         (idx {reorder_idx}); actions: {actions:?}"
+    );
+}
+
+/// Regression test for the NIC-mode `HttpDev1` de-enumeration hang.
+///
+/// On a zero-DPU host, a reboot during the boot-order phase can de-enumerate the
+/// BlueField from Redfish, reverting the `HttpDev1` UEFI HTTP-boot device to the
+/// onboard default. `set_boot_order_dpu_first` only reorders the boot options it
+/// finds, so it cannot bring `HttpDev1` back -- the boot order never verifies and
+/// the host wedges in SetBootOrder/CheckBootOrder. SetBootOrder now re-asserts
+/// `machine_setup` on each attempt, re-enabling the device so the reorder sticks.
+///
+/// The sim models this: `set_http_dev1_reverted` disables the device, so the
+/// first `set_boot_order_dpu_first` records the boot order as *not* configured;
+/// only the re-assert's `machine_setup` re-enables it. Without the re-assert the
+/// host never leaves CheckBootOrder; with it, the host recovers to Measuring.
+#[crate::sqlx_test]
+async fn test_set_boot_order_reasserts_machine_setup_when_http_dev1_de_enumerates(
+    pool: sqlx::PgPool,
+) {
+    let env = create_zero_dpu_test_env(pool).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    assert!(
+        mh.dpu_ids.is_empty(),
+        "zero-DPU fixture should produce no DPU machines"
+    );
+    let host_id = mh.host().id;
+    let boot_nic_mac = host_inband_nic_mac(&env, host_id).await;
+
+    // Model the BlueField de-enumerating: HttpDev1 reverts to the onboard
+    // default, so the first reorder won't make the boot order verify.
+    env.redfish_sim.set_http_dev1_reverted();
+
+    set_host_stuck_in_set_boot_order(&env, host_id).await;
+
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    let recovered = drive_until_past_set_boot_order(&env, &mh, 15).await;
+    if !recovered {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        panic!(
+            "expected SetBootOrder to re-assert machine_setup and recover a de-enumerated \
+             HttpDev1 (reaching HostInit/Measuring), but the host wedged at: {:?}",
+            host.current_state()
+        );
+    }
+
+    // The recovery hinges on machine_setup running -- targeting the boot NIC --
+    // before the reorder during the boot-order phase.
+    let actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    assert_machine_setup_precedes_reorder_for(&actions, boot_nic_mac);
+}
+
+/// Healthy-path counterpart: when `HttpDev1` was never de-enumerated, the
+/// SetBootOrder `machine_setup` re-assert is idempotent -- the host still
+/// advances out of SetBootOrder exactly as before, and machine_setup is invoked
+/// without changing the outcome. Guards against the re-assert regressing the
+/// normal zero-DPU boot-order path.
+#[crate::sqlx_test]
+async fn test_set_boot_order_reassert_is_idempotent_on_healthy_zero_dpu_host(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let host_id = mh.host().id;
+    let boot_nic_mac = host_inband_nic_mac(&env, host_id).await;
+
+    // No de-enumeration this time: HttpDev1 stays enabled throughout.
+    set_host_stuck_in_set_boot_order(&env, host_id).await;
+
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    let recovered = drive_until_past_set_boot_order(&env, &mh, 15).await;
+    assert!(
+        recovered,
+        "a healthy zero-DPU host should still advance past SetBootOrder with the re-assert in place"
+    );
+
+    // The re-assert still runs (targeting the boot NIC) before the reorder; on
+    // the healthy path it just doesn't change the outcome.
+    let actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    assert_machine_setup_precedes_reorder_for(&actions, boot_nic_mac);
 }
 
 /// When HostInit/PollingBiosSetup retry budget is exhausted, enter Failed and recover via is_bios_setup.

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11105,6 +11105,25 @@ async fn set_host_boot_order(
                 }
             };
 
+            // Re-assert the platform BIOS config before reordering -- a NIC-mode
+            // reboot can de-enumerate the BlueField and revert HttpDev1 to the
+            // onboard default, and `set_boot_order_dpu_first` only reorders the
+            // boot options it finds, so it can't bring HttpDev1 back on its own.
+            // Re-running `machine_setup` (by interface id) restores the HTTP boot
+            // device for the reorder, the same recovery the BIOS-setup phase
+            // already does. Idempotent when it's already set, and applied by the
+            // existing RebootHost restart; the returned job id is dropped
+            // (zero-DPU hosts swallow it as `NoDpu`, and CheckBootOrder tracks
+            // the boot-order job below).
+            call_machine_setup_and_handle_no_dpu_error(
+                redfish_client,
+                Some(&boot_interface),
+                mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
+                &ctx.services.site_config,
+            )
+            .await
+            .map_err(|e| redfish_error("machine_setup", e))?;
+
             let jid = match set_boot_order_dpu_first_and_handle_no_dpu_error(
                 redfish_client,
                 &boot_interface,

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -56,7 +56,6 @@ struct RedfishSimState {
     get_task_trigger_evidence_returns_interrupted: bool,
     machine_setup_bios_job_id: Option<String>,
     is_bios_setup: Option<bool>,
-    is_boot_order_setup: Option<bool>,
     default_lockdown: Option<EnabledDisabled>,
     job_state_sequence: VecDeque<JobState>,
     /// Offset (in seconds) applied to the BMC `DateTime` returned by
@@ -81,6 +80,22 @@ struct RedfishSimHostState {
     power: PowerState,
     lockdown: libredfish::EnabledDisabled,
     actions: Vec<RedfishSimAction>,
+    /// Whether this host's `HttpDev1` UEFI HTTP-boot device is enabled in BIOS.
+    /// Defaults to `true` (the steady state after `machine_setup`): the boot
+    /// device is present, so `set_boot_order_dpu_first` can promote it and
+    /// `is_boot_order_setup` reports the order as configured. Tests flip it to
+    /// `false` via [`RedfishSim::set_http_dev1_reverted`] to model a NIC-mode
+    /// reboot de-enumerating the BlueField, which reverts the attribute to the
+    /// onboard default; only a fresh `machine_setup` re-enables it. Per-host so
+    /// one host's de-enumeration (or recovery) doesn't bleed into the others.
+    http_dev1_enabled: bool,
+    /// Whether this host reports its boot order as configured. `None` defers to
+    /// the default (`true`); `set_boot_order_dpu_first` records it as
+    /// `Some(http_dev1_enabled)` -- the reorder only "sticks" while the HTTP
+    /// boot device is present -- and `set_is_boot_order_setup` forces it.
+    /// Per-host so one host's boot-order state can't flip another host's
+    /// `is_boot_order_setup` check.
+    is_boot_order_setup: Option<bool>,
 }
 
 impl Default for RedfishSimHostState {
@@ -89,6 +104,10 @@ impl Default for RedfishSimHostState {
             power: PowerState::default(),
             lockdown: libredfish::EnabledDisabled::Disabled,
             actions: Vec::default(),
+            // Enabled by default so existing tests, which never model a
+            // de-enumeration, see the boot order configure normally.
+            http_dev1_enabled: true,
+            is_boot_order_setup: None,
         }
     }
 }
@@ -170,9 +189,31 @@ impl RedfishSim {
         self.state.lock().unwrap().is_bios_setup = Some(ready);
     }
 
-    /// Configure whether simulated Redfish reports the host boot order as ready.
+    /// Force whether simulated Redfish reports the boot order as configured,
+    /// for every current host. A later `set_boot_order_dpu_first` overwrites it
+    /// per host (last write wins), the same as a real boot-order setup would.
     pub fn set_is_boot_order_setup(&self, ready: bool) {
-        self.state.lock().unwrap().is_boot_order_setup = Some(ready);
+        let mut state = self.state.lock().unwrap();
+        for host_state in state.hosts.values_mut() {
+            host_state.is_boot_order_setup = Some(ready);
+        }
+    }
+
+    /// Model a NIC-mode reboot de-enumerating the BlueField: the `HttpDev1`
+    /// UEFI HTTP-boot device reverts to the onboard default and is no longer
+    /// enabled. While reverted, `set_boot_order_dpu_first` records the boot
+    /// order as *not* configured (it can only reorder a device that exists),
+    /// so `is_boot_order_setup` reports `false` until a fresh `machine_setup`
+    /// re-enables the device.
+    ///
+    /// The flag is per-host, so reverting every current host here is just the
+    /// no-host-id entry point; a later `machine_setup` re-enables only the host
+    /// it targets, which is what keeps multi-host tests isolated.
+    pub fn set_http_dev1_reverted(&self) {
+        let mut state = self.state.lock().unwrap();
+        for host_state in state.hosts.values_mut() {
+            host_state.http_dev1_enabled = false;
+        }
     }
 
     /// Configure simulated BMC lockdown state for existing and future clients.
@@ -351,12 +392,19 @@ impl Redfish for RedfishSimClient {
     ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             let mut state = self.state.lock().unwrap();
+            let job_id = state.machine_setup_bios_job_id.clone();
             let host_state = state.hosts.get_mut(&self._host).unwrap();
+            // `machine_setup` re-asserts the platform BIOS config, which
+            // re-enables this host's `HttpDev1` HTTP-boot device. This is the
+            // recovery a de-enumeration relies on: a subsequent
+            // `set_boot_order_dpu_first` can then promote the device and the
+            // boot order sticks. Per-host, so it recovers only this host.
+            host_state.http_dev1_enabled = true;
             host_state.actions.push(RedfishSimAction::MachineSetup {
                 oem_manager_profiles: oem_manager_profiles.clone(),
                 boot_interface_mac: boot_interface.map(boot_interface_ref_to_string),
             });
-            Ok(state.machine_setup_bios_job_id.clone())
+            Ok(job_id)
         })
     }
 
@@ -1225,8 +1273,11 @@ impl Redfish for RedfishSimClient {
     ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
             let mut state = self.state.lock().unwrap();
-            state.is_boot_order_setup = Some(true);
             let host_state = state.hosts.get_mut(&self._host).unwrap();
+            // Reordering only promotes an existing boot device; it can't
+            // re-create a de-enumerated one. So the order reads as configured
+            // exactly when this host's HTTP boot device is currently enabled.
+            host_state.is_boot_order_setup = Some(host_state.http_dev1_enabled);
             host_state
                 .actions
                 .push(RedfishSimAction::SetBootOrderDpuFirst {
@@ -1407,8 +1458,11 @@ impl Redfish for RedfishSimClient {
     ) -> libredfish::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let mut state = self.state.lock().unwrap();
-            let is_boot_order_setup = state.is_boot_order_setup.unwrap_or(true);
             let host_state = state.hosts.get_mut(&self._host).unwrap();
+            // Readiness is per-host: it defaults to configured (`true`) and is
+            // updated only by this host's own `set_boot_order_dpu_first` /
+            // `set_is_boot_order_setup`, so other hosts can't flip it.
+            let is_boot_order_setup = host_state.is_boot_order_setup.unwrap_or(true);
             host_state.actions.push(RedfishSimAction::IsBootOrderSetup {
                 boot_interface_mac: boot_interface_ref_to_string(boot_interface),
             });
@@ -1862,6 +1916,8 @@ impl RedfishClientPool for RedfishSim {
                     power: PowerState::On,
                     lockdown: default_lockdown,
                     actions: Default::default(),
+                    http_dev1_enabled: true,
+                    is_boot_order_setup: None,
                 });
             if state.fw_version.is_empty() {
                 state.fw_version = Arc::new("24.10-17".to_string());

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -123,6 +123,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>The amount of Power Shelves that had been created by Site Explorer after being identified</td></tr>
 <tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
 <tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
+<tr><td>carbide_site_explorer_last_run_status</td><td>gauge</td><td>The status of the latest Site Explorer run</td></tr>
 <tr><td>carbide_site_explorer_phase_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration phase</td></tr>
 <tr><td>carbide_site_explorer_update_explored_endpoints_count</td><td>gauge</td><td>Counts from the last update_explored_endpoints phase by kind</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>


### PR DESCRIPTION
`SetBootOrder` now re-asserts the HTTP boot device before reordering, so a NIC-mode host's boot setup stays solid even when the BlueField NIC briefly drops off Redfish across a reboot. The BIOS-setup phase already does this on recovery -- this gives `SetBootOrder` the same small touch, rounding out the zero-DPU boot-interface workflow.

The motivating case: on a reboot the BlueField can de-enumerate and `HttpDev1` reverts to the onboard default. `set_boot_order_dpu_first` only reorders the boot options it finds, so the "HTTP Device 1" option would be gone and `is_boot_order_setup` could never pass on retry. Re-running `machine_setup` (by interface id) at the top of the SetBootOrder attempt re-enables it -- the existing `RebootHost` restart applies it in the same reboot, so no extra reboot, and it's a no-op when HttpDev1 is already set.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/2947 and https://github.com/NVIDIA/infra-controller/issues/2821.
