### PR TITLE
feat: HPE ProLiant DL380a bmc mock

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -174,6 +174,14 @@ async fn test_integration() -> eyre::Result<()> {
             Ipv4Addr::new(10, 10, 11, 2),
         )
         .boxed(),
+        test_machine_a_tron_singledpu_nic_mode(
+            HostHardwareType::HpeProliantDl380aGen11,
+            &test_env,
+            &bmc_address_registry,
+            // Relay IP in host-inband net
+            Ipv4Addr::new(10, 10, 11, 2),
+        )
+        .boxed(),
         test_machine_a_tron_dpu_to_nic_mode_reregistration(
             HostHardwareType::DellPowerEdgeR750,
             &test_env,

--- a/crates/bmc-explorer/tests/hpe_proliant_dl380a_gen11_explore.rs
+++ b/crates/bmc-explorer/tests/hpe_proliant_dl380a_gen11_explore.rs
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+mod common;
+
+use bmc_explorer::nv_generate_exploration_report;
+use bmc_mock::test_support;
+use model::site_explorer::{EndpointType, InternalLockdownStatus};
+use tokio::test;
+
+#[test]
+async fn explore_hpe_proliant_dl380a_gen11() {
+    let h = test_support::hpe_proliant_dl380a_gen11_bmc().await;
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+
+    assert_eq!(report.endpoint_type, EndpointType::Bmc);
+    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Hpe));
+    assert!(!report.systems.is_empty(), "systems must be present");
+    assert!(!report.chassis.is_empty(), "chassis must be present");
+
+    let system = &report.systems[0];
+    assert_eq!(system.model.as_deref(), Some("ProLiant DL380a Gen11"));
+
+    // The mock presents the locked-down production state:
+    // UsbBoot=Disabled and iLO VirtualNICEnabled=false.
+    let lockdown = report
+        .lockdown_status
+        .as_ref()
+        .expect("lockdown status must be present for HPE");
+    assert_eq!(lockdown.status, InternalLockdownStatus::Enabled);
+
+    assert!(
+        report
+            .machine_setup_status
+            .as_ref()
+            .is_some_and(|status| !status.diffs.is_empty() || status.is_done),
+        "machine setup status must be present and structurally valid"
+    );
+}

