### PR TITLE
fix(rest-api): pin workflow-schema protobuf plugins to CI versions

### DIFF
--- a/rest-api/workflow-schema/buf.gen.yaml
+++ b/rest-api/workflow-schema/buf.gen.yaml
@@ -1,13 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
----
-version: v1
+version: v2
 plugins:
-  - name: go
+  - remote: buf.build/protocolbuffers/go:v1.36.11
     out: schema/site-agent/workflows/v1
     opt: paths=source_relative
-  - name: go-grpc
+  - remote: buf.build/grpc/go:v1.6.1
     out: schema/site-agent/workflows/v1
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary

- Pin `rest-api/workflow-schema/buf.gen.yaml` to buf remote plugins matching CI (`protoc-gen-go@v1.36.11`, `protoc-gen-go-grpc@v1.6.1`)
- Prevents local regeneration with a newer PATH-installed `protoc-gen-go-grpc` (e.g. v1.6.2) from failing `Check REST Core Proto Sync` and `Check Protobuf Generated Code`

## Context

Those checks only rewrite version header comments in a few `*_grpc.pb.go` files when plugin versions drift. Main already has the correct v1.6.1 headers from #2586; this change stops the drift from recurring.

## Test plan

- [ ] `make -C rest-api core-proto` followed by `scripts/check-repo-clean.sh "REST Core protobuf sync"`
- [ ] REST CI `Check Protobuf Generated Code` passes