### PR TITLE
fix(rest-api): Use local binaries for CI protobuf generation

### DIFF
--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -284,6 +284,26 @@ core-proto-fmt:
 	cd workflow-schema/cmd/core-proto-fmt && go run main.go
 
 core-protogen:
+	if ! command -v buf >/dev/null 2>&1; then \
+		echo "buf is not installed. Please install buf: https://buf.build/docs/installation"; \
+		exit 1; \
+	fi
+	if ! command -v protoc-gen-go >/dev/null 2>&1; then \
+		echo "protoc-gen-go is not installed. Please install it: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11"; \
+		exit 1; \
+	fi
+	if ! protoc-gen-go --version | grep -q "1.36.11"; then \
+		echo "protoc-gen-go is not version 1.36.11. Please install it: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11"; \
+		exit 1; \
+	fi
+	if ! command -v protoc-gen-go-grpc >/dev/null 2>&1; then \
+		echo "protoc-gen-go-grpc is not installed. Please install it: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1"; \
+		exit 1; \
+	fi
+	if ! protoc-gen-go-grpc --version | grep -q "1.6.1"; then \
+		echo "protoc-gen-go-grpc is not version 1.6.1. Please install it: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1"; \
+		exit 1; \
+	fi
 	echo "Generating protobuf for Core"
 	cd workflow-schema && buf generate
 	go fmt ./...

--- a/rest-api/workflow-schema/buf.gen.yaml
+++ b/rest-api/workflow-schema/buf.gen.yaml
@@ -3,10 +3,10 @@
 
 version: v2
 plugins:
-  - remote: buf.build/protocolbuffers/go:v1.36.11
+  - local: protoc-gen-go
     out: schema/site-agent/workflows/v1
     opt: paths=source_relative
-  - remote: buf.build/grpc/go:v1.6.1
+  - local: protoc-gen-go-grpc
     out: schema/site-agent/workflows/v1
     opt:
       - paths=source_relative


### PR DESCRIPTION
Remote library reference for protobuf CI job is getting rate limited. Switching to local binaries.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Manual testing performed
