### PR TITLE
feat: Dpf: Support for multiple DpuDeployments to handle BF3, BF4 and other deployment strategy 

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1170,13 +1170,12 @@ pub struct DpfDeploymentConfig {
     /// URL to the BlueField firmware bundle (BFB) for DPU provisioning.
     pub bfb_url: String,
     /// Kubernetes DPUFlavor CR name.
-    #[serde(default = "default_dpf_flavor_name")]
     pub flavor_name: String,
     /// Kubernetes DPUDeployment CR name.
     pub deployment_name: String,
     /// Label key applied to DPUNode CRs for this deployment's node selector.
-    #[serde(default = "default_dpf_node_label_key")]
     pub node_label_key: String,
+    // TODO: add optional services handling here.
 }
 
 /// Named DPUDeployment configurations under `[dpf.deployments]`.

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1048,6 +1048,10 @@ pub struct DpfConfig {
     /// configured to route outbound HTTPS traffic through the specified proxy.
     #[serde(default)]
     pub proxy: Option<DpfProxyDetails>,
+    /// Additional named DPUDeployments (e.g. `bf4_generic`).
+    /// Each entry creates its own BFB, DPUFlavor, and DPUDeployment CR at startup.
+    #[serde(default)]
+    pub deployments: DpfDeploymentsConfig,
 }
 
 impl Default for DpfConfig {
@@ -1061,6 +1065,7 @@ impl Default for DpfConfig {
             docker_image_pull_secret: None,
             services: Box::default(),
             proxy: None,
+            deployments: DpfDeploymentsConfig::default(),
         }
     }
 }
@@ -1156,6 +1161,31 @@ pub struct DpfServiceConfig {
     /// Secret to use to pull the docker images.
     #[serde(default = "default_dpf_image_pull_secret")]
     pub docker_image_pull_secret: String,
+}
+
+/// Per-deployment DPF configuration for named entries under `[dpf.deployments]`.
+/// Services are inherited from the top-level [`DpfConfig`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DpfDeploymentConfig {
+    /// URL to the BlueField firmware bundle (BFB) for DPU provisioning.
+    pub bfb_url: String,
+    /// Kubernetes DPUFlavor CR name.
+    #[serde(default = "default_dpf_flavor_name")]
+    pub flavor_name: String,
+    /// Kubernetes DPUDeployment CR name.
+    pub deployment_name: String,
+    /// Label key applied to DPUNode CRs for this deployment's node selector.
+    #[serde(default = "default_dpf_node_label_key")]
+    pub node_label_key: String,
+}
+
+/// Named DPUDeployment configurations under `[dpf.deployments]`.
+/// Each entry creates its own BFB, DPUFlavor, and DPUDeployment CR at startup.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct DpfDeploymentsConfig {
+    /// BF4 generic deployment (NICo + BF4 via DPF).
+    #[serde(default)]
+    pub bf4_generic: Option<DpfDeploymentConfig>,
 }
 
 /// Machine identity (SPIFFE JWT-SVID) configuration.

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1017,24 +1017,11 @@ pub enum ComputeAllocationEnforcement {
 
 /// DPF (DPU Platform Framework) configuration for
 /// deploying DPU fabric as a Kubernetes service.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Default, Deserialize)]
 pub struct DpfConfig {
     /// Enables DPF deployment.
     #[serde(default)]
     pub enabled: bool,
-    /// Kubernetes deployment name for the DPF service.
-    #[serde(default = "default_dpf_deployment_name")]
-    pub deployment_name: String,
-    /// Kubernetes DPUFlavor CR name.
-    #[serde(default = "default_dpf_flavor_name")]
-    pub flavor_name: String,
-    /// Label key applied to DPUNode CRs for deployment matching.
-    #[serde(default = "default_dpf_node_label_key")]
-    pub node_label_key: String,
-    /// URL to the BlueField firmware bundle (BFB) for
-    /// DPU provisioning.
-    #[serde(default = "default_dpf_bfb_url")]
-    pub bfb_url: String,
     /// Optional override for the Kubernetes `imagePullSecrets` entry used to pull the
     /// docker images of the mandatory services. When set, it is applied to every
     /// mandatory service except `dts` and `doca_hbn`. This also overrides if
@@ -1048,26 +1035,10 @@ pub struct DpfConfig {
     /// configured to route outbound HTTPS traffic through the specified proxy.
     #[serde(default)]
     pub proxy: Option<DpfProxyDetails>,
-    /// Additional named DPUDeployments (e.g. `bf4_generic`).
-    /// Each entry creates its own BFB, DPUFlavor, and DPUDeployment CR at startup.
+    /// Per-generation DPUDeployment configurations. BF3 is always present with sensible
+    /// defaults; BF4Generic is opt-in via `[dpf.deployments.bf4_generic]`.
     #[serde(default)]
     pub deployments: DpfDeploymentsConfig,
-}
-
-impl Default for DpfConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            deployment_name: default_dpf_deployment_name(),
-            flavor_name: default_dpf_flavor_name(),
-            node_label_key: default_dpf_node_label_key(),
-            bfb_url: String::new(),
-            docker_image_pull_secret: None,
-            services: Box::default(),
-            proxy: None,
-            deployments: DpfDeploymentsConfig::default(),
-        }
-    }
 }
 
 impl DpfConfig {
@@ -1165,9 +1136,16 @@ pub struct DpfServiceConfig {
 
 /// Per-deployment DPF configuration for named entries under `[dpf.deployments]`.
 /// Services are inherited from the top-level [`DpfConfig`].
+///
+/// No serde field defaults: when `[dpf.deployments.bf3]` or
+/// `[dpf.deployments.bf4_generic]` is written in the config file, all four
+/// fields are required. The `Default` impl (BF3 values) is only used when the
+/// entire `[dpf.deployments.bf3]` block is absent, via `#[serde(default)]` on
+/// the `bf3` field of [`DpfDeploymentsConfig`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DpfDeploymentConfig {
     /// URL to the BlueField firmware bundle (BFB) for DPU provisioning.
+    #[serde(default = "default_dpf_bfb_url")]
     pub bfb_url: String,
     /// Kubernetes DPUFlavor CR name.
     pub flavor_name: String,
@@ -1178,13 +1156,85 @@ pub struct DpfDeploymentConfig {
     // TODO: add optional services handling here.
 }
 
+impl Default for DpfDeploymentConfig {
+    fn default() -> Self {
+        Self {
+            bfb_url: default_dpf_bfb_url(),
+            flavor_name: default_dpf_flavor_name(),
+            deployment_name: default_dpf_deployment_name(),
+            node_label_key: default_dpf_node_label_key(),
+        }
+    }
+}
+
 /// Named DPUDeployment configurations under `[dpf.deployments]`.
 /// Each entry creates its own BFB, DPUFlavor, and DPUDeployment CR at startup.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DpfDeploymentsConfig {
+    /// BF3 deployment. Present by default with sensible values; override individual
+    /// fields in `[dpf.deployments.bf3]` when the site uses non-default names or BFBs.
+    #[serde(default)]
+    pub bf3: DpfDeploymentConfig,
     /// BF4 generic deployment (NICo + BF4 via DPF).
     #[serde(default)]
     pub bf4_generic: Option<DpfDeploymentConfig>,
+}
+
+impl DpfDeploymentsConfig {
+    /// Returns all active deployment configs as `(name, config)` pairs.
+    /// Add new deployments here when they are introduced.
+    fn all(&self) -> Vec<(&'static str, &DpfDeploymentConfig)> {
+        let mut v = vec![("bf3", &self.bf3)];
+        if let Some(bf4) = &self.bf4_generic {
+            v.push(("bf4_generic", bf4));
+        }
+        v
+    }
+
+    /// Validates that no two active deployments share a `deployment_name`,
+    /// `flavor_name`, or `node_label_key`. Returns an error listing every
+    /// conflict so the operator can fix them all in one pass.
+    pub fn validate_unique_identifiers(&self) -> eyre::Result<()> {
+        let deployments = self.all();
+        let mut errors: Vec<String> = Vec::new();
+
+        let name_vals: Vec<(&str, &str)> = deployments
+            .iter()
+            .map(|(n, c)| (*n, c.deployment_name.as_str()))
+            .collect();
+        let flavor_vals: Vec<(&str, &str)> = deployments
+            .iter()
+            .map(|(n, c)| (*n, c.flavor_name.as_str()))
+            .collect();
+        let label_vals: Vec<(&str, &str)> = deployments
+            .iter()
+            .map(|(n, c)| (*n, c.node_label_key.as_str()))
+            .collect();
+        let checks = [
+            ("deployment_name", &name_vals),
+            ("flavor_name", &flavor_vals),
+            ("node_label_key", &label_vals),
+        ];
+        for (field, values) in &checks {
+            let mut seen: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+            for (name, value) in values.iter() {
+                if let Some(prev) = seen.insert(value, name) {
+                    errors.push(format!(
+                        "{field} {value:?} is shared by deployments {prev:?} and {name:?}"
+                    ));
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(eyre::eyre!(
+                "DPF deployment configuration has conflicting identifiers:\n  - {}",
+                errors.join("\n  - ")
+            ))
+        }
+    }
 }
 
 /// Machine identity (SPIFFE JWT-SVID) configuration.

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -30,7 +30,9 @@ use carbide_dpf::{
     ServiceInterface, ServiceNAD, ServiceNADResourceType,
 };
 
-use crate::cfg::file::{DEFAULT_DPF_IMAGE_PULL_SECRET, DpfServiceConfig};
+use crate::cfg::file::{
+    DEFAULT_DPF_IMAGE_PULL_SECRET, DpfMandatoryServicesConfig, DpfServiceConfig,
+};
 
 /// Default DOCA helm registry (DPUServiceTemplate source.repoURL).
 pub const DEFAULT_DOCA_HELM_REGISTRY: &str = "https://helm.ngc.nvidia.com/nvidia/doca";
@@ -425,6 +427,18 @@ pub fn otelcol_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
             &cfg.helm_version,
         )
     }
+}
+
+/// Build the full list of mandatory DPU services from config.
+pub fn mandatory_services(cfg: &DpfMandatoryServicesConfig) -> Vec<ServiceDefinition> {
+    vec![
+        dts_service(&cfg.dts),
+        doca_hbn_service(&cfg.doca_hbn),
+        dhcp_server_service(&cfg.dhcp_server),
+        dpu_agent_service(&cfg.dpu_agent),
+        fmds_service(&cfg.fmds),
+        otelcol_service(&cfg.otel),
+    ]
 }
 
 #[cfg(test)]

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -651,44 +651,50 @@ async fn initialize_dpf_sdk(
 
     let provider = CarbideBmcPasswordProvider::new(credential_manager, db_pool.clone());
 
+    carbide_config
+        .dpf
+        .deployments
+        .validate_unique_identifiers()
+        .map_err(|err| eyre::eyre!("Invalid DPF deployment configuration: {err}"))?;
+
     let mandatory_services = carbide_config.dpf.resolved_mandatory_services();
 
     // This is just temporary code until we make v2 only option. (just 2 weeks)
     // Soon v2 flag will be removed and will become only mode for dpf handling.
-    let init_config = carbide_dpf::InitDpfResourcesConfig {
-        bfb_url: carbide_config.dpf.bfb_url.clone(),
-        flavor_name: carbide_config.dpf.flavor_name.clone(),
-        deployment_name: carbide_config.dpf.deployment_name.clone(),
-        services: crate::dpf_services::mandatory_services(&mandatory_services),
-        proxy: carbide_config.dpf.proxy.clone(),
-        deployment_type: DpuDeploymentType::Bf3,
-    };
-
     let deployment_type_labels = build_deployment_type_labels(carbide_config);
 
     let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
         .with_labeler(
-            CarbideDPFLabeler::new(carbide_config.dpf.node_label_key.clone())
+            CarbideDPFLabeler::new(carbide_config.dpf.deployments.bf3.node_label_key.clone())
                 .with_deployment_type_labels(deployment_type_labels),
         )
         .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
         .with_join_set(join_set)
-        .initialize(&init_config)
+        .build_without_resources()
         .await
         .map_err(|err| eyre::eyre!("Failed to initialize DPF SDK: {err}"))?;
 
-    // Initialize any additional named deployments (e.g. bf4_generic).
-    // Services are inherited from the top-level DPF config.
-    if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
-        let bf4_init_config = carbide_dpf::InitDpfResourcesConfig {
-            bfb_url: bf4.bfb_url.clone(),
-            flavor_name: bf4.flavor_name.clone(),
-            deployment_name: bf4.deployment_name.clone(),
+    let make_init_config = |deployment: &crate::cfg::file::DpfDeploymentConfig,
+                            deployment_type: DpuDeploymentType| {
+        carbide_dpf::InitDpfResourcesConfig {
+            bfb_url: deployment.bfb_url.clone(),
+            flavor_name: deployment.flavor_name.clone(),
+            deployment_name: deployment.deployment_name.clone(),
             services: crate::dpf_services::mandatory_services(&mandatory_services),
             proxy: carbide_config.dpf.proxy.clone(),
-            deployment_type: DpuDeploymentType::Bf4Generic,
-        };
-        sdk.create_initialization_objects(&bf4_init_config)
+            deployment_type,
+        }
+    };
+
+    sdk.create_initialization_objects(&make_init_config(
+        &carbide_config.dpf.deployments.bf3,
+        DpuDeploymentType::Bf3,
+    ))
+    .await
+    .map_err(|err| eyre::eyre!("Failed to initialize bf3 DPF deployment: {err}"))?;
+
+    if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
+        sdk.create_initialization_objects(&make_init_config(bf4, DpuDeploymentType::Bf4Generic))
             .await
             .map_err(|err| eyre::eyre!("Failed to initialize bf4_generic DPF deployment: {err}"))?;
     }
