### PR TITLE
nvlink: fix NMX-C default port

### DIFF
--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -60,6 +60,7 @@ const SWITCH_BMC_STATIC_IP: std::net::IpAddr =
     std::net::IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 1, 50));
 const SWITCH_NVOS_STATIC_IP: std::net::IpAddr =
     std::net::IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1));
+const NMXC_SIMULATOR_PORT: u16 = 9601;
 
 #[crate::sqlx_test]
 async fn test_nmx_c_partition_id_migration_deletes_legacy_nmx_m_rows(pool: sqlx::PgPool) {
@@ -2116,6 +2117,7 @@ async fn run_create_instance_with_nvl_config_nmxc_simulator_scenario(
     let mut config = common::api_fixtures::get_config();
     if let Some(nvlink_config) = config.nvlink_config.as_mut() {
         nvlink_config.enabled = true;
+        nvlink_config.nmx_c_endpoint_port = Some(NMXC_SIMULATOR_PORT);
         if with_mtls {
             nvlink_config.nmx_c_tls_ca_cert_path = Some(NMXC_SIMULATOR_TLS_CA.to_string());
             nvlink_config.nmx_c_tls_client_cert_path = Some(NMXC_SIMULATOR_TLS_CERT.to_string());
@@ -2425,6 +2427,7 @@ async fn test_rack_switch_create_instance_with_nvl_config_use_nmxc_simulator(poo
     let mut config = common::api_fixtures::get_config();
     if let Some(nvlink_config) = config.nvlink_config.as_mut() {
         nvlink_config.enabled = true;
+        nvlink_config.nmx_c_endpoint_port = Some(NMXC_SIMULATOR_PORT);
         nvlink_config.allow_insecure = true;
     }
 
@@ -2586,6 +2589,7 @@ async fn assert_switch_cert_monitor_nmxc_simulator_probe(
     let mut config = common::api_fixtures::get_config();
     if let Some(nvlink_config) = config.nvlink_config.as_mut() {
         nvlink_config.enabled = true;
+        nvlink_config.nmx_c_endpoint_port = Some(NMXC_SIMULATOR_PORT);
         nvlink_config.nmx_c_tls_ca_cert_path = Some(NMXC_SIMULATOR_TLS_CA.to_string());
         nvlink_config.nmx_c_tls_client_cert_path = Some(NMXC_SIMULATOR_TLS_CERT.to_string());
         nvlink_config.nmx_c_tls_client_key_path = Some(NMXC_SIMULATOR_TLS_CLIENT_KEY.to_string());

--- a/crates/nvlink-manager/src/config.rs
+++ b/crates/nvlink-manager/src/config.rs
@@ -45,6 +45,9 @@ pub struct NvLinkConfig {
     /// TLS server name (SNI / cert verification hostname) for NMX-C HTTPS. Defaults to the endpoint URL host if unset.
     #[serde(default)]
     pub nmx_c_tls_authority: Option<String>,
+    /// TCP port for NMX-C endpoints derived from switch NVOS IP. Defaults to the production NMX-C port.
+    #[serde(default)]
+    pub nmx_c_endpoint_port: Option<u16>,
     /// Set to true if NMX-C doesn't adhere to security requirements. Defaults to false.
     pub allow_insecure: bool,
 
@@ -135,6 +138,7 @@ impl Default for NvLinkConfig {
             nmx_c_tls_client_cert_path: None,
             nmx_c_tls_client_key_path: None,
             nmx_c_tls_authority: None,
+            nmx_c_endpoint_port: None,
             allow_insecure: false,
             nmx_c_certificate_rotation: NmxCCertificateRotationConfig::default(),
         }
@@ -160,6 +164,7 @@ mod test {
                 nmx_c_tls_client_cert_path: None,
                 nmx_c_tls_client_key_path: None,
                 nmx_c_tls_authority: None,
+                nmx_c_endpoint_port: None,
                 allow_insecure: true,
                 nmx_c_certificate_rotation: NmxCCertificateRotationConfig::default(),
             }

--- a/crates/nvlink-manager/src/nmx_c_endpoint.rs
+++ b/crates/nvlink-manager/src/nmx_c_endpoint.rs
@@ -24,7 +24,7 @@ use db::{self, DatabaseResult};
 use crate::config::NvLinkConfig;
 
 /// Default NMX-C gRPC port when switch NVOS info does not specify one.
-pub const NMX_C_DEFAULT_GRPC_PORT: u16 = 9601;
+pub const NMX_C_DEFAULT_GRPC_PORT: u16 = 9370;
 
 fn nmx_c_endpoint_uses_tls(config: &NvLinkConfig) -> bool {
     config.nmx_c_tls_client_cert_path.is_some() && config.nmx_c_tls_client_key_path.is_some()
@@ -48,7 +48,8 @@ pub fn nmx_c_endpoint_url_from_nvos_ip(
         "{}://{}:{}",
         nmx_c_endpoint_scheme(config),
         ip,
-        port.unwrap_or(NMX_C_DEFAULT_GRPC_PORT)
+        port.or(config.nmx_c_endpoint_port)
+            .unwrap_or(NMX_C_DEFAULT_GRPC_PORT)
     )
 }
 
@@ -113,13 +114,25 @@ mod tests {
         };
         assert_eq!(
             nmx_c_endpoint_url_from_nvos_ip(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None, &config),
-            "http://10.0.0.1:9601"
+            "http://10.0.0.1:9370"
         );
     }
 
     #[test]
     fn endpoint_url_uses_https_by_default() {
         let config = NvLinkConfig::default();
+        assert_eq!(
+            nmx_c_endpoint_url_from_nvos_ip(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None, &config),
+            "https://10.0.0.1:9370"
+        );
+    }
+
+    #[test]
+    fn endpoint_url_uses_configured_port() {
+        let config = NvLinkConfig {
+            nmx_c_endpoint_port: Some(9601),
+            ..Default::default()
+        };
         assert_eq!(
             nmx_c_endpoint_url_from_nvos_ip(&IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), None, &config),
             "https://10.0.0.1:9601"


### PR DESCRIPTION
The default port for NMX-C was set to 9601, real NMX-Cs use 9370. Fix this and make it configurable.

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->
https://github.com/NVIDIA/infra-controller/issues/2968

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

