### PR TITLE
fix(pxe): use default HTTP port for embedded iPXE

### DIFF
--- a/crates/ipxe-renderer/src/lib.rs
+++ b/crates/ipxe-renderer/src/lib.rs
@@ -1251,6 +1251,22 @@ mod tests {
     }
 
     #[test]
+    fn static_ipxe_menu_uses_the_dhcp_pxe_http_endpoint() {
+        for path in ["whoami", "boot?buildarch=${buildarch}"] {
+            assert!(
+                STATIC_IPXE_MENU_TEMPLATE
+                    .contains(&format!("http://${{next-server}}/api/v0/pxe/{path}")),
+                "static iPXE menu should use next-server over the standard HTTP port for {path}"
+            );
+        }
+
+        assert!(
+            !STATIC_IPXE_MENU_TEMPLATE.contains("${next-server}:8080"),
+            "static iPXE menu should not use the PXE container's internal port"
+        );
+    }
+
+    #[test]
     fn test_get_template_by_name() {
         let renderer = DefaultIpxeScriptRenderer::new();
 

--- a/pxe/ipxe/local/embed.ipxe
+++ b/pxe/ipxe/local/embed.ipxe
@@ -19,12 +19,14 @@ ifconf -c dhcp
 # X-Forwarded-For when proxied, TCP socket peer otherwise) and resolves
 # to a machine_interface_id via find_by_ip. iPXE doesn't need to encode
 # anything identity-related in the URL -- the network layer carries it.
-time chain --autofree http://${next-server}:8080/api/v0/pxe/whoami
+# next-server is an IPv4 address from DHCP, so use the standard HTTP port
+# exposed by the PXE service instead of the container's internal port.
+time chain --autofree http://${next-server}/api/v0/pxe/whoami
 goto nico_menu
 
 :nico
 ifconf -c dhcp
-time chain --autofree http://${next-server}:8080/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
+time chain --autofree http://${next-server}/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
 
 :nico_menu
 menu NICo - ${hostname}


### PR DESCRIPTION
## Description

Remove the embedded iPXE script hardcoded `:8080` suffix so its `whoami` and boot chains use the standard HTTP port at the DHCP-provided `next-server` address.

This change:

- keeps the DHCP `next-server` IPv4 address as the PXE endpoint;
- routes both embedded iPXE chains through standard HTTP port 80, matching the external PXE service; and
- adds a regression test for the rendered static iPXE menu.

## Related issues

Closes #2598

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed locally:

- `cargo test -p carbide-ipxe-renderer --locked` (35 tests)
- `cargo clippy -p carbide-ipxe-renderer --all-targets --locked -- -D warnings`
- `rustup run nightly-2026-06-16 rustfmt --check crates/ipxe-renderer/src/lib.rs`
- `git diff --check`

## Additional Notes

The embedded iPXE script now relies on HTTP default port 80, which is exposed by `nico-pxe-external-80` and targets the PXE container on port 8080.

I also attempted full EFI artifact builds locally. The native ARM build parsed the embedded script but then hit existing TPM-patch warnings treated as errors; the AMD64 Docker build reached compilation but hit a GCC internal compiler error under emulation. Neither failure references this change; the repository CI boot-artifact build remains the authoritative validation for those binaries.