### PR TITLE
Git and make should be on host - minimal Ubuntu install doesn't have …

### DIFF
--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -4,7 +4,7 @@ This section provides instructions for building the containers for NVIDIA Infra 
 
 ## Installing Prerequisite Software
 
-You need an Ubuntu 24.04 host or VM with 150GB+ of free disk space (macOS is not supported).
+An Ubuntu 24.04 host or VM with at least 150GB of free disk space is required, and git and make must also be installed (macOS is not supported).
 
 Clone the repo and run the build-host bootstrap. It installs everything needed to build
 the containers and boot artifacts -- system packages, rustup, the mkosi/ipxe git


### PR DESCRIPTION
This PR just adds the words git and make to the Ubuntu node requirement for the building_nico_containers.md which might be missing if doing a minimal Ubuntu install.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

