### PR TITLE
fix(helm): move vpc-vni pool out of FNN section to fix duplicate-key …

### DIFF
--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -147,7 +147,11 @@ nico-api:
 
       [pools.vpc-vni]
       type = "integer"
-      ranges = []                                # REQUIRED: your VPC VNI range, e.g. [{ start = "0", end = "100" }]
+      # REQUIRED: your VPC VNI range. FNN sites: use the range allocated by your network team —
+      # must match the config on your FNN gateways and must NOT be expanded without coordinating
+      # with your network team. The range must also NOT include the fixed admin_vpc vpc_vni
+      # value set in [fnn.admin_vpc] below. Example for non-FNN: [{ start = "0", end = "100" }]
+      ranges = []
 
       # -----------------------------------------------------------------------
       # Networks — named L3 segments visible to nico-api.
@@ -297,14 +301,9 @@ nico-api:
         { start = "10.255.247.3", end = "10.255.247.255" },  # Default pool added from VpcVrfLoopbackPrefix 10.255.247.0/24
       ]
 
-      [pools.vpc-vni]
-      type = "integer"
-      # Change 61326 and 61424 to the actual VNI values. Range should be sufficient to cover all VPCs that will be needed at the site.
-      ranges = [{ start = "61326", end = "61424" }]
-
-      #
-      # This pool MUST NOT be expanded without coordination with GNI.
-      # The range used here must have matching config on our FNN GWs.
+      # NOTE: [pools.vpc-vni] is defined in the required pools section above — set it there.
+      # It MUST NOT be expanded without coordinating with your network team and must match
+      # config on your FNN gateways.
       #
       [pools.external-vpc-vni]
       type = "integer"


### PR DESCRIPTION
`[pools.vpc-vni]` appeared twice in the rendered TOML site config — once in the basic required pools section and again inside the FNN block — causing nico-api to crash on startup with:

```
duplicate key 'vpc-vni' in table 'pools'
```

`vpc-vni` is a mandatory pool for all sites (not FNN-specific). The fix keeps the definition in the basic required-pools section and removes the duplicate from the FNN block. The basic-section comment is updated to carry the FNN-specific guidance that was previously only in the deleted block: GNI coordination requirement, FNN GW matching constraint, and the `admin_vpc.vpc_vni` exclusion note.

Fixes: nvbug 6391901

## Related issues

- nvbug 6391901

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed — deployed end-to-end on dev6, nico-api reached `Running` state

## Additional Notes
Root cause: the FNN section was added with its own `[pools.vpc-vni]` block containing example ranges for FNN sites. Any site that had both the basic placeholder and the FNN block in their TOML would hit the duplicate key error. The FNN block's definition is the one removed since `vpc-vni` is not FNN-exclusive — `api-db/src/resource_pool.rs` places it in `pool_names` (mandatory), not `optional_pool_names`.