@@ -720,7 +726,7 @@ fn build_deployment_type_labels(
 
     let mut map = std::collections::BTreeMap::from([(
         DpuDeploymentType::Bf3,
-        make_labels(&carbide_config.dpf.node_label_key),
+        make_labels(&carbide_config.dpf.deployments.bf3.node_label_key),
     )]);
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -522,15 +522,67 @@ pub async fn start_api(
             proxy: carbide_config.dpf.proxy.clone(),
         };
 
+        // Build per-deployment node selector labels for the labeler registry.
+        // BF3 (the default deployment) is always registered; additional deployments
+        // are added from [dpf.deployments].
+        let deployment_node_labels = {
+            let make_labels = |key: &str| {
+                std::collections::BTreeMap::from([
+                    (
+                        "feature.node.kubernetes.io/dpu-enabled".to_string(),
+                        "true".to_string(),
+                    ),
+                    (key.to_string(), "true".to_string()),
+                ])
+            };
+            let mut map = std::collections::BTreeMap::from([(
+                carbide_config.dpf.deployment_name.clone(),
+                make_labels(&carbide_config.dpf.node_label_key),
+            )]);
+            if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
+                map.insert(
+                    bf4.deployment_name.clone(),
+                    make_labels(&bf4.node_label_key),
+                );
+            }
+            map
+        };
+
         let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
-            .with_labeler(CarbideDPFLabeler::new(
-                carbide_config.dpf.node_label_key.clone(),
-            ))
+            .with_labeler(
+                CarbideDPFLabeler::new(carbide_config.dpf.node_label_key.clone())
+                    .with_deployment_node_labels(deployment_node_labels),
+            )
             .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
             .with_join_set(join_set)
             .initialize(&init_config)
             .await
             .map_err(|err| eyre::eyre!("Failed to initialize DPF SDK: {err}"))?;
