### PR TITLE
fix(otelecho): log trace ID as a structured field

### DIFF
--- a/rest-api/common/pkg/otelecho/echo.go
+++ b/rest-api/common/pkg/otelecho/echo.go
@@ -53,7 +53,7 @@ func Middleware(service string, opts ...upstreamotelecho.Option) echo.Middleware
 			// We log from created span (child span), which inherits the same trace ID
 			scc := span.SpanContext()
 			traceID := scc.TraceID().String()
-			log.Info().Msgf("span traceid: %s", traceID)
+			log.Info().Str("trace_id", traceID).Msg("span traceid")
 			c.Response().Header().Set(TraceHdr, traceID)
 
 			// Always store tracer in context for use by other packages (like util/tracer.go)

--- a/rest-api/common/pkg/otelecho/echo_test.go
+++ b/rest-api/common/pkg/otelecho/echo_test.go
@@ -4,14 +4,19 @@
 package otelecho
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	b3prop "go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -281,4 +286,59 @@ func TestWrapperPreservesUpstreamBehavior(t *testing.T) {
 	assert.True(t, spanContext.HasSpanID(), "Span should have span ID")
 
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+}
+
+// TestTraceIDLoggedAsStructuredField verifies the trace ID is emitted as a
+// queryable `trace_id` log field rather than interpolated into the message text,
+// so logs can be correlated to traces.
+func TestTraceIDLoggedAsStructuredField(t *testing.T) {
+	provider := trace.NewNoopTracerProvider()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	defer otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+
+	// Redirect the global zerolog logger to a buffer for the duration of the test.
+	var buf bytes.Buffer
+	origLogger := log.Logger
+	log.Logger = zerolog.New(&buf)
+	defer func() { log.Logger = origLogger }()
+
+	r := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	// Inject a parent trace context so the span carries a known trace ID.
+	ctx := context.Background()
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10},
+		SpanID:  trace.SpanID{0x01},
+	})
+	ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
+	ctx, _ = provider.Tracer(TracerName).Start(ctx, "parent")
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(r.Header))
+
+	router := echo.New()
+	router.Use(Middleware("test-service", WithTracerProvider(provider)))
+	router.GET("/test", func(c echo.Context) error {
+		return c.NoContent(200)
+	})
+
+	router.ServeHTTP(w, r)
+
+	expectedTraceID := w.Result().Header.Get(TraceHdr)
+	assert.NotEmpty(t, expectedTraceID, "X-Ngc-Trace-Id header should be set")
+
+	// The "span traceid" line must carry trace_id as a structured field equal to
+	// the header value -- not embedded in the message string.
+	var found bool
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry map[string]any
+		require.NoError(t, json.Unmarshal(line, &entry))
+		if entry["message"] == "span traceid" {
+			found = true
+			assert.Equal(t, expectedTraceID, entry["trace_id"], "trace ID should be a structured log field")
+		}
+	}
+	assert.True(t, found, "expected a 'span traceid' log line; got: %s", buf.String())
 }


### PR DESCRIPTION
The trace-ID middleware logged the trace ID by interpolating it into the message text:

```go
log.Info().Msgf("span traceid: %s", traceID)
```

so it was emitted as message content rather than a structured field. The middleware's purpose (per its doc comment) is log↔trace correlation, but a trace ID buried in the message string isn't queryable/filterable by log tooling. The `X-Ngc-Trace-Id` response header already exposes the value, but the log line did not surface it usably.

This emits it as a structured `trace_id` field instead:

```go
log.Info().Str("trace_id", traceID).Msg("span traceid")
```

## Related issues
None.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

Added `TestTraceIDLoggedAsStructuredField`, which redirects the global zerolog logger to a buffer, drives the middleware with an injected parent trace context (same harness as `TestTraceIDHeader`), and asserts the `span traceid` log line carries a `trace_id` field equal to the `X-Ngc-Trace-Id` header. Verified it fails against the previous behavior (message `span traceid: <id>`, no field) and passes with the fix. `go test`, `go vet`, and `gofmt` on the package are clean.
