### PR TITLE
fix(bmc-explorer): skip BF4 boot options with null Members

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "mac_address",
  "nv-redfish",
  "regex",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -74,6 +74,7 @@ bmc-mock = { path = "../bmc-mock" }
 # Self dev-dependency so the crate's own integration tests get the test-support
 # helpers; applies only to test/bench targets, never the production library.
 bmc-explorer = { path = ".", features = ["test-support"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -131,6 +131,12 @@ impl<B: Bmc> ExploredChassisCollection<B> {
             })
     }
 
+    pub fn is_bluefield4(&self) -> bool {
+        self.members
+            .iter()
+            .any(|c| c.chassis.hardware_id().model == Some(Model::new("B4240")))
+    }
+
     pub fn dpu_card1_serial_number(&self) -> Result<Option<&str>, Error<B>> {
         let maybe_sn = self
             .members

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -56,6 +56,8 @@ pub struct Config<'a, B: Bmc> {
     // This is expected to be fixed in BMC firmware 24.10-39, which adds
     // internal retries.
     pub retry_404_on_eth_interfaces: bool,
+    // Collect boot options (if set to false then assume that they are empty).
+    pub need_boot_options: bool,
     pub explore: &'a ExploreConfig<'a, B>,
 }
 
@@ -73,10 +75,11 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         system: ComputerSystem<B>,
         config: &Config<'_, B>,
     ) -> Result<Self, Error<B>> {
-        let boot_options = if let Some(collection) = system
-            .boot_options()
-            .await
-            .map_err(Error::nv_redfish("boot options"))?
+        let boot_options = if config.need_boot_options
+            && let Some(collection) = system
+                .boot_options()
+                .await
+                .map_err(Error::nv_redfish("boot options"))?
         {
             collection
                 .members()

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -136,6 +136,9 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
         need_oem_nvidia_bluefield: is_bluefield_system,
         ignore_500_on_bios_fetch: is_bluefield_system,
         retry_404_on_eth_interfaces: is_bluefield_system,
+        // BlueField-4 returns null in the Members field in
+        // BootOptions. This is a workaround for this bug.
+        need_boot_options: !explored_chassis.is_bluefield4(),
         explore: config,
     };
     let explored_system = ExploredComputerSystem::explore(system, &system_explore_config).await?;

--- a/crates/bmc-explorer/src/test_support.rs
+++ b/crates/bmc-explorer/src/test_support.rs
@@ -72,6 +72,7 @@ pub async fn detect_hw_type<B: Bmc>(
         need_oem_nvidia_bluefield: is_bluefield_system,
         ignore_500_on_bios_fetch: is_bluefield_system,
         retry_404_on_eth_interfaces: is_bluefield_system,
+        need_boot_options: !explored_chassis.is_bluefield4(),
         explore: config,
     };
     let explored_system = ExploredComputerSystem::explore(system, &system_explore_config).await?;

--- a/crates/bmc-explorer/tests/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield3_explore.rs
@@ -70,6 +70,32 @@ async fn explore_bluefield3_without_system_eth_interfaces() {
 }
 
 #[test]
+async fn explore_bluefield3_recovers_oob_interface_from_boot_options() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    h.state.injection.put(vec![bmc_mock::injection::Rule {
+        id: "missing_system_eth_interfaces".into(),
+        selector: bmc_mock::injection::Selector::Path {
+            method: Some("GET".into()),
+            glob: "/redfish/v1/Systems/Bluefield/EthernetInterfaces".into(),
+        },
+        action: bmc_mock::injection::Action::JsonMerge(serde_json::json!({
+            "Members": [],
+            "Members@odata.count": 0,
+        })),
+        remaining: None,
+    }]);
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+    let system = report.systems.first().expect("systems must be present");
+
+    assert!(system.ethernet_interfaces.iter().any(|interface| {
+        interface.id.as_deref() == Some("oob_net0") && interface.mac_address.is_some()
+    }));
+}
+
+#[test]
 async fn explore_bluefield3_retries_transient_404_on_system_eth_interfaces() {
     let settings = DpuSettings::default();
 

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -150,7 +150,7 @@ impl Bluefield3<'_> {
                     .uefi_device_path(&format!("MAC({mocked_mac_no_colons},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()"))
                     .build(),
             ]
