### PR TITLE
fix(rest-api): Fix regression with detaching NSG from VPCs

### DIFF
--- a/rest-api/api/pkg/api/handler/vpc.go
+++ b/rest-api/api/pkg/api/handler/vpc.go
@@ -754,13 +754,9 @@ func (uvh UpdateVPCHandler) Handle(c echo.Context) error {
 
 		clearInput := cdbm.VpcClearInput{VpcID: vpc.ID}
 		shouldClear := false
-		// If this request is attempting to clear the OS for the instance, set it.
-		if apiRequest.NetworkSecurityGroupID != nil && *apiRequest.NetworkSecurityGroupID == "" {
-			clearInput.NetworkSecurityGroupID = true
-			shouldClear = true
-		}
 
-		// If this request is attempting to clear NSG for the VPC, set it.
+		// NSG updates clear propagation details so users do not see stale status.
+		// An empty ID also clears the VPC association itself.
 		if apiRequest.NetworkSecurityGroupID != nil {
 			if *apiRequest.NetworkSecurityGroupID == "" {
 				clearInput.NetworkSecurityGroupID = true

--- a/rest-api/api/pkg/api/handler/vpc_test.go
+++ b/rest-api/api/pkg/api/handler/vpc_test.go
@@ -1255,6 +1255,14 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 	nsgTenant2Site1 := testBuildNetworkSecurityGroup(t, dbSession, "test-nsg-3", tn2, st, cdbm.NetworkSecurityGroupStatusReady)
 	assert.NotNil(t, nsgTenant2Site1)
 
+	vpcWithNSG := testVPCBuildVPC(t, dbSession, "test-vpc-with-nsg", ip, tn, st, cutil.GetPtr(cdbm.VpcEthernetVirtualizer), nil, map[string]string{"zone": "west7"}, cdbm.VpcStatusReady, tnu)
+	assert.NotNil(t, vpcWithNSG)
+	vpcWithNSG.NetworkSecurityGroupID = cutil.GetPtr(nsgTenant1Site1.ID)
+	testUpdateVPC(t, dbSession, vpcWithNSG)
+
+	vpcForNSGSet := testVPCBuildVPC(t, dbSession, "test-vpc-set-nsg", ip, tn, st, cutil.GetPtr(cdbm.VpcEthernetVirtualizer), nil, map[string]string{"zone": "west8"}, cdbm.VpcStatusReady, tnu)
+	assert.NotNil(t, vpcForNSGSet)
+
 	e := echo.New()
 	cfg := common.GetTestConfig()
 	tc := &tmocks.Client{}
@@ -1298,12 +1306,15 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 	tst.Mock.On("TerminateWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	tests := []struct {
-		name                         string
-		fields                       fields
-		args                         args
-		wantErr                      bool
-		verifyChildSpanner           bool
-		expectedNVLinkPartitionValue *string
+		name                              string
+		fields                            fields
+		args                              args
+		wantErr                           bool
+		verifyChildSpanner                bool
+		expectedNVLinkPartitionValue      *string
+		expectNVLinkPartitionNil          bool
+		expectedNetworkSecurityGroupValue *string
+		expectNetworkSecurityGroupNil     bool
 	}{
 		{
 			name: "test VPC update success",
@@ -1329,6 +1340,27 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			wantErr:            false,
 			verifyChildSpanner: true,
+		},
+		{
+			name: "test VPC update to set NSG - success",
+			fields: fields{
+				dbSession: dbSession,
+				tc:        tc,
+				cfg:       cfg,
+			},
+			args: args{
+				reqData: &model.APIVpcUpdateRequest{
+					NetworkSecurityGroupID: &nsgTenant1Site1.ID,
+				},
+				reqVPCID: vpcForNSGSet.ID.String(),
+				reqVPC:   vpcForNSGSet,
+				reqOrg:   tnOrg,
+				reqUser:  tnu,
+				respCode: http.StatusOK,
+			},
+			wantErr:                           false,
+			verifyChildSpanner:                true,
+			expectedNetworkSecurityGroupValue: &nsgTenant1Site1.ID,
 		},
 		{
 			name: "test VPC update NSG with bad tenant - fail",
@@ -1414,21 +1446,17 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 			},
 			args: args{
 				reqData: &model.APIVpcUpdateRequest{
-					Name:                   cutil.GetPtr(uuid.NewString()),
-					Description:            cutil.GetPtr("Test VPC Description"),
 					NetworkSecurityGroupID: cutil.GetPtr(""),
-					Labels: map[string]string{
-						"zone": "westnew",
-					},
 				},
-				reqVPCID: vpc.ID.String(),
-				reqVPC:   vpc,
+				reqVPCID: vpcWithNSG.ID.String(),
+				reqVPC:   vpcWithNSG,
 				reqOrg:   tnOrg,
 				reqUser:  tnu,
 				respCode: http.StatusOK,
 			},
-			wantErr:            false,
-			verifyChildSpanner: true,
+			wantErr:                       false,
+			verifyChildSpanner:            true,
+			expectNetworkSecurityGroupNil: true,
 		},
 
 		{
@@ -1601,8 +1629,8 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 				reqUser:  tnu,
 				respCode: http.StatusOK,
 			},
-			wantErr:                      false,
-			expectedNVLinkPartitionValue: cutil.GetPtr(""),
+			wantErr:                  false,
+			expectNVLinkPartitionNil: true,
 		},
 		{
 			name: "test VPC update to set NVLink Logical Partition ID after clearing - success",
@@ -1676,8 +1704,13 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 				t.Fatal(serr)
 			}
 
-			assert.Equal(t, rst.Name, *tt.args.reqData.Name)
-			assert.Equal(t, *rst.Description, *tt.args.reqData.Description)
+			if tt.args.reqData.Name != nil {
+				assert.Equal(t, *tt.args.reqData.Name, rst.Name)
+			}
+			if tt.args.reqData.Description != nil {
+				require.NotNil(t, rst.Description)
+				assert.Equal(t, *tt.args.reqData.Description, *rst.Description)
+			}
 			assert.NotEqual(t, rst.Updated.String(), tt.args.reqVPC.Updated.String())
 
 			if tt.args.reqData.NVLinkLogicalPartitionID != nil {
@@ -1692,8 +1725,22 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 				assert.Equal(t, len(rst.Labels), len(tt.args.reqData.Labels))
 			}
 
-			if tt.expectedNVLinkPartitionValue != nil {
-				var lastUpdateVPCReq *cwssaws.VpcUpdateRequest
+			if tt.args.reqData.NetworkSecurityGroupID != nil {
+				persistedVpc, err := cdbm.NewVpcDAO(tt.fields.dbSession).GetByID(ctx, nil, uuid.MustParse(tt.args.reqVPCID), nil)
+				require.NoError(t, err)
+				if *tt.args.reqData.NetworkSecurityGroupID == "" {
+					assert.Nil(t, rst.NetworkSecurityGroupID, "Failed to clear VPC NSG ID in response")
+					assert.Nil(t, persistedVpc.NetworkSecurityGroupID, "Failed to clear persisted VPC NSG ID")
+				} else {
+					require.NotNil(t, rst.NetworkSecurityGroupID)
+					require.NotNil(t, persistedVpc.NetworkSecurityGroupID)
+					assert.Equal(t, *tt.args.reqData.NetworkSecurityGroupID, *rst.NetworkSecurityGroupID)
+					assert.Equal(t, *tt.args.reqData.NetworkSecurityGroupID, *persistedVpc.NetworkSecurityGroupID)
+				}
+			}
+
+			var lastUpdateVPCReq *cwssaws.VpcUpdateRequest
+			if tt.expectedNVLinkPartitionValue != nil || tt.expectNVLinkPartitionNil || tt.expectedNetworkSecurityGroupValue != nil || tt.expectNetworkSecurityGroupNil {
 				for i := len(tsc.Mock.Calls) - 1; i >= 0; i-- {
 					call := tsc.Mock.Calls[i]
 					if call.Method == "ExecuteWorkflow" && len(call.Arguments) >= 4 {
@@ -1704,8 +1751,19 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 					}
 				}
 				require.NotNil(t, lastUpdateVPCReq, "UpdateVPC workflow should have been called")
+			}
+
+			if tt.expectNVLinkPartitionNil {
+				assert.Nil(t, lastUpdateVPCReq.DefaultNvlinkLogicalPartitionId, "DefaultNvlinkLogicalPartitionId should be nil in workflow request")
+			} else if tt.expectedNVLinkPartitionValue != nil {
 				require.NotNil(t, lastUpdateVPCReq.DefaultNvlinkLogicalPartitionId, "DefaultNvlinkLogicalPartitionId should be set in workflow request")
 				assert.Equal(t, *tt.expectedNVLinkPartitionValue, lastUpdateVPCReq.DefaultNvlinkLogicalPartitionId.Value)
+			}
+			if tt.expectNetworkSecurityGroupNil {
+				assert.Nil(t, lastUpdateVPCReq.NetworkSecurityGroupId, "NetworkSecurityGroupId should be nil in workflow request")
+			} else if tt.expectedNetworkSecurityGroupValue != nil {
+				require.NotNil(t, lastUpdateVPCReq.NetworkSecurityGroupId, "NetworkSecurityGroupId should be set in workflow request")
+				assert.Equal(t, *tt.expectedNetworkSecurityGroupValue, *lastUpdateVPCReq.NetworkSecurityGroupId)
 			}
 
 			if tt.verifyChildSpanner {

--- a/rest-api/api/pkg/api/model/vpc.go
+++ b/rest-api/api/pkg/api/model/vpc.go
@@ -238,34 +238,19 @@ func (asur APIVpcUpdateRequest) Validate() error {
 // sending the post-merge state matches the pre-existing handler
 // behaviour and keeps unchanged fields populated.
 //
-// `*string` and `*NVLinkLogicalPartitionId` overrides are applied for
-// `NetworkSecurityGroupID` and `NVLinkLogicalPartitionID` so the
-// API-level distinction between "not provided" (nil) and "explicitly
-// clear" (non-nil pointer to empty string) survives onto the wire:
-//   - nil  -> use the entity-derived value (post-merge DB state).
-//   - &""  -> send the empty value through, so the Site sees a detach.
-//   - &"x" -> send the (already-validated) DB value through; the entity
-//     is the source of truth so any normalisation done at persist
-//     time is preserved.
+// API-level clear intent is represented by the handler clearing the
+// persisted entity before this is called. That keeps the Site/Core wire
+// contract tied to persisted state: cleared associations are omitted
+// instead of serialized as invalid empty IDs, and non-empty updates come
+// from the validated DB value.
 func (asur APIVpcUpdateRequest) ToProto(vpc *cdbm.Vpc) *cwssaws.VpcUpdateRequest {
 	vpcProto := vpc.ToProto()
-	req := &cwssaws.VpcUpdateRequest{
+	return &cwssaws.VpcUpdateRequest{
 		Id:                              vpcProto.Id,
 		NetworkSecurityGroupId:          vpcProto.NetworkSecurityGroupId,
 		DefaultNvlinkLogicalPartitionId: vpcProto.DefaultNvlinkLogicalPartitionId,
 		Metadata:                        vpcProto.Metadata,
 	}
-	if asur.NetworkSecurityGroupID != nil {
-		req.NetworkSecurityGroupId = asur.NetworkSecurityGroupID
-	}
-	if asur.NVLinkLogicalPartitionID != nil {
-		if *asur.NVLinkLogicalPartitionID == "" {
-			req.DefaultNvlinkLogicalPartitionId = &cwssaws.NVLinkLogicalPartitionId{Value: ""}
-		} else if vpc.NVLinkLogicalPartitionID != nil {
-			req.DefaultNvlinkLogicalPartitionId = &cwssaws.NVLinkLogicalPartitionId{Value: vpc.NVLinkLogicalPartitionID.String()}
-		}
-	}
-	return req
 }
 
 // APIVpcVirtualizationUpdateRequest captures the request data for updating virtualization type for a give VPC

--- a/rest-api/api/pkg/api/model/vpc_test.go
+++ b/rest-api/api/pkg/api/model/vpc_test.go
@@ -649,28 +649,26 @@ func TestAPIVpcUpdateRequest_ToProto(t *testing.T) {
 		assert.Equal(t, "nsg-1", *got.NetworkSecurityGroupId)
 	})
 
-	t.Run("preserves explicit NSG detach (request nil-vs-empty distinction)", func(t *testing.T) {
+	t.Run("serializes cleared NSG as omitted field", func(t *testing.T) {
 		// Simulates the handler path: handler cleared the DB row, so
-		// vpc.NetworkSecurityGroupID is now nil, but the API request
-		// carried &"" — the wire must reflect the detach intent.
+		// vpc.NetworkSecurityGroupID is now nil. Core interprets an
+		// omitted field as clear; a present empty string is invalid.
 		vpc := &cdbm.Vpc{ID: id, Name: "vpc-a", NetworkSecurityGroupID: nil}
 		got := APIVpcUpdateRequest{NetworkSecurityGroupID: &empty}.ToProto(vpc)
-		require.NotNil(t, got.NetworkSecurityGroupId)
-		assert.Equal(t, "", *got.NetworkSecurityGroupId)
+		assert.Nil(t, got.NetworkSecurityGroupId)
 	})
 
-	t.Run("API-request NSG overrides the entity-derived value", func(t *testing.T) {
+	t.Run("uses entity NSG rather than raw API request value", func(t *testing.T) {
 		vpc := &cdbm.Vpc{ID: id, Name: "vpc-a", NetworkSecurityGroupID: &nsg}
 		got := APIVpcUpdateRequest{NetworkSecurityGroupID: &other}.ToProto(vpc)
 		require.NotNil(t, got.NetworkSecurityGroupId)
-		assert.Equal(t, "nsg-other", *got.NetworkSecurityGroupId)
+		assert.Equal(t, "nsg-1", *got.NetworkSecurityGroupId)
 	})
 
-	t.Run("explicit NVLink detach sends empty value on the wire", func(t *testing.T) {
+	t.Run("serializes cleared NVLink default partition as omitted field", func(t *testing.T) {
 		vpc := &cdbm.Vpc{ID: id, Name: "vpc-a", NVLinkLogicalPartitionID: nil}
 		got := APIVpcUpdateRequest{NVLinkLogicalPartitionID: &empty}.ToProto(vpc)
-		require.NotNil(t, got.DefaultNvlinkLogicalPartitionId)
-		assert.Equal(t, "", got.DefaultNvlinkLogicalPartitionId.Value)
+		assert.Nil(t, got.DefaultNvlinkLogicalPartitionId)
 	})
 
 	t.Run("NVLink override sends the entity-resolved partition ID", func(t *testing.T) {

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -1443,6 +1443,7 @@ func TestVpcSQLDAO_ClearFromParams(t *testing.T) {
 				Description:                            tt.args.description,
 				ControllerVpcID:                        tt.args.controllerVpcID,
 				Labels:                                 tt.args.labels,
+				NetworkSecurityGroupID:                 tt.args.networkSecuritygroupID,
 				NetworkSecurityGroupPropagationDetails: tt.args.networkSecurityGroupPropagationDetails,
 			}
 
@@ -1470,6 +1471,7 @@ func TestVpcSQLDAO_ClearFromParams(t *testing.T) {
 			}
 
 			if tt.args.networkSecuritygroupID {
+				assert.Nil(t, got.NetworkSecurityGroupID)
 				assert.Nil(t, got.NetworkSecurityGroup)
 			}
 		})

--- a/rest-api/sdk/standard/api_host_firmware_config.go
+++ b/rest-api/sdk/standard/api_host_firmware_config.go
@@ -44,9 +44,6 @@ func (r ApiCreateOrUpdateHostFirmwareConfigRequest) Execute() (*HostFirmwareConf
 /*
 CreateOrUpdateHostFirmwareConfig Create or Update Host Firmware Config
 
-**WARNING:** As of the 2.0 release, NICo core will store the config data sent by
-this request, but will not yet rely on it to determine firmware installed on host.
-
 Create or update host firmware config for the org/site. The target Site
 is specified by `siteId` in the request body.
 

--- a/rest-api/sdk/standard/client.go
+++ b/rest-api/sdk/standard/client.go
@@ -555,15 +555,6 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
-	if r, ok := v.(*io.Reader); ok {
-		*r = bytes.NewReader(b)
-		return nil
-	}
-	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
-	if p, ok := v.(*[]byte); ok {
-		*p = b
-		return nil
-	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/rest-api/sdk/standard/model_operating_system.go
+++ b/rest-api/sdk/standard/model_operating_system.go
@@ -53,7 +53,7 @@ type OperatingSystem struct {
 	IpxeScript NullableString `json:"ipxeScript,omitempty"`
 	// User data for the Operating System
 	UserData NullableString `json:"userData,omitempty"`
-	// Specified when the Operating System is cloud-init based
+	// Whether the Operating System is cloud-init based; true if there is non-empty `userData`, false otherwise.
 	IsCloudInit *bool `json:"isCloudInit,omitempty"`
 	// Indicates whether the Phone Home service should be enabled or disabled for Operating System
 	PhoneHomeEnabled *bool `json:"phoneHomeEnabled,omitempty"`

--- a/rest-api/sdk/standard/model_operating_system_create_request.go
+++ b/rest-api/sdk/standard/model_operating_system_create_request.go
@@ -56,7 +56,8 @@ type OperatingSystemCreateRequest struct {
 	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
 	// User data for the Operating System
 	UserData NullableString `json:"userData,omitempty"`
-	// Specified when the Operating System is cloud-init based
+	// Deprecated and ignored: whether the Operating System is cloud-init based. Value now derived from `userData`.
+	// Deprecated
 	IsCloudInit *bool `json:"isCloudInit,omitempty"`
 	// Indicates if the user data can be overridden at Instance creation time
 	AllowOverride *bool `json:"allowOverride,omitempty"`
@@ -704,6 +705,7 @@ func (o *OperatingSystemCreateRequest) UnsetUserData() {
 }
 
 // GetIsCloudInit returns the IsCloudInit field value if set, zero value otherwise.
+// Deprecated
 func (o *OperatingSystemCreateRequest) GetIsCloudInit() bool {
 	if o == nil || IsNil(o.IsCloudInit) {
 		var ret bool
@@ -714,6 +716,7 @@ func (o *OperatingSystemCreateRequest) GetIsCloudInit() bool {
 
 // GetIsCloudInitOk returns a tuple with the IsCloudInit field value if set, nil otherwise
 // and a boolean to check if the value has been set.
+// Deprecated
 func (o *OperatingSystemCreateRequest) GetIsCloudInitOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsCloudInit) {
 		return nil, false
@@ -731,6 +734,7 @@ func (o *OperatingSystemCreateRequest) HasIsCloudInit() bool {
 }
 
 // SetIsCloudInit gets a reference to the given bool and assigns it to the IsCloudInit field.
+// Deprecated
 func (o *OperatingSystemCreateRequest) SetIsCloudInit(v bool) {
 	o.IsCloudInit = &v
 }

--- a/rest-api/sdk/standard/model_operating_system_update_request.go
+++ b/rest-api/sdk/standard/model_operating_system_update_request.go
@@ -46,7 +46,8 @@ type OperatingSystemUpdateRequest struct {
 	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
 	// User data for the Operating System
 	UserData NullableString `json:"userData,omitempty"`
-	// Specified when the Operating System is cloud-init based
+	// Deprecated and ignored: whether the Operating System is cloud-init based. Value now derived from `userData`.
+	// Deprecated
 	IsCloudInit NullableBool `json:"isCloudInit,omitempty"`
 	// Indicates if the user data can be overridden at Instance creation time
 	AllowOverride NullableBool `json:"allowOverride,omitempty"`
@@ -590,6 +591,7 @@ func (o *OperatingSystemUpdateRequest) UnsetUserData() {
 }
 
 // GetIsCloudInit returns the IsCloudInit field value if set, zero value otherwise (both if not set or set to explicit null).
+// Deprecated
 func (o *OperatingSystemUpdateRequest) GetIsCloudInit() bool {
 	if o == nil || IsNil(o.IsCloudInit.Get()) {
 		var ret bool
@@ -601,6 +603,7 @@ func (o *OperatingSystemUpdateRequest) GetIsCloudInit() bool {
 // GetIsCloudInitOk returns a tuple with the IsCloudInit field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
+// Deprecated
 func (o *OperatingSystemUpdateRequest) GetIsCloudInitOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
@@ -618,6 +621,7 @@ func (o *OperatingSystemUpdateRequest) HasIsCloudInit() bool {
 }
 
 // SetIsCloudInit gets a reference to the given NullableBool and assigns it to the IsCloudInit field.
+// Deprecated
 func (o *OperatingSystemUpdateRequest) SetIsCloudInit(v bool) {
 	o.IsCloudInit.Set(&v)
 }


### PR DESCRIPTION
Recent refactors introduced a regression that prevents NSGs from being detached from VPCs.

This PR fixes that and also does the same for nvlink partition ID. (NOTE: there doesn't seem to be actual support in the Rust back-end for changing the nvlink partition ID, but the REST code should be corrected, regardless).

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

