### PR TITLE
docs: explain phoneHomeEnabled flag and the phone-home flow

### DIFF
--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -605,17 +605,17 @@ phone_home:
   post: all
 ```
 
-The injected `url` is the site-configured phone-home endpoint (`site.phoneHomeUrl`; default `http://169.254.169.254:7777/latest/meta-data/phone_home`), which the platform operator can override per deployment. If you supply no `userData`, NICo generates a minimal `#cloud-config` containing only the block above. Disabling phone-home reverses this: NICo removes the matching `phone_home` block it manages. Because NICo rewrites your user-data as YAML, **any `userData` you provide must be valid cloud-init YAML (a `#cloud-config` mapping) when phone-home is enabled** -- the API rejects a request whose non-empty user-data is not. (Supplying no user-data is fine: NICo generates the minimal `#cloud-config` shown above.)
+The injected `url` is the site-configured phone-home endpoint (`site.phoneHomeUrl`; default `http://169.254.169.254:7777/latest/meta-data/phone_home`), which the platform operator can override per deployment. If you supply no `userData`, NICo generates a minimal `#cloud-config` containing only the block above. Disabling phone-home reverses this, and NICo removes the matching `phone_home` block it manages. Because NICo rewrites your user-data as YAML, **any `userData` you provide must be valid cloud-init YAML (a `#cloud-config` mapping) when phone-home is enabled**. The API rejects requests with invalid user-data. (Supplying no user-data is fine: NICo generates the minimal `#cloud-config` shown above.)
 
-cloud-init runs the `phone_home` module in its final stage, after the rest of your configuration has been applied, so the callback fires only once your setup has completed. When NICo receives the POST it records the contact and releases the readiness gate, allowing the instance to become `Ready`.
+cloud-init runs the `phone_home` module in its final stage, after the rest of your configuration has been applied, so the callback fires only after your setup has completed. When NICo receives the POST, it records the contact and releases the readiness gate, allowing the instance to become `Ready`.
 
-**When to use it.** Enable phone-home when "ready" must mean "the guest has finished its own first-boot setup" -- for example, to delay readiness until cloud-init has applied SSH keys and passwords, so that automation watching for `Ready` does not connect before the host is fully configured. Leave it disabled when NICo finishing provisioning is a sufficient ready signal and you do not need a callback from inside the guest.
+**When to use it.** Enable phone-home when "ready" must mean "the guest has finished its own first-boot setup" -- for example, to delay readiness until cloud-init has applied SSH keys and passwords, so that automation watching for `Ready` does not connect before the host is fully configured. Leave phone-home disabled when NICo finishing provisioning is a sufficient ready signal and you do not need a callback from inside the guest.
 
 **Notes and caveats.**
 
 - Phone-home only gates *status reporting*. It does not change how the host is provisioned or booted -- the reboot into the provisioned OS happens identically whether or not phone-home is enabled.
-- If phone-home is enabled but the booted OS never runs cloud-init -- or the guest cannot reach the metadata endpoint -- the callback never arrives and the instance stays in its provisioning state, never reporting ready.
-- The metadata endpoint (`169.254.169.254:7777`) is reachable only from the provisioned host over its link-local metadata link; it is not a tenant-facing API.
+- If phone-home is enabled but the booted OS never runs cloud-init, or the guest cannot reach the metadata endpoint, the callback never arrives and the instance stays in its provisioning state, never reporting ready.
+- The metadata endpoint (by default, `169.254.169.254:7777`) is not a tenant-facing API, and is reachable only from the provisioned host over its link-local metadata link.
 - Rebooting the instance with a one-time custom iPXE override (`instance update --reboot-with-custom-ipxe=true`) re-arms the gate when phone-home is enabled: NICo clears the recorded contact, so the OS must phone home again before the instance is reported ready.
 
 ### Batch Instance Creation

--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -589,6 +589,35 @@ nicocli instance status-history <instance-id>
 
 The instance detail response is rich -- it includes `interfaces[]` with assigned IP addresses and VPC prefix info, `ipxeScript` showing the live boot script, `serialConsoleUrl` for console access, full machine and SKU metadata, and any active `deprecations[]` warnings. The API uses inline `deprecations[]` arrays to flag fields scheduled for removal -- watch for these in your responses.
 
