### PR TITLE
fix: rename dev/mac-local-dev/run-carbide-api.sh to run-nico-api.sh

### DIFF
--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -165,16 +165,16 @@ The script:
 
 ```bash
 # List all machines
-./dev/mac-local-dev/run-nico-admin-cli.sh machine list
+./dev/mac-local-dev/run-nico-admin-cli.sh machine show
 
 # Show details for a specific machine
 ./dev/mac-local-dev/run-nico-admin-cli.sh machine show <machine-id>
 
 # List OS images
-./dev/mac-local-dev/run-nico-admin-cli.sh os-image list
+./dev/mac-local-dev/run-nico-admin-cli.sh os-image show
 
 # List network segments
-./dev/mac-local-dev/run-nico-admin-cli.sh network-segment list
+./dev/mac-local-dev/run-nico-admin-cli.sh network-segment show
 
 # List tenants (JSON output)
 ./dev/mac-local-dev/run-nico-admin-cli.sh --format json tenant show

--- a/dev/mac-local-dev/nico-api-config.toml
+++ b/dev/mac-local-dev/nico-api-config.toml
@@ -57,11 +57,11 @@ hardware_health_reports = "MonitorOnly"
 [firmware_global]
 autoupdate = true
 
-# NOTE: carbide-api resolves these paths relative to the process working
-# directory, NOT relative to this config file.  Do NOT run carbide-api
+# NOTE: nico-api resolves these paths relative to the process working
+# directory, NOT relative to this config file.  Do NOT run nico-api
 # directly with this file from an IDE or any directory other than the repo
 # root — cert loading will fail silently.
-# run-carbide-api.sh works around this by copying the config to /tmp and
+# run-nico-api.sh works around this by copying the config to /tmp and
 # rewriting these values to absolute paths before passing it to the binary.
 [tls]
 identity_pemfile_path = "dev/certs/localhost/localhost.crt"

--- a/dev/mac-local-dev/run-nico-admin-cli.sh
+++ b/dev/mac-local-dev/run-nico-admin-cli.sh
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Wrapper to run nico-admin-cli against the local dev carbide-api instance
-# started by run-carbide-api.sh.
+# Wrapper to run nico-admin-cli against the local dev nico-api instance
+# started by run-nico-api.sh.
 #
 # Usage (from repo root or any directory):
 #   ./dev/mac-local-dev/run-nico-admin-cli.sh <subcommand> [args...]
@@ -12,10 +12,10 @@
 # Examples:
 #   ./dev/mac-local-dev/run-nico-admin-cli.sh version
 #   ./dev/mac-local-dev/run-nico-admin-cli.sh machine show
-#   ./dev/mac-local-dev/run-nico-admin-cli.sh ipxe-template list
+#   ./dev/mac-local-dev/run-nico-admin-cli.sh ipxe-template show
 #   ./dev/mac-local-dev/run-nico-admin-cli.sh ipxe-template get ubuntu-24.04-netboot
 #   ./dev/mac-local-dev/run-nico-admin-cli.sh os-image show
-#   ./dev/mac-local-dev/run-nico-admin-cli.sh --format json ipxe-template list
+#   ./dev/mac-local-dev/run-nico-admin-cli.sh --format json ipxe-template show
 #
 
 set -euo pipefail
@@ -26,7 +26,7 @@ export REPO_ROOT="$REPO_ROOT"
 # Default to the locally-generated certs produced by dev/certs/localhost/gen-certs.sh.
 # server_identity.pem / forge_developer_local_only_root_cert_pem are checked-in
 # certs that have long expired and cannot be renewed without the NVIDIA CA private key.
-CARBIDE_API_URL="${CARBIDE_API_URL:-https://localhost:1079}"
+NICO_API_URL="${NICO_API_URL:-https://localhost:1079}"
 FORGE_ROOT_CA_PATH="${FORGE_ROOT_CA_PATH:-$REPO_ROOT/dev/certs/localhost/ca.crt}"
 CLIENT_CERT_PATH="${CLIENT_CERT_PATH:-$REPO_ROOT/dev/certs/localhost/client.crt}"
 CLIENT_KEY_PATH="${CLIENT_KEY_PATH:-$REPO_ROOT/dev/certs/localhost/client.key}"
@@ -39,7 +39,7 @@ if [ ! -x "$CLI_BIN" ]; then
 fi
 
 exec "$CLI_BIN" \
-  --carbide-api "$CARBIDE_API_URL" \
+  --carbide-url "$NICO_API_URL" \
   --forge-root-ca-path "$FORGE_ROOT_CA_PATH" \
   --client-cert-path "$CLIENT_CERT_PATH" \
   --client-key-path "$CLIENT_KEY_PATH" \

--- a/dev/mac-local-dev/run-nico-api.sh
+++ b/dev/mac-local-dev/run-nico-api.sh
@@ -136,7 +136,10 @@ fi
 # -----------------------------------------------------------------------------
 # Environment
 # -----------------------------------------------------------------------------
-export NICO_WEB_AUTH_TYPE="${NICO_WEB_AUTH_TYPE:-none}"
+# api-web currently reads CARBIDE_WEB_AUTH_TYPE; keep both vars in sync during rename.
+WEB_AUTH_TYPE="${CARBIDE_WEB_AUTH_TYPE:-${NICO_WEB_AUTH_TYPE:-none}}"
+export NICO_WEB_AUTH_TYPE="$WEB_AUTH_TYPE"
+export CARBIDE_WEB_AUTH_TYPE="$WEB_AUTH_TYPE"
 export DATABASE_URL="postgresql://postgres:admin@localhost"
 export VAULT_ADDR="$VAULT_ADDR"
 # Vault runs without TLS in local dev (HTTP). The code requires VAULT_CACERT to
@@ -165,7 +168,8 @@ fi
 # We rewrite those paths to absolute ones in a throwaway /tmp copy so the
 # binary is always given correct paths regardless of CWD.
 # -----------------------------------------------------------------------------
-NICO_TMP_CONFIG="/tmp/nico-api-config-$$.toml"
+NICO_TMP_CONFIG="$(mktemp "${TMPDIR:-/tmp}/nico-api-config.XXXXXX.toml")" || die "Failed to create temporary config file"
+trap 'rm -f "$NICO_TMP_CONFIG"' EXIT
 sed "s|= \"dev/|= \"$REPO_ROOT/dev/|g" \
   "$REPO_ROOT/dev/mac-local-dev/nico-api-config.toml" > "$NICO_TMP_CONFIG"
 ok "Resolved config written to $NICO_TMP_CONFIG"

--- a/dev/mac-local-dev/run-nico-api.sh
+++ b/dev/mac-local-dev/run-nico-api.sh
@@ -3,8 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Self-contained script to start carbide-api on macOS.
-# Run from the repository root: ./dev/mac-local-dev/run-carbide-api.sh
+# Self-contained script to start nico-api on macOS.
+# Run from the repository root: ./dev/mac-local-dev/run-nico-api.sh
 #
 # Prerequisites: Docker Desktop, Rust toolchain, jq
 #
@@ -14,10 +14,10 @@ set -euo pipefail
 # -----------------------------------------------------------------------------
 # Configuration
 # -----------------------------------------------------------------------------
-VAULT_CONTAINER="carbide-vault"
+VAULT_CONTAINER="nico-vault"
 VAULT_PORT=8201
 VAULT_ADDR="http://localhost:$VAULT_PORT"
-TOKEN_FILE="/tmp/carbide-localdev-vault-root-token"
+TOKEN_FILE="/tmp/nico-localdev-vault-root-token"
 PG_CONTAINER="pgdev"
 
 # -----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ cd "$REPO_ROOT"
 # Prerequisites
 # -----------------------------------------------------------------------------
 echo ""
-echo "=== Carbide API - Mac Local Development ==="
+echo "=== Nico API - Mac Local Development ==="
 echo ""
 
 for cmd in docker cargo jq curl; do
@@ -58,7 +58,7 @@ fi
 ok "Docker is running"
 
 # -----------------------------------------------------------------------------
-# Start Vault (port 8201 - dedicated for carbide, avoids kind cluster conflict)
+# Start Vault (port 8201 - dedicated for nico, avoids kind cluster conflict)
 # -----------------------------------------------------------------------------
 if docker ps --format '{{.Names}}' | grep -w "$VAULT_CONTAINER" >/dev/null; then
   ok "Vault container already running"
@@ -136,7 +136,7 @@ fi
 # -----------------------------------------------------------------------------
 # Environment
 # -----------------------------------------------------------------------------
-export CARBIDE_WEB_AUTH_TYPE="${CARBIDE_WEB_AUTH_TYPE:-none}"
+export NICO_WEB_AUTH_TYPE="${NICO_WEB_AUTH_TYPE:-none}"
 export DATABASE_URL="postgresql://postgres:admin@localhost"
 export VAULT_ADDR="$VAULT_ADDR"
 # Vault runs without TLS in local dev (HTTP). The code requires VAULT_CACERT to
@@ -148,7 +148,7 @@ export VAULT_PKI_ROLE_NAME="role"
 export VAULT_TOKEN="$(cat "$TOKEN_FILE")"
 
 # -----------------------------------------------------------------------------
-# Firmware directory (carbide expects this)
+# Firmware directory (nico expects this)
 # -----------------------------------------------------------------------------
 if [ ! -d /opt/carbide/firmware ]; then
   info "Creating /opt/carbide/firmware (may prompt for password)..."
@@ -158,17 +158,17 @@ fi
 # -----------------------------------------------------------------------------
 # Generate a resolved config with absolute TLS paths
 #
-# carbide-api opens TLS paths relative to the process working directory, not
+# nico-api opens TLS paths relative to the process working directory, not
 # relative to the config file.  The checked-in config uses relative paths
 # (e.g. "dev/certs/…") which only work when CWD == repo root.  When launched
 # from an IDE or any other directory the cert load will silently fail.
 # We rewrite those paths to absolute ones in a throwaway /tmp copy so the
 # binary is always given correct paths regardless of CWD.
 # -----------------------------------------------------------------------------
-CARBIDE_TMP_CONFIG="/tmp/carbide-api-config-$$.toml"
+NICO_TMP_CONFIG="/tmp/nico-api-config-$$.toml"
 sed "s|= \"dev/|= \"$REPO_ROOT/dev/|g" \
-  "$REPO_ROOT/dev/mac-local-dev/carbide-api-config.toml" > "$CARBIDE_TMP_CONFIG"
-ok "Resolved config written to $CARBIDE_TMP_CONFIG"
+  "$REPO_ROOT/dev/mac-local-dev/nico-api-config.toml" > "$NICO_TMP_CONFIG"
+ok "Resolved config written to $NICO_TMP_CONFIG"
 
 # -----------------------------------------------------------------------------
 # Migrations & Run
@@ -178,7 +178,7 @@ echo "=== Running migrations ==="
 cargo run --package carbide-api --no-default-features migrate || die "Database migrations failed; fix the issue above and re-run this script."
 
 echo ""
-echo "=== Starting Carbide API ==="
+echo "=== Starting Nico API ==="
 info "TPM/attestation features are not supported on Mac (requires Linux + TPM)."
 echo "   All other functionality is available."
 echo ""
@@ -187,4 +187,4 @@ echo "   gRPC:   grpcurl -insecure localhost:1079 list"
 echo ""
 
 exec env RUST_BACKTRACE=1 cargo run --package carbide-api --no-default-features -- run \
-  --config-path "$CARBIDE_TMP_CONFIG"
+  --config-path "$NICO_TMP_CONFIG"


### PR DESCRIPTION
Rename dev/mac-local-dev/run-carbide-api.sh to run-nico-api.sh
Rename from carbide to nico where possible in dev/mac-local-dev.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)
