### PR TITLE
feat(cli): Support VPC creation from CLI

### DIFF
--- a/crates/admin-cli/src/vpc/create/args.rs
+++ b/crates/admin-cli/src/vpc/create/args.rs
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::vpc::VpcId;
+use clap::Parser;
+use rpc::{Metadata, forge};
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a tenant VPC:
+    $ nico-admin-cli --cloud-unsafe-op=my_username vpc create --name tenant-vpc-1 --org-id tenant-org-1
+
+Create a tenant VPC with flat virtualization and a chosen ID:
+    $ nico-admin-cli --cloud-unsafe-op=my_username vpc create --name tenant-vpc-1 --org-id tenant-org-1 --id ad1f9fd5-8438-4407-b259-72fdb7896d42 --virtualization-type flat
+
+")]
+pub struct Args {
+    #[clap(long, help = "Name to give the new VPC")]
+    pub name: String,
+
+    #[clap(long, help = "Discription for the new VPC")]
+    pub description: Option<String>,
+
+    #[clap(
+        long,
+        value_name = "VpcId",
+        help = "Optional VPC ID to use instead of allowing the API server to generate one"
+    )]
+    pub id: Option<VpcId>,
+
+    #[clap(
+        long,
+        help = "Tenant organization ID (Plain text string, used by cloud API)"
+    )]
+    pub org_id: String,
+
+    #[clap(
+        long,
+        value_enum,
+        default_value = "ethernet-virtualizer",
+        help = "Network virtualization type"
+    )]
+    pub virtualization_type: forge::VpcVirtualizationType,
+}
+
+impl From<Args> for forge::VpcCreationRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            tenant_organization_id: args.org_id,
+            tenant_keyset_id: None,
+            network_virtualization_type: Some(args.virtualization_type as _),
+            id: None,
+            metadata: Some(Metadata {
+                name: args.name,
+                description: args.description.unwrap_or_default(),
+                ..Default::default()
+            }),
+            network_security_group_id: None,
+            default_nvlink_logical_partition_id: None,
+            vni: None,
+            routing_profile_type: None,
+        }
+    }
+}

--- a/crates/admin-cli/src/vpc/create/cmd.rs
+++ b/crates/admin-cli/src/vpc/create/cmd.rs
@@ -15,26 +15,29 @@
  * limitations under the License.
  */
 
-mod create;
-mod set_virtualizer;
-mod show;
+use ::rpc::admin_cli::output::OutputFormat;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowVpc;
-pub use show::cmd::show;
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
 
-#[cfg(test)]
-mod tests;
+pub async fn create(
+    args: Args,
+    output_format: OutputFormat,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let vpc = api_client.0.create_vpc(args).await?;
 
-use clap::Parser;
+    match output_format {
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&vpc)?),
+        OutputFormat::AsciiTable => {
+            println!(
+                "{}",
+                crate::vpc::show::cmd::convert_vpc_to_nice_format(&vpc)?
+            );
+        }
+        _ => println!("{}", serde_yaml::to_string(&vpc)?),
+    }
 
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Create VPC")]
-    Create(create::Args),
-    #[clap(about = "Display VPC information")]
-    Show(show::Args),
-    SetVirtualizer(set_virtualizer::Args),
+    Ok(())
 }

--- a/crates/admin-cli/src/vpc/create/mod.rs
+++ b/crates/admin-cli/src/vpc/create/mod.rs
@@ -15,26 +15,18 @@
  * limitations under the License.
  */
 
-mod create;
-mod set_virtualizer;
-mod show;
+pub mod args;
+pub mod cmd;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowVpc;
-pub use show::cmd::show;
+pub use args::Args;
 
-#[cfg(test)]
-mod tests;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Create VPC")]
-    Create(create::Args),
-    #[clap(about = "Display VPC information")]
-    Show(show::Args),
-    SetVirtualizer(set_virtualizer::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        ctx.assert_cloud_unsafe_op_message()?;
+        cmd::create(self, ctx.config.format, &ctx.api_client).await
+    }
 }

--- a/crates/admin-cli/src/vpc/show/cmd.rs
+++ b/crates/admin-cli/src/vpc/show/cmd.rs
@@ -180,7 +180,7 @@ fn convert_vpcs_to_nice_table(vpcs: forgerpc::VpcList) -> Box<Table> {
 }
 
 #[allow(deprecated)]
-fn convert_vpc_to_nice_format(vpc: &forgerpc::Vpc) -> CarbideCliResult<String> {
+pub fn convert_vpc_to_nice_format(vpc: &forgerpc::Vpc) -> CarbideCliResult<String> {
     let width = 25;
     let mut lines = String::new();
     let config = vpc_config(vpc);

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -989,6 +989,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "forge.DeviceCredentialRotationStatus",
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )
+        .type_attribute(
+            ".forge.NetworkSegmentType",
+            "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
+        )
+        .type_attribute(
+            ".forge.VpcVirtualizationType",
+            "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
+        )
         .build_server(true)
         .build_client(true)
         .protoc_arg("--experimental_allow_proto3_optional")


### PR DESCRIPTION
A nice-to-have for zero-dpu: If an environment is bootstrapped without a flat VPC defined, it's helpful to be able to create one via the admin CLI rather than having to redo the config file and redeploy.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3142

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes