### PR TITLE
feat(cli): Support network segment creation from CLI

### DIFF
--- a/crates/admin-cli/src/network_segment/create/args.rs
+++ b/crates/admin-cli/src/network_segment/create/args.rs
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+
+use carbide_uuid::domain::DomainId;
+use carbide_uuid::network::NetworkSegmentId;
+use carbide_uuid::vpc::VpcId;
+use clap::Parser;
+use ipnet::IpNet;
+use rpc::forge;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a tenant network segment with an IPv4 prefix:
+    $ nico-admin-cli --cloud-unsafe-op=my_username network-segment create --name tenant-segment-1 --vpc-id 12345678-1234-5678-90ab-cdef01234567 --prefix 10.0.0.0/24 --gateway 10.0.0.1
+
+Create a dual-stack host in-band segment with a chosen ID:
+    $ nico-admin-cli --cloud-unsafe-op=my_username network-segment create --name host-inband-a --segment-type host-inband --id 12345678-1234-5678-90ab-cdef01234567 --prefix 192.0.2.0/24 --gateway 192.0.2.1 --prefix 2001:db8::/64 --dhcpv6-link-address fe80::1 --subdomain-id 3ea8d9a2-4fe3-4189-97fc-cf9134e31f8f
+
+")]
+pub struct Args {
+    #[clap(long, help = "Network segment name")]
+    pub name: String,
+
+    #[clap(
+        long,
+        value_name = "NetworkSegmentId",
+        help = "Optional network segment ID to use instead of allowing the API server to generate one"
+    )]
+    pub id: Option<NetworkSegmentId>,
+
+    #[clap(
+        long,
+        value_name = "VpcId",
+        help = "Optional VPC ID to attach the new segment to"
+    )]
+    pub vpc_id: Option<VpcId>,
+
+    #[clap(
+        long,
+        value_name = "DomainId",
+        help = "DNS subdomain ID used for DHCP and DNS records on the segment. Required for segments of type host-inband"
+    )]
+    pub subdomain_id: Option<DomainId>,
+
+    #[clap(
+        long,
+        value_name = "MTU",
+        help = "Optional MTU for the segment. Defaults to 9000 for tenant segments and 1500 for other segment types"
+    )]
+    pub mtu: Option<i32>,
+
+    #[clap(
+        long,
+        name = "prefix",
+        value_name = "CIDR-prefix",
+        help = "Network prefix in CIDR notation. Repeat once per address family",
+        action = clap::ArgAction::Append,
+        required = true
+    )]
+    pub prefix: Vec<IpNet>,
+
+    #[clap(
+        long,
+        value_name = "IP-address",
+        help = "IPv4 gateway for the IPv4 prefix"
+    )]
+    pub gateway: Option<IpAddr>,
+
+    #[clap(
+        long,
+        name = "dhcpv6-link-address",
+        value_name = "IPv6-address",
+        help = "DHCPv6 relay link-address for the IPv6 prefix"
+    )]
+    pub dhcpv6_link_address: Option<IpAddr>,
+
+    #[clap(
+        long,
+        default_value_t = 0,
+        value_name = "COUNT",
+        help = "Number of addresses to reserve before dynamic allocation starts"
+    )]
+    pub reserve_first: i32,
+
+    #[clap(
+        long,
+        value_enum,
+        default_value = "tenant",
+        help = "Network segment type"
+    )]
+    pub segment_type: forge::NetworkSegmentType,
+}
+
+impl From<Args> for forge::NetworkSegmentCreationRequest {
+    fn from(args: Args) -> Self {
+        let prefixes = args
+            .prefix
+            .into_iter()
+            .map(|prefix| forge::NetworkPrefix {
+                id: None,
+                prefix: prefix.to_string(),
+                gateway: args.gateway.map(|gw| gw.to_string()),
+                reserve_first: args.reserve_first,
+                free_ip_count: 0,
+                svi_ip: None,
+            })
+            .collect();
+
+        Self {
+            vpc_id: args.vpc_id,
+            name: args.name,
+            subdomain_id: args.subdomain_id,
+            mtu: args.mtu,
+            prefixes,
+            segment_type: args.segment_type as i32,
+            id: args.id,
+        }
+    }
+}