--- a/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
+++ b/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
@@ -1,0 +1,252 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use bmc_vendor::BMCVendor;
+use carbide_utils::arch::CpuArchitecture;
+use mac_address::MacAddress;
+use rpc::machine_discovery::{BlockDevice, CpuInfo, DiscoveryInfo, DmiData, MemoryDevice};
+use serde_json::json;
+
+use crate::{BootOptionKind, Callbacks, hw, redfish};
+
+/// Values are taken from a Redfish dump of a real ProLiant DL380a Gen11
+/// (iLO 6 v1.58, BIOS U58 v2.22) with a BlueField-3 SuperNIC installed.
+pub struct HpeProliantDl380aGen11<'a> {
+    pub bmc_mac_address: MacAddress,
+    pub product_serial_number: Cow<'a, str>,
+    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
+}
+
+const MODEL: &str = "ProLiant DL380a Gen11";
+const SKU: &str = "P54903-B21";
+
+impl HpeProliantDl380aGen11<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: "1",
+                eth_interfaces: Some(vec![
+                    redfish::ethernet_interface::builder(
+                        &redfish::ethernet_interface::manager_resource("1", "1"),
+                    )
+                    .description("Manager Dedicated Network Interface")
+                    .mac_address(self.bmc_mac_address)
+                    .interface_enabled(true)
+                    .build(),
+                ]),
+                host_interfaces: None,
+                firmware_version: Some("iLO 6 v1.58"),
+                oem: Some(redfish::manager::Oem::Hpe),
+            }],
+        }
+    }
+
+    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+        let system_id = "1";
+
+        let eth_interfaces = self
+            .nics
+            .iter()
+            .enumerate()
+            .map(|(index, (_slot, nic))| {
+                let eth_id = format!("DA00000{index}");
+                let resource = redfish::ethernet_interface::system_resource(system_id, &eth_id);
+                redfish::ethernet_interface::builder(&resource)
+                    .mac_address(nic.mac_address)
+                    .interface_enabled(true)
+                    .build()
+            })
+            .collect();
+
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
+                .boot_option_reference(id)
+        };
+        let boot_options = self
+            .nics
+            .iter()
+            .map(|(slot_number, nic)| {
+                (
+                    format!(
+                        "HTTP(IPv4) in Slot {slot_number} Port 1 : Nvidia Network Adapter - {}",
+                        nic.mac_address
+                    ),
+                    BootOptionKind::Network,
+                )
+            })
+            .chain(std::iter::once((
+                "NVMe Drive 1 : Internal NVMe SSD".to_string(),
+                BootOptionKind::Disk,
+            )))
+            .enumerate()
+            .map(|(index, (display_name, kind))| {
+                boot_opt_builder(&format!("Boot{index:04X}"), kind)
+                    .display_name(&display_name)
+                    .build()
+            })
+            .collect::<Vec<_>>();
+
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed(system_id),
+                manufacturer: Some("HPE".into()),
+                model: Some(MODEL.into()),
+                eth_interfaces: Some(eth_interfaces),
+                serial_number: Some(self.product_serial_number.to_string().into()),
+                boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                callbacks: Some(callbacks),
+                chassis: vec![system_id.into()],
+                boot_options: Some(boot_options.into()),
+                bios_mode: redfish::computer_system::BiosMode::Generic,
+                oem: redfish::computer_system::Oem::Generic,
+                log_services: None,
+                storage: None,
+                processors: None,
+                secure_boot_available: true,
+                // Locked-down production state expected by nico: USB boot off,
+                // virtualization on, UEFI HTTP boot available, serial console
+                // redirected to the iLO virtual serial port (the attribute set
+                // libredfish's HPE driver reads and writes).
+                base_bios: Some(
+                    redfish::bios::builder(&redfish::bios::resource(system_id))
+                        .attributes(json!({
+                            "UsbBoot": "Disabled",
+                            "IntelProcVtd": "Enabled",
+                            "Dhcpv4": "Enabled",
+                            "HttpSupport": "Auto",
+                            "EmbeddedSerialPort": "Com2Irq3",
+                            "EMSConsole": "Virtual",
+                            "SerialConsoleBaudRate": "BaudRate115200",
+                            "SerialConsoleEmulation": "Vt100Plus",
+                            "SerialConsolePort": "Virtual",
+                            "UefiSerialDebugLevel": "ErrorsOnly",
+                            "VirtualSerialPort": "Com1Irq4",
+                        }))
+                        .build(),
+                ),
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let chassis_id = "1";
+
+        let network_adapters = self
+            .nics
+            .iter()
+            .map(|(slot, nic)| {
+                redfish::network_adapter::builder_from_nic(
+                    &redfish::network_adapter::chassis_resource(
+                        chassis_id,
+                        &format!("DA00000{slot}"),
+                    ),
+                    nic,
+                )
+                .status(redfish::resource::Status::Ok)
+                .build()
+            })
+            .collect();
+
+        let pcie_devices = self
+            .nics
+            .iter()
+            .map(|(slot, nic)| {
+                let pcie_device_id = format!("mat_{}", slot);
+                redfish::pcie_device::builder_from_nic(
+                    &redfish::pcie_device::chassis_resource(chassis_id, &pcie_device_id),
+                    nic,
+                )
+                .status(redfish::resource::Status::Ok)
+                .build()
+            })
+            .collect();
+
+        redfish::chassis::ChassisConfig {
+            chassis: vec![redfish::chassis::SingleChassisConfig {
+                id: Cow::Borrowed(chassis_id),
+                chassis_type: "RackMount".into(),
+                manufacturer: Some("HPE".into()),
+                model: Some(MODEL.into()),
+                part_number: Some(SKU.into()),
+                serial_number: Some(self.product_serial_number.to_string().into()),
+                network_adapters: Some(network_adapters),
+                pcie_devices: Some(pcie_devices),
+                ..redfish::chassis::SingleChassisConfig::defaults()
+            }],
+        }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: vec![],
+        }
+    }
+
+    pub fn discovery_info(&self) -> DiscoveryInfo {
+        DiscoveryInfo {
+            network_interfaces: self
+                .nics
+                .iter()
+                .map(|(slot, nic)| nic.discovery_info(*slot))
+                .collect(),
+            infiniband_interfaces: vec![],
+            cpu_info: vec![CpuInfo {
+                model: "Intel(R) Xeon(R) Gold 6430 CPU".into(),
+                vendor: "GenuineIntel".into(),
+                sockets: 2,
+                cores: 32,
+                threads: 64,
+            }],
+            block_devices: (0..2)
+                .map(|n| BlockDevice {
+                    model: "HPE NS204i-u Gen11 Boot Controller".into(),
+                    revision: "1.2.14.1004".into(),
+                    serial: format!("FAKESERNUM{n}"),
+                    device_type: "".into(),
+                })
+                .collect(),
+            machine_type: CpuArchitecture::X86_64.to_string(),
+            machine_arch: Some(rpc::utils::cpu_architecture_to_rpc(CpuArchitecture::X86_64)),
+            nvme_devices: vec![],
+            dmi_data: Some(DmiData {
+                board_name: "P54903".into(),
+                board_version: "A1".into(),
+                bios_version: "U58 v2.22".into(),
+                bios_date: "06/19/2024".into(),
+                product_serial: self.product_serial_number.to_string(),
+                board_serial: self.product_serial_number.to_string(),
+                chassis_serial: self.product_serial_number.to_string(),
+                product_name: MODEL.into(),
+                sys_vendor: hw::bmc_vendor_to_udev_dmi(BMCVendor::Hpe).into(),
+            }),
+            dpu_info: None,
+            gpus: vec![],
+            memory_devices: (0..16)
+                .map(|_| MemoryDevice {
+                    size_mb: Some(32768),
+                    mem_type: Some("DDR5".into()),
+                })
+                .collect(),
+            tpm_ek_certificate: None,
+            tpm_description: None,
+            ..Default::default()
+        }
+    }
+}

