### PR TITLE
fix(bmc-explorer): skip boot options for B4240V BlueField-4

### DIFF
--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -132,9 +132,10 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     }
 
     pub fn is_bluefield4(&self) -> bool {
-        self.members
-            .iter()
-            .any(|c| c.chassis.hardware_id().model == Some(Model::new("B4240")))
+        self.members.iter().any(|c| {
+            c.chassis.hardware_id().model == Some(Model::new("B4240"))
+                || c.chassis.hardware_id().model == Some(Model::new("B4240V"))
+        })
     }
 
     pub fn dpu_card1_serial_number(&self) -> Result<Option<&str>, Error<B>> {

--- a/crates/bmc-explorer/tests/bluefield4_explore.rs
+++ b/crates/bmc-explorer/tests/bluefield4_explore.rs
@@ -87,3 +87,23 @@ async fn explore_bluefield4_and_generate_machine_id_from_bluefield_bmc_chassis_s
     );
     assert_eq!(report.machine_id, Some(machine_id));
 }
+
+#[test]
+async fn explore_b4240v_and_generate_machine_id() {
+    let h = test_support::nvidia_dgx_vr_bluefield4_dpu_bmc(DpuSettings::default()).await;
+    let mut report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .expect("B4240V exploration should succeed");
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
+    assert!(report.chassis.iter().any(|chassis| {
+        chassis.id == "Bluefield_BMC" && chassis.model.as_deref() == Some("B4240V")
+    }));
+
+    let machine_id = report
+        .generate_machine_id(false)
+        .expect("B4240V report should have enough collected data for machine ID")
+        .expect("B4240V report should generate a DPU machine ID");
+    assert!(machine_id.machine_type().is_dpu());
+}

--- a/crates/bmc-mock/src/hw/bluefield4.rs
+++ b/crates/bmc-mock/src/hw/bluefield4.rs
@@ -25,10 +25,19 @@ use serde_json::json;
 
 use crate::{Callbacks, LogService, LogServices, hw, redfish};
 
+#[derive(Clone, Copy, Debug)]
+pub enum Mode {
+    // B4240V installed on VR NVL.
+    B4240V,
+    // Air Cooled Bluefield-4 DPU
+    B4240,
+}
+
 pub struct Bluefield4<'a> {
     pub product_serial_number: Cow<'a, str>,
     pub host_mac_address: MacAddress,
     pub bmc_mac_address: MacAddress,
+    pub mode: Mode,
 }
 
 impl Bluefield4<'_> {
@@ -53,7 +62,7 @@ impl Bluefield4<'_> {
                     id: "Bluefield_BMC".into(),
                     chassis_type: "Component".into(),
                     manufacturer: Some("Nvidia".into()),
-                    model: Some("B4240".into()),
+                    model: Some(self.model().into()),
                     part_number: Some(self.part_number().into()),
                     pcie_devices: Some(vec![]),
                     sensors: Some(vec![]),
@@ -160,15 +169,27 @@ impl Bluefield4<'_> {
     }
 
     pub fn host_nic(&self) -> hw::nic::Nic<'static> {
-        hw::nic::Nic {
-            mac_address: self.host_mac_address,
-            serial_number: Some(format!("{}", self.product_serial_number).into()),
-            manufacturer: Some("Mellanox Technologies".into()),
-            model: Some("B4240".into()),
-            description: Some("CX9 Family [ConnectX-9]".into()),
-            part_number: Some(self.part_number().into()),
-            firmware_version: Some("82.48.0802".into()),
-            is_mat_dpu: true,
+        match self.mode {
+            Mode::B4240 => hw::nic::Nic {
+                mac_address: self.host_mac_address,
+                serial_number: Some(format!("{}", self.product_serial_number).into()),
+                manufacturer: Some("Mellanox Technologies".into()),
+                model: Some("B4240".into()),
+                description: Some("CX9 Family [ConnectX-9]".into()),
+                part_number: Some(self.part_number().into()),
+                firmware_version: Some("82.48.0802".into()),
+                is_mat_dpu: true,
+            },
+            Mode::B4240V => hw::nic::Nic {
+                mac_address: self.host_mac_address,
+                serial_number: Some(format!("{}", self.product_serial_number).into()),
+                manufacturer: Some("NVIDIA".into()),
+                model: Some("NVIDIA BlueField-4 B4240V 800G Liquid Cooled DPU, Dual-port 400GbE / NDR, QSFP112, PCIe Gen6 x16, 64 Arm cores, 128GB LPDDR5x, integrated BMC, Crypto Enabled, Secure Boot Enabled".into()),
+                description: None,
+                part_number: Some(self.part_number().into()),
+                firmware_version: None,
+                is_mat_dpu: true,
+            },
         }
     }
 
