### PR TITLE
fix(setup): increase nico-core helm install timeout to 600s

### DIFF
--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -435,7 +435,7 @@ else
         -f "${_CORE_VALUES_ARG}"
         --set-string "global.image.repository=${NICO_IMAGE_REGISTRY}/nvmetal-carbide"
         --set-string "global.image.tag=${NICO_CORE_IMAGE_TAG}"
-        --timeout 300s --wait
+        --timeout 600s --wait
     )
     _NICO_CORE_CMD_DISPLAY=""
     for _arg in "${NICO_CORE_CMD[@]}"; do


### PR DESCRIPTION
<!-- Describe what this PR does -->
nico-pxe boot-artifact init containers can take ~6 minutes to pull, exceeding the previous 300s timeout and causing the install to fail. Increased timeout to 600s.

Fixes: nvbug 6391901

## Related issues
- nvbug 6391901

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

## Additional Notes
nico-pxe observed taking ~5m50s to complete init containers in production. The previous 300s (5 min) hard timeout caused `helm upgrade --install nico` to fail before nico-pxe finished pulling boot-artifact images. 600s gives ~4 minutes of headroom.