+
+        // Initialize any additional named deployments (e.g. bf4_generic).
+        // Services are inherited from the top-level DPF config.
+        if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
+            let inherited_services = carbide_config.dpf.resolved_mandatory_services();
+            let bf4_init_config = carbide_dpf::InitDpfResourcesConfig {
+                bfb_url: bf4.bfb_url.clone(),
+                flavor_name: bf4.flavor_name.clone(),
+                deployment_name: bf4.deployment_name.clone(),
+                services: vec![
+                    crate::dpf_services::dts_service(&inherited_services.dts),
+                    crate::dpf_services::doca_hbn_service(&inherited_services.doca_hbn),
+                    crate::dpf_services::dhcp_server_service(&inherited_services.dhcp_server),
+                    crate::dpf_services::dpu_agent_service(&inherited_services.dpu_agent),
+                    crate::dpf_services::fmds_service(&inherited_services.fmds),
+                    crate::dpf_services::otelcol_service(&inherited_services.otel),
+                ],
+                proxy: carbide_config.dpf.proxy.clone(),
+            };
+            sdk.create_initialization_objects(&bf4_init_config)
+                .await
+                .map_err(|err| {
+                    eyre::eyre!("Failed to initialize bf4_generic DPF deployment: {err}")
+                })?;
+        }
 
         Some(Arc::new(DpfSdkOps::new(
             Arc::new(sdk),

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use carbide_dpa::DpaInfo;
 use carbide_dpa_manager::DpaMonitor;
+use carbide_dpf::DpuDeploymentType;
 use carbide_firmware::FirmwareDownloader;
 use carbide_health_metrics::PerObjectMetricsRegistry;
 use carbide_ib_fabric::IbFabricMonitor;
@@ -492,111 +493,13 @@ pub async fn start_api(
         .map_err(|e| eyre::eyre!("Failed to build NMX-C client pool: {e}"))?;
     let shared_nmxc_pool: Arc<dyn libnmxc::NmxcPool> = Arc::new(nmxc_client_pool);
 
-    // Create DPF SDK and initialize CRs if enabled
-    // If we end up having static DPUDeployments, we could move the static CRs outside of the API.
-    let dpf_sdk: Option<Arc<dyn DpfOperations>> = if carbide_config.dpf.enabled {
-        tracing::info!("Initializing DPF SDK");
-        let repo = carbide_dpf::KubeRepository::new()
-            .await
-            .map_err(|e| eyre::eyre!("Failed to create DPF repository: {e}"))?;
-
-        let provider = CarbideBmcPasswordProvider::new(credential_manager.clone(), db_pool.clone());
-
-        let mandatory_services = carbide_config.dpf.resolved_mandatory_services();
-        let dpf_mandatory_services = vec![
-            crate::dpf_services::dts_service(&mandatory_services.dts),
-            crate::dpf_services::doca_hbn_service(&mandatory_services.doca_hbn),
-            crate::dpf_services::dhcp_server_service(&mandatory_services.dhcp_server),
-            crate::dpf_services::dpu_agent_service(&mandatory_services.dpu_agent),
-            crate::dpf_services::fmds_service(&mandatory_services.fmds),
-            crate::dpf_services::otelcol_service(&mandatory_services.otel),
-        ];
-
-        // This is just temparary code until we make v2 only option. (just 2 weeks)
-        // Soon v2 flag will be removed and will become only mode for dpf handling.
-        let init_config = carbide_dpf::InitDpfResourcesConfig {
-            bfb_url: carbide_config.dpf.bfb_url.clone(),
-            flavor_name: carbide_config.dpf.flavor_name.clone(),
-            deployment_name: carbide_config.dpf.deployment_name.clone(),
-            services: dpf_mandatory_services,
-            proxy: carbide_config.dpf.proxy.clone(),
-        };
-
-        // Build per-deployment node selector labels for the labeler registry.
-        // BF3 (the default deployment) is always registered; additional deployments
-        // are added from [dpf.deployments].
-        let deployment_node_labels = {
-            let make_labels = |key: &str| {
-                std::collections::BTreeMap::from([
-                    (
-                        "feature.node.kubernetes.io/dpu-enabled".to_string(),
-                        "true".to_string(),
-                    ),
-                    (key.to_string(), "true".to_string()),
-                ])
-            };
-            let mut map = std::collections::BTreeMap::from([(
-                carbide_config.dpf.deployment_name.clone(),
-                make_labels(&carbide_config.dpf.node_label_key),
-            )]);
-            if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
-                map.insert(
-                    bf4.deployment_name.clone(),
-                    make_labels(&bf4.node_label_key),
-                );
-            }
-            map
-        };
-
-        let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
-            .with_labeler(
-                CarbideDPFLabeler::new(carbide_config.dpf.node_label_key.clone())
-                    .with_deployment_node_labels(deployment_node_labels),
-            )
-            .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
-            .with_join_set(join_set)
-            .initialize(&init_config)
-            .await
-            .map_err(|err| eyre::eyre!("Failed to initialize DPF SDK: {err}"))?;
-
-        // Initialize any additional named deployments (e.g. bf4_generic).
-        // Services are inherited from the top-level DPF config.
-        if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
-            let inherited_services = carbide_config.dpf.resolved_mandatory_services();
-            let bf4_init_config = carbide_dpf::InitDpfResourcesConfig {
-                bfb_url: bf4.bfb_url.clone(),
-                flavor_name: bf4.flavor_name.clone(),
-                deployment_name: bf4.deployment_name.clone(),
-                services: vec![
-                    crate::dpf_services::dts_service(&inherited_services.dts),
-                    crate::dpf_services::doca_hbn_service(&inherited_services.doca_hbn),
-                    crate::dpf_services::dhcp_server_service(&inherited_services.dhcp_server),
-                    crate::dpf_services::dpu_agent_service(&inherited_services.dpu_agent),
-                    crate::dpf_services::fmds_service(&inherited_services.fmds),
-                    crate::dpf_services::otelcol_service(&inherited_services.otel),
-                ],
-                proxy: carbide_config.dpf.proxy.clone(),
-            };
-            sdk.create_initialization_objects(&bf4_init_config)
-                .await
-                .map_err(|err| {
-                    eyre::eyre!("Failed to initialize bf4_generic DPF deployment: {err}")
-                })?;
-        }
-
-        Some(Arc::new(DpfSdkOps::new(
-            Arc::new(sdk),
-            db_pool.clone(),
-            join_set,
-        )?))
-    } else {
-        tracing::warn!(
-            removed_in = "v2.1",
-            docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
-            "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
-        );
-        None
-    };
+    let dpf_sdk = initialize_dpf_sdk(
+        &carbide_config,
+        credential_manager.clone(),
+        db_pool.clone(),
+        join_set,
+    )
+    .await?;
 
     let component_manager = if let Some(cd_config) = &carbide_config.component_manager {
         match component_manager::component_manager::build_component_manager(
@@ -720,6 +623,114 @@ pub async fn start_api(
         .ok();
 
     Ok(())
+}
+
+/// Initialize the DPF SDK and create all required Kubernetes CRs.
+///
+/// Returns `None` (with a deprecation warning) when DPF is disabled.
+async fn initialize_dpf_sdk(
+    carbide_config: &CarbideConfig,
+    credential_manager: Arc<dyn CredentialManager>,
+    db_pool: PgPool,
+    join_set: &mut JoinSet<()>,
+) -> eyre::Result<Option<Arc<dyn DpfOperations>>> {
+    if !carbide_config.dpf.enabled {
+        tracing::warn!(
+            removed_in = "v2.1",
+            docs = "https://docs.nvidia.com/infra-controller/documentation/getting-started/installation-options/dpf-setup",
+            "iPXE provisioning strategy (internally) is deprecated; enable DPF management for DPUs to migrate"
+        );
+        return Ok(None);
+    }
+
+    tracing::info!("Initializing DPF SDK");
+
+    let repo = carbide_dpf::KubeRepository::new()
+        .await
+        .map_err(|e| eyre::eyre!("Failed to create DPF repository: {e}"))?;
+
+    let provider = CarbideBmcPasswordProvider::new(credential_manager, db_pool.clone());
+
+    let mandatory_services = carbide_config.dpf.resolved_mandatory_services();
+
+    // This is just temporary code until we make v2 only option. (just 2 weeks)
+    // Soon v2 flag will be removed and will become only mode for dpf handling.
+    let init_config = carbide_dpf::InitDpfResourcesConfig {
+        bfb_url: carbide_config.dpf.bfb_url.clone(),
+        flavor_name: carbide_config.dpf.flavor_name.clone(),
+        deployment_name: carbide_config.dpf.deployment_name.clone(),
+        services: crate::dpf_services::mandatory_services(&mandatory_services),
+        proxy: carbide_config.dpf.proxy.clone(),
+        deployment_type: DpuDeploymentType::Bf3,
+    };
+
+    let deployment_type_labels = build_deployment_type_labels(carbide_config);
+
+    let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
+        .with_labeler(
+            CarbideDPFLabeler::new(carbide_config.dpf.node_label_key.clone())
+                .with_deployment_type_labels(deployment_type_labels),
+        )
+        .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
+        .with_join_set(join_set)
+        .initialize(&init_config)
+        .await
+        .map_err(|err| eyre::eyre!("Failed to initialize DPF SDK: {err}"))?;
+
+    // Initialize any additional named deployments (e.g. bf4_generic).
+    // Services are inherited from the top-level DPF config.
+    if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
+        let bf4_init_config = carbide_dpf::InitDpfResourcesConfig {
+            bfb_url: bf4.bfb_url.clone(),
+            flavor_name: bf4.flavor_name.clone(),
+            deployment_name: bf4.deployment_name.clone(),
+            services: crate::dpf_services::mandatory_services(&mandatory_services),
+            proxy: carbide_config.dpf.proxy.clone(),
+            deployment_type: DpuDeploymentType::Bf4Generic,
+        };
+        sdk.create_initialization_objects(&bf4_init_config)
+            .await
+            .map_err(|err| eyre::eyre!("Failed to initialize bf4_generic DPF deployment: {err}"))?;
+    }
+
+    Ok(Some(Arc::new(DpfSdkOps::new(
+        Arc::new(sdk),
+        db_pool,
+        join_set,
+    )?)))
+}
+
+/// Build per-deployment-type node selector labels for the DPF labeler registry.
+///
+/// Each deployment gets two labels: the shared `dpu-enabled` marker and its
+/// own deployment-specific key. BF3 is always included;
+/// BF4Generic is added when configured.
+fn build_deployment_type_labels(
+    carbide_config: &CarbideConfig,
+) -> std::collections::BTreeMap<DpuDeploymentType, std::collections::BTreeMap<String, String>> {
+    let make_labels = |key: &str| {
+        std::collections::BTreeMap::from([
+            (
+                "feature.node.kubernetes.io/dpu-enabled".to_string(),
+                "true".to_string(),
+            ),
+            (key.to_string(), "true".to_string()),
+        ])
+    };
+
+    let mut map = std::collections::BTreeMap::from([(
+        DpuDeploymentType::Bf3,
+        make_labels(&carbide_config.dpf.node_label_key),
+    )]);
+
+    if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
+        map.insert(
+            DpuDeploymentType::Bf4Generic,
+            make_labels(&bf4.node_label_key),
+        );
+    }
+
+    map
 }
 
 #[derive(Debug)]

--- a/crates/api-core/src/tests/dpf/duplicate_events.rs
+++ b/crates/api-core/src/tests/dpf/duplicate_events.rs
@@ -58,7 +58,13 @@ fn dpf_left_operator_provisioning_substates(host: &ManagedHostState) -> bool {
 fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
-        bfb_url: "http://example.com/test.bfb".to_string(),
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: "http://example.com/test.bfb".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -67,7 +73,7 @@ fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_register_dpu_device().returning(|_| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
 }
 

--- a/crates/api-core/src/tests/dpf/duplicate_events.rs
+++ b/crates/api-core/src/tests/dpf/duplicate_events.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use carbide_dpf::DpuPhase;
+use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_redfish::libredfish::test_support::RedfishSimAction;
 use carbide_uuid::machine::MachineId;
@@ -66,7 +66,9 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
 fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_register_dpu_device().returning(|_| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
-    mock.expect_verify_node_labels().returning(|_| Ok(true));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
 }
 
 async fn reset_host_to_waiting_for_ready(

--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -42,7 +42,7 @@ fn default_mock() -> MockDpfOperations {
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock
 }
@@ -54,7 +54,13 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     let mut config = get_config();
     config.dpf = crate::cfg::file::DpfConfig {
         enabled: true,
-        bfb_url: "http://example.com/test.bfb".to_string(),
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: "http://example.com/test.bfb".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     };
 

--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use carbide_dpf::DpuPhase;
+use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::DpfOperations;
 use model::machine::ManagedHostState;
 use tokio::time::timeout;
@@ -41,7 +41,9 @@ fn default_mock() -> MockDpfOperations {
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
-    mock.expect_verify_node_labels().returning(|_| Ok(true));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock
 }
 

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -25,8 +25,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use carbide_dpf::DpuPhase;
 use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
+use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
 use model::machine::{
@@ -78,7 +78,9 @@ fn provisioning_mock_with_dpu_count(
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
-    mock.expect_verify_node_labels().returning(|_| Ok(true));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
     mock.expect_get_dpu_phase().returning(move |_, _| {
@@ -376,7 +378,9 @@ fn capturing_mock(
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
-    mock.expect_verify_node_labels().returning(|_| Ok(true));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
 

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -79,7 +79,7 @@ fn provisioning_mock_with_dpu_count(
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
@@ -96,7 +96,13 @@ fn provisioning_mock_with_dpu_count(
 fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
-        bfb_url: "http://example.com/test.bfb".to_string(),
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: "http://example.com/test.bfb".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -379,7 +385,7 @@ fn capturing_mock(
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));

--- a/crates/api-core/src/tests/dpf/stale_labels.rs
+++ b/crates/api-core/src/tests/dpf/stale_labels.rs
@@ -43,7 +43,13 @@ const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
-        bfb_url: "http://example.com/test.bfb".to_string(),
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: "http://example.com/test.bfb".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     }
 }
@@ -57,7 +63,7 @@ fn provisioning_mock_with_labels_valid(labels_valid: Arc<AtomicBool>) -> MockDpf
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels()
         .returning(move |_, _| Ok(labels_valid.load(Ordering::SeqCst)));
     mock

--- a/crates/api-core/src/tests/dpf/stale_labels.rs
+++ b/crates/api-core/src/tests/dpf/stale_labels.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use carbide_dpf::DpuPhase;
+use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
 use model::machine::{DpfState, DpuInitState, FailureCause, FailureDetails, ManagedHostState};
@@ -56,8 +56,10 @@ fn provisioning_mock_with_labels_valid(labels_valid: Arc<AtomicBool>) -> MockDpf
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
     mock.expect_verify_node_labels()
-        .returning(move |_| Ok(labels_valid.load(Ordering::SeqCst)));
+        .returning(move |_, _| Ok(labels_valid.load(Ordering::SeqCst)));
     mock
 }
 

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use carbide_dpf::DpuPhase;
+use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_redfish::libredfish::test_support::RedfishSimAction;
@@ -57,7 +57,9 @@ fn dpf_left_operator_provisioning_substates(host: &ManagedHostState) -> bool {
 fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_register_dpu_device().returning(|_| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
-    mock.expect_verify_node_labels().returning(|_| Ok(true));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
 }
 
 fn dpf_config() -> crate::cfg::file::DpfConfig {

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -58,14 +58,20 @@ fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_register_dpu_device().returning(|_| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
 }
 
 fn dpf_config() -> crate::cfg::file::DpfConfig {
     crate::cfg::file::DpfConfig {
         enabled: true,
-        bfb_url: "http://example.com/test.bfb".to_string(),
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: "http://example.com/test.bfb".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     }
 }

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -754,7 +754,7 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| DpuDeploymentType::Bf3);
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(carbide_dpf::DpuPhase::Ready));
@@ -772,7 +772,13 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     let mut config = get_config();
     config.dpf = crate::cfg::file::DpfConfig {
         enabled: true,
-        bfb_url: "http://example.com/test.bfb".to_string(),
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: "http://example.com/test.bfb".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
         ..Default::default()
     };
 

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -24,6 +24,7 @@ use ::rpc::forge::forge_server::Forge;
 use ::rpc::forge::{
     AdminForceDeleteMachineRequest, IbPartitionStatus, InstancesByIdsRequest, TenantState,
 };
+use carbide_dpf::DpuDeploymentType;
 use carbide_ib_fabric::config::IBFabricConfig;
 use carbide_ib_fabric::ib::{self, IBFabricManager};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
@@ -752,7 +753,9 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     mock.expect_release_maintenance_hold().returning(|_| Ok(()));
     mock.expect_is_reboot_required().returning(|_| Ok(false));
-    mock.expect_verify_node_labels().returning(|_| Ok(true));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| DpuDeploymentType::Bf3);
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(carbide_dpf::DpuPhase::Ready));
 

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -27,8 +27,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use carbide_dpf::repository::{DpuRepository, K8sConfigRepository};
 use carbide_dpf::{
-    DpfError, DpfSdk, DpfSdkBuilder, DpuDeviceInfo, DpuNodeInfo, InitDpfResourcesConfig,
-    KubeRepository, NAMESPACE, ServiceDefinition, dpu_node_cr_name,
+    DpfError, DpfSdk, DpfSdkBuilder, DpuDeploymentType, DpuDeviceInfo, DpuNodeInfo,
+    InitDpfResourcesConfig, KubeRepository, NAMESPACE, ServiceDefinition, dpu_node_cr_name,
 };
 use clap::{Parser, Subcommand};
 use libredfish::model::BootProgressTypes;
@@ -729,6 +729,7 @@ async fn run_provisioning_flow(
             serial_number: dpu.serial_number.clone(),
             dpu_machine_id: String::new(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
         sdk.register_dpu_device(info).await?;
         tracing::info!(device_name = %dpu.device_name, serial = %dpu.serial_number, "Registered device");
@@ -739,6 +740,7 @@ async fn run_provisioning_flow(
         node_id: node_id.to_string(),
         host_bmc_ip: host_bmc_ip_addr,
         device_ids: dpus.iter().map(|d| d.device_name.clone()).collect(),
+        deployment_type: DpuDeploymentType::Bf3,
     };
     sdk.register_dpu_node(node_info).await?;
     tracing::info!(dpu_count = dpus.len(), "Node registered");

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -24,7 +24,7 @@ use crate::crds::dpuflavors_generated::{
     DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesOperation, DpuFlavorDpuMode,
     DpuFlavorNvconfig, DpuFlavorNvconfigDevice, DpuFlavorSpec,
 };
-use crate::types::DpfProxyDetails;
+use crate::types::{DpfProxyDetails, DpuDeploymentType};
 
 pub const DEFAULT_FLAVOR_NAME: &str = "dpu-flavor";
 
@@ -75,6 +75,23 @@ fn validate_proxy_string(value: &str, field: &str) -> Result<(), crate::error::D
         )));
     }
     Ok(())
+}
+
+/// Build the DPUFlavor spec for a specific deployment type. If `proxy` is set, a containerd
+/// proxy drop-in config file is appended so the DPU can pull images through the proxy.
+///
+/// Returns `ConfigError` if any proxy string contains characters that would break the generated
+/// systemd `Environment="..."` lines (quotes, newlines, or other control characters).
+///
+/// `metadata.name` is left unset; callers must set it (typically via [`DPUFlavor::unique_name`])
+/// before creating the resource in the cluster.
+pub fn default_flavor_for(
+    namespace: &str,
+    proxy: &Option<DpfProxyDetails>,
+    // This should be used to create a separate flavor for BF3, BF4Generic, BF4Astra
+    _deployment_type: DpuDeploymentType,
+) -> Result<DPUFlavor, crate::error::DpfError> {
+    default_flavor(namespace, proxy)
 }
 
 /// Build the default DPUFlavor spec. If `proxy` is set, a containerd proxy drop-in config file

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -79,10 +79,11 @@ pub use sdk::{
 };
 pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
-    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuErrorEvent, DpuEvent,
-    DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent, InitDpfResourcesConfig, MaintenanceEvent,
-    RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType,
+    BmcPasswordProvider, ConfigPortsServiceType, DpuDeploymentType, DpuDeviceInfo, DpuErrorEvent,
+    DpuEvent, DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent, InitDpfResourcesConfig,
+    MaintenanceEvent, RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort,
+    ServiceConfigPortProtocol, ServiceDefinition, ServiceInterface, ServiceNAD,
+    ServiceNADResourceType,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -115,10 +115,8 @@ pub trait ResourceLabeler: Send + Sync {
     /// Returns `ConfigError` if no deployment is configured for the requested type.
     fn node_labels_for_deployment_type(
         &self,
-        _deployment_type: DpuDeploymentType,
-    ) -> Result<BTreeMap<String, String>, crate::DpfError> {
-        Ok(BTreeMap::new())
-    }
+        deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, crate::DpfError>;
 
     /// Contextual labels applied to DPUNode resources on creation only.
     /// Unlike `node_labels`, these are NOT used for selectors or removal
@@ -137,7 +135,14 @@ pub trait ResourceLabeler: Send + Sync {
 /// Default labeler that applies no labels.
 pub struct NoLabels;
 
-impl ResourceLabeler for NoLabels {}
+impl ResourceLabeler for NoLabels {
+    fn node_labels_for_deployment_type(
+        &self,
+        _deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, crate::DpfError> {
+        Ok(BTreeMap::new())
+    }
+}
 
 /// The main DPF SDK interface.
 ///
@@ -2295,6 +2300,13 @@ mod tests {
 
         fn node_labels(&self) -> BTreeMap<String, String> {
             BTreeMap::from([("test/node".to_string(), "true".to_string())])
+        }
+
+        fn node_labels_for_deployment_type(
+            &self,
+            _deployment_type: DpuDeploymentType,
+        ) -> Result<BTreeMap<String, String>, crate::DpfError> {
+            Ok(self.node_labels())
         }
 
         fn node_context_labels(&self, _info: &DpuNodeInfo) -> BTreeMap<String, String> {

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -105,9 +105,15 @@ pub trait ResourceLabeler: Send + Sync {
     }
 
     /// Static labels applied to DPUNode resources on creation.
-    /// Also used as the `dpu_node_selector` in DPUDeployment
-    /// and removed on node deletion.
+    /// Also used for removal patches on node deletion.
     fn node_labels(&self) -> BTreeMap<String, String> {
+        BTreeMap::new()
+    }
+
+    /// Node selector labels for a specific DPUDeployment CR.
+    /// Used by [`build_deployment`] to populate `dpuNodeSelector.matchLabels`.
+    /// Returns an empty map by default (no selector).
+    fn node_labels_for_deployment(&self, _deployment_name: &str) -> BTreeMap<String, String> {
         BTreeMap::new()
     }
 
@@ -741,7 +747,7 @@ pub fn build_deployment<L: ResourceLabeler>(
         "feature.node.kubernetes.io/dpu-enabled".to_string(),
         "true".to_string(),
     )]);
-    for (k, v) in labeler.node_labels() {
+    for (k, v) in labeler.node_labels_for_deployment(deployment_name) {
         node_labels.insert(k, v);
     }
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -76,11 +76,11 @@ use crate::repository::{
 };
 use crate::types::{
     BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
-    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails, DpuDeviceInfo, DpuDeviceSummary,
-    DpuMismatch, DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
-    DpuServiceInterfaceTemplateType, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot,
-    InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
+    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails, DpuDeploymentType, DpuDeviceInfo,
+    DpuDeviceSummary, DpuMismatch, DpuNodeInfo, DpuNodeSummary, DpuPhase,
+    DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType, DpuSummary,
+    FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME,
+    ServiceConfigPortProtocol, ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
 };
 use crate::watcher::DpuWatcherBuilder;
 
@@ -110,11 +110,14 @@ pub trait ResourceLabeler: Send + Sync {
         BTreeMap::new()
     }
 
-    /// Node selector labels for a specific DPUDeployment CR.
+    /// Node selector labels for a specific deployment type.
     /// Used by [`build_deployment`] to populate `dpuNodeSelector.matchLabels`.
-    /// Returns an empty map by default (no selector).
-    fn node_labels_for_deployment(&self, _deployment_name: &str) -> BTreeMap<String, String> {
-        BTreeMap::new()
+    /// Returns `ConfigError` if no deployment is configured for the requested type.
+    fn node_labels_for_deployment_type(
+        &self,
+        _deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, crate::DpfError> {
+        Ok(BTreeMap::new())
     }
 
     /// Contextual labels applied to DPUNode resources on creation only.
@@ -459,8 +462,9 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
     namespace: &str,
     default_flavor_name: &str,
     proxy: &Option<DpfProxyDetails>,
+    deployment_type: DpuDeploymentType,
 ) -> Result<String, DpfError> {
-    let mut flavor = crate::flavor::default_flavor(namespace, proxy)?;
+    let mut flavor = crate::flavor::default_flavor_for(namespace, proxy, deployment_type)?;
     let name = flavor.unique_name(default_flavor_name)?;
     flavor.metadata.name = Some(name.clone());
 
@@ -650,14 +654,14 @@ pub fn build_service_nad(svc: &ServiceDefinition, namespace: &str) -> Option<DPU
     })
 }
 
-pub fn build_deployment<L: ResourceLabeler>(
+pub fn build_deployment(
     services: &[ServiceDefinition],
     deployment_name: &str,
     bfb_name: &str,
     flavor_name: &str,
     namespace: &str,
-    labeler: &L,
     interfaces: &[DpuServiceInterfaceTemplateDefinition],
+    deployment_node_labels: BTreeMap<String, String>,
 ) -> DPUDeployment {
     let services_map: BTreeMap<String, DpuDeploymentServices> = services
         .iter()
@@ -747,9 +751,7 @@ pub fn build_deployment<L: ResourceLabeler>(
         "feature.node.kubernetes.io/dpu-enabled".to_string(),
         "true".to_string(),
     )]);
-    for (k, v) in labeler.node_labels_for_deployment(deployment_name) {
-        node_labels.insert(k, v);
-    }
+    node_labels.extend(deployment_node_labels);
 
     DPUDeployment {
         metadata: ObjectMeta {
@@ -1075,8 +1077,10 @@ async fn create_flavor_services_and_deployment<
     bfb_name: &str,
     default_flavor_name: &str,
     proxy: &Option<DpfProxyDetails>,
+    deployment_type: DpuDeploymentType,
 ) -> Result<(), DpfError> {
-    let flavor_name = create_dpu_flavor(repo, namespace, default_flavor_name, proxy).await?;
+    let flavor_name =
+        create_dpu_flavor(repo, namespace, default_flavor_name, proxy, deployment_type).await?;
 
     let interfaces = build_dpu_interfaces_vec();
 
@@ -1094,14 +1098,15 @@ async fn create_flavor_services_and_deployment<
         }
     }
 
+    let deployment_node_labels = labeler.node_labels_for_deployment_type(deployment_type)?;
     let deployment = build_deployment(
         services,
         deployment_name,
         bfb_name,
         &flavor_name,
         namespace,
-        labeler,
         &interfaces,
+        deployment_node_labels,
     );
     DpuDeploymentRepository::apply(repo, &deployment).await?;
     Ok(())
@@ -1146,6 +1151,7 @@ impl<
             &bfb_name,
             &config.flavor_name,
             &config.proxy,
+            config.deployment_type,
         )
         .await?;
 
@@ -1270,7 +1276,9 @@ impl<R: DpuNodeRepository, L: ResourceLabeler> DpfSdk<R, L> {
                 name: Some(node_name.clone()),
                 namespace: Some(self.namespace.clone()),
                 labels: {
-                    let mut labels = self.labeler.node_labels();
+                    let mut labels = self
+                        .labeler
+                        .node_labels_for_deployment_type(info.deployment_type)?;
                     labels.extend(self.labeler.node_context_labels(&info));
                     if labels.is_empty() {
                         None
@@ -1330,14 +1338,20 @@ impl<R: DpuNodeRepository, L: ResourceLabeler> DpfSdk<R, L> {
     /// labeler's `node_labels()`. Returns `false` when the node exists but
     /// has stale labels (e.g. from a previous label version). Returns `true`
     /// when the node does not exist yet.
-    pub async fn verify_node_labels(&self, node_name: &str) -> Result<bool, DpfError> {
+    pub async fn verify_node_labels(
+        &self,
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<bool, DpfError> {
         let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace).await?;
 
         let Some(node) = node else {
             return Ok(true);
         };
 
-        let required_labels = self.labeler.node_labels();
+        let required_labels = self
+            .labeler
+            .node_labels_for_deployment_type(deployment_type)?;
         let node_labels = node.metadata.labels.as_ref();
 
         Ok(required_labels.iter().all(|(key, required_value)| {
@@ -1877,8 +1891,8 @@ mod tests {
             "bfb",
             "flavor",
             TEST_NAMESPACE,
-            &NoLabels,
             &[],
+            BTreeMap::new(),
         );
 
         let otel = deployment
@@ -2165,6 +2179,7 @@ mod tests {
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -2188,6 +2203,7 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string(), "dpu-002".to_string()],
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -2215,6 +2231,7 @@ mod tests {
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -2244,6 +2261,7 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -2300,6 +2318,7 @@ mod tests {
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -2336,6 +2355,7 @@ mod tests {
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_device(info).await.unwrap();
@@ -2360,6 +2380,7 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -2385,6 +2406,7 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk.register_dpu_node(info).await.unwrap();
@@ -2453,6 +2475,7 @@ mod tests {
             serial_number: "SN123".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
         sdk.register_dpu_device(device_info).await.unwrap();
 
@@ -2550,6 +2573,7 @@ mod tests {
             serial_number: "SN111".to_string(),
             dpu_machine_id: "dpu-111".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         let info2 = DpuDeviceInfo {
@@ -2559,6 +2583,7 @@ mod tests {
             serial_number: "SN222".to_string(),
             dpu_machine_id: "dpu-222".to_string(),
             is_primary: false,
+            deployment_type: DpuDeploymentType::Bf3,
         };
 
         sdk1.register_dpu_device(info1).await.unwrap();
@@ -2718,6 +2743,7 @@ mod tests {
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
         let err = sdk.register_dpu_device(info).await.unwrap_err();
         assert!(
@@ -2763,6 +2789,7 @@ mod tests {
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
         sdk.register_dpu_device(info).await.unwrap();
     }
@@ -2799,6 +2826,7 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
+            deployment_type: DpuDeploymentType::Bf3,
         };
         let err = sdk.register_dpu_node(info).await.unwrap_err();
         assert!(
@@ -2838,6 +2866,7 @@ mod tests {
             node_id: "host-001".to_string(),
             host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
+            deployment_type: DpuDeploymentType::Bf3,
         };
         sdk.register_dpu_node(info).await.unwrap();
     }
@@ -2850,6 +2879,7 @@ mod tests {
             TEST_NAMESPACE,
             crate::flavor::DEFAULT_FLAVOR_NAME,
             &None,
+            DpuDeploymentType::Bf3,
         )
         .await
         .unwrap();
@@ -2886,6 +2916,7 @@ mod tests {
             TEST_NAMESPACE,
             crate::flavor::DEFAULT_FLAVOR_NAME,
             &proxy,
+            DpuDeploymentType::Bf3,
         )
         .await
         .unwrap();
@@ -2937,6 +2968,7 @@ mod tests {
             TEST_NAMESPACE,
             crate::flavor::DEFAULT_FLAVOR_NAME,
             &None,
+            DpuDeploymentType::Bf3,
         )
         .await
         .unwrap_err();
@@ -2968,6 +3000,7 @@ mod tests {
             TEST_NAMESPACE,
             crate::flavor::DEFAULT_FLAVOR_NAME,
             &None,
+            DpuDeploymentType::Bf3,
         )
         .await
         .unwrap_err();
@@ -2997,6 +3030,7 @@ mod tests {
             TEST_NAMESPACE,
             crate::flavor::DEFAULT_FLAVOR_NAME,
             &None,
+            DpuDeploymentType::Bf3,
         )
         .await
         .unwrap();
@@ -3179,6 +3213,7 @@ mod tests {
                     node_id: "host-001".to_string(),
                     host_bmc_ip: "10.0.0.1".parse().unwrap(),
                     device_ids: vec!["dpu-001".to_string()],
+                    deployment_type: DpuDeploymentType::Bf3,
                 })
                 .await
                 .unwrap();
@@ -3186,7 +3221,7 @@ mod tests {
 
             // DpfError isn't PartialEq, so render it to a String for the
             // table's Outcome comparison; these rows all expect success anyway.
-            sdk.verify_node_labels(row.query)
+            sdk.verify_node_labels(row.query, DpuDeploymentType::Bf3)
                 .await
                 .map_err(|e| e.to_string())
         };

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -200,6 +200,7 @@ async fn test_register_devices_node_and_force_delete() {
             serial_number: format!("SN-{}", i),
             dpu_machine_id: format!("dpu-{}-id", i),
             is_primary: true,
+            deployment_type: DpuDeploymentType::Bf3,
         };
         sdk.register_dpu_device(info).await.unwrap();
     }
@@ -209,6 +210,7 @@ async fn test_register_devices_node_and_force_delete() {
         node_id: "host-001".to_string(),
         host_bmc_ip: "192.168.1.1".parse().unwrap(),
         device_ids: vec!["dpu-1".to_string(), "dpu-2".to_string()],
+        deployment_type: DpuDeploymentType::Bf3,
     };
     sdk.register_dpu_node(node_info).await.unwrap();
 

--- a/crates/dpf/src/test/sdk_reboot_annotation.rs
+++ b/crates/dpf/src/test/sdk_reboot_annotation.rs
@@ -147,6 +147,7 @@ async fn test_reboot_annotation_set_check_clear() {
         node_id: "host-001".to_string(),
         host_bmc_ip: "192.168.1.1".parse().unwrap(),
         device_ids: vec!["dpu-001".to_string()],
+        deployment_type: DpuDeploymentType::Bf3,
     };
     sdk.register_dpu_node(node_info).await.unwrap();
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -63,6 +63,8 @@ pub struct InitDpfResourcesConfig {
     pub services: Vec<ServiceDefinition>,
 
     pub proxy: Option<DpfProxyDetails>,
+    /// Deployment type — determines which DPUFlavor spec to build.
+    pub deployment_type: DpuDeploymentType,
 }
 
 impl Default for InitDpfResourcesConfig {
@@ -73,6 +75,7 @@ impl Default for InitDpfResourcesConfig {
             flavor_name: crate::flavor::DEFAULT_FLAVOR_NAME.to_string(),
             services: Vec::new(),
             proxy: None,
+            deployment_type: DpuDeploymentType::Bf3,
         }
     }
 }
@@ -239,6 +242,14 @@ pub struct DpuFlavorBridgeDefinition {
     pub vf_intercept_bridge_sf: String,
 }
 
+/// Deployment type of a DPU — used to route devices to the correct
+/// DPUDeployment and select the appropriate DPUFlavor configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum DpuDeploymentType {
+    Bf3,
+    Bf4Generic,
+}
+
 /// Information about a DPU device (DPUDevice CR).
 #[derive(Debug, Clone)]
 pub struct DpuDeviceInfo {
@@ -256,6 +267,8 @@ pub struct DpuDeviceInfo {
     pub dpu_machine_id: String,
     /// is _primary dpu?
     pub is_primary: bool,
+    /// Deployment type for this DPU — used to look up deployment-specific labels.
+    pub deployment_type: DpuDeploymentType,
 }
 
 /// Information about a DPU node (host with DPUs).
@@ -268,6 +281,8 @@ pub struct DpuNodeInfo {
     pub host_bmc_ip: IpAddr,
     /// Identifiers of each device attached to this node.
     pub device_ids: Vec<String>,
+    /// Deployment type for the DPUs on this node — used to look up deployment-specific labels.
+    pub deployment_type: DpuDeploymentType,
 }
 
 /// Phase of DPU lifecycle.

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -160,11 +160,28 @@ pub async fn dpf_dpudevices_and_dpunode_crs_noexist(
 ///   creation and propagate to DPU CRs, but are not part of selectors.
 pub struct CarbideDPFLabeler {
     node_label_key: String,
+    /// Per-deployment node selector labels: DPUDeployment CR name → labels.
+    /// Populated for each configured deployment so that [`build_deployment`]
+    /// can look up the correct `dpuNodeSelector.matchLabels` by deployment name.
+    deployment_node_labels: BTreeMap<String, BTreeMap<String, String>>,
 }
 
 impl CarbideDPFLabeler {
     pub fn new(node_label_key: String) -> Self {
-        Self { node_label_key }
+        Self {
+            node_label_key,
+            deployment_node_labels: BTreeMap::new(),
+        }
+    }
+
+    /// Register per-deployment node selector labels. Call once per configured
+    /// DPUDeployment before passing the labeler to the DPF SDK builder.
+    pub fn with_deployment_node_labels(
+        mut self,
+        deployment_node_labels: BTreeMap<String, BTreeMap<String, String>>,
+    ) -> Self {
+        self.deployment_node_labels = deployment_node_labels;
+        self
     }
 }
 
@@ -195,6 +212,13 @@ impl ResourceLabeler for CarbideDPFLabeler {
                 "true".to_string(),
             ),
         ])
+    }
+
+    fn node_labels_for_deployment(&self, deployment_name: &str) -> BTreeMap<String, String> {
+        self.deployment_node_labels
+            .get(deployment_name)
+            .cloned()
+            .unwrap_or_default()
     }
 
     fn node_context_labels(&self, info: &DpuNodeInfo) -> BTreeMap<String, String> {

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -29,7 +29,7 @@ use carbide_dpf::{
 use carbide_uuid::machine::MachineId;
 use model::dpu_machine_update::OutdatedDpfDpu;
 use model::machine::{Machine, ManagedHostStateSnapshot};
-use model::site_explorer::is_bf3_dpu_part_number;
+use model::site_explorer::{is_bf3_dpu_part_number, is_bf4_dpu_part_number};
 use sqlx::PgPool;
 use state_controller::controller::Enqueuer;
 use tokio::task::JoinSet;
@@ -87,7 +87,9 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     async fn reboot_complete(&self, node_name: &str) -> Result<(), DpfError>;
 
     /// Resolve the deployment type of a DPU based on its hardware (BF3 vs BF4).
-    fn deployment_type_for_dpu(&self, dpu: &Machine) -> DpuDeploymentType;
+    /// Returns `Err` when the part number is absent or does not match any known generation,
+    /// so unrecognized hardware never silently routes to a wrong deployment.
+    fn deployment_type_for_dpu(&self, dpu: &Machine) -> Result<DpuDeploymentType, DpfError>;
 
     /// Check that a DPUNode's labels match the current expected labels.
     /// Returns `false` when the node exists but has stale labels.
@@ -530,7 +532,7 @@ impl DpfOperations for DpfSdkOps {
         self.sdk.reboot_complete(node_name).await
     }
 
-    fn deployment_type_for_dpu(&self, dpu: &Machine) -> DpuDeploymentType {
+    fn deployment_type_for_dpu(&self, dpu: &Machine) -> Result<DpuDeploymentType, DpfError> {
         let part_number = dpu
             .hardware_info
             .as_ref()
@@ -538,10 +540,21 @@ impl DpfOperations for DpfSdkOps {
             .map(|d| d.part_number.as_str())
             .unwrap_or_default();
 
+        if part_number.is_empty() {
+            return Err(DpfError::InvalidState(format!(
+                "cannot determine DPU deployment type for machine {}: part number is absent",
+                dpu.id,
+            )));
+        }
         if is_bf3_dpu_part_number(part_number) {
-            DpuDeploymentType::Bf3
+            Ok(DpuDeploymentType::Bf3)
+        } else if is_bf4_dpu_part_number(part_number) {
+            Ok(DpuDeploymentType::Bf4Generic)
         } else {
-            DpuDeploymentType::Bf4Generic
+            Err(DpfError::InvalidState(format!(
+                "cannot determine DPU deployment type for machine {}: unrecognized part number {part_number:?}",
+                dpu.id,
+            )))
         }
     }
 

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -23,12 +23,13 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use carbide_dpf::types::{HostDpfSnapshot, ServiceTemplateVersion};
 use carbide_dpf::{
-    BmcPasswordProvider, DpfError, DpfSdk, DpuDeviceInfo, DpuNodeInfo, DpuPhase, DpuWatcher,
-    KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
+    BmcPasswordProvider, DpfError, DpfSdk, DpuDeploymentType, DpuDeviceInfo, DpuNodeInfo, DpuPhase,
+    DpuWatcher, KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
 };
 use carbide_uuid::machine::MachineId;
 use model::dpu_machine_update::OutdatedDpfDpu;
-use model::machine::ManagedHostStateSnapshot;
+use model::machine::{Machine, ManagedHostStateSnapshot};
+use model::site_explorer::is_bf3_dpu_part_number;
 use sqlx::PgPool;
 use state_controller::controller::Enqueuer;
 use tokio::task::JoinSet;
@@ -85,9 +86,16 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// Mark DPU node as rebooted (clear the external reboot required annotation).
     async fn reboot_complete(&self, node_name: &str) -> Result<(), DpfError>;
 
+    /// Resolve the deployment type of a DPU based on its hardware (BF3 vs BF4).
+    fn deployment_type_for_dpu(&self, dpu: &Machine) -> DpuDeploymentType;
+
     /// Check that a DPUNode's labels match the current expected labels.
     /// Returns `false` when the node exists but has stale labels.
-    async fn verify_node_labels(&self, node_name: &str) -> Result<bool, DpfError>;
+    async fn verify_node_labels(
+        &self,
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<bool, DpfError>;
 
     /// Curated snapshot of all DPF CRs related to one host (DPUNode +
     /// DPUDevices + DPUs). `node_name` is the full DPUNode CR name.
@@ -160,27 +168,27 @@ pub async fn dpf_dpudevices_and_dpunode_crs_noexist(
 ///   creation and propagate to DPU CRs, but are not part of selectors.
 pub struct CarbideDPFLabeler {
     node_label_key: String,
-    /// Per-deployment node selector labels: DPUDeployment CR name → labels.
+    /// Per-deployment-type node selector labels: DpuDeploymentType → labels.
     /// Populated for each configured deployment so that [`build_deployment`]
-    /// can look up the correct `dpuNodeSelector.matchLabels` by deployment name.
-    deployment_node_labels: BTreeMap<String, BTreeMap<String, String>>,
+    /// can look up the correct `dpuNodeSelector.matchLabels` by type.
+    deployment_type_labels: BTreeMap<DpuDeploymentType, BTreeMap<String, String>>,
 }
 
 impl CarbideDPFLabeler {
     pub fn new(node_label_key: String) -> Self {
         Self {
             node_label_key,
-            deployment_node_labels: BTreeMap::new(),
+            deployment_type_labels: BTreeMap::new(),
         }
     }
 
-    /// Register per-deployment node selector labels. Call once per configured
+    /// Register per-deployment-type node selector labels. Call once per configured
     /// DPUDeployment before passing the labeler to the DPF SDK builder.
-    pub fn with_deployment_node_labels(
+    pub fn with_deployment_type_labels(
         mut self,
-        deployment_node_labels: BTreeMap<String, BTreeMap<String, String>>,
+        deployment_type_labels: BTreeMap<DpuDeploymentType, BTreeMap<String, String>>,
     ) -> Self {
-        self.deployment_node_labels = deployment_node_labels;
+        self.deployment_type_labels = deployment_type_labels;
         self
     }
 }
@@ -214,11 +222,18 @@ impl ResourceLabeler for CarbideDPFLabeler {
         ])
     }
 
-    fn node_labels_for_deployment(&self, deployment_name: &str) -> BTreeMap<String, String> {
-        self.deployment_node_labels
-            .get(deployment_name)
+    fn node_labels_for_deployment_type(
+        &self,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, DpfError> {
+        self.deployment_type_labels
+            .get(&deployment_type)
             .cloned()
-            .unwrap_or_default()
+            .ok_or_else(|| {
+                DpfError::ConfigError(format!(
+                    "no DPUDeployment configured for {deployment_type:?}",
+                ))
+            })
     }
 
     fn node_context_labels(&self, info: &DpuNodeInfo) -> BTreeMap<String, String> {
@@ -515,8 +530,29 @@ impl DpfOperations for DpfSdkOps {
         self.sdk.reboot_complete(node_name).await
     }
 
-    async fn verify_node_labels(&self, node_name: &str) -> Result<bool, DpfError> {
-        self.sdk.verify_node_labels(node_name).await
+    fn deployment_type_for_dpu(&self, dpu: &Machine) -> DpuDeploymentType {
+        let part_number = dpu
+            .hardware_info
+            .as_ref()
+            .and_then(|hw| hw.dpu_info.as_ref())
+            .map(|d| d.part_number.as_str())
+            .unwrap_or_default();
+
+        if is_bf3_dpu_part_number(part_number) {
+            DpuDeploymentType::Bf3
+        } else {
+            DpuDeploymentType::Bf4Generic
+        }
+    }
+
+    async fn verify_node_labels(
+        &self,
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<bool, DpfError> {
+        self.sdk
+            .verify_node_labels(node_name, deployment_type)
+            .await
     }
 
     async fn snapshot_host(&self, node_name: &str) -> Result<HostDpfSnapshot, DpfError> {

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -202,12 +202,23 @@ async fn create_and_register_dpudevices_and_dpunode(
             serial_number: serial_number.to_string(),
             dpu_machine_id: dpu.id.to_string(),
             is_primary: dpu.id == primary_dpu_id,
+            deployment_type: dpf_sdk.deployment_type_for_dpu(dpu),
         };
         dpf_sdk
             .register_dpu_device(device_info)
             .await
             .map_err(dpf_error)?;
     }
+
+    let primary_dpu = state
+        .dpu_snapshots
+        .iter()
+        .find(|dpu| dpu.id == primary_dpu_id)
+        .ok_or_else(|| StateHandlerError::MissingData {
+            object_id: state.host_snapshot.id.to_string(),
+            missing: "primary_dpu_snapshot",
+        })?;
+    let deployment_type = dpf_sdk.deployment_type_for_dpu(primary_dpu);
 
     let device_ids: Vec<String> = state
         .dpu_snapshots
@@ -218,6 +229,7 @@ async fn create_and_register_dpudevices_and_dpunode(
         node_id: dpf_id(&state.host_snapshot)?,
         host_bmc_ip: bmc_ip(&state.host_snapshot)?,
         device_ids,
+        deployment_type,
     };
     dpf_sdk
         .register_dpu_node(node_info)
@@ -479,8 +491,9 @@ pub async fn handle_dpf_state(
     dpf_sdk: &dyn DpfOperations,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
+    let deployment_type = dpf_sdk.deployment_type_for_dpu(dpu_snapshot);
     if !dpf_sdk
-        .verify_node_labels(&node_name)
+        .verify_node_labels(&node_name, deployment_type)
         .await
         .map_err(dpf_error)?
     {

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -202,7 +202,7 @@ async fn create_and_register_dpudevices_and_dpunode(
             serial_number: serial_number.to_string(),
             dpu_machine_id: dpu.id.to_string(),
             is_primary: dpu.id == primary_dpu_id,
-            deployment_type: dpf_sdk.deployment_type_for_dpu(dpu),
+            deployment_type: dpf_sdk.deployment_type_for_dpu(dpu).map_err(dpf_error)?,
         };
         dpf_sdk
             .register_dpu_device(device_info)
@@ -218,7 +218,9 @@ async fn create_and_register_dpudevices_and_dpunode(
             object_id: state.host_snapshot.id.to_string(),
             missing: "primary_dpu_snapshot",
         })?;
-    let deployment_type = dpf_sdk.deployment_type_for_dpu(primary_dpu);
+    let deployment_type = dpf_sdk
+        .deployment_type_for_dpu(primary_dpu)
+        .map_err(dpf_error)?;
 
     let device_ids: Vec<String> = state
         .dpu_snapshots
@@ -491,7 +493,9 @@ pub async fn handle_dpf_state(
     dpf_sdk: &dyn DpfOperations,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
-    let deployment_type = dpf_sdk.deployment_type_for_dpu(dpu_snapshot);
+    let deployment_type = dpf_sdk
+        .deployment_type_for_dpu(dpu_snapshot)
+        .map_err(dpf_error)?;
     if !dpf_sdk
         .verify_node_labels(&node_name, deployment_type)
         .await


### PR DESCRIPTION
Adds support for multiple DPUDeployments in DPF, enabling BF4 DPUs to be provisionedalongside BF3 using a separate deployment configuration. BF3 and BF4 DPUs are now automatically routed to their respective deployments based on hardware part number. 

Attempting to register a BF4 DPU when no BF4 deployment is configured fails with a clear error. 

For the completeness, a BF4Generic deployment is added, but Dpuflavor is not implemented. This will be done in another PR when the information is available.

This PR also restructures the `BF3` config into `deployments` section. The BF3 section is default, thus will be configured even if not present in the toml.

The updated TOML looks like:
```toml
  [dpf]
  enabled = false

  # Optional: override the pull secret for all mandatory services (except dts and doca_hbn)
  docker_image_pull_secret = "dpf-pull-secret"
  
  # Optional: route DPU containerd traffic through a proxy
  [dpf.proxy]
  https_proxy = "http://proxy.example.com:3128"
  no_proxy = "localhost,127.0.0.1,.cluster.local"

  # BF3 deployment — all fields have defaults; omit the block entirely or override all values (except BFB url has a  default).
  [dpf.deployments.bf3]
  bfb_url        = "https://content.mellanox.com/BlueField/BFBs/Ubuntu24.04/bf-bundle-
  3.2.2-125_26.02_ubuntu-24.04_64k_prod.bfb"
  flavor_name    = "carbide-dpu-flavor"
  deployment_name = "nico-deployment-v2"
  node_label_key = "carbide.nvidia.com/controlled.node.v2"

  # BF4 deployment — omit the block entirely to disable BF4 support.
  # All fields are required when the block is present (no defaults, except BFB url).
  [dpf.deployments.bf4_generic]
  bfb_url         = "https://..."   # required
  flavor_name     = "..."           # required
  deployment_name = "..."           # required
  node_label_key  = "..."           # required

  # Mandatory Helm services — defaults are built in; only override when using custom 
  chart repos or versions.
  [dpf.services.dpu_agent]
  name                   = "dpu-agent"
  helm_repo_url          = "..."
  helm_chart             = "dpu-agent"
  helm_version           = "x.y.z"
  docker_repo_url        = "..."
  docker_image_tag       = "x.y.z"
  docker_image_pull_secret = "dpf-pull-secret"

  # Same shape for: dpf.services.dts, dpf.services.doca_hbn,
  #                 dpf.services.dhcp_server, dpf.services.fmds, dpf.services.otel

```

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

```bash
❯ dk get dpuflavor
NAME                                      AGE
carbide-dpu-flavor-bf4-cd1e6cece4f0eef2   8m29s
carbide-dpu-flavor-cd1e6cece4f0eef2       8m29s

❯ dk get dpudeployment
NAME                  READY   PHASE     AGE
nico-deployment-bf4   True    Success   8m37s
nico-deployment-v2    False   Pending   34d

❯ dk get bfb
NAME                                                                         PHASE   AGE
bf-bundle-69c915a5eaba405efc58d0fc6d87fdd7eb409f0bc71bea3e48085e05540d65fb   Ready   8m52s
bf-bundle-9ab002d8fc58c12a0f831cfdf2006b335bd2fb6b60e9ed3ffd8a14760745dd5e   Ready   8m52s

```

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

