### PR TITLE
fix(redfish): bracket IPv6 BMC hosts in nv-redfish URLs

### DIFF
--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -15,15 +15,17 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use carbide_secrets::credentials::Credentials;
 use carbide_utils::HostPortPair;
+use carbide_utils::redfish::format_forwarded_host_parameter;
 pub use nv_redfish::bmc_http::reqwest::BmcError;
 use nv_redfish::bmc_http::reqwest::{
     Client as RedfishReqwestClient, ClientParams as RedfishReqwestClientParams,
@@ -32,6 +34,7 @@ use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
 use nv_redfish::oem::hpe::ilo_service_ext::ManagerType as HpeManagerType;
 use nv_redfish::{Error as NvError, ServiceRoot as NvServiceRoot};
 use reqwest::header::HeaderMap;
+use url::Url;
 
 pub type RedfishBmc = HttpBmc<RedfishReqwestClient>;
 pub type ServiceRoot = NvServiceRoot<RedfishBmc>;
@@ -267,21 +270,14 @@ impl NvRedfishClientPool {
         connection_close: bool,
     ) -> Result<Arc<RedfishBmc>, Error> {
         let proxy_address = self.proxy_address.load();
-        let bmc_url = match proxy_address.as_ref() {
-            // No override
-            None => format!("https://{bmc_address}"),
-            Some(HostPortPair::HostAndPort(h, p)) => format!("https://{h}:{p}"),
-            Some(HostPortPair::HostOnly(h)) => format!("https://{h}:{}", bmc_address.port()),
-            Some(HostPortPair::PortOnly(p)) => format!("https://{}:{p}", bmc_address.ip()),
-        }
-        .parse::<url::Url>()
-        .expect("Generated URI is expected to be valid");
+        let bmc_url = build_bmc_url(proxy_address.as_ref(), bmc_address)
+            .map_err(|e| Error::Bmc(BmcError::InvalidRequest(format!("invalid BMC URL: {e}"))))?;
 
         let mut headers = HeaderMap::new();
         if proxy_address.is_some() {
             headers.insert(
                 reqwest::header::FORWARDED,
-                format!("host={}", bmc_address.ip())
+                format_forwarded_host_parameter(&bmc_address.ip().to_string())
                     .parse()
                     .expect("Generated header is expected to be valid"),
             );
@@ -305,6 +301,35 @@ impl NvRedfishClientPool {
             headers,
         )))
     }
+}
+
+/// Builds the BMC base URL, applying any configured proxy override.
+///
+/// Mirrors `health::BmcAddr::to_url()`: IPv6 hosts are bracketed so the URL
+/// authority parses — a bare `IpAddr` Display leaves IPv6 unbracketed
+/// (e.g. `2001:db8::1`), which `Url::parse` rejects.
+fn build_bmc_url(
+    proxy_address: &Option<HostPortPair>,
+    bmc_address: SocketAddr,
+) -> Result<Url, url::ParseError> {
+    // Bracket the BMC's own IP if IPv6; IPv4 renders unchanged.
+    let bmc_host = match bmc_address.ip() {
+        IpAddr::V4(v4) => v4.to_string(),
+        IpAddr::V6(v6) => format!("[{v6}]"),
+    };
+    let (host, port) = match proxy_address {
+        // No override: the BMC's own IP and port.
+        None => (bmc_host, bmc_address.port()),
+        // An operator-supplied override may replace the host, the port, or
+        // both; `url_host()` brackets an IPv6 literal proxy host.
+        Some(proxy) => (
+            proxy.url_host().map_or(bmc_host, Cow::into_owned),
+            proxy.port().unwrap_or_else(|| bmc_address.port()),
+        ),
+    };
+    let mut url = Url::parse(&format!("https://{host}"))?;
+    let _ = url.set_port(Some(port));
+    Ok(url)
 }
 
 #[cfg(test)]
