### PR TITLE
docs: correct nico-admin-cli API URL flag from -c to -a

### DIFF
--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -231,8 +231,8 @@ The detail view for an instance type includes an `allocationStats` section showi
 Instance type creation is a gRPC operation via nico-admin-cli:
 
 ```
-nico-admin-cli -c <core-api-url> instance-type create --name "GB200-NVL72" --gpu-count 72
-nico-admin-cli -c <core-api-url> instance-type associate --instance-type-id <id> --machine-id <machine-id>
+nico-admin-cli -a <core-api-url> instance-type create --name "GB200-NVL72" --gpu-count 72
+nico-admin-cli -a <core-api-url> instance-type associate --instance-type-id <id> --machine-id <machine-id>
 ```
 
 See the Quick Start Guide, Step 7 for nico-admin-cli access patterns. The REST API exposes instance type CRUD endpoints, but machine association management is currently gRPC-only.
@@ -690,10 +690,10 @@ For stuck or unresponsive machines that cannot be managed through the instance A
 
 ```
 # Force-reboot via BMC
-nico-admin-cli -c <core-api-url> machine reboot --machine-id="<machine-id>"
+nico-admin-cli -a <core-api-url> machine reboot --machine-id="<machine-id>"
 
 # Force-delete a stuck machine (destructive -- wipes machine state)
-nico-admin-cli -c <core-api-url> machine force-delete --machine="<machine-id>"
+nico-admin-cli -a <core-api-url> machine force-delete --machine="<machine-id>"
 ```
 
 See the [Machine Reboot](../playbooks/machine_reboot.md) and [Force Delete](../playbooks/force_delete.md) playbooks in the core documentation for detailed procedures.

--- a/docs/dpu-management/dpu-lifecycle-management.md
+++ b/docs/dpu-management/dpu-lifecycle-management.md
@@ -108,8 +108,8 @@ Because there is no Redfish task to poll, NICo monitors the network install indi
 During normal ingestion no manual action is required. Operators can monitor the state with:
 
 ```bash
-nico-admin-cli -c <api-url> managed-host show --all
-nico-admin-cli -c <api-url> managed-host show <machine-id>
+nico-admin-cli -a <api-url> managed-host show --all
+nico-admin-cli -a <api-url> managed-host show <machine-id>
 ```
 
 For Redfish BFB installs, the handler outcome reports install percentage. For UEFI HTTP Boot installs, the handler outcome reports DPU discovery and reboot status.
@@ -164,7 +164,7 @@ A DPU update is treated as a host-level maintenance event because the host and i
 Operators can inspect DPU firmware status with:
 
 ```bash
-nico-admin-cli -c <api-url> dpu versions
+nico-admin-cli -a <api-url> dpu versions
 ```
 
 ## Containerized Cumulus and NVUE
@@ -216,8 +216,8 @@ NICo uses DPU health to gate state transitions and allocation:
 When a DPU becomes unhealthy, inspect the managed host state and DPU health report:
 
 ```bash
-nico-admin-cli -c <api-url> managed-host show <machine-id>
-nico-admin-cli -c <api-url> machine network status
+nico-admin-cli -a <api-url> managed-host show <machine-id>
+nico-admin-cli -a <api-url> machine network status
 ```
 
 Key fields to check in the output:
@@ -252,7 +252,7 @@ Automatic DPU reprovisioning is triggered when Machine Update Manager selects an
 The API requires a `HostUpdateInProgress` health alert on the host before it accepts a reprovisioning request. Use `--update-message` to apply this alert:
 
 ```bash
-nico-admin-cli -c <api-url> dpu reprovision set \
+nico-admin-cli -a <api-url> dpu reprovision set \
   --id <host-or-dpu-machine-id> \
   --update-message "<maintenance-reference>"
 ```
@@ -262,8 +262,8 @@ Firmware is always verified and updated during reprovisioning regardless of whet
 ### Monitoring Reprovisioning Progress
 
 ```bash
-nico-admin-cli -c <api-url> dpu reprovision list
-nico-admin-cli -c <api-url> managed-host show <machine-id>
+nico-admin-cli -a <api-url> dpu reprovision list
+nico-admin-cli -a <api-url> managed-host show <machine-id>
 ```
 
 The `managed-host show` output displays the current reprovisioning substate, percent complete for BFB installation (when available), and any handler errors.