+### Phone-home
+
+`phoneHomeEnabled` (`--phone-home-enabled`) controls whether NICo waits for the booted operating system to call back -- to "phone home" -- before it reports the instance as ready. It is a property of the operating-system definition (`operating-system create` / `operating-system update`) and can also be set per instance (`instance create` / `instance update`).
+
+**What it does.** When phone-home is enabled, NICo does not consider the instance fully provisioned until the booted OS contacts NICo's metadata service from inside the guest. The instance is held in a provisioning state -- the transition to `Ready` is gated -- until that callback arrives. When it is disabled, NICo reports the instance ready as soon as provisioning and config sync finish, without waiting for any signal from the OS.
+
+**What NICo injects.** When phone-home is enabled, NICo edits your `userData` for you -- you do *not* add the callback yourself. NICo parses your cloud-init YAML, strips any existing [`phone_home`](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#phone-home) block, and inserts one that POSTs to the site's metadata endpoint:
+
+```yaml
+#cloud-config
+# ... your first-boot setup (SSH keys, passwords, packages, ...) ...
+phone_home:
+  url: http://169.254.169.254:7777/latest/meta-data/phone_home
+  post: all
+```
+
+The injected `url` is the site-configured phone-home endpoint (`site.phoneHomeUrl`; default `http://169.254.169.254:7777/latest/meta-data/phone_home`), which the platform operator can override per deployment. If you supply no `userData`, NICo generates a minimal `#cloud-config` containing only the block above. Disabling phone-home reverses this: NICo removes the matching `phone_home` block it manages. Because NICo rewrites your user-data as YAML, **any `userData` you provide must be valid cloud-init YAML (a `#cloud-config` mapping) when phone-home is enabled** -- the API rejects a request whose non-empty user-data is not. (Supplying no user-data is fine: NICo generates the minimal `#cloud-config` shown above.)
+
+cloud-init runs the `phone_home` module in its final stage, after the rest of your configuration has been applied, so the callback fires only once your setup has completed. When NICo receives the POST it records the contact and releases the readiness gate, allowing the instance to become `Ready`.
+
+**When to use it.** Enable phone-home when "ready" must mean "the guest has finished its own first-boot setup" -- for example, to delay readiness until cloud-init has applied SSH keys and passwords, so that automation watching for `Ready` does not connect before the host is fully configured. Leave it disabled when NICo finishing provisioning is a sufficient ready signal and you do not need a callback from inside the guest.
+
+**Notes and caveats.**
+
+- Phone-home only gates *status reporting*. It does not change how the host is provisioned or booted -- the reboot into the provisioned OS happens identically whether or not phone-home is enabled.
+- If phone-home is enabled but the booted OS never runs cloud-init -- or the guest cannot reach the metadata endpoint -- the callback never arrives and the instance stays in its provisioning state, never reporting ready.
+- The metadata endpoint (`169.254.169.254:7777`) is reachable only from the provisioned host over its link-local metadata link; it is not a tenant-facing API.
+- Rebooting the instance with a one-time custom iPXE override (`instance update --reboot-with-custom-ipxe=true`) re-arms the gate when phone-home is enabled: NICo clears the recorded contact, so the OS must phone home again before the instance is reported ready.
+
 ### Batch Instance Creation
 
 For creating multiple identical instances at once, use `instance batch-create`. Unlike `create`, batch-create takes a single shared spec plus a count -- it provisions N instances with auto-generated names from the same instance type, tenant, and VPC. `nicocli instance batch-create --help` shows:

--- a/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-create.md
+++ b/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-create.md
@@ -52,7 +52,7 @@ Hold the instance in a provisioning state until the booted OS calls back
 ("phones home") to NICo's metadata service, instead of reporting it ready as
 soon as provisioning finishes. NICo injects the cloud-init `phone_home` block
 into your user-data for you, so your `userData` must be valid cloud-init YAML
-when this is enabled. See
+when this is enabled. Refer to
 [Phone-home](../../../../configuration/tenant_management.md#phone-home) for
 what it injects, the endpoint, and usage guidance.
 
@@ -97,4 +97,4 @@ nico-admin-cli operating-system create --name ubuntu-22.04 --org fds34511233a --
 
 ---
 
-**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../README.md)
+**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../index.md)

--- a/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-create.md
+++ b/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-create.md
@@ -48,7 +48,13 @@ Whether this OS definition is active (default: true).\
 Allow users to override OS parameters.
 
 **--phone-home-enabled**  