@@ -332,5 +357,104 @@ mod tests {
         assert!(cache.roots.is_empty());
         assert!(cache.expirations.is_empty());
         assert_eq!(cache.next_generation, 1);
+    }
+
+    fn sock(s: &str) -> SocketAddr {
+        s.parse().expect("valid socket addr")
+    }
+
+    // Regression: an IPv6 BMC behind a port-only proxy must yield a bracketed
+    // authority. Pre-fix the manual format produced `https://2001:db8::1:8443`,
+    // which `Url::parse` rejects — and `create_bmc` `.expect()`s the parse, so it
+    // panicked.
+    #[test]
+    fn port_only_proxy_brackets_ipv6_bmc() {
+        let url = build_bmc_url(
+            &Some(HostPortPair::PortOnly(8443)),
+            sock("[2001:db8::1]:443"),
+        )
+        .expect("url should build");
+        assert_eq!(url.host_str(), Some("[2001:db8::1]"));
+        assert_eq!(url.port(), Some(8443));
+        assert_eq!(url.as_str(), "https://[2001:db8::1]:8443/");
+    }
+
+    // IPv4 BMCs keep their unbracketed authority.
+    #[test]
+    fn port_only_proxy_leaves_ipv4_unchanged() {
+        let url = build_bmc_url(&Some(HostPortPair::PortOnly(8443)), sock("10.0.0.5:443"))
+            .expect("url should build");
+        assert_eq!(url.host_str(), Some("10.0.0.5"));
+        assert_eq!(url.port(), Some(8443));
+    }
+
+    // No proxy: the BMC's own IP and port form the authority; IPv6 is bracketed.
+    // 443 is the https default, so the url crate canonicalizes it out of the
+    // explicit port (as it always did when the old string was parsed).
+    #[test]
+    fn no_proxy_brackets_ipv6_bmc() {
+        let url = build_bmc_url(&None, sock("[2001:db8::1]:443")).expect("url should build");
+        assert_eq!(url.host_str(), Some("[2001:db8::1]"));
+        assert_eq!(url.port_or_known_default(), Some(443));
+        assert_eq!(url.as_str(), "https://[2001:db8::1]/");
+    }
+
+    // A proxy host supplied as a bare IPv6 literal is bracketed too.
+    #[test]
+    fn proxy_host_ipv6_literal_is_bracketed() {
+        let host_only = build_bmc_url(
+            &Some(HostPortPair::HostOnly("2001:db8::2".to_string())),
+            sock("10.0.0.5:443"),
+        )
+        .expect("url should build");
+        assert_eq!(host_only.host_str(), Some("[2001:db8::2]"));
+        assert_eq!(host_only.port_or_known_default(), Some(443));
+
+        let host_and_port = build_bmc_url(
+            &Some(HostPortPair::HostAndPort("2001:db8::2".to_string(), 8443)),
+            sock("10.0.0.5:443"),
+        )
+        .expect("url should build");
+        assert_eq!(host_and_port.host_str(), Some("[2001:db8::2]"));
+        assert_eq!(host_and_port.port(), Some(8443));
+    }
+
+    // A hostname proxy is passed through untouched.
+    #[test]
+    fn proxy_hostname_unchanged() {
+        let url = build_bmc_url(
+            &Some(HostPortPair::HostAndPort(
+                "bmc-proxy.example".to_string(),
+                8443,
+            )),
+            sock("10.0.0.5:443"),
+        )
+        .expect("url should build");
+        assert_eq!(url.host_str(), Some("bmc-proxy.example"));
+        assert_eq!(url.port(), Some(8443));
+    }
+
+    // Regression (#3008 review): the `Forwarded` `host` parameter that
+    // `create_bmc` sends must bracket an IPv6 BMC per RFC 7239; IPv4 and
+    // hostnames keep the bare token form, and the result must be a valid
+    // header value (create_bmc `.expect()`s the parse).
+    #[test]
+    fn forwarded_host_parameter_brackets_ipv6_bmc() {
+        let v6: IpAddr = "2001:db8::1".parse().unwrap();
+        let v4: IpAddr = "10.0.0.5".parse().unwrap();
+        assert_eq!(
+            format_forwarded_host_parameter(&v6.to_string()),
+            "host=\"[2001:db8::1]\""
+        );
+        assert_eq!(
+            format_forwarded_host_parameter(&v4.to_string()),
+            "host=10.0.0.5"
+        );
+        for ip in [v6, v4] {
+            reqwest::header::HeaderValue::from_str(&format_forwarded_host_parameter(
+                &ip.to_string(),
+            ))
+            .expect("valid Forwarded header value");
+        }
     }
 }


### PR DESCRIPTION
`NvRedfishClientPool::create_bmc` builds the BMC base URL with bare `format!`s and then `.expect()`s `Url::parse`. IPv6 hosts were left unbracketed, so an IPv6 BMC produced an invalid authority such as `https://2001:db8::1:8443` — which `Url::parse` rejects, **panicking the caller**.

The codebase already brackets IPv6 on the sibling path (`crates/health/src/endpoint/model.rs::BmcAddr::to_url`); the `nv_redfish` pool was missing the same handling.

This extracts a small, testable `build_bmc_url` helper that brackets IPv6 literals in every arm:
- **port-only proxy** — brackets the BMC's own `IpAddr` (the panicking case),
- **host / host+port proxy** — brackets a config-supplied IPv6 literal proxy host,
- **no override** — unchanged; `SocketAddr`'s `Display` already brackets.

Hostnames, IPv4 literals, and already-bracketed hosts are passed through untouched.

## Related issues
Part of the #2237 IPv6 bug bucket; addresses the Redfish-bracket item of #2406. (Scoped to just this fix, so it does not close the multi-item #2406.)

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

`cargo test -p carbide-redfish --features test-support nv_redfish::tests` — 5 passing, covering each arm. The new `port_only_proxy_brackets_ipv6_bmc` test **fails before this change** (produces `https://2001:db8::1:8443`, asserted against the bracketed `https://[2001:db8::1]:8443`). `cargo clippy -- -D warnings` and `cargo fmt --check` both clean.

## Additional Notes
The `libredfish` proxy path (`crates/redfish/src/libredfish/implementation.rs`) constructs its endpoint inside the external `libredfish` crate and is out of scope here.
