### PR TITLE
Support interfaces named enx* in scout.

### DIFF
--- a/pxe/mkosi.extra/etc/systemd/network/dhcp.network
+++ b/pxe/mkosi.extra/etc/systemd/network/dhcp.network
@@ -1,5 +1,5 @@
 [Match]
-Name=enp* enP*
+Name=enx* enp* enP*
 
 [Network]
 DHCP=yes


### PR DESCRIPTION
Lets the DHCP service configure interfaces that start with "enx".

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