-        })).collect();
+        })).collect::<Vec<_>>();
 
         redfish::computer_system::Config {
             systems: vec![redfish::computer_system::SingleSystemConfig {
@@ -162,7 +162,7 @@ impl Bluefield3<'_> {
                 serial_number: Some(self.product_serial_number.to_string().into()),
                 boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                 callbacks: Some(callbacks),
-                boot_options: Some(boot_options),
+                boot_options: Some(boot_options.into()),
                 bios_mode: redfish::computer_system::BiosMode::Generic,
                 oem: redfish::computer_system::Oem::NvidiaBluefield,
                 base_bios: Some(

--- a/crates/bmc-mock/src/hw/bluefield4.rs
+++ b/crates/bmc-mock/src/hw/bluefield4.rs
@@ -114,7 +114,7 @@ impl Bluefield4<'_> {
                 serial_number: None,
                 boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                 callbacks: Some(callbacks),
-                boot_options: Some(vec![]),
+                boot_options: Some(redfish::computer_system::BootOptionsConfig::NullMembers),
                 bios_mode: redfish::computer_system::BiosMode::Generic,
                 oem: redfish::computer_system::Oem::NvidiaBluefield,
                 base_bios: Some(

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -164,7 +164,7 @@ impl DellPowerEdgeR750<'_> {
                     .display_name(&display_name)
                     .build()
             })
-            .collect();
+            .collect::<Vec<_>>();
 
         redfish::computer_system::Config {
             systems: vec![redfish::computer_system::SingleSystemConfig {
@@ -176,7 +176,7 @@ impl DellPowerEdgeR750<'_> {
                 boot_order_mode: redfish::computer_system::BootOrderMode::DellOem,
                 callbacks,
                 chassis: vec!["System.Embedded.1".into()],
-                boot_options: Some(boot_options),
+                boot_options: Some(boot_options.into()),
                 bios_mode: redfish::computer_system::BiosMode::DellOem,
                 oem: redfish::computer_system::Oem::Generic,
                 log_services: Some(Arc::new(DellLogServices {

--- a/crates/bmc-mock/src/hw/dell_poweredge_r760_bf4.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r760_bf4.rs
@@ -115,7 +115,7 @@ impl DellPowerEdgeR760Bf4<'_> {
                 boot_order_mode: redfish::computer_system::BootOrderMode::DellOem,
                 callbacks,
                 chassis: vec!["System.Embedded.1".into()],
-                boot_options: Some(boot_options),
+                boot_options: Some(boot_options.into()),
                 bios_mode: redfish::computer_system::BiosMode::DellOem,
                 oem: redfish::computer_system::Oem::Generic,
                 log_services: None,

--- a/crates/bmc-mock/src/hw/dgx_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/dgx_gb300_nvl.rs
@@ -138,7 +138,7 @@ impl DgxGB300Nvl<'_> {
                     .build()
                 }),
         )
-        .collect();
+        .collect::<Vec<_>>();
 
         let eth_interfaces = [&self.embedded_1g_nic.ethernet_nic()]
             .iter()
@@ -177,7 +177,7 @@ impl DgxGB300Nvl<'_> {
                 redfish::computer_system::SingleSystemConfig {
                     base_bios: Some(base_bios(system_id)),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
-                    boot_options: Some(boot_options),
+                    boot_options: Some(boot_options.into()),
                     boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
                     chassis: vec!["Chassis_0".into()],
                     eth_interfaces: Some(eth_interfaces),

--- a/crates/bmc-mock/src/hw/generic_ami.rs
+++ b/crates/bmc-mock/src/hw/generic_ami.rs
@@ -78,7 +78,7 @@ impl GenericAmi<'_> {
                     .display_name(&display_name)
                     .build()
             })
-            .collect();
+            .collect::<Vec<_>>();
         redfish::computer_system::Config {
             systems: vec![redfish::computer_system::SingleSystemConfig {
                 id: Cow::Borrowed(system_id),
@@ -89,7 +89,7 @@ impl GenericAmi<'_> {
                 boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
                 callbacks: Some(callbacks),
                 chassis: vec!["Self".into()],
-                boot_options: Some(boot_options),
+                boot_options: Some(boot_options.into()),
                 bios_mode: redfish::computer_system::BiosMode::Generic,
                 oem: redfish::computer_system::Oem::Generic,
                 log_services: None,

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -138,7 +138,7 @@ impl LenovoGB300Nvl<'_> {
                     .build()
                 }),
         )
-        .collect();
+        .collect::<Vec<_>>();
 
         // Not: No DPU in EthernetInterfaces.
         let eth_interfaces = [&self.embedded_1g_nic.ethernet_nic()]
@@ -181,7 +181,7 @@ impl LenovoGB300Nvl<'_> {
                 redfish::computer_system::SingleSystemConfig {
                     base_bios: Some(base_bios(system_id)),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
-                    boot_options: Some(boot_options),
+                    boot_options: Some(boot_options.into()),
                     boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
                     chassis: vec!["Chassis_0".into()],
                     eth_interfaces: Some(eth_interfaces),

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -166,7 +166,7 @@ impl NvidiaDgxH100<'_> {
             .display_name("UEFI OS")
             .build(),
         ))
-        .collect();
+        .collect::<Vec<_>>();
 
         redfish::computer_system::Config {
             systems: vec![
@@ -179,7 +179,7 @@ impl NvidiaDgxH100<'_> {
                     boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                     callbacks,
                     chassis: vec!["BMC".into()],
-                    boot_options: Some(boot_options),
+                    boot_options: Some(boot_options.into()),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
                     oem: redfish::computer_system::Oem::Generic,
                     base_bios: Some(base_bios(system_id)),

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -139,7 +139,7 @@ impl SupermicroGB300Nvl<'_> {
                     .build()
                 }),
         )
-        .collect();
+        .collect::<Vec<_>>();
 
         let eth_interfaces = [&self.embedded_1g_nic.ethernet_nic()]
             .iter()
@@ -178,7 +178,7 @@ impl SupermicroGB300Nvl<'_> {
                 redfish::computer_system::SingleSystemConfig {
                     base_bios: Some(base_bios(system_id)),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
-                    boot_options: Some(boot_options),
+                    boot_options: Some(boot_options.into()),
                     boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
                     chassis: vec!["Chassis_0".into()],
                     eth_interfaces: Some(eth_interfaces),

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -92,7 +92,7 @@ impl WiwynnGB200Nvl<'_> {
                 .display_name(&display_name)
                 .uefi_device_path(&format!("MAC({mac},0x1)/IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()"))
                 .build()
-        })).collect();
+        })).collect::<Vec<_>>();
 
         let hgx_baseboard_id = "HGX_Baseboard_0";
 
@@ -107,7 +107,7 @@ impl WiwynnGB200Nvl<'_> {
                     boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                     callbacks,
                     chassis: vec!["BMC_0".into()],
-                    boot_options: Some(boot_options),
+                    boot_options: Some(boot_options.into()),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
                     oem: redfish::computer_system::Oem::Generic,
                     base_bios: Some(

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -135,6 +135,26 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
         )
 }
 
+pub enum BootOptionsConfig {
+    Options(Vec<redfish::boot_option::BootOption>),
+    NullMembers,
+}
+
+impl BootOptionsConfig {
+    fn as_options(&self) -> Option<&[redfish::boot_option::BootOption]> {
+        match self {
+            Self::Options(v) => Some(v),
+            Self::NullMembers => None,
+        }
+    }
+}
+
+impl From<Vec<redfish::boot_option::BootOption>> for BootOptionsConfig {
+    fn from(v: Vec<redfish::boot_option::BootOption>) -> Self {
+        Self::Options(v)
+    }
+}
+
 pub struct SingleSystemConfig {
     pub id: Cow<'static, str>,
     pub eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
@@ -144,7 +164,7 @@ pub struct SingleSystemConfig {
     pub boot_order_mode: BootOrderMode,
     pub callbacks: Option<Arc<dyn Callbacks>>,
     pub chassis: Vec<Cow<'static, str>>,
-    pub boot_options: Option<Vec<redfish::boot_option::BootOption>>,
+    pub boot_options: Option<BootOptionsConfig>,
     pub bios_mode: BiosMode,
     pub base_bios: Option<serde_json::Value>,
     pub log_services: Option<Arc<dyn LogServices>>,
@@ -256,7 +276,9 @@ impl SingleSystemState {
     pub fn find_boot_option(&self, option_id: &str) -> Option<&redfish::boot_option::BootOption> {
         self.config
             .boot_options
-            .iter()
+            .as_ref()
+            .and_then(|v| v.as_options())
+            .into_iter()
             .flatten()
             .find(|v| v.id == option_id)
     }
@@ -283,7 +305,9 @@ impl SingleSystemState {
             .filter(|kind| {
                 self.config
                     .boot_options
-                    .iter()
+                    .as_ref()
+                    .and_then(|v| v.as_options())
+                    .into_iter()
                     .flatten()
                     .any(|opt| opt.kind == *kind)
             })
@@ -295,7 +319,9 @@ impl SingleSystemState {
                 overrides.first().and_then(|optref| {
                     self.config
                         .boot_options
-                        .iter()
+                        .as_ref()
+                        .and_then(|v| v.as_options())
+                        .into_iter()
                         .flatten()
                         .find(|v| v.boot_reference() == optref)
                         .map(|opt| opt.kind)
@@ -305,7 +331,8 @@ impl SingleSystemState {
         .or_else(|| {
             self.config
                 .boot_options
-                .as_ref()?
+                .as_ref()
+                .and_then(|v| v.as_options())?
                 .first()
                 .map(|opt| opt.kind)
         })
@@ -346,7 +373,9 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
             b = b.boot_order(
                 &config
                     .boot_options
-                    .iter()
+                    .as_ref()
+                    .and_then(|v| v.as_options())
+                    .into_iter()
                     .flatten()
                     .map(|v| v.boot_reference())
                     .collect::<Vec<_>>(),
@@ -615,34 +644,46 @@ async fn get_boot_options_collection(
     let Some(boot_options) = &system_state.config.boot_options else {
         return http::not_found();
     };
-    let boot_options_order = match system_state.config.boot_order_mode {
-        BootOrderMode::DellOem => {
-            // Carbide relies that Dell sorts boot options in according to boot
-            // order. Code below simulates the same.
-            if let Some(boot_order) = system_state.boot_order_override() {
-                let mut indices = (0..boot_options.len()).collect::<Vec<_>>();
-                indices.sort_by_key(|&i| {
-                    boot_order
-                        .iter()
-                        .enumerate()
-                        .find(|(_, id)| *id == &boot_options[i].id)
-                        .map(|(idx, _)| idx)
-                        .unwrap_or(boot_options.len())
-                });
-                indices
-            } else {
-                (0..boot_options.len()).collect::<Vec<_>>()
-            }
+    match boot_options {
+        BootOptionsConfig::Options(boot_options) => {
+            let boot_options_order = match system_state.config.boot_order_mode {
+                BootOrderMode::DellOem => {
+                    // Carbide relies that Dell sorts boot options in according to boot
+                    // order. Code below simulates the same.
+                    if let Some(boot_order) = system_state.boot_order_override() {
+                        let mut indices = (0..boot_options.len()).collect::<Vec<_>>();
+                        indices.sort_by_key(|&i| {
+                            boot_order
+                                .iter()
+                                .enumerate()
+                                .find(|(_, id)| *id == &boot_options[i].id)
+                                .map(|(idx, _)| idx)
+                                .unwrap_or(boot_options.len())
+                        });
+                        indices
+                    } else {
+                        (0..boot_options.len()).collect::<Vec<_>>()
+                    }
+                }
+                BootOrderMode::Generic | BootOrderMode::ViaSettings => {
+                    (0..boot_options.len()).collect()
+                }
+            };
+            let members = boot_options_order
+                .into_iter()
+                .map(|idx| {
+                    redfish::boot_option::resource(&system_id, &boot_options[idx].id).entity_ref()
+                })
+                .collect::<Vec<_>>();
+            redfish::boot_option::collection(&system_id)
+                .with_members(&members)
+                .into_ok_response()
         }
-        BootOrderMode::Generic | BootOrderMode::ViaSettings => (0..boot_options.len()).collect(),
-    };
-    let members = boot_options_order
-        .into_iter()
-        .map(|idx| redfish::boot_option::resource(&system_id, &boot_options[idx].id).entity_ref())
-        .collect::<Vec<_>>();
-    redfish::boot_option::collection(&system_id)
-        .with_members(&members)
-        .into_ok_response()
+        BootOptionsConfig::NullMembers => redfish::boot_option::collection(&system_id)
+            .with_members(&[] as &[String])
+            .patch(json!({"Members": null}))
+            .into_ok_response(),
+    }
 }
 
 async fn get_boot_option(


### PR DESCRIPTION
BlueField-4 firmware may return null for BootOptions Members, so skip boot option collection only for detected BF4 systems while preserving BF3 boot-option exploration.

Update bmc-mock to model null BootOptions Members for BF4 and add coverage that BF3 still recovers the OOB interface from boot options.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