@@ -273,13 +273,13 @@ The `managed-host show` output displays the current reprovisioning substate, per
 To restart a DPU reprovisioning flow for all DPUs on a host:
 
 ```bash
-nico-admin-cli -c <api-url> dpu reprovision restart --id <host-machine-id>
+nico-admin-cli -a <api-url> dpu reprovision restart --id <host-machine-id>
 ```
 
 To clear a pending reprovisioning request that has not started:
 
 ```bash
-nico-admin-cli -c <api-url> dpu reprovision clear --id <host-or-dpu-machine-id>
+nico-admin-cli -a <api-url> dpu reprovision clear --id <host-or-dpu-machine-id>
 ```
 
 For the complete reprovisioning state machine, see [DPU Reprovision State Details](../architecture/state_machines/managedhost.md#dpu-reprovision-state-details-dpureprovisionstate).

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -531,9 +531,9 @@ kubectl get svc nico-api -n nico-system -o jsonpath='{.status.loadBalancer.ingre
 Configure the credentials NICo will apply to BMCs and UEFI after ingestion:
 
 ```bash
-nico-admin-cli -c <api-url> credential add-bmc --kind=site-wide-root --password='<password>'
-nico-admin-cli -c <api-url> host generate-host-uefi-password
-nico-admin-cli -c <api-url> credential add-uefi --kind=host --password='<password>'
+nico-admin-cli -a <api-url> credential add-bmc --kind=site-wide-root --password='<password>'
+nico-admin-cli -a <api-url> host generate-host-uefi-password
+nico-admin-cli -a <api-url> credential add-uefi --kind=host --password='<password>'
 ```
 
 ### Upload the Expected Machines Manifest
@@ -556,7 +556,7 @@ Prepare an `expected_machines.json` with the BMC MAC address, factory default cr
 Upload the manifest:
 
 ```bash
-nico-admin-cli -c <api-url> em replace-all --filename expected_machines.json
+nico-admin-cli -a <api-url> em replace-all --filename expected_machines.json
 ```
 
 ### Approve the host for ingestion
@@ -564,7 +564,7 @@ nico-admin-cli -c <api-url> em replace-all --filename expected_machines.json
 NICo uses Measured Boot with TPM v2.0 to enforce cryptographic identity:
 
 ```bash
-nico-admin-cli -c <api-url> att mb site trusted-machine approve \* persist --pcr-registers="0,3,5,6"
+nico-admin-cli -a <api-url> att mb site trusted-machine approve \* persist --pcr-registers="0,3,5,6"
 ```
 
 NICo will now discover the host via Redfish, pair it with its DPU(s), provision the DPU, and bring the host to a ready state. For more details, refer to the [Ingesting Hosts](../provisioning/ingesting-hosts.md) guide.

--- a/docs/manuals/dpu_extension_service.md
+++ b/docs/manuals/dpu_extension_service.md
@@ -64,7 +64,7 @@ To create a service definition of type `KubernetesPod`, prepare a Pod manifest a
 **Admin CLI:**
 
 ```bash
-carbide-admin-cli extension-service create \
+nico-admin-cli extension-service create \
   --id <<some UUID>>  \
   --name test1 \
   --type 0 \
@@ -76,7 +76,7 @@ To include private registry credentials, add a `credentials` object to the reque
 
 ```bash
 # With private registry credentials
-carbide-admin-cli extension-service create \
+nico-admin-cli extension-service create \
   --id <service_uuid>  \
   --name test1 \
   --type 0 \
@@ -97,7 +97,7 @@ Optional query parameters: `siteId`, `status`, `query`, `includeRelation`, `page
 **Admin CLI:**
 
 ```bash
-carbide-admin-cli extension-service show
+nico-admin-cli extension-service show
 ```
 
 Optional filters: `--type`, `--name`, `--tenant-organization-id`.
@@ -111,7 +111,7 @@ Retrieve a single service, including its latest version and list of active versi
 **Admin CLI:**
 
 ```bash
-carbide-admin-cli extension-service show --id <service-id>
+nico-admin-cli extension-service show --id <service-id>
 ```
 
 ### Get a DPU Extension Service Version
@@ -123,7 +123,7 @@ Retrieve the Pod manifest and metadata for a specific version.
 **Admin CLI:**
 
 ```bash
-carbide-admin-cli extension-service get-version --id <service-id> --version <version>
+nico-admin-cli extension-service get-version --id <service-id> --version <version>
 ```
 
 ### Update a DPU Extension Service
@@ -143,7 +143,7 @@ Optional fields: `name`, `description`, `credentials`, and `observability`. Omit
 **Admin CLI:**
 
 ```bash
-carbide-admin-cli extension-service update \
+nico-admin-cli extension-service update \
   --id <service-id> \
   --data "$(cat pod-v2.yaml)" \
   --if-version-ctr-match 2
@@ -165,10 +165,10 @@ Deletion succeeds only when no Instance is using the version being deleted. If a
 
 ```bash
 # Delete the entire service (all versions)
-carbide-admin-cli extension-service delete --id <service-id>
+nico-admin-cli extension-service delete --id <service-id>
 
 # Delete specific versions
-carbide-admin-cli extension-service delete --id <service-id> --version <version1>,<version2>,...
+nico-admin-cli extension-service delete --id <service-id> --version <version1>,<version2>,...
 ```
 
 
@@ -228,7 +228,7 @@ The response includes `dpuExtensionServiceDeployments` with per-service deployme
 **Admin CLI:**
 
 ```bash
-carbide-admin-cli extension-service show-instances --id <service-id>
+nico-admin-cli extension-service show-instances --id <service-id>
 ```
 
 Optionally filter by version: `--version <version>`.

--- a/docs/operations/firmware-updates.md
+++ b/docs/operations/firmware-updates.md
@@ -39,7 +39,7 @@ Use `nico-admin-cli` for CLI examples. These commands talk to the NICo Core
 gRPC API:
 
 ```bash
-nico-admin-cli -c <core-api-url> <command>
+nico-admin-cli -a <core-api-url> <command>
 ```
 
 ## Machine Update Manager
@@ -150,7 +150,7 @@ required.
 List host firmware entries known to NICo:
 
 ```bash
-nico-admin-cli -c <core-api-url> firmware show
+nico-admin-cli -a <core-api-url> firmware show
 ```
 
 The output includes vendor, model, component type, inventory-name match,
@@ -212,15 +212,15 @@ During a host firmware update, NICo can:
 Enable, disable, or clear machine-specific auto-update behavior:
 
 ```bash
-nico-admin-cli -c <core-api-url> machine auto-update --machine <machine-id> --enable
-nico-admin-cli -c <core-api-url> machine auto-update --machine <machine-id> --disable
-nico-admin-cli -c <core-api-url> machine auto-update --machine <machine-id> --clear
+nico-admin-cli -a <core-api-url> machine auto-update --machine <machine-id> --enable
+nico-admin-cli -a <core-api-url> machine auto-update --machine <machine-id> --disable
+nico-admin-cli -a <core-api-url> machine auto-update --machine <machine-id> --clear
 ```
 
 Set an explicit firmware update window for one or more machines:
 
 ```bash
-nico-admin-cli -c <core-api-url> managed-host start-updates \
+nico-admin-cli -a <core-api-url> managed-host start-updates \
   --machines <machine-id-1> <machine-id-2> \
   --start 2026-05-22T01:00:00-0700 \
   --end 2026-05-22T05:00:00-0700
@@ -229,7 +229,7 @@ nico-admin-cli -c <core-api-url> managed-host start-updates \
 Cancel pending start windows:
 
 ```bash
-nico-admin-cli -c <core-api-url> managed-host start-updates \
+nico-admin-cli -a <core-api-url> managed-host start-updates \
   --machines <machine-id> \
   --cancel
 ```
@@ -238,7 +238,7 @@ Request host reprovisioning when the host must be put back through the
 managed-host firmware path:
 
 ```bash
-nico-admin-cli -c <core-api-url> host reprovision set \
+nico-admin-cli -a <core-api-url> host reprovision set \
   --id <machine-id> \
   --update-firmware \
   --update-message "<ticket-or-maintenance-reference>"
@@ -262,7 +262,7 @@ against the configured baseline.
 Inspect DPU firmware status:
 
 ```bash
-nico-admin-cli -c <core-api-url> dpu versions
+nico-admin-cli -a <core-api-url> dpu versions
 ```
 
 For the full DPU firmware flow, see
@@ -308,7 +308,7 @@ After the field procedure is complete, mark the manual firmware upgrade
 complete so NICo can resume automatic checks:
 
 ```bash
-nico-admin-cli -c <core-api-url> host reprovision mark-manual-upgrade-complete --id <machine-id>
+nico-admin-cli -a <core-api-url> host reprovision mark-manual-upgrade-complete --id <machine-id>
 ```
 
 ### OEM Platforms
@@ -405,12 +405,12 @@ Use component-manager only for lower-level switch and power shelf firmware
 workflows when a REST workflow is not available for that component:
 
 ```bash
-nico-admin-cli -c <core-api-url> component-manager update-firmware switch \
+nico-admin-cli -a <core-api-url> component-manager update-firmware switch \
   --switch-id <switch-id> \
   --target-version <target-version> \
   --component bmc,cpld,bios,nvos
 
-nico-admin-cli -c <core-api-url> component-manager update-firmware power-shelf \
+nico-admin-cli -a <core-api-url> component-manager update-firmware power-shelf \
   --power-shelf-id <power-shelf-id> \
   --target-version <target-version> \
   --component pmc,psu
@@ -419,8 +419,8 @@ nico-admin-cli -c <core-api-url> component-manager update-firmware power-shelf \
 Check component firmware status:
 
 ```bash
-nico-admin-cli -c <core-api-url> component-manager get-firmware-update-status switch --switch-id <switch-id>
-nico-admin-cli -c <core-api-url> component-manager get-firmware-update-status power-shelf --power-shelf-id <power-shelf-id>
+nico-admin-cli -a <core-api-url> component-manager get-firmware-update-status switch --switch-id <switch-id>
+nico-admin-cli -a <core-api-url> component-manager get-firmware-update-status power-shelf --power-shelf-id <power-shelf-id>
 ```
 
 ## Monitor Progress
@@ -430,12 +430,12 @@ is unclear.
 
 | Task | Command |
 |---|---|
-| Show managed-host state and handler outcome | `nico-admin-cli -c <core-api-url> managed-host show <machine-id>` |
-| Show machine details and health reports | `nico-admin-cli -c <core-api-url> machine show <machine-id>` |
-| Show host firmware baseline entries | `nico-admin-cli -c <core-api-url> firmware show` |
-| Show DPU firmware status | `nico-admin-cli -c <core-api-url> dpu versions` |
+| Show managed-host state and handler outcome | `nico-admin-cli -a <core-api-url> managed-host show <machine-id>` |
+| Show machine details and health reports | `nico-admin-cli -a <core-api-url> machine show <machine-id>` |
+| Show host firmware baseline entries | `nico-admin-cli -a <core-api-url> firmware show` |
+| Show DPU firmware status | `nico-admin-cli -a <core-api-url> dpu versions` |
 | Start rack or tray firmware update workflow | Use the rack and tray REST firmware endpoints. The response returns `taskIds`. |
-| Show switch or power shelf component firmware status | `nico-admin-cli -c <core-api-url> component-manager get-firmware-update-status <target> ...` |
+| Show switch or power shelf component firmware status | `nico-admin-cli -a <core-api-url> component-manager get-firmware-update-status <target> ...` |
 
 Useful metrics:
 
@@ -475,5 +475,5 @@ After the platform condition is corrected, reset a failed host reprovisioning
 flow only when the site runbook calls for it:
 
 ```bash
-nico-admin-cli -c <core-api-url> managed-host reset-host-reprovisioning --machine <machine-id>
+nico-admin-cli -a <core-api-url> managed-host reset-host-reprovisioning --machine <machine-id>
 ```

--- a/docs/operations/tenant-lifecycle-cleanup.md
+++ b/docs/operations/tenant-lifecycle-cleanup.md
@@ -42,8 +42,8 @@ nicocli instance get <instance-id>
 Core gRPC operation is required:
 
 ```bash
-nico-admin-cli -c <core-api-url> instance release --instance <instance-id>
-nico-admin-cli -c <core-api-url> instance release --machine <machine-id>
+nico-admin-cli -a <core-api-url> instance release --instance <instance-id>
+nico-admin-cli -a <core-api-url> instance release --machine <machine-id>
 ```
 
 `<core-api-url>` is the NICo Core gRPC API endpoint used by
@@ -111,19 +111,19 @@ If cleanup progress is unclear from the instance lifecycle, check the
 managed-host state:
 
 ```bash
-nico-admin-cli -c <core-api-url> managed-host show <machine-id>
+nico-admin-cli -a <core-api-url> managed-host show <machine-id>
 ```
 
 Check the machine view for state history and platform details:
 
 ```bash
-nico-admin-cli -c <core-api-url> machine show <machine-id>
+nico-admin-cli -a <core-api-url> machine show <machine-id>
 ```
 
 Check health reports when cleanup appears blocked:
 
 ```bash
-nico-admin-cli -c <core-api-url> machine health-report show <machine-id>
+nico-admin-cli -a <core-api-url> machine health-report show <machine-id>
 ```
 
 ### Happy Path Verification
@@ -133,8 +133,8 @@ A normal release can be verified with this sequence:
 ```bash
 nicocli instance delete <instance-id>
 nicocli instance status-history <instance-id>
-nico-admin-cli -c <core-api-url> managed-host show <machine-id>
-nico-admin-cli -c <core-api-url> machine health-report show <machine-id>
+nico-admin-cli -a <core-api-url> managed-host show <machine-id>
+nico-admin-cli -a <core-api-url> machine health-report show <machine-id>
 ```
 
 Success indicators:
@@ -249,8 +249,8 @@ firmware management, measured boot, and site policy.
 Useful attestation commands include:
 
 ```bash
-nico-admin-cli -c <core-api-url> attestation measured-boot machine show <machine-id>
-nico-admin-cli -c <core-api-url> att mb machine show <machine-id>
+nico-admin-cli -a <core-api-url> attestation measured-boot machine show <machine-id>
+nico-admin-cli -a <core-api-url> att mb machine show <machine-id>
 ```
 
 ## Return-to-Pool Checklist
@@ -288,8 +288,8 @@ If the REST lifecycle does not explain the stall, inspect the Core cleanup
 state:
 
 ```bash
-nico-admin-cli -c <core-api-url> managed-host show <machine-id>
-nico-admin-cli -c <core-api-url> machine health-report show <machine-id>
+nico-admin-cli -a <core-api-url> managed-host show <machine-id>
+nico-admin-cli -a <core-api-url> machine health-report show <machine-id>
 ```
 
 | State | What it means | Checks |

--- a/docs/playbooks/debugging_machine/debug_bundle.md
+++ b/docs/playbooks/debugging_machine/debug_bundle.md
@@ -80,7 +80,7 @@ nico-admin-cli -a <API_URL> mh debug-bundle <MACHINE_ID> --start-time <TIME> [--
 
 **Required:**
 
-- `-c <API_URL>`: NICo API endpoint
+- `-a <API_URL>`: NICo API endpoint
   - From outside cluster: `https://<your-nico-api-url>/`
   - From inside cluster: `https://127.0.0.1:1079`
 - `<MACHINE_ID>`: The machine ID to collect debug information for

--- a/docs/playbooks/debugging_machine/debug_bundle.md
+++ b/docs/playbooks/debugging_machine/debug_bundle.md
@@ -73,7 +73,7 @@ export https_proxy=socks5://127.0.0.1:8888
 ### Command Syntax
 
 ```bash
-nico-admin-cli -c <API_URL> mh debug-bundle <MACHINE_ID> --start-time <TIME> [--grafana-url <URL>] [--end-time <TIME>] [--output-path <PATH>] [--batch-size <SIZE>] [--utc]
+nico-admin-cli -a <API_URL> mh debug-bundle <MACHINE_ID> --start-time <TIME> [--grafana-url <URL>] [--end-time <TIME>] [--output-path <PATH>] [--batch-size <SIZE>] [--utc]
 ```
 
 ### Parameters
@@ -101,7 +101,7 @@ nico-admin-cli -c <API_URL> mh debug-bundle <MACHINE_ID> --start-time <TIME> [--
 ```bash
 GRAFANA_AUTH_TOKEN=<your-token> \
 https_proxy=socks5://127.0.0.1:8888 \
-nico-admin-cli -c https://<your-nico-api-url>/ mh debug-bundle \
+nico-admin-cli -a https://<your-nico-api-url>/ mh debug-bundle \
   <machine-id> \
   --start-time 06:00:00 \
   --grafana-url https://grafana.example.com
@@ -112,7 +112,7 @@ nico-admin-cli -c https://<your-nico-api-url>/ mh debug-bundle \
 ```bash
 GRAFANA_AUTH_TOKEN=<your-token> \
 https_proxy=socks5://127.0.0.1:8888 \
-nico-admin-cli -c https://<your-nico-api-url>/ mh debug-bundle \
+nico-admin-cli -a https://<your-nico-api-url>/ mh debug-bundle \
   <machine-id> \
   --start-time 06:00:00 \
   --end-time 18:00:00 \
@@ -123,7 +123,7 @@ nico-admin-cli -c https://<your-nico-api-url>/ mh debug-bundle \
 **Without Grafana (metadata only):**
 
 ```bash
-nico-admin-cli -c https://<your-nico-api-url>/ mh debug-bundle \
+nico-admin-cli -a https://<your-nico-api-url>/ mh debug-bundle \
   <machine-id> \
   --start-time 06:00:00
 ```

--- a/docs/playbooks/force_delete.md
+++ b/docs/playbooks/force_delete.md
@@ -37,7 +37,7 @@ It returns all machine-ids and instance-ids it acted on, as well as the BMC info
 Example:
 
 ```
-/opt/nico/nico-admin-cli -c https://127.0.0.1:1079 machine force-delete --machine="60cef902-9779-4666-8362-c9bb4b37184f"
+/opt/nico/nico-admin-cli -a https://127.0.0.1:1079 machine force-delete --machine="60cef902-9779-4666-8362-c9bb4b37184f"
 ```
 
 ### 3. Use the returned BMC IP/port and machine-id to reboot the host

--- a/docs/playbooks/machine_reboot.md
+++ b/docs/playbooks/machine_reboot.md
@@ -34,12 +34,12 @@ the NICo site controller.
 
 **Example:**
 
-```
+```bash
 /opt/nico/nico-admin-cli -a https://127.0.0.1:1079 machine reboot --address 123.123.123.123 --port 9999 --machine-id="60cef902-9779-4666-8362-c9bb4b37184f"
 ```
 
 or using username and password:
 
-```
+```bash
 /opt/nico/nico-admin-cli -a https://127.0.0.1:1079 machine reboot --address 123.123.123.123 --port 9999 --username myhost --password mypassword
 ```

--- a/docs/playbooks/machine_reboot.md
+++ b/docs/playbooks/machine_reboot.md
@@ -35,11 +35,11 @@ the NICo site controller.
 **Example:**
 
 ```
-/opt/nico/nico-admin-cli -c https://127.0.0.1:1079 machine reboot --address 123.123.123.123 --port 9999 --machine-id="60cef902-9779-4666-8362-c9bb4b37184f"
+/opt/nico/nico-admin-cli -a https://127.0.0.1:1079 machine reboot --address 123.123.123.123 --port 9999 --machine-id="60cef902-9779-4666-8362-c9bb4b37184f"
 ```
 
 or using username and password:
 
 ```
-/opt/nico/nico-admin-cli -c https://127.0.0.1:1079 machine reboot --address 123.123.123.123 --port 9999 --username myhost --password mypassword
+/opt/nico/nico-admin-cli -a https://127.0.0.1:1079 machine reboot --address 123.123.123.123 --port 9999 --username myhost --password mypassword
 ```

--- a/docs/playbooks/stuck_objects/diagnostic_tools.md
+++ b/docs/playbooks/stuck_objects/diagnostic_tools.md
@@ -41,7 +41,7 @@ Common connection options:
 ## Query State History
 
 ```bash
-nico-admin-cli -c <api-url> -f json machine show <machine-id>
+nico-admin-cli -a <api-url> -f json machine show <machine-id>
 ```
 
 Use this to inspect state transitions, timestamps, and handler outcomes.

--- a/docs/playbooks/stuck_objects/diagnostic_tools.md
+++ b/docs/playbooks/stuck_objects/diagnostic_tools.md
@@ -8,14 +8,14 @@ operation incident.
 `nico-admin-cli` is the primary operator CLI for NICo site state.
 
 ```bash
-cargo build -p carbide-admin-cli
+cargo build -p nico-admin-cli
 ```
 
 Common connection options:
 
 | Option | Meaning |
 |---|---|
-| `-c <url>` | NICo API gRPC endpoint. |
+| `-a <url>` | NICo API gRPC endpoint. |
 | `-f json` | JSON output for scripting. |
 | `API_URL` | Environment variable for the API URL. |
 | `https_proxy=socks5://...` | SOCKS5 proxy when reaching the site from off-site. |

--- a/docs/provisioning/attestation_and_security.md
+++ b/docs/provisioning/attestation_and_security.md
@@ -157,7 +157,7 @@ One issue with Measured Boot is that the PCR values can change quite frequently.
 When a site had just been set up and the attestation had been enabled, all machines will fail attestation unless it had been configured. In order to enable the "accept anything" type of attestation, the easiest way is to execute a command similar to this one:
 
 ```sh
-nico-admin-cli -c https://nico-api.forge/ measured-boot site trusted-machine approve \* persist --pcr-registers="0,3,5,6"
+nico-admin-cli -a https://nico-api.forge/ measured-boot site trusted-machine approve \* persist --pcr-registers="0,3,5,6"
 ```
 
 This will insert a rule to automatically approve all reports for all machines on site `az32`, that rule will persist and bundles will be created out of reports using PCR registers 0, 3, 5 and 6. Obviously, such attestation is not enforcing any specific PCR register values, so it should be used with caution.

--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -98,7 +98,7 @@ The optional `host_nics` array declares specifics for individual host NICs. Each
 **CLI** (single host):
 
 ```bash
-nico-admin-cli -c <api-url> em add \
+nico-admin-cli -a <api-url> em add \
   --bmc-mac-address C4:5A:B1:C8:38:0D \
   --bmc-username root --bmc-password default-password1 \
   --chassis-serial-number SERIAL-1 \
@@ -168,8 +168,8 @@ NICo keeps the DPUs explored, linked, and underlay-addressed (running agents for
 To change a host that's already ingested (e.g. from managed-DPU to NIC mode), update its Expected Machine `dpu_mode`, then force-delete and let it re-ingest so site-explorer re-explores and applies the new mode:
 
 ```bash
-nico-admin-cli -c <api-url> em patch --bmc-mac-address <bmc-mac> --dpu-mode nic-mode
-nico-admin-cli -c <api-url> machine force-delete --machine <machine-id> --delete-interfaces
+nico-admin-cli -a <api-url> em patch --bmc-mac-address <bmc-mac> --dpu-mode nic-mode
+nico-admin-cli -a <api-url> machine force-delete --machine <machine-id> --delete-interfaces
 ```
 
 See the [Force Delete playbook](../playbooks/force_delete.md) for the full re-ingest procedure. NICo preserves the host's boot-interface **Redfish id** across the deletion gap via the retained-boot-interface mechanism ([Section 7.3](#73-retained-boot-interfaces)), so the host can be re-targeted for boot before a fresh exploration completes. After a flip, you can re-apply the resolved boot interface with one click via **Restore Boot Interface** in the web UI ([Section 5](#5-web-ui)).
@@ -324,7 +324,7 @@ The same precedence applies wherever NICo picks a boot interface, over owned row
 **Check a host's boot interface:**
 
 ```bash
-nico-admin-cli -c <api-url> managed-host show <machine-id>
+nico-admin-cli -a <api-url> managed-host show <machine-id>
 ```
 
 The interfaces section shows each NIC's MAC, segment, and which one is `primary` (the boot interface). The web UI machine-detail page shows the same with a primary indicator.

--- a/docs/provisioning/ingesting-hosts.md
+++ b/docs/provisioning/ingesting-hosts.md
@@ -116,7 +116,7 @@ https://api-<ENVIRONMENT_NAME>.<SITE_DOMAIN_NAME> --nico-root-ca-path <NICO_ROOT
 Run this command to update the desired Host and DPU BMC password:
 
 ```bash
-nico-admin-cli -c <api-url> credential add-bmc --kind=site-wide-root --password='x'
+nico-admin-cli -a <api-url> credential add-bmc --kind=site-wide-root --password='x'
 ```
 
 ### Update Host UEFI Password
@@ -124,19 +124,19 @@ nico-admin-cli -c <api-url> credential add-bmc --kind=site-wide-root --password=
 Run this command to generate the desired host UEFI password:
 
 ```bash
-nico-admin-cli -c <api-url> host generate-host-uefi-password
+nico-admin-cli -a <api-url> host generate-host-uefi-password
 ```
 
 
 Run this command to update host uefi password:
 
 ```bash
-nico-admin-cli -c <api-url> credential add-uefi --kind=host --password='<password-gemerated-in-previous-step>'
+nico-admin-cli -a <api-url> credential add-uefi --kind=host --password='<password-gemerated-in-previous-step>'
 ```
 
 Run this command to update DPU uefi password:
 ```bash
-nico-admin-cli -c <api-url> credential add-uefi --kind=dpu --password='x'
+nico-admin-cli -a <api-url> credential add-uefi --kind=dpu --password='x'
 ```
 
 ## Add Expected Machines Table
@@ -197,7 +197,7 @@ Each entry supports additional optional fields:
 When the file is ready, upload it to the site with the following command:
 
 ```bash
-nico-admin-cli -c <api-url> em replace-all --filename expected_machines.json
+nico-admin-cli -a <api-url> em replace-all --filename expected_machines.json
 ```
 
 ## Approve all Machines for Ingestion
@@ -206,7 +206,7 @@ NICo uses Measured Boot using the on-host Trusted Platform Module (TPM) v2.0 to 
 The following command configures NICo to approve all pending machines based on PCR Registers 0, 3, 5, and 6.
 
 ```bash
-nico-admin-cli -c <api-url> att mb site trusted-machine approve \* persist --pcr-registers="0,3,5,6"
+nico-admin-cli -a <api-url> att mb site trusted-machine approve \* persist --pcr-registers="0,3,5,6"
 ```
 
 ## What Happens After Approval: Ingestion to Ready
@@ -234,8 +234,8 @@ When a machine is not being created or is stuck in a pre-`Ready` state, `nico-ap
 You can check the current detailed state of any managed host using:
 
 ```bash
-nico-admin-cli -c <api-url> managed-host show --all
-nico-admin-cli -c <api-url> managed-host show <machine-id>
+nico-admin-cli -a <api-url> managed-host show --all
+nico-admin-cli -a <api-url> managed-host show <machine-id>
 ```
 
 For a full guide on diagnosing stuck objects, including how to use the NICo Grafana dashboard and how to read state handler error logs, see [Stuck Objects Runbook](../playbooks/stuck_objects/stuck_objects.md).
@@ -275,7 +275,7 @@ The following are the conditions in which Site Explorer cannot complete pairing 
 For DPU pairing failures, including `dpu_pf0_mac_missing` and cases where the DPU is in an unknown or corrupt state, a common fix is to install a vanilla pre-ingestion BFB image via rshim to return the DPU to a clean state. This runs as part of the preingestion state machine:
 
 ```bash
-nico-admin-cli -c <api-url> site-explorer copy-bfb-to-dpu-rshim \
+nico-admin-cli -a <api-url> site-explorer copy-bfb-to-dpu-rshim \
   --host-bmc-ip <host-bmc-ip> \
   <dpu-bmc-ip>
 ```
@@ -302,9 +302,9 @@ The expected machines table in the nico-api database holds the following fields 
 Use `nico-admin-cli` to operate on individual entries:
 
 ```bash
-nico-admin-cli -c <api-url> em update ...
-nico-admin-cli -c <api-url> em add ...
-nico-admin-cli -c <api-url> em delete ...
+nico-admin-cli -a <api-url> em update ...
+nico-admin-cli -a <api-url> em add ...
+nico-admin-cli -a <api-url> em delete ...
 ```
 
 ### Bulk operations
@@ -312,13 +312,13 @@ nico-admin-cli -c <api-url> em delete ...
 Replace all entries from a JSON file:
 
 ```bash
-nico-admin-cli -c <api-url> em replace-all --filename expected_machines.json
+nico-admin-cli -a <api-url> em replace-all --filename expected_machines.json
 ```
 
 Erase all entries:
 
 ```bash
-nico-admin-cli -c <api-url> em erase
+nico-admin-cli -a <api-url> em erase
 ```
 
 ### Export
@@ -326,5 +326,5 @@ nico-admin-cli -c <api-url> em erase
 Export the current table as JSON:
 
 ```bash
-nico-admin-cli -c <api-url> -f json em show
+nico-admin-cli -a <api-url> -f json em show
 ```


### PR DESCRIPTION
Corrects `nico-admin-cli` documentation inconsistencies.

**Primary fix — removed `-c` API-URL flag.** In 2.0 the admin-cli field was renamed `carbide_api` → `api_url`; with clap's derived `short`, the option changed from `--carbide-api` / `-c` to `--api-url` / `-a` (`--carbide-url` retained as a visible alias — see `crates/admin-cli/src/cfg/cli_options.rs`). Every documented `-c` example fails against a current build. Sweep replaces `nico-admin-cli -c` → `nico-admin-cli -a` (79 occurrences across 12 files), including real-URL examples and parameter/option tables.

**Related cleanups (from review):**
- Add `bash` language tag to two code fences in `machine_reboot.md` (MD040).
- Fix stale `cargo build -p carbide-admin-cli` → `nico-admin-cli` (package renamed).
- Rename stale `carbide-admin-cli` binary invocations to `nico-admin-cli` in `dpu_extension_service.md` (the intentional `carbide-admin-cli`/`forge-admin-cli` completion aliases in `generate-shell-complete.md` are left as-is).

## Related issues
Related to #3112

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Docs-only change; no code affected. Verified `-a` matches the current `cli_options.rs` flag definition, that `nico-admin-cli` is the actual crate/binary name, and that no stale `nico-admin-cli -c` or unintended `carbide-admin-cli` references remain in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)