### PR TITLE
feat(health): add NVUE REST reboot and leakage collection

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -222,11 +222,13 @@ request_timeout = "30s"
 
 [collectors.nvue.rest.paths]
 system_health_enabled = true
+system_reboot_reason_enabled = true
 cluster_apps_enabled = true
 sdn_partitions_enabled = true
 interfaces_enabled = true
 platform_environment_fan_enabled = true
 platform_environment_temperature_enabled = true
+platform_environment_leakage_enabled = true
 platform_environment_status_enabled = true
 
 # NVUE gNMI streaming collector which subscribes to

--- a/crates/health/src/collectors/nvue/rest/client.rs
+++ b/crates/health/src/collectors/nvue/rest/client.rs
@@ -841,6 +841,7 @@ mod tests {
         assert!(empty_temps.is_empty());
 
         let empty_leakage: LeakageEnvironmentResponse = serde_json::from_str("{}").unwrap();
+
         assert!(empty_leakage.is_empty());
 
         let empty_env: PlatformEnvironmentResponse = serde_json::from_str("{}").unwrap();

--- a/crates/health/src/collectors/nvue/rest/client.rs
+++ b/crates/health/src/collectors/nvue/rest/client.rs
@@ -30,11 +30,13 @@ use crate::HealthError;
 use crate::config::NvueRestPaths;
 
 const NVUE_SYSTEM_HEALTH: &str = "/nvue_v1/system/health";
+const NVUE_SYSTEM_REBOOT_REASON: &str = "/nvue_v1/system/reboot/reason";
 const NVUE_CLUSTER_APPS: &str = "/nvue_v1/cluster/apps";
 const NVUE_SDN_PARTITIONS: &str = "/nvue_v1/sdn/partition";
 const NVUE_INTERFACES: &str = "/nvue_v1/interface";
 const NVUE_PLATFORM_ENVIRONMENT_FAN: &str = "/nvue_v1/platform/environment/fan";
 const NVUE_PLATFORM_ENVIRONMENT_TEMPERATURE: &str = "/nvue_v1/platform/environment/temperature";
+const NVUE_PLATFORM_ENVIRONMENT_LEAKAGE: &str = "/nvue_v1/platform/environment/leakage";
 const NVUE_PLATFORM_ENVIRONMENT: &str = "/nvue_v1/platform/environment";
 
 #[derive(Clone)]
@@ -50,6 +52,23 @@ impl std::fmt::Debug for UsernamePassword {
             .field("password", &self.password.as_ref().map(|_| "<redacted>"))
             .finish()
     }
+}
+
+/// Result envelope for NVUE REST paths where HTTP 200 `null` is meaningful.
+///
+/// `Null` means the request succeeded and NVUE returned a JSON `null` body, so
+/// the collector can apply endpoint-specific unavailable handling instead of
+/// acting as if the path was disabled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptionalNvueResponse<T> {
+    /// Path disabled by caller; no HTTP request was made.
+    Disabled,
+
+    /// Path was polled and returned a top-level JSON `null`.
+    Null,
+
+    /// Path was polled and returned a concrete response payload.
+    Present(T),
 }
 
 pub struct RestClient {
@@ -92,6 +111,29 @@ impl RestClient {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_with_base_url_for_test(
+        switch_id: String,
+        base_url: Url,
+        request_timeout: Duration,
+        paths: NvueRestPaths,
+    ) -> Result<Self, HealthError> {
+        let client = Client::builder()
+            .timeout(request_timeout)
+            .build()
+            .map_err(|e| {
+                HealthError::HttpError(format!("{base_url}: failed to create HTTP client: {e}"))
+            })?;
+
+        Ok(Self {
+            switch_id,
+            base_url,
+            credentials: ArcSwapOption::empty(),
+            paths,
+            client,
+        })
+    }
+
     pub fn set_credentials(&self, creds: UsernamePassword) {
         self.credentials.store(Some(Arc::new(creds)));
     }
@@ -110,6 +152,17 @@ impl RestClient {
         }
         let url = self.join_path(NVUE_SYSTEM_HEALTH)?;
         self.do_get(url, &[]).await.map(Some)
+    }
+
+    pub async fn get_system_reboot_reason(
+        &self,
+    ) -> Result<OptionalNvueResponse<RebootReasonResponse>, HealthError> {
+        if !self.paths.system_reboot_reason_enabled {
+            return Ok(OptionalNvueResponse::Disabled);
+        }
+
+        let url = self.join_path(NVUE_SYSTEM_REBOOT_REASON)?;
+        self.do_get_nullable(url, &[]).await
     }
 
     pub async fn get_cluster_apps(&self) -> Result<Option<ClusterAppsResponse>, HealthError> {
@@ -146,6 +199,17 @@ impl RestClient {
         }
         let url = self.join_path(NVUE_PLATFORM_ENVIRONMENT_TEMPERATURE)?;
         self.do_get(url, &[]).await.map(Some)
+    }
+
+    pub async fn get_platform_environment_leakage(
+        &self,
+    ) -> Result<OptionalNvueResponse<LeakageEnvironmentResponse>, HealthError> {
+        if !self.paths.platform_environment_leakage_enabled {
+            return Ok(OptionalNvueResponse::Disabled);
+        }
+
+        let url = self.join_path(NVUE_PLATFORM_ENVIRONMENT_LEAKAGE)?;
+        self.do_get_nullable(url, &[]).await
     }
 
     pub async fn get_platform_environment(
@@ -248,6 +312,20 @@ impl RestClient {
             ))
         })
     }
