### PR TITLE
ci: parameterize container registries for downstream mirrors (fail-closed)

### DIFF
--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -163,6 +163,18 @@ jobs:
           echo "Pulling build container: ${{ inputs.build_container }}"
           docker pull ${{ inputs.build_container }}
 
+      - name: Log out of source registry
+        env:
+          EXTRAS: ${{ inputs.extras_container }}
+          BUILD: ${{ inputs.build_container }}
+        run: |
+          # Later build tasks pull public images from the same host (e.g.
+          # nvcr.io/nvidia/doca in the bfb flow); a scoped credential denies
+          # those pulls while anonymous access succeeds. All authenticated
+          # pulls are done at this point.
+          if [ -n "${BUILD}" ]; then docker logout "${BUILD%%/*}" 2>/dev/null || true; fi
+          if [ -n "${EXTRAS}" ]; then docker logout "${EXTRAS%%/*}" 2>/dev/null || true; fi
+
       - name: Set up environment variables
         run: |
           echo "CARGO_HOME=${{ github.workspace }}/cargo" >> $GITHUB_ENV

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -3,6 +3,11 @@ name: Build Artifacts (Boot & Ephemeral Images)
 on:
   workflow_call:
     inputs:
+      target_login:
+        description: 'Allow authenticating to the build-container host when it differs from the extras host (publish runs only)'
+        required: false
+        default: false
+        type: boolean
       arch:
         description: 'Target architecture: x86_64 or aarch64'
         required: true
@@ -164,7 +169,7 @@ jobs:
       # the build container ref points at the target registry after a rebuild;
       # log in there too when it is a different host.
       - name: Setup Docker authentication (target)
-        if: inputs.use_container == true && inputs.build_container != '' && steps.registry-hosts.outputs.build_host != steps.registry-hosts.outputs.extras_host
+        if: inputs.target_login == true && inputs.use_container == true && inputs.build_container != '' && steps.registry-hosts.outputs.build_host != steps.registry-hosts.outputs.extras_host
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-hosts.outputs.build_host }}

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -144,12 +144,32 @@ jobs:
           arch: ${{ inputs.arch }}
 
       # Setup Docker for container-based builds
-      - name: Setup Docker authentication
+      - name: Derive registry hosts
+        id: registry-hosts
+        env:
+          EXTRAS: ${{ inputs.extras_container }}
+          BUILD: ${{ inputs.build_container }}
+        run: |
+          echo "extras_host=${EXTRAS%%/*}" >> "$GITHUB_OUTPUT"
+          echo "build_host=${BUILD%%/*}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Docker authentication (source)
         if: inputs.use_container == true || inputs.inject_extras == true
         uses: ./.github/actions/docker-auth
         with:
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          registry: ${{ steps.registry-hosts.outputs.extras_host || 'nvcr.io' }}
+          username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
+
+      # the build container ref points at the target registry after a rebuild;
+      # log in there too when it is a different host.
+      - name: Setup Docker authentication (target)
+        if: inputs.use_container == true && inputs.build_container != '' && steps.registry-hosts.outputs.build_host != steps.registry-hosts.outputs.extras_host
+        uses: ./.github/actions/docker-auth
+        with:
+          registry: ${{ steps.registry-hosts.outputs.build_host }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Pull carbide-extras container
         if: inputs.inject_extras == true && inputs.extras_container != ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,9 @@ jobs:
     runs-on: linux-amd64-cpu4
     outputs:
       version: ${{ steps.version.outputs.version }}
+      image_registry: ${{ steps.registry.outputs.registry }}
+      registry_host: ${{ steps.registry.outputs.registry_host }}
+      prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
       helm_version: ${{ steps.version.outputs.helm_version }}
       short_sha: ${{ steps.version.outputs.short_sha }}
       extras_container_ref: ${{ steps.resolve-extras.outputs.extras_container_ref }}
@@ -176,16 +179,38 @@ jobs:
           echo "| VERSION | \`${VERSION}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| HELM_VERSION | \`${HELM_VERSION}\` |" >> $GITHUB_STEP_SUMMARY
 
+      # Single definition point so downstream mirrors/forks only set repo
+      # variables (IMAGE_REGISTRY / PROD_IMAGE_REGISTRY); defaults keep upstream
+      # behavior unchanged.
+      - name: Resolve container registries
+        id: registry
+        env:
+          REGISTRY_OVERRIDE: ${{ vars.IMAGE_REGISTRY }}
+          PROD_REGISTRY_OVERRIDE: ${{ vars.PROD_IMAGE_REGISTRY }}
+        run: |
+          set -euo pipefail
+          REGISTRY="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
+          REGISTRY="${REGISTRY%%/}"
+          PROD_REGISTRY="${PROD_REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide}"
+          PROD_REGISTRY="${PROD_REGISTRY%%/}"
+          {
+            echo "registry=${REGISTRY}"
+            echo "registry_host=${REGISTRY%%/*}"
+            echo "prod_registry=${PROD_REGISTRY}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Container registry: ${REGISTRY} (prod: ${PROD_REGISTRY})"
+
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ steps.registry.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Resolve pinned carbide-extras image digest
         id: resolve-extras
         env:
-          EXTRAS_IMAGE: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide-extras:latest
+          EXTRAS_IMAGE: ${{ steps.registry.outputs.registry }}/nvmetal-carbide-extras:latest
         run: |
           set -euo pipefail
           docker pull "${EXTRAS_IMAGE}"
@@ -339,6 +364,7 @@ jobs:
       - name: Prepare release container build args
         id: release-metadata
         env:
+          REGISTRY: ${{ steps.registry.outputs.registry }}
           VERSION: ${{ steps.version.outputs.version }}
           SHORT_SHA: ${{ steps.version.outputs.short_sha }}
           BUILD_VERSION: ${{ steps.base-container-gate.outputs.build_container_x86_64_version }}
@@ -349,8 +375,8 @@ jobs:
           set -euo pipefail
 
           # x86_64 build args
-          BUILD_REF="nvcr.io/0837451325059433/carbide-dev/build-container-x86_64:${BUILD_VERSION}"
-          RUNTIME_REF="nvcr.io/0837451325059433/carbide-dev/runtime-container-x86_64:${RUNTIME_VERSION}"
+          BUILD_REF="${REGISTRY}/build-container-x86_64:${BUILD_VERSION}"
+          RUNTIME_REF="${REGISTRY}/runtime-container-x86_64:${RUNTIME_VERSION}"
 
           BUILD_ARGS=$(jq -n -c \
             --arg VERSION "$VERSION" \
@@ -362,8 +388,8 @@ jobs:
           echo "build_args=${BUILD_ARGS}" >> "$GITHUB_OUTPUT"
 
           # aarch64 build args
-          BUILD_REF_AARCH64="nvcr.io/0837451325059433/carbide-dev/build-container-aarch64:${BUILD_VERSION_AARCH64}"
-          RUNTIME_REF_AARCH64="nvcr.io/0837451325059433/carbide-dev/runtime-container-aarch64:${RUNTIME_VERSION_AARCH64}"
+          BUILD_REF_AARCH64="${REGISTRY}/build-container-aarch64:${BUILD_VERSION_AARCH64}"
+          RUNTIME_REF_AARCH64="${REGISTRY}/runtime-container-aarch64:${RUNTIME_VERSION_AARCH64}"
 
           BUILD_ARGS_AARCH64=$(jq -n -c \
             --arg VERSION "$VERSION" \
@@ -385,7 +411,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.build-container-x86_64
-      image_name: nvcr.io/0837451325059433/carbide-dev/build-container-x86_64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_container_x86_64_version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
@@ -401,7 +427,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.build-container-aarch64
-      image_name: nvcr.io/0837451325059433/carbide-dev/build-container-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_container_aarch64_version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -417,7 +443,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.runtime-container-x86_64
-      image_name: nvcr.io/0837451325059433/carbide-dev/runtime-container-x86_64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64
       image_tag: ${{ needs.prepare.outputs.runtime_container_x86_64_version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
@@ -433,7 +459,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.runtime-container-aarch64
-      image_name: nvcr.io/0837451325059433/carbide-dev/runtime-container-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64
       image_tag: ${{ needs.prepare.outputs.runtime_container_aarch64_version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -449,7 +475,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-x86_64
-      image_name: nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-x86_64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
@@ -465,7 +491,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-aarch64
-      image_name: nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -499,7 +525,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-container-x86_64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args }}
-      image_name: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
+      image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu16
@@ -530,7 +556,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-container-aarch64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args_aarch64 }}
-      image_name: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu16
@@ -561,6 +587,7 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
@@ -572,9 +599,9 @@ jobs:
           retry_wait_seconds: 20
           command: |
             docker buildx imagetools create -t \
-              nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide:${{ needs.prepare.outputs.version }} \
-              nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide@${{ needs.build-release-container-x86_64.outputs.image_digest }} \
-              nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide-aarch64@${{ needs.build-release-container-aarch64.outputs.image_digest }}
+              ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide@${{ needs.build-release-container-x86_64.outputs.image_digest }} \
+              ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64@${{ needs.build-release-container-aarch64.outputs.image_digest }}
 
   test-release-container-services:
     if: >-
@@ -599,12 +626,13 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Run release-container service tests
         env:
-          BUILD_CONTAINER: nvcr.io/0837451325059433/carbide-dev/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
+          BUILD_CONTAINER: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
           CI_COMMIT_SHORT_SHA: ${{ needs.prepare.outputs.short_sha }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
@@ -649,9 +677,9 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
-      image_name: nvcr.io/0837451325059433/carbide-dev/forge-admin-cli-x86_64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-x86_64:${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64:${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
@@ -667,9 +695,9 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
-      image_name: nvcr.io/0837451325059433/carbide-dev/forge-admin-cli-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}"}'
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
@@ -693,6 +721,7 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
@@ -704,14 +733,14 @@ jobs:
           retry_wait_seconds: 20
           command: |
             docker buildx imagetools create -t \
-              nvcr.io/0837451325059433/carbide-dev/forge-admin-cli:${{ needs.prepare.outputs.version }} \
-              nvcr.io/0837451325059433/carbide-dev/forge-admin-cli-x86_64:${{ needs.prepare.outputs.version }} \
-              nvcr.io/0837451325059433/carbide-dev/forge-admin-cli-aarch64:${{ needs.prepare.outputs.version }}
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.version }}
 
             docker buildx imagetools create -t \
-              nvcr.io/0837451325059433/carbide-dev/forge-admin-cli:latest \
-              nvcr.io/0837451325059433/carbide-dev/forge-admin-cli-x86_64:${{ needs.prepare.outputs.version }} \
-              nvcr.io/0837451325059433/carbide-dev/forge-admin-cli-aarch64:${{ needs.prepare.outputs.version }}
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli:latest \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.version }}
 
   # ============================================================================
   # BUILD STAGE - Boot Artifacts
@@ -727,7 +756,7 @@ jobs:
       arch: x86_64
       build_type: boot
       cargo_make_task: build-boot-artifacts-x86-host-ci
-      build_container: nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-x86_64:${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
+      build_container: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64:${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
       runner: linux-amd64-cpu4
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
@@ -745,7 +774,7 @@ jobs:
       arch: aarch64
       build_type: boot
       cargo_make_task: build-boot-artifacts-bfb-ci
-      build_container: nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
+      build_container: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
       runner: linux-arm64-cpu16
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
@@ -810,7 +839,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
-      image_name: nvcr.io/0837451325059433/carbide-dev/boot-artifacts-x86_64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
       # Multi-arch on push so this x86_64 boot-artifacts carrier can run as an
       # init container on both amd64 and arm64 control-plane nodes; the payload
@@ -841,7 +870,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
-      image_name: nvcr.io/0837451325059433/carbide-dev/boot-artifacts-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
       # Container arch is independent of the payload: this carrier always ships
       # the aarch64 boot blobs as files. Build it multi-arch on push so it can
@@ -928,9 +957,9 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.machine-validation-runner
-      image_name: nvcr.io/0837451325059433/carbide-dev/machine-validation-runner
+      image_name: ${{ needs.prepare.outputs.image_registry }}/machine-validation-runner
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"nvcr.io/0837451325059433/carbide-dev/runtime-container-x86_64:${{ needs.prepare.outputs.runtime_container_x86_64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64:${{ needs.prepare.outputs.runtime_container_x86_64_version }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
@@ -946,9 +975,9 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config
-      image_name: nvcr.io/0837451325059433/carbide-dev/machine_validation
+      image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"nvcr.io/0837451325059433/carbide-dev/runtime-container-x86_64:${{ needs.prepare.outputs.runtime_container_x86_64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64:${{ needs.prepare.outputs.runtime_container_x86_64_version }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
@@ -970,9 +999,9 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config-aarch64
-      image_name: nvcr.io/0837451325059433/carbide-dev/machine_validation-aarch64
+      image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_AARCH64":"nvcr.io/0837451325059433/carbide-dev/runtime-container-aarch64:${{ needs.prepare.outputs.runtime_container_aarch64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_AARCH64":"${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64:${{ needs.prepare.outputs.runtime_container_aarch64_version }}"}'
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ !contains(github.ref, 'pull-request/') }}
@@ -1000,6 +1029,7 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
@@ -1011,9 +1041,9 @@ jobs:
           retry_wait_seconds: 20
           command: |
             docker buildx imagetools create -t \
-              nvcr.io/0837451325059433/carbide-dev/machine_validation:${{ needs.prepare.outputs.version }} \
-              nvcr.io/0837451325059433/carbide-dev/machine_validation@${{ needs.build-release-machine-validation-artifacts-x86-host.outputs.image_digest }} \
-              nvcr.io/0837451325059433/carbide-dev/machine_validation-aarch64@${{ needs.build-release-machine-validation-artifacts-arm-host.outputs.image_digest }}
+              ${{ needs.prepare.outputs.image_registry }}/machine_validation:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/machine_validation@${{ needs.build-release-machine-validation-artifacts-x86-host.outputs.image_digest }} \
+              ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64@${{ needs.build-release-machine-validation-artifacts-arm-host.outputs.image_digest }}
 
   proto-police:
     needs:
@@ -1102,7 +1132,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.prepare.outputs.source_files_changed == 'true' && contains(github.ref, 'pull-request/') }}
     runs-on: linux-amd64-cpu16
     container:
-      image: nvcr.io/0837451325059433/carbide-dev/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
+      image: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
       credentials:
         username: ${{ secrets.NVCR_USERNAME }}
         password: ${{ secrets.NVCR_TOKEN }}
@@ -1239,11 +1269,12 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Pull build container
-        run: docker pull nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
+        run: docker pull ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
 
       - name: Compile bluefield Rust binaries
         run: |
@@ -1253,7 +1284,7 @@ jobs:
             -e CARGO_HOME=/workspace/cargo \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu \
-            nvcr.io/0837451325059433/carbide-dev/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }} \
+            ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }} \
             bash -c "git config --global --add safe.directory /workspace && \
               cargo make --cwd bluefield build-dpu-agent-and-dhcp-server-ci && \
               cargo make --cwd bluefield build-fmds-ci && \
@@ -1279,7 +1310,7 @@ jobs:
     with:
       dockerfile_path: bluefield/containers/otelcol-contrib/Dockerfile
       context_path: .
-      image_name: nvcr.io/0837451325059433/carbide-dev/otelcol-contrib
+      image_name: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1295,7 +1326,7 @@ jobs:
     with:
       dockerfile_path: bluefield/containers/transceiver-exporter/Dockerfile
       context_path: .
-      image_name: nvcr.io/0837451325059433/carbide-dev/transceiver-exporter
+      image_name: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1329,7 +1360,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
-      image_name: nvcr.io/0837451325059433/carbide-dev/forge-dpu-agent
+      image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1346,7 +1377,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
-      image_name: nvcr.io/0837451325059433/carbide-dev/forge-dhcp-server
+      image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1363,7 +1394,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
-      image_name: nvcr.io/0837451325059433/carbide-dev/carbide-fmds
+      image_name: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1557,9 +1588,9 @@ jobs:
       - build-release-container-x86_64
     uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@760d2d7964b479fde431cd3e0b980bc6b6a26ccd
     with:
-      source: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
+      source: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       source_tag: ${{ needs.prepare.outputs.version }}
-      destination: nvcr.io/0837451325059433/carbide/nvmetal-carbide
+      destination: ${{ needs.prepare.outputs.prod_image_registry }}/nvmetal-carbide
       destination_tag: "to-be-scanned"
     secrets:
       SOURCE_USERNAME: ${{ secrets.NVCR_USERNAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1361,7 +1361,7 @@ jobs:
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
@@ -1399,7 +1399,7 @@ jobs:
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
@@ -1633,7 +1633,7 @@ jobs:
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
@@ -1645,7 +1645,7 @@ jobs:
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
@@ -1657,7 +1657,7 @@ jobs:
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
@@ -1669,7 +1669,7 @@ jobs:
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,7 +199,6 @@ jobs:
         env:
           TARGET_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
           SOURCE_OVERRIDE: ${{ vars.NICO_SOURCE_IMAGE_REGISTRY }}
-          PROD_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
           EXTRAS_OVERRIDE: ${{ vars.NICO_EXTRAS_IMAGE }}
           NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
           HAS_SOURCE_TOKEN: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN != '' }}
@@ -208,7 +207,7 @@ jobs:
           set -euo pipefail
           CANONICAL_DEV="nvcr.io/0837451325059433/carbide-dev"
           CANONICAL_PROD="nvcr.io/0837451325059433/carbide"
-          for V in "${TARGET_OVERRIDE}" "${SOURCE_OVERRIDE}" "${PROD_OVERRIDE}" "${EXTRAS_OVERRIDE}" "${NGC_PATH_OVERRIDE}"; do
+          for V in "${TARGET_OVERRIDE}" "${SOURCE_OVERRIDE}" "${EXTRAS_OVERRIDE}" "${NGC_PATH_OVERRIDE}"; do
             if [[ "${V}" == *$'\n'* || "${V}" == *$'\r'* ]]; then
               echo "::error::registry variables must be single-line values"
               exit 1
@@ -225,7 +224,7 @@ jobs:
               exit 1
             fi
             TARGET="${TARGET_OVERRIDE}"
-            PROD="${PROD_OVERRIDE:-${TARGET_OVERRIDE}}"
+            PROD="${TARGET}"
             # normalize host (case, default port) before the canonical denylist
             normalize() {
               local x="${1%/}" h p

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -249,8 +249,8 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry.outputs.source_registry_host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Resolve pinned carbide-extras image digest
         id: resolve-extras
@@ -654,8 +654,8 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.registry_host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Create and push multi-arch manifest
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
@@ -693,8 +693,18 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.source_registry_host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
+
+      # base refs may point at the target registry after a rebuild; log in
+      # there too when it is a different host (same-host uses one credential).
+      - name: Login to target registry
+        if: ${{ needs.prepare.outputs.registry_host != needs.prepare.outputs.source_registry_host }}
+        uses: ./.github/actions/docker-auth
+        with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Run release-container service tests
         env:
@@ -790,8 +800,8 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.registry_host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Create and push multi-arch manifest
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
@@ -1103,8 +1113,8 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.registry_host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Create and push multi-arch manifest
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
@@ -1345,8 +1355,18 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.source_registry_host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
+
+      # base refs may point at the target registry after a rebuild; log in
+      # there too when it is a different host (same-host uses one credential).
+      - name: Login to target registry
+        if: ${{ needs.prepare.outputs.registry_host != needs.prepare.outputs.source_registry_host }}
+        uses: ./.github/actions/docker-auth
+        with:
+          registry: ${{ needs.prepare.outputs.registry_host }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Pull build container
         run: docker pull ${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       image_registry: ${{ steps.registry.outputs.registry }}
       registry_path: ${{ steps.registry.outputs.registry_path }}
+      source_registry_host: ${{ steps.registry.outputs.source_registry_host }}
+      publish_images: ${{ steps.release-gate.outputs.publish_built_container }}
       registry_host: ${{ steps.registry.outputs.registry_host }}
       prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
       helm_version: ${{ steps.version.outputs.helm_version }}
@@ -103,6 +105,12 @@ jobs:
       extras_container_ref: ${{ steps.resolve-extras.outputs.extras_container_ref }}
       build_container_x86_64_run: ${{ steps.base-container-gate.outputs.build_container_x86_64_run }}
       build_container_x86_64_version: ${{ steps.base-container-gate.outputs.build_container_x86_64_version }}
+      build_container_x86_64_ref: ${{ steps.base-container-gate.outputs.build_container_x86_64_ref }}
+      runtime_container_x86_64_ref: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_ref }}
+      build_container_aarch64_ref: ${{ steps.base-container-gate.outputs.build_container_aarch64_ref }}
+      runtime_container_aarch64_ref: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_ref }}
+      build_artifacts_container_x86_64_ref: ${{ steps.base-container-gate.outputs.build_artifacts_container_x86_64_ref }}
+      build_artifacts_container_aarch64_ref: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_ref }}
       runtime_container_x86_64_run: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_run }}
       runtime_container_x86_64_version: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_version }}
       build_container_aarch64_run: ${{ steps.base-container-gate.outputs.build_container_aarch64_run }}
@@ -180,39 +188,66 @@ jobs:
           echo "| VERSION | \`${VERSION}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| HELM_VERSION | \`${HELM_VERSION}\` |" >> $GITHUB_STEP_SUMMARY
 
-      # Single definition point so downstream mirrors/forks only set repo
-      # variables (IMAGE_REGISTRY / PROD_IMAGE_REGISTRY); defaults keep upstream
-      # behavior unchanged.
+      # Single definition point for registries. The canonical repo keeps
+      # upstream defaults; any other repo must set NICO_TARGET_IMAGE_REGISTRY
+      # and may not target the canonical registries (fail closed for mirrors).
+      # Source registry = read-only dependencies (extras, non-rebuilt base
+      # containers); target registry = everything this run publishes.
       - name: Resolve container registries
         id: registry
         env:
-          REGISTRY_OVERRIDE: ${{ vars.IMAGE_REGISTRY }}
-          PROD_REGISTRY_OVERRIDE: ${{ vars.PROD_IMAGE_REGISTRY }}
+          TARGET_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
+          SOURCE_OVERRIDE: ${{ vars.NICO_SOURCE_IMAGE_REGISTRY }}
+          PROD_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
+          EXTRAS_OVERRIDE: ${{ vars.NICO_EXTRAS_IMAGE }}
         run: |
           set -euo pipefail
-          REGISTRY="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
-          REGISTRY="${REGISTRY%%/}"
-          PROD_REGISTRY="${PROD_REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide}"
-          PROD_REGISTRY="${PROD_REGISTRY%%/}"
+          CANONICAL_DEV="nvcr.io/0837451325059433/carbide-dev"
+          CANONICAL_PROD="nvcr.io/0837451325059433/carbide"
+          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
+            TARGET="${TARGET_OVERRIDE:-${CANONICAL_DEV}}"
+            PROD="${PROD_OVERRIDE:-${CANONICAL_PROD}}"
+          else
+            if [[ -z "${TARGET_OVERRIDE}" ]]; then
+              echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
+              exit 1
+            fi
+            TARGET="${TARGET_OVERRIDE}"
+            PROD="${PROD_OVERRIDE:-${TARGET_OVERRIDE}}"
+            for R in "${TARGET%/}" "${PROD%/}"; do
+              if [[ "${R}" == "${CANONICAL_DEV}" || "${R}" == "${CANONICAL_PROD}" ]]; then
+                echo "::error::this repository must not target the canonical registry ${R}"
+                exit 1
+              fi
+            done
+          fi
+          TARGET="${TARGET%/}"
+          PROD="${PROD%/}"
+          SOURCE="${SOURCE_OVERRIDE:-${CANONICAL_DEV}}"
+          SOURCE="${SOURCE%/}"
+          EXTRAS="${EXTRAS_OVERRIDE:-${SOURCE}/nvmetal-carbide-extras:latest}"
           {
-            echo "registry=${REGISTRY}"
-            echo "registry_host=${REGISTRY%%/*}"
-            echo "registry_path=${REGISTRY#*/}"
-            echo "prod_registry=${PROD_REGISTRY}"
+            echo "registry=${TARGET}"
+            echo "registry_host=${TARGET%%/*}"
+            echo "registry_path=${TARGET#*/}"
+            echo "source_registry=${SOURCE}"
+            echo "source_registry_host=${SOURCE%%/*}"
+            echo "extras_image=${EXTRAS}"
+            echo "prod_registry=${PROD}"
           } >> "$GITHUB_OUTPUT"
-          echo "Container registry: ${REGISTRY} (prod: ${PROD_REGISTRY})"
+          echo "Registries: target=${TARGET} source=${SOURCE} prod=${PROD}"
 
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
-          registry: ${{ steps.registry.outputs.registry_host }}
+          registry: ${{ steps.registry.outputs.source_registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Resolve pinned carbide-extras image digest
         id: resolve-extras
         env:
-          EXTRAS_IMAGE: ${{ steps.registry.outputs.registry }}/nvmetal-carbide-extras:latest
+          EXTRAS_IMAGE: ${{ steps.registry.outputs.extras_image }}
         run: |
           set -euo pipefail
           docker pull "${EXTRAS_IMAGE}"
@@ -234,6 +269,8 @@ jobs:
       - name: Decide if build-container-x86_64 must run
         id: base-container-gate
         env:
+          TARGET_REGISTRY: ${{ steps.registry.outputs.registry }}
+          SOURCE_REGISTRY: ${{ steps.registry.outputs.source_registry }}
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -312,38 +349,50 @@ jobs:
 
           if [[ "$build_container_x86_64_run" == "true" ]]; then
             echo "build_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_ref=${TARGET_REGISTRY}/build-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "build_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$runtime_container_x86_64_run" == "true" ]]; then
             echo "runtime_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_x86_64_ref=${TARGET_REGISTRY}/runtime-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_x86_64_ref=${SOURCE_REGISTRY}/runtime-container-x86_64:latest" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$build_container_aarch64_run" == "true" ]]; then
             echo "build_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_ref=${TARGET_REGISTRY}/build-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "build_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_ref=${SOURCE_REGISTRY}/build-container-aarch64:latest" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$runtime_container_aarch64_run" == "true" ]]; then
             echo "runtime_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_aarch64_ref=${TARGET_REGISTRY}/runtime-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_aarch64_ref=${SOURCE_REGISTRY}/runtime-container-aarch64:latest" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$build_artifacts_container_x86_64_run" == "true" ]]; then
             echo "build_artifacts_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_x86_64_ref=${TARGET_REGISTRY}/build-artifacts-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "build_artifacts_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_x86_64_ref=${SOURCE_REGISTRY}/build-artifacts-container-x86_64:latest" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$build_artifacts_container_aarch64_run" == "true" ]]; then
             echo "build_artifacts_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_aarch64_ref=${TARGET_REGISTRY}/build-artifacts-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "build_artifacts_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_aarch64_ref=${SOURCE_REGISTRY}/build-artifacts-container-aarch64:latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Decide release container publish strategy
@@ -366,7 +415,10 @@ jobs:
       - name: Prepare release container build args
         id: release-metadata
         env:
-          REGISTRY: ${{ steps.registry.outputs.registry }}
+          BUILD_REF: ${{ steps.base-container-gate.outputs.build_container_x86_64_ref }}
+          RUNTIME_REF: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_ref }}
+          BUILD_REF_AARCH64: ${{ steps.base-container-gate.outputs.build_container_aarch64_ref }}
+          RUNTIME_REF_AARCH64: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_ref }}
           VERSION: ${{ steps.version.outputs.version }}
           SHORT_SHA: ${{ steps.version.outputs.short_sha }}
           BUILD_VERSION: ${{ steps.base-container-gate.outputs.build_container_x86_64_version }}
@@ -377,8 +429,6 @@ jobs:
           set -euo pipefail
 
           # x86_64 build args
