### PR TITLE
fix(utils): parse and render IPv6 hosts in HostPortPair

### DIFF
--- a/crates/utils/src/host_port_pair.rs
+++ b/crates/utils/src/host_port_pair.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::fmt::{Display, Formatter};
+use std::net::Ipv6Addr;
 use std::str::FromStr;
 
 use serde::de::Visitor;
@@ -67,6 +68,33 @@ impl FromStr for HostPortPair {
             return Err(UriUnsupported);
         }
 
+        // A bracketed host is the canonical way to write an IPv6 literal, e.g.
+        // `[2001:db8::1]` or `[2001:db8::1]:443`. The host is stored without the
+        // brackets so callers can use it directly. The plain `split(':')` below
+        // can't handle this because an IPv6 address itself contains colons.
+        if let Some(rest) = s.strip_prefix('[') {
+            let (host, after) = rest.split_once(']').ok_or(InvalidString)?;
+            if host.is_empty() {
+                return Err(InvalidString);
+            }
+            return match after {
+                "" => Ok(HostPortPair::HostOnly(host.to_string())),
+                _ => {
+                    let port = after.strip_prefix(':').ok_or(InvalidString)?;
+                    let port = port
+                        .parse::<u16>()
+                        .map_err(|_| InvalidPort(port.to_string()))?;
+                    Ok(HostPortPair::HostAndPort(host.to_string(), port))
+                }
+            };
+        }
+
+        // A bare (unbracketed) IPv6 literal is a host with no port; its colons
+        // would otherwise be misread as host/port separators below.
+        if s.parse::<Ipv6Addr>().is_ok() {
+            return Ok(HostPortPair::HostOnly(s.to_string()));
+        }
+
         match s.split(":").collect::<Vec<_>>().as_slice() {
             [h, p] => {
                 let p = p.parse::<u16>().map_err(|_| InvalidPort(p.to_string()))?;
@@ -94,6 +122,11 @@ impl Display for HostPortPair {
         match self {
             HostPortPair::HostOnly(h) => write!(f, "{h}"),
             HostPortPair::PortOnly(p) => write!(f, "{p}"),
+            // Bracket an IPv6 literal host so the `host:port` form is
+            // unambiguous and round-trips back through `from_str`.
+            HostPortPair::HostAndPort(h, p) if h.parse::<Ipv6Addr>().is_ok() => {
+                write!(f, "[{h}]:{p}")
+            }
             HostPortPair::HostAndPort(h, p) => write!(f, "{h}:{p}"),
         }
     }
@@ -154,7 +187,9 @@ mod tests {
     use carbide_test_support::{Case, check_cases};
 
     use crate::host_port_pair::HostPortPair;
-    use crate::host_port_pair::HostPortParseError::{EmptyString, InvalidPort, UriUnsupported};
+    use crate::host_port_pair::HostPortParseError::{
+        EmptyString, InvalidPort, InvalidString, UriUnsupported,
+    };
 
     #[test]
     fn test_proxy_address_parsing() {
@@ -205,8 +240,81 @@ mod tests {
                     input: "https://proxyhost",
                     expect: FailsWith(UriUnsupported),
                 },
+                Case {
+                    scenario: "bracketed IPv6 host and port",
+                    input: "[2001:db8::1]:8443",
+                    expect: Yields(HostPortPair::HostAndPort("2001:db8::1".to_string(), 8443)),
+                },
+                Case {
+                    scenario: "bracketed IPv6 host only",
+                    input: "[2001:db8::1]",
+                    expect: Yields(HostPortPair::HostOnly("2001:db8::1".to_string())),
+                },
+                Case {
+                    scenario: "bare IPv6 literal is a host with no port",
+                    input: "2001:db8::1",
+                    expect: Yields(HostPortPair::HostOnly("2001:db8::1".to_string())),
+                },
+                Case {
+                    scenario: "bare IPv6 loopback is a host with no port",
+                    input: "::1",
+                    expect: Yields(HostPortPair::HostOnly("::1".to_string())),
+                },
+                Case {
+                    scenario: "bracketed IPv6 with empty port keeps the offending text",
+                    input: "[2001:db8::1]:",
+                    expect: FailsWith(InvalidPort("".to_string())),
+                },
+                Case {
+                    scenario: "bracketed IPv6 with non-numeric port keeps the offending text",
+                    input: "[2001:db8::1]:notaport",
+                    expect: FailsWith(InvalidPort("notaport".to_string())),
+                },
+                Case {
+                    scenario: "unclosed bracket is rejected",
+                    input: "[2001:db8::1",
+                    expect: FailsWith(InvalidString),
+                },
+                Case {
+                    scenario: "empty brackets are rejected",
+                    input: "[]",
+                    expect: FailsWith(InvalidString),
+                },
             ],
             HostPortPair::from_str,
         );
+    }
+
+    /// An IPv6 host must survive a `Display` -> `from_str` round trip. Before
+    /// brackets were emitted, `HostAndPort("2001:db8::1", 443)` displayed as the
+    /// ambiguous `2001:db8::1:443`, which then failed to parse back.
+    #[test]
+    fn test_ipv6_display_round_trips() {
+        let cases = [
+            (
+                HostPortPair::HostAndPort("2001:db8::1".to_string(), 443),
+                "[2001:db8::1]:443",
+            ),
+            (
+                HostPortPair::HostOnly("2001:db8::1".to_string()),
+                "2001:db8::1",
+            ),
+            (
+                HostPortPair::HostAndPort("proxyhost".to_string(), 1234),
+                "proxyhost:1234",
+            ),
+            (
+                HostPortPair::HostAndPort("10.0.0.1".to_string(), 443),
+                "10.0.0.1:443",
+            ),
+        ];
+        for (pair, rendered) in cases {
+            assert_eq!(pair.to_string(), rendered, "Display of {pair:?}");
+            assert_eq!(
+                HostPortPair::from_str(rendered),
+                Ok(pair.clone()),
+                "round trip of {rendered:?}"
+            );
+        }
     }
 }