+
+    async fn do_get_nullable<T: for<'de> Deserialize<'de>>(
+        &self,
+        url: Url,
+        extra_query: &[(&str, &str)],
+    ) -> Result<OptionalNvueResponse<T>, HealthError> {
+        // A report-backed NVUE endpoint can return HTTP 200 with body `null`.
+        // Keep that distinct from a disabled path so downstream health reports
+        // still show that the probe ran but the switch did not provide data.
+        match self.do_get::<Option<T>>(url, extra_query).await? {
+            Some(value) => Ok(OptionalNvueResponse::Present(value)),
+            None => Ok(OptionalNvueResponse::Null),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -268,6 +346,19 @@ pub struct SystemHealthResponse {
 #[derive(Debug, Clone, Deserialize)]
 pub struct IssueInfo {
     pub issue: Option<String>,
+}
+
+/// `/nvue_v1/system/reboot/reason` response.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct RebootReasonResponse {
+    /// Reason reported by NVUE for the last or pending reboot action.
+    pub reason: Option<String>,
+
+    /// NVUE generation time for the reboot reason.
+    pub gentime: Option<String>,
+
+    /// User associated with the reboot reason when NVUE provides one.
+    pub user: Option<String>,
 }
 
 pub type ClusterAppsResponse = HashMap<String, ClusterApp>;
@@ -341,6 +432,20 @@ pub struct TempData {
     /// Critical threshold in Celsius as a string (e.g. "120.00").
     pub crit: Option<String>,
     /// Sensor state as string (e.g. "ok").
+    pub state: Option<String>,
+}
+
+/// `/nvue_v1/platform/environment/leakage` response keyed by leakage sensor
+/// name.
+///
+/// NVUE may encode an individual sensor as JSON `null`; the collector maps that
+/// sensor to `unknown` and reports it as a sensor failure.
+pub type LeakageEnvironmentResponse = HashMap<String, Option<LeakageSensorData>>;
+
+/// Leakage sensor entry inside `/nvue_v1/platform/environment/leakage`.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LeakageSensorData {
+    /// Leakage sensor state, expected as "ok" or "leak".
     pub state: Option<String>,
 }
 
@@ -420,6 +525,17 @@ mod tests {
         assert_eq!(resp.status.as_deref(), Some("OK"));
         assert_eq!(resp.status_led.as_deref(), Some("green"));
         assert!(resp.issues.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_parse_reboot_reason() {
+        let json = r#"{"reason":"reboot command","gentime":"2026-07-05 12:34:56","user":"admin"}"#;
+
+        let resp: RebootReasonResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(resp.reason.as_deref(), Some("reboot command"));
+        assert_eq!(resp.gentime.as_deref(), Some("2026-07-05 12:34:56"));
+        assert_eq!(resp.user.as_deref(), Some("admin"));
     }
 
     #[test]
@@ -659,6 +775,30 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_platform_environment_leakage() {
+        let json = r#"{"LEAK0":null,"LEAK1":{"state":"ok"},"LEAK2":{"state":"leak"}}"#;
+
+        let resp: LeakageEnvironmentResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(resp.len(), 3);
+        assert!(resp["LEAK0"].is_none());
+
+        assert_eq!(
+            resp["LEAK1"]
+                .as_ref()
+                .and_then(|sensor| sensor.state.as_deref()),
+            Some("ok")
+        );
+
+        assert_eq!(
+            resp["LEAK2"]
+                .as_ref()
+                .and_then(|sensor| sensor.state.as_deref()),
+            Some("leak")
+        );
+    }
+
+    #[test]
     fn test_parse_platform_environment_fan_status() {
         // Parent summary carries the aggregate `FAN_STATUS` LED entry alongside
         // nested `fan`/`temperature` subtree objects of a different shape. The
@@ -699,6 +839,9 @@ mod tests {
 
         let empty_temps: TemperatureEnvironmentResponse = serde_json::from_str("{}").unwrap();
         assert!(empty_temps.is_empty());
+
+        let empty_leakage: LeakageEnvironmentResponse = serde_json::from_str("{}").unwrap();
+        assert!(empty_leakage.is_empty());
 
         let empty_env: PlatformEnvironmentResponse = serde_json::from_str("{}").unwrap();
         assert!(empty_env.is_empty());

--- a/crates/health/src/collectors/nvue/rest/collector.rs
+++ b/crates/health/src/collectors/nvue/rest/collector.rs
@@ -18,13 +18,19 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use super::client::{RestClient, UsernamePassword};
+use super::client::{
+    LeakageEnvironmentResponse, LeakageSensorData, OptionalNvueResponse, RebootReasonResponse,
+    RestClient, UsernamePassword,
+};
 use crate::HealthError;
 use crate::bmc::{CREDENTIAL_REFRESH_TIMEOUT, CredentialProvider, is_auth_error};
 use crate::collectors::{IterationResult, PeriodicCollector};
 use crate::config::NvueRestConfig;
 use crate::endpoint::{BmcAddr, BmcCredentials, BmcEndpoint, EndpointMetadata};
-use crate::sink::{CollectorEvent, DataSink, EventContext, MetricSample};
+use crate::sink::{
+    Classification, CollectorEvent, DataSink, EventContext, HealthReport, HealthReportAlert,
+    HealthReportSuccess, HealthReportTarget, MetricSample, Probe, ReportSource,
+};
 
 const COLLECTOR_NAME: &str = "nvue_rest";
 
@@ -88,6 +94,22 @@ fn temp_to_f64(value: Option<&str>) -> Option<f64> {
     value.and_then(|s| s.trim().parse::<f64>().ok())
 }
 
+const LEAKAGE_STATES: &[&str] = &["ok", "leak", "unknown"];
+
+/// Maps NVUE leakage sensor strings to the emitted StateSet domain.
+///
+/// NVUE OpenAPI defines populated leakage sensor states as `ok` or `leak`.
+/// `unknown` is an emitted fallback for per-sensor `null`, absent state, or an
+/// unrecognized value; the health report classifies that fallback as a sensor
+/// failure.
+fn leakage_state_to_state(state: Option<&str>) -> &'static str {
+    match state.map(str::trim) {
+        Some(s) if s.eq_ignore_ascii_case("ok") => "ok",
+        Some(s) if s.eq_ignore_ascii_case("leak") => "leak",
+        _ => "unknown",
+    }
+}
+
 const TEMP_STATE_STATES: &[&str] = &["ok", "not_ok"];
 
 /// Sensor `state` -> StateSet: "ok" (case-insensitive) => "ok", other present
@@ -115,6 +137,21 @@ fn fan_led_to_state(state: Option<&str>) -> Option<&'static str> {
         Some("ok")
     } else {
         Some("not_ok")
+    }
+}
+
+/// Builds a switch-target health report with the current observation time.
+fn switch_report(
+    source: ReportSource,
+    successes: Vec<HealthReportSuccess>,
+    alerts: Vec<HealthReportAlert>,
+) -> HealthReport {
+    HealthReport {
+        source,
+        target: Some(HealthReportTarget::Switch),
+        observed_at: Some(chrono::Utc::now()),
+        successes,
+        alerts,
     }
 }
 
@@ -203,6 +240,24 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
                 error = ?e,
                 switch_id = %self.switch_id,
                 "nvue_rest: failed to collect system health"
+                );
+            }
+        }
+
+        match self.client.get_system_reboot_reason().await {
+            Ok(OptionalNvueResponse::Present(reason)) => {
+                self.emit_reboot_reason_data(&reason);
+
+                entity_count += 1;
+            }
+            Ok(OptionalNvueResponse::Null | OptionalNvueResponse::Disabled) => {}
+            Err(e) => {
+                fetch_failures += 1;
+                saw_auth_failure |= is_auth_error(&e);
+                tracing::warn!(
+                error = ?e,
+                switch_id = %self.switch_id,
+                "nvue_rest: failed to collect system reboot reason"
                 );
             }
         }
