### PR TITLE
agent: Detect changes in unversioned ManagedHostNetworkConfigResponse fields

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -1927,6 +1927,7 @@ impl InterfaceTranslationMode {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
     use std::io::Write;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -2261,7 +2262,7 @@ mod tests {
                 vf_intercept_bridge_name: "br-beans".to_string(),
                 vf_intercept_bridge_port: "patch-br-beans-to-hbn".to_string(),
                 vf_intercept_bridge_sf: "pf0dpu5".to_string(),
-                host_representor_intercept_bridging: HashMap::from([(
+                host_representor_intercept_bridging: BTreeMap::from([(
                     "pf0hpf".to_string(),
                     rpc::HostRepresentorInterceptBridging {
                         bridge: "br-pf0".to_string(),
@@ -3037,7 +3038,7 @@ mod tests {
                     vf_intercept_bridge_sf: "pf0dpu5".to_string(),
                     internal_bridge_routing_prefix: "10.10.10.0/29".to_string(),
                     hbn_bridge: "br-hbn".to_string(),
-                    host_representor_intercept_bridging: HashMap::from([(
+                    host_representor_intercept_bridging: BTreeMap::from([(
                         "pf0hpf".to_string(),
                         rpc::HostRepresentorInterceptBridging {
                             bridge: "br-pf0".to_string(),

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -449,7 +449,14 @@ impl CurrentNetworkVersion {
             && self.instance_network_config_version.as_deref() == instance_network_config_version;
         match (config_versions_identical, self.unversioned_fields_hash) {
             (true, Some(unversioned_fields_hash)) => {
-                unversioned_fields_hash == Self::hash_unversioned_fields(conf)
+                if unversioned_fields_hash == Self::hash_unversioned_fields(conf) {
+                    true
+                } else {
+                    tracing::info!(
+                        "An unversioned field in ManagedHostNetworkConfigResponse has changed"
+                    );
+                    false
+                }
             }
             (false, _) => false,
             (_, None) => false,

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashSet;
 use std::ffi::OsStr;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::net::IpAddr;
 use std::ops::Add;
 use std::path::PathBuf;
@@ -428,9 +429,12 @@ struct IterationResult {
 struct CurrentNetworkVersion {
     managed_host_config_version: Option<String>,
     instance_network_config_version: Option<String>,
+    // This hashes over a bunch of unversioned fields from the API.
+    unversioned_fields_hash: Option<u64>,
 }
 
 impl CurrentNetworkVersion {
+    // Return whether our stored version matches the specific config.
     pub fn matches_versions_from(
         &self,
         conf: impl AsRef<ManagedHostNetworkConfigResponse>,
@@ -440,8 +444,16 @@ impl CurrentNetworkVersion {
         let instance_network_config_version =
             get_non_empty_str(&conf.instance_network_config_version);
 
-        self.managed_host_config_version.as_deref() == managed_host_config_version
-            && self.instance_network_config_version.as_deref() == instance_network_config_version
+        let config_versions_identical = self.managed_host_config_version.as_deref()
+            == managed_host_config_version
+            && self.instance_network_config_version.as_deref() == instance_network_config_version;
+        match (config_versions_identical, self.unversioned_fields_hash) {
+            (true, Some(unversioned_fields_hash)) => {
+                unversioned_fields_hash == Self::hash_unversioned_fields(conf)
+            }
+            (false, _) => false,
+            (_, None) => false,
+        }
     }
 
     pub fn update_from(&mut self, conf: impl AsRef<ManagedHostNetworkConfigResponse>) {
@@ -450,6 +462,73 @@ impl CurrentNetworkVersion {
             get_non_empty_str(&conf.managed_host_config_version).map(String::from);
         self.instance_network_config_version =
             get_non_empty_str(&conf.instance_network_config_version).map(String::from);
+        self.unversioned_fields_hash
+            .replace(Self::hash_unversioned_fields(conf));
+    }
+
+    // Some of the fields aren't covered by any of the ConfigVersions that we
+    // receive from the API, so let's try to catch changes in these so that we
+    // don't skip a needed config update.
+    fn hash_unversioned_fields(conf: &ManagedHostNetworkConfigResponse) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        let h = &mut hasher;
+
+        conf.additional_route_target_imports.hash(h);
+        conf.anycast_site_prefixes.hash(h);
+        conf.asn.hash(h);
+        conf.bgp_leaf_session_password.hash(h);
+        conf.common_internal_route_target.hash(h);
+        conf.datacenter_asn.hash(h);
+        conf.deny_prefixes.hash(h);
+        conf.deprecated_deny_prefixes.hash(h);
+        conf.dhcp_servers.hash(h);
+        conf.internet_l3_vni.hash(h);
+        conf.network_security_policy_overrides.hash(h);
+        conf.ntp_servers.hash(h);
+        conf.remote_id.hash(h);
+        conf.route_servers.hash(h);
+        conf.site_global_vpc_vni.hash(h);
+        conf.stateful_acls_enabled.hash(h);
+        conf.tenant_host_asn.hash(h);
+        conf.vni_device.hash(h);
+        conf.vpc_isolation_behavior.hash(h);
+
+        conf.dpu_extension_services
+            .iter()
+            .for_each(|dpu_extension_service| {
+                dpu_extension_service.removed.hash(h);
+                dpu_extension_service.service_id.hash(h);
+                // We can probably ignore the other fields, assuming good
+                // behavior from the versioning.
+            });
+
+        if let Some(routing_profile) = &conf.routing_profile {
+            routing_profile.accepted_leaks_from_underlay.hash(h);
+            routing_profile.allowed_anycast_prefixes.hash(h);
+            routing_profile.leak_default_route_from_underlay.hash(h);
+            routing_profile.leak_tenant_host_routes_to_underlay.hash(h);
+            routing_profile.route_target_imports.hash(h);
+            routing_profile.route_targets_on_exports.hash(h);
+            routing_profile.tenant_leak_communities_accepted.hash(h);
+        }
+
+        if let Some(traffic_intercept_config) = &conf.traffic_intercept_config {
+            traffic_intercept_config.additional_overlay_vtep_ip.hash(h);
+            traffic_intercept_config.public_prefixes.hash(h);
+            traffic_intercept_config
+                .secondary_vtep_aggregate_prefixes
+                .hash(h);
+            if let Some(bridging) = &traffic_intercept_config.bridging {
+                bridging.hbn_bridge.hash(h);
+                bridging.host_representor_intercept_bridging.hash(h);
+                bridging.internal_bridge_routing_prefix.hash(h);
+                bridging.vf_intercept_bridge_name.hash(h);
+                bridging.vf_intercept_bridge_port.hash(h);
+                bridging.vf_intercept_bridge_sf.hash(h);
+            }
+        }
+
+        hasher.finish()
     }
 }
 

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -345,6 +345,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("forge.TrafficInterceptConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.TrafficInterceptBridging", "#[derive(serde::Serialize)]")
+        .btree_map("forge.TrafficInterceptBridging.host_representor_intercept_bridging")
         .type_attribute("forge.HostRepresentorInterceptBridging", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkPrefix", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkPrefixEvent", "#[derive(serde::Serialize)]")


### PR DESCRIPTION
This improves the code committed in #2848 by hashing over a bunch of unversioned fields in the `ManagedHostNetworkConfigResponse` message, so that we still update our network configuration when the API configuration or unversioned database resources change.

Somewhat related to this, I also added a directive to prost's builder such that the `TrafficInterceptBridging.host_representor_intercept_bridging` field (a `map` in the protobuf definition) becomes a `BTreeMap` and not a `HashMap`. I don't have any real proof, but a `HashMap` could potentially result in different ordering of the values between api processes/replicas that is then reflected in the rendered config as needless churn.

## Related issues
#2848 
#1994 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