--- a/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
+++ b/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
@@ -126,6 +126,7 @@ impl HpeProliantDl380aGen11<'_> {
                 // libredfish's HPE driver reads and writes).
                 base_bios: Some(
                     redfish::bios::builder(&redfish::bios::resource(system_id))
+                        .odata_context("/redfish/v1/$metadata#Bios.Bios")
                         .attributes(json!({
                             "UsbBoot": "Disabled",
                             "IntelProcVtd": "Enabled",

--- a/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
+++ b/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
@@ -208,30 +208,36 @@ impl HpeProliantDl380aGen11<'_> {
                 .collect(),
             infiniband_interfaces: vec![],
             cpu_info: vec![CpuInfo {
-                model: "Intel(R) Xeon(R) Gold 6430 CPU".into(),
+                model: "INTEL(R) XEON(R) GOLD 6542Y".into(),
                 vendor: "GenuineIntel".into(),
                 sockets: 2,
-                cores: 32,
-                threads: 64,
+                cores: 24,
+                threads: 48,
             }],
             block_devices: (0..2)
                 .map(|n| BlockDevice {
-                    model: "HPE NS204i-u Gen11 Boot Controller".into(),
-                    revision: "1.2.14.1004".into(),
-                    serial: format!("FAKESERNUM{n}"),
-                    device_type: "".into(),
+                    model: "VO001920KXPTN".into(),
+                    revision: "HPK0".into(),
+                    serial: format!("KNC8N5359I0108R1{}", if n == 0 { "X" } else { "W" }),
+                    device_type: "disk".into(),
                 })
                 .collect(),
             machine_type: CpuArchitecture::X86_64.to_string(),
             machine_arch: Some(rpc::utils::cpu_architecture_to_rpc(CpuArchitecture::X86_64)),
-            nvme_devices: vec![],
+            nvme_devices: (0..2)
+                .map(|n| rpc::machine_discovery::NvmeDevice {
+                    model: "VO001920KXPTN".into(),
+                    firmware_rev: "HPK0".into(),
+                    serial: format!("KNC8N5359I0108R1{}", if n == 0 { "X" } else { "W" }),
+                })
+                .collect(),
             dmi_data: Some(DmiData {
-                board_name: "P54903".into(),
-                board_version: "A1".into(),
-                bios_version: "U58 v2.22".into(),
+                board_name: MODEL.into(),
+                board_version: "".into(),
+                bios_version: "2.22".into(),
                 bios_date: "06/19/2024".into(),
                 product_serial: self.product_serial_number.to_string(),
-                board_serial: self.product_serial_number.to_string(),
+                board_serial: "PYFCA0ARHJM00Z".into(),
                 chassis_serial: self.product_serial_number.to_string(),
                 product_name: MODEL.into(),
                 sys_vendor: hw::bmc_vendor_to_udev_dmi(BMCVendor::Hpe).into(),
@@ -240,7 +246,7 @@ impl HpeProliantDl380aGen11<'_> {
             gpus: vec![],
             memory_devices: (0..16)
                 .map(|_| MemoryDevice {
-                    size_mb: Some(32768),
+                    size_mb: Some(16384),
                     mem_type: Some("DDR5".into()),
                 })
                 .collect(),

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -30,6 +30,9 @@ pub mod bluefield4;
 /// Generic AMI server.
 pub mod generic_ami;
 
+/// Support of HPE ProLiant DL380a Gen11 servers (iLO 6).
+pub mod hpe_proliant_dl380a_gen11;
+
 /// Support of Dell PowerEdge R750 servers.
 pub mod dell_poweredge_r750;
 

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -76,6 +76,8 @@ pub enum HostHardwareType {
     NvidiaDgxH100,
     #[serde(rename = "generic_ami")]
     GenericAmi,
+    #[serde(rename = "hpe_proliant_dl380a_gen11")]
+    HpeProliantDl380aGen11,
     /// A non-GB300 Supermicro-vendor server (no NVIDIA GB300 GPU chassis). Reuses the
     /// generic-server representation but reports a Supermicro vendor; used to assert that
     /// the `is_gb300()` gate keeps such a box classified as generic `Supermicro`.
@@ -97,6 +99,7 @@ impl fmt::Display for HostHardwareType {
             Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
             Self::NvidiaDgxH100 => "NVIDIA DGX H100".fmt(f),
             Self::GenericAmi => "Generic AMI Server".fmt(f),
+            Self::HpeProliantDl380aGen11 => "HPE ProLiant DL380a Gen11".fmt(f),
             Self::GenericSupermicro => "Generic Supermicro Server".fmt(f),
         }
     }
@@ -119,6 +122,7 @@ impl HostHardwareType {
             Self::NvidiaSwitchNd5200Ld => Some(0),
             Self::NvidiaDgxH100 => Some(1),
             Self::GenericAmi => None,
+            Self::HpeProliantDl380aGen11 => None,
             Self::GenericSupermicro => None,
         }
     }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -118,6 +118,7 @@ impl DpuMachineInfo {
             HostHardwareType::DellPowerEdgeR750
             | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::GenericAmi
+            | HostHardwareType::HpeProliantDl380aGen11
             | HostHardwareType::GenericSupermicro => hw::bluefield3::Mode::SuperNIC {
                 nic_mode: self.settings.nic_mode,
             },
@@ -155,6 +156,7 @@ impl DpuMachineInfo {
             HostHardwareType::DellPowerEdgeR750
             | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::GenericAmi
+            | HostHardwareType::HpeProliantDl380aGen11
             | HostHardwareType::GenericSupermicro
             | HostHardwareType::WiwynnGB200Nvl
             | HostHardwareType::LenovoGB300Nvl
@@ -180,6 +182,7 @@ impl DpuMachineInfo {
             HostHardwareType::DellPowerEdgeR750
             | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::GenericAmi
+            | HostHardwareType::HpeProliantDl380aGen11
             | HostHardwareType::GenericSupermicro
             | HostHardwareType::WiwynnGB200Nvl
             | HostHardwareType::LenovoGB300Nvl
@@ -314,6 +317,7 @@ impl HostMachineInfo {
             | HostHardwareType::NvidiaDgxH100
             | HostHardwareType::NvidiaSwitchNd5200Ld
             | HostHardwareType::GenericAmi
+            | HostHardwareType::HpeProliantDl380aGen11
             | HostHardwareType::GenericSupermicro => redfish::oem::State::Other,
         }
     }
@@ -338,6 +342,7 @@ impl HostMachineInfo {
             }
             HostHardwareType::NvidiaDgxH100 => redfish::oem::BmcVendor::Ami,
             HostHardwareType::GenericAmi => redfish::oem::BmcVendor::Ami,
+            HostHardwareType::HpeProliantDl380aGen11 => redfish::oem::BmcVendor::Hpe,
             HostHardwareType::GenericSupermicro => redfish::oem::BmcVendor::Supermicro,
         }
     }
@@ -357,6 +362,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
             HostHardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
             HostHardwareType::GenericAmi => Some("AMI Redfish Server"),
+            HostHardwareType::HpeProliantDl380aGen11 => Some("ProLiant DL380a Gen11"),
             HostHardwareType::GenericSupermicro => Some("Super Server"),
         }
     }
@@ -375,6 +381,7 @@ impl HostMachineInfo {
             HostHardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
             HostHardwareType::NvidiaDgxH100 => "1.11.0",
             HostHardwareType::GenericAmi => "1.17.0",
+            HostHardwareType::HpeProliantDl380aGen11 => "1.13.0",
             HostHardwareType::GenericSupermicro => "1.17.0",
         }
     }
@@ -395,6 +402,9 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().manager_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
+            HostHardwareType::HpeProliantDl380aGen11 => {
+                self.hpe_proliant_dl380a_gen11().manager_config()
+            }
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
                 self.generic_server().manager_config()
             }
@@ -424,6 +434,9 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().system_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
+            HostHardwareType::HpeProliantDl380aGen11 => {
+                self.hpe_proliant_dl380a_gen11().system_config(callbacks)
+            }
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
                 self.generic_server().system_config(callbacks)
             }
