### PR TITLE
fix(rest-api): Require ScrapeIntervalSeconds >= 1 for Prometheus observability

### DIFF
--- a/rest-api/api/pkg/api/model/dpuextensionservice.go
+++ b/rest-api/api/pkg/api/model/dpuextensionservice.go
@@ -438,7 +438,9 @@ type APIDpuExtensionServiceObservabilityConfigPrometheus struct {
 // Validate ensures that the prometheus observability config is valid
 func (desop APIDpuExtensionServiceObservabilityConfigPrometheus) Validate() error {
 	err := validation.ValidateStruct(&desop,
-		validation.Field(&desop.ScrapeIntervalSeconds, validation.Min(uint32(1)).Error("must be greater than 0")),
+		validation.Field(&desop.ScrapeIntervalSeconds,
+			validation.Required.Error("must be greater than 0"),
+			validation.Min(uint32(1)).Error("must be greater than 0")),
 		validation.Field(&desop.Endpoint, validation.Required.Error(validationErrorValueRequired)),
 		validation.Field(&desop.Endpoint, validation.Length(0, DpuExtensionServiceMaxObservabilityPropertyLength).Error(fmt.Sprintf("length must not exceed %d", DpuExtensionServiceMaxObservabilityPropertyLength))),
 	)

--- a/rest-api/api/pkg/api/model/dpuextensionservice_test.go
+++ b/rest-api/api/pkg/api/model/dpuextensionservice_test.go
@@ -361,6 +361,26 @@ func TestAPIDpuExtensionServiceCreateRequest_Validate(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			desc: "error when observability prometheus scrapeIntervalSeconds is zero",
+			obj: APIDpuExtensionServiceCreateRequest{
+				Name:        "test-service",
+				ServiceType: DpuExtensionServiceTypeKubernetesPod,
+				SiteID:      validUUID,
+				Data:        "apiVersion: v1\nkind: Pod\nmetadata:\n  name: test",
+				Observability: &APIDpuExtensionServiceObservability{
+					Configs: []APIDpuExtensionServiceObservabilityConfig{
+						{
+							Prometheus: &APIDpuExtensionServiceObservabilityConfigPrometheus{
+								ScrapeIntervalSeconds: 0,
+								Endpoint:              "busybox:9090",
+							},
+						},
+					},
+				},
+			},
+			expectErr: true,
+		},
+		{
 			desc: "error when observability endpoint contains invalid characters",
 			obj: APIDpuExtensionServiceCreateRequest{
 				Name:        "test-service",


### PR DESCRIPTION
There is a [bug](https://nvbugspro.nvidia.com/bug/6408469) found. `prometheus.scrapeIntervalSeconds: 0` is accepted with response code 201, meaning that the `Min(1)` validation was silently skipped for the zero value. 

The root cause is because the Go-ozzo validation skips all rules on a field whose value equals the type's zero value unless Required or NotNil is also present. Therefore, when 0 is supplied, ozzo treats the field as empty and skips the `validation.Min(uint32(1))` check.

Adding `validation.Required` to force validation to evaluate the field even when its value is 0, so `validation.Min(uint32(1))` now runs correctly. 

## Related issues
nvbug https://nvbugspro.nvidia.com/bug/6408469

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