-          BUILD_REF="${REGISTRY}/build-container-x86_64:${BUILD_VERSION}"
-          RUNTIME_REF="${REGISTRY}/runtime-container-x86_64:${RUNTIME_VERSION}"
 
           BUILD_ARGS=$(jq -n -c \
             --arg VERSION "$VERSION" \
@@ -390,8 +440,6 @@ jobs:
           echo "build_args=${BUILD_ARGS}" >> "$GITHUB_OUTPUT"
 
           # aarch64 build args
-          BUILD_REF_AARCH64="${REGISTRY}/build-container-aarch64:${BUILD_VERSION_AARCH64}"
-          RUNTIME_REF_AARCH64="${REGISTRY}/runtime-container-aarch64:${RUNTIME_VERSION_AARCH64}"
 
           BUILD_ARGS_AARCH64=$(jq -n -c \
             --arg VERSION "$VERSION" \
@@ -412,12 +460,13 @@ jobs:
       - prepare
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.build-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_container_x86_64_version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: true
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: true
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -428,12 +477,13 @@ jobs:
       - prepare
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.build-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_container_aarch64_version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: true
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -444,12 +494,13 @@ jobs:
       - prepare
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.runtime-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64
       image_tag: ${{ needs.prepare.outputs.runtime_container_x86_64_version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: true
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: true
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -460,12 +511,13 @@ jobs:
       - prepare
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.runtime-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64
       image_tag: ${{ needs.prepare.outputs.runtime_container_aarch64_version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: true
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -476,12 +528,13 @@ jobs:
       - prepare
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: true
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: true
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -492,12 +545,13 @@ jobs:
       - prepare
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: true
+      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -524,6 +578,7 @@ jobs:
       - lint-police
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.release-container-x86_64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args }}
@@ -531,7 +586,7 @@ jobs:
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/amd64
       runner: linux-amd64-cpu16
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
       tag_latest: false
@@ -555,6 +610,7 @@ jobs:
       - check-rest-core-proto-sync
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.release-container-aarch64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args_aarch64 }}
@@ -562,7 +618,7 @@ jobs:
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu16
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: false
     secrets: inherit
@@ -577,7 +633,7 @@ jobs:
       - prepare
       - build-release-container-x86_64
       - build-release-container-aarch64
-    if: ${{ !cancelled() && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') && needs.build-release-container-x86_64.result == 'success' && needs.build-release-container-aarch64.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.outputs.publish_images == 'true' && needs.build-release-container-x86_64.result == 'success' && needs.build-release-container-aarch64.result == 'success' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -628,13 +684,13 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
-          registry: ${{ needs.prepare.outputs.registry_host }}
+          registry: ${{ needs.prepare.outputs.source_registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Run release-container service tests
         env:
-          BUILD_CONTAINER: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
+          BUILD_CONTAINER: ${{ needs.prepare.outputs.build_container_x86_64_ref }}
           CI_COMMIT_SHORT_SHA: ${{ needs.prepare.outputs.short_sha }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
@@ -678,13 +734,14 @@ jobs:
     if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64:${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.build_artifacts_container_x86_64_ref }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
     secrets: inherit
@@ -696,13 +753,14 @@ jobs:
     if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}"}'
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
     secrets: inherit
 
@@ -711,7 +769,7 @@ jobs:
       - prepare
       - build-forge-cli-x86_64
       - build-forge-cli-aarch64
-    if: ${{ !cancelled() && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') && needs.build-forge-cli-x86_64.result == 'success' && needs.build-forge-cli-aarch64.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.outputs.publish_images == 'true' && needs.build-forge-cli-x86_64.result == 'success' && needs.build-forge-cli-aarch64.result == 'success' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -758,7 +816,7 @@ jobs:
       arch: x86_64
       build_type: boot
       cargo_make_task: build-boot-artifacts-x86-host-ci
-      build_container: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64:${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
+      build_container: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_ref }}
       runner: linux-amd64-cpu4
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
@@ -776,7 +834,7 @@ jobs:
       arch: aarch64
       build_type: boot
       cargo_make_task: build-boot-artifacts-bfb-ci
-      build_container: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
+      build_container: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}
       runner: linux-arm64-cpu16
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
@@ -840,6 +898,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-x86.result == 'success' && needs.build-boot-artifacts-ephemeral-image-x86-host.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -848,9 +907,9 @@ jobs:
       # it ships is unchanged (x86_64 boot blobs). The Dockerfile has no RUN
       # steps (FROM alpine + COPY only), so no QEMU is needed. Single-arch on PR
       # so the image loads to the daemon for the Grype scan.
-      platforms: ${{ !contains(github.ref, 'pull-request/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+      platforms: ${{ needs.prepare.outputs.publish_images == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       runner: linux-amd64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
       download_artifacts: true  # Download boot and ephemeral artifacts for packaging
@@ -871,6 +930,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-bfb.result == 'success' && needs.build-boot-artifacts-ephemeral-image-arm-host.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -879,9 +939,9 @@ jobs:
       # run as an init container on both amd64 and arm64 control-plane nodes. The
       # Dockerfile has no RUN steps (FROM alpine + COPY only), so no QEMU is
       # needed. Single-arch on PR so the image loads to the daemon for Grype.
-      platforms: ${{ !contains(github.ref, 'pull-request/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+      platforms: ${{ needs.prepare.outputs.publish_images == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       runner: linux-amd64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
       download_artifacts: true  # Download boot and ephemeral artifacts for packaging
@@ -958,13 +1018,14 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-runtime-container-x86_64.result) }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-runner
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine-validation-runner
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64:${{ needs.prepare.outputs.runtime_container_x86_64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.runtime_container_x86_64_ref }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true  # load to daemon so the Grype scan can read it on PR builds
       scan: true
     secrets: inherit
@@ -976,13 +1037,14 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-release-machine-validation-runner.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64:${{ needs.prepare.outputs.runtime_container_x86_64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.runtime_container_x86_64_ref }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true  # load to daemon so the Grype scan can read it on PR builds
       scan: true
     secrets: inherit
@@ -1000,13 +1062,14 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-runtime-container-aarch64.result) }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
-      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_AARCH64":"${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64:${{ needs.prepare.outputs.runtime_container_aarch64_version }}"}'
+      build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_AARCH64":"${{ needs.prepare.outputs.runtime_container_aarch64_ref }}"}'
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true  # load to daemon so the Grype scan can read it on PR builds
       scan: true
     secrets: inherit
@@ -1019,7 +1082,7 @@ jobs:
       - prepare
       - build-release-machine-validation-artifacts-x86-host
       - build-release-machine-validation-artifacts-arm-host
-    if: ${{ !cancelled() && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') && needs.build-release-machine-validation-artifacts-x86-host.result == 'success' && needs.build-release-machine-validation-artifacts-arm-host.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.outputs.publish_images == 'true' && needs.build-release-machine-validation-artifacts-x86-host.result == 'success' && needs.build-release-machine-validation-artifacts-arm-host.result == 'success' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -1134,7 +1197,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.prepare.outputs.source_files_changed == 'true' && contains(github.ref, 'pull-request/') }}
     runs-on: linux-amd64-cpu16
     container:
-      image: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
+      image: ${{ needs.prepare.outputs.build_container_x86_64_ref }}
       credentials:
         username: ${{ secrets.NVCR_USERNAME }}
         password: ${{ secrets.NVCR_TOKEN }}
@@ -1200,7 +1263,7 @@ jobs:
     needs:
       - prepare
       - build-validate-helm-chart
-    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-helm-chart.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-helm-chart.result == 'success' && needs.prepare.outputs.publish_images == 'true' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -1237,7 +1300,7 @@ jobs:
     needs:
       - prepare
       - build-validate-helm-prereqs-chart
-    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-helm-prereqs-chart.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-helm-prereqs-chart.result == 'success' && needs.prepare.outputs.publish_images == 'true' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -1271,12 +1334,12 @@ jobs:
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
-          registry: ${{ needs.prepare.outputs.registry_host }}
+          registry: ${{ needs.prepare.outputs.source_registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Pull build container
-        run: docker pull ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
+        run: docker pull ${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}
 
       - name: Compile bluefield Rust binaries
         run: |
@@ -1286,7 +1349,7 @@ jobs:
             -e CARGO_HOME=/workspace/cargo \
             -e CARGO_INCREMENTAL=0 \
             -e CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu \
-            ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64:${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }} \
+            ${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }} \
             bash -c "git config --global --add safe.directory /workspace && \
               cargo make --cwd bluefield build-dpu-agent-and-dhcp-server-ci && \
               cargo make --cwd bluefield build-fmds-ci && \
@@ -1310,13 +1373,14 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: bluefield/containers/otelcol-contrib/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
     secrets: inherit
 
@@ -1326,13 +1390,14 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: bluefield/containers/transceiver-exporter/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
     secrets: inherit
 
@@ -1361,12 +1426,13 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' && needs.download-mft-aarch64.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       download_artifacts: true
     secrets: inherit
@@ -1378,12 +1444,13 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       download_artifacts: true
     secrets: inherit
@@ -1395,12 +1462,13 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
+      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds
       image_tag: ${{ needs.prepare.outputs.version }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ !contains(github.ref, 'pull-request/') }}
+      push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       download_artifacts: true
     secrets: inherit
@@ -1450,7 +1518,7 @@ jobs:
     needs:
       - prepare
       - build-validate-bluefield-helm-charts
-    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-bluefield-helm-charts.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-validate-bluefield-helm-charts.result == 'success' && needs.prepare.outputs.publish_images == 'true' }}
     runs-on: linux-amd64-cpu4
     steps:
       - name: Checkout code
@@ -1584,7 +1652,7 @@ jobs:
 
   promote-to-be-scanned-image:
     # Skip for pull-request/* branches (main, release/*, and tags are allowed by workflow trigger)
-    if: ${{ !cancelled() && needs.build-release-container-x86_64.result == 'success' && github.event_name != 'schedule' && !contains(github.ref, 'pull-request/') }}
+    if: ${{ !cancelled() && github.repository == 'NVIDIA/infra-controller' && needs.build-release-container-x86_64.result == 'success' && github.event_name != 'schedule' && needs.prepare.outputs.publish_images == 'true' }}
     needs:
       - prepare
       - build-release-container-x86_64

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,6 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       image_registry: ${{ steps.registry.outputs.registry }}
-      registry_path: ${{ steps.registry.outputs.registry_path }}
       source_registry_host: ${{ steps.registry.outputs.source_registry_host }}
       publish_images: ${{ steps.release-gate.outputs.publish_built_container }}
       target_ngc_path: ${{ steps.registry.outputs.target_ngc_path }}
@@ -202,6 +201,7 @@ jobs:
           PROD_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
           EXTRAS_OVERRIDE: ${{ vars.NICO_EXTRAS_IMAGE }}
           NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
+          HAS_SOURCE_TOKEN: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN != '' }}
         run: |
           set -euo pipefail
           CANONICAL_DEV="nvcr.io/0837451325059433/carbide-dev"
@@ -216,8 +216,16 @@ jobs:
             fi
             TARGET="${TARGET_OVERRIDE}"
             PROD="${PROD_OVERRIDE:-${TARGET_OVERRIDE}}"
-            for R in "${TARGET%/}" "${PROD%/}"; do
-              if [[ "${R}" == "${CANONICAL_DEV}" || "${R}" == "${CANONICAL_PROD}" ]]; then
+            # normalize host (case, default port) before the canonical denylist
+            normalize() {
+              local x="${1%/}" h p
+              h="${x%%/*}"; p="${x#*/}"
+              h="${h,,}"; h="${h%:443}"
+              printf '%s/%s' "${h}" "${p}"
+            }
+            for R in "${TARGET}" "${PROD}"; do
+              N="$(normalize "${R}")"
+              if [[ "${N}" == "${CANONICAL_DEV}" || "${N}" == "${CANONICAL_PROD}" ]]; then
                 echo "::error::this repository must not target the canonical registry ${R}"
                 exit 1
               fi
@@ -232,11 +240,19 @@ jobs:
             NGC_PATH="${NGC_PATH_OVERRIDE:-${TARGET#*/}}"
           else
             NGC_PATH="${NGC_PATH_OVERRIDE:-}"
+            case "${NGC_PATH%/}" in
+              "${CANONICAL_DEV#*/}"|"${CANONICAL_PROD#*/}")
+                echo "::error::this repository must not publish helm/resources to the canonical NGC path ${NGC_PATH}"
+                exit 1;;
+            esac
+          fi
+          if [[ "${SOURCE%%/*}" != "nvcr.io" && "${HAS_SOURCE_TOKEN}" != "true" ]]; then
+            echo "::error::non-NVCR source registry requires NICO_SOURCE_REGISTRY_* secrets (refusing to send NVCR credentials elsewhere)"
+            exit 1
           fi
           {
             echo "registry=${TARGET}"
             echo "registry_host=${TARGET%%/*}"
-            echo "registry_path=${TARGET#*/}"
             echo "source_registry=${SOURCE}"
             echo "source_registry_host=${SOURCE%%/*}"
             echo "extras_image=${EXTRAS}"
@@ -406,6 +422,8 @@ jobs:
       - name: Decide release container publish strategy
         id: release-gate
         env:
+          TARGET_REGISTRY: ${{ steps.registry.outputs.registry }}
+          HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
@@ -418,6 +436,11 @@ jobs:
             PUBLISH=true
           fi
 
+          TARGET_HOST="${TARGET_REGISTRY%%/*}"
+          if [[ "${PUBLISH}" == "true" && "${TARGET_HOST}" != "nvcr.io" && "${HAS_TARGET_TOKEN}" != "true" ]]; then
+            echo "::error::publishing to a non-NVCR target requires NICO_TARGET_REGISTRY_* secrets (refusing to send NVCR credentials elsewhere)"
+            exit 1
+          fi
           echo "publish_built_container=${PUBLISH}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release container build args

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       image_registry: ${{ steps.registry.outputs.registry }}
+      registry_path: ${{ steps.registry.outputs.registry_path }}
       registry_host: ${{ steps.registry.outputs.registry_host }}
       prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
       helm_version: ${{ steps.version.outputs.helm_version }}
@@ -196,6 +197,7 @@ jobs:
           {
             echo "registry=${REGISTRY}"
             echo "registry_host=${REGISTRY%%/*}"
+            echo "registry_path=${REGISTRY#*/}"
             echo "prod_registry=${PROD_REGISTRY}"
           } >> "$GITHUB_OUTPUT"
           echo "Container registry: ${REGISTRY} (prod: ${PROD_REGISTRY})"
@@ -1212,7 +1214,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ needs.prepare.outputs.registry_path }}
           ngc-duplicate: fail
 
   build-validate-helm-prereqs-chart:
@@ -1249,7 +1251,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ needs.prepare.outputs.registry_path }}
           ngc-duplicate: fail
 
   # ============================================================================
@@ -1462,7 +1464,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ needs.prepare.outputs.registry_path }}
           ngc-duplicate: fail
 
       - name: Package and push nico-dpu-agent chart
@@ -1473,7 +1475,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ needs.prepare.outputs.registry_path }}
           ngc-duplicate: fail
 
       - name: Package and push nico-dhcp-server chart
