### PR TITLE
fix(ssh-console): avoid exposing ipmitool passwords

### DIFF
--- a/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
@@ -45,6 +45,8 @@ use crate::io_util::{
     self, PtyAllocError, set_controlling_terminal_on_exec, write_data_to_async_fd,
 };
 
+const IPMITOOL_PASSWORD_ENV_VAR: &str = "IPMITOOL_PASSWORD";
+
 /// Spawn ipmitool in the background to connect to the given BMC specified by `connection_details`,
 /// and proxy data between it and the SSH frontend.
 ///
@@ -75,17 +77,8 @@ pub async fn spawn(
 
     // Run `ipmitool sol activate` with the appropriate args
     let mut command = tokio::process::Command::new("ipmitool");
+    configure_ipmitool_connection(&mut command, connection_details.as_ref());
     command
-        .arg("-I")
-        .arg("lanplus")
-        .arg("-H")
-        .arg(connection_details.addr.ip().to_string())
-        .arg("-p")
-        .arg(connection_details.addr.port().to_string())
-        .arg("-U")
-        .arg(&connection_details.user)
-        .arg("-P")
-        .arg(&connection_details.password)
         // connect stdin/stdout/stderr to the pty
         .stdin(
             pty_slave
@@ -457,17 +450,8 @@ impl IpmitoolMessageProxy {
 
     async fn power_reset(&mut self) -> Result<(), PowerResetError> {
         let mut command = tokio::process::Command::new("ipmitool");
+        configure_ipmitool_connection(&mut command, self.connection_details.as_ref());
         command
-            .arg("-I")
-            .arg("lanplus")
-            .arg("-H")
-            .arg(self.connection_details.addr.ip().to_string())
-            .arg("-p")
-            .arg(self.connection_details.addr.port().to_string())
-            .arg("-U")
-            .arg(&self.connection_details.user)
-            .arg("-P")
-            .arg(&self.connection_details.password)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
@@ -503,6 +487,23 @@ impl IpmitoolMessageProxy {
     }
 }
 
+fn configure_ipmitool_connection(
+    command: &mut tokio::process::Command,
+    connection_details: &ConnectionDetails,
+) {
+    command
+        .arg("-I")
+        .arg("lanplus")
+        .arg("-H")
+        .arg(connection_details.addr.ip().to_string())
+        .arg("-p")
+        .arg(connection_details.addr.port().to_string())
+        .arg("-U")
+        .arg(&connection_details.user)
+        .arg("-E")
+        .env(IPMITOOL_PASSWORD_ENV_VAR, &connection_details.password);
+}
+
 #[derive(Clone)]
 pub struct ConnectionDetails {
     pub machine_id: MachineId,
@@ -519,5 +520,57 @@ impl Debug for ConnectionDetails {
             .field("user", &self.user)
             .field("machine_id", &self.machine_id.to_string())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
+
+    use super::{ConnectionDetails, IPMITOOL_PASSWORD_ENV_VAR, configure_ipmitool_connection};
+
+    #[test]
+    fn configure_ipmitool_connection_passes_password_through_environment() {
+        let connection_details = ConnectionDetails {
+            machine_id: MachineId::new(MachineIdSource::Tpm, [0; 32], MachineType::Host),
+            addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 623),
+            user: "admin".to_string(),
+            password: "hunter2".to_string(),
+        };
+        let mut command = tokio::process::Command::new("ipmitool");
+
+        configure_ipmitool_connection(&mut command, &connection_details);
+
+        let args: Vec<_> = command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_str().expect("ipmitool args should be valid UTF-8"))
+            .collect();
+        let expected_args = [
+            "-I",
+            "lanplus",
+            "-H",
+            "127.0.0.1",
+            "-p",
+            "623",
+            "-U",
+            "admin",
+            "-E",
+        ];
+        assert_eq!(args.as_slice(), expected_args.as_slice());
+        assert!(!args.contains(&"-P"));
+        assert!(!args.contains(&"hunter2"));
+
+        let password_env = command.as_std().get_envs().find_map(|(key, value)| {
+            if key == OsStr::new(IPMITOOL_PASSWORD_ENV_VAR) {
+                value.and_then(OsStr::to_str)
+            } else {
+                None
+            }
+        });
+        assert_eq!(password_env, Some("hunter2"));
     }
 }


### PR DESCRIPTION
## Description

Prevent ssh-console from exposing BMC passwords in ipmitool process arguments.

This change:

- passes BMC passwords through `IPMITOOL_PASSWORD` and uses ipmitool's `-E` option for both SOL activation and power reset;
- centralizes the shared ipmitool connection arguments so the two command paths cannot drift back to different password handling; and
- adds regression coverage proving the password and `-P` option are absent from argv while the password is supplied through the environment.

## Related issues

Closes #2535

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

No API, protobuf schema, configuration, or user-facing CLI changes are included.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed locally:

- Linux/container `cargo test -p carbide-ssh-console configure_ipmitool_connection_passes_password_through_environment` (1/1 pass)
- Linux/container `cargo test -p carbide-ssh-console` (24 library tests and 3 integration tests pass)
- Linux/container `cargo clippy -p carbide-ssh-console --all-targets --all-features --no-deps -- -D warnings`
- pinned-nightly `cargo fmt --all -- --check`
- `git diff --check`
- static verification that ssh-console has no remaining `.arg("-P")` call and both command paths use the shared `-E` plus `IPMITOOL_PASSWORD` setup

## Additional Notes

The crate's existing Linux-specific `termios` and `ioctl` code does not compile directly on macOS/aarch64. The focused test, full crate suite, and Clippy therefore ran in the repository's Rust 1.96 Linux container.

Running strict Clippy across dependencies in that standalone minimal container exposes an unrelated existing `api-core` unknown-lint warning for `txn_without_commit`, because the repository's custom lint is not loaded there. Strict `--no-deps` Clippy for the changed crate passes.