@@ -446,6 +459,9 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().chassis_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
+            HostHardwareType::HpeProliantDl380aGen11 => {
+                self.hpe_proliant_dl380a_gen11().chassis_config()
+            }
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
                 self.generic_server().chassis_config()
             }
@@ -472,6 +488,9 @@ impl HostMachineInfo {
                 self.nvidia_switch_nd5200_ld().update_service_config()
             }
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
+            HostHardwareType::HpeProliantDl380aGen11 => {
+                self.hpe_proliant_dl380a_gen11().update_service_config()
+            }
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
                 self.generic_server().update_service_config()
             }
@@ -490,6 +509,9 @@ impl HostMachineInfo {
             HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().discovery_info(),
             HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().discovery_info(),
+            HostHardwareType::HpeProliantDl380aGen11 => {
+                self.hpe_proliant_dl380a_gen11().discovery_info()
+            }
             HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
                 self.generic_server().discovery_info()
             }
@@ -830,6 +852,29 @@ impl HostMachineInfo {
             bmc_mac_address_eth0: next_mac(),
             bmc_mac_address_usb0: next_mac(),
             hgx_bmc_mac_address_usb0: next_mac(),
+        }
+    }
+
+    fn hpe_proliant_dl380a_gen11(
+        &self,
+    ) -> hw::hpe_proliant_dl380a_gen11::HpeProliantDl380aGen11<'_> {
+        let nics = if self.dpus.is_empty() {
+            self.non_dpu_mac_address
+                .iter()
+                .enumerate()
+                .map(|(index, mac_address)| (index + 1, hw::nic::Nic::rooftop(*mac_address)))
+                .collect()
+        } else {
+            self.dpus
+                .iter()
+                .enumerate()
+                .map(|(index, dpu)| (index + 1, dpu.bluefield3().host_nic()))
+                .collect()
+        };
+        hw::hpe_proliant_dl380a_gen11::HpeProliantDl380aGen11 {
+            bmc_mac_address: self.bmc_mac_address,
+            product_serial_number: Cow::Borrowed(&self.serial),
+            nics,
         }
     }
 