@@ -391,6 +446,25 @@ impl PeriodicCollector<crate::bmc::BmcClient> for NvueRestCollector {
             }
         }
 
+        match self.client.get_platform_environment_leakage().await {
+            Ok(OptionalNvueResponse::Present(leakage)) => {
+                entity_count += self.emit_leakage_data(&leakage);
+            }
+            Ok(OptionalNvueResponse::Null) => {
+                self.emit_leakage_unavailable();
+            }
+            Ok(OptionalNvueResponse::Disabled) => {}
+            Err(e) => {
+                fetch_failures += 1;
+                saw_auth_failure |= is_auth_error(&e);
+                tracing::warn!(
+                error = ?e,
+                switch_id = %self.switch_id,
+                "nvue_rest: failed to collect platform environment leakage"
+                );
+            }
+        }
+
         match self.client.get_platform_environment().await {
             Ok(Some(env)) => {
                 // Switch-level FAN_STATUS LED. Emit only when present and mappable.
@@ -471,6 +545,121 @@ impl NvueRestCollector {
         }
     }
 
+    /// Emits reboot-reason metadata as an info metric.
+    ///
+    /// The reason endpoint records context for a reboot decision but is not
+    /// itself a health condition, so it does not generate a health report.
+    fn emit_reboot_reason_data(&self, reason: &RebootReasonResponse) {
+        self.emit_metric(
+            "reboot_reason_info",
+            None,
+            1.0,
+            "info",
+            vec![
+                (
+                    Cow::Borrowed("reason"),
+                    reason.reason.as_deref().unwrap_or("unknown").to_string(),
+                ),
+                (
+                    Cow::Borrowed("gentime"),
+                    reason.gentime.as_deref().unwrap_or("unknown").to_string(),
+                ),
+                (
+                    Cow::Borrowed("user"),
+                    reason.user.as_deref().unwrap_or("unknown").to_string(),
+                ),
+            ],
+        );
+    }
+
+    fn emit_leakage_data(&self, leakage: &LeakageEnvironmentResponse) -> usize {
+        let mut sensors = leakage.iter().collect::<Vec<_>>();
+        sensors.sort_by(|left, right| left.0.cmp(right.0));
+
+        for &(sensor_name, sensor) in &sensors {
+            let current =
+                leakage_state_to_state(sensor.as_ref().and_then(|sensor| sensor.state.as_deref()));
+
+            self.emit_state_set(
+                "leakage_state",
+                Some(sensor_name.as_str()),
+                current,
+                LEAKAGE_STATES,
+                vec![(Cow::Borrowed("sensor"), sensor_name.clone())],
+            );
+        }
+
+        let report = self.build_leakage_report(sensors.as_slice());
+        self.emit_event(CollectorEvent::HealthReport(Arc::new(report)));
+
+        sensors.len()
+    }
+
+    /// Emits a switch-level alert when the leakage endpoint returns top-level
+    /// JSON `null`.
+    ///
+    /// A concrete empty map means "no sensors reported" and is a source success;
+    /// top-level `null` means the switch did not provide leakage data, so the
+    /// previous leakage state must not be cleared as healthy.
+    fn emit_leakage_unavailable(&self) {
+        let report = switch_report(
+            ReportSource::NvueLeakage,
+            Vec::new(),
+            vec![HealthReportAlert {
+                probe_id: Probe::NvueLeakage,
+                target: None,
+                message: "NVUE leakage data is unavailable".to_string(),
+                classifications: vec![Classification::SensorFailure],
+            }],
+        );
+
+        self.emit_event(CollectorEvent::HealthReport(Arc::new(report)));
+    }
+
+    /// Builds the switch-level health report for NVUE leakage sensors.
+    ///
+    /// Empty leakage data means the endpoint was reachable and no sensors were
+    /// reported, so the source is healthy. Per-sensor `null` or unrecognized
+    /// states alert as sensor failures; explicit `leak` states alert as leaks.
+    fn build_leakage_report(
+        &self,
+        sensors: &[(&String, &Option<LeakageSensorData>)],
+    ) -> HealthReport {
+        let mut successes = Vec::new();
+        let mut alerts = Vec::new();
+
+        if sensors.is_empty() {
+            successes.push(HealthReportSuccess {
+                probe_id: Probe::NvueLeakage,
+                target: None,
+            });
+        }
+
+        for (sensor_name, sensor) in sensors {
+            match leakage_state_to_state(sensor.as_ref().and_then(|sensor| sensor.state.as_deref()))
+            {
+                "ok" => successes.push(HealthReportSuccess {
+                    probe_id: Probe::NvueLeakage,
+                    target: Some((*sensor_name).clone()),
+                }),
+                "leak" => alerts.push(HealthReportAlert {
+                    probe_id: Probe::NvueLeakage,
+                    target: Some((*sensor_name).clone()),
+                    message: format!("NVUE leakage sensor {sensor_name} reports leak"),
+                    classifications: vec![Classification::Leak],
+                }),
+                _ => alerts.push(HealthReportAlert {
+                    probe_id: Probe::NvueLeakage,
+                    target: Some((*sensor_name).clone()),
+                    message: format!("NVUE leakage sensor {sensor_name} state is unknown"),
+                    classifications: vec![Classification::SensorFailure],
+                }),
+            }
+        }
+
+        switch_report(ReportSource::NvueLeakage, successes, alerts)
+    }
+
     fn emit_event(&self, event: CollectorEvent) {
         if let Some(data_sink) = &self.data_sink {
             data_sink.handle_event(&self.event_context, &event);
@@ -545,10 +734,12 @@ impl NvueRestCollector {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
     use std::sync::Mutex as StdMutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread::JoinHandle;
     use std::time::Duration;
 
     use mac_address::MacAddress;
@@ -592,6 +783,34 @@ mod tests {
                     sample.labels.iter().any(|(k, v)| k == label && v == value),
                     "{metric_type} state {state}: missing entity label {label}={value}"
                 );
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct CapturingSink {
+        samples: StdMutex<Vec<MetricSample>>,
+        reports: StdMutex<Vec<HealthReport>>,
+    }
+
+    impl DataSink for CapturingSink {
+        fn sink_type(&self) -> &'static str {
+            "capturing_sink"
+        }
+
+        fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+            match event {
+                CollectorEvent::Metric(sample) => {
+                    self.samples.lock().unwrap().push((**sample).clone());
+                }
+                CollectorEvent::HealthReport(report) => {
+                    self.reports.lock().unwrap().push((**report).clone());
+                }
+                CollectorEvent::MetricCollectionStart
+                | CollectorEvent::MetricCollectionEnd
+                | CollectorEvent::CollectorRemoved
+                | CollectorEvent::Log(_)
+                | CollectorEvent::Firmware(_) => {}
             }
         }
     }
@@ -654,6 +873,19 @@ mod tests {
         assert_eq!(temp_to_f64(Some("x")), None);
         assert_eq!(temp_to_f64(Some("")), None);
         assert_eq!(temp_to_f64(None), None);
+    }
+
+    #[test]
+    fn test_leakage_state_mapping() {
+        assert_eq!(leakage_state_to_state(Some("ok")), "ok");
+        assert_eq!(leakage_state_to_state(Some("OK")), "ok");
+        assert_eq!(leakage_state_to_state(Some(" ok ")), "ok");
+        assert_eq!(leakage_state_to_state(Some("leak")), "leak");
+        assert_eq!(leakage_state_to_state(Some("LEAK")), "leak");
+        assert_eq!(leakage_state_to_state(Some(" leak ")), "leak");
+        assert_eq!(leakage_state_to_state(Some("missing")), "unknown");
+        assert_eq!(leakage_state_to_state(Some("   ")), "unknown");
+        assert_eq!(leakage_state_to_state(None), "unknown");
     }
 
     #[test]
@@ -1082,6 +1314,134 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_reboot_reason_emits_info_metric_labels() {
+        let sink = Arc::new(CapturingSink::default());
+        let mut collector = collector_with_provider(ScriptedProvider::new(vec![]));
+        collector.data_sink = Some(sink.clone());
+
+        let reason = RebootReasonResponse {
+            reason: Some("package upgrade".to_string()),
+            gentime: Some("2026-07-05 12:34:56".to_string()),
+            user: Some("admin".to_string()),
+        };
+
+        collector.emit_reboot_reason_data(&reason);
+
+        let samples = sink.samples.lock().unwrap();
+        let reports = sink.reports.lock().unwrap();
+        let sample = samples.first().expect("reboot reason emits one sample");
+        let label_value = |label: &str| {
+            sample
+                .labels
+                .iter()
+                .find_map(|(key, value)| (key == label).then_some(value.as_str()))
+        };
+
+        assert_eq!(samples.len(), 1);
+        assert!(reports.is_empty());
+        assert_eq!(sample.name, COLLECTOR_NAME);
+        assert_eq!(sample.key, "reboot_reason_info");
+        assert_eq!(sample.metric_type, "reboot_reason_info");
+        assert_eq!(sample.unit, "info");
+        assert_eq!(sample.value, 1.0);
+        assert_eq!(label_value("reason"), Some("package upgrade"));
+        assert_eq!(label_value("gentime"), Some("2026-07-05 12:34:56"));
+        assert_eq!(label_value("user"), Some("admin"));
+    }
+
+    #[test]
+    fn test_leakage_emits_metrics_and_switch_report() {
+        let sink = Arc::new(CapturingSink::default());
+        let mut collector = collector_with_provider(ScriptedProvider::new(vec![]));
+        collector.data_sink = Some(sink.clone());
+
+        let leakage: LeakageEnvironmentResponse = serde_json::from_str(
+            r#"{
+                "LEAK1":{"state":"ok"},
+                "LEAK2":{"state":"leak"},
+                "LEAK3":{"state":"unknown"},
+                "LEAK4": null
+            }"#,
+        )
+        .expect("leakage json parses");
+
+        let entity_count = collector.emit_leakage_data(&leakage);
+
+        let samples = sink.samples.lock().unwrap();
+
+        assert_eq!(entity_count, 4);
+        assert_eq!(samples.len(), 12);
+
+        let leak2_samples = samples
+            .iter()
+            .filter(|sample| {
+                sample.metric_type == "leakage_state"
+                    && sample
+                        .labels
+                        .iter()
+                        .any(|(key, value)| key == "sensor" && value == "LEAK2")
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_state_set(
+            &leak2_samples,
+            "leakage_state",
+            Some(("sensor", "LEAK2")),
+            LEAKAGE_STATES,
+            "leak",
+        );
+
+        let reports = sink.reports.lock().unwrap();
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].source, ReportSource::NvueLeakage);
+        assert_eq!(reports[0].target, Some(HealthReportTarget::Switch));
+        assert_eq!(reports[0].successes.len(), 1);
+        assert_eq!(reports[0].alerts.len(), 3);
+
+        assert!(
+            reports[0]
+                .alerts
+                .iter()
+                .any(|alert| alert.classifications.contains(&Classification::Leak))
+        );
+
+        assert!(reports[0].alerts.iter().any(|alert| {
+            alert
+                .classifications
+                .contains(&Classification::SensorFailure)
+        }));
+    }
+
+    #[test]
+    fn test_empty_leakage_emits_source_success_report() {
+        let sink = Arc::new(CapturingSink::default());
+        let mut collector = collector_with_provider(ScriptedProvider::new(vec![]));
+        collector.data_sink = Some(sink.clone());
+
+        let leakage: LeakageEnvironmentResponse =
+            serde_json::from_str("{}").expect("empty leakage json parses");
+
+        let entity_count = collector.emit_leakage_data(&leakage);
+
+        let samples = sink.samples.lock().unwrap();
+
+        assert_eq!(entity_count, 0);
+        assert!(samples.is_empty());
+
+        let reports = sink.reports.lock().unwrap();
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].source, ReportSource::NvueLeakage);
+        assert_eq!(reports[0].target, Some(HealthReportTarget::Switch));
+        assert_eq!(reports[0].successes.len(), 1);
+        assert_eq!(reports[0].successes[0].probe_id, Probe::NvueLeakage);
+        assert_eq!(reports[0].successes[0].target, None);
+        assert!(reports[0].alerts.is_empty());
+    }
+
     struct ScriptedProvider {
         calls: AtomicUsize,
         // Each call pops the front. An empty queue yields an error. HealthError
@@ -1129,11 +1489,13 @@ mod tests {
     fn paths_all_disabled() -> NvueRestPaths {
         NvueRestPaths {
             system_health_enabled: false,
+            system_reboot_reason_enabled: false,
             cluster_apps_enabled: false,
             sdn_partitions_enabled: false,
             interfaces_enabled: false,
             platform_environment_fan_enabled: false,
             platform_environment_temperature_enabled: false,
+            platform_environment_leakage_enabled: false,
             platform_environment_status_enabled: false,
         }
     }
@@ -1165,6 +1527,83 @@ mod tests {
             addr,
             provider,
         }
+    }
+
+    fn spawn_json_response_server(body: &'static str) -> (url::Url, JoinHandle<()>) {
+        let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .expect("test server binds local port");
+
+        let addr = listener.local_addr().expect("test server local addr");
+        let base_url = url::Url::parse(&format!("http://{addr}")).expect("test server url parses");
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("test server accepts request");
+            let mut buffer = [0_u8; 2048];
+            let _bytes_read = stream.read(&mut buffer).expect("test server reads request");
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+
+            stream
+                .write_all(response.as_bytes())
+                .expect("test server writes response");
+        });
+
+        (base_url, handle)
+    }
+
+    fn collector_with_json_response(
+        paths: NvueRestPaths,
+        body: &'static str,
+    ) -> (NvueRestCollector, Arc<CapturingSink>, JoinHandle<()>) {
+        let (base_url, server) = spawn_json_response_server(body);
+
+        let client = RestClient::new_with_base_url_for_test(
+            "test-switch".to_string(),
+            base_url,
+            Duration::from_secs(1),
+            paths,
+        )
+        .expect("test rest client builds");
+
+        client.set_credentials(UsernamePassword {
+            username: "admin".to_string(),
+            password: None,
+        });
+
+        let sink = Arc::new(CapturingSink::default());
+        let mut collector = collector_with_provider(ScriptedProvider::new(vec![]));
+        collector.client = client;
+        collector.data_sink = Some(sink.clone());
+
+        (collector, sink, server)
+    }
+
+    async fn collect_response(
+        paths: NvueRestPaths,
+        body: &'static str,
+    ) -> (IterationResult, Vec<MetricSample>, Vec<HealthReport>) {
+        let (mut collector, sink, server) = collector_with_json_response(paths, body);
+
+        let result = collector
+            .run_iteration()
+            .await
+            .expect("response iteration succeeds");
+
+        server.join().expect("test server exits cleanly");
+
+        let samples = sink.samples.lock().unwrap().clone();
+        let reports = sink.reports.lock().unwrap().clone();
+
+        (result, samples, reports)
+    }
+
+    async fn collect_null_response(
+        paths: NvueRestPaths,
+    ) -> (IterationResult, Vec<MetricSample>, Vec<HealthReport>) {
+        collect_response(paths, "null").await
     }
 
     #[tokio::test]