-Enable phone-home on first boot.
+Hold the instance in a provisioning state until the booted OS calls back
+("phones home") to NICo's metadata service, instead of reporting it ready as
+soon as provisioning finishes. NICo injects the cloud-init `phone_home` block
+into your user-data for you, so your `userData` must be valid cloud-init YAML
+when this is enabled. See
+[Phone-home](../../../../configuration/tenant_management.md#phone-home) for
+what it injects, the endpoint, and usage guidance.
 
 **--user-data** *\<USER_DATA\>*  
 Optional cloud-init / user-data script.

--- a/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-update.md
+++ b/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-update.md
@@ -49,7 +49,13 @@ Set whether users can override OS parameters.\
 - false
 
 **--phone-home-enabled** *\<PHONE_HOME_ENABLED\>*  
-Set whether phone-home on first boot is enabled.\
+Set whether the instance is held in a provisioning state until the booted OS
+calls back ("phones home") to NICo's metadata service, instead of being
+reported ready as soon as provisioning finishes. NICo injects the cloud-init
+`phone_home` block into your user-data for you, so your `userData` must be
+valid cloud-init YAML when this is enabled. See
+[Phone-home](../../../../configuration/tenant_management.md#phone-home) for
+what it injects, the endpoint, and usage guidance.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-update.md
+++ b/docs/manuals/nico-admin-cli/commands/operating-system/operating-system-update.md
@@ -53,7 +53,7 @@ Set whether the instance is held in a provisioning state until the booted OS
 calls back ("phones home") to NICo's metadata service, instead of being
 reported ready as soon as provisioning finishes. NICo injects the cloud-init
 `phone_home` block into your user-data for you, so your `userData` must be
-valid cloud-init YAML when this is enabled. See
+valid cloud-init YAML when this is enabled. Refer to
 [Phone-home](../../../../configuration/tenant_management.md#phone-home) for
 what it injects, the endpoint, and usage guidance.\
 
@@ -110,4 +110,4 @@ nico-admin-cli operating-system update 12345678-1234-5678-90ab-cdef01234567 --ip
 
 ---
 
-**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../README.md)
+**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../index.md)


### PR DESCRIPTION
Documents the `phoneHomeEnabled` flag, which was previously a one-liner ("Enable phone-home on first boot") across the operating-system and instance docs with no explanation of what it does, what NICo injects, or how the callback works.

The explanation is traced from the code, not inferred:

- **Readiness gate.** When enabled, NICo holds the instance in a provisioning state and does not report it `Ready` until the booted OS phones home. This is the carbide tenant-state gate in `crates/rpc/src/model/instance/status/tenant.rs` (`phone_home_pending = phone_home_enrolled && phone_home_last_contact.is_none()`), fed by `instance_config.os.phone_home_enabled` in `crates/rpc/src/model/instance/status.rs`. The proto note on `InstanceOperatingSystemConfig.phone_home_enabled` says the same: *"the instance will not transition to a Ready state until InstancePhoneHomeLastContact is updated."*
- **NICo injects nothing.** User-data is served verbatim by the metadata endpoint (`USER_DATA_CATEGORY => metadata.user_data.clone()` in `crates/agent/src/instance_metadata_endpoint.rs`); no code mutates user-data based on the flag. The OS must supply a cloud-init `phone_home` module that POSTs to the link-local metadata endpoint `http://169.254.169.254:7777/latest/meta-data/phone_home` (the canonical example appears in `rest-api/openapi/spec.yaml`). The `update_phone_home_last_contact` handler (`crates/api-core/src/handlers/instance.rs`) authorizes the calling host/DPU and records the contact timestamp (`UPDATE instances SET phone_home_last_contact=now()`), which releases the gate.
- **Guidance + caveats.** Directly answers the issue's ISV use case (delay `Ready` until cloud-init finishes applying SSH keys/passwords), and documents the gotchas: enabling the flag without adding a `phone_home` module leaves the instance never-ready, and a one-time custom-iPXE reboot re-arms the gate (`clear_phone_home_last_contact` when `boot_with_custom_ipxe && phone_home_enabled`).

Adds a **Phone-home** section to `docs/configuration/tenant_management.md` (the page that already covers the instance lifecycle) and links the `operating-system create` / `operating-system update` CLI reference pages to it.

## Related issues
Fixes #2790

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

Docs-only change. The added relative link (`../../../../configuration/tenant_management.md#phone-home`) resolves to the existing page and anchor.

## Additional Notes
Scoped to documentation only. The flag descriptions in the two CLI reference pages now point at one authoritative explanation rather than duplicating it.