--- a/crates/utils/src/host_port_pair.rs
+++ b/crates/utils/src/host_port_pair.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use std::net::Ipv6Addr;
 use std::str::FromStr;
@@ -57,6 +58,25 @@ impl HostPortPair {
             HostPortPair::HostOnly(_) => None,
             HostPortPair::PortOnly(p) | HostPortPair::HostAndPort(_, p) => Some(*p),
         }
+    }
+
+    /// Returns the host formatted for use in a URL authority: a bare IPv6
+    /// literal is bracketed (`[2001:db8::1]`); hostnames and IPv4 literals are
+    /// returned unchanged. `None` when there is no host.
+    ///
+    /// Use this instead of [`Self::host`] when interpolating into a URL or
+    /// `host:port` authority, where an unbracketed IPv6 literal is invalid.
+    pub fn url_host(&self) -> Option<Cow<'_, str>> {
+        self.host().map(bracket_ipv6)
+    }
+}
+
+/// Brackets `host` when it is a bare IPv6 literal; other hosts pass through.
+fn bracket_ipv6(host: &str) -> Cow<'_, str> {
+    if host.parse::<Ipv6Addr>().is_ok() {
+        Cow::Owned(format!("[{host}]"))
+    } else {
+        Cow::Borrowed(host)
     }
 }
 
@@ -124,10 +144,7 @@ impl Display for HostPortPair {
             HostPortPair::PortOnly(p) => write!(f, "{p}"),
             // Bracket an IPv6 literal host so the `host:port` form is
             // unambiguous and round-trips back through `from_str`.
-            HostPortPair::HostAndPort(h, p) if h.parse::<Ipv6Addr>().is_ok() => {
-                write!(f, "[{h}]:{p}")
-            }
-            HostPortPair::HostAndPort(h, p) => write!(f, "{h}:{p}"),
+            HostPortPair::HostAndPort(h, p) => write!(f, "{}:{p}", bracket_ipv6(h)),
         }
     }
 }
@@ -315,6 +332,35 @@ mod tests {
                 Ok(pair.clone()),
                 "round trip of {rendered:?}"
             );
+        }
+    }
+
+    /// `url_host` brackets bare IPv6 literal hosts (which are stored
+    /// unbracketed) so they can be interpolated into a URL authority;
+    /// hostnames and IPv4 literals pass through unchanged.
+    #[test]
+    fn test_url_host_brackets_ipv6() {
+        let cases = [
+            (
+                HostPortPair::HostAndPort("2001:db8::1".to_string(), 443),
+                Some("[2001:db8::1]"),
+            ),
+            (
+                HostPortPair::HostOnly("2001:db8::1".to_string()),
+                Some("[2001:db8::1]"),
+            ),
+            (
+                HostPortPair::HostOnly("proxyhost".to_string()),
+                Some("proxyhost"),
+            ),
+            (
+                HostPortPair::HostAndPort("10.0.0.1".to_string(), 443),
+                Some("10.0.0.1"),
+            ),
+            (HostPortPair::PortOnly(8443), None),
+        ];
+        for (pair, expected) in cases {
+            assert_eq!(pair.url_host().as_deref(), expected, "url_host of {pair:?}");
         }
     }
 }


### PR DESCRIPTION
## Description

`HostPortPair::from_str` split its input on **every** `:`, so any IPv6 literal host yielded more fields than the one or two it expected and was rejected as `InvalidString`. None of the standard ways to write an IPv6 host could be parsed:

- bracketed host+port `[2001:db8::1]:443`
- bracketed host-only `[2001:db8::1]`
- bare literal `2001:db8::1` / `::1`

…even though every IPv4 `host:port` parsed fine.

This is reachable from admin input: the `site-explorer.bmc_proxy` dynamic setting is parsed through this `from_str` (`crates/api-core/src/handlers/api.rs`), so an IPv6 BMC proxy could not be configured at all.

`Display` had the matching defect — `HostAndPort("2001:db8::1", 443)` rendered as the ambiguous `2001:db8::1:443`, which then failed to parse back, breaking the `Serialize`/`Deserialize` round trip (the value is stored back out via `Serialize`).

### Fix
- `from_str` now accepts the canonical bracketed forms and treats a bare string that parses as an `Ipv6Addr` as a host-only value. The host is still stored **unbracketed**, so existing callers that read `.host()` and bracket it themselves (e.g. the nv-redfish / bmc-proxy URL builders) are unaffected.
- `Display` brackets an IPv6 literal host in the `host:port` form so it is unambiguous and round-trips.
- IPv4 and hostname inputs are unchanged.

Part of #2237 (IPv6 Bug Scan Bucket).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Extended the existing `test_proxy_address_parsing` table with bracketed/bare IPv6 cases (including malformed `[2001:db8::1]:`, `[2001:db8::1`, `[]`).
- Added `test_ipv6_display_round_trips` asserting `Display` output and the `Display` → `from_str` round trip.
- Verified both new tests **fail before** this change (`Display` produced `2001:db8::1:443`; `from_str("[2001:db8::1]:8443")` returned `Err(InvalidString)`) and pass after.
- `cargo test -p carbide-utils`, `cargo clippy -p carbide-utils --all-targets -- -D warnings`, and `cargo fmt -p carbide-utils -- --check` all green.