--- a/crates/bmc-mock/src/redfish/bios.rs
+++ b/crates/bmc-mock/src/redfish/bios.rs
@@ -53,6 +53,13 @@ impl BiosBuilder {
         self.apply_patch(json!({"Attributes": value}))
     }
 
+    /// libredfish's HPE `Bios` model requires `@odata.context` (real iLOs
+    /// always send it); without it the machine controller's lockdown check
+    /// fails to deserialize the response.
+    pub fn odata_context(self, value: &str) -> Self {
+        self.apply_patch(json!({"@odata.context": value}))
+    }
+
     pub fn build(self) -> serde_json::Value {
         self.value
     }

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -16,7 +16,7 @@
  */
 
 use std::borrow::Cow;
-use std::sync::{Arc, atomic};
+use std::sync::{Arc, Mutex, atomic};
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
@@ -172,7 +172,10 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const ETH_ID: &str = "{ethernet_id}";
     const HOST_IF_ID: &str = "{hostif_id}";
     r.route(&collection().odata_id, get(get_manager_collection))
-        .route(&resource(MGR_ID).odata_id, get(get_manager))
+        .route(
+            &resource(MGR_ID).odata_id,
+            get(get_manager).patch(patch_manager),
+        )
         .route(
             &redfish::ethernet_interface::manager_collection(MGR_ID).odata_id,
             get(get_ethernet_interface_collection),
@@ -249,6 +252,9 @@ pub struct SingleManagerState {
     id: &'static str,
     ipmi_enabled: Arc<atomic::AtomicBool>,
     config: SingleConfig,
+    // PATCHes applied to the manager resource (e.g. HPE lockdown flips
+    // Oem.Hpe.VirtualNICEnabled); merged over the built JSON on GET.
+    overrides: Arc<Mutex<serde_json::Value>>,
 }
 
 impl SingleManagerState {
@@ -257,6 +263,7 @@ impl SingleManagerState {
             id: config.id,
             config: config.clone(),
             ipmi_enabled: Arc::new(false.into()),
+            overrides: Arc::new(Mutex::new(json!({}))),
         }
     }
 }
