### PR TITLE
fix(ci): Don't make lint-police a prereq of test-release-container-se…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -594,7 +594,6 @@ jobs:
       - build-container-x86_64
       - build-runtime-container-x86_64
       - check-rest-core-proto-sync
-      - lint-police
     runs-on: linux-amd64-cpu16
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -519,14 +519,12 @@ jobs:
         && contains('success,skipped', needs.build-container-aarch64.result)
         && contains('success,skipped', needs.build-runtime-container-aarch64.result)
         && contains('success,skipped', needs.check-rest-core-proto-sync.result)
-        && contains('success,skipped', needs.lint-police.result)
       }}
     needs:
       - prepare
       - build-container-aarch64
       - build-runtime-container-aarch64
       - check-rest-core-proto-sync
-      - lint-police
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.release-container-aarch64
@@ -587,7 +585,6 @@ jobs:
         && contains('success,skipped', needs.build-container-x86_64.result)
         && contains('success,skipped', needs.build-runtime-container-x86_64.result)
         && contains('success,skipped', needs.check-rest-core-proto-sync.result)
-        && contains('success,skipped', needs.lint-police.result)
       }}
     needs:
       - prepare


### PR DESCRIPTION
…rvices

The lint-police check ends up running an individual build of every crate as part of a check that ensures the crates build individually and not just as a workspace... its cost was justified by the fact that it was supposed to run in parallel with the test-release-container-services check, but I inadvertently added this dependency which prevents them running in parallel. This undoes that.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
Thanks @poroh for pointing out the regression here