@@ -1252,6 +1691,62 @@ mod tests {
             ),
             other => panic!("unexpected error variant: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn run_iteration_reboot_reason_null_is_unavailable_metadata() {
+        let mut paths = paths_all_disabled();
+        paths.system_reboot_reason_enabled = true;
+
+        let (result, samples, reports) = collect_null_response(paths).await;
+
+        assert_eq!(result.fetch_failures, 0);
+        assert_eq!(result.entity_count, Some(0));
+        assert!(samples.is_empty());
+        assert!(reports.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_iteration_metric_path_null_counts_fetch_failure() {
+        let mut paths = paths_all_disabled();
+        paths.cluster_apps_enabled = true;
+
+        let (result, samples, reports) = collect_null_response(paths).await;
+
+        assert_eq!(result.fetch_failures, 1);
+        assert_eq!(result.entity_count, Some(0));
+        assert!(samples.is_empty());
+        assert!(reports.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_iteration_leakage_null_emits_unavailable_alert_report() {
+        let mut paths = paths_all_disabled();
+        paths.platform_environment_leakage_enabled = true;
+
+        let (result, samples, reports) = collect_null_response(paths).await;
+
+        assert_eq!(result.fetch_failures, 0);
+        assert_eq!(result.entity_count, Some(0));
+        assert!(samples.is_empty());
+
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].source, ReportSource::NvueLeakage);
+        assert_eq!(reports[0].target, Some(HealthReportTarget::Switch));
+        assert!(reports[0].successes.is_empty());
+        assert_eq!(reports[0].alerts.len(), 1);
+        assert_eq!(reports[0].alerts[0].probe_id, Probe::NvueLeakage);
+        assert_eq!(reports[0].alerts[0].target, None);
+
+        assert_eq!(
+            reports[0].alerts[0].classifications,
+            vec![Classification::SensorFailure]
+        );
+
+        assert_eq!(
+            reports[0].alerts[0].message,
+            "NVUE leakage data is unavailable"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/health/src/collectors/nvue/rest/collector.rs
+++ b/crates/health/src/collectors/nvue/rest/collector.rs
@@ -140,21 +140,6 @@ fn fan_led_to_state(state: Option<&str>) -> Option<&'static str> {
     }
 }
 
-/// Builds a switch-target health report with the current observation time.
-fn switch_report(
-    source: ReportSource,
-    successes: Vec<HealthReportSuccess>,
-    alerts: Vec<HealthReportAlert>,
-) -> HealthReport {
-    HealthReport {
-        source,
-        target: Some(HealthReportTarget::Switch),
-        observed_at: Some(chrono::Utc::now()),
-        successes,
-        alerts,
-    }
-}
-
 pub struct NvueRestCollectorConfig {
     pub rest_config: NvueRestConfig,
     pub data_sink: Option<Arc<dyn DataSink>>,
@@ -547,28 +532,28 @@ impl NvueRestCollector {
 
     /// Emits reboot-reason metadata as an info metric.
     ///
-    /// The reason endpoint records context for a reboot decision but is not
-    /// itself a health condition, so it does not generate a health report.
+    /// `reason` is intentionally kept as the Prometheus grouping label because
+    /// the metric is not useful without it. `gentime` and `user` are excluded
+    /// from labels because they churn per event and can expose operator data.
     fn emit_reboot_reason_data(&self, reason: &RebootReasonResponse) {
+        let reason_text = reason.reason.as_deref().unwrap_or("unknown");
+        let gentime = reason.gentime.as_deref().unwrap_or("unknown");
+        let user = reason.user.as_deref().unwrap_or("unknown");
+
+        tracing::info!(
+            switch_id = %self.switch_id,
+            reason = reason_text,
+            gentime,
+            user,
+            "nvue_rest: collected system reboot reason"
+        );
+
         self.emit_metric(
             "reboot_reason_info",
             None,
             1.0,
             "info",
-            vec![
-                (
-                    Cow::Borrowed("reason"),
-                    reason.reason.as_deref().unwrap_or("unknown").to_string(),
-                ),
-                (
-                    Cow::Borrowed("gentime"),
-                    reason.gentime.as_deref().unwrap_or("unknown").to_string(),
-                ),
-                (
-                    Cow::Borrowed("user"),
-                    reason.user.as_deref().unwrap_or("unknown").to_string(),
-                ),
-            ],
+            vec![(Cow::Borrowed("reason"), reason_text.to_string())],
         );
     }
 
@@ -602,16 +587,18 @@ impl NvueRestCollector {
     /// top-level `null` means the switch did not provide leakage data, so the
     /// previous leakage state must not be cleared as healthy.
     fn emit_leakage_unavailable(&self) {
-        let report = switch_report(
-            ReportSource::NvueLeakage,
-            Vec::new(),
-            vec![HealthReportAlert {
+        let report = HealthReport {
+            source: ReportSource::NvueLeakage,
+            target: Some(HealthReportTarget::Switch),
+            observed_at: Some(chrono::Utc::now()),
+            successes: Vec::new(),
+            alerts: vec![HealthReportAlert {
                 probe_id: Probe::NvueLeakage,
                 target: None,
                 message: "NVUE leakage data is unavailable".to_string(),
                 classifications: vec![Classification::SensorFailure],
             }],
-        );
+        };
 
         self.emit_event(CollectorEvent::HealthReport(Arc::new(report)));
     }
@@ -657,7 +644,13 @@ impl NvueRestCollector {
             }
         }
 
-        switch_report(ReportSource::NvueLeakage, successes, alerts)
+        HealthReport {
+            source: ReportSource::NvueLeakage,
+            target: Some(HealthReportTarget::Switch),
+            observed_at: Some(chrono::Utc::now()),
+            successes,
+            alerts,
+        }
     }
 
     fn emit_event(&self, event: CollectorEvent) {
@@ -1315,7 +1308,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reboot_reason_emits_info_metric_labels() {
+    fn test_reboot_reason_emits_reason_label_without_user_or_gentime() {
         let sink = Arc::new(CapturingSink::default());
         let mut collector = collector_with_provider(ScriptedProvider::new(vec![]));
         collector.data_sink = Some(sink.clone());
@@ -1331,12 +1324,6 @@ mod tests {
         let samples = sink.samples.lock().unwrap();
         let reports = sink.reports.lock().unwrap();
         let sample = samples.first().expect("reboot reason emits one sample");
-        let label_value = |label: &str| {
-            sample
-                .labels
-                .iter()
-                .find_map(|(key, value)| (key == label).then_some(value.as_str()))
-        };
 
         assert_eq!(samples.len(), 1);
         assert!(reports.is_empty());
@@ -1345,13 +1332,15 @@ mod tests {
         assert_eq!(sample.metric_type, "reboot_reason_info");
         assert_eq!(sample.unit, "info");
         assert_eq!(sample.value, 1.0);
-        assert_eq!(label_value("reason"), Some("package upgrade"));
-        assert_eq!(label_value("gentime"), Some("2026-07-05 12:34:56"));
-        assert_eq!(label_value("user"), Some("admin"));
+
+        assert_eq!(
+            sample.labels,
+            vec![(Cow::Borrowed("reason"), "package upgrade".to_string())]
+        );
     }
 
     #[test]
-    fn test_leakage_emits_metrics_and_switch_report() {
+    fn test_leakage_emits_metrics_and_health_report() {
         let sink = Arc::new(CapturingSink::default());
         let mut collector = collector_with_provider(ScriptedProvider::new(vec![]));
         collector.data_sink = Some(sink.clone());

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1045,22 +1045,30 @@ impl Default for NvueRestConfig {
 
 /// Supported NVUE REST API paths.
 /// - system_health_enabled: Poll `/nvue_v1/system/health`.
+/// - system_reboot_reason_enabled: Poll `/nvue_v1/system/reboot/reason`.
 /// - cluster_apps_enabled: Poll `/nvue_v1/cluster/apps`.
 /// - sdn_partitions_enabled: Poll `/nvue_v1/sdn/partition` (including per-partition details)
 /// - interfaces_enabled: Poll `/nvue_v1/interface`.
 /// - platform_environment_fan_enabled: Poll `/nvue_v1/platform/environment/fan`.
 /// - platform_environment_temperature_enabled: Poll `/nvue_v1/platform/environment/temperature`.
+/// - platform_environment_leakage_enabled: Poll `/nvue_v1/platform/environment/leakage`.
 /// - platform_environment_status_enabled: Poll `/nvue_v1/platform/environment` parent
 ///   summary for the aggregate `FAN_STATUS` LED state.
+///
+/// Disabling a flag skips the HTTP request. This is separate from leakage
+/// returning top-level JSON `null`, which still means the path was polled and
+/// should produce an explicit health-report result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct NvueRestPaths {
     pub system_health_enabled: bool,
+    pub system_reboot_reason_enabled: bool,
     pub cluster_apps_enabled: bool,
     pub sdn_partitions_enabled: bool,
     pub interfaces_enabled: bool,
     pub platform_environment_fan_enabled: bool,
     pub platform_environment_temperature_enabled: bool,
+    pub platform_environment_leakage_enabled: bool,
     pub platform_environment_status_enabled: bool,
 }
 
@@ -1068,11 +1076,13 @@ impl Default for NvueRestPaths {
     fn default() -> Self {
         Self {
             system_health_enabled: true,
+            system_reboot_reason_enabled: true,
             cluster_apps_enabled: true,
             sdn_partitions_enabled: true,
             interfaces_enabled: true,
             platform_environment_fan_enabled: true,
             platform_environment_temperature_enabled: true,
+            platform_environment_leakage_enabled: true,
             platform_environment_status_enabled: true,
         }
     }
@@ -1738,9 +1748,11 @@ skip_empty_reports = false
             assert_eq!(rest.poll_interval, Duration::from_secs(300));
             assert_eq!(rest.request_timeout, Duration::from_secs(30));
             assert!(rest.paths.system_health_enabled);
+            assert!(rest.paths.system_reboot_reason_enabled);
             assert!(rest.paths.cluster_apps_enabled);
             assert!(rest.paths.sdn_partitions_enabled);
             assert!(rest.paths.interfaces_enabled);
+            assert!(rest.paths.platform_environment_leakage_enabled);
         }
     }
 
@@ -1771,6 +1783,8 @@ request_timeout = "45s"
                 assert_eq!(rest.poll_interval, Duration::from_secs(120));
                 assert_eq!(rest.request_timeout, Duration::from_secs(45));
                 assert!(rest.paths.system_health_enabled);
+                assert!(rest.paths.system_reboot_reason_enabled);
+                assert!(rest.paths.platform_environment_leakage_enabled);
             } else {
                 panic!("nvue rest config should be enabled");
             }
@@ -1846,9 +1860,11 @@ poll_interval = "1m"
 
 [collectors.nvue.rest.paths]
 system_health_enabled = true
+system_reboot_reason_enabled = false
 cluster_apps_enabled = false
 sdn_partitions_enabled = true
 interfaces_enabled = false
+platform_environment_leakage_enabled = false
 "#;
 
         let config: Config = Figment::new()
@@ -1860,9 +1876,11 @@ interfaces_enabled = false
         if let Configurable::Enabled(ref nvue) = config.collectors.nvue {
             if let Configurable::Enabled(ref rest) = nvue.rest {
                 assert!(rest.paths.system_health_enabled);
+                assert!(!rest.paths.system_reboot_reason_enabled);
                 assert!(!rest.paths.cluster_apps_enabled);
                 assert!(rest.paths.sdn_partitions_enabled);
                 assert!(!rest.paths.interfaces_enabled);
+                assert!(!rest.paths.platform_environment_leakage_enabled);
             } else {
                 panic!("nvue rest config should be enabled");
             }

--- a/crates/health/src/processor/leak_events.rs
+++ b/crates/health/src/processor/leak_events.rs
@@ -40,13 +40,6 @@ impl LeakEventProcessor {
     }
 }
 
-fn is_leak_detector_alert(alert: &HealthReportAlert) -> bool {
-    alert
-        .classifications
-        .iter()
-        .any(|classification| classification == &Classification::LeakDetector)
-}
-
 fn leak_details(alerts: &[&HealthReportAlert]) -> String {
     let targets: BTreeSet<String> = alerts
         .iter()
@@ -74,15 +67,37 @@ impl EventProcessor for LeakEventProcessor {
             return Vec::new();
         };
 
-        if report.source != ReportSource::BmcLeakDetectors {
-            return Vec::new();
-        }
+        // Normalize each source's leak signal into the derived tray leak report
+        // consumed by rack leak aggregation.
+        let (target, leak_classification, alert_kind, detail_kind) = match report.source {
+            ReportSource::BmcLeakDetectors => (
+                HealthReportTarget::Machine,
+                Classification::LeakDetector,
+                "leak-detector",
+                "detectors",
+            ),
+            ReportSource::NvueLeakage => (
+                HealthReportTarget::Switch,
+                Classification::Leak,
+                "nvue-leakage",
+                "leakage sensors",
+            ),
+            _ => return Vec::new(),
+        };
 
         let leak_alerts: Vec<&HealthReportAlert> = report
             .alerts
             .iter()
-            .filter(|alert| is_leak_detector_alert(alert))
+            .filter(|alert| alert.classifications.contains(&leak_classification))
             .collect();
+
+        if report.source == ReportSource::NvueLeakage
+            && leak_alerts.is_empty()
+            && !report.alerts.is_empty()
+        {
+            // Non-leak NVUE alerts are sensor or availability failures, not an all-clear.
+            return Vec::new();
+        }
 
         let alerts = if self.is_leaking(leak_alerts.len()) {
             let details = leak_details(&leak_alerts);
@@ -91,9 +106,11 @@ impl EventProcessor for LeakEventProcessor {
                 probe_id: Probe::LeakDetection,
                 target: None,
                 message: format!(
-                    "Leak detected: {} leak-detector alerts reached threshold {} (detectors: {})",
+                    "Leak detected: {} {} alerts reached threshold {} ({}: {})",
                     leak_alerts.len(),
+                    alert_kind,
                     self.minimum_alerts_per_report,
+                    detail_kind,
                     details
                 ),
                 classifications: vec![Classification::Leak],
@@ -113,7 +130,7 @@ impl EventProcessor for LeakEventProcessor {
 
         let leak_report = HealthReport {
             source: ReportSource::TrayLeakDetection,
-            target: Some(HealthReportTarget::Machine),
+            target: Some(target),
             observed_at: Some(chrono::Utc::now()),
             successes,
             alerts,
@@ -209,6 +226,96 @@ mod tests {
                 .iter()
                 .any(|classification| classification == &Classification::Leak)
         );
+    }
+
+    #[test]
+    fn emits_switch_leak_report_for_nvue_leakage() {
+        let processor = LeakEventProcessor::new(1);
+
+        let report = HealthReport {
+            source: ReportSource::NvueLeakage,
+            target: Some(HealthReportTarget::Switch),
+            observed_at: Some(chrono::Utc::now()),
+            successes: Vec::new(),
+            alerts: vec![HealthReportAlert {
+                probe_id: Probe::NvueLeakage,
+                target: Some("LEAK1".to_string()),
+                message: "NVUE leakage sensor state".to_string(),
+                classifications: vec![Classification::Leak],
+            }],
+        };
+
+        let emitted =
+            processor.process_event(&context(), &CollectorEvent::HealthReport(Arc::new(report)));
+
+        assert_eq!(emitted.len(), 1);
+
+        let CollectorEvent::HealthReport(derived) = &emitted[0] else {
+            panic!("expected derived health report");
+        };
+
+        assert_eq!(derived.source, ReportSource::TrayLeakDetection);
+        assert_eq!(derived.target, Some(HealthReportTarget::Switch));
+        assert_eq!(derived.alerts.len(), 1);
+
+        assert!(
+            derived.alerts[0]
+                .classifications
+                .contains(&Classification::Leak)
+        );
+    }
+
+    #[test]
+    fn emits_switch_success_for_nvue_leakage_clear_report() {
+        let processor = LeakEventProcessor::new(1);
+
+        let report = HealthReport {
+            source: ReportSource::NvueLeakage,
+            target: Some(HealthReportTarget::Switch),
+            observed_at: Some(chrono::Utc::now()),
+            successes: vec![HealthReportSuccess {
+                probe_id: Probe::NvueLeakage,
+                target: Some("LEAK1".to_string()),
+            }],
+            alerts: Vec::new(),
+        };
+
+        let emitted =
+            processor.process_event(&context(), &CollectorEvent::HealthReport(Arc::new(report)));
+
+        assert_eq!(emitted.len(), 1);
+
+        let CollectorEvent::HealthReport(derived) = &emitted[0] else {
+            panic!("expected derived health report");
+        };
+
+        assert_eq!(derived.target, Some(HealthReportTarget::Switch));
+        assert!(derived.alerts.is_empty());
+        assert_eq!(derived.successes.len(), 1);
+        assert_eq!(derived.successes[0].probe_id, Probe::LeakDetection);
+    }
+
+    #[test]
+    fn ignores_nvue_leakage_failure_without_leak_alert() {
+        let processor = LeakEventProcessor::new(1);
+
+        let report = HealthReport {
+            source: ReportSource::NvueLeakage,
+            target: Some(HealthReportTarget::Switch),
+            observed_at: Some(chrono::Utc::now()),
+            successes: Vec::new(),
+            alerts: vec![HealthReportAlert {
+                probe_id: Probe::NvueLeakage,
+                target: Some("LEAK1".to_string()),
+                message: "NVUE leakage sensor state".to_string(),
+                classifications: vec![Classification::SensorFailure],
+            }],
+        };
+
+        let emitted =
+            processor.process_event(&context(), &CollectorEvent::HealthReport(Arc::new(report)));
+
+        assert!(emitted.is_empty());
     }
 
     #[test]

--- a/crates/health/src/processor/rack_leak.rs
+++ b/crates/health/src/processor/rack_leak.rs
@@ -101,7 +101,10 @@ impl EventProcessor for RackLeakProcessor {
             return Vec::new();
         }
 
-        if report.target != Some(HealthReportTarget::Machine) {
+        if !matches!(
+            report.target,
+            Some(HealthReportTarget::Machine | HealthReportTarget::Switch)
+        ) {
             return Vec::new();
         }
 
@@ -234,6 +237,35 @@ mod tests {
         assert_eq!(report.target, Some(HealthReportTarget::Rack));
         assert!(report.alerts.is_empty());
         assert_eq!(report.successes.len(), 1);
+    }
+
+    #[test]
+    fn counts_switch_target_tray_leak_reports() {
+        let processor = RackLeakProcessor::new(1);
+        let ctx = context_with_rack("42:9e:b1:bd:9d:dd", "rack-1");
+
+        let event = CollectorEvent::HealthReport(Arc::new(HealthReport {
+            source: ReportSource::TrayLeakDetection,
+            target: Some(HealthReportTarget::Switch),
+            observed_at: Some(chrono::Utc::now()),
+            successes: vec![],
+            alerts: vec![HealthReportAlert {
+                probe_id: Probe::LeakDetection,
+                target: None,
+                message: "switch leaking".to_string(),
+                classifications: vec![Classification::Leak],
+            }],
+        }));
+
+        let emitted = processor.process_event(&ctx, &event);
+
+        let CollectorEvent::HealthReport(report) = &emitted[0] else {
+            panic!("expected health report");
+        };
+
+        assert_eq!(report.source, ReportSource::RackLeakDetection);
+        assert_eq!(report.target, Some(HealthReportTarget::Rack));
+        assert_eq!(report.alerts.len(), 1);
     }
 
     #[test]

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -374,6 +374,7 @@ pub enum ReportSource {
     BmcLeakDetectors,
     TrayLeakDetection,
     RackLeakDetection,
+    NvueLeakage,
 }
 
 impl ReportSource {
@@ -384,6 +385,7 @@ impl ReportSource {
             Self::BmcLeakDetectors => "bmc-leak-detectors",
             Self::TrayLeakDetection => "tray-leak-detection",
             Self::RackLeakDetection => "rack-leak-detection",
+            Self::NvueLeakage => "nvue-leakage",
         }
     }
 }
@@ -393,6 +395,7 @@ pub enum Probe {
     Sensor,
     IntrusionSensorTriggered,
     LeakDetection,
+    NvueLeakage,
 }
 
 impl Probe {
@@ -401,6 +404,7 @@ impl Probe {
             Self::Sensor => "BmcSensor",
             Self::IntrusionSensorTriggered => "IntrusionSensorTriggered",
             Self::LeakDetection => "BmcLeakDetection",
+            Self::NvueLeakage => "NvueLeakage",
         }
     }
 }
@@ -805,6 +809,10 @@ mod tests {
             "rack leak detection" {
                 ReportSource::RackLeakDetection => "rack-leak-detection",
             }
+
+            "NVUE leakage" {
+                ReportSource::NvueLeakage => "nvue-leakage",
+            }
         );
     }
 
@@ -836,6 +844,13 @@ mod tests {
                 Probe::LeakDetection => ProbeSummary {
                     as_str: "BmcLeakDetection",
                     health_report_id: "BmcLeakDetection".to_string(),
+                },
+            }
+
+            "NVUE leakage" {
+                Probe::NvueLeakage => ProbeSummary {
+                    as_str: "NvueLeakage",
+                    health_report_id: "NvueLeakage".to_string(),
                 },
             }
         );
@@ -907,6 +922,7 @@ mod tests {
                     health_report_classification: "LeakDetector".to_string(),
                 },
             }
+
         );
     }
 


### PR DESCRIPTION
Added NVUE REST collection for:

- `/nvue_v1/system/reboot/reason`
- `/nvue_v1/platform/environment/leakage`

Behavior:

- Emits `reboot_reason_info` metadata with `reason`, `gentime`, and `user`.
- Emits leakage StateSet metrics for each leakage sensor.
- Sends switch health reports for leakage data:
  - `ok` sensors become successes.
  - `leak` sensors become leak alerts.
  - unknown, missing, or per-sensor `null` states become sensor-failure alerts.
  - top-level leakage `null` becomes a sensor-failure alert because of unavailable data.
- Adds per-path config flags for reboot reason and leakage collection.

## Related issues
<!-- Refer to existing GitHub issues here -->
Closes #3123

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)