### PR TITLE
chore(api-web): Add VPC peerings table to VPC detail page

### DIFF
--- a/crates/api-web/src/vpc.rs
+++ b/crates/api-web/src/vpc.rs
@@ -174,6 +174,11 @@ async fn fetch_vpcs(api: Arc<Api>) -> Result<Vec<forgerpc::Vpc>, tonic::Status> 
     Ok(vpcs)
 }
 
+struct VpcPeeringRow {
+    id: String,
+    peer_vpc_id: String,
+}
+
 #[derive(Template)]
 #[template(path = "vpc_detail.html")]
 struct VpcDetail {
@@ -184,6 +189,7 @@ struct VpcDetail {
     routing_profile_type: String,
     vni: String,
     metadata_detail: super::MetadataDetail,
+    peerings: Vec<VpcPeeringRow>,
 }
 
 impl From<forgerpc::Vpc> for VpcDetail {
@@ -205,6 +211,7 @@ impl From<forgerpc::Vpc> for VpcDetail {
                 metadata: vpc.metadata.clone().unwrap_or_default(),
                 metadata_version: vpc.version,
             },
+            peerings: Vec::new(),
         }
     }
 }
@@ -259,8 +266,80 @@ pub async fn detail(
         return (StatusCode::OK, Json(vpc)).into_response();
     }
 
-    let tmpl: VpcDetail = vpc.into();
+    let mut tmpl: VpcDetail = vpc.into();
+
+    let peerings = fetch_vpc_peerings(state, vpc_id_string).await;
+    tmpl.peerings = peerings;
+
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}
+
+async fn fetch_vpc_peerings(state: Arc<Api>, vpc_id_string: String) -> Vec<VpcPeeringRow> {
+    let Ok(vpc_id) = vpc_id_string.parse() else {
+        return Vec::new();
+    };
+
+    // Get the peering IDs for the VPC
+    let peering_ids = match state
+        .find_vpc_peering_ids(tonic::Request::new(forgerpc::VpcPeeringSearchFilter {
+            vpc_id: Some(vpc_id),
+        }))
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(id_list) => id_list.vpc_peering_ids,
+        Err(err) => {
+            tracing::error!(%err, "find_vpc_peering_ids");
+            return Vec::new();
+        }
+    };
+
+    // Short circuit if there are no peerings
+    if peering_ids.is_empty() {
+        return Vec::new();
+    }
+
+    // Get the peerings by IDs
+    let peerings = match state
+        .find_vpc_peerings_by_ids(tonic::Request::new(forgerpc::VpcPeeringsByIdsRequest {
+            vpc_peering_ids: peering_ids,
+        }))
+        .await
+        .map(|response| response.into_inner())
+    {
+        Ok(peerings) => peerings.vpc_peerings,
+        Err(err) => {
+            tracing::error!(%err, "find_vpc_peerings_by_ids");
+            Vec::new()
+        }
+    };
+
+    peerings
+        .into_iter()
+        .map(|p| {
+            let vpc_id_str = p
+                .vpc_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default();
+            let peer_vpc_id_str = p
+                .peer_vpc_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default();
+            // The search filter may return peerings where the current VPC is on
+            // either side; resolve to whichever side is not the current VPC.
+            let peer_vpc_id = if vpc_id_str == vpc_id_string {
+                peer_vpc_id_str
+            } else {
+                vpc_id_str
+            };
+            VpcPeeringRow {
+                id: p.id.map(|id| id.to_string()).unwrap_or_default(),
+                peer_vpc_id,
+            }
+        })
+        .collect()
 }
 
 impl super::Base for VpcShow {}

--- a/crates/api-web/templates/vpc_detail.html
+++ b/crates/api-web/templates/vpc_detail.html
@@ -18,4 +18,20 @@
 <h2>Metadata</h2>
 {{ metadata_detail|safe }}
 
+<h2>VPC Peerings</h2>
+{% if peerings.is_empty() %}
+<p>No VPC peerings found.</p>
+{% else %}
+<table class="sortable overview">
+	<thead>
+		<tr><th>Peering ID</th><th>Peer VPC</th></tr>
+	</thead>
+	<tbody>
+		{% for peering in peerings %}
+		<tr><td>{{ peering.id }}</td><td><a href="/admin/vpc/{{ peering.peer_vpc_id }}">{{ peering.peer_vpc_id }}</a></td></tr>
+		{% endfor %}
+	</tbody>
+</table>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
Adding a table of peer VPCs on the VPC detail page of web UI. The table shows each peering ID and links tot he peer VPC's own detail page. 

When VPC peerings found:
<img width="1186" height="225" alt="Screenshot 2026-07-01 at 4 19 26 PM" src="https://github.com/user-attachments/assets/c34a3cdf-8578-4ade-948e-2d8860346c05" />

When no VPC peerings found: 
<img width="1214" height="116" alt="Screenshot 2026-07-01 at 4 19 48 PM" src="https://github.com/user-attachments/assets/d32bc24c-7eff-4718-960e-e0a4813be080" />



## Related issues

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


