### PR TITLE
docs: document machine validation reliability and stale recovery capabilities

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -534,6 +534,7 @@ Extends `StateControllerConfig` with:
 | `enabled` | `bool` | `false` | Enable machine validation tests. |
 | `test_selection_mode` | `MachineValidationTestSelectionMode` | `Default` | `Default`, `EnableAll`, or `DisableAll`. |
 | `run_interval` | `Duration` | `60s` | Validation check interval. |
+| `stale_run_timeout` | `Duration` | `24h` | Grace period before an active validation run is considered stale. Values below `90s` are raised to `90s` to avoid marking healthy heartbeat-based runs stale. |
 | `tests` | `Vec<MachineValidationTestConfig>` | `[]` | Per-test enable/disable overrides. |
 
 ### `BomValidationConfig`

--- a/docs/provisioning/machine-validation.md
+++ b/docs/provisioning/machine-validation.md
@@ -129,6 +129,7 @@ A site can also control the catalog selection behavior:
 enabled = true
 test_selection_mode = "Default"
 run_interval = "60s"
+stale_run_timeout = "24h"
 tests = [
   { id = "CudaSample", enable = true },
 ]
@@ -139,6 +140,7 @@ tests = [
 | `enabled` | Enables or disables Machine Validation for the site. |
 | `test_selection_mode` | Controls how configured tests are selected. `Default` uses the catalog and per-test settings, `EnableAll` enables all configured tests, and `DisableAll` disables all configured tests. |
 | `run_interval` | Controls how often the controller processes pending validation work. |
+| `stale_run_timeout` | Grace period before an active validation run is considered stale. The default is `24h`; configured values below `90s` are raised to `90s` so healthy runs are not failed between Scout heartbeats. |
 | `tests` | Optional per-test overrides. Use the test identifiers reported by `tests show` for the running site. |
 
 ## External Configuration
@@ -287,6 +289,45 @@ Tests can also declare output file locations with `--extra-output-file` and
 `--extra-err-file` when a command writes important diagnostics outside stdout or
 stderr. Keep those outputs concise. Scout records command output for result
 review, but Machine Validation is not a replacement for long-term log storage.
+
+## Run Tracking and Stale Recovery
+
+Machine Validation tracks active work at two levels:
+
+- Run items show which tests were selected for a validation run.
+- Attempts show each execution of a selected test, including state, timing, exit
+  code, and output summaries.
+
+Scout sends heartbeats while tests are running. The controller uses the latest
+heartbeat to find work that stopped making progress. If a record has no
+heartbeat, the controller falls back to the run start time, expected duration,
+and `stale_run_timeout`.
+
+When stale work is found, the controller fails the validation and records the
+normal failed-validation health alert. This keeps a machine from staying stuck
+in an active validation state after Scout stops reporting.
+
+Operators can monitor this behavior with:
+
+| Metric | Meaning |
+| --- | --- |
+| `carbide_machine_validation_oldest_active_age_seconds` | Age of the oldest active validation run. |
+| `carbide_machine_validation_stale_runs_count` | Number of active validation runs considered stale in the latest reconciliation pass. |
+
+## Database Changes and Upgrades
+
+Recent Machine Validation reliability work introduced database schema changes
+for execution tracking and stale recovery:
+
+| Area | Database change |
+| --- | --- |
+| Execution tracking | Adds `machine_validation_run_items` and `machine_validation_attempts` tables. |
+| Heartbeat recovery | Adds `machine_validation.last_heartbeat_at` and heartbeat indexes for active validations, run items, and attempts. |
+
+Deployments must apply the normal API database migrations before relying on the
+new run tracking and stale recovery behavior. No manual data backfill is
+required for existing validation rows. Older rows without heartbeat timestamps
+continue to use the duration-based stale detection fallback.
 
 ## Updating Site-Specific Tests
 


### PR DESCRIPTION
Updates the Machine Validation documentation to cover the reliability and stale recovery changes 

  This PR documents:
  - how active validation runs are tracked through run items and attempts
  - how Scout heartbeats are used to detect stale validation work
  - how the controller falls back to duration-based stale detection when heartbeat data is unavailable
  - how `stale_run_timeout` works, including the default `24h` value and minimum effective `90s` value
  - what DB migrations add for execution tracking and heartbeat recovery
  - what operators should expect when a stale run or attempt is reconciled
  
## Related issues
Closes https://github.com/NVIDIA/infra-controller/issues/454

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

