### PR TITLE
nvlink: rotate NVSwitch cert via RMS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ dependencies = [
  "async-trait",
  "carbide-api-db",
  "carbide-api-model",
+ "carbide-rack",
  "carbide-secrets",
  "carbide-utils",
  "carbide-uuid",
@@ -2480,6 +2481,7 @@ dependencies = [
  "http",
  "libnmxc",
  "libnmxm",
+ "librms",
  "opentelemetry",
  "rand 0.10.1",
  "rcgen",
@@ -6624,7 +6626,7 @@ dependencies = [
 [[package]]
 name = "librms"
 version = "0.0.14"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-rc1#dd35e101e21f5d35240d57e62f24e33767c3c770"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-mts-rc04#ea1a14375cbc153ca096713daf184cb65a185538"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11617,7 +11619,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-rc1#dd35e101e21f5d35240d57e62f24e33767c3c770"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-mts-rc04#ea1a14375cbc153ca096713daf184cb65a185538"
 dependencies = [
  "async-trait",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.16" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-rc1" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -39,7 +39,7 @@ use carbide_machine_controller::io::MachineStateControllerIO;
 use carbide_network_segment_controller::context::NetworkSegmentStateHandlerServices;
 use carbide_network_segment_controller::handler::NetworkSegmentStateHandler;
 use carbide_network_segment_controller::io::NetworkSegmentStateControllerIO;
-use carbide_nvlink_manager::NvLinkManager;
+use carbide_nvlink_manager::{NvLinkManager, NvLinkManagerArgs};
 use carbide_power_shelf_controller::context::PowerShelfStateHandlerServices;
 use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
 use carbide_power_shelf_controller::io::PowerShelfStateControllerIO;
@@ -1383,14 +1383,17 @@ async fn initialize_and_start_controllers<'a>(
     )
     .start(join_set, cancel_token.clone())?;
 
-    NvLinkManager::new(
-        db_pool.clone(),
-        api_service.nmxc_client_pool.clone(),
-        meter.clone(),
-        carbide_config.nvlink_config.clone().unwrap_or_default(),
-        carbide_config.host_health,
-        work_lock_manager_handle.clone(),
-    )
+    NvLinkManager::new(NvLinkManagerArgs {
+        db_pool: db_pool.clone(),
+        nmxc_client_pool: api_service.nmxc_client_pool.clone(),
+        meter: meter.clone(),
+        config: carbide_config.nvlink_config.clone().unwrap_or_default(),
+        host_health: carbide_config.host_health,
+        rms_client: api_service.rms_client.clone(),
+        credential_manager: api_service.credential_manager.clone(),
+        rack_profiles: carbide_config.rack_profiles.clone(),
+        work_lock_manager_handle: work_lock_manager_handle.clone(),
+    })
     .start(join_set, cancel_token.clone())?;
 
     if carbide_config.is_dpa_enabled() {

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1421,6 +1421,9 @@ pub async fn create_test_env_with_overrides(
         db_pool.clone(),
         test_meter.meter(),
         config.nvlink_config.clone().unwrap(),
+        rms_sim.as_rms_client(),
+        composite_manager.clone(),
+        config.rack_profiles.clone(),
         api.work_lock_manager_handle.clone(),
     );
 

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -16,6 +16,9 @@
  */
 
 use ::rpc::machine_discovery::Gpu;
+use carbide_secrets::credentials::{
+    BmcCredentialType, CredentialKey, CredentialWriter, Credentials,
+};
 use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use common::api_fixtures::instance::{
@@ -35,6 +38,7 @@ use common::api_fixtures::{
 use db::switch as db_switch;
 use ipnetwork::IpNetwork;
 use libnmxc::nmxc_model::{GetGpuInfoListRequest, GetPartitionInfoListRequest, GpuAttr};
+use librms::protos::rack_manager as rms;
 use model::expected_switch::ExpectedSwitch;
 use model::instance::config::nvlink::InstanceNvLinkConfig;
 use model::metadata::Metadata;
@@ -2412,6 +2416,32 @@ async fn create_rack_switch_for_nmxc_simulator(env: &TestEnv, rack_id: &RackId) 
         .await
         .expect("set primary switch");
     txn.commit().await.expect("commit switch");
+
+    let credentials = Credentials::UsernamePassword {
+        username: "admin".to_string(),
+        password: "password".to_string(),
+    };
+    env.test_credential_manager
+        .set_credentials(
+            &CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::BmcRoot {
+                    bmc_mac_address: bmc_mac,
+                },
+            },
+            &credentials,
+        )
+        .await
+        .expect("set switch BMC credentials");
+    env.test_credential_manager
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin {
+                bmc_mac_address: bmc_mac,
+            },
+            &credentials,
+        )
+        .await
+        .expect("set switch NVOS credentials");
+
     switch_id
 }
 
@@ -2586,7 +2616,7 @@ async fn assert_switch_cert_monitor_nmxc_simulator_probe(
     desired_server_cert_path: &std::path::Path,
     expected_fingerprint_mismatches: usize,
 ) {
-    let mut config = common::api_fixtures::get_config();
+    let mut config = common::api_fixtures::get_config_with_rack_profiles();
     if let Some(nvlink_config) = config.nvlink_config.as_mut() {
         nvlink_config.enabled = true;
         nvlink_config.nmx_c_endpoint_port = Some(NMXC_SIMULATOR_PORT);
@@ -2612,7 +2642,22 @@ async fn assert_switch_cert_monitor_nmxc_simulator_probe(
         .expect("create rack");
     txn.commit().await.expect("commit rack");
 
-    create_rack_switch_for_nmxc_simulator(&env, &rack_id).await;
+    let switch_id = create_rack_switch_for_nmxc_simulator(&env, &rack_id).await;
+
+    if expected_fingerprint_mismatches > 0 {
+        env.rms_sim
+            .queue_configure_switch_certificate_response(Ok(
+                rms::ConfigureSwitchCertificateResponse {
+                    response: Some(rms::NodeBatchResponse {
+                        status: rms::ReturnCode::Success as i32,
+                        job_id: "test-switch-cert-job".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+            ))
+            .await;
+    }
 
     let result = env.run_switch_cert_monitor_iteration().await;
     assert_eq!(result.observed_endpoints, 1);
@@ -2623,6 +2668,96 @@ async fn assert_switch_cert_monitor_nmxc_simulator_probe(
     );
     assert_eq!(result.desired_cert_errors, 0);
     assert_eq!(result.probe_errors, 0);
+    assert_eq!(result.applied_updates, 0);
+    assert_eq!(result.pending_updates, expected_fingerprint_mismatches);
+    assert_eq!(result.apply_errors, 0);
+
+    let rms_requests = env
+        .rms_sim
+        .submitted_configure_switch_certificate_requests()
+        .await;
+    assert_eq!(rms_requests.len(), expected_fingerprint_mismatches);
+    if expected_fingerprint_mismatches > 0 {
+        let request = rms_requests.first().expect("RMS request");
+        assert_eq!(
+            request.services,
+            vec![rms::SwitchService::ScaleUpFabricManager as i32]
+        );
+        assert!(request.test_hello);
+        assert_eq!(request.domain.as_deref(), Some(rack_id.as_ref()));
+        let node = request
+            .nodes
+            .as_ref()
+            .expect("RMS request node set")
+            .nodes
+            .first()
+            .expect("RMS request node");
+        assert_eq!(node.node_id, switch_id.to_string());
+        assert_eq!(node.rack_id, rack_id.to_string());
+
+        env.rms_sim
+            .queue_get_configure_switch_certificate_job_status_response(Ok(
+                rms::GetConfigureSwitchCertificateJobStatusResponse {
+                    status: rms::ReturnCode::Success as i32,
+                    job_id: "test-switch-cert-job".to_string(),
+                    state: "running".to_string(),
+                    ..Default::default()
+                },
+            ))
+            .await;
+        let result = env.run_switch_cert_monitor_iteration().await;
+        assert_eq!(result.observed_endpoints, 1);
+        assert_eq!(result.successful_probes, 1);
+        assert_eq!(
+            result.fingerprint_mismatches,
+            expected_fingerprint_mismatches
+        );
+        assert_eq!(result.applied_updates, 0);
+        assert_eq!(result.pending_updates, expected_fingerprint_mismatches);
+        assert_eq!(result.apply_errors, 0);
+        assert_eq!(
+            env.rms_sim
+                .submitted_configure_switch_certificate_requests()
+                .await
+                .len(),
+            1
+        );
+
+        let job_status_requests = env
+            .rms_sim
+            .submitted_get_configure_switch_certificate_job_status_requests()
+            .await;
+        assert_eq!(job_status_requests.len(), 1);
+        assert_eq!(job_status_requests[0].job_id, "test-switch-cert-job");
+
+        env.rms_sim
+            .queue_get_configure_switch_certificate_job_status_response(Ok(
+                rms::GetConfigureSwitchCertificateJobStatusResponse {
+                    status: rms::ReturnCode::Success as i32,
+                    job_id: "test-switch-cert-job".to_string(),
+                    state: "completed".to_string(),
+                    ..Default::default()
+                },
+            ))
+            .await;
+        let result = env.run_switch_cert_monitor_iteration().await;
+        assert_eq!(result.observed_endpoints, 1);
+        assert_eq!(result.successful_probes, 1);
+        assert_eq!(
+            result.fingerprint_mismatches,
+            expected_fingerprint_mismatches
+        );
+        assert_eq!(result.applied_updates, expected_fingerprint_mismatches);
+        assert_eq!(result.pending_updates, 0);
+        assert_eq!(result.apply_errors, 0);
+        assert_eq!(
+            env.rms_sim
+                .submitted_configure_switch_certificate_requests()
+                .await
+                .len(),
+            1
+        );
+    }
 }
 
 #[crate::sqlx_test]

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -582,6 +582,7 @@ pub struct SwitchEndpointRow {
 pub struct ReadyControlPlaneSwitchEndpointRow {
     pub switch_id: SwitchId,
     pub rack_id: RackId,
+    pub rack_profile_id: Option<RackProfileId>,
     pub nvos_ip: IpAddr,
 }
 
@@ -644,10 +645,13 @@ where
 {
     let sql = r#"
         SELECT DISTINCT ON (s.rack_id)
-            s.id              AS switch_id,
-            s.rack_id         AS rack_id,
-            nvos_mia.address  AS nvos_ip
+            s.id               AS switch_id,
+            s.rack_id          AS rack_id,
+            r.rack_profile_id  AS rack_profile_id,
+            nvos_mia.address   AS nvos_ip
         FROM switches s
+        LEFT JOIN racks r
+            ON r.id = s.rack_id
         JOIN expected_switches es
             ON es.bmc_mac_address = s.bmc_mac_address
         JOIN machine_interfaces nvos_mi

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -218,6 +218,16 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
     configure_scale_up_fabric_manager_calls: Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>,
 
+    configure_switch_certificate_responses:
+        Mutex<VecDeque<Result<rms::ConfigureSwitchCertificateResponse, RackManagerError>>>,
+    configure_switch_certificate_calls: Mutex<Vec<rms::ConfigureSwitchCertificateRequest>>,
+
+    get_configure_switch_certificate_job_status_responses: Mutex<
+        VecDeque<Result<rms::GetConfigureSwitchCertificateJobStatusResponse, RackManagerError>>,
+    >,
+    get_configure_switch_certificate_job_status_calls:
+        Mutex<Vec<rms::GetConfigureSwitchCertificateJobStatusRequest>>,
+
     batch_set_scale_up_fabric_state_responses:
         Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>,
     batch_set_scale_up_fabric_state_calls: Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>,
@@ -338,6 +348,10 @@ impl MockRmsApi {
             get_switch_system_image_job_status_calls: Default::default(),
             configure_scale_up_fabric_manager_responses: Default::default(),
             configure_scale_up_fabric_manager_calls: Default::default(),
+            configure_switch_certificate_responses: Default::default(),
+            configure_switch_certificate_calls: Default::default(),
+            get_configure_switch_certificate_job_status_responses: Default::default(),
+            get_configure_switch_certificate_job_status_calls: Default::default(),
             batch_set_scale_up_fabric_state_responses: Default::default(),
             batch_set_scale_up_fabric_state_calls: Default::default(),
             batch_get_scale_up_fabric_service_status_responses: Default::default(),
@@ -690,6 +704,22 @@ impl MockRmsApi {
         configure_scale_up_fabric_manager_calls,
         rms::ConfigureScaleUpFabricManagerRequest,
         rms::ConfigureScaleUpFabricManagerResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_configure_switch_certificate,
+        configure_switch_certificate_calls,
+        configure_switch_certificate_responses,
+        configure_switch_certificate_calls,
+        rms::ConfigureSwitchCertificateRequest,
+        rms::ConfigureSwitchCertificateResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_configure_switch_certificate_job_status,
+        get_configure_switch_certificate_job_status_calls,
+        get_configure_switch_certificate_job_status_responses,
+        get_configure_switch_certificate_job_status_calls,
+        rms::GetConfigureSwitchCertificateJobStatusRequest,
+        rms::GetConfigureSwitchCertificateJobStatusResponse
     );
     impl_enqueue_inspect!(
         enqueue_batch_set_scale_up_fabric_state,
@@ -1361,6 +1391,31 @@ impl RmsApi for MockRmsApi {
         pop_or_err(
             &mut self
                 .configure_scale_up_fabric_manager_responses
+                .lock()
+                .await,
+        )
+    }
+    async fn configure_switch_certificate(
+        &self,
+        cmd: rms::ConfigureSwitchCertificateRequest,
+    ) -> Result<rms::ConfigureSwitchCertificateResponse, RackManagerError> {
+        self.configure_switch_certificate_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.configure_switch_certificate_responses.lock().await)
+    }
+    async fn get_configure_switch_certificate_job_status(
+        &self,
+        cmd: rms::GetConfigureSwitchCertificateJobStatusRequest,
+    ) -> Result<rms::GetConfigureSwitchCertificateJobStatusResponse, RackManagerError> {
+        self.get_configure_switch_certificate_job_status_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .get_configure_switch_certificate_job_status_responses
                 .lock()
                 .await,
         )

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -484,6 +484,7 @@ fn build_power_shelf_node_info(
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.pmc_ip.to_string(),
                 mac_address: ep.pmc_mac.to_string(),
+                host_name: None,
             }),
             port: POWER_SHELF_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.pmc_credentials)),
@@ -909,6 +910,7 @@ fn build_switch_node_info(
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.bmc_ip.to_string(),
                 mac_address: ep.bmc_mac.to_string(),
+                host_name: None,
             }),
             port: SWITCH_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.bmc_credentials)),
@@ -918,6 +920,7 @@ fn build_switch_node_info(
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.nvos_ip.to_string(),
                 mac_address: ep.nvos_mac.to_string(),
+                host_name: None,
             }),
             port: 0,
             credentials: Some(credentials_to_rms(&ep.nvos_credentials)),
@@ -1155,6 +1158,7 @@ fn build_compute_tray_node_info(
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.bmc_ip.to_string(),
                 mac_address: bmc_mac.to_string(),
+                host_name: None,
             }),
             port: COMPUTE_TRAY_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.bmc_credentials)),

--- a/crates/nvlink-manager/Cargo.toml
+++ b/crates/nvlink-manager/Cargo.toml
@@ -16,6 +16,7 @@ test-support = []
 [dependencies]
 carbide-api-db = { path = "../api-db" }
 carbide-api-model = { path = "../api-model" }
+carbide-rack = { path = "../rack" }
 carbide-secrets = { path = "../secrets" }
 carbide-utils = { path = "../utils" }
 carbide-uuid = { path = "../uuid" }
@@ -30,6 +31,7 @@ duration-str = { workspace = true }
 eyre = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+librms = { workspace = true }
 opentelemetry = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -27,6 +27,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
+use carbide_secrets::credentials::CredentialManager;
 use carbide_utils::periodic_timer::PeriodicTimer;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::nvlink::{NvLinkDomainId, NvLinkLogicalPartitionId, NvLinkPartitionId};
@@ -58,6 +59,7 @@ use model::machine::nvlink::{MachineNvLinkGpuStatusObservation, MachineNvLinkSta
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostStateSnapshot};
 use model::nvl_logical_partition::LogicalPartition;
 use model::nvl_partition::{NvlPartition, NvlPartitionName};
+use model::rack_type::RackProfileConfig;
 use sqlx::PgPool;
 #[cfg(feature = "test-support")]
 pub use switch_cert_monitor::{SwitchCertificateMonitor, SwitchCertificateMonitorIterationResult};
@@ -898,25 +900,36 @@ pub struct NvLinkManager {
     meter: opentelemetry::metrics::Meter,
     config: NvLinkConfig,
     host_health: HostHealthConfig,
+    rms_client: Option<Arc<dyn librms::RmsApi>>,
+    credential_manager: Arc<dyn CredentialManager>,
+    rack_profiles: RackProfileConfig,
     work_lock_manager_handle: WorkLockManagerHandle,
 }
 
+pub struct NvLinkManagerArgs {
+    pub db_pool: PgPool,
+    pub nmxc_client_pool: Arc<dyn NmxcPool>,
+    pub meter: opentelemetry::metrics::Meter,
+    pub config: NvLinkConfig,
+    pub host_health: HostHealthConfig,
+    pub rms_client: Option<Arc<dyn librms::RmsApi>>,
+    pub credential_manager: Arc<dyn CredentialManager>,
+    pub rack_profiles: RackProfileConfig,
+    pub work_lock_manager_handle: WorkLockManagerHandle,
+}
+
 impl NvLinkManager {
-    pub fn new(
-        db_pool: PgPool,
-        nmxc_client_pool: Arc<dyn NmxcPool>,
-        meter: opentelemetry::metrics::Meter,
-        config: NvLinkConfig,
-        host_health: HostHealthConfig,
-        work_lock_manager_handle: WorkLockManagerHandle,
-    ) -> Self {
+    pub fn new(args: NvLinkManagerArgs) -> Self {
         Self {
-            db_pool,
-            nmxc_client_pool,
-            meter,
-            config,
-            host_health,
-            work_lock_manager_handle,
+            db_pool: args.db_pool,
+            nmxc_client_pool: args.nmxc_client_pool,
+            meter: args.meter,
+            config: args.config,
+            host_health: args.host_health,
+            rms_client: args.rms_client,
+            credential_manager: args.credential_manager,
+            rack_profiles: args.rack_profiles,
+            work_lock_manager_handle: args.work_lock_manager_handle,
         }
     }
 
@@ -940,6 +953,9 @@ impl NvLinkManager {
                 self.db_pool,
                 self.meter,
                 self.config,
+                self.rms_client,
+                self.credential_manager,
+                self.rack_profiles,
                 self.work_lock_manager_handle,
             );
             join_set

--- a/crates/nvlink-manager/src/switch_cert_monitor.rs
+++ b/crates/nvlink-manager/src/switch_cert_monitor.rs
@@ -20,13 +20,18 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{fmt, io};
 
+use carbide_rack::firmware_update::{build_new_node_info, load_switch_firmware_device_info};
+use carbide_rack::rms_node_type::switch_node_type_for_profile;
+use carbide_secrets::credentials::CredentialManager;
 use carbide_utils::metrics::SharedMetricsHolder;
 use carbide_utils::periodic_timer::PeriodicTimer;
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::SwitchId;
 use chrono::Utc;
 use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
+use librms::protos::rack_manager as rms;
+use model::rack_type::RackProfileConfig;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};
 use rustls::{ClientConfig, RootCertStore};
@@ -34,6 +39,7 @@ use rustls_pki_types::{CertificateDer, PrivateKeyDer, ServerName};
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 use tokio_rustls::TlsConnector;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -53,7 +59,29 @@ struct CertificateInfo {
 struct SwitchCertificateMonitorTarget {
     switch_id: SwitchId,
     rack_id: RackId,
+    rack_profile_id: Option<RackProfileId>,
     endpoint_url: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SwitchCertApplyStatus {
+    NotNeeded,
+    Pending,
+    Applied,
+    Error,
+    Skipped,
+}
+
+impl SwitchCertApplyStatus {
+    fn as_metric_label(self) -> &'static str {
+        match self {
+            Self::NotNeeded => "not_needed",
+            Self::Pending => "pending",
+            Self::Applied => "applied",
+            Self::Error => "error",
+            Self::Skipped => "skipped",
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -65,6 +93,8 @@ struct ObservedSwitchCertMetrics {
     expires_within_warning_window: bool,
     observed_cert: Option<CertificateInfo>,
     error: String,
+    apply_status: SwitchCertApplyStatus,
+    apply_error: String,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -77,6 +107,7 @@ enum SwitchCertMonitorErrorKind {
     EndpointConfig,
     ServerCertificate,
     Configuration,
+    Rms,
     Other,
 }
 
@@ -91,6 +122,7 @@ impl SwitchCertMonitorErrorKind {
             Self::EndpointConfig => "endpoint_config",
             Self::ServerCertificate => "server_certificate",
             Self::Configuration => "configuration",
+            Self::Rms => "rms",
             Self::Other => "other",
         }
     }
@@ -128,13 +160,25 @@ impl fmt::Display for SwitchCertMonitorMetrics {
             .iter()
             .filter(|cert| !cert.desired_cert_error.is_empty())
             .count();
+        let applied_updates = self
+            .observed_certs
+            .iter()
+            .filter(|cert| cert.apply_status == SwitchCertApplyStatus::Applied)
+            .count();
+        let pending_updates = self
+            .observed_certs
+            .iter()
+            .filter(|cert| cert.apply_status == SwitchCertApplyStatus::Pending)
+            .count();
         write!(
             f,
-            "{{ observed_endpoints: {}, desired_cert_errors: {}, successful_probes: {}, matching_fingerprints: {}, duration: {} }}",
+            "{{ observed_endpoints: {}, desired_cert_errors: {}, successful_probes: {}, matching_fingerprints: {}, applied_updates: {}, pending_updates: {}, duration: {} }}",
             self.observed_certs.len(),
             desired_cert_errors,
             successful_probes,
             matching_fingerprints,
+            applied_updates,
+            pending_updates,
             self.recording_started_at.elapsed().as_millis(),
         )
     }
@@ -305,6 +349,56 @@ impl SwitchCertMonitorInstruments {
         }
 
         {
+            let metrics = shared_metrics.clone();
+            meter
+                .u64_observable_gauge("carbide_nvlink_switch_cert_monitor_apply_status")
+                .with_description("Number of NMX-C switch certificate apply outcomes by status")
+                .with_callback(move |observer| {
+                    metrics.if_available(|metrics, attrs| {
+                        for (status, count) in
+                            count_by_status(&metrics.observed_certs, apply_status)
+                        {
+                            observer.observe(
+                                count,
+                                &metric_attrs(attrs, &[KeyValue::new("status", status)]),
+                            );
+                        }
+                    })
+                })
+                .build();
+        }
+
+        {
+            let metrics = shared_metrics.clone();
+            meter
+                .u64_observable_gauge("carbide_nvlink_switch_cert_monitor_apply_error_count")
+                .with_description("Number of NMX-C switch certificate apply failures by error kind")
+                .with_callback(move |observer| {
+                    metrics.if_available(|metrics, attrs| {
+                        let error_counts = count_errors_by_kind(
+                            metrics
+                                .observed_certs
+                                .iter()
+                                .map(|cert| cert.apply_error.as_str()),
+                        );
+                        for (error_kind, count) in error_counts {
+                            observer.observe(
+                                count,
+                                &metric_attrs(
+                                    attrs,
+                                    &[
+                                        KeyValue::new("status", "error"),
+                                        KeyValue::new("error_kind", error_kind.as_metric_label()),
+                                    ],
+                                ),
+                            );
+                        }
+                    })
+                })
+                .build();
+        }
+
+        {
             let metrics = shared_metrics;
             meter
                 .u64_observable_gauge("carbide_nvlink_switch_cert_monitor_probe_error_count")
@@ -369,8 +463,39 @@ impl MetricHolder {
 pub struct SwitchCertificateMonitor {
     db_pool: PgPool,
     config: NvLinkConfig,
+    rms_client: Option<Arc<dyn librms::RmsApi>>,
+    credential_manager: Arc<dyn CredentialManager>,
+    rack_profiles: RackProfileConfig,
     metric_holder: Arc<MetricHolder>,
     work_lock_manager_handle: WorkLockManagerHandle,
+    in_flight_certificate_jobs: Mutex<BTreeMap<SwitchCertJobKey, InFlightSwitchCertJob>>,
+}
+
+#[derive(Clone, Debug)]
+struct InFlightSwitchCertJob {
+    job_id: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct SwitchCertJobKey {
+    switch_id: String,
+    rack_id: String,
+}
+
+impl SwitchCertJobKey {
+    fn from_target(target: &SwitchCertificateMonitorTarget) -> Self {
+        Self {
+            switch_id: target.switch_id.to_string(),
+            rack_id: target.rack_id.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RmsSwitchCertJobState {
+    Pending(String),
+    Completed,
+    Failed(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -380,6 +505,9 @@ pub struct SwitchCertificateMonitorIterationResult {
     pub fingerprint_mismatches: usize,
     pub desired_cert_errors: usize,
     pub probe_errors: usize,
+    pub applied_updates: usize,
+    pub pending_updates: usize,
+    pub apply_errors: usize,
 }
 
 impl SwitchCertificateMonitorIterationResult {
@@ -406,6 +534,21 @@ impl SwitchCertificateMonitorIterationResult {
                 .iter()
                 .filter(|cert| !cert.error.is_empty())
                 .count(),
+            applied_updates: metrics
+                .observed_certs
+                .iter()
+                .filter(|cert| cert.apply_status == SwitchCertApplyStatus::Applied)
+                .count(),
+            pending_updates: metrics
+                .observed_certs
+                .iter()
+                .filter(|cert| cert.apply_status == SwitchCertApplyStatus::Pending)
+                .count(),
+            apply_errors: metrics
+                .observed_certs
+                .iter()
+                .filter(|cert| !cert.apply_error.is_empty())
+                .count(),
         }
     }
 }
@@ -413,11 +556,15 @@ impl SwitchCertificateMonitorIterationResult {
 impl SwitchCertificateMonitor {
     const ITERATION_WORK_KEY: &'static str = "SwitchCertificateMonitor::run_single_iteration";
     const PROBE_CANCELLED_ERROR: &'static str = "NMX-C server certificate probe cancelled";
+    const APPLY_CANCELLED_ERROR: &'static str = "NMX-C server certificate apply cancelled";
 
     pub fn new(
         db_pool: PgPool,
         meter: Meter,
         config: NvLinkConfig,
+        rms_client: Option<Arc<dyn librms::RmsApi>>,
+        credential_manager: Arc<dyn CredentialManager>,
+        rack_profiles: RackProfileConfig,
         work_lock_manager_handle: WorkLockManagerHandle,
     ) -> Self {
         let hold_period = config
@@ -428,8 +575,12 @@ impl SwitchCertificateMonitor {
         Self {
             db_pool,
             config,
+            rms_client,
+            credential_manager,
+            rack_profiles,
             metric_holder,
             work_lock_manager_handle,
+            in_flight_certificate_jobs: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -563,6 +714,8 @@ impl SwitchCertificateMonitor {
                         expires_within_warning_window: false,
                         observed_cert: None,
                         error: String::new(),
+                        apply_status: SwitchCertApplyStatus::Skipped,
+                        apply_error: String::new(),
                     });
                     continue;
                 }
@@ -598,6 +751,31 @@ impl SwitchCertificateMonitor {
                         );
                     }
 
+                    let (apply_status, apply_error) = if fingerprint_matches {
+                        (SwitchCertApplyStatus::NotNeeded, String::new())
+                    } else {
+                        match self
+                            .reconcile_desired_certificate_apply(&target, cancel_token)
+                            .await
+                        {
+                            Ok(apply_status) => (apply_status, String::new()),
+                            Err(error) if error == Self::APPLY_CANCELLED_ERROR => {
+                                tracing::info!("SwitchCertificateMonitor stop was requested");
+                                return Ok(());
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    switch_id = %target.switch_id,
+                                    rack_id = %rack_id_label,
+                                    endpoint = %target.endpoint_url,
+                                    error = %error,
+                                    "Failed to request RMS NMX-C switch certificate configuration"
+                                );
+                                (SwitchCertApplyStatus::Error, error)
+                            }
+                        }
+                    };
+
                     if expires_within_warning_window {
                         tracing::warn!(
                             switch_id = %target.switch_id,
@@ -627,6 +805,8 @@ impl SwitchCertificateMonitor {
                         expires_within_warning_window,
                         observed_cert: Some(observed_cert),
                         error: String::new(),
+                        apply_status,
+                        apply_error,
                     }
                 }
                 Err(error) if error == Self::PROBE_CANCELLED_ERROR => {
@@ -649,6 +829,8 @@ impl SwitchCertificateMonitor {
                         expires_within_warning_window: false,
                         observed_cert: None,
                         error,
+                        apply_status: SwitchCertApplyStatus::Skipped,
+                        apply_error: String::new(),
                     }
                 }
             };
@@ -656,6 +838,66 @@ impl SwitchCertificateMonitor {
         }
 
         Ok(())
+    }
+
+    async fn reconcile_desired_certificate_apply(
+        &self,
+        target: &SwitchCertificateMonitorTarget,
+        cancel_token: &CancellationToken,
+    ) -> Result<SwitchCertApplyStatus, String> {
+        let key = SwitchCertJobKey::from_target(target);
+        let in_flight_job = self
+            .in_flight_certificate_jobs
+            .lock()
+            .await
+            .get(&key)
+            .cloned();
+
+        if let Some(in_flight_job) = in_flight_job {
+            let job_state = self
+                .get_in_flight_certificate_job_state(&in_flight_job.job_id, cancel_token)
+                .await?;
+            match job_state {
+                RmsSwitchCertJobState::Pending(state) => {
+                    tracing::info!(
+                        switch_id = %target.switch_id,
+                        rack_id = %target.rack_id,
+                        endpoint = %target.endpoint_url,
+                        job_id = %in_flight_job.job_id,
+                        state = %state,
+                        "RMS NMX-C switch certificate configuration job is still in progress"
+                    );
+                    Ok(SwitchCertApplyStatus::Pending)
+                }
+                RmsSwitchCertJobState::Completed => {
+                    self.in_flight_certificate_jobs.lock().await.remove(&key);
+                    tracing::info!(
+                        switch_id = %target.switch_id,
+                        rack_id = %target.rack_id,
+                        endpoint = %target.endpoint_url,
+                        job_id = %in_flight_job.job_id,
+                        "RMS NMX-C switch certificate configuration job completed"
+                    );
+                    Ok(SwitchCertApplyStatus::Applied)
+                }
+                RmsSwitchCertJobState::Failed(error) => {
+                    self.in_flight_certificate_jobs.lock().await.remove(&key);
+                    Err(format!(
+                        "RMS NMX-C switch certificate configuration job {} failed: {}",
+                        in_flight_job.job_id, error
+                    ))
+                }
+            }
+        } else {
+            let job_id = self
+                .apply_desired_certificate_with_rms(target, cancel_token)
+                .await?;
+            self.in_flight_certificate_jobs
+                .lock()
+                .await
+                .insert(key, InFlightSwitchCertJob { job_id });
+            Ok(SwitchCertApplyStatus::Pending)
+        }
     }
 
     async fn load_switch_certificate_monitor_targets(
@@ -672,6 +914,7 @@ impl SwitchCertificateMonitor {
             .map(|row| SwitchCertificateMonitorTarget {
                 switch_id: row.switch_id,
                 rack_id: row.rack_id,
+                rack_profile_id: row.rack_profile_id,
                 endpoint_url: nmx_c_endpoint::nmx_c_endpoint_url_from_nvos_ip(
                     &row.nvos_ip,
                     None,
@@ -679,6 +922,175 @@ impl SwitchCertificateMonitor {
                 ),
             })
             .collect())
+    }
+
+    async fn apply_desired_certificate_with_rms(
+        &self,
+        target: &SwitchCertificateMonitorTarget,
+        cancel_token: &CancellationToken,
+    ) -> Result<String, String> {
+        let rms_client = self.rms_client.as_ref().ok_or_else(|| {
+            "RMS client is not configured, so NMX-C switch certificate cannot be applied"
+                .to_string()
+        })?;
+
+        let rack_profile_id = target.rack_profile_id.as_ref().ok_or_else(|| {
+            format!(
+                "rack {} has no rack_profile_id, so RMS switch node type and topology cannot be resolved",
+                target.rack_id
+            )
+        })?;
+        let profile = self
+            .rack_profiles
+            .get(rack_profile_id.as_ref())
+            .ok_or_else(|| {
+                format!(
+                    "rack profile {} is not configured, so RMS switch node type and topology cannot be resolved",
+                    rack_profile_id
+                )
+            })?;
+        let switch_node_type = switch_node_type_for_profile(profile)
+            .map_err(|error| format!("failed to resolve RMS switch node type: {error}"))?;
+
+        let switch = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Err(Self::APPLY_CANCELLED_ERROR.to_string());
+            }
+            switch = load_switch_firmware_device_info(
+                &self.db_pool,
+                self.credential_manager.as_ref(),
+                &target.switch_id,
+            ) => switch
+                .map_err(|error| {
+                    format!(
+                        "failed to load switch endpoint info for RMS certificate apply: {error}"
+                    )
+                })?,
+        };
+
+        validate_switch_for_rms_certificate_apply(&switch)?;
+
+        let response = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Err(Self::APPLY_CANCELLED_ERROR.to_string());
+            }
+            response = rms_client.configure_switch_certificate(
+                rms::ConfigureSwitchCertificateRequest {
+                    nodes: Some(rms::NodeSet {
+                        nodes: vec![build_new_node_info(
+                            &target.rack_id,
+                            &switch,
+                            switch_node_type,
+                        )],
+                    }),
+                    services: vec![rms::SwitchService::ScaleUpFabricManager as i32],
+                    test_hello: true,
+                    domain: Some(target.rack_id.to_string()),
+                }
+            ) => response.map_err(|error| {
+                format!("RMS ConfigureSwitchCertificate failed: {error}")
+            })?,
+        };
+
+        let batch_response = response.response.ok_or_else(|| {
+            "RMS ConfigureSwitchCertificate response did not include a batch response".to_string()
+        })?;
+        if batch_response.status != rms::ReturnCode::Success as i32 {
+            let message = if batch_response.message.trim().is_empty() {
+                "no error details provided".to_string()
+            } else {
+                batch_response.message
+            };
+            return Err(format!(
+                "RMS ConfigureSwitchCertificate returned status {}: {}",
+                batch_response.status, message
+            ));
+        }
+
+        let switch_id = target.switch_id.to_string();
+        let child_job_id = response
+            .jobs
+            .iter()
+            .find(|job| job.node_id == switch_id)
+            .map(|job| job.job_id.trim())
+            .filter(|job_id| !job_id.is_empty());
+        let job_id = child_job_id
+            .or_else(|| {
+                let parent_job_id = batch_response.job_id.trim();
+                if parent_job_id.is_empty() {
+                    None
+                } else {
+                    Some(parent_job_id)
+                }
+            })
+            .ok_or_else(|| {
+                "RMS ConfigureSwitchCertificate response did not include a job id".to_string()
+            })?
+            .to_string();
+
+        tracing::info!(
+            switch_id = %target.switch_id,
+            rack_id = %target.rack_id,
+            job_id = %job_id,
+            "Submitted RMS switch certificate configuration"
+        );
+
+        Ok(job_id)
+    }
+
+    async fn get_in_flight_certificate_job_state(
+        &self,
+        job_id: &str,
+        cancel_token: &CancellationToken,
+    ) -> Result<RmsSwitchCertJobState, String> {
+        let rms_client = self.rms_client.as_ref().ok_or_else(|| {
+            "RMS client is not configured, so NMX-C switch certificate job status cannot be checked"
+                .to_string()
+        })?;
+
+        let response = tokio::select! {
+            _ = cancel_token.cancelled() => {
+                return Err(Self::APPLY_CANCELLED_ERROR.to_string());
+            }
+            response = rms_client.get_configure_switch_certificate_job_status(
+                rms::GetConfigureSwitchCertificateJobStatusRequest {
+                    job_id: job_id.to_string(),
+                },
+            ) => response.map_err(|error| {
+                format!("RMS GetConfigureSwitchCertificateJobStatus failed: {error}")
+            })?,
+        };
+
+        if response.status != rms::ReturnCode::Success as i32 {
+            return Ok(RmsSwitchCertJobState::Failed(format!(
+                "RMS GetConfigureSwitchCertificateJobStatus returned status {}: {}",
+                response.status,
+                non_empty_or(response.error_message.as_str(), response.message.as_str())
+            )));
+        }
+
+        let state = response.state.trim().to_ascii_lowercase();
+        match state.as_str() {
+            "completed" | "complete" | "succeeded" | "success" => {
+                Ok(RmsSwitchCertJobState::Completed)
+            }
+            "failed" | "failure" | "error" => Ok(RmsSwitchCertJobState::Failed(non_empty_or(
+                response.error_message.as_str(),
+                response.message.as_str(),
+            ))),
+            "queued" | "running" | "pending" | "active" | "in_progress" => {
+                Ok(RmsSwitchCertJobState::Pending(state))
+            }
+            "" => Ok(RmsSwitchCertJobState::Pending("unknown".to_string())),
+            _ => {
+                tracing::warn!(
+                    job_id = %job_id,
+                    state = %response.state,
+                    "RMS returned unknown NMX-C switch certificate job state; treating as pending"
+                );
+                Ok(RmsSwitchCertJobState::Pending(response.state))
+            }
+        }
     }
 
     async fn probe_endpoint_certificate(
@@ -769,6 +1181,27 @@ fn desired_server_cert_path(config: &NvLinkConfig, rack_id: &RackId) -> Result<S
             "nmx_c_certificate_rotation.server_cert_path or server_cert_path_template is not configured"
                 .to_string()
         })
+}
+
+fn validate_switch_for_rms_certificate_apply(
+    switch: &model::rack::FirmwareUpgradeDeviceInfo,
+) -> Result<(), String> {
+    if switch.os_ip.as_deref().unwrap_or_default().is_empty() {
+        return Err(format!(
+            "switch {} is missing an NVOS IP address for RMS certificate apply",
+            switch.node_id
+        ));
+    }
+    if switch.os_username.as_deref().unwrap_or_default().is_empty()
+        || switch.os_password.as_deref().unwrap_or_default().is_empty()
+    {
+        return Err(format!(
+            "switch {} is missing NVOS credentials for RMS certificate apply",
+            switch.node_id
+        ));
+    }
+
+    Ok(())
 }
 
 async fn build_tls_client_config(config: &NvLinkConfig) -> Result<ClientConfig, String> {
@@ -862,6 +1295,14 @@ fn cert_expires_within(cert: &CertificateInfo, window: Duration) -> bool {
     not_after <= warning_threshold
 }
 
+fn non_empty_or(primary: &str, fallback: &str) -> String {
+    if primary.trim().is_empty() {
+        fallback.trim().to_string()
+    } else {
+        primary.trim().to_string()
+    }
+}
+
 fn metric_attrs(base_attrs: &[KeyValue], extra_attrs: &[KeyValue]) -> Vec<KeyValue> {
     [base_attrs, extra_attrs].concat()
 }
@@ -915,6 +1356,10 @@ fn expiry_status(cert: &ObservedSwitchCertMetrics) -> &'static str {
     }
 }
 
+fn apply_status(cert: &ObservedSwitchCertMetrics) -> &'static str {
+    cert.apply_status.as_metric_label()
+}
+
 fn switch_cert_monitor_error_kind(error: &str) -> SwitchCertMonitorErrorKind {
     let error = error.to_ascii_lowercase();
     if error.contains("timed out") {
@@ -937,8 +1382,14 @@ fn switch_cert_monitor_error_kind(error: &str) -> SwitchCertMonitorErrorKind {
         SwitchCertMonitorErrorKind::EndpointConfig
     } else if error.contains("did not serve") || error.contains("empty certificate chain") {
         SwitchCertMonitorErrorKind::ServerCertificate
-    } else if error.contains("not configured") || error.contains("required") {
+    } else if error.contains("not configured")
+        || error.contains("required")
+        || error.contains("rack profile")
+        || error.contains("missing")
+    {
         SwitchCertMonitorErrorKind::Configuration
+    } else if error.contains("rms ") || error.contains("configurescaleupfabricmanager") {
+        SwitchCertMonitorErrorKind::Rms
     } else {
         SwitchCertMonitorErrorKind::Other
     }

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -2101,6 +2101,7 @@ pub async fn handle_maintenance(
                             switch_node_type,
                         )),
                         topology_type: topology_type.clone(),
+                        domain: None,
                     })
                     .await
                 {

--- a/crates/rack/src/firmware_update.rs
+++ b/crates/rack/src/firmware_update.rs
@@ -151,25 +151,52 @@ pub async fn load_rack_switch_firmware_inventory(
 
     let mut switches = Vec::with_capacity(switch_endpoints.len());
     for switch in &switch_endpoints {
-        let (bmc_username, bmc_password) =
-            fetch_bmc_credentials(credential_manager, switch.bmc_mac).await?;
-        let nvos_creds = fetch_nvos_credentials(credential_manager, switch.bmc_mac).await;
-        switches.push(FirmwareUpgradeDeviceInfo {
-            node_id: switch.switch_id.to_string(),
-            mac: switch.bmc_mac.to_string(),
-            bmc_ip: switch.bmc_ip.to_string(),
-            bmc_username,
-            bmc_password,
-            os_mac: switch.nvos_mac.map(|mac| mac.to_string()),
-            os_ip: switch.nvos_ip.map(|ip| ip.to_string()),
-            os_username: nvos_creds.as_ref().map(|(username, _)| username.clone()),
-            os_password: nvos_creds.map(|(_, password)| password),
-        });
+        switches.push(switch_endpoint_to_firmware_device_info(credential_manager, switch).await?);
     }
 
     Ok(RackSwitchFirmwareInventory {
         switch_ids,
         switches,
+    })
+}
+
+pub async fn load_switch_firmware_device_info(
+    db_pool: &PgPool,
+    credential_manager: &dyn CredentialManager,
+    switch_id: &SwitchId,
+) -> Result<FirmwareUpgradeDeviceInfo> {
+    let switch_endpoint = {
+        let mut txn = db_pool.begin().await?;
+        let mut switch_endpoints =
+            db_switch::find_switch_endpoints_by_ids(txn.as_mut(), std::slice::from_ref(switch_id))
+                .await?;
+        txn.commit().await?;
+        switch_endpoints
+            .pop()
+            .ok_or_else(|| eyre!("switch {} missing endpoint info", switch_id))?
+    };
+
+    switch_endpoint_to_firmware_device_info(credential_manager, &switch_endpoint).await
+}
+
+async fn switch_endpoint_to_firmware_device_info(
+    credential_manager: &dyn CredentialManager,
+    switch: &db_switch::SwitchEndpointRow,
+) -> Result<FirmwareUpgradeDeviceInfo> {
+    let (bmc_username, bmc_password) =
+        fetch_bmc_credentials(credential_manager, switch.bmc_mac).await?;
+    let nvos_creds = fetch_nvos_credentials(credential_manager, switch.bmc_mac).await;
+
+    Ok(FirmwareUpgradeDeviceInfo {
+        node_id: switch.switch_id.to_string(),
+        mac: switch.bmc_mac.to_string(),
+        bmc_ip: switch.bmc_ip.to_string(),
+        bmc_username,
+        bmc_password,
+        os_mac: switch.nvos_mac.map(|mac| mac.to_string()),
+        os_ip: switch.nvos_ip.map(|ip| ip.to_string()),
+        os_username: nvos_creds.as_ref().map(|(username, _)| username.clone()),
+        os_password: nvos_creds.map(|(_, password)| password),
     })
 }
 
@@ -228,6 +255,7 @@ pub fn build_new_node_info(
             interface: Some(rms::NetworkInterface {
                 ip_address: device.bmc_ip.clone(),
                 mac_address: device.mac.clone(),
+                host_name: None,
             }),
             port: 443,
             credentials: user_pass_credentials(&device.bmc_username, &device.bmc_password),
@@ -270,6 +298,7 @@ fn build_host_interface(device: &FirmwareUpgradeDeviceInfo) -> Option<rms::Netwo
     Some(rms::NetworkInterface {
         ip_address: ip_address.clone(),
         mac_address: mac_address.clone(),
+        host_name: None,
     })
 }
 

--- a/crates/rack/src/rms_client.rs
+++ b/crates/rack/src/rms_client.rs
@@ -92,6 +92,19 @@ pub mod test_support {
         queued_configure_scale_up_fabric_manager_responses: Arc<
             Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
         >,
+        submitted_configure_switch_certificate_requests:
+            Arc<Mutex<Vec<rms::ConfigureSwitchCertificateRequest>>>,
+        queued_configure_switch_certificate_responses:
+            Arc<Mutex<VecDeque<Result<rms::ConfigureSwitchCertificateResponse, RackManagerError>>>>,
+        submitted_get_configure_switch_certificate_job_status_requests:
+            Arc<Mutex<Vec<rms::GetConfigureSwitchCertificateJobStatusRequest>>>,
+        queued_get_configure_switch_certificate_job_status_responses: Arc<
+            Mutex<
+                VecDeque<
+                    Result<rms::GetConfigureSwitchCertificateJobStatusResponse, RackManagerError>,
+                >,
+            >,
+        >,
         submitted_batch_set_scale_up_fabric_state_requests:
             Arc<Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>>,
         queued_batch_set_scale_up_fabric_state_responses:
@@ -134,6 +147,16 @@ pub mod test_support {
                     Vec::new(),
                 )),
                 queued_configure_scale_up_fabric_manager_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
+                submitted_configure_switch_certificate_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_configure_switch_certificate_responses: Arc::new(
+                    Mutex::new(VecDeque::new()),
+                ),
+                submitted_get_configure_switch_certificate_job_status_requests: Arc::new(
+                    Mutex::new(Vec::new()),
+                ),
+                queued_get_configure_switch_certificate_job_status_responses: Arc::new(Mutex::new(
                     VecDeque::new(),
                 )),
                 submitted_batch_set_scale_up_fabric_state_requests: Arc::new(
@@ -210,6 +233,18 @@ pub mod test_support {
                     .clone(),
                 queued_configure_scale_up_fabric_manager_responses: self
                     .queued_configure_scale_up_fabric_manager_responses
+                    .clone(),
+                submitted_configure_switch_certificate_requests: self
+                    .submitted_configure_switch_certificate_requests
+                    .clone(),
+                queued_configure_switch_certificate_responses: self
+                    .queued_configure_switch_certificate_responses
+                    .clone(),
+                submitted_get_configure_switch_certificate_job_status_requests: self
+                    .submitted_get_configure_switch_certificate_job_status_requests
+                    .clone(),
+                queued_get_configure_switch_certificate_job_status_responses: self
+                    .queued_get_configure_switch_certificate_job_status_responses
                     .clone(),
                 submitted_batch_set_scale_up_fabric_state_requests: self
                     .submitted_batch_set_scale_up_fabric_state_requests
@@ -413,6 +448,44 @@ pub mod test_support {
                 .clone()
         }
 
+        pub async fn queue_configure_switch_certificate_response(
+            &self,
+            response: Result<rms::ConfigureSwitchCertificateResponse, RackManagerError>,
+        ) {
+            self.queued_configure_switch_certificate_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        pub async fn submitted_configure_switch_certificate_requests(
+            &self,
+        ) -> Vec<rms::ConfigureSwitchCertificateRequest> {
+            self.submitted_configure_switch_certificate_requests
+                .lock()
+                .await
+                .clone()
+        }
+
+        pub async fn queue_get_configure_switch_certificate_job_status_response(
+            &self,
+            response: Result<rms::GetConfigureSwitchCertificateJobStatusResponse, RackManagerError>,
+        ) {
+            self.queued_get_configure_switch_certificate_job_status_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        pub async fn submitted_get_configure_switch_certificate_job_status_requests(
+            &self,
+        ) -> Vec<rms::GetConfigureSwitchCertificateJobStatusRequest> {
+            self.submitted_get_configure_switch_certificate_job_status_requests
+                .lock()
+                .await
+                .clone()
+        }
+
         pub async fn queue_batch_set_scale_up_fabric_state_response(
             &self,
             response: Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>,
@@ -512,6 +585,19 @@ pub mod test_support {
             Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
         queued_configure_scale_up_fabric_manager_responses: Arc<
             Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
+        >,
+        submitted_configure_switch_certificate_requests:
+            Arc<Mutex<Vec<rms::ConfigureSwitchCertificateRequest>>>,
+        queued_configure_switch_certificate_responses:
+            Arc<Mutex<VecDeque<Result<rms::ConfigureSwitchCertificateResponse, RackManagerError>>>>,
+        submitted_get_configure_switch_certificate_job_status_requests:
+            Arc<Mutex<Vec<rms::GetConfigureSwitchCertificateJobStatusRequest>>>,
+        queued_get_configure_switch_certificate_job_status_responses: Arc<
+            Mutex<
+                VecDeque<
+                    Result<rms::GetConfigureSwitchCertificateJobStatusResponse, RackManagerError>,
+                >,
+            >,
         >,
         submitted_batch_set_scale_up_fabric_state_requests:
             Arc<Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>>,
@@ -921,6 +1007,44 @@ pub mod test_support {
                 .await
                 .pop_front()
                 .unwrap_or(Ok(rms::ConfigureScaleUpFabricManagerResponse::default()))
+        }
+        async fn configure_switch_certificate(
+            &self,
+            cmd: rms::ConfigureSwitchCertificateRequest,
+        ) -> Result<rms::ConfigureSwitchCertificateResponse, RackManagerError> {
+            self.submitted_configure_switch_certificate_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_configure_switch_certificate_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::ConfigureSwitchCertificateResponse {
+                    response: Some(rms::NodeBatchResponse {
+                        status: rms::ReturnCode::Success as i32,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+        }
+        async fn get_configure_switch_certificate_job_status(
+            &self,
+            cmd: rms::GetConfigureSwitchCertificateJobStatusRequest,
+        ) -> Result<rms::GetConfigureSwitchCertificateJobStatusResponse, RackManagerError> {
+            self.submitted_get_configure_switch_certificate_job_status_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_get_configure_switch_certificate_job_status_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::GetConfigureSwitchCertificateJobStatusResponse {
+                    status: rms::ReturnCode::Success as i32,
+                    state: "running".to_string(),
+                    ..Default::default()
+                }))
         }
         async fn batch_set_scale_up_fabric_state(
             &self,

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -301,6 +301,7 @@ impl MachineCreator {
                             interface: Some(rms::NetworkInterface {
                                 ip_address: explored_host.host_bmc_ip.to_string(),
                                 mac_address: expected_machine.bmc_mac_address.to_string(),
+                                host_name: None,
                             }),
                             port: 443,
                             credentials: bmc_credentials.map(|(username, password)| {


### PR DESCRIPTION
Recently an NVSwitch mTLS probe was added that compares the cert being presented by the switch and the "desired" cert from the site config file. If that probe detects a mismatch, invoke the RMS ConfigureSwitchCertificate gRPC to rotate the cert.

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