--- a/crates/admin-cli/src/network_segment/create/cmd.rs
+++ b/crates/admin-cli/src/network_segment/create/cmd.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::output::OutputFormat;
+use rpc::forge;
+
+use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::rpc::ApiClient;
+
+pub async fn create(
+    args: Args,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    if args.segment_type == forge::NetworkSegmentType::HostInband && args.subdomain_id.is_none() {
+        return Err(CarbideCliError::GenericError(
+            "host_inband segment require a valid subdomain for working DHCP".to_string(),
+        ));
+    }
+
+    let segment = api_client.0.create_network_segment(args).await?;
+
+    match output_format {
+        OutputFormat::AsciiTable => {
+            println!(
+                "{}",
+                crate::network_segment::show::cmd::convert_network_to_nice_format(
+                    segment, None, api_client,
+                )
+                .await?
+            );
+        }
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&segment)?),
+        _ => println!("{}", serde_yaml::to_string(&segment)?),
+    }
+
+    Ok(())
+}

--- a/crates/admin-cli/src/network_segment/create/mod.rs
+++ b/crates/admin-cli/src/network_segment/create/mod.rs
@@ -15,30 +15,18 @@
  * limitations under the License.
  */
 
-mod attach_vpc;
-mod create;
-mod delete;
-mod show;
+pub mod args;
+pub mod cmd;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowNetworkSegment;
-pub use show::cmd::handle_show;
+pub use args::Args;
 
-#[cfg(test)]
-mod tests;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Network Segment information")]
-    Show(show::Args),
-    #[clap(about = "Attach Network Segment to VPC")]
-    AttachVpc(attach_vpc::Args),
-    #[clap(about = "Delete Network Segment")]
-    Delete(delete::Args),
-    #[clap(about = "Create Network Segment")]
-    Create(create::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        ctx.assert_cloud_unsafe_op_message()?;
+        cmd::create(self, ctx.config.format, &ctx.api_client).await
+    }
 }

--- a/crates/admin-cli/src/network_segment/show/cmd.rs
+++ b/crates/admin-cli/src/network_segment/show/cmd.rs
@@ -48,9 +48,9 @@ fn convert_old_history(
 }
 
 #[allow(deprecated)]
-async fn convert_network_to_nice_format(
+pub async fn convert_network_to_nice_format(
     segment: forgerpc::NetworkSegment,
-    history: Vec<forgerpc::StateHistoryRecord>,
+    history: Option<Vec<forgerpc::StateHistoryRecord>>,
     api_client: &ApiClient,
 ) -> CarbideCliResult<String> {
     let name = segment
@@ -157,28 +157,30 @@ async fn convert_network_to_nice_format(
         }
     }
 
-    writeln!(&mut lines, "STATE HISTORY: (Latest 5 only)")?;
-    if history.is_empty() {
-        writeln!(&mut lines, "\tEMPTY")?;
-    } else {
-        writeln!(
-            &mut lines,
-            "\tState          Version                      Time"
-        )?;
-        writeln!(
-            &mut lines,
-            "\t---------------------------------------------------"
-        )?;
-        for x in history.iter().rev().take(5).rev() {
+    if let Some(history) = history {
+        writeln!(&mut lines, "STATE HISTORY: (Latest 5 only)")?;
+        if history.is_empty() {
+            writeln!(&mut lines, "\tEMPTY")?;
+        } else {
             writeln!(
                 &mut lines,
-                "\t{:<15} {:25} {}",
-                serde_json::from_str::<NetworkState>(&x.state)
-                    .map(|ns| ns.state)
-                    .unwrap_or_else(|_| x.state.clone()),
-                x.version,
-                x.time.unwrap_or_default()
+                "\tState          Version                      Time"
             )?;
+            writeln!(
+                &mut lines,
+                "\t---------------------------------------------------"
+            )?;
+            for x in history.iter().rev().take(5).rev() {
+                writeln!(
+                    &mut lines,
+                    "\t{:<15} {:25} {}",
+                    serde_json::from_str::<NetworkState>(&x.state)
+                        .map(|ns| ns.state)
+                        .unwrap_or_else(|_| x.state.clone()),
+                    x.version,
+                    x.time.unwrap_or_default()
+                )?;
+            }
         }
     }
 
@@ -331,7 +333,7 @@ async fn show_network_information(
     } else {
         println!(
             "{}",
-            convert_network_to_nice_format(segment, history, api_client).await?
+            convert_network_to_nice_format(segment, Some(history), api_client).await?
         );
     }
     Ok(())

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -989,6 +989,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "forge.DeviceCredentialRotationStatus",
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )
+        .type_attribute(
+            ".forge.NetworkSegmentType",
+            "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
+        )
+        .type_attribute(
+            ".forge.VpcVirtualizationType",
+            "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
+        )
         .build_server(true)
         .build_client(true)
         .protoc_arg("--experimental_allow_proto3_optional")


### PR DESCRIPTION
A nice-to-have for zero-dpu: If an environment is bootstrapped without a host-inband network segment defined, it's helpful to be able to create one via the admin CLI rather than having to redo the config file and redeploy.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3141

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

