### PR TITLE
ci: gate merges on release artifact chains

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1655,7 +1655,7 @@ jobs:
   # Fails iff any required job listed in `needs` is `failure` or `cancelled`.
   # `skipped` counts as pass — that's how rest-only PRs unblock when the
   # `changes` gate intentionally skips the core pipeline.
-  # Every stage of each release-artifact chain is listed so an upstream failure
+  # Every stage of each gated release chain is listed so an upstream failure
   # cannot be hidden when its downstream jobs become SKIPPED.
   # `changes` + `prepare` are also included so a gate or prepare failure doesn't
   # silently pass.
@@ -1667,7 +1667,13 @@ jobs:
     needs:
       - changes
       - prepare
+      # x86_64 release-container chain
+      - build-container-x86_64
+      - build-runtime-container-x86_64
       - build-release-container-x86_64
+      # aarch64 release-container chain
+      - build-container-aarch64
+      - build-runtime-container-aarch64
       - build-release-container-aarch64
       - test-release-container-services
       # x86_64 release-artifact chain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1652,11 +1652,13 @@ jobs:
   # ============================================================================
   # AGGREGATOR — single required check for branch protection
   # ============================================================================
-  # Fails iff any leaf job's result is `failure` or `cancelled`.
+  # Fails iff any required job listed in `needs` is `failure` or `cancelled`.
   # `skipped` counts as pass — that's how rest-only PRs unblock when the
   # `changes` gate intentionally skips the core pipeline.
-  # `changes` + `prepare` are in needs so a gate or prepare failure doesn't
-  # silently pass (downstream leaves become SKIPPED in those cases).
+  # Every stage of each release-artifact chain is listed so an upstream failure
+  # cannot be hidden when its downstream jobs become SKIPPED.
+  # `changes` + `prepare` are also included so a gate or prepare failure doesn't
+  # silently pass.
   # Branch protection ruleset should require ONLY this aggregator + rest-ci-pass.
   core-ci-pass:
     name: core-ci-pass
@@ -1668,6 +1670,16 @@ jobs:
       - build-release-container-x86_64
       - build-release-container-aarch64
       - test-release-container-services
+      # x86_64 release-artifact chain
+      - build-artifacts-container-x86_64
+      - build-boot-artifacts-x86
+      - build-boot-artifacts-ephemeral-image-x86-host
+      - build-release-artifacts-x86-host
+      # aarch64 release-artifact chain
+      - build-artifacts-container-aarch64
+      - build-boot-artifacts-bfb
+      - build-boot-artifacts-ephemeral-image-arm-host
+      - build-release-artifacts-arm-host
       - security-secret-scan
       - lint-police
       - check-rest-core-proto-sync


### PR DESCRIPTION
Make the required `core-ci-pass` check wait for the complete x86_64 and
aarch64 release-artifact build chains.

## Why

The `main` ruleset requires only `core-ci-pass` and `rest-ci-pass`. PR #3047
showed that `core-ci-pass` could succeed while
`build-release-artifacts-arm-host` was still running because the artifact
chain was outside the aggregator's `needs` list.

All stages are included, rather than only the two leaf jobs, because the
aggregator intentionally treats `skipped` as passing. If an upstream build
failed, an omitted upstream job could otherwise be hidden by skipped
downstream jobs.

## Related issues

Related PRs: #3047, #1800, #2434

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation performed:

- `git diff --check`
- YAML parsing with Ruby
- `actionlint` v1.7.12 workflow validation
- `yq` checks that every `needs` entry resolves to a job and all eight
  artifact-chain jobs are present
- recursive dependency-closure check for both release-artifact leaf jobs
- synthetic aggregator-result checks: intentional skips pass, while upstream
  failure or cancellation with skipped descendants blocks

## Additional Notes

End-to-end CI should confirm that `core-ci-pass` does not start or complete
until both `build-release-artifacts-x86-host` and
`build-release-artifacts-arm-host` finish. Conditional artifact-container jobs
may still skip normally when their Dockerfiles are unchanged.

This intentionally increases merge-gate latency to cover the complete artifact
build chains.
