### PR TITLE
fix: bump libredfish to v0.44.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.16#211f6e8dcdf4fa59500e3308246a6bc21a24276e"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.18#855c57dc567301f36801ac39c3a00432b17de08f"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.16" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.18" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
Bump up the libredfish version to 0.44.18 to include Vera Rubin hardware type. 

## Related issues
https://jirasw.nvidia.com/browse/FORGE-8111
