### PR TITLE
chore(ci): make isolated package builds optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1141,9 +1141,6 @@ jobs:
       - name: Check bans
         run: cargo make --no-workspace check-bans
 
-      - name: Check isolated package builds
-        run: cargo xtask check-isolated-package-builds
-
       - name: Check repository is clean
         run: bash scripts/check-repo-clean.sh "Core pre-build checks"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,9 @@ cargo make check-workspace-deps # Validate dependency declarations in Cargo.toml
 cargo make check-licenses      # Validate no restricted licenses introduced
 cargo make check-bans          # Check for banned dependencies
 
+# Optional maintenance check (not part of required CI or pre-commit):
+cargo make check-isolated-package-builds # Check each package with default features
+
 # Auto-fix formatting:
 cargo fmt --all
 cargo make format-nightly      # Also sort imports
@@ -124,14 +127,15 @@ cargo make format-nightly      # Also sort imports
 > `carbide-lints`. The stable toolchain pinned in `rust-toolchain.toml` is used
 > for everything else.
 
-### Top-level Makefile (rest-api entrypoint)
+### Top-level Makefile entrypoints
 
 A top-level [`Makefile`](Makefile) at the repo root provides a thin
-discoverable entrypoint for the `rest-api/` Go services. It just
-delegates to `rest-api/Makefile`.
+discoverable entrypoint for selected Core workflows and the `rest-api/` Go
+services. It delegates to cargo-make or `rest-api/Makefile`.
 
 ```bash
-make help                # default goal: list rest-* targets
+make help                # default goal: list available targets
+make core/check-isolated-package-builds # optional independent default-feature builds
 make rest-build          # build rest-api Go binaries
 make rest-test           # run rest-api unit tests
 make rest-lint           # lint rest-api
@@ -141,9 +145,6 @@ make rest-docker-build-local
 make rest-kind-reset     # spin up the local kind dev cluster (~10 min)
 make rest-api/<target>   # pass any target through to rest-api/Makefile
 ```
-
-Core (Rust) tasks are not in this Makefile; use cargo and `cargo make`
-directly as documented above.
 
 ## Coding Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Top-level Makefile for the rest-api/ Go services.
+# Top-level Makefile for selected Core workflows and the rest-api/ Go services.
 #
-# Thin discoverable entrypoint that delegates to rest-api/Makefile.
-# rest-api/Makefile continues to work directly; this file is an
-# additive convenience layer.
+# Thin discoverable entrypoint that delegates to cargo-make and
+# rest-api/Makefile. Both underlying entrypoints continue to work directly;
+# this file is an additive convenience layer.
 #
 # Run `make help` (default goal) for the inventory of targets.
 
@@ -38,11 +38,22 @@ help: ## Show this help and exit (default goal)
 	@echo "Container images (build from a clean clone):"
 	@grep -E '^images[a-zA-Z0-9_-]*:.*## ' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "} {printf "  %-26s %s\n", $$1, $$2}'
 	@echo ""
+	@echo "Core (Rust):"
+	@grep -E '^core/[a-zA-Z0-9_-]+:.*## ' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "} {printf "  %-26s %s\n", $$1, $$2}'
+	@echo ""
 	@echo "Rest (Go services in rest-api/):"
 	@grep -E '^rest-[a-zA-Z0-9_-]+:.*## ' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "} {printf "  %-26s %s\n", $$1, $$2}'
 	@echo "  rest-api/<target>          Pass any target through to rest-api/Makefile"
 	@echo ""
 	@echo "  cat rest-api/Makefile      See all rest-api/ targets directly"
+
+# =============================================================================
+# Core (Rust; delegate to cargo-make)
+# =============================================================================
+
+.PHONY: core/check-isolated-package-builds
+core/check-isolated-package-builds: ## Check each Rust package independently with default features
+	cargo make --no-workspace check-isolated-package-builds
 
 # =============================================================================
 # Getting started (build host setup)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -583,7 +583,6 @@ dependencies = [
   "carbide-lints",
   "check-format-nightly",
   "check-workspace-deps",
-  "check-isolated-package-builds",
   "check-licenses",
   "check-bans",
 ]


### PR DESCRIPTION
Move isolated package build checks out of required CI/pre-build checks and document them as an optional maintenance workflow.

## Related issues

Closes #2984 

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