@@ -1484,7 +1486,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ needs.prepare.outputs.registry_path }}
           ngc-duplicate: fail
 
       - name: Package and push nico-fmds chart
@@ -1495,7 +1497,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ needs.prepare.outputs.registry_path }}
           ngc-duplicate: fail
 
   build-summary:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       image_registry: ${{ steps.registry.outputs.registry }}
       source_registry_host: ${{ steps.registry.outputs.source_registry_host }}
+      bases_rebuilt: ${{ steps.base-container-gate.outputs.build_container_x86_64_run == 'true' || steps.base-container-gate.outputs.runtime_container_x86_64_run == 'true' || steps.base-container-gate.outputs.build_container_aarch64_run == 'true' || steps.base-container-gate.outputs.runtime_container_aarch64_run == 'true' || steps.base-container-gate.outputs.build_artifacts_container_x86_64_run == 'true' || steps.base-container-gate.outputs.build_artifacts_container_aarch64_run == 'true' }}
       publish_images: ${{ steps.release-gate.outputs.publish_built_container }}
       target_ngc_path: ${{ steps.registry.outputs.target_ngc_path }}
       registry_host: ${{ steps.registry.outputs.registry_host }}
@@ -506,6 +507,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_container_x86_64_version }}
@@ -523,6 +525,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_container_aarch64_version }}
@@ -540,6 +543,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.runtime-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64
       image_tag: ${{ needs.prepare.outputs.runtime_container_x86_64_version }}
@@ -557,6 +561,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.runtime-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64
       image_tag: ${{ needs.prepare.outputs.runtime_container_aarch64_version }}
@@ -574,6 +579,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
@@ -591,6 +597,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
@@ -624,6 +631,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-container-x86_64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args }}
@@ -656,6 +664,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-container-aarch64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args_aarch64 }}
@@ -790,6 +799,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -809,6 +819,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -868,6 +879,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-artifacts-container-x86_64.result) }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
+      target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
       arch: x86_64
       build_type: boot
       cargo_make_task: build-boot-artifacts-x86-host-ci
@@ -886,6 +898,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-artifacts-container-aarch64.result) }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
+      target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
       arch: aarch64
       build_type: boot
       cargo_make_task: build-boot-artifacts-bfb-ci
@@ -910,6 +923,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-x86.result == 'success' }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
+      target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
       arch: x86_64
       build_type: ephemeral
       cargo_make_task: create-ephemeral-image-x86-host-ci
@@ -929,6 +943,7 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-bfb.result == 'success' }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
+      target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
       arch: aarch64
       build_type: ephemeral
       cargo_make_task: create-ephemeral-image-arm-host-ci
@@ -954,6 +969,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -986,6 +1002,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1074,6 +1091,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-runner
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine-validation-runner
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1093,6 +1111,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1118,6 +1137,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,7 +231,7 @@ jobs:
               local x="${1%/}" h p
               h="${x%%/*}"; p="${x#*/}"
               h="${h,,}"; h="${h%:443}"
-              printf '%s/%s' "${h}" "${p}"
+              printf '%s/%s' "${h}" "${p,,}"
             }
             for R in "${TARGET}" "${PROD}"; do
               N="$(normalize "${R}")"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,7 @@ jobs:
       registry_path: ${{ steps.registry.outputs.registry_path }}
       source_registry_host: ${{ steps.registry.outputs.source_registry_host }}
       publish_images: ${{ steps.release-gate.outputs.publish_built_container }}
+      target_ngc_path: ${{ steps.registry.outputs.target_ngc_path }}
       registry_host: ${{ steps.registry.outputs.registry_host }}
       prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
       helm_version: ${{ steps.version.outputs.helm_version }}
@@ -200,6 +201,7 @@ jobs:
           SOURCE_OVERRIDE: ${{ vars.NICO_SOURCE_IMAGE_REGISTRY }}
           PROD_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
           EXTRAS_OVERRIDE: ${{ vars.NICO_EXTRAS_IMAGE }}
+          NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
           set -euo pipefail
           CANONICAL_DEV="nvcr.io/0837451325059433/carbide-dev"
@@ -226,6 +228,11 @@ jobs:
           SOURCE="${SOURCE_OVERRIDE:-${CANONICAL_DEV}}"
           SOURCE="${SOURCE%/}"
           EXTRAS="${EXTRAS_OVERRIDE:-${SOURCE}/nvmetal-carbide-extras:latest}"
+          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
+            NGC_PATH="${NGC_PATH_OVERRIDE:-${TARGET#*/}}"
+          else
+            NGC_PATH="${NGC_PATH_OVERRIDE:-}"
+          fi
           {
             echo "registry=${TARGET}"
             echo "registry_host=${TARGET%%/*}"
@@ -234,6 +241,7 @@ jobs:
             echo "source_registry_host=${SOURCE%%/*}"
             echo "extras_image=${EXTRAS}"
             echo "prod_registry=${PROD}"
+            echo "target_ngc_path=${NGC_PATH}"
           } >> "$GITHUB_OUTPUT"
           echo "Registries: target=${TARGET} source=${SOURCE} prod=${PROD}"
 
@@ -1270,6 +1278,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm chart to NGC
+        if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm
@@ -1277,7 +1286,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: ${{ needs.prepare.outputs.registry_path }}
+          ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
   build-validate-helm-prereqs-chart:
@@ -1307,6 +1316,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm prereqs chart to NGC
+        if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: helm-prereqs
@@ -1314,7 +1324,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: ${{ needs.prepare.outputs.registry_path }}
+          ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
   # ============================================================================
@@ -1525,6 +1535,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push nico-otelcol chart
+        if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-otelcol
@@ -1532,10 +1543,11 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: ${{ needs.prepare.outputs.registry_path }}
+          ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
       - name: Package and push nico-dpu-agent chart
+        if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-dpu-agent
@@ -1543,10 +1555,11 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: ${{ needs.prepare.outputs.registry_path }}
+          ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
       - name: Package and push nico-dhcp-server chart
+        if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-dhcp-server
@@ -1554,10 +1567,11 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: ${{ needs.prepare.outputs.registry_path }}
+          ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
       - name: Package and push nico-fmds chart
+        if: ${{ needs.prepare.outputs.target_ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: bluefield/charts/nico-fmds
@@ -1565,7 +1579,7 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_TOKEN }}
-          ngc-path: ${{ needs.prepare.outputs.registry_path }}
+          ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
 
   build-summary:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1383,7 +1383,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
-      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      # public bases only: skip source login so anonymous nvcr pulls keep working
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/otelcol-contrib/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib
@@ -1400,7 +1401,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
-      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      # public bases only: skip source login so anonymous nvcr pulls keep working
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/transceiver-exporter/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter
@@ -1436,7 +1438,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' && needs.download-mft-aarch64.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
-      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      # public bases only: skip source login so anonymous nvcr pulls keep working
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1454,7 +1457,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
-      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      # public bases only: skip source login so anonymous nvcr pulls keep working
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1472,7 +1476,8 @@ jobs:
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-bluefield-binaries.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
-      source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
+      # public bases only: skip source login so anonymous nvcr pulls keep working
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds
       image_tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,15 +242,20 @@ jobs:
           fi
           TARGET="${TARGET%/}"
           PROD="${PROD%/}"
-          SOURCE="${SOURCE_OVERRIDE:-${CANONICAL_DEV}}"
-          SOURCE="${SOURCE%/}"
-          EXTRAS="${EXTRAS_OVERRIDE:-${SOURCE}/nvmetal-carbide-extras:latest}"
+          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
+            SOURCE="${CANONICAL_DEV}"
+            EXTRAS="${SOURCE}/nvmetal-carbide-extras:latest"
+          else
+            SOURCE="${SOURCE_OVERRIDE:-${CANONICAL_DEV}}"
+            SOURCE="${SOURCE%/}"
+            EXTRAS="${EXTRAS_OVERRIDE:-${SOURCE}/nvmetal-carbide-extras:latest}"
+          fi
           if [[ "${EXTRAS%%/*}" != "${SOURCE%%/*}" ]]; then
             echo "::error::NICO_EXTRAS_IMAGE must live on the source registry host (${SOURCE%%/*}); refusing to send source credentials to ${EXTRAS%%/*}"
             exit 1
           fi
           if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
-            NGC_PATH="${NGC_PATH_OVERRIDE:-${TARGET#*/}}"
+            NGC_PATH="${TARGET#*/}"
           else
             NGC_PATH="${NGC_PATH_OVERRIDE:-}"
             case "${NGC_PATH%/}" in
@@ -506,7 +511,6 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_container_x86_64_version }}
@@ -524,7 +528,6 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_container_aarch64_version }}
@@ -542,7 +545,6 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.runtime-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64
       image_tag: ${{ needs.prepare.outputs.runtime_container_x86_64_version }}
@@ -560,7 +562,6 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.runtime-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64
       image_tag: ${{ needs.prepare.outputs.runtime_container_aarch64_version }}
@@ -578,7 +579,6 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
@@ -596,7 +596,6 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
@@ -630,7 +629,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-container-x86_64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args }}
@@ -663,7 +662,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-container-aarch64
       context_path: .
       build_args: ${{ needs.prepare.outputs.release_build_args_aarch64 }}
@@ -798,7 +797,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -818,7 +817,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -968,7 +967,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1001,7 +1000,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1090,7 +1089,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-runner
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine-validation-runner
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1110,7 +1109,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1136,7 +1135,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
-      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' }}
+      target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -202,13 +202,22 @@ jobs:
           EXTRAS_OVERRIDE: ${{ vars.NICO_EXTRAS_IMAGE }}
           NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
           HAS_SOURCE_TOKEN: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN != '' }}
+          HAS_SOURCE_USERNAME: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME != '' }}
         run: |
           set -euo pipefail
           CANONICAL_DEV="nvcr.io/0837451325059433/carbide-dev"
           CANONICAL_PROD="nvcr.io/0837451325059433/carbide"
+          for V in "${TARGET_OVERRIDE}" "${SOURCE_OVERRIDE}" "${PROD_OVERRIDE}" "${EXTRAS_OVERRIDE}" "${NGC_PATH_OVERRIDE}"; do
+            if [[ "${V}" == *$'\n'* || "${V}" == *$'\r'* ]]; then
+              echo "::error::registry variables must be single-line values"
+              exit 1
+            fi
+          done
           if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
-            TARGET="${TARGET_OVERRIDE:-${CANONICAL_DEV}}"
-            PROD="${PROD_OVERRIDE:-${CANONICAL_PROD}}"
+            # canonical endpoints are constants: repository variables must not
+            # be able to redirect canonical credentials without a workflow diff
+            TARGET="${CANONICAL_DEV}"
+            PROD="${CANONICAL_PROD}"
           else
             if [[ -z "${TARGET_OVERRIDE}" ]]; then
               echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
@@ -236,6 +245,10 @@ jobs:
           SOURCE="${SOURCE_OVERRIDE:-${CANONICAL_DEV}}"
           SOURCE="${SOURCE%/}"
           EXTRAS="${EXTRAS_OVERRIDE:-${SOURCE}/nvmetal-carbide-extras:latest}"
+          if [[ "${EXTRAS%%/*}" != "${SOURCE%%/*}" ]]; then
+            echo "::error::NICO_EXTRAS_IMAGE must live on the source registry host (${SOURCE%%/*}); refusing to send source credentials to ${EXTRAS%%/*}"
+            exit 1
+          fi
           if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
             NGC_PATH="${NGC_PATH_OVERRIDE:-${TARGET#*/}}"
           else
@@ -246,7 +259,7 @@ jobs:
                 exit 1;;
             esac
           fi
-          if [[ "${SOURCE%%/*}" != "nvcr.io" && "${HAS_SOURCE_TOKEN}" != "true" ]]; then
+          if [[ "${SOURCE%%/*}" != "nvcr.io" && ( "${HAS_SOURCE_TOKEN}" != "true" || "${HAS_SOURCE_USERNAME}" != "true" ) ]]; then
             echo "::error::non-NVCR source registry requires NICO_SOURCE_REGISTRY_* secrets (refusing to send NVCR credentials elsewhere)"
             exit 1
           fi
@@ -424,6 +437,7 @@ jobs:
         env:
           TARGET_REGISTRY: ${{ steps.registry.outputs.registry }}
           HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
+          HAS_TARGET_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME != '' }}
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
@@ -437,7 +451,7 @@ jobs:
           fi
 
           TARGET_HOST="${TARGET_REGISTRY%%/*}"
-          if [[ "${PUBLISH}" == "true" && "${TARGET_HOST}" != "nvcr.io" && "${HAS_TARGET_TOKEN}" != "true" ]]; then
+          if [[ "${PUBLISH}" == "true" && "${TARGET_HOST}" != "nvcr.io" && ( "${HAS_TARGET_TOKEN}" != "true" || "${HAS_TARGET_USERNAME}" != "true" ) ]]; then
             echo "::error::publishing to a non-NVCR target requires NICO_TARGET_REGISTRY_* secrets (refusing to send NVCR credentials elsewhere)"
             exit 1
           fi
@@ -722,7 +736,7 @@ jobs:
       # base refs may point at the target registry after a rebuild; log in
       # there too when it is a different host (same-host uses one credential).
       - name: Login to target registry
-        if: ${{ needs.prepare.outputs.registry_host != needs.prepare.outputs.source_registry_host }}
+        if: ${{ needs.prepare.outputs.publish_images == 'true' && needs.prepare.outputs.registry_host != needs.prepare.outputs.source_registry_host }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.registry_host }}
@@ -1240,8 +1254,8 @@ jobs:
     container:
       image: ${{ needs.prepare.outputs.build_container_x86_64_ref }}
       credentials:
-        username: ${{ secrets.NVCR_USERNAME }}
-        password: ${{ secrets.NVCR_TOKEN }}
+        username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+        password: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -1384,7 +1398,7 @@ jobs:
       # base refs may point at the target registry after a rebuild; log in
       # there too when it is a different host (same-host uses one credential).
       - name: Login to target registry
