### PR TITLE
docs: housekeeping - fern tweaks, codeowners, rumdl config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,8 @@
 # Documentation (To be re-enabled once as have a doc reviewer)
 #/docs/ @CoCo-Ben
 #/fern/ @CoCo-Ben
+/docs/ @polarweasel
+/fern/ @polarweasel
 
 # Network IP module
 /common/network/src/ip/ @DrewBloechl

--- a/docs/.rumdl.toml
+++ b/docs/.rumdl.toml
@@ -1,0 +1,159 @@
+# toml-language-server: $schema=https://raw.githubusercontent.com/rvben/rumdl/main/rumdl.schema.json
+
+# rumdl configuration file
+#
+# Configuration reference: https://rumdl.dev/global-settings/
+# Rules reference: https://rumdl.dev/rules/
+
+# Inherit settings from another config file (relative to this file's directory)
+# extends = "../base.rumdl.toml"
+
+# Global configuration options
+
+[global]
+# List of rules to disable
+# disable = ["MD013", "MD014", "MD033", "MD036"]
+disable = [
+  "line-length",
+  "commands-show-output",
+  "no-inline-html",
+  "no-emphasis-as-heading",
+]
+
+# List of rules to enable exclusively (replaces defaults; only these rules will run)
+# enable = ["MD001", "MD003", "MD004"]
+
+# Additional rules to enable on top of defaults (additive, does not replace)
+# Use this to activate opt-in rules like MD060, MD063, MD072, MD073, MD074
+# extend-enable = ["MD060", "MD063"]
+
+# Additional rules to disable on top of the disable list (additive)
+# extend-disable = ["MD041"]
+
+# List of file/directory patterns to include for linting (if provided, only these will be linted)
+# include = [
+#    "docs/*.md",
+#    "src/**/*.md",
+#    "README.md"
+# ]
+
+# List of file/directory patterns to exclude from linting
+exclude = [
+    # Common directories to exclude
+    ".git",
+    ".github",
+    ".gitlab",
+    "node_modules",
+    "vendor",
+    "dist",
+    "build",
+
+    # Specific files or patterns
+    "CHANGELOG.md",
+    "LICENSE.md",
+]
+
+# Respect .gitignore files when scanning directories (default: true)
+respect-gitignore = true
+
+# Markdown flavor/dialect (uncomment to enable)
+# Options: standard (default), gfm, commonmark, mkdocs, mdx, quarto
+flavor = "mdx"
+
+[per-file-flavor]
+"**/*.md" = "standard"
+
+# Disable specific rules for specific files
+[per-file-ignores]
+"**/snippets/**/*.mdx" = ["MD041"]  # Snippets don't need to start with an H1
+
+# Rule-specific configurations
+
+[MD004]
+# Unordered list style (asterisk, plus, dash, consistent)
+# after-marker default is 1 space after the marker
+style = "consistent"
+# after-marker = 1
+
+[MD007]
+# ul-indent
+# indent = 4
+style = "text-aligned"
+
+[MD009]
+# no-trailing-spaces
+list_item_empty_lines = false
+strict = false
+
+[MD010]
+# no-hard-tabs
+spaces-per-tab = 4  # Number of spaces to replace each tab with (default: 4)
+
+# [MD013]
+# line-length = 100  # Line length
+# code-blocks = false  # Exclude code blocks from line length check
+# tables = false  # Exclude tables from line length check
+# headings = true  # Include headings in line length check
+
+[MD024]
+# no-duplicate-heading
+siblings_only = true
+
+[MD025]
+level = 1                        # The heading level that should be unique (default: 1)
+front-matter-title = "title"     # Regex pattern to match title in YAML front matter (default: "title")
+allow-document-sections = true  # Allow multiple H1s separated by --- thematic breaks (default: false)
+allow-with-separators = true    # Allow multiple H1s as document section titles (default: false)
+
+[MD029]
+# ol-prefix
+# Style options:
+# - "one" or "one-one": All items numbered "1." (easiest maintenance)
+# - "ordered": Sequential numbering (1, 2, 3...)
+# - "ordered0": Zero-based sequential (0, 1, 2...)
+# - "one-or-ordered": Auto-detect per list (either all-ones OR sequential)
+# - "consistent": Document-wide consistency - uses most common style across all lists
+style = "one-one"
+
+[MD041]
+# first-line-heading
+level = 1
+
+[MD044]
+# names = ["NVIDIA Config Manager", "NVIDIA"]
+# code-blocks = false
+
+[MD046]
+# code-block-style
+style = "fenced"
+
+[MD048]
+# code-fence-style
+style = "backtick"
+
+[MD054]
+# link-image-style
+# default is all true
+autolink = false    # Allow <https://example.com>
+# inline = true       # Allow [text](url) and ![alt](url)
+# full = true         # Allow [text][ref] with separate [ref]: url definition
+# collapsed = true    # Allow [text][] with separate [text]: url definition
+# shortcut = true     # Allow [text] with separate [text]: url definition
+# url-inline = true   # Allow [https://example.com](https://example.com)
+
+[MD055]
+# table-pipe-style
+style = "leading_and_trailing"
+
+[MD060]
+# table-column-style
+style = "compact"
+
+[MD076]
+# list-item-spacing
+style = "consistent"              # "consistent" (default), "loose", or "tight"
+allow-loose-continuation = true  # allow blank lines around continuation paragraphs
+
+[MD077]
+# list-continuation-indent
+# severity = "info"

