### PR TITLE
fix(bmc-proxy): bracket IPv6 BMC hosts in upstream URI authority

### DIFF
--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -17,7 +17,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::net::{AddrParseError, IpAddr};
+use std::net::{AddrParseError, IpAddr, Ipv6Addr};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -919,6 +919,26 @@ impl TryFrom<forge::BmcCredentials> for BmcCredentials {
     }
 }
 
+/// Format a host as a URI authority component, bracketing bare IPv6 literals
+/// and appending the port when present.
+///
+/// A bare IPv6 address such as `2001:db8::1` is not a valid URI authority — it
+/// must be bracketed (`[2001:db8::1]`). Without brackets, `http::uri::Authority`
+/// parsing (used by the caller to build the upstream URI) rejects the host, and
+/// an appended port is misparsed as part of the address. IPv4 addresses,
+/// hostnames, and already-bracketed IPv6 literals are left unchanged.
+fn build_authority(host: Cow<'_, str>, port: Option<u16>) -> Cow<'_, str> {
+    let host = if host.parse::<Ipv6Addr>().is_ok() {
+        Cow::Owned(format!("[{host}]"))
+    } else {
+        host
+    };
+    match port {
+        Some(port) => Cow::Owned(format!("{host}:{port}")),
+        None => host,
+    }
+}
+
 async fn create_client(
     ip: IpAddr,
     api_client: &ForgeApiClient,
@@ -944,10 +964,7 @@ async fn create_client(
 
     let credentials = get_bmc_credentials(ip, api_client, credential_cache).await?;
 
-    let base_authority = match (host, port) {
-        (host, Some(port)) => Cow::Owned(format!("{}:{}", host, port)),
-        (host, None) => host,
-    };
+    let base_authority = build_authority(host, port);
 
     let base_upstream_uri = Uri::builder()
         .scheme("https")
@@ -1040,6 +1057,7 @@ async fn evict_cached_credentials(ip: IpAddr, credential_cache: &CredentialCache
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
     use std::collections::HashMap;
     use std::convert::Infallible;
     use std::net::{IpAddr, Ipv4Addr};
@@ -1063,10 +1081,10 @@ mod tests {
     use tokio_stream::iter;
 
     use super::{
-        BmcCredentials, BmcProxyState, CredentialCache, ForwardedTarget, build_response,
-        copy_request_headers, create_client, evict_cached_credentials, forwarded_header_value,
-        get_http_client, ip_for_forwarded_target, is_hop_by_hop_header, method_supports_body,
-        parse_forwarded_host_value, request_principal_ids,
+        BmcCredentials, BmcProxyState, CredentialCache, ForwardedTarget, build_authority,
+        build_response, copy_request_headers, create_client, evict_cached_credentials,
+        forwarded_header_value, get_http_client, ip_for_forwarded_target, is_hop_by_hop_header,
+        method_supports_body, parse_forwarded_host_value, request_principal_ids,
     };
 
     #[derive(Clone, Copy)]
@@ -1326,6 +1344,45 @@ mod tests {
             credentials: summarize_credentials(client.credentials),
         })
         .map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn build_authority_brackets_ipv6() {
+        value_scenarios!(
+            run = |(host, port): (&str, Option<u16>)| {
+                let authority = build_authority(Cow::Borrowed(host), port).into_owned();
+                // The result is fed into `Uri::builder().authority(..)`, which
+                // rejects a bare IPv6 literal — guard that it always parses.
+                assert!(
+                    authority.parse::<http::uri::Authority>().is_ok(),
+                    "produced an invalid authority: {authority}"
+                );
+                authority
+            };
+            "IPv4 without port" {
+                ("192.0.2.5", None) => "192.0.2.5".to_string(),
+            }
+
+            "IPv4 with port" {
+                ("192.0.2.5", Some(443)) => "192.0.2.5:443".to_string(),
+            }
+
+            "bare IPv6 is bracketed" {
+                ("2001:db8::1", None) => "[2001:db8::1]".to_string(),
+            }
+
+            "bare IPv6 with port is bracketed" {
+                ("2001:db8::1", Some(443)) => "[2001:db8::1]:443".to_string(),
+            }
+
+            "already bracketed IPv6 is left unchanged" {
+                ("[2001:db8::1]", Some(443)) => "[2001:db8::1]:443".to_string(),
+            }
+
+            "hostname is left unchanged" {
+                ("bmc.example.com", Some(443)) => "bmc.example.com:443".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -925,8 +925,12 @@ impl TryFrom<forge::BmcCredentials> for BmcCredentials {
 /// A bare IPv6 address such as `2001:db8::1` is not a valid URI authority — it
 /// must be bracketed (`[2001:db8::1]`). Without brackets, `http::uri::Authority`
 /// parsing (used by the caller to build the upstream URI) rejects the host, and
-/// an appended port is misparsed as part of the address. IPv4 addresses,
-/// hostnames, and already-bracketed IPv6 literals are left unchanged.
+/// an appended port is misparsed as part of the address.
+///
+/// The parse guard here covers operator-supplied override hosts, which are
+/// genuinely strings; the BMC's own typed `IpAddr` is bracketed off its enum
+/// variant by the caller and passes through unchanged (as do IPv4 addresses
+/// and hostnames).
 fn build_authority(host: Cow<'_, str>, port: Option<u16>) -> Cow<'_, str> {
     let host = if host.parse::<Ipv6Addr>().is_ok() {
         Cow::Owned(format!("[{host}]"))
@@ -946,15 +950,21 @@ async fn create_client(
     client_cache: &HttpClientCache,
     bmc_proxy: &Option<HostPortPair>,
 ) -> Result<BmcClientInfo, BmcProxyError> {
+    // Bracket the BMC's own IP off its typed variant (IPv4 renders unchanged),
+    // mirroring health::BmcAddr::to_url() and the nv-redfish client.
+    let bmc_host = match ip {
+        IpAddr::V4(v4) => v4.to_string(),
+        IpAddr::V6(v6) => format!("[{v6}]"),
+    };
     let (host, port, add_custom_header) = match bmc_proxy {
         // No override
-        None => (Cow::<str>::Owned(ip.to_string()), None, false),
+        None => (Cow::<str>::Owned(bmc_host), None, false),
         // Override the host and port
         Some(HostPortPair::HostAndPort(h, p)) => (Cow::Borrowed(h.as_str()), Some(*p), true),
         // Only override the host
         Some(HostPortPair::HostOnly(h)) => (Cow::Borrowed(h.as_str()), None, true),
         // Only override the port
-        Some(HostPortPair::PortOnly(p)) => (Cow::Owned(ip.to_string()), Some(*p), false),
+        Some(HostPortPair::PortOnly(p)) => (Cow::Owned(bmc_host), Some(*p), false),
     };
     let mut header_map = HeaderMap::new();
     if add_custom_header {


### PR DESCRIPTION
When the BMC proxy builds the upstream URI for a BMC, `create_client` formed the authority from the BMC address with a bare `format!("{host}:{port}")` (or `host` alone). For an IPv6 BMC this produces an **unbracketed** authority — e.g. `2001:db8::1` or `2001:db8::1:443` — which `Uri::builder().authority(..)` rejects (a bare IPv6 literal is not a valid URI authority, and any appended port is misparsed as part of the address). The result is that the proxy cannot reach IPv6 BMCs.

The fix extracts a small pure `build_authority` helper that wraps a bare IPv6 literal in brackets (`[2001:db8::1]`) before appending the port. IPv4 addresses, hostnames, and already-bracketed IPv6 literals pass through unchanged. This mirrors the bracketing already applied to nv-redfish BMC URLs.

## Related issues
Part of #2237 (IPv6 Bug Scan Bucket).

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

Added a table-driven `build_authority_brackets_ipv6` test covering IPv4, bare IPv6, bracketed IPv6, and hostname inputs (with and without a port). Each case additionally asserts the produced string parses as a valid `http::uri::Authority` — the same parse `create_client` relies on. The bare-IPv6 case fails prior to this fix.

`cargo test -p carbide-bmc-proxy`, `cargo clippy -p carbide-bmc-proxy -- -D warnings`, and `cargo fmt -p carbide-bmc-proxy -- --check` all pass.

## Additional Notes
Scope is intentionally limited to the IPv6-authority bug. The config-string proxy-override arms (`HostAndPort`/`HostOnly`) flow through the same helper, so a bare-IPv6 override host is now bracketed too, while operator-supplied bracketed values are left intact.