-        if: ${{ needs.prepare.outputs.registry_host != needs.prepare.outputs.source_registry_host }}
+        if: ${{ needs.prepare.outputs.publish_images == 'true' && needs.prepare.outputs.registry_host != needs.prepare.outputs.source_registry_host }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ needs.prepare.outputs.registry_host }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,7 @@ jobs:
       source_registry_host: ${{ steps.registry.outputs.source_registry_host }}
       bases_rebuilt: ${{ steps.base-container-gate.outputs.build_container_x86_64_run == 'true' || steps.base-container-gate.outputs.runtime_container_x86_64_run == 'true' || steps.base-container-gate.outputs.build_container_aarch64_run == 'true' || steps.base-container-gate.outputs.runtime_container_aarch64_run == 'true' || steps.base-container-gate.outputs.build_artifacts_container_x86_64_run == 'true' || steps.base-container-gate.outputs.build_artifacts_container_aarch64_run == 'true' }}
       publish_images: ${{ steps.release-gate.outputs.publish_built_container }}
+      lint_container_ref: ${{ steps.release-gate.outputs.lint_container_ref }}
       target_ngc_path: ${{ steps.registry.outputs.target_ngc_path }}
       registry_host: ${{ steps.registry.outputs.registry_host }}
       prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
@@ -442,6 +443,9 @@ jobs:
         env:
           TARGET_REGISTRY: ${{ steps.registry.outputs.registry }}
           HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
+          BUILD_X86_RUN: ${{ steps.base-container-gate.outputs.build_container_x86_64_run }}
+          BUILD_X86_REF: ${{ steps.base-container-gate.outputs.build_container_x86_64_ref }}
+          SOURCE_REGISTRY: ${{ steps.registry.outputs.source_registry }}
           HAS_TARGET_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME != '' }}
           EVENT_NAME: ${{ github.event_name }}
           REF: ${{ github.ref }}
@@ -461,6 +465,13 @@ jobs:
             exit 1
           fi
           echo "publish_built_container=${PUBLISH}" >> "$GITHUB_OUTPUT"
+          # job containers log in before any step runs, so the lint job must
+          # never point at a target ref that was not published (mirror PRs)
+          if [[ "${BUILD_X86_RUN}" == "true" && "${GITHUB_REPOSITORY}" != "NVIDIA/infra-controller" && "${PUBLISH}" != "true" ]]; then
+            echo "lint_container_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "lint_container_ref=${BUILD_X86_REF}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Prepare release container build args
         id: release-metadata
@@ -1270,7 +1281,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.prepare.outputs.source_files_changed == 'true' && contains(github.ref, 'pull-request/') }}
     runs-on: linux-amd64-cpu16
     container:
-      image: ${{ needs.prepare.outputs.build_container_x86_64_ref }}
+      image: ${{ needs.prepare.outputs.lint_container_ref }}
       credentials:
         username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
         password: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -250,7 +250,7 @@ jobs:
             [ -z "${TAG}" ] && continue
             docker push "${TAG}"
           done <<< "${TAGS}"
-          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${PRIMARY}" | grep -F "${PRIMARY%:*}@" | head -1)
+          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${PRIMARY}" | grep -m1 -F "${PRIMARY%:*}@")
           echo "digest=${DIGEST##*@}" >> "$GITHUB_OUTPUT"
 
       # Scan the image the build step just loaded into the daemon — no rebuild.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,7 +33,7 @@ on:
         type: boolean
         default: true
       image_name:
-        description: 'Image name without registry prefix'
+        description: 'Full image repository (registry/path/name), no tag'
         required: true
         type: string
       image_tag:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,11 @@ name: Build Container with Buildx
 on:
   workflow_call:
     inputs:
+      source_registry_host:
+        description: 'Registry host for read-only base-image pulls (empty = skip source login)'
+        required: false
+        default: ''
+        type: string
       dockerfile_path:
         description: 'Path to Dockerfile'
         required: true
@@ -77,6 +82,12 @@ on:
       NVCR_TOKEN:
         description: "NVIDIA Container Registry API token"
         required: false
+      NICO_SOURCE_REGISTRY_USERNAME:
+        description: "Username for the read-only source registry (falls back to NVCR_USERNAME)"
+        required: false
+      NICO_SOURCE_REGISTRY_TOKEN:
+        description: "Token for the read-only source registry (falls back to NVCR_TOKEN)"
+        required: false
     outputs:
       image_digest:
         description: 'Image digest'
@@ -124,7 +135,19 @@ jobs:
           IMAGE_NAME: ${{ inputs.image_name }}
         run: echo "host=${IMAGE_NAME%%/*}" >> "$GITHUB_OUTPUT"
 
-      - name: Login to NVCR
+      # Pull credentials and push credentials can differ in mirrors: base
+      # images come from the source registry, the built image goes to the
+      # target. Target login is only needed when pushing.
+      - name: Login to source registry
+        if: ${{ inputs.source_registry_host != '' }}
+        uses: ./.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.source_registry_host }}
+          username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
+
+      - name: Login to target registry
+        if: ${{ inputs.push }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -219,6 +219,10 @@ jobs:
           # store, so they keep pushing straight from the build step
           push: ${{ inputs.push && contains(inputs.platforms, ',') }}
           load: ${{ (inputs.load || inputs.push) && !contains(inputs.platforms, ',') }}
+          # deliberate tradeoff: attestations are disabled so single- and
+          # multi-platform paths produce consistent artifacts (nothing in the
+          # pipeline consumes provenance today)
+          provenance: false
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: type=gha

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -145,7 +145,7 @@ jobs:
       # images come from the source registry, the built image goes to the
       # target. Target login is only needed when pushing.
       - name: Login to source registry
-        if: ${{ inputs.source_registry_host != '' }}
+        if: ${{ inputs.source_registry_host != '' && (inputs.source_registry_host != steps.registry-host.outputs.host || !inputs.push) }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ inputs.source_registry_host }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -118,9 +118,16 @@ jobs:
         with:
           buildkitd-config: /etc/buildkit/buildkitd.toml
 
+      - name: Derive registry host
+        id: registry-host
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+        run: echo "host=${IMAGE_NAME%%/*}" >> "$GITHUB_OUTPUT"
+
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ steps.registry-host.outputs.host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -160,7 +160,7 @@ jobs:
       # needed when this run rebuilt base containers (their refs point at the
       # target) and for multi-platform builds that push from the build step
       - name: Login to target registry (pre-build)
-        if: ${{ (inputs.target_prebuild_login && inputs.source_registry_host != '') || (inputs.push && contains(inputs.platforms, ',')) }}
+        if: ${{ (inputs.target_prebuild_login && inputs.source_registry_host != '') || (inputs.push && (contains(inputs.platforms, ',') || github.repository == 'NVIDIA/infra-controller')) }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}
@@ -215,21 +215,23 @@ jobs:
           context: ${{ inputs.context_path }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ inputs.platforms }}
-          # multi-platform images cannot be loaded into the classic image
-          # store, so they keep pushing straight from the build step
-          push: ${{ inputs.push && contains(inputs.platforms, ',') }}
-          load: ${{ (inputs.load || inputs.push) && !contains(inputs.platforms, ',') }}
-          # deliberate tradeoff: attestations are disabled so single- and
-          # multi-platform paths produce consistent artifacts (nothing in the
-          # pipeline consumes provenance today)
-          provenance: false
+          # canonical pushes straight from the build step (original behavior,
+          # BuildKit provenance intact); mirrors defer the push until after the
+          # build so no credential is present during base pulls. Multi-platform
+          # images cannot be loaded into the classic store, so they always push
+          # directly.
+          push: ${{ inputs.push && (contains(inputs.platforms, ',') || github.repository == 'NVIDIA/infra-controller') }}
+          load: ${{ (inputs.load && !inputs.push) || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller') }}
+          # mirrors: the docker exporter cannot attach attestations, and
+          # provenance would embed private downstream repo refs into artifacts
+          provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: type=gha
           cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
 
       - name: Login to target registry
-        if: ${{ inputs.push && !contains(inputs.platforms, ',') }}
+        if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}
@@ -238,7 +240,7 @@ jobs:
 
       - name: Push image tags
         id: push
-        if: ${{ inputs.push && !contains(inputs.platforms, ',') }}
+        if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}
         env:
           TAGS: ${{ steps.tag_list.outputs.tags }}
           PRIMARY: ${{ steps.tag_list.outputs.primary }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,11 @@ name: Build Container with Buildx
 on:
   workflow_call:
     inputs:
+      target_prebuild_login:
+        description: 'Log into the target registry before the build (base refs point there after a rebuild)'
+        required: false
+        default: false
+        type: boolean
       source_registry_host:
         description: 'Registry host for read-only base-image pulls (empty = skip source login)'
         required: false
@@ -145,12 +150,22 @@ jobs:
       # target (whose login happens after the build, so no credential is
       # ever presented during base-image pulls).
       - name: Login to source registry
-        if: ${{ inputs.source_registry_host != '' && (inputs.source_registry_host != steps.registry-host.outputs.host || !inputs.push) }}
+        if: ${{ inputs.source_registry_host != '' }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ inputs.source_registry_host }}
           username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
           token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
+
+      # needed when this run rebuilt base containers (their refs point at the
+      # target) and for multi-platform builds that push from the build step
+      - name: Login to target registry (pre-build)
+        if: ${{ (inputs.target_prebuild_login && inputs.source_registry_host != '') || (inputs.push && contains(inputs.platforms, ',')) }}
+        uses: ./.github/actions/docker-auth
+        with:
+          registry: ${{ steps.registry-host.outputs.host }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Prepare tag list
         id: tag_list
@@ -193,22 +208,24 @@ jobs:
             echo "build_args=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build and optionally push Docker image
+      - name: Build image
         id: build
         uses: docker/build-push-action@v5
         with:
           context: ${{ inputs.context_path }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ inputs.platforms }}
-          push: false
-          load: ${{ inputs.load || inputs.push }}
+          # multi-platform images cannot be loaded into the classic image
+          # store, so they keep pushing straight from the build step
+          push: ${{ inputs.push && contains(inputs.platforms, ',') }}
+          load: ${{ (inputs.load || inputs.push) && !contains(inputs.platforms, ',') }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: type=gha
           cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
 
       - name: Login to target registry
-        if: ${{ inputs.push }}
+        if: ${{ inputs.push && !contains(inputs.platforms, ',') }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}
@@ -217,7 +234,7 @@ jobs:
 
       - name: Push image tags
         id: push
-        if: ${{ inputs.push }}
+        if: ${{ inputs.push && !contains(inputs.platforms, ',') }}
         env:
           TAGS: ${{ steps.tag_list.outputs.tags }}
           PRIMARY: ${{ steps.tag_list.outputs.primary }}
@@ -227,7 +244,7 @@ jobs:
             [ -z "${TAG}" ] && continue
             docker push "${TAG}"
           done <<< "${TAGS}"
-          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${PRIMARY}" | grep -F "${PRIMARY%%:*}@" | head -1)
+          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${PRIMARY}" | grep -F "${PRIMARY%:*}@" | head -1)
           echo "digest=${DIGEST##*@}" >> "$GITHUB_OUTPUT"
 
       # Scan the image the build step just loaded into the daemon — no rebuild.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,6 +88,12 @@ on:
       NICO_SOURCE_REGISTRY_TOKEN:
         description: "Token for the read-only source registry (falls back to NVCR_TOKEN)"
         required: false
+      NICO_TARGET_REGISTRY_USERNAME:
+        description: "Username for the push target registry (falls back to NVCR_USERNAME)"
+        required: false
+      NICO_TARGET_REGISTRY_TOKEN:
+        description: "Token for the push target registry (falls back to NVCR_TOKEN)"
+        required: false
     outputs:
       image_digest:
         description: 'Image digest'
@@ -151,8 +157,8 @@ jobs:
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Prepare tag list
         id: tag_list

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
     outputs:
-      digest: ${{ steps.build.outputs.digest }}
+      digest: ${{ steps.push.outputs.digest || steps.build.outputs.digest }}
       image_tag: ${{ inputs.image_tag }}
       image_ref: ${{ steps.tag_list.outputs.primary }}
       tags: ${{ steps.tag_list.outputs.tags }}
@@ -130,7 +130,6 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        if: inputs.push
         uses: docker/setup-buildx-action@v3
         with:
           buildkitd-config: /etc/buildkit/buildkitd.toml
@@ -143,7 +142,8 @@ jobs:
 
       # Pull credentials and push credentials can differ in mirrors: base
       # images come from the source registry, the built image goes to the
-      # target. Target login is only needed when pushing.
+      # target (whose login happens after the build, so no credential is
+      # ever presented during base-image pulls).
       - name: Login to source registry
         if: ${{ inputs.source_registry_host != '' && (inputs.source_registry_host != steps.registry-host.outputs.host || !inputs.push) }}
         uses: ./.github/actions/docker-auth
@@ -151,14 +151,6 @@ jobs:
           registry: ${{ inputs.source_registry_host }}
           username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
           token: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
-
-      - name: Login to target registry
-        if: ${{ inputs.push }}
-        uses: ./.github/actions/docker-auth
-        with:
-          registry: ${{ steps.registry-host.outputs.host }}
-          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
-          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Prepare tag list
         id: tag_list
@@ -208,12 +200,35 @@ jobs:
           context: ${{ inputs.context_path }}
           file: ${{ inputs.dockerfile_path }}
           platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.push }}