@@ -197,8 +218,18 @@ impl Bluefield4<'_> {
         }
     }
 
+    pub fn model(&self) -> &'static str {
+        match self.mode {
+            Mode::B4240V => "B4240V",
+            Mode::B4240 => "B4240",
+        }
+    }
+
     fn part_number(&self) -> &'static str {
-        "900-9D4B4-CWAA-TSA"
+        match self.mode {
+            Mode::B4240 => "900-9D4B4-CWAA-TSA",
+            Mode::B4240V => "900-9D4A4-00CB-TS4",
+        }
     }
 }
 

--- a/crates/bmc-mock/src/hw/dgx_vr_nvl.rs
+++ b/crates/bmc-mock/src/hw/dgx_vr_nvl.rs
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! DGX VR NVL compute tray.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use mac_address::MacAddress;
+use rpc::DiscoveryInfo;
+use serde_json::json;
+
+use crate::{BootOptionKind, Callbacks, hw, redfish};
+
+pub struct DgxVrNvl<'a> {
+    pub system_0_serial_number: Cow<'a, str>,
+    pub chassis_0_serial_number: Cow<'a, str>,
+    pub dpu: hw::bluefield4::Bluefield4<'a>,
+    pub bmc_mac_address_eth0: MacAddress,
+}
+
+impl DgxVrNvl<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        let bmc_manager_id = "BMC_0";
+        let bmc_eth_builder = |eth| {
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
+                bmc_manager_id,
+                eth,
+            ))
+        };
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: bmc_manager_id,
+                eth_interfaces: Some(vec![
+                    bmc_eth_builder("eth0")
+                        .mac_address(self.bmc_mac_address_eth0)
+                        .interface_enabled(true)
+                        .build(),
+                ]),
+                host_interfaces: None,
+                firmware_version: None,
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+        let system_id = "System_0";
+        let boot_options = std::iter::once(
+            redfish::boot_option::builder(
+                &redfish::boot_option::resource(system_id, "0002"),
+                BootOptionKind::Disk,
+            )
+            .boot_option_reference("Boot0002")
+            .display_name("ubuntu")
+            .build(),
+        )
+        .chain(
+            [&self.dpu.host_nic()]
+                .into_iter()
+                .enumerate()
+                .map(|(n, nic)| {
+                    let id = format!("{:04X}", n + 3); // Starting with 0003
+                    let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
+                    redfish::boot_option::builder(
+                        &redfish::boot_option::resource(system_id, &id),
+                        BootOptionKind::Network,
+                    )
+                    .boot_option_reference(&format!("Boot{id}"))
+                    .display_name(&format!(
+                        "[SlotFFFF]: PXE IPv4 Some Network Adapter - {}",
+                        nic.mac_address
+                    ))
+                    .uefi_device_path(&format!(
+                        "{pci_path}/MAC({},0x1)\
+                             /IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                        nic.mac_address.to_string().replace(":", "")
+                    ))
+                    .build()
+                }),
+        )
+        .collect::<Vec<_>>();
+
+        redfish::computer_system::Config {
+            systems: vec![
+                redfish::computer_system::SingleSystemConfig {
+                    base_bios: None,
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    boot_options: None,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                    chassis: vec!["HGX_Chassis_0".into()],
+                    eth_interfaces: None,
+                    id: "HGX_Baseboard_0".into(),
+                    log_services: None,
+                    manufacturer: Some("NVIDIA".into()),
+                    model: Some("VR NVL".into()),
+                    oem: redfish::computer_system::Oem::Generic,
+                    callbacks: None,
+                    secure_boot_available: false,
+                    serial_number: None,
+                    storage: None,
+                    processors: None,
+                },
+                redfish::computer_system::SingleSystemConfig {
+                    base_bios: Some(base_bios(system_id)),
+                    bios_mode: redfish::computer_system::BiosMode::Generic,
+                    boot_options: Some(boot_options.into()),
+                    boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                    chassis: vec!["Chassis_0".into()],
+                    eth_interfaces: None,
+                    id: system_id.into(),
+                    log_services: None,
+                    manufacturer: Some("NVIDIA".into()),
+                    model: Some("VR NVL72".into()),
+                    oem: redfish::computer_system::Oem::Generic,
+                    callbacks: Some(callbacks),
+                    secure_boot_available: true,
+                    serial_number: Some(self.system_0_serial_number.to_string().into()),
+                    storage: None,
+                    processors: None,
+                },
+            ],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        redfish::chassis::ChassisConfig {
+            chassis: vec![
+                redfish::chassis::SingleChassisConfig {
+                    id: "Chassis_0".into(),
+                    chassis_type: "RackMount".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: None,
+                    model: Some("VR NVL72".into()),
+                    serial_number: Some(self.chassis_0_serial_number.to_string().into()),
+                    sensors: None,
+                    leak_detectors: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+                redfish::chassis::SingleChassisConfig {
+                    id: "HGX_Chassis_0".into(),
+                    chassis_type: "Zone".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    part_number: None,
+                    model: Some("VR NVL144".into()),
+                    serial_number: None,
+                    sensors: None,
+                    leak_detectors: None,
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+            ],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo::default()
+    }
+}
+
+fn base_bios(system_id: &str) -> serde_json::Value {
+    redfish::bios::builder(&redfish::bios::resource(system_id))
+        .attributes(json!({
+            "EmbeddedUefiShell": "Enabled"
+        }))
+        .build()
+}

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -48,6 +48,9 @@ pub mod dgx_gb300_nvl;
 /// Support of Supermicro (SMC) GB300 NVL servers (Supermicro OpenBMC host).
 pub mod supermicro_gb300_nvl;
 
+/// Support of DGX VR NVL servers.
+pub mod dgx_vr_nvl;
+
 /// Support of LiteOn Power Shelf.
 pub mod liteon_power_shelf;
 

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -66,6 +66,8 @@ pub enum HostHardwareType {
     NvidiaDgxGb300,
     #[serde(rename = "supermicro_gb300_nvl")]
     SupermicroGb300Nvl,
+    #[serde(rename = "nvidia_dgx_vr")]
+    NvidiaDgxVr,
     #[serde(rename = "liteon_power_shelf")]
     LiteOnPowerShelf,
     #[serde(rename = "nvidia_switch_nd5200_ld")]
@@ -90,6 +92,7 @@ impl fmt::Display for HostHardwareType {
             Self::LenovoGB300Nvl => "Lenovo GB300 NVL".fmt(f),
             Self::NvidiaDgxGb300 => "NVIDIA DGX GB300 NVL".fmt(f),
             Self::SupermicroGb300Nvl => "Supermicro GB300 NVL".fmt(f),
+            Self::NvidiaDgxVr => "NVIDIA DGX VR NVL".fmt(f),
             Self::LiteOnPowerShelf => "Lite-On Power Shelf".fmt(f),
             Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
             Self::NvidiaDgxH100 => "NVIDIA DGX H100".fmt(f),
@@ -111,6 +114,7 @@ impl HostHardwareType {
             Self::LenovoGB300Nvl => Some(1),
             Self::NvidiaDgxGb300 => Some(1),
             Self::SupermicroGb300Nvl => Some(1),
+            Self::NvidiaDgxVr => Some(1),
             Self::LiteOnPowerShelf => Some(0),
             Self::NvidiaSwitchNd5200Ld => Some(0),
             Self::NvidiaDgxH100 => Some(1),

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -129,6 +129,7 @@ impl DpuMachineInfo {
             | HostHardwareType::SupermicroGb300Nvl => hw::bluefield3::Mode::B3240ColdAisle,
             HostHardwareType::LiteOnPowerShelf
             | HostHardwareType::NvidiaSwitchNd5200Ld
+            | HostHardwareType::NvidiaDgxVr
             | HostHardwareType::DellPowerEdgeR760Bf4 => {
                 panic!("Bluefield3 DPU is defined for {}", self.hw_type)
             }
@@ -150,10 +151,27 @@ impl DpuMachineInfo {
     }
 
     fn bluefield4(&self) -> hw::bluefield4::Bluefield4<'_> {
+        let mode = match self.hw_type {
+            HostHardwareType::DellPowerEdgeR750
+            | HostHardwareType::NvidiaDgxH100
+            | HostHardwareType::GenericAmi
+            | HostHardwareType::GenericSupermicro
+            | HostHardwareType::WiwynnGB200Nvl
+            | HostHardwareType::LenovoGB300Nvl
+            | HostHardwareType::NvidiaDgxGb300
+            | HostHardwareType::SupermicroGb300Nvl
+            | HostHardwareType::LiteOnPowerShelf
+            | HostHardwareType::NvidiaSwitchNd5200Ld => {
+                panic!("Bluefield4 DPU is defined for {}", self.hw_type)
+            }
+            HostHardwareType::NvidiaDgxVr => hw::bluefield4::Mode::B4240V,
+            HostHardwareType::DellPowerEdgeR760Bf4 => hw::bluefield4::Mode::B4240,
+        };
         hw::bluefield4::Bluefield4 {
             host_mac_address: self.host_mac_address,
             bmc_mac_address: self.bmc_mac_address,
             product_serial_number: Cow::Borrowed(&self.serial),
+            mode,
         }
     }
 
@@ -169,14 +187,16 @@ impl DpuMachineInfo {
             | HostHardwareType::SupermicroGb300Nvl
             | HostHardwareType::LiteOnPowerShelf
             | HostHardwareType::NvidiaSwitchNd5200Ld => DpuType::Bluefield3,
-            HostHardwareType::DellPowerEdgeR760Bf4 => DpuType::Bluefield4,
+            HostHardwareType::DellPowerEdgeR760Bf4 | HostHardwareType::NvidiaDgxVr => {
+                DpuType::Bluefield4
+            }
         }
     }
 
     pub fn bmc_product(&self) -> Option<&'static str> {
         match self.dpu_type() {
             DpuType::Bluefield3 => Some("BlueField-3 DPU"),
-            DpuType::Bluefield4 => Some("B4240"),
+            DpuType::Bluefield4 => Some(self.bluefield4().model()),
         }
     }
 
@@ -275,6 +295,7 @@ impl HostMachineInfo {
             | HostHardwareType::LenovoGB300Nvl
             | HostHardwareType::NvidiaDgxGb300
             | HostHardwareType::SupermicroGb300Nvl
+            | HostHardwareType::NvidiaDgxVr
             | HostHardwareType::LiteOnPowerShelf
             | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::NvidiaSwitchNd5200Ld
@@ -294,6 +315,9 @@ impl HostMachineInfo {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
             HostHardwareType::SupermicroGb300Nvl => redfish::oem::BmcVendor::Supermicro,
+            HostHardwareType::NvidiaDgxVr => {
+                redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
+            }
             HostHardwareType::LiteOnPowerShelf => redfish::oem::BmcVendor::LiteOn,
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
@@ -314,6 +338,7 @@ impl HostMachineInfo {
             HostHardwareType::LenovoGB300Nvl => Some("AMI Redfish Server"),
             HostHardwareType::NvidiaDgxGb300 => Some("GB BMC"),
             HostHardwareType::SupermicroGb300Nvl => Some("GB NVL"),
+            HostHardwareType::NvidiaDgxVr => Some("VR NVL72"),
             HostHardwareType::LiteOnPowerShelf => None,
             HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
             HostHardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
@@ -331,6 +356,7 @@ impl HostMachineInfo {
             HostHardwareType::LenovoGB300Nvl => "1.21.1",
             HostHardwareType::NvidiaDgxGb300 => "1.17.0",
             HostHardwareType::SupermicroGb300Nvl => "1.17.0",
+            HostHardwareType::NvidiaDgxVr => "1.17.0",
             HostHardwareType::LiteOnPowerShelf => "1.9.0",
             HostHardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
             HostHardwareType::NvidiaDgxH100 => "1.11.0",
@@ -349,6 +375,7 @@ impl HostMachineInfo {
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().manager_config(),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().manager_config(),
             HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().manager_config(),
+            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().manager_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().manager_config()
@@ -374,6 +401,7 @@ impl HostMachineInfo {
             HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().system_config(callbacks),
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().system_config(callbacks),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().system_config(callbacks),
+            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().system_config(callbacks),
             HostHardwareType::SupermicroGb300Nvl => {
                 self.supermicro_gb300_nvl().system_config(callbacks)
             }
@@ -398,6 +426,7 @@ impl HostMachineInfo {
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().chassis_config(),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().chassis_config(),
             HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().chassis_config(),
+            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().chassis_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().chassis_config()
@@ -423,6 +452,7 @@ impl HostMachineInfo {
             HostHardwareType::SupermicroGb300Nvl => {
                 self.supermicro_gb300_nvl().update_service_config()
             }
+            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().update_service_config(),
             HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
             HostHardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().update_service_config()
@@ -444,6 +474,7 @@ impl HostMachineInfo {
             HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().discovery_info(),
             HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().discovery_info(),
+            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().discovery_info(),
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
                 self.generic_server().discovery_info()
@@ -700,6 +731,19 @@ impl HostMachineInfo {
                     serial_number: io_board1_sn.into(),
                 },
             ],
+        }
+    }
+
+    fn dgx_vr_nvl(&self) -> hw::dgx_vr_nvl::DgxVrNvl<'_> {
+        let mut dpus = self.dpus.iter();
+        hw::dgx_vr_nvl::DgxVrNvl {
+            system_0_serial_number: "012345678901234567890123".into(),
+            chassis_0_serial_number: Cow::Borrowed(&self.serial),
+            dpu: dpus
+                .next()
+                .expect("One DPU must present for VR NVL")
+                .bluefield4(),
+            bmc_mac_address_eth0: self.bmc_mac_address,
         }
     }
 

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -224,6 +224,24 @@ pub async fn dell_poweredge_r760_bluefield4_bmc(dpu: DpuMachineInfo) -> TestBmcH
     .await
 }
 
+pub async fn nvidia_dgx_vr_bluefield4_dpu_bmc(settings: DpuSettings) -> TestBmcHandle {
+    let machine_info = {
+        let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
+        MachineInfo::Dpu(DpuMachineInfo::new(
+            HostHardwareType::NvidiaDgxVr,
+            &mut mac_pool,
+            settings,
+        ))
+    };
+    test_bmc(machine_router(
+        &machine_info,
+        Arc::new(NoopCallbacks),
+        "test-dpu-id".to_string(),
+        false,
+    ))
+    .await
+}
+
 pub async fn generic_ami_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         &host_info(HostHardwareType::GenericAmi),


### PR DESCRIPTION
Treat B4240V chassis as BlueField-4 so exploration avoids fetching BootOptions when Redfish returns Members: null. Add DGX VR NVL mock support with B4240V metadata to cover the new variant.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

