### PR TITLE
docs: display helm-diff install syntax for helm 3 or 4

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -67,6 +67,10 @@ The following tools must be installed on the machine that you will use to run `s
 The `helmfile` tool requires the `helm-diff` plugin. Install it as follows:
 
 ```bash
+# Helm v4
+helm plugin install https://github.com/databus23/helm-diff --verify=false
+
+# Helm v3
 helm plugin install https://github.com/databus23/helm-diff
 ```
 


### PR DESCRIPTION
This PR shows installation of helm-diff plugin depending on which version of helm being used.  If version 4 then --verify=false and if version 3 no need for switch.

## Related issues
None

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

