### PR TITLE
feat(api): link switches and power shelves to their BMC via machine_interfaces

### DIFF
--- a/crates/admin-cli/src/power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/show/cmd.rs
@@ -42,7 +42,10 @@ pub fn show_power_shelves(
             "Voltage(V)",
             "Power State",
             "Health",
-            "State"
+            "State",
+            "BMC IP",
+            "BMC MAC",
+            "BMC Interface ID"
         ]);
 
         for shelf in shelves {
@@ -51,6 +54,22 @@ pub fn show_power_shelves(
                 .as_ref()
                 .map(|m| m.name.as_str())
                 .unwrap_or("N/A");
+
+            let bmc_ip = shelf
+                .bmc_info
+                .as_ref()
+                .and_then(|b| b.ip.clone())
+                .unwrap_or_else(|| "N/A".to_string());
+            let bmc_mac = shelf
+                .bmc_info
+                .as_ref()
+                .and_then(|b| b.mac.clone())
+                .unwrap_or_else(|| "N/A".to_string());
+            let bmc_interface_id = shelf
+                .bmc_info
+                .as_ref()
+                .and_then(|b| b.machine_interface_id.map(|id| id.to_string()))
+                .unwrap_or_else(|| "N/A".to_string());
 
             table.add_row(row![
                 shelf
@@ -87,6 +106,9 @@ pub fn show_power_shelves(
                     .and_then(|s| s.health_status.as_deref())
                     .unwrap_or("N/A"),
                 shelf.controller_state,
+                bmc_ip,
+                bmc_mac,
+                bmc_interface_id,
             ]);
         }
 

--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -394,6 +394,12 @@ fn switch_details_text(switch: &Switch) -> CarbideCliResult<String> {
     writeln!(&mut lines, "\nBMC:")?;
     if let Some(bmc) = &switch.bmc_info {
         let bmc_data: Vec<(&str, String)> = vec![
+            (
+                "Machine Interface ID",
+                bmc.machine_interface_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
             ("IP", bmc.ip.clone().unwrap_or_else(|| "N/A".to_string())),
             ("MAC", bmc.mac.clone().unwrap_or_else(|| "N/A".to_string())),
             (

--- a/crates/api-core/src/handlers/power_shelf.rs
+++ b/crates/api-core/src/handlers/power_shelf.rs
@@ -75,15 +75,24 @@ pub async fn find_power_shelf(
         message: format!("Failed to commit transaction: {}", e),
     })?;
 
-    let power_shelves: Vec<rpc::PowerShelf> = power_shelf_list
+    let power_shelves = convert_power_shelves(power_shelf_list)?;
+
+    Ok(Response::new(rpc::PowerShelfList { power_shelves }))
+}
+
+/// Convert DB power shelves into their RPC representation. `bmc_info` is
+/// populated by the power-shelf load query and carried through the model->rpc
+/// conversion, so no extra resolution is needed here.
+fn convert_power_shelves(
+    power_shelf_list: Vec<model::power_shelf::PowerShelf>,
+) -> Result<Vec<rpc::PowerShelf>, CarbideError> {
+    power_shelf_list
         .into_iter()
         .map(rpc::PowerShelf::try_from)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| CarbideError::Internal {
             message: format!("Failed to convert power shelf: {}", e),
-        })?;
-
-    Ok(Response::new(rpc::PowerShelfList { power_shelves }))
+        })
 }
 
 pub async fn find_ids(
@@ -129,47 +138,9 @@ pub async fn find_by_ids(
     )
     .await?;
 
-    let bmc_info_map: std::collections::HashMap<_, _> = {
-        let rows = db_power_shelf::find_bmc_info_by_power_shelf_ids(&mut txn, &power_shelf_ids)
-            .await
-            .map_err(|e| CarbideError::Internal {
-                message: format!("Failed to get power shelf BMC info: {}", e),
-            })?;
-
-        rows.into_iter()
-            .map(|row| {
-                (
-                    row.power_shelf_id,
-                    rpc::BmcInfo {
-                        ip: Some(row.pmc_ip.to_string()),
-                        mac: Some(row.pmc_mac.to_string()),
-                        version: None,
-                        firmware_version: None,
-                        port: None,
-                        machine_interface_id: None,
-                    },
-                )
-            })
-            .collect()
-    };
-
     let _ = txn.rollback().await;
 
-    let power_shelves: Vec<rpc::PowerShelf> = power_shelf_list
-        .into_iter()
-        .map(|ps| {
-            let id = ps.id;
-            let bmc_info = bmc_info_map.get(&id).cloned();
-
-            rpc::PowerShelf::try_from(ps).map(|mut rpc_ps| {
-                rpc_ps.bmc_info = bmc_info;
-                rpc_ps
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| CarbideError::Internal {
-            message: format!("Failed to convert power shelf: {}", e),
-        })?;
+    let power_shelves = convert_power_shelves(power_shelf_list)?;
 
     Ok(Response::new(rpc::PowerShelfList { power_shelves }))
 }

--- a/crates/api-core/src/handlers/switch.rs
+++ b/crates/api-core/src/handlers/switch.rs
@@ -89,17 +89,13 @@ pub async fn find_switch(
     let switches: Vec<rpc::Switch> = switch_list
         .into_iter()
         .map(|s| {
-            let endpoint_info = endpoint_info_map.get(&s.id);
+            let id = s.id;
+            let endpoint_info = endpoint_info_map.get(&id);
 
+            // `bmc_info` is populated by the switch load query and carried
+            // through the model->rpc conversion; only nvos_info is stitched in
+            // here from the endpoint lookup.
             rpc::Switch::try_from(s).map(|mut rpc_switch| {
-                rpc_switch.bmc_info = endpoint_info.map(|row| rpc::BmcInfo {
-                    ip: Some(row.bmc_ip.to_string()),
-                    mac: Some(row.bmc_mac.to_string()),
-                    version: None,
-                    firmware_version: None,
-                    port: None,
-                    machine_interface_id: None,
-                });
                 rpc_switch.nvos_info = endpoint_info.and_then(|row| {
                     let (Some(nvos_mac), Some(nvos_ip)) =
                         (row.nvos_mac.as_ref(), row.nvos_ip.as_ref())
@@ -180,17 +176,13 @@ pub async fn find_by_ids(
     let switches: Vec<rpc::Switch> = switch_list
         .into_iter()
         .map(|s| {
-            let endpoint_info = endpoint_info_map.get(&s.id);
+            let id = s.id;
+            let endpoint_info = endpoint_info_map.get(&id);
 
+            // `bmc_info` is populated by the switch load query and carried
+            // through the model->rpc conversion; only nvos_info is stitched in
+            // here from the endpoint lookup.
             rpc::Switch::try_from(s).map(|mut rpc_switch| {
-                rpc_switch.bmc_info = endpoint_info.map(|row| rpc::BmcInfo {
-                    ip: Some(row.bmc_ip.to_string()),
-                    mac: Some(row.bmc_mac.to_string()),
-                    version: None,
-                    firmware_version: None,
-                    port: None,
-                    machine_interface_id: None,
-                });
                 rpc_switch.nvos_info = endpoint_info.and_then(|row| {
                     let (Some(nvos_mac), Some(nvos_ip)) =
                         (row.nvos_mac.as_ref(), row.nvos_ip.as_ref())

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -1974,6 +1974,23 @@ pub async fn new_switch(
         .await
         .map_err(|e| eyre::eyre!("Failed to create switch: {:?}", e))?;
 
+    // Mirror site-explorer ingestion (switch_creator): link the switch's BMC
+    // machine_interface back to the switch and annotate it `Bmc`, so that
+    // `bmc_info` resolves via the interface link.
+    let bmc_interfaces =
+        db::machine_interface::find_by_mac_address(&mut *txn, expected_switch.bmc_mac_address)
+            .await
+            .map_err(|e| eyre::eyre!("Failed to find BMC machine interface: {:?}", e))?;
+    if let Some(interface) = bmc_interfaces.first() {
+        db::machine_interface::associate_bmc_interface(
+            &interface.id,
+            model::machine_interface_address::MachineInterfaceAssociation::Switch(switch_id),
+            &mut txn,
+        )
+        .await
+        .map_err(|e| eyre::eyre!("Failed to link BMC machine interface: {:?}", e))?;
+    }
+
     txn.commit().await.unwrap();
 
     Ok(switch_id)

--- a/crates/api-db/migrations/20260630120000_link_bmc_switch_power_shelf_interfaces.sql
+++ b/crates/api-db/migrations/20260630120000_link_bmc_switch_power_shelf_interfaces.sql
@@ -1,0 +1,37 @@
+-- Persist the Switch/PowerShelf <-> BMC interface link on machine_interfaces,
+-- extending the Machine <-> BMC work from #1610 to switches (#1722) and power
+-- shelves (#1723). New hardware gets this link during ingestion; this migration
+-- backfills the link for hardware already in the database.
+
+-- Power shelves: the PMC interface is already associated with the shelf
+-- (create_power_shelf set power_shelf_id), so this is a pure annotation -- mark
+-- it `Bmc` and demote it from primary, matching how machine BMCs are stored.
+UPDATE machine_interfaces
+SET interface_type = 'Bmc',
+    primary_interface = FALSE
+WHERE power_shelf_id IS NOT NULL
+  AND interface_type = 'Data';
+
+-- Switches: the BMC interface was never linked to the switch (only NVOS data
+-- interfaces were), so match on the switch's stored BMC MAC. Matching on
+-- bmc_mac_address -- rather than switch_id -- is what keeps us from relabeling
+-- the already-linked NVOS data interfaces as `Bmc`.
+UPDATE machine_interfaces mi
+SET switch_id = s.id,
+    association_type = 'Switch',
+    interface_type = 'Bmc',
+    primary_interface = FALSE
+FROM switches s
+WHERE mi.mac_address = s.bmc_mac_address
+  AND mi.power_shelf_id IS NULL
+  AND (mi.switch_id IS NULL OR mi.switch_id = s.id);
+
+-- Indexes backing find_bmc_info_by_{switch,power_shelf}_ids, mirroring the
+-- machine_interfaces_bmc_machine_id_idx added in #1610.
+CREATE INDEX IF NOT EXISTS machine_interfaces_bmc_switch_id_idx
+ON machine_interfaces(switch_id)
+WHERE interface_type = 'Bmc';
+
+CREATE INDEX IF NOT EXISTS machine_interfaces_bmc_power_shelf_id_idx
+ON machine_interfaces(power_shelf_id)
+WHERE interface_type = 'Bmc';

--- a/crates/api-db/src/bmc_metadata.rs
+++ b/crates/api-db/src/bmc_metadata.rs
@@ -88,8 +88,12 @@ pub async fn update_bmc_network_into_machine_interfaces(
         )));
     }
 
-    crate::machine_interface::associate_bmc_interface_with_machine(&interface.id, machine_id, txn)
-        .await?;
+    crate::machine_interface::associate_bmc_interface(
+        &interface.id,
+        model::machine_interface_address::MachineInterfaceAssociation::Machine(*machine_id),
+        txn,
+    )
+    .await?;
     bmc_info.machine_interface_id = Some(interface.id);
 
     update_bmc_network_into_topologies(txn, machine_id, bmc_info).await

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -261,20 +261,46 @@ pub async fn associate_interface_with_dpu_machine(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-pub async fn associate_bmc_interface_with_machine(
+/// Link an interface as the BMC of its owning entity in one statement:
+/// associate it with the machine / switch / power shelf (per `association`),
+/// annotate it as `Bmc`, and demote it from primary (a BMC is a management
+/// interface, never the primary data interface).
+///
+/// Mirrors [`associate_interface_with_machine`] but additionally forces
+/// `interface_type='Bmc'` and `primary_interface=false`.
+pub async fn associate_bmc_interface(
     interface_id: &MachineInterfaceId,
-    machine_id: &MachineId,
+    association: MachineInterfaceAssociation,
     txn: &mut PgConnection,
 ) -> DatabaseResult<MachineInterfaceId> {
-    let query = "UPDATE machine_interfaces
-        SET machine_id=$1,
-            association_type='Machine'::association_type,
-            interface_type='Bmc'::interface_type,
-            primary_interface=false
-        WHERE id=$2::uuid
-        RETURNING id";
+    let (query, association_type, id_value) = match association {
+        MachineInterfaceAssociation::Machine(id) => (
+            "UPDATE machine_interfaces SET machine_id=$1, association_type=$2::association_type, \
+             interface_type='Bmc'::interface_type, primary_interface=false \
+             WHERE id=$3::uuid RETURNING id",
+            "Machine",
+            id.to_string(),
+        ),
+        MachineInterfaceAssociation::Switch(id) => (
+            "UPDATE machine_interfaces SET switch_id=$1, association_type=$2::association_type, \
+             interface_type='Bmc'::interface_type, primary_interface=false \
+             WHERE id=$3::uuid RETURNING id",
+            "Switch",
+            id.to_string(),
+        ),
+        MachineInterfaceAssociation::PowerShelf(id) => (
+            "UPDATE machine_interfaces SET power_shelf_id=$1, association_type=$2::association_type, \
+             interface_type='Bmc'::interface_type, primary_interface=false \
+             WHERE id=$3::uuid RETURNING id",
+            "PowerShelf",
+            id.to_string(),
+        ),
+    };
+    // `primary_interface` is always forced to false here, so the one-primary
+    // constraint cannot fire -- only the single-association one is relevant.
     sqlx::query_as(query)
-        .bind(machine_id)
+        .bind(id_value)
+        .bind(association_type)
         .bind(*interface_id)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -123,6 +123,7 @@ pub async fn create(
         status: None,
         deleted: None,
         bmc_mac_address: new_power_shelf.bmc_mac_address,
+        bmc_info: None,
         controller_state: Versioned {
             value: state,
             version: controller_state_version,
@@ -234,11 +235,41 @@ pub async fn find_ids(
         .map_err(|e| DatabaseError::new("power_shelf::find_ids", e))
 }
 
+/// Base relation for loading power shelves. Wraps the `power_shelves` table in a
+/// derived table (aliased `power_shelves`) that adds a `bmc_info` JSON column
+/// resolved from the `Bmc` machine_interface linked back to the shelf --
+/// mirroring how the machine snapshot query materializes `bmc_info` (see
+/// `sql/machine_snapshots.sql.template`). Keeping the alias `power_shelves` lets
+/// the generic `FilterableQueryBuilder` filters reference unqualified columns.
+const POWER_SHELVES_WITH_BMC_INFO: &str = r#"SELECT * FROM (
+    SELECT ps.*, bmc.json AS bmc_info
+    FROM power_shelves ps
+    LEFT JOIN LATERAL (
+        SELECT jsonb_strip_nulls(jsonb_build_object(
+            'machine_interface_id', bmc_i.id,
+            'ip', host(bmc_addr.address),
+            'mac', bmc_i.mac_address::text
+        )) AS json
+        FROM machine_interfaces bmc_i
+        LEFT JOIN LATERAL (
+            SELECT a.address
+            FROM machine_interface_addresses a
+            WHERE a.interface_id = bmc_i.id
+            ORDER BY family(a.address), a.address
+            LIMIT 1
+        ) AS bmc_addr ON true
+        WHERE bmc_i.power_shelf_id = ps.id
+          AND bmc_i.interface_type = 'Bmc'
+        ORDER BY bmc_i.created ASC
+        LIMIT 1
+    ) AS bmc ON true
+) AS power_shelves"#;
+
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = PowerShelf>>(
     txn: &mut PgConnection,
     filter: ObjectColumnFilter<'a, C>,
 ) -> DatabaseResult<Vec<PowerShelf>> {
-    let mut query = FilterableQueryBuilder::new("SELECT * FROM power_shelves").filter(&filter);
+    let mut query = FilterableQueryBuilder::new(POWER_SHELVES_WITH_BMC_INFO).filter(&filter);
 
     query
         .build_query_as()
@@ -463,31 +494,6 @@ pub async fn update_metadata(
     }
 }
 
-/// Resolve PowerShelfIds to BMC MAC + IP via machine_interfaces.
-pub async fn find_bmc_info_by_power_shelf_ids(
-    db: impl crate::db_read::DbReader<'_>,
-    power_shelf_ids: &[PowerShelfId],
-) -> DatabaseResult<Vec<PowerShelfEndpointRow>> {
-    let sql = r#"
-        SELECT DISTINCT ON (mi.power_shelf_id)
-            mi.power_shelf_id  AS power_shelf_id,
-            mi.mac_address     AS pmc_mac,
-            mia.address        AS pmc_ip
-        FROM machine_interfaces mi
-        JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
-        JOIN network_segments ns ON ns.id = mi.segment_id
-        WHERE mi.power_shelf_id = ANY($1)
-          AND ns.network_segment_type = 'underlay'
-        ORDER BY mi.power_shelf_id
-    "#;
-
-    sqlx::query_as(sql)
-        .bind(power_shelf_ids)
-        .fetch_all(db)
-        .await
-        .map_err(|err| DatabaseError::new("power_shelf::find_bmc_info_by_power_shelf_ids", err))
-}
-
 /// A power shelf resolved by its BMC MAC address, along with the rack it
 /// belongs to. Used by the Component Manager state controller wrapper to
 /// build a rack-level `MaintenanceScope` for the power shelves it's been
@@ -618,6 +624,99 @@ mod tests {
             rack_id: None,
         };
         create(txn, &new_power_shelf).await
+    }
+
+    /// The power-shelf load query must surface `bmc_info` (PMC MAC + IP +
+    /// machine-interface id) resolved from the BMC machine_interface linked
+    /// back to the shelf (`power_shelf_id` + `interface_type = 'Bmc'`),
+    /// regardless of which network segment the interface lives on. A shelf with
+    /// only a non-BMC interface must load with `bmc_info == None`.
+    #[crate::sqlx_test]
+    async fn test_find_by_populates_bmc_info(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use carbide_uuid::machine::MachineInterfaceId;
+        use carbide_uuid::network::NetworkSegmentId;
+        use model::allocation_type::AllocationType;
+
+        let mut txn = pool.begin().await?;
+
+        let shelf = create_test_power_shelf(&mut txn, 10, "BMC info shelf").await?;
+        let other = create_test_power_shelf(&mut txn, 11, "Data-only shelf").await?;
+
+        // A non-underlay segment on purpose: resolution must not depend on the
+        // segment type, only on the BMC link back to the shelf.
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version, network_segment_type)
+             VALUES ($1, 'V1-T0', 'tenant') RETURNING id",
+        )
+        .bind("power-shelf-bmc-info")
+        .fetch_one(txn.as_mut())
+        .await?;
+
+        let pmc_mac = "02:00:00:00:0a:01";
+        let pmc_ip: IpAddr = "10.20.30.40".parse()?;
+        let bmc_interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (power_shelf_id, association_type, segment_id, mac_address,
+                  primary_interface, hostname, interface_type)
+             VALUES ($1, 'PowerShelf', $2, $3::macaddr, false, 'pmc', 'Bmc')
+             RETURNING id",
+        )
+        .bind(shelf.id)
+        .bind(segment_id)
+        .bind(pmc_mac)
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            bmc_interface_id,
+            pmc_ip,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        // A 'Data' interface linked to a different shelf must be ignored.
+        let data_interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (power_shelf_id, association_type, segment_id, mac_address,
+                  primary_interface, hostname, interface_type)
+             VALUES ($1, 'PowerShelf', $2, $3::macaddr, false, 'data', 'Data')
+             RETURNING id",
+        )
+        .bind(other.id)
+        .bind(segment_id)
+        .bind("02:00:00:00:0a:02")
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            data_interface_id,
+            "10.20.30.41".parse::<IpAddr>()?,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        let loaded = find_by_id(&mut txn, &shelf.id)
+            .await?
+            .expect("power shelf should exist");
+        let bmc_info = loaded
+            .bmc_info
+            .expect("shelf load should populate bmc_info from the BMC interface");
+        assert_eq!(bmc_info.machine_interface_id, Some(bmc_interface_id));
+        assert_eq!(bmc_info.mac, Some(pmc_mac.parse()?));
+        assert_eq!(bmc_info.ip, Some(pmc_ip));
+
+        // The shelf whose only interface is `Data` must load without bmc_info.
+        let other_loaded = find_by_id(&mut txn, &other.id)
+            .await?
+            .expect("power shelf should exist");
+        assert!(
+            other_loaded.bmc_info.is_none(),
+            "a shelf with only a non-BMC interface must not surface bmc_info"
+        );
+
+        Ok(())
     }
 
     #[crate::sqlx_test]

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -124,6 +124,7 @@ pub async fn create(txn: &mut PgConnection, new_switch: &NewSwitch) -> DatabaseR
         status: None,
         deleted: None,
         bmc_mac_address: new_switch.bmc_mac_address,
+        bmc_info: None,
         controller_state: Versioned {
             value: state,
             version: controller_state_version,
@@ -285,11 +286,41 @@ where
         })
 }
 
+/// Base relation for loading switches. Wraps the `switches` table in a derived
+/// table (aliased `switches`) that adds a `bmc_info` JSON column resolved from
+/// the `Bmc` machine_interface linked back to the switch -- mirroring how the
+/// machine snapshot query materializes `bmc_info` (see
+/// `sql/machine_snapshots.sql.template`). Keeping the alias `switches` lets the
+/// generic `FilterableQueryBuilder` filters reference unqualified columns.
+const SWITCHES_WITH_BMC_INFO: &str = r#"SELECT * FROM (
+    SELECT s.*, bmc.json AS bmc_info
+    FROM switches s
+    LEFT JOIN LATERAL (
+        SELECT jsonb_strip_nulls(jsonb_build_object(
+            'machine_interface_id', bmc_i.id,
+            'ip', host(bmc_addr.address),
+            'mac', bmc_i.mac_address::text
+        )) AS json
+        FROM machine_interfaces bmc_i
+        LEFT JOIN LATERAL (
+            SELECT a.address
+            FROM machine_interface_addresses a
+            WHERE a.interface_id = bmc_i.id
+            ORDER BY family(a.address), a.address
+            LIMIT 1
+        ) AS bmc_addr ON true
+        WHERE bmc_i.switch_id = s.id
+          AND bmc_i.interface_type = 'Bmc'
+        ORDER BY bmc_i.created ASC
+        LIMIT 1
+    ) AS bmc ON true
+) AS switches"#;
+
 pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Switch>>(
     txn: &mut PgConnection,
     filter: ObjectColumnFilter<'a, C>,
 ) -> DatabaseResult<Vec<Switch>> {
-    let mut query = FilterableQueryBuilder::new("SELECT * FROM switches").filter(&filter);
+    let mut query = FilterableQueryBuilder::new(SWITCHES_WITH_BMC_INFO).filter(&filter);
 
     query
         .build_query_as()
@@ -795,4 +826,121 @@ pub async fn remove_health_report(
     source: &str,
 ) -> Result<(), DatabaseError> {
     crate::health_report::remove_health_report(txn, "switches", switch_id, mode, source).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use carbide_uuid::machine::MachineInterfaceId;
+    use carbide_uuid::network::NetworkSegmentId;
+    use model::allocation_type::AllocationType;
+    use model::switch::{NewSwitch, SwitchConfig};
+
+    use super::*;
+
+    /// The switch load query must surface `bmc_info` (MAC + IP +
+    /// machine-interface id) resolved from the BMC machine_interface linked
+    /// back to the switch (`switch_id` + `interface_type = 'Bmc'`), regardless
+    /// of network segment. A non-BMC interface on the same switch must be
+    /// ignored.
+    #[crate::sqlx_test]
+    async fn test_find_by_populates_bmc_info(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+
+        let switch_id =
+            SwitchId::from_str("sw100nsner0op5osl6n85t7772j010jmhafm934n7oej4mlome3okrn9b60")?;
+        // `switches.bmc_mac_address` is an FK into `expected_switches`, so seed
+        // the expected switch before creating the switch.
+        sqlx::query(
+            "INSERT INTO expected_switches (serial_number, bmc_mac_address, bmc_username, bmc_password)
+             VALUES ('SW-SN-BMC', '02:00:00:00:0b:01'::macaddr, 'admin', 'pw')",
+        )
+        .execute(txn.as_mut())
+        .await?;
+        create(
+            &mut txn,
+            &NewSwitch {
+                id: switch_id,
+                config: SwitchConfig {
+                    name: "BMC info switch".to_string(),
+                    enable_nmxc: false,
+                    fabric_manager_config: None,
+                },
+                bmc_mac_address: Some("02:00:00:00:0b:01".parse()?),
+                metadata: None,
+                rack_id: None,
+                slot_number: None,
+                tray_index: None,
+            },
+        )
+        .await?;
+
+        // A non-underlay segment on purpose: resolution must not depend on the
+        // segment type, only on the BMC link back to the switch.
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version, network_segment_type)
+             VALUES ($1, 'V1-T0', 'tenant') RETURNING id",
+        )
+        .bind("switch-bmc-info")
+        .fetch_one(txn.as_mut())
+        .await?;
+
+        let bmc_mac = "02:00:00:00:0b:01";
+        let bmc_ip: IpAddr = "10.30.40.50".parse()?;
+        let bmc_interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (switch_id, association_type, segment_id, mac_address,
+                  primary_interface, hostname, interface_type)
+             VALUES ($1, 'Switch', $2, $3::macaddr, false, 'bmc', 'Bmc')
+             RETURNING id",
+        )
+        .bind(switch_id)
+        .bind(segment_id)
+        .bind(bmc_mac)
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            bmc_interface_id,
+            bmc_ip,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        // An NVOS 'Data' interface on the same switch must be ignored.
+        let data_interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (switch_id, association_type, segment_id, mac_address,
+                  primary_interface, hostname, interface_type)
+             VALUES ($1, 'Switch', $2, $3::macaddr, false, 'nvos', 'Data')
+             RETURNING id",
+        )
+        .bind(switch_id)
+        .bind(segment_id)
+        .bind("02:00:00:00:0b:02")
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            data_interface_id,
+            "10.30.40.51".parse::<IpAddr>()?,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        let switch = find_by_id(&mut txn, &switch_id)
+            .await?
+            .expect("switch should exist");
+        let bmc_info = switch
+            .bmc_info
+            .expect("switch load should populate bmc_info from the BMC interface");
+        assert_eq!(bmc_info.machine_interface_id, Some(bmc_interface_id));
+        assert_eq!(bmc_info.mac, Some(bmc_mac.parse()?));
+        assert_eq!(bmc_info.ip, Some(bmc_ip));
+
+        Ok(())
+    }
 }

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -27,6 +27,7 @@ use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
 use crate::StateSla;
+use crate::bmc_info::BmcInfo;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
@@ -73,6 +74,13 @@ pub struct PowerShelf {
 
     pub bmc_mac_address: Option<MacAddress>,
 
+    /// BMC/PMC endpoint (MAC/IP + machine-interface id) resolved from the `Bmc`
+    /// machine_interface linked back to this power shelf. Populated by the
+    /// standard power-shelf load query, so every consumer (handlers, state
+    /// machines) gets it without re-resolving. `None` when no BMC interface is
+    /// linked yet.
+    pub bmc_info: Option<BmcInfo>,
+
     /// The rack that this power shelf is associated with.
     pub rack_id: Option<RackId>,
 
@@ -108,12 +116,18 @@ impl<'r> FromRow<'r, PgRow> for PowerShelf {
             description: row.try_get("description")?,
             labels: labels.0,
         };
+        let bmc_info = row
+            .try_get::<Option<sqlx::types::Json<BmcInfo>>, _>("bmc_info")
+            .ok()
+            .flatten()
+            .map(|j| j.0);
         Ok(PowerShelf {
             id: row.try_get("id")?,
             config: config.0,
             status: status.map(|s| s.0),
             deleted: row.try_get("deleted")?,
             bmc_mac_address: row.try_get("bmc_mac_address").ok().flatten(),
+            bmc_info,
             controller_state: Versioned {
                 value: controller_state.0,
                 version: row.try_get("controller_state_version")?,

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -27,6 +27,7 @@ use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
 use crate::StateSla;
+use crate::bmc_info::BmcInfo;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
@@ -162,6 +163,12 @@ pub struct Switch {
 
     pub bmc_mac_address: Option<MacAddress>,
 
+    /// BMC endpoint (MAC/IP + machine-interface id) resolved from the `Bmc`
+    /// machine_interface linked back to this switch. Populated by the standard
+    /// switch load query, so every consumer (handlers, state machines) gets it
+    /// without re-resolving. `None` when no BMC interface is linked yet.
+    pub bmc_info: Option<BmcInfo>,
+
     pub controller_state: Versioned<SwitchControllerState>,
 
     /// The result of the last attempt to change state
@@ -224,12 +231,18 @@ impl<'r> FromRow<'r, PgRow> for Switch {
             description: row.try_get("description")?,
             labels: labels.0,
         };
+        let bmc_info = row
+            .try_get::<Option<sqlx::types::Json<BmcInfo>>, _>("bmc_info")
+            .ok()
+            .flatten()
+            .map(|j| j.0);
         Ok(Switch {
             id: row.try_get("id")?,
             config: config.0,
             status: status.map(|s| s.0),
             deleted: row.try_get("deleted")?,
             bmc_mac_address: row.try_get("bmc_mac_address").ok().flatten(),
+            bmc_info,
             controller_state: Versioned {
                 value: controller_state.0,
                 version: row.try_get("controller_state_version")?,

--- a/crates/api-web/templates/power_shelf_detail.html
+++ b/crates/api-web/templates/power_shelf_detail.html
@@ -53,6 +53,12 @@
 <h2>BMC</h2>
 <table class="detailsview">
 	{% if let Some(bmc_info) = bmc_info %}
+	{% if let Some(machine_interface_id) = bmc_info.machine_interface_id %}
+	<tr>
+		<th>Machine Interface ID</th>
+		<td>{{ machine_interface_id }}</td>
+	</tr>
+	{% endif %}
 	{% if let Some(ip) = bmc_info.ip %}
 	<tr>
 		<th>BMC IP</th>

--- a/crates/api-web/templates/switch_detail.html
+++ b/crates/api-web/templates/switch_detail.html
@@ -71,6 +71,12 @@
 <h2>BMC</h2>
 <table class="detailsview">
 	{% if let Some(bmc_info) = bmc_info %}
+	{% if let Some(machine_interface_id) = bmc_info.machine_interface_id %}
+	<tr>
+		<th>Machine Interface ID</th>
+		<td>{{ machine_interface_id }}</td>
+	</tr>
+	{% endif %}
 	{% if let Some(ip) = bmc_info.ip %}
 	<tr>
 		<th>BMC IP</th>

--- a/crates/power-shelf-controller/src/maintenance.rs
+++ b/crates/power-shelf-controller/src/maintenance.rs
@@ -28,7 +28,6 @@ use db::power_shelf as db_power_shelf;
 use mac_address::MacAddress;
 use model::component_manager::PowerAction;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
-use sqlx::PgPool;
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -127,7 +126,6 @@ async fn invoke_power_operation(
     let endpoint = match build_power_shelf_endpoint(
         power_shelf_id,
         state,
-        &ctx.services.db_pool,
         ctx.services.credential_manager.as_ref(),
     )
     .await
@@ -213,12 +211,12 @@ async fn invoke_power_operation(
 }
 
 /// Build the `PowerShelfEndpoint` describing this power shelf for component
-/// manager power operations. Resolves the BMC IP from the database and BMC
-/// credentials via the credential manager.
+/// manager power operations. The BMC MAC/IP come from the `bmc_info` carried on
+/// the loaded `PowerShelf` model (resolved by the power-shelf load query); BMC
+/// credentials are resolved via the credential manager.
 pub(super) async fn build_power_shelf_endpoint(
     power_shelf_id: &PowerShelfId,
     state: &PowerShelf,
-    db_pool: &PgPool,
     credential_manager: &dyn CredentialManager,
 ) -> Result<PowerShelfEndpoint, String> {
     let bmc_mac = state.bmc_mac_address.ok_or_else(|| {
@@ -228,38 +226,24 @@ pub(super) async fn build_power_shelf_endpoint(
         )
     })?;
 
-    let bmc_ip = lookup_power_shelf_bmc_ip(db_pool, power_shelf_id, bmc_mac).await?;
-    let credentials = lookup_bmc_credentials(credential_manager, bmc_mac).await?;
-
-    Ok(PowerShelfEndpoint {
-        pmc_ip: bmc_ip
-            .parse()
-            .map_err(|error| format!("invalid BMC IP {bmc_ip}: {error}"))?,
-        pmc_mac: bmc_mac,
-        pmc_vendor: PowerShelfVendor::DEFAULT,
-        pmc_credentials: credentials,
-    })
-}
-
-/// Fetch the power shelf's BMC IP via the underlay machine_interfaces path.
-async fn lookup_power_shelf_bmc_ip(
-    db_pool: &PgPool,
-    power_shelf_id: &PowerShelfId,
-    bmc_mac: MacAddress,
-) -> Result<String, String> {
-    let rows = db_power_shelf::find_bmc_info_by_power_shelf_ids(db_pool, &[*power_shelf_id])
-        .await
-        .map_err(|error| format!("failed to look up BMC info: {}", error))?;
-
-    rows.into_iter()
-        .find(|row| row.power_shelf_id == *power_shelf_id)
-        .map(|row| row.pmc_ip.to_string())
+    let pmc_ip = state
+        .bmc_info
+        .as_ref()
+        .and_then(|info| info.ip)
         .ok_or_else(|| {
             format!(
                 "no BMC IP found for power shelf {} (bmc_mac {})",
                 power_shelf_id, bmc_mac
             )
-        })
+        })?;
+    let credentials = lookup_bmc_credentials(credential_manager, bmc_mac).await?;
+
+    Ok(PowerShelfEndpoint {
+        pmc_ip,
+        pmc_mac: bmc_mac,
+        pmc_vendor: PowerShelfVendor::DEFAULT,
+        pmc_credentials: credentials,
+    })
 }
 
 /// Resolve BMC root credentials for the given MAC, falling back to the

--- a/crates/power-shelf-controller/src/ready.rs
+++ b/crates/power-shelf-controller/src/ready.rs
@@ -99,7 +99,6 @@ async fn poll_power_state(
     let endpoint = match build_power_shelf_endpoint(
         power_shelf_id,
         state,
-        &ctx.services.db_pool,
         ctx.services.credential_manager.as_ref(),
     )
     .await

--- a/crates/rpc/src/model/power_shelf.rs
+++ b/crates/rpc/src/model/power_shelf.rs
@@ -134,7 +134,7 @@ impl TryFrom<PowerShelf> for rpc::PowerShelf {
             controller_state,
             metadata: Some(src.metadata.into()),
             version: src.version.version_string(),
-            bmc_info: None,
+            bmc_info: src.bmc_info.map(Into::into),
             state_version,
             rack_id: src.rack_id,
         })

--- a/crates/rpc/src/model/switch.rs
+++ b/crates/rpc/src/model/switch.rs
@@ -186,7 +186,7 @@ impl TryFrom<Switch> for rpc::Switch {
             status,
             deleted,
             controller_state,
-            bmc_info: None,
+            bmc_info: src.bmc_info.map(Into::into),
             nvos_info: None,
             state_version,
             metadata: Some(src.metadata.into()),
@@ -236,6 +236,7 @@ mod tests {
             }),
             deleted: None,
             bmc_mac_address: None,
+            bmc_info: None,
             controller_state: Versioned::new(
                 SwitchControllerState::Ready,
                 config_version::ConfigVersion::initial(),
@@ -298,6 +299,7 @@ mod tests {
             status: None,
             deleted: None,
             bmc_mac_address: None,
+            bmc_info: None,
             controller_state: Versioned::new(
                 SwitchControllerState::Created,
                 config_version::ConfigVersion::initial(),

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -85,7 +85,6 @@ pub use managed_host::is_endpoint_in_managed_host;
 use model::DpuModel;
 use model::expected_machine::DpuMode;
 use model::firmware::FirmwareComponentType;
-use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
 mod switch_creator;
 use carbide_uuid::rack::RackId;
@@ -1102,9 +1101,16 @@ impl SiteExplorer {
             db::machine_interface::find_by_mac_address(&mut *txn, expected_shelf.bmc_mac_address)
                 .await?;
         if let Some(interface) = mi.first() {
-            db::machine_interface::associate_interface_with_machine(
+            // A power shelf's BMC/PMC interface is its management endpoint, so
+            // associate it with the shelf and annotate it as `Bmc` (like
+            // host/switch BMC interfaces), demoting it from primary in one
+            // statement. This `Bmc` link is what lets the power-shelf load query
+            // resolve the shelf's MAC/IP into the `PowerShelf.bmc_info` field.
+            db::machine_interface::associate_bmc_interface(
                 &interface.id,
-                MachineInterfaceAssociation::PowerShelf(power_shelf_id),
+                model::machine_interface_address::MachineInterfaceAssociation::PowerShelf(
+                    power_shelf_id,
+                ),
                 &mut txn,
             )
             .await?;

--- a/crates/site-explorer/src/switch_creator.rs
+++ b/crates/site-explorer/src/switch_creator.rs
@@ -196,6 +196,22 @@ impl SwitchCreator {
 
         _ = db::switch::create(txn, &new_switch).await?;
 
+        // Link the switch's BMC machine_interface back to the switch and mark it
+        // as a `Bmc` interface (mirroring host BMC linking from #1610 and the
+        // power shelf PMC linking). This is what lets the API resolve the
+        // switch's `bmc_info` (MAC/IP + interface id) via the interface link.
+        let bmc_interfaces =
+            db::machine_interface::find_by_mac_address(&mut *txn, expected_switch.bmc_mac_address)
+                .await?;
+        if let Some(interface) = bmc_interfaces.first() {
+            db::machine_interface::associate_bmc_interface(
+                &interface.id,
+                model::machine_interface_address::MachineInterfaceAssociation::Switch(switch_id),
+                &mut *txn,
+            )
+            .await?;
+        }
+
         if let Some(ref rack_id) = expected_switch.rack_id {
             let _ = crate::ensure_rack_exists(&mut *txn, rack_id).await?;
         }


### PR DESCRIPTION
<!-- Describe what this PR does -->

feat(api): link switches and power shelves to their BMC via machine_interfaces


## Related issues
https://github.com/NVIDIA/infra-controller/issues/1632
https://github.com/NVIDIA/infra-controller/issues/1722
https://github.com/NVIDIA/infra-controller/issues/1723

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