@@ -311,7 +318,21 @@ async fn get_manager(State(state): State<BmcState>, Path(manager_id): Path<Strin
             &this.config.firmware_version,
         )
         .build()
+        .patch(this.overrides.lock().expect("mutex poisoned").clone())
         .into_ok_response()
+}
+
+async fn patch_manager(
+    State(state): State<BmcState>,
+    Path(manager_id): Path<String>,
+    Json(patch_request): Json<serde_json::Value>,
+) -> Response {
+    let Some(this) = state.manager.find(&manager_id) else {
+        return http::not_found();
+    };
+    let mut overrides = this.overrides.lock().expect("mutex poisoned");
+    *overrides = overrides.clone().patch(patch_request);
+    json!({}).into_ok_response()
 }
 
 async fn get_ethernet_interface_collection(

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -132,6 +132,17 @@ impl ManagerBuilder {
                     }
                 }
             })),
+            // bmc-explorer's HPE lockdown check reads
+            // Oem.Hpe.VirtualNICEnabled; false is the locked-down state.
+            Oem::Hpe => self.apply_patch(json!({
+                "Oem": {
+                    "Hpe": {
+                        "@odata.context": "/redfish/v1/$metadata#HpeiLO.HpeiLO",
+                        "@odata.type": "#HpeiLO.v2_11_0.HpeiLO",
+                        "VirtualNICEnabled": false,
+                    }
+                }
+            })),
         }
     }
 
@@ -192,6 +203,7 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
 #[derive(Clone, Copy)]
 pub enum Oem {
     Dell,
+    Hpe,
 }
 
 impl AsRef<Oem> for Oem {

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -67,7 +67,6 @@ impl BmcVendor {
             BmcVendor::Ami => {
                 format!("{}/SD", resource.odata_id)
             }
-            // iLO uses a lowercase `settings` resource (per the DL380a Gen11 scrape).
             BmcVendor::Hpe => {
                 format!("{}/settings", resource.odata_id)
             }

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -28,6 +28,7 @@ pub enum BmcVendor {
     LiteOn,
     Ami,
     Supermicro,
+    Hpe,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -46,6 +47,7 @@ impl BmcVendor {
             BmcVendor::LiteOn => None,
             BmcVendor::Ami => Some("AMI"),
             BmcVendor::Supermicro => Some("Supermicro"),
+            BmcVendor::Hpe => Some("HPE"),
         }
     }
     // This function creates settings of the resource from the resource
@@ -64,6 +66,10 @@ impl BmcVendor {
             }
             BmcVendor::Ami => {
                 format!("{}/SD", resource.odata_id)
+            }
+            // iLO uses a lowercase `settings` resource (per the DL380a Gen11 scrape).
+            BmcVendor::Hpe => {
+                format!("{}/settings", resource.odata_id)
             }
         }
     }

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -242,6 +242,16 @@ pub async fn nvidia_dgx_vr_bluefield4_dpu_bmc(settings: DpuSettings) -> TestBmcH
     .await
 }
 
+pub async fn hpe_proliant_dl380a_gen11_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        &host_info(HostHardwareType::HpeProliantDl380aGen11),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+        false,
+    ))
+    .await
+}
+
 pub async fn generic_ami_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         &host_info(HostHardwareType::GenericAmi),


### PR DESCRIPTION
This PR adds `HostHardwareType::HpeProliantDl380aGen11` to bmc-mock, the first HPE hardware type. Modeled from a Redfish dump of a real DL380a Gen11 with a BF3 SuperNIC: real identity values (SKU, iLO/BIOS versions, Redfish 1.13.0), the locked-down state nico expects (`UsbBoot=Disabled`, `Oem.Hpe.VirtualNICEnabled=false`), the iLO serial-console BIOS attributes, and discovery info captured from the actual box. 

New exploration test `bmc-explorer/tests/hpe_proliant_dl380a_gen11_explore.rs`: bmc-explorer classifies the mock as HPE, matches the model, and reports lockdown `Enabled`. Full `cargo test -p bmc-mock -p bmc-explorer` green; downstream consumers (machine-a-tron, ssh-console, api-test-helper, site-explorer) still compile.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3132

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

