### PR TITLE
preingestion: resolve URL-only firmware artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
  "opentelemetry",
  "prometheus-text-parser",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1620,6 +1620,10 @@ impl CarbideConfig {
             max_concurrent_bfb_copies: self.firmware_global.max_concurrent_bfb_copies,
             autoupdate: self.firmware_global.autoupdate,
             no_reset_retries: self.firmware_global.no_reset_retries,
+            firmware_download_cache_directory: self
+                .firmware_global
+                .firmware_download_cache_directory
+                .clone(),
             firmware: self.get_firmware_config(),
         }
     }

--- a/crates/firmware/src/artifact_resolution.rs
+++ b/crates/firmware/src/artifact_resolution.rs
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::{Path, PathBuf};
+
+use eyre::{Result, eyre};
+use model::firmware::FirmwareEntry;
+
+use crate::artifact_cache::firmware_cache_filename;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedFirmwareArtifact {
+    pub local_path: PathBuf,
+    pub source: ResolvedFirmwareArtifactSource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResolvedFirmwareArtifactSource {
+    Remote { url: String, sha256: String },
+    Local,
+}
+
+pub fn resolve_files_firmware_artifact(
+    firmware_cache_directory: &Path,
+    firmware: &FirmwareEntry,
+    pos: u32,
+) -> Result<Option<ResolvedFirmwareArtifact>> {
+    if firmware.files.is_empty() {
+        return Ok(None);
+    }
+
+    let index = usize::try_from(pos).unwrap_or(usize::MAX);
+    let artifact = firmware.files.get(index).ok_or_else(|| {
+        eyre!(
+            "firmware version {} has no files[] artifact at index {}",
+            firmware.version,
+            pos
+        )
+    })?;
+
+    let url = artifact
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty());
+
+    let filename = artifact
+        .filename
+        .as_deref()
+        .map(str::trim)
+        .filter(|filename| !filename.is_empty());
+
+    let local_path = if let Some(url) = url {
+        firmware_cache_filename(firmware_cache_directory, url).ok_or_else(|| {
+            eyre!(
+                "firmware version {} files[] artifact at index {} URL does not include a filename",
+                firmware.version,
+                pos
+            )
+        })?
+    } else if let Some(filename) = filename {
+        PathBuf::from(filename)
+    } else {
+        return Err(eyre!(
+            "firmware version {} files[] artifact at index {} has no filename or URL",
+            firmware.version,
+            pos
+        ));
+    };
+
+    let source = match url {
+        Some(url) => ResolvedFirmwareArtifactSource::Remote {
+            url: url.to_owned(),
+            sha256: artifact.sha256.clone(),
+        },
+        None => ResolvedFirmwareArtifactSource::Local,
+    };
+
+    Ok(Some(ResolvedFirmwareArtifact { local_path, source }))
+}
+
+#[cfg(test)]
+mod tests {
+    use model::firmware::FirmwareFileArtifact;
+
+    use super::*;
+
+    #[test]
+    fn resolve_files_firmware_artifact_uses_url_as_remote_source() {
+        let firmware_cache_directory = Path::new("/mnt/persistence/fw/download-cache");
+        let firmware = firmware_with_files(vec![FirmwareFileArtifact {
+            filename: None,
+            url: Some("https://firmware.example.invalid/path/fw.bin".to_string()),
+            sha256: "abc123".to_string(),
+        }]);
+
+        let artifact = resolve_files_firmware_artifact(firmware_cache_directory, &firmware, 0)
+            .unwrap()
+            .unwrap();
+
+        assert!(artifact.local_path.starts_with(firmware_cache_directory));
+        assert_eq!(artifact.local_path.file_name().unwrap(), "fw.bin");
+        assert_eq!(
+            artifact.source,
+            ResolvedFirmwareArtifactSource::Remote {
+                url: "https://firmware.example.invalid/path/fw.bin".to_string(),
+                sha256: "abc123".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_files_firmware_artifact_uses_filename_as_local_source() {
+        let firmware = firmware_with_files(vec![FirmwareFileArtifact {
+            filename: Some("/opt/carbide/firmware/fw.bin".to_string()),
+            url: None,
+            sha256: "abc123".to_string(),
+        }]);
+
+        let artifact = resolve_files_firmware_artifact(Path::new("/cache"), &firmware, 0)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            artifact.local_path,
+            PathBuf::from("/opt/carbide/firmware/fw.bin")
+        );
+        assert_eq!(artifact.source, ResolvedFirmwareArtifactSource::Local);
+    }
+
+    #[test]
+    fn resolve_files_firmware_artifact_gives_url_precedence_over_filename() {
+        let firmware_cache_directory = Path::new("/mnt/persistence/fw/download-cache");
+        let firmware = firmware_with_files(vec![FirmwareFileArtifact {
+            filename: Some("/opt/carbide/firmware/local.bin".to_string()),
+            url: Some("https://firmware.example.invalid/remote.bin".to_string()),
+            sha256: "abc123".to_string(),
+        }]);
+
+        let artifact = resolve_files_firmware_artifact(firmware_cache_directory, &firmware, 0)
+            .unwrap()
+            .unwrap();
+
+        assert!(artifact.local_path.starts_with(firmware_cache_directory));
+        assert_eq!(artifact.local_path.file_name().unwrap(), "remote.bin");
+        assert_eq!(
+            artifact.source,
+            ResolvedFirmwareArtifactSource::Remote {
+                url: "https://firmware.example.invalid/remote.bin".to_string(),
+                sha256: "abc123".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn resolve_files_firmware_artifact_returns_none_without_files() {
+        let firmware = FirmwareEntry::standard("1.0");
+
+        let artifact = resolve_files_firmware_artifact(Path::new("/cache"), &firmware, 0).unwrap();
+
+        assert_eq!(artifact, None);
+    }
+
+    #[test]
+    fn resolve_files_firmware_artifact_rejects_url_without_filename() {
+        let firmware = firmware_with_files(vec![FirmwareFileArtifact {
+            filename: None,
+            url: Some("https://firmware.example.invalid/".to_string()),
+            sha256: "abc123".to_string(),
+        }]);
+
+        let error = resolve_files_firmware_artifact(Path::new("/cache"), &firmware, 0)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("URL does not include a filename"));
+    }
+
+    fn firmware_with_files(files: Vec<FirmwareFileArtifact>) -> FirmwareEntry {
+        FirmwareEntry {
+            version: "1.0".to_string(),
+            files,
+            ..FirmwareEntry::default()
+        }
+    }
+}

--- a/crates/firmware/src/lib.rs
+++ b/crates/firmware/src/lib.rs
@@ -20,6 +20,8 @@ mod tests;
 
 mod artifact_cache;
 
+mod artifact_resolution;
+
 pub mod config;
 
 pub mod defaults;
@@ -30,5 +32,8 @@ pub mod downloader;
 pub mod test_support;
 
 pub use artifact_cache::firmware_cache_filename;
+pub use artifact_resolution::{
+    ResolvedFirmwareArtifact, ResolvedFirmwareArtifactSource, resolve_files_firmware_artifact,
+};
 pub use config::{FirmwareConfig, FirmwareConfigSnapshot};
 pub use downloader::FirmwareDownloader;

--- a/crates/machine-controller/src/handler/firmware_artifact.rs
+++ b/crates/machine-controller/src/handler/firmware_artifact.rs
@@ -15,87 +15,30 @@
  * limitations under the License.
  */
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
-use carbide_firmware::firmware_cache_filename;
+use carbide_firmware::resolve_files_firmware_artifact;
+pub(crate) use carbide_firmware::{ResolvedFirmwareArtifact, ResolvedFirmwareArtifactSource};
 use eyre::eyre;
 use model::firmware::{FirmwareEntry, FirmwareFileArtifact};
 use state_controller::state_handler::StateHandlerError;
 
 use crate::rpc::scout_firmware_upgrade::FileArtifact;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ResolvedFirmwareArtifact {
-    pub(crate) local_path: PathBuf,
-    pub(crate) source: ResolvedFirmwareArtifactSource,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum ResolvedFirmwareArtifactSource {
-    Remote { url: String, sha256: String },
-    Local,
-}
-
 pub(crate) fn resolve_firmware_artifact(
     firmware_download_cache_directory: &Path,
     firmware: &FirmwareEntry,
     pos: u32,
 ) -> Result<ResolvedFirmwareArtifact, StateHandlerError> {
-    if firmware.files.is_empty() {
-        return Ok(ResolvedFirmwareArtifact {
+    match resolve_files_firmware_artifact(firmware_download_cache_directory, firmware, pos)
+        .map_err(StateHandlerError::GenericError)?
+    {
+        Some(artifact) => Ok(artifact),
+        None => Ok(ResolvedFirmwareArtifact {
             local_path: firmware.get_filename(pos),
             source: ResolvedFirmwareArtifactSource::Local,
-        });
+        }),
     }
-
-    let index = usize::try_from(pos).unwrap_or(usize::MAX);
-    let artifact = firmware.files.get(index).ok_or_else(|| {
-        StateHandlerError::GenericError(eyre!(
-            "firmware version {} has no files[] artifact at index {}",
-            firmware.version,
-            pos
-        ))
-    })?;
-
-    let url = artifact
-        .url
-        .as_deref()
-        .map(str::trim)
-        .filter(|url| !url.is_empty());
-
-    let filename = artifact
-        .filename
-        .as_deref()
-        .map(str::trim)
-        .filter(|filename| !filename.is_empty());
-
-    let local_path = if let Some(url) = url {
-        firmware_cache_filename(firmware_download_cache_directory, url).ok_or_else(|| {
-            StateHandlerError::GenericError(eyre!(
-                "firmware version {} files[] artifact at index {} URL does not include a filename",
-                firmware.version,
-                pos
-            ))
-        })?
-    } else if let Some(filename) = filename {
-        PathBuf::from(filename)
-    } else {
-        return Err(StateHandlerError::GenericError(eyre!(
-            "firmware version {} files[] artifact at index {} has no filename or URL",
-            firmware.version,
-            pos
-        )));
-    };
-
-    let source = match url {
-        Some(url) => ResolvedFirmwareArtifactSource::Remote {
-            url: url.to_owned(),
-            sha256: artifact.sha256.clone(),
-        },
-        None => ResolvedFirmwareArtifactSource::Local,
-    };
-
-    Ok(ResolvedFirmwareArtifact { local_path, source })
 }
 
 pub(crate) fn resolve_scout_file_artifact(
@@ -166,6 +109,8 @@ fn firmware_artifact_url(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
 
     const FIRMWARE_DOWNLOAD_CACHE_DIRECTORY: &str = "/mnt/persistence/fw/download-cache";

--- a/crates/preingestion-manager/Cargo.toml
+++ b/crates/preingestion-manager/Cargo.toml
@@ -41,6 +41,7 @@ carbide-firmware = { path = "../firmware", features = ["test-support"] }
 carbide-test-harness = { path = "../test-harness" }
 carbide-uuid = { path = "../uuid" }
 prometheus-text-parser = { path = "../prometheus-text-parser" }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/preingestion-manager/src/config.rs
+++ b/crates/preingestion-manager/src/config.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::path::PathBuf;
 use std::time::Duration;
 
 use carbide_firmware::FirmwareConfig;
@@ -27,5 +28,6 @@ pub struct PreingestionManagerConfig {
     pub max_concurrent_bfb_copies: usize,
     pub autoupdate: bool,
     pub no_reset_retries: bool,
+    pub firmware_download_cache_directory: PathBuf,
     pub firmware: FirmwareConfig,
 }

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -24,10 +24,13 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use carbide_firmware::FirmwareDownloader;
+use carbide_firmware::{
+    FirmwareDownloader, ResolvedFirmwareArtifactSource, resolve_files_firmware_artifact,
+};
 use carbide_redfish::libredfish::conv::IntoLibredfish;
 use carbide_redfish::libredfish::{RedfishClientCreationError, RedfishClientPool};
 use carbide_secrets::credentials::{
@@ -60,6 +63,7 @@ use crate::errors::{PreingestionManagerError, PreingestionManagerResult};
 use crate::metrics::PreingestionMetrics;
 
 const NOT_FOUND: u16 = 404;
+const LEGACY_NO_URL_SENTINEL: &str = "file://dev/null";
 
 /// Fallback timeout for BFB copy. SSH layer has 30-min timeout that should fire first;
 /// this catches edge cases where the task dies without reporting.
@@ -695,16 +699,8 @@ impl PreingestionManagerStatic {
 
                     tracing::info!("Installing {:?} on {}", to_install, endpoint.address);
 
-                    initiate_update(
-                        endpoint,
-                        &self.redfish_client_pool,
-                        &to_install,
-                        &fw_type,
-                        &self.downloader,
-                        0,
-                        db,
-                    )
-                    .await?;
+                    self.initiate_update(endpoint, &to_install, &fw_type, 0, db)
+                        .await?;
 
                     // initiate_update only returned an error for database issues.  If it truly succeeded, it updated
                     // the database with a new state.  If the firmware download was not yet complete or we had a Redfish
@@ -769,9 +765,9 @@ impl PreingestionManagerStatic {
                                 component_info.known_firmware.iter().find(|&x| x.default)
                         {
                             let firmware_number = firmware_number + 1;
-                            if firmware_number
-                                < selected_firmware.filenames.len().try_into().unwrap_or(0)
-                            {
+                            if usize::try_from(firmware_number).is_ok_and(|firmware_number| {
+                                firmware_number < selected_firmware.artifact_count()
+                            }) {
                                 tracing::info!(
                                     "Installing {:?} chain step {} on {}",
                                     selected_firmware,
@@ -779,12 +775,10 @@ impl PreingestionManagerStatic {
                                     endpoint.address
                                 );
 
-                                initiate_update(
+                                self.initiate_update(
                                     endpoint,
-                                    &self.redfish_client_pool,
                                     selected_firmware,
                                     upgrade_type,
-                                    &self.downloader,
                                     firmware_number,
                                     db,
                                 )
@@ -2710,155 +2704,242 @@ fn need_upgrade(
         .cloned()
 }
 
-/// initiate_update will start a Redfish connection to the given address and start an update
-/// by doing an upload.  It may be unable to start it if the firmware has not been previously
-/// downloaded; if that happens it also returns success, but has not modified the state.  On Redfish
-///  errors, we return Ok but leave the state as it was, with the intention that we will retry
-///  on the next go.
-async fn initiate_update(
-    endpoint_clone: &ExploredEndpoint,
-    redfish_client_pool: &Arc<dyn RedfishClientPool>,
-    to_install: &FirmwareEntry,
-    firmware_type: &FirmwareComponentType,
-    downloader: &FirmwareDownloader,
-    firmware_number: u32,
-    db_pool: &PgPool,
-) -> Result<(), DatabaseError> {
-    if !to_install.get_filename(firmware_number).ends_with("bfb")
-        && !downloader.available(
-            &to_install.get_filename(firmware_number),
-            &to_install.get_url(),
-            &to_install.get_checksum(),
-        )
-    {
-        tracing::debug!(
-            "{} is being downloaded from {}, update deferred",
-            to_install.get_filename(firmware_number).display(),
-            to_install.get_url()
-        );
-
-        return Ok(());
-    }
-
-    // Setup the Redfish connection
-    let redfish_client = match redfish_client_pool
-        .create_client_for_ingested_host(endpoint_clone.address, db_pool)
-        .await
-    {
-        Ok(redfish_client) => redfish_client,
-        Err(e) => {
-            tracing::debug!(
-                "Failed to open redfish to {}: {e}",
-                endpoint_clone.address.to_string()
-            );
-            return Ok(());
-        }
-    };
-
-    tracing::debug!(
-        "initiate_update: Started upload of firmware to {}",
-        endpoint_clone.address
-    );
-    let redfish_component_type: libredfish::model::update_service::ComponentType =
-        match to_install.install_only_specified {
-            false => libredfish::model::update_service::ComponentType::Unknown,
-            true => firmware_type.into_libredfish(),
+impl PreingestionManagerStatic {
+    /// initiate_update will start a Redfish connection to the given address and start an update
+    /// by doing an upload.  It may be unable to start it if the firmware has not been previously
+    /// downloaded; if that happens it also returns success, but has not modified the state.  On Redfish
+    ///  errors, we return Ok but leave the state as it was, with the intention that we will retry
+    ///  on the next go.
+    async fn initiate_update(
+        &self,
+        endpoint_clone: &ExploredEndpoint,
+        to_install: &FirmwareEntry,
+        firmware_type: &FirmwareComponentType,
+        firmware_number: u32,
+        db_pool: &PgPool,
+    ) -> Result<(), DatabaseError> {
+        let artifact = match resolve_preingestion_firmware_artifact(
+            &self.config.firmware_download_cache_directory,
+            to_install,
+            firmware_number,
+        ) {
+            Ok(artifact) => artifact,
+            Err(error) => {
+                tracing::error!("Failed to resolve firmware artifact: {error}");
+                return Ok(());
+            }
         };
-    let task = if to_install.get_filename(firmware_number).ends_with("bfb") {
-        let _ = redfish_client
-            .enable_rshim_bmc()
-            .await
-            .map_err(|e| tracing::error!("initiate_update: Failed to call enable_rshim_bmc: {e}"));
-        let image_uri = format!(
-            "{}/{}",
-            to_install.get_url(),
-            to_install.get_filename(firmware_number).display()
-        );
-        tracing::debug!(
-            "initiate_update: Using simple_update with image URI: {}",
-            image_uri
-        );
-        match redfish_client
-            .update_firmware_simple_update(
-                image_uri.as_str(),
-                vec!["redfish/v1/UpdateService/FirmwareInventory/DPU_OS".to_string()],
-                TransferProtocolType::HTTP,
-            )
+
+        if !is_bfb_artifact(&artifact.local_path) {
+            match &artifact.source {
+                ResolvedFirmwareArtifactSource::Remote { url, sha256 } => {
+                    if !self.downloader.available(&artifact.local_path, url, sha256) {
+                        tracing::debug!(
+                            "{} is being downloaded from {}, update deferred",
+                            artifact.local_path.display(),
+                            url
+                        );
+
+                        return Ok(());
+                    }
+                }
+                ResolvedFirmwareArtifactSource::Local => {
+                    if !artifact.local_path.exists() {
+                        tracing::error!(
+                            "Firmware artifact {} is not present",
+                            artifact.local_path.display()
+                        );
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        // Setup the Redfish connection
+        let redfish_client = match self
+            .redfish_client_pool
+            .create_client_for_ingested_host(endpoint_clone.address, db_pool)
             .await
         {
-            Ok(task) => task.id,
+            Ok(redfish_client) => redfish_client,
             Err(e) => {
-                tracing::error!(
-                    "initiate_update: Failed to call update_firmware_simple_update {}: {e}",
-                    endpoint_clone.address
+                tracing::debug!(
+                    "Failed to open redfish to {}: {e}",
+                    endpoint_clone.address.to_string()
                 );
                 return Ok(());
             }
-        }
-    } else {
-        match redfish_client
-            .update_firmware_multipart(
-                to_install.get_filename(firmware_number).as_path(),
-                true,
-                Duration::from_secs(120),
-                redfish_component_type,
-            )
-            .await
-        {
-            Ok(task) => task,
-            Err(RedfishError::NotSupported(err)) => {
-                tracing::warn!(
-                    "Multipart update is not supported: {err}. Trying to use HttpPushUri"
-                );
-                let file =
-                    match File::open(to_install.get_filename(firmware_number).as_path()).await {
+        };
+
+        tracing::debug!(
+            "initiate_update: Started upload of firmware to {}",
+            endpoint_clone.address
+        );
+
+        let redfish_component_type: libredfish::model::update_service::ComponentType =
+            match to_install.install_only_specified {
+                false => libredfish::model::update_service::ComponentType::Unknown,
+                true => firmware_type.into_libredfish(),
+            };
+
+        let task = if is_bfb_artifact(&artifact.local_path) {
+            let _ = redfish_client.enable_rshim_bmc().await.map_err(|e| {
+                tracing::error!("initiate_update: Failed to call enable_rshim_bmc: {e}")
+            });
+            tracing::debug!(
+                "initiate_update: Using simple_update with image URI: {}",
+                artifact.bfb_image_uri
+            );
+            match redfish_client
+                .update_firmware_simple_update(
+                    artifact.bfb_image_uri.as_str(),
+                    vec!["redfish/v1/UpdateService/FirmwareInventory/DPU_OS".to_string()],
+                    TransferProtocolType::HTTP,
+                )
+                .await
+            {
+                Ok(task) => task.id,
+                Err(e) => {
+                    tracing::error!(
+                        "initiate_update: Failed to call update_firmware_simple_update {}: {e}",
+                        endpoint_clone.address
+                    );
+                    return Ok(());
+                }
+            }
+        } else {
+            match redfish_client
+                .update_firmware_multipart(
+                    artifact.local_path.as_path(),
+                    true,
+                    Duration::from_secs(120),
+                    redfish_component_type,
+                )
+                .await
+            {
+                Ok(task) => task,
+                Err(RedfishError::NotSupported(err)) => {
+                    tracing::warn!(
+                        "Multipart update is not supported: {err}. Trying to use HttpPushUri"
+                    );
+                    let file = match File::open(artifact.local_path.as_path()).await {
                         Ok(f) => f,
                         Err(e) => {
                             tracing::error!("Failed to open a file: {e}");
                             return Ok(());
                         }
                     };
-                match redfish_client.update_firmware(file).await {
-                    Ok(task) => task.id,
-                    Err(e) => {
-                        tracing::error!(
-                            "initiate_update: Failed uploading firmware to {}: {e}",
-                            endpoint_clone.address
-                        );
-                        return Ok(());
+                    match redfish_client.update_firmware(file).await {
+                        Ok(task) => task.id,
+                        Err(e) => {
+                            tracing::error!(
+                                "initiate_update: Failed uploading firmware to {}: {e}",
+                                endpoint_clone.address
+                            );
+                            return Ok(());
+                        }
                     }
                 }
+                Err(e) => {
+                    tracing::warn!(
+                        "initiate_update: Failed uploading firmware to {}: {e}",
+                        endpoint_clone.address
+                    );
+                    return Ok(());
+                }
             }
-            Err(e) => {
-                tracing::warn!(
-                    "initiate_update: Failed uploading firmware to {}: {e}",
-                    endpoint_clone.address
-                );
-                return Ok(());
+        };
+
+        tracing::debug!(
+            "initiate_update: Completed upload of firmware to {}",
+            endpoint_clone.address
+        );
+
+        db_pool
+            .with_txn(|txn| {
+                Box::pin(db::explored_endpoints::set_preingestion_waittask(
+                    endpoint_clone.address,
+                    task,
+                    &to_install.version,
+                    firmware_type,
+                    to_install.power_drains_needed,
+                    firmware_number,
+                    txn,
+                ))
+            })
+            .await??;
+
+        Ok(())
+    }
+}
+
+struct PreingestionFirmwareArtifact {
+    local_path: PathBuf,
+    source: ResolvedFirmwareArtifactSource,
+    bfb_image_uri: String,
+}
+
+fn resolve_preingestion_firmware_artifact(
+    firmware_download_cache_directory: &Path,
+    to_install: &FirmwareEntry,
+    firmware_number: u32,
+) -> Result<PreingestionFirmwareArtifact, String> {
+    if let Some(artifact) = resolve_files_firmware_artifact(
+        firmware_download_cache_directory,
+        to_install,
+        firmware_number,
+    )
+    .map_err(|error| error.to_string())?
+    {
+        let bfb_image_uri = match &artifact.source {
+            ResolvedFirmwareArtifactSource::Remote { url, .. } => url.clone(),
+            ResolvedFirmwareArtifactSource::Local => {
+                legacy_bfb_image_uri(to_install, &artifact.local_path)
             }
-        }
+        };
+
+        return Ok(PreingestionFirmwareArtifact {
+            local_path: artifact.local_path,
+            source: artifact.source,
+            bfb_image_uri,
+        });
+    }
+
+    let local_path = to_install.get_filename(firmware_number);
+    let bfb_image_uri = legacy_bfb_image_uri(to_install, &local_path);
+    let source = match legacy_artifact_remote_url(to_install) {
+        Some(url) => ResolvedFirmwareArtifactSource::Remote {
+            url: url.to_string(),
+            sha256: to_install.get_checksum(),
+        },
+        None => ResolvedFirmwareArtifactSource::Local,
     };
 
-    tracing::debug!(
-        "initiate_update: Completed upload of firmware to {}",
-        endpoint_clone.address
-    );
+    Ok(PreingestionFirmwareArtifact {
+        local_path,
+        source,
+        bfb_image_uri,
+    })
+}
 
-    db_pool
-        .with_txn(|txn| {
-            Box::pin(db::explored_endpoints::set_preingestion_waittask(
-                endpoint_clone.address,
-                task,
-                &to_install.version,
-                firmware_type,
-                to_install.power_drains_needed,
-                firmware_number,
-                txn,
-            ))
-        })
-        .await??;
+fn legacy_artifact_remote_url(to_install: &FirmwareEntry) -> Option<&str> {
+    to_install
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty() && *url != LEGACY_NO_URL_SENTINEL)
+}
 
-    Ok(())
+fn legacy_bfb_image_uri(to_install: &FirmwareEntry, local_path: &Path) -> String {
+    format!("{}/{}", to_install.get_url(), local_path.display())
+}
+
+fn is_bfb_artifact(path: &Path) -> bool {
+    path.ends_with("bfb")
+        || path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("bfb"))
 }
 
 trait CreateClientForIngestedHost {
@@ -2886,5 +2967,60 @@ impl CreateClientForIngestedHost for Arc<dyn RedfishClientPool> {
                 }
                 _ => PreingestionManagerError::internal(format!("{e}")),
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_preingestion_firmware_artifact_preserves_legacy_local_entries() {
+        for url in [None, Some(LEGACY_NO_URL_SENTINEL.to_string())] {
+            let mut firmware =
+                FirmwareEntry::standard_filename("1.0.0", "/firmware/local-artifact.bin");
+            firmware.url = url;
+
+            let artifact =
+                resolve_preingestion_firmware_artifact(Path::new("/cache"), &firmware, 0).unwrap();
+
+            assert_eq!(
+                artifact.local_path,
+                Path::new("/firmware/local-artifact.bin")
+            );
+            assert_eq!(artifact.source, ResolvedFirmwareArtifactSource::Local);
+        }
+    }
+
+    #[test]
+    fn resolve_preingestion_firmware_artifact_preserves_legacy_remote_entries() {
+        let mut firmware = FirmwareEntry::standard_filename("1.0.0", "/firmware/artifact.bin");
+        firmware.url = Some("https://firmware.example.invalid/artifact.bin".to_string());
+        firmware.checksum = Some("abc123".to_string());
+
+        let artifact =
+            resolve_preingestion_firmware_artifact(Path::new("/cache"), &firmware, 0).unwrap();
+
+        assert_eq!(artifact.local_path, Path::new("/firmware/artifact.bin"));
+        assert_eq!(
+            artifact.source,
+            ResolvedFirmwareArtifactSource::Remote {
+                url: "https://firmware.example.invalid/artifact.bin".to_string(),
+                sha256: "abc123".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn is_bfb_artifact_matches_legacy_component_and_bfb_extension() {
+        for (path, expected) in [
+            ("/firmware/bfb", true),
+            ("/firmware/foo.bfb", true),
+            ("/firmware/foo.BFB", true),
+            ("/firmware/foo.bin", false),
+            ("/firmware/bfb.bin", false),
+        ] {
+            assert_eq!(is_bfb_artifact(Path::new(path)), expected, "{path}");
+        }
     }
 }

--- a/crates/preingestion-manager/tests/integration/host_bmc_firmware.rs
+++ b/crates/preingestion-manager/tests/integration/host_bmc_firmware.rs
@@ -15,15 +15,19 @@
  * limitations under the License.
  */
 
+use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_firmware::test_support::script_setup;
 use carbide_preingestion_manager::PreingestionManager;
 use carbide_redfish::libredfish::test_support::RedfishSim;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::default_config;
+use model::firmware::{FirmwareComponentType, FirmwareEntry, FirmwareFileArtifact};
 use model::site_explorer::{InitialResetPhase, PowerDrainState, PreingestionState};
 use rpc::forge::DhcpDiscovery;
 
@@ -220,6 +224,83 @@ async fn test_preingestion_bmc_upgrade(pool: PgPool) -> Result<(), Box<dyn std::
             == 1
     );
     txn.commit().await?;
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_preingestion_bmc_upgrade_with_url_only_files_artifacts(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool.clone()).build().await;
+    let domain = env.test_domain().await;
+    let nc = env.network_controller();
+    let underlay_segment = nc.create_underlay_segment(&domain).await;
+    let tempdir = tempfile::tempdir()?;
+
+    let first_artifact = tempdir.path().join("first.bin");
+    let second_artifact = tempdir.path().join("second.bin");
+    fs::write(&first_artifact, b"firmware-one")?;
+    fs::write(&second_artifact, b"firmware-two")?;
+
+    let mut config = default_config::get();
+    config.firmware_global.firmware_download_cache_directory = tempdir.path().join("cache");
+    let bmc_component = config
+        .host_models
+        .get_mut("1")
+        .unwrap()
+        .components
+        .get_mut(&FirmwareComponentType::Bmc)
+        .unwrap();
+    bmc_component.known_firmware = vec![FirmwareEntry {
+        version: "6.00.30.00".to_string(),
+        default: true,
+        files: vec![
+            FirmwareFileArtifact {
+                filename: None,
+                url: Some(file_url(&first_artifact)),
+                sha256: "bd0d2c3b17ef6983be51bfff3e505b2c365430630afe7b9f53451e3f279d39a1"
+                    .to_string(),
+            },
+            FirmwareFileArtifact {
+                filename: None,
+                url: Some(file_url(&second_artifact)),
+                sha256: "c46897d1cfe1d2b7341d30eaacce68ffc752738de147dc820ed016e1f51b8f14"
+                    .to_string(),
+            },
+        ],
+        ..FirmwareEntry::default()
+    }];
+
+    let mgr = PreingestionManager::new(
+        pool.clone(),
+        config.preingestion_manager(),
+        Arc::new(RedfishSim::default()),
+        env.test_meter.meter(),
+        None,
+        None,
+        None,
+        env.api().work_lock_manager_handle(),
+        config.ntp_servers.clone(),
+    );
+
+    let response = env
+        .api()
+        .discover_dhcp(
+            DhcpDiscovery::builder("b8:3f:d2:90:97:a6", underlay_segment.relay_address)
+                .vendor_string("iDRac")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    let mut txn = pool.begin().await.unwrap();
+    let addr = response.address.as_str();
+    common::insert_endpoint_version(&mut txn, addr, "4.9", "1.13.2", false).await?;
+    txn.commit().await?;
+
+    run_until_firmware_number(&mgr, &pool, Some(0)).await?;
+    run_until_firmware_number(&mgr, &pool, Some(1)).await?;
 
     Ok(())
 }
@@ -427,6 +508,42 @@ async fn test_preingestion_preupdate_powercycling(
     txn.commit().await?;
 
     Ok(())
+}
+
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.display())
+}
+
+async fn run_until_firmware_number(
+    mgr: &PreingestionManager,
+    pool: &PgPool,
+    expected_firmware_number: Option<u32>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut last_state = None;
+    for _ in 0..10 {
+        mgr.run_single_iteration().await?;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut txn = pool.begin().await?;
+        let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
+        txn.commit().await?;
+        let Some(endpoint) = endpoints.first() else {
+            continue;
+        };
+        last_state = Some(endpoint.preingestion_state.clone());
+
+        if let PreingestionState::UpgradeFirmwareWait {
+            firmware_number, ..
+        } = endpoint.preingestion_state
+            && firmware_number == expected_firmware_number
+        {
+            return Ok(());
+        }
+    }
+
+    panic!(
+        "Expected preingestion firmware_number {expected_firmware_number:?}, last state: {last_state:?}"
+    );
 }
 
 #[sqlx_test]


### PR DESCRIPTION
Add shared firmware files[] artifact resolution and use it in preingestion firmware uploads. This lets preingestion handle metadata where files[] entries provide URLs without legacy filename/filenames fields, while preserving the legacy fallback path for existing metadata.

The state controller was changed similarly previously.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
The legacy `filename`/`filenames` paths are intentionally preserved. URL-based `files[]` support is added without enabling DB/API precedence for preingestion yet.