--- a/docs/development/release_and_qa_process.md
+++ b/docs/development/release_and_qa_process.md
@@ -22,9 +22,9 @@ operators who want to understand which version of NICo they should be running.
 
 ## Where Releases Live
 
-- **GitHub releases:** <https://github.com/NVIDIA/infra-controller/releases>
-- **Issue tracker:** <https://github.com/NVIDIA/infra-controller/issues>
-- **Source:** <https://github.com/NVIDIA/infra-controller>
+- **GitHub releases:** [https://github.com/NVIDIA/infra-controller/releases](https://github.com/NVIDIA/infra-controller/releases)
+- **Issue tracker:** [https://github.com/NVIDIA/infra-controller/issues](https://github.com/NVIDIA/infra-controller/issues)
+- **Source:** [https://github.com/NVIDIA/infra-controller](https://github.com/NVIDIA/infra-controller)
 
 Every published minor and patch release is available on the GitHub releases page
 above, tagged with its semver version (see [Tag Naming](#tag-naming) below).

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -40,6 +40,6 @@ redirects:
   - source: "/infra-controller/documentation/introduction"
     destination: "/infra-controller/documentation/overview/what-is-nico"
   - source: "/infra-controller/documentation/getting-started/site-setup"
-    destination: "infra-controller/documentation/getting-started/quick-start-guide"
+    destination: "/infra-controller/documentation/getting-started/quick-start-guide"
   - source: "/infra-controller/documentation/getting-started/building-ni-co-containers"
     destination: "/infra-controller/documentation/getting-started/building-nico-containers"

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
+
+global-theme: nvidia
+
 instances:
   - url: nvidia-ncx-infra-controller.docs.buildwithfern.com/infra-controller
     custom-domain: docs.nvidia.com/infra-controller
@@ -14,54 +18,6 @@ metadata:
 ai-search:
   location:
     - docs
-
-global-theme: nvidia
-
-footer: ./components/CustomFooter.tsx
-
-layout:
-  searchbar-placement: header
-  page-width: 1376px
-  sidebar-width: 248px
-  content-width: 812px
-  tabs-placement: header
-  hide-feedback: true
-
-colors:
-  accentPrimary:
-    dark: "#76B900"
-    light: "#76B900"
-  background:
-    light: "#FFFFFF"
-    dark: "#000000"
-
-theme:
-  page-actions: toolbar
-  footer-nav: minimal
-
-typography:
-  bodyFont:
-    name: NVIDIA
-    paths:
-      - path: assets/fonts/NVIDIASans.woff2
-        style: normal
-      - path: assets/fonts/NVIDIASans_Italic.woff2
-        style: italic
-  codeFont:
-    name: RobotoMono
-    paths:
-      - path: assets/fonts/RobotoMono.woff2
-
-logo:
-  dark: ./assets/NVIDIA_dark.svg
-  light: ./assets/NVIDIA_light.svg
-  height: 20
-  href: /
-
-favicon: ./assets/NVIDIA_symbol.svg
-
-css:
-  - ./main.css
 
 navbar-links:
   - type: filled
@@ -87,7 +43,3 @@ redirects:
     destination: "infra-controller/documentation/getting-started/quick-start-guide"
   - source: "/infra-controller/documentation/getting-started/building-ni-co-containers"
     destination: "/infra-controller/documentation/getting-started/building-nico-containers"
-
-experimental:
-  mdx-components:
-    - ./components

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "5.40.1"
+  "version": "5.57.0"
 }


### PR DESCRIPTION
1. Update Fern CLI to the [latest version](https://buildwithfern.com/learn/cli-api-reference/cli-reference/changelog/2026/6/29) that fixes a stale content issue
1. Add myself to CODEOWNERS for the docs and fern folders
1. Quick fix to satisfy `fern docs md check`
1. Remove unneeded fern config items (covered by the global theme now)
1. Add [rumdl](https://rumdl.dev) linter configuration file

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