-          load: ${{ inputs.load && !inputs.push }}
+          push: false
+          load: ${{ inputs.load || inputs.push }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: type=gha
           cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
+
+      - name: Login to target registry
+        if: ${{ inputs.push }}
+        uses: ./.github/actions/docker-auth
+        with:
+          registry: ${{ steps.registry-host.outputs.host }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
+
+      - name: Push image tags
+        id: push
+        if: ${{ inputs.push }}
+        env:
+          TAGS: ${{ steps.tag_list.outputs.tags }}
+          PRIMARY: ${{ steps.tag_list.outputs.primary }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r TAG; do
+            [ -z "${TAG}" ] && continue
+            docker push "${TAG}"
+          done <<< "${TAGS}"
+          DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${PRIMARY}" | grep -F "${PRIMARY%%:*}@" | head -1)
+          echo "digest=${DIGEST##*@}" >> "$GITHUB_OUTPUT"
 
       # Scan the image the build step just loaded into the daemon — no rebuild.
       # Only runs when the image is actually loaded (load=true and not pushing,

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -33,6 +33,10 @@ jobs:
     outputs:
       version: ${{ inputs.version }}
       helm_version: ${{ steps.version.outputs.helm_version }}
+      image_registry: ${{ steps.registry.outputs.registry }}
+      registry_host: ${{ steps.registry.outputs.registry_host }}
+      prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
+      prod_registry_path: ${{ steps.registry.outputs.prod_registry_path }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,14 +54,35 @@ jobs:
           echo "helm_version=${HELM_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Promoting chart version ${HELM_VERSION} from release ${VERSION}"
 
+      - name: Resolve container registries
+        id: registry
+        env:
+          REGISTRY_OVERRIDE: ${{ vars.IMAGE_REGISTRY }}
+          PROD_REGISTRY_OVERRIDE: ${{ vars.PROD_IMAGE_REGISTRY }}
+        run: |
+          set -euo pipefail
+          REGISTRY="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
+          REGISTRY="${REGISTRY%/}"
+          PROD_REGISTRY="${PROD_REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide}"
+          PROD_REGISTRY="${PROD_REGISTRY%/}"
+          {
+            echo "registry=${REGISTRY}"
+            echo "registry_host=${REGISTRY%%/*}"
+            echo "prod_registry=${PROD_REGISTRY}"
+            echo "prod_registry_path=${PROD_REGISTRY#*/}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Container registry: ${REGISTRY} (prod: ${PROD_REGISTRY})"
+
       - name: Login to NVCR
         uses: ./.github/actions/docker-auth
         with:
+          registry: ${{ steps.registry.outputs.registry_host }}
           username: ${{ secrets.NVCR_USERNAME }}
           token: ${{ secrets.NVCR_TOKEN }}
 
       - name: Validate source images exist
         env:
+          REGISTRY: ${{ steps.registry.outputs.registry }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -67,9 +92,9 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
 
           IMAGES=(
-            "nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide:${VERSION}"
-            "nvcr.io/0837451325059433/carbide-dev/carbide-release-artifacts-aarch64:${VERSION}"
-            "nvcr.io/0837451325059433/carbide-dev/carbide-release-artifacts-x86_64:${VERSION}"
+            "${REGISTRY}/nvmetal-carbide:${VERSION}"
+            "${REGISTRY}/carbide-release-artifacts-aarch64:${VERSION}"
+            "${REGISTRY}/carbide-release-artifacts-x86_64:${VERSION}"
           )
 
           FAILED=0
@@ -125,9 +150,9 @@ jobs:
       - approve-promotion
     uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
-      source: nvcr.io/0837451325059433/carbide-dev/nvmetal-carbide
+      source: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       source_tag: ${{ needs.prepare.outputs.version }}
-      destination: nvcr.io/0837451325059433/carbide/nvmetal-carbide
+      destination: ${{ needs.prepare.outputs.prod_image_registry }}/nvmetal-carbide
       destination_tag: ${{ needs.prepare.outputs.version }}
     secrets:
       SOURCE_USERNAME: ${{ secrets.NVCR_USERNAME }}
@@ -144,9 +169,9 @@ jobs:
       - approve-promotion
     uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
-      source: nvcr.io/0837451325059433/carbide-dev/carbide-release-artifacts-aarch64
+      source: ${{ needs.prepare.outputs.image_registry }}/carbide-release-artifacts-aarch64
       source_tag: ${{ needs.prepare.outputs.version }}
-      destination: nvcr.io/0837451325059433/carbide/carbide-release-artifacts-aarch64
+      destination: ${{ needs.prepare.outputs.prod_image_registry }}/carbide-release-artifacts-aarch64
       destination_tag: ${{ needs.prepare.outputs.version }}
     secrets:
       SOURCE_USERNAME: ${{ secrets.NVCR_USERNAME }}
@@ -163,9 +188,9 @@ jobs:
       - approve-promotion
     uses: NVIDIA/dsx-github-actions/.github/workflows/promote-image.yml@95e609360851cfc141918c2c21e57762d77394ac
     with:
-      source: nvcr.io/0837451325059433/carbide-dev/carbide-release-artifacts-x86_64
+      source: ${{ needs.prepare.outputs.image_registry }}/carbide-release-artifacts-x86_64
       source_tag: ${{ needs.prepare.outputs.version }}
-      destination: nvcr.io/0837451325059433/carbide/carbide-release-artifacts-x86_64
+      destination: ${{ needs.prepare.outputs.prod_image_registry }}/carbide-release-artifacts-x86_64
       destination_tag: ${{ needs.prepare.outputs.version }}
     secrets:
       SOURCE_USERNAME: ${{ secrets.NVCR_USERNAME }}
@@ -193,5 +218,5 @@ jobs:
           app-version: ${{ needs.prepare.outputs.version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_PROD_TOKEN }}
-          ngc-path: 0837451325059433/carbide
+          ngc-path: ${{ needs.prepare.outputs.prod_registry_path }}
           ngc-duplicate: fail

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -29,6 +29,8 @@ jobs:
   # PREPARE - Validate source images exist
   # ============================================================================
   prepare:
+    # Production promotion never runs outside the canonical repo.
+    if: github.repository == 'NVIDIA/infra-controller'
     runs-on: linux-amd64-cpu4
     outputs:
       version: ${{ inputs.version }}
@@ -53,18 +55,6 @@ jobs:
 
           echo "helm_version=${HELM_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Promoting chart version ${HELM_VERSION} from release ${VERSION}"
-
-      # Promotion moves artifacts toward production; outside the canonical
-      # repo it must be explicitly configured, never inherited.
-      - name: Repository guard
-        env:
-          PROD_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
-        run: |
-          set -euo pipefail
-          if [[ "${GITHUB_REPOSITORY}" != "NVIDIA/infra-controller" && -z "${PROD_OVERRIDE}" ]]; then
-            echo "::error::promotion is disabled outside NVIDIA/infra-controller unless NICO_PROD_IMAGE_REGISTRY is set"
-            exit 1
-          fi
 
       - name: Resolve container registries
         id: registry

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -58,15 +58,12 @@ jobs:
 
       - name: Resolve container registries
         id: registry
-        env:
-          REGISTRY_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
-          PROD_REGISTRY_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
+        # promotion only runs in the canonical repo; endpoints are constants so
+        # repository variables can never redirect staging/production credentials
         run: |
           set -euo pipefail
-          REGISTRY="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
-          REGISTRY="${REGISTRY%/}"
-          PROD_REGISTRY="${PROD_REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide}"
-          PROD_REGISTRY="${PROD_REGISTRY%/}"
+          REGISTRY="nvcr.io/0837451325059433/carbide-dev"
+          PROD_REGISTRY="nvcr.io/0837451325059433/carbide"
           {
             echo "registry=${REGISTRY}"
             echo "registry_host=${REGISTRY%%/*}"

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -54,11 +54,23 @@ jobs:
           echo "helm_version=${HELM_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Promoting chart version ${HELM_VERSION} from release ${VERSION}"
 
+      # Promotion moves artifacts toward production; outside the canonical
+      # repo it must be explicitly configured, never inherited.
+      - name: Repository guard
+        env:
+          PROD_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REPOSITORY}" != "NVIDIA/infra-controller" && -z "${PROD_OVERRIDE}" ]]; then
+            echo "::error::promotion is disabled outside NVIDIA/infra-controller unless NICO_PROD_IMAGE_REGISTRY is set"
+            exit 1
+          fi
+
       - name: Resolve container registries
         id: registry
         env:
-          REGISTRY_OVERRIDE: ${{ vars.IMAGE_REGISTRY }}
-          PROD_REGISTRY_OVERRIDE: ${{ vars.PROD_IMAGE_REGISTRY }}
+          REGISTRY_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
+          PROD_REGISTRY_OVERRIDE: ${{ vars.NICO_PROD_IMAGE_REGISTRY }}
         run: |
           set -euo pipefail
           REGISTRY="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -52,6 +52,12 @@ on:
         required: false
       NVCR_TOKEN:
         description: "NVIDIA Container Registry API token"
+      NICO_TARGET_REGISTRY_USERNAME:
+        description: "Username for the push target registry (falls back to NVCR_USERNAME)"
+        required: false
+      NICO_TARGET_REGISTRY_TOKEN:
+        description: "Token for the push target registry (falls back to NVCR_TOKEN)"
+        required: false
         required: false
 
 jobs:

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -86,7 +86,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-rest-db:
     name: Build nico-rest-db
@@ -105,7 +110,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-rest-site-manager:
     name: Build nico-rest-site-manager
@@ -124,7 +134,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-rest-workflow:
     name: Build nico-rest-workflow
@@ -143,7 +158,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-rest-site-agent:
     name: Build nico-rest-site-agent
@@ -162,7 +182,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-rest-cert-manager:
     name: Build nico-rest-cert-manager
@@ -181,7 +206,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-flow:
     name: Build nico-flow
@@ -200,7 +230,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-psm:
     name: Build nico-psm
@@ -219,7 +254,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-nico-nsm:
     name: Build nico-nsm
@@ -238,7 +278,12 @@ jobs:
       push_enabled: ${{ inputs.push_enabled }}
       is_main_branch: ${{ inputs.is_main_branch }}
       release_tag: ${{ inputs.release_tag }}
-    secrets: inherit
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   build-summary:
     name: Build Summary

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -6,6 +6,11 @@ name: Build and Push Docker Images
 on:
   workflow_call:
     inputs:
+      ngc_path:
+        description: 'NGC org/team for resource uploads (empty = skip)'
+        required: false
+        type: string
+        default: ''
       runner:
         description: "Runner type for the build jobs"
         required: false
@@ -65,6 +70,7 @@ jobs:
     name: Build nico-rest-api
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-rest-api
       binary_name: api
@@ -83,6 +89,7 @@ jobs:
     name: Build nico-rest-db
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-rest-db
       binary_name: migrations
@@ -101,6 +108,7 @@ jobs:
     name: Build nico-rest-site-manager
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-rest-site-manager
       binary_name: sitemgr
@@ -119,6 +127,7 @@ jobs:
     name: Build nico-rest-workflow
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-rest-workflow
       binary_name: workflow
@@ -137,6 +146,7 @@ jobs:
     name: Build nico-rest-site-agent
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-rest-site-agent
       binary_name: site-agent
@@ -155,6 +165,7 @@ jobs:
     name: Build nico-rest-cert-manager
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-rest-cert-manager
       binary_name: credsmgr
@@ -173,6 +184,7 @@ jobs:
     name: Build nico-flow
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-flow
       binary_name: flow
@@ -191,6 +203,7 @@ jobs:
     name: Build nico-psm
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-psm
       binary_name: psm
@@ -209,6 +222,7 @@ jobs:
     name: Build nico-nsm
     uses: ./.github/workflows/rest-build-push-service.yml
     with:
+      ngc_path: ${{ inputs.ngc_path }}
       runner: ${{ inputs.runner }}
       service_name: nico-nsm
       binary_name: nsm

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -57,12 +57,12 @@ on:
         required: false
       NVCR_TOKEN:
         description: "NVIDIA Container Registry API token"
+        required: false
       NICO_TARGET_REGISTRY_USERNAME:
         description: "Username for the push target registry (falls back to NVCR_USERNAME)"
         required: false
       NICO_TARGET_REGISTRY_TOKEN:
         description: "Token for the push target registry (falls back to NVCR_TOKEN)"
-        required: false
         required: false
 
 jobs:

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -64,6 +64,9 @@ on:
       NICO_TARGET_REGISTRY_TOKEN:
         description: "Token for the push target registry (falls back to NVCR_TOKEN)"
         required: false
+      NICO_NGC_TOKEN:
+        description: "Key for NGC helm/resource uploads (falls back to NVCR_TOKEN)"
+        required: false
 
 jobs:
   build-nico-rest-api:

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -57,9 +57,10 @@ on:
         default: ""
         type: string
       ngc_path:
-        description: 'NGC path for resource uploads'
+        description: 'NGC org/team for resource uploads (empty = skip)'
         required: false
-        default: '0837451325059433/carbide-dev'
+        type: string
+        default: ''
         type: string
     secrets:
       NVCR_USERNAME:
@@ -115,13 +116,14 @@ jobs:
         id: registry-host
         env:
           TARGET_REGISTRY: ${{ inputs.target_registry }}
-          NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
+          PUSH_ENABLED: ${{ inputs.push_enabled }}
+          HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
         run: |
-          echo "host=${TARGET_REGISTRY%%/*}" >> "$GITHUB_OUTPUT"
-          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
-            echo "ngc_path=${NGC_PATH_OVERRIDE:-${TARGET_REGISTRY#*/}}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ngc_path=${NGC_PATH_OVERRIDE:-}" >> "$GITHUB_OUTPUT"
+          HOST="${TARGET_REGISTRY%%/*}"
+          echo "host=${HOST}" >> "$GITHUB_OUTPUT"
+          if [ "${PUSH_ENABLED}" = "true" ] && [ "${HOST}" != "nvcr.io" ] && [ "${HAS_TARGET_TOKEN}" != "true" ]; then
+            echo "::error::pushing to a non-NVCR target requires NICO_TARGET_REGISTRY_* secrets"
+            exit 1
           fi
 
       - name: Login to target registry
@@ -218,7 +220,7 @@ jobs:
         run: docker push "${{ steps.docker-tags.outputs.arch_tag }}"
 
       - name: Upload binary artifact with semantic version
-        if: inputs.push_enabled == true && steps.registry-host.outputs.ngc_path != ''
+        if: inputs.push_enabled == true && inputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -226,11 +228,11 @@ jobs:
           description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
-          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
+          ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch == 'true' && inputs.push_enabled == true && steps.registry-host.outputs.ngc_path != ''
+        if: inputs.is_main_branch == 'true' && inputs.push_enabled == true && inputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -238,7 +240,7 @@ jobs:
           description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: latest
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
-          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
+          ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
   # Stitch the per-arch images pushed by `build` into one multi-arch manifest at the
@@ -259,13 +261,14 @@ jobs:
         id: registry-host
         env:
           TARGET_REGISTRY: ${{ inputs.target_registry }}
-          NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
+          PUSH_ENABLED: ${{ inputs.push_enabled }}
+          HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
         run: |
-          echo "host=${TARGET_REGISTRY%%/*}" >> "$GITHUB_OUTPUT"
-          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
-            echo "ngc_path=${NGC_PATH_OVERRIDE:-${TARGET_REGISTRY#*/}}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ngc_path=${NGC_PATH_OVERRIDE:-}" >> "$GITHUB_OUTPUT"
+          HOST="${TARGET_REGISTRY%%/*}"
+          echo "host=${HOST}" >> "$GITHUB_OUTPUT"
+          if [ "${PUSH_ENABLED}" = "true" ] && [ "${HOST}" != "nvcr.io" ] && [ "${HAS_TARGET_TOKEN}" != "true" ]; then
+            echo "::error::pushing to a non-NVCR target requires NICO_TARGET_REGISTRY_* secrets"
+            exit 1
           fi
 
       - name: Login to target registry
@@ -314,7 +317,7 @@ jobs:
             | gzip > "artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz"
 
       - name: Upload Docker image artifact with semantic version
-        if: steps.registry-host.outputs.ngc_path != ''
+        if: inputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
@@ -322,11 +325,11 @@ jobs:
           description: ${{ inputs.service_name }} image
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
-          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
+          ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch == 'true' && steps.registry-host.outputs.ngc_path != ''
+        if: inputs.is_main_branch == 'true' && inputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
@@ -334,5 +337,5 @@ jobs:
           description: ${{ inputs.service_name }} image
           version: latest
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
-          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
+          ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -109,16 +109,22 @@ jobs:
         id: registry-host
         env:
           TARGET_REGISTRY: ${{ inputs.target_registry }}
+          NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
           echo "host=${TARGET_REGISTRY%%/*}" >> "$GITHUB_OUTPUT"
-          echo "path=${TARGET_REGISTRY#*/}" >> "$GITHUB_OUTPUT"
+          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+            echo "ngc_path=${NGC_PATH_OVERRIDE:-${TARGET_REGISTRY#*/}}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ngc_path=${NGC_PATH_OVERRIDE:-}" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Login to NVCR
+      - name: Login to target registry
+        if: ${{ inputs.push_enabled == true }}
         uses: docker/login-action@v3
         with:
           registry: ${{ steps.registry-host.outputs.host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          password: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Determine Docker tags
         id: docker-tags
@@ -206,7 +212,7 @@ jobs:
         run: docker push "${{ steps.docker-tags.outputs.arch_tag }}"
 
       - name: Upload binary artifact with semantic version
-        if: inputs.push_enabled == true
+        if: inputs.push_enabled == true && steps.registry-host.outputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -214,11 +220,11 @@ jobs:
           description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
-          ngc-path: ${{ steps.registry-host.outputs.path }}
+          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload binary artifact with latest tag
-        if: inputs.is_main_branch == 'true' && inputs.push_enabled == true
+        if: inputs.is_main_branch == 'true' && inputs.push_enabled == true && steps.registry-host.outputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-binary-${{ matrix.arch }}
@@ -226,7 +232,7 @@ jobs:
           description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: latest
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
-          ngc-path: ${{ steps.registry-host.outputs.path }}
+          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
   # Stitch the per-arch images pushed by `build` into one multi-arch manifest at the
@@ -247,16 +253,22 @@ jobs:
         id: registry-host
         env:
           TARGET_REGISTRY: ${{ inputs.target_registry }}
+          NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
           echo "host=${TARGET_REGISTRY%%/*}" >> "$GITHUB_OUTPUT"
-          echo "path=${TARGET_REGISTRY#*/}" >> "$GITHUB_OUTPUT"
+          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+            echo "ngc_path=${NGC_PATH_OVERRIDE:-${TARGET_REGISTRY#*/}}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ngc_path=${NGC_PATH_OVERRIDE:-}" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Login to NVCR
+      - name: Login to target registry
+        if: ${{ inputs.push_enabled == true }}
         uses: docker/login-action@v3
         with:
           registry: ${{ steps.registry-host.outputs.host }}
-          username: ${{ secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NVCR_TOKEN }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          password: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Determine Docker tags
         id: docker-tags
@@ -296,6 +308,7 @@ jobs:
             | gzip > "artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz"
 
       - name: Upload Docker image artifact with semantic version
+        if: steps.registry-host.outputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
@@ -303,11 +316,11 @@ jobs:
           description: ${{ inputs.service_name }} image
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
-          ngc-path: ${{ steps.registry-host.outputs.path }}
+          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload Docker image artifact with latest tag
-        if: inputs.is_main_branch == 'true'
+        if: inputs.is_main_branch == 'true' && steps.registry-host.outputs.ngc_path != ''
         uses: NVIDIA/dsx-github-actions/.github/actions/resource-push-ngc@ae74448cafa69f20fe0011c5351c2a864a8f632d
         with:
           name: ${{ inputs.service_name }}-image
@@ -315,5 +328,5 @@ jobs:
           description: ${{ inputs.service_name }} image
           version: latest
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
-          ngc-path: ${{ steps.registry-host.outputs.path }}
+          ngc-path: ${{ steps.registry-host.outputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -117,10 +117,11 @@ jobs:
           TARGET_REGISTRY: ${{ inputs.target_registry }}
           PUSH_ENABLED: ${{ inputs.push_enabled }}
           HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
+          HAS_TARGET_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME != '' }}
         run: |
           HOST="${TARGET_REGISTRY%%/*}"
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
-          if [ "${PUSH_ENABLED}" = "true" ] && [ "${HOST}" != "nvcr.io" ] && [ "${HAS_TARGET_TOKEN}" != "true" ]; then
+          if [ "${PUSH_ENABLED}" = "true" ] && [ "${HOST}" != "nvcr.io" ] && { [ "${HAS_TARGET_TOKEN}" != "true" ] || [ "${HAS_TARGET_USERNAME}" != "true" ]; }; then
             echo "::error::pushing to a non-NVCR target requires NICO_TARGET_REGISTRY_* secrets"
             exit 1
           fi
@@ -262,10 +263,11 @@ jobs:
           TARGET_REGISTRY: ${{ inputs.target_registry }}
           PUSH_ENABLED: ${{ inputs.push_enabled }}
           HAS_TARGET_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN != '' }}
+          HAS_TARGET_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME != '' }}
         run: |
           HOST="${TARGET_REGISTRY%%/*}"
           echo "host=${HOST}" >> "$GITHUB_OUTPUT"
-          if [ "${PUSH_ENABLED}" = "true" ] && [ "${HOST}" != "nvcr.io" ] && [ "${HAS_TARGET_TOKEN}" != "true" ]; then
+          if [ "${PUSH_ENABLED}" = "true" ] && [ "${HOST}" != "nvcr.io" ] && { [ "${HAS_TARGET_TOKEN}" != "true" ] || [ "${HAS_TARGET_USERNAME}" != "true" ]; }; then
             echo "::error::pushing to a non-NVCR target requires NICO_TARGET_REGISTRY_* secrets"
             exit 1
           fi

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -125,14 +125,6 @@ jobs:
             exit 1
           fi
 
-      - name: Login to target registry
-        if: ${{ inputs.push_enabled == true }}
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ steps.registry-host.outputs.host }}
-          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
-          password: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
-
       - name: Determine Docker tags
         id: docker-tags
         run: |
@@ -213,6 +205,14 @@ jobs:
           got="$(file -b "artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}")"
           echo "${got}" | grep -q "${want}" \
             || { echo "::error::${{ matrix.arch }} ${{ inputs.binary_name }} is not ${want}: ${got}"; exit 1; }
+
+      - name: Login to target registry
+        if: ${{ inputs.push_enabled == true }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.registry-host.outputs.host }}
+          username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
+          password: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Push ${{ matrix.arch }} image
         if: inputs.push_enabled == true

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -61,19 +61,18 @@ on:
         required: false
         type: string
         default: ''
-        type: string
     secrets:
       NVCR_USERNAME:
         description: 'NVCR username'
         required: false
       NVCR_TOKEN:
         description: 'NVCR token'
+        required: false
       NICO_TARGET_REGISTRY_USERNAME:
         description: "Username for the push target registry (falls back to NVCR_USERNAME)"
         required: false
       NICO_TARGET_REGISTRY_TOKEN:
         description: "Token for the push target registry (falls back to NVCR_TOKEN)"
-        required: false
         required: false
 
 jobs:

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -105,10 +105,18 @@ jobs:
           # directly — avoids unauthenticated 429 rate limits. Matches core docker-build.yml.
           buildkitd-config: /etc/buildkit/buildkitd.toml
 
+      - name: Derive registry host
+        id: registry-host
+        env:
+          TARGET_REGISTRY: ${{ inputs.target_registry }}
+        run: |
+          echo "host=${TARGET_REGISTRY%%/*}" >> "$GITHUB_OUTPUT"
+          echo "path=${TARGET_REGISTRY#*/}" >> "$GITHUB_OUTPUT"
+
       - name: Login to NVCR
         uses: docker/login-action@v3
         with:
-          registry: nvcr.io
+          registry: ${{ steps.registry-host.outputs.host }}
           username: ${{ secrets.NVCR_USERNAME }}
           password: ${{ secrets.NVCR_TOKEN }}
 
@@ -206,7 +214,7 @@ jobs:
           description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
-          ngc-path: ${{ inputs.ngc_path }}
+          ngc-path: ${{ steps.registry-host.outputs.path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload binary artifact with latest tag
@@ -218,7 +226,7 @@ jobs:
           description: ${{ inputs.service_name }} binary (${{ matrix.arch }})
           version: latest
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
-          ngc-path: ${{ inputs.ngc_path }}
+          ngc-path: ${{ steps.registry-host.outputs.path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
   # Stitch the per-arch images pushed by `build` into one multi-arch manifest at the
@@ -235,10 +243,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Derive registry host
+        id: registry-host
+        env:
+          TARGET_REGISTRY: ${{ inputs.target_registry }}
+        run: |
+          echo "host=${TARGET_REGISTRY%%/*}" >> "$GITHUB_OUTPUT"
+          echo "path=${TARGET_REGISTRY#*/}" >> "$GITHUB_OUTPUT"
+
       - name: Login to NVCR
         uses: docker/login-action@v3
         with:
-          registry: nvcr.io
+          registry: ${{ steps.registry-host.outputs.host }}
           username: ${{ secrets.NVCR_USERNAME }}
           password: ${{ secrets.NVCR_TOKEN }}
 
@@ -287,7 +303,7 @@ jobs:
           description: ${{ inputs.service_name }} image
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
-          ngc-path: ${{ inputs.ngc_path }}
+          ngc-path: ${{ steps.registry-host.outputs.path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}
 
       - name: Upload Docker image artifact with latest tag
@@ -299,5 +315,5 @@ jobs:
           description: ${{ inputs.service_name }} image
           version: latest
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
-          ngc-path: ${{ inputs.ngc_path }}
+          ngc-path: ${{ steps.registry-host.outputs.path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -67,6 +67,12 @@ on:
         required: false
       NVCR_TOKEN:
         description: 'NVCR token'
+      NICO_TARGET_REGISTRY_USERNAME:
+        description: "Username for the push target registry (falls back to NVCR_USERNAME)"
+        required: false
+      NICO_TARGET_REGISTRY_TOKEN:
+        description: "Token for the push target registry (falls back to NVCR_TOKEN)"
+        required: false
         required: false
 
 jobs:

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -74,6 +74,9 @@ on:
       NICO_TARGET_REGISTRY_TOKEN:
         description: "Token for the push target registry (falls back to NVCR_TOKEN)"
         required: false
+      NICO_NGC_TOKEN:
+        description: "Key for NGC helm/resource uploads (falls back to NVCR_TOKEN)"
+        required: false
 
 jobs:
   # Build each architecture natively on its own runner. A single multi-platform
@@ -229,7 +232,7 @@ jobs:
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
           ngc-path: ${{ inputs.ngc_path }}
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Upload binary artifact with latest tag
         if: inputs.is_main_branch == 'true' && inputs.push_enabled == true && inputs.ngc_path != ''
@@ -241,7 +244,7 @@ jobs:
           version: latest
           path: artifacts/${{ inputs.binary_name }}-${{ matrix.arch }}
           ngc-path: ${{ inputs.ngc_path }}
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
 
   # Stitch the per-arch images pushed by `build` into one multi-arch manifest at the
   # bare tag, then export/upload the image tarball. Push refs only.
@@ -327,7 +330,7 @@ jobs:
           version: ${{ steps.docker-tags.outputs.artifact_version }}
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
           ngc-path: ${{ inputs.ngc_path }}
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
 
       - name: Upload Docker image artifact with latest tag
         if: inputs.is_main_branch == 'true' && inputs.ngc_path != ''
@@ -339,4 +342,4 @@ jobs:
           version: latest
           path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
           ngc-path: ${{ inputs.ngc_path }}
-          ngc-key: ${{ secrets.NVCR_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -127,6 +127,7 @@ jobs:
       short_sha: ${{ needs.prepare.outputs.short_sha }}
       branch_sha_tag: ${{ needs.prepare.outputs.branch_sha_tag }}
       target_registry: ${{ needs.prepare.outputs.target_registry }}
+      ngc_path: ${{ needs.prepare.outputs.target_ngc_path }}
       branch_name: ${{ needs.prepare.outputs.branch_name }}
       is_main_branch: ${{ needs.prepare.outputs.is_main_branch }}
       push_enabled: ${{ github.event_name != 'workflow_dispatch' && !contains(github.ref, 'pull-request/') }}

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -142,6 +142,7 @@ jobs:
     if: ${{ !cancelled() && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/rest-helm-workflows.yml
     with:
+      ngc_path: ${{ needs.prepare.outputs.target_registry_path }}
       app_version: ${{ needs.prepare.outputs.semantic_version }}
       chart_version: ${{ needs.prepare.outputs.helm_version }}
     secrets:

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -142,7 +142,7 @@ jobs:
     if: ${{ !cancelled() && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/rest-helm-workflows.yml
     with:
-      ngc_path: ${{ needs.prepare.outputs.target_registry_path }}
+      ngc_path: ${{ needs.prepare.outputs.target_ngc_path }}
       app_version: ${{ needs.prepare.outputs.semantic_version }}
       chart_version: ${{ needs.prepare.outputs.helm_version }}
     secrets:

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -134,6 +134,8 @@ jobs:
     secrets:
       NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
       NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
 
   helm:
     name: Helm Charts

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -137,6 +137,7 @@ jobs:
       NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
       NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
       NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   helm:
     name: Helm Charts
@@ -150,6 +151,7 @@ jobs:
       chart_version: ${{ needs.prepare.outputs.helm_version }}
     secrets:
       NVCR_STG_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
   # ============================================================================
   # AGGREGATOR — single required check for branch protection

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -21,6 +21,8 @@ on:
     secrets:
       NVCR_STG_TOKEN:
         required: true
+      NICO_NGC_TOKEN:
+        required: false
 
 jobs:
   validate-charts:
@@ -69,6 +71,6 @@ jobs:
           chart-version: ${{ inputs.chart_version }}
           app-version: ${{ inputs.app_version }}
           lint: 'false'
-          ngc-key: ${{ secrets.NVCR_STG_TOKEN }}
+          ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_STG_TOKEN }}
           ngc-path: ${{ inputs.ngc_path }}
           ngc-duplicate: fail

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -9,7 +9,7 @@ on:
       ngc_path:
         required: false
         type: string
-        default: '0837451325059433/carbide-dev'
+        default: ''
       app_version:
         description: "Application version for Helm chart appVersion"
         required: true
@@ -62,6 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Package and push Helm chart to NGC
+        if: ${{ inputs.ngc_path != '' }}
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-package-push@7de619729962a6bd5e8355b6fb3582a22517d7e5
         with:
           chart-path: ${{ matrix.chart }}

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -6,6 +6,10 @@ name: Helm Charts
 on:
   workflow_call:
     inputs:
+      ngc_path:
+        required: false
+        type: string
+        default: '0837451325059433/carbide-dev'
       app_version:
         description: "Application version for Helm chart appVersion"
         required: true
@@ -65,5 +69,5 @@ jobs:
           app-version: ${{ inputs.app_version }}
           lint: 'false'
           ngc-key: ${{ secrets.NVCR_STG_TOKEN }}
-          ngc-path: 0837451325059433/carbide-dev
+          ngc-path: ${{ inputs.ngc_path }}
           ngc-duplicate: fail

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -26,6 +26,8 @@ on:
         value: ${{ jobs.prepare.outputs.target_registry }}
       target_registry_path:
         value: ${{ jobs.prepare.outputs.target_registry_path }}
+      target_ngc_path:
+        value: ${{ jobs.prepare.outputs.target_ngc_path }}
       branch_name:
         description: "Sanitized branch name for use in image tags"
         value: ${{ jobs.prepare.outputs.branch_name }}
@@ -56,6 +58,7 @@ jobs:
       full_sha: ${{ steps.generate-version.outputs.full_sha }}
       target_registry: ${{ steps.generate-version.outputs.target_registry }}
       target_registry_path: ${{ steps.generate-version.outputs.target_registry_path }}
+      target_ngc_path: ${{ steps.generate-version.outputs.target_ngc_path }}
       branch_name: ${{ steps.generate-version.outputs.branch_name }}
       branch_sha_tag: ${{ steps.generate-version.outputs.branch_sha_tag }}
       is_main_branch: ${{ steps.generate-version.outputs.is_main_branch }}
@@ -74,6 +77,7 @@ jobs:
         id: generate-version
         env:
           REGISTRY_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
+          NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
           git fetch --tags --force
           RAW_VERSION=$(git describe --tags --first-parent --always --long)
@@ -126,6 +130,11 @@ jobs:
           echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
           echo "target_registry=$target_registry" >> $GITHUB_OUTPUT
           echo "target_registry_path=${target_registry#*/}" >> $GITHUB_OUTPUT
+          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+            echo "target_ngc_path=${NGC_PATH_OVERRIDE:-${target_registry#*/}}" >> $GITHUB_OUTPUT
+          else
+            echo "target_ngc_path=${NGC_PATH_OVERRIDE:-}" >> $GITHUB_OUTPUT
+          fi
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "branch_sha_tag=$BRANCH_SHA_TAG" >> $GITHUB_OUTPUT
           echo "is_main_branch=$IS_MAIN_BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Generate version and build information
         id: generate-version
         env:
-          REGISTRY_OVERRIDE: ${{ vars.IMAGE_REGISTRY }}
+          REGISTRY_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
         run: |
           git fetch --tags --force
           RAW_VERSION=$(git describe --tags --first-parent --always --long)
@@ -82,7 +82,20 @@ jobs:
           SHORT_SHA=$(git rev-parse --short HEAD)
           FULL_SHA=$(git rev-parse HEAD)
 
-          target_registry="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
+          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+            target_registry="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
+          else
+            if [ -z "${REGISTRY_OVERRIDE}" ]; then
+              echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
+              exit 1
+            fi
+            case "${REGISTRY_OVERRIDE%/}" in
+              "nvcr.io/0837451325059433/carbide-dev"|"nvcr.io/0837451325059433/carbide")
+                echo "::error::this repository must not target the canonical registries"
+                exit 1;;
+            esac
+            target_registry="${REGISTRY_OVERRIDE}"
+          fi
           target_registry="${target_registry%/}"
 
           BRANCH_NAME="${{ github.ref_name }}"

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -24,6 +24,8 @@ on:
       target_registry:
         description: "Target NVCR registry path"
         value: ${{ jobs.prepare.outputs.target_registry }}
+      target_registry_path:
+        value: ${{ jobs.prepare.outputs.target_registry_path }}
       branch_name:
         description: "Sanitized branch name for use in image tags"
         value: ${{ jobs.prepare.outputs.branch_name }}
@@ -53,6 +55,7 @@ jobs:
       short_sha: ${{ steps.generate-version.outputs.short_sha }}
       full_sha: ${{ steps.generate-version.outputs.full_sha }}
       target_registry: ${{ steps.generate-version.outputs.target_registry }}
+      target_registry_path: ${{ steps.generate-version.outputs.target_registry_path }}
       branch_name: ${{ steps.generate-version.outputs.branch_name }}
       branch_sha_tag: ${{ steps.generate-version.outputs.branch_sha_tag }}
       is_main_branch: ${{ steps.generate-version.outputs.is_main_branch }}
@@ -69,6 +72,8 @@ jobs:
 
       - name: Generate version and build information
         id: generate-version
+        env:
+          REGISTRY_OVERRIDE: ${{ vars.IMAGE_REGISTRY }}
         run: |
           git fetch --tags --force
           RAW_VERSION=$(git describe --tags --first-parent --always --long)
@@ -77,7 +82,8 @@ jobs:
           SHORT_SHA=$(git rev-parse --short HEAD)
           FULL_SHA=$(git rev-parse HEAD)
 
-          target_registry="nvcr.io/0837451325059433/carbide-dev"
+          target_registry="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
+          target_registry="${target_registry%/}"
 
           BRANCH_NAME="${{ github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//')
@@ -106,6 +112,7 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
           echo "target_registry=$target_registry" >> $GITHUB_OUTPUT
+          echo "target_registry_path=${target_registry#*/}" >> $GITHUB_OUTPUT
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "branch_sha_tag=$BRANCH_SHA_TAG" >> $GITHUB_OUTPUT
           echo "is_main_branch=$IS_MAIN_BRANCH" >> $GITHUB_OUTPUT

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -91,7 +91,13 @@ jobs:
               echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
               exit 1
             fi
-            case "${REGISTRY_OVERRIDE%/}" in
+            if [ "$(printf '%s' "${REGISTRY_OVERRIDE}${NGC_PATH_OVERRIDE}" | wc -l)" != "0" ]; then
+              echo "::error::registry variables must be single-line values"
+              exit 1
+            fi
+            _norm="${REGISTRY_OVERRIDE%/}"
+            _host=$(printf '%s' "${_norm%%/*}" | tr '[:upper:]' '[:lower:]'); _host="${_host%:443}"
+            case "${_host}/${_norm#*/}" in
               "nvcr.io/0837451325059433/carbide-dev"|"nvcr.io/0837451325059433/carbide")
                 echo "::error::this repository must not target the canonical registries"
                 exit 1;;

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -84,15 +84,16 @@ jobs:
           SHORT_SHA=$(git rev-parse --short HEAD)
           FULL_SHA=$(git rev-parse HEAD)
 
+          if [[ "${REGISTRY_OVERRIDE}${NGC_PATH_OVERRIDE}" == *$'\n'* || "${REGISTRY_OVERRIDE}${NGC_PATH_OVERRIDE}" == *$'\r'* ]]; then
+            echo "::error::registry variables must be single-line values"
+            exit 1
+          fi
+          # canonical endpoints are constants: variables must not redirect them
           if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
-            target_registry="${REGISTRY_OVERRIDE:-nvcr.io/0837451325059433/carbide-dev}"
+            target_registry="nvcr.io/0837451325059433/carbide-dev"
           else
             if [ -z "${REGISTRY_OVERRIDE}" ]; then
               echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
-              exit 1
-            fi
-            if [ "$(printf '%s' "${REGISTRY_OVERRIDE}${NGC_PATH_OVERRIDE}" | wc -l)" != "0" ]; then
-              echo "::error::registry variables must be single-line values"
               exit 1
             fi
             _norm="${REGISTRY_OVERRIDE%/}"
@@ -134,7 +135,7 @@ jobs:
           echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
           echo "target_registry=$target_registry" >> $GITHUB_OUTPUT
           if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
-            echo "target_ngc_path=${NGC_PATH_OVERRIDE:-${target_registry#*/}}" >> $GITHUB_OUTPUT
+            echo "target_ngc_path=${target_registry#*/}" >> $GITHUB_OUTPUT
           else
             case "${NGC_PATH_OVERRIDE%/}" in
               "0837451325059433/carbide-dev"|"0837451325059433/carbide")

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -98,7 +98,8 @@ jobs:
             fi
             _norm="${REGISTRY_OVERRIDE%/}"
             _host=$(printf '%s' "${_norm%%/*}" | tr '[:upper:]' '[:lower:]'); _host="${_host%:443}"
-            case "${_host}/${_norm#*/}" in
+            _path=$(printf '%s' "${_norm#*/}" | tr '[:upper:]' '[:lower:]')
+            case "${_host}/${_path}" in
               "nvcr.io/0837451325059433/carbide-dev"|"nvcr.io/0837451325059433/carbide")
                 echo "::error::this repository must not target the canonical registries"
                 exit 1;;

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -24,8 +24,6 @@ on:
       target_registry:
         description: "Target NVCR registry path"
         value: ${{ jobs.prepare.outputs.target_registry }}
-      target_registry_path:
-        value: ${{ jobs.prepare.outputs.target_registry_path }}
       target_ngc_path:
         value: ${{ jobs.prepare.outputs.target_ngc_path }}
       branch_name:
@@ -57,7 +55,6 @@ jobs:
       short_sha: ${{ steps.generate-version.outputs.short_sha }}
       full_sha: ${{ steps.generate-version.outputs.full_sha }}
       target_registry: ${{ steps.generate-version.outputs.target_registry }}
-      target_registry_path: ${{ steps.generate-version.outputs.target_registry_path }}
       target_ngc_path: ${{ steps.generate-version.outputs.target_ngc_path }}
       branch_name: ${{ steps.generate-version.outputs.branch_name }}
       branch_sha_tag: ${{ steps.generate-version.outputs.branch_sha_tag }}
@@ -77,6 +74,7 @@ jobs:
         id: generate-version
         env:
           REGISTRY_OVERRIDE: ${{ vars.NICO_TARGET_IMAGE_REGISTRY }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
           git fetch --tags --force
@@ -119,7 +117,7 @@ jobs:
             RELEASE_TAG=""
           fi
 
-          if echo "${{ github.event.head_commit.message }}" | grep -q "push-container"; then
+          if printf '%s' "${COMMIT_MESSAGE}" | grep -q "push-container"; then
             PUSH_REQUESTED="true"
           else
             PUSH_REQUESTED="false"
@@ -129,10 +127,14 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
           echo "target_registry=$target_registry" >> $GITHUB_OUTPUT
-          echo "target_registry_path=${target_registry#*/}" >> $GITHUB_OUTPUT
           if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
             echo "target_ngc_path=${NGC_PATH_OVERRIDE:-${target_registry#*/}}" >> $GITHUB_OUTPUT
           else
+            case "${NGC_PATH_OVERRIDE%/}" in
+              "0837451325059433/carbide-dev"|"0837451325059433/carbide")
+                echo "::error::this repository must not publish helm/resources to the canonical NGC path"
+                exit 1;;
+            esac
             echo "target_ngc_path=${NGC_PATH_OVERRIDE:-}" >> $GITHUB_OUTPUT
           fi
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What

Makes every container-registry reference in CI resolvable through repository variables, so a private downstream mirror (#3088) can build and publish to its own isolated registry with **configuration only — no workflow edits**. This repo is unchanged: all defaults preserve current behavior bit-for-bit (direct push + provenance intact).

## Knobs (Actions repo variables — unset here = today's behavior)

| Variable | Meaning |
|---|---|
| `NICO_TARGET_IMAGE_REGISTRY` | where images/charts are published |
| `NICO_SOURCE_IMAGE_REGISTRY` | read-only deps (base + extras); defaults to target |
| `NICO_EXTRAS_IMAGE` | extras image ref (must share source host) |
| `NICO_TARGET_NGC_PATH` | NGC org/team for helm + resources |

Optional secrets `NICO_{SOURCE,TARGET}_REGISTRY_*` and `NICO_NGC_TOKEN` fall back to `NVCR_*`, but only for `nvcr.io` hosts.

## Safety (fail-closed)

- Canonical repo **ignores all overrides** — repo variables can't redirect canonical/prod credentials without a reviewed workflow diff.
- Any other repo **must** set the target and **may not** point it at the canonical registries.
- NVCR credentials are never sent to a non-nvcr host without the dedicated secret.

## Validation

Full build + publish exercised end-to-end on an internal mirror (deferred-push path → `vr-dev`) and on canonical infra (direct-push path → `carbide-dev`): 15/15 version tags, multi-arch manifests, helm/NGC resources, promotion correctly gated to `main`, and pre-existing mutable tags left untouched.

## Coordination

Pairs with #2998: once both land, `release-gate` needs one line so `feat/*` keeps publishing. Happy to add it in whichever merges second.

Part of #3088.
