### PR TITLE
Fix redfish vendor vera rubin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.18#855c57dc567301f36801ac39c3a00432b17de08f"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.16#211f6e8dcdf4fa59500e3308246a6bc21a24276e"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.16#211f6e8dcdf4fa59500e3308246a6bc21a24276e"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.18#855c57dc567301f36801ac39c3a00432b17de08f"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.16" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.18" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.18" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.16" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -155,7 +155,8 @@ pub fn bmc_vendor(r: libredfish::model::service_root::RedfishVendor) -> BMCVendo
         | RedfishVendor::NvidiaGBx00
         | RedfishVendor::NvidiaGH200
         | RedfishVendor::NvidiaGBSwitch
-        | RedfishVendor::P3809 => BMCVendor::Nvidia,
+        | RedfishVendor::P3809
+        | RedfishVendor::VeraRubin => BMCVendor::Nvidia,
         RedfishVendor::Dell => BMCVendor::Dell,
         RedfishVendor::Hpe => BMCVendor::Hpe,
         RedfishVendor::Lenovo => BMCVendor::Lenovo,

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -231,7 +231,8 @@ impl RedfishClient {
             | RedfishVendor::P3809
             | RedfishVendor::LiteOnPowerShelf
             | RedfishVendor::DeltaPowerShelf
-            | RedfishVendor::NvidiaGBx00 => {
+            | RedfishVendor::NvidiaGBx00
+            | RedfishVendor::VeraRubin => {
                 // change_password does things that require a password and DPUs need a first
                 // password use to be change, so just change it directly
                 //


### PR DESCRIPTION
fix: Add RedfishVendor::VeraRubin to be compatible with libredfish changes. 
Bump up the libredfish version

## Related issues
Vera Rubin compute tray ingestion. 


