### PR TITLE
fix: Bump nico-nsm base image to alpine 3.24 to resolve container CVEs

### DIFF
--- a/rest-api/docker/local/Dockerfile.nico-nsm
+++ b/rest-api/docker/local/Dockerfile.nico-nsm
@@ -37,7 +37,7 @@ RUN go build -ldflags "-extldflags '-static'" \
     .
 
 # Runtime stage — NSM requires shell tools for firmware update scripts
-FROM alpine:3.19 AS final
+FROM alpine:3.24 AS final
 
 RUN apk add --no-cache \
     libc6-compat \

--- a/rest-api/docker/production/Dockerfile.nico-nsm
+++ b/rest-api/docker/production/Dockerfile.nico-nsm
@@ -38,7 +38,7 @@ RUN go build -ldflags "-extldflags '-static'" \
     .
 
 # Runtime stage — NSM requires shell tools for firmware update scripts
-FROM alpine:3.19 AS final
+FROM alpine:3.24 AS final
 
 RUN apk add --no-cache \
     libc6-compat \


### PR DESCRIPTION
This container is not using distroless image because it needs a shell environment, it causes many critical findings in Grype, so we should at least update the container image base to resolve these.