### PR TITLE
feat(rest-api): add iPXE template + templated-OS data model & proto

### DIFF
--- a/rest-api/db/pkg/db/model/ipxetemplate.go
+++ b/rest-api/db/pkg/db/model/ipxetemplate.go
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+const (
+	// IpxeTemplateRelationName is the relation name for the IpxeTemplate model
+	IpxeTemplateRelationName = "IpxeTemplate"
+	// IpxeTemplateOrderByCreated is the field name for ordering by created timestamp
+	IpxeTemplateOrderByCreated = "created"
+	// ipxeTemplateOrderByUpdated is the field name for ordering by updated timestamp
+	ipxeTemplateOrderByUpdated = "updated"
+	// IpxeTemplateOrderByName is the field name for ordering by name
+	IpxeTemplateOrderByName = "name"
+	// IpxeTemplateOrderByDefault is the default field for ordering
+	IpxeTemplateOrderByDefault = IpxeTemplateOrderByName
+
+	// IpxeTemplateScopeInternal represents an internal-only template
+	IpxeTemplateScopeInternal = "Internal"
+	// IpxeTemplateScopePublic represents a public template
+	IpxeTemplateScopePublic = "Public"
+)
+
+var (
+	// IpxeTemplateOrderByFields is a list of valid order by fields for the IpxeTemplate model
+	IpxeTemplateOrderByFields = []string{IpxeTemplateOrderByCreated, ipxeTemplateOrderByUpdated, IpxeTemplateOrderByName}
+	// IpxeTemplateRelatedEntities is a list of valid relation by fields for the IpxeTemplate model.
+	// Per-site availability is tracked via IpxeTemplateSiteAssociation, not via a direct site relation.
+	IpxeTemplateRelatedEntities = map[string]bool{}
+)
+
+// IpxeTemplate represents an iPXE script template propagated from nico-core.
+// The primary key `ID` is the template UUID assigned by core and is consistent across
+// REST and core. Per-site availability is tracked via IpxeTemplateSiteAssociation rows.
+type IpxeTemplate struct {
+	bun.BaseModel `bun:"table:ipxe_template,alias:ipxet"`
+
+	ID                uuid.UUID `bun:"id,pk,type:uuid"`
+	Name              string    `bun:"name,notnull,unique"`
+	Template          string    `bun:"template,notnull,default:''"`
+	RequiredParams    []string  `bun:"required_params,type:text[],default:'{}'"`
+	ReservedParams    []string  `bun:"reserved_params,type:text[],default:'{}'"`
+	RequiredArtifacts []string  `bun:"required_artifacts,type:text[],default:'{}'"`
+	Scope             string    `bun:"scope,notnull"`
+	Created           time.Time `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated           time.Time `bun:"updated,nullzero,notnull,default:current_timestamp"`
+}
+
+// IpxeTemplateCreateInput are input parameters for the Create method.
+// `ID` must be supplied (it is the stable template UUID from core).
+type IpxeTemplateCreateInput struct {
+	ID                uuid.UUID
+	Name              string
+	Template          string
+	RequiredParams    []string
+	ReservedParams    []string
+	RequiredArtifacts []string
+	Scope             string
+}
+
+// IpxeTemplateUpdateInput are input parameters for the Update method. All fields
+// except IpxeTemplateID are optional; only non-nil fields are written, matching
+// the partial-update convention used by the other model DAOs.
+type IpxeTemplateUpdateInput struct {
+	IpxeTemplateID    uuid.UUID
+	Name              *string
+	Template          *string
+	RequiredParams    *[]string
+	ReservedParams    *[]string
+	RequiredArtifacts *[]string
+	Scope             *string
+}
+
+// IpxeTemplateFilterInput are input parameters for the filter/GetAll method.
+// Note: only `Public`-scoped templates are ever propagated into REST (see the
+// workflow activity `UpdateIpxeTemplatesInDB`), so there is no scope filter.
+//
+// IDs filters on the template's primary key (which equals core's TemplateID).
+// Names filters on the unique template name.
+type IpxeTemplateFilterInput struct {
+	IDs   []uuid.UUID
+	Names []string
+}
+
+var _ bun.BeforeAppendModelHook = (*IpxeTemplate)(nil)
+
+// BeforeAppendModel is a hook called before the model is appended to the query
+func (it *IpxeTemplate) BeforeAppendModel(ctx context.Context, query bun.Query) error {
+	switch query.(type) {
+	case *bun.InsertQuery:
+		it.Created = db.GetCurTime()
+		it.Updated = db.GetCurTime()
+	case *bun.UpdateQuery:
+		it.Updated = db.GetCurTime()
+	}
+	return nil
+}
+
+// IpxeTemplateDAO is an interface for interacting with the IpxeTemplate model
+type IpxeTemplateDAO interface {
+	// Create inserts a new iPXE template row
+	Create(ctx context.Context, tx *db.Tx, input IpxeTemplateCreateInput) (*IpxeTemplate, error)
+	// Update updates an existing iPXE template row
+	Update(ctx context.Context, tx *db.Tx, input IpxeTemplateUpdateInput) (*IpxeTemplate, error)
+	// Delete removes an iPXE template row by ID
+	Delete(ctx context.Context, tx *db.Tx, id uuid.UUID) error
+	// GetAll returns all rows matching the filter and page inputs
+	GetAll(ctx context.Context, tx *db.Tx, filter IpxeTemplateFilterInput, page paginator.PageInput) ([]IpxeTemplate, int, error)
+	// Get returns the row for the specified ID (which is the core template UUID)
+	Get(ctx context.Context, tx *db.Tx, id uuid.UUID) (*IpxeTemplate, error)
+}
+
+// IpxeTemplateSQLDAO is an implementation of the IpxeTemplateDAO interface
+type IpxeTemplateSQLDAO struct {
+	dbSession *db.Session
+	IpxeTemplateDAO
+	tracerSpan *stracer.TracerSpan
+}
+
+// Create inserts a new IpxeTemplate from the given parameters
+func (itd IpxeTemplateSQLDAO) Create(ctx context.Context, tx *db.Tx, input IpxeTemplateCreateInput) (*IpxeTemplate, error) {
+	ctx, span := itd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateDAO.Create")
+	if span != nil {
+		defer span.End()
+	}
+
+	it := &IpxeTemplate{
+		ID:                input.ID,
+		Name:              input.Name,
+		Template:          input.Template,
+		RequiredParams:    input.RequiredParams,
+		ReservedParams:    input.ReservedParams,
+		RequiredArtifacts: input.RequiredArtifacts,
+		Scope:             input.Scope,
+	}
+
+	_, err := db.GetIDB(tx, itd.dbSession).NewInsert().Model(it).Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return itd.Get(ctx, tx, it.ID)
+}
+
+// Get returns an IpxeTemplate by ID
+// Returns db.ErrDoesNotExist if the record is not found
+func (itd IpxeTemplateSQLDAO) Get(ctx context.Context, tx *db.Tx, id uuid.UUID) (*IpxeTemplate, error) {
+	ctx, span := itd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateDAO.Get")
+	if span != nil {
+		defer span.End()
+		itd.tracerSpan.SetAttribute(span, "id", id)
+	}
+
+	it := &IpxeTemplate{}
+
+	err := db.GetIDB(tx, itd.dbSession).NewSelect().Model(it).Where("ipxet.id = ?", id).Scan(ctx)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, db.ErrDoesNotExist
+		}
+		return nil, err
+	}
+
+	return it, nil
+}
+
+// setQueryWithFilter populates the lookup query based on the specified filter
+func (itd IpxeTemplateSQLDAO) setQueryWithFilter(filter IpxeTemplateFilterInput, query *bun.SelectQuery, span *stracer.CurrentContextSpan) (*bun.SelectQuery, error) {
+	if len(filter.IDs) > 0 {
+		query = query.Where("ipxet.id IN (?)", bun.In(filter.IDs))
+		if span != nil {
+			itd.tracerSpan.SetAttribute(span, "ids", filter.IDs)
+		}
+	}
+
+	if len(filter.Names) > 0 {
+		query = query.Where("ipxet.name IN (?)", bun.In(filter.Names))
+		if span != nil {
+			itd.tracerSpan.SetAttribute(span, "names", filter.Names)
+		}
+	}
+
+	return query, nil
+}
+
+// GetAll returns all IpxeTemplates with optional filters
+// If orderBy is nil, records are ordered by IpxeTemplateOrderByDefault in ascending order
+func (itd IpxeTemplateSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter IpxeTemplateFilterInput, page paginator.PageInput) ([]IpxeTemplate, int, error) {
+	ctx, span := itd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateDAO.GetAll")
+	if span != nil {
+		defer span.End()
+	}
+
+	templates := []IpxeTemplate{}
+
+	if filter.IDs != nil && len(filter.IDs) == 0 {
+		return templates, 0, nil
+	}
+
+	query := db.GetIDB(tx, itd.dbSession).NewSelect().Model(&templates)
+
+	query, err := itd.setQueryWithFilter(filter, query, span)
+	if err != nil {
+		return templates, 0, err
+	}
+
+	if page.OrderBy == nil {
+		page.OrderBy = paginator.NewDefaultOrderBy(IpxeTemplateOrderByDefault)
+	}
+
+	pager, err := paginator.NewPaginator(ctx, query, page.Offset, page.Limit, page.OrderBy, IpxeTemplateOrderByFields)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = pager.Query.Limit(pager.Limit).Offset(pager.Offset).Scan(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return templates, pager.Total, nil
+}
+
+// Update updates the specified (non-nil) fields of an existing IpxeTemplate.
+func (itd IpxeTemplateSQLDAO) Update(ctx context.Context, tx *db.Tx, input IpxeTemplateUpdateInput) (*IpxeTemplate, error) {
+	ctx, span := itd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateDAO.Update")
+	if span != nil {
+		defer span.End()
+		itd.tracerSpan.SetAttribute(span, "id", input.IpxeTemplateID)
+	}
+
+	it := &IpxeTemplate{ID: input.IpxeTemplateID}
+	updatedFields := []string{}
+
+	if input.Name != nil {
+		it.Name = *input.Name
+		updatedFields = append(updatedFields, "name")
+	}
+	if input.Template != nil {
+		it.Template = *input.Template
+		updatedFields = append(updatedFields, "template")
+	}
+	if input.RequiredParams != nil {
+		it.RequiredParams = *input.RequiredParams
+		updatedFields = append(updatedFields, "required_params")
+	}
+	if input.ReservedParams != nil {
+		it.ReservedParams = *input.ReservedParams
+		updatedFields = append(updatedFields, "reserved_params")
+	}
+	if input.RequiredArtifacts != nil {
+		it.RequiredArtifacts = *input.RequiredArtifacts
+		updatedFields = append(updatedFields, "required_artifacts")
+	}
+	if input.Scope != nil {
+		it.Scope = *input.Scope
+		updatedFields = append(updatedFields, "scope")
+	}
+
+	if len(updatedFields) > 0 {
+		updatedFields = append(updatedFields, "updated")
+		if _, err := db.GetIDB(tx, itd.dbSession).NewUpdate().Model(it).Column(updatedFields...).Where("ipxet.id = ?", input.IpxeTemplateID).Exec(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return itd.Get(ctx, tx, it.ID)
+}
+
+// Delete removes an IpxeTemplate by ID
+func (itd IpxeTemplateSQLDAO) Delete(ctx context.Context, tx *db.Tx, id uuid.UUID) error {
+	ctx, span := itd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateDAO.Delete")
+	if span != nil {
+		defer span.End()
+		itd.tracerSpan.SetAttribute(span, "id", id)
+	}
+
+	it := &IpxeTemplate{ID: id}
+
+	_, err := db.GetIDB(tx, itd.dbSession).NewDelete().Model(it).Where("id = ?", id).Exec(ctx)
+	return err
+}
+
+// NewIpxeTemplateDAO returns a new IpxeTemplateDAO
+func NewIpxeTemplateDAO(dbSession *db.Session) IpxeTemplateDAO {
+	return &IpxeTemplateSQLDAO{
+		dbSession:  dbSession,
+		tracerSpan: stracer.NewTracerSpan(),
+	}
+}

--- a/rest-api/db/pkg/db/model/ipxetemplate.go
+++ b/rest-api/db/pkg/db/model/ipxetemplate.go
@@ -87,11 +87,11 @@ type IpxeTemplateUpdateInput struct {
 // Note: only `Public`-scoped templates are ever propagated into REST (see the
 // workflow activity `UpdateIpxeTemplatesInDB`), so there is no scope filter.
 //
-// IDs filters on the template's primary key (which equals core's TemplateID).
+// IpxeTemplateIDs filters on the template's primary key (which equals core's TemplateID).
 // Names filters on the unique template name.
 type IpxeTemplateFilterInput struct {
-	IDs   []uuid.UUID
-	Names []string
+	IpxeTemplateIDs []uuid.UUID
+	Names           []string
 }
 
 var _ bun.BeforeAppendModelHook = (*IpxeTemplate)(nil)
@@ -178,10 +178,10 @@ func (itd IpxeTemplateSQLDAO) Get(ctx context.Context, tx *db.Tx, id uuid.UUID) 
 
 // setQueryWithFilter populates the lookup query based on the specified filter
 func (itd IpxeTemplateSQLDAO) setQueryWithFilter(filter IpxeTemplateFilterInput, query *bun.SelectQuery, span *stracer.CurrentContextSpan) (*bun.SelectQuery, error) {
-	if len(filter.IDs) > 0 {
-		query = query.Where("ipxet.id IN (?)", bun.In(filter.IDs))
+	if len(filter.IpxeTemplateIDs) > 0 {
+		query = query.Where("ipxet.id IN (?)", bun.In(filter.IpxeTemplateIDs))
 		if span != nil {
-			itd.tracerSpan.SetAttribute(span, "ids", filter.IDs)
+			itd.tracerSpan.SetAttribute(span, "ids", filter.IpxeTemplateIDs)
 		}
 	}
 
@@ -205,7 +205,11 @@ func (itd IpxeTemplateSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter Ipxe
 
 	templates := []IpxeTemplate{}
 
-	if filter.IDs != nil && len(filter.IDs) == 0 {
+	if filter.IpxeTemplateIDs != nil && len(filter.IpxeTemplateIDs) == 0 {
+		return templates, 0, nil
+	}
+
+	if filter.Names != nil && len(filter.Names) == 0 {
 		return templates, 0, nil
 	}
 

--- a/rest-api/db/pkg/db/model/ipxetemplate_test.go
+++ b/rest-api/db/pkg/db/model/ipxetemplate_test.go
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"context"
+	"testing"
+
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testIpxeTemplateSetupSchema(t *testing.T, dbSession *db.Session) {
+	ctx := context.Background()
+	require.Nil(t, dbSession.DB.ResetModel(ctx, (*IpxeTemplate)(nil)))
+
+	// Add UNIQUE(name). This is applied by migration 20260623150000_ipxe_os_and_templates.go
+	// in production; tests use ResetModel so we add it here to match.
+	_, err := dbSession.DB.Exec("ALTER TABLE ipxe_template DROP CONSTRAINT IF EXISTS ipxe_template_name_key")
+	require.Nil(t, err)
+	_, err = dbSession.DB.Exec("ALTER TABLE ipxe_template ADD CONSTRAINT ipxe_template_name_key UNIQUE (name)")
+	require.Nil(t, err)
+}
+
+func testIpxeTemplateInitDB(t *testing.T) *db.Session {
+	return util.GetTestDBSession(t, false)
+}
+
+func testIpxeTemplateCreate(ctx context.Context, t *testing.T, dao IpxeTemplateDAO, name, scope string) *IpxeTemplate {
+	tmpl, err := dao.Create(ctx, nil, IpxeTemplateCreateInput{
+		ID:                uuid.New(),
+		Name:              name,
+		RequiredParams:    []string{"kernel_params"},
+		ReservedParams:    []string{"base_url", "console"},
+		RequiredArtifacts: []string{"kernel", "initrd"},
+		Scope:             scope,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, tmpl)
+	return tmpl
+}
+
+func TestIpxeTemplateSQLDAO_Create(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+
+	tests := []struct {
+		desc        string
+		input       IpxeTemplateCreateInput
+		expectError bool
+	}{
+		{
+			desc: "create public template",
+			input: IpxeTemplateCreateInput{
+				ID:                uuid.New(),
+				Name:              "kernel-initrd",
+				RequiredParams:    []string{"kernel_params"},
+				ReservedParams:    []string{"base_url", "console"},
+				RequiredArtifacts: []string{"kernel", "initrd"},
+				Scope:             IpxeTemplateScopePublic,
+			},
+		},
+		{
+			desc: "create internal template",
+			input: IpxeTemplateCreateInput{
+				ID:                uuid.New(),
+				Name:              "discovery-scout-x86_64",
+				RequiredParams:    []string{"mac", "cli_cmd", "machine_id", "server_uri"},
+				ReservedParams:    []string{"base_url"},
+				RequiredArtifacts: []string{},
+				Scope:             IpxeTemplateScopeInternal,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			tmpl, err := dao.Create(ctx, nil, tc.input)
+			assert.Equal(t, tc.expectError, err != nil)
+			if !tc.expectError {
+				require.NotNil(t, tmpl)
+				assert.Equal(t, tc.input.ID, tmpl.ID)
+				assert.Equal(t, tc.input.Name, tmpl.Name)
+				assert.Equal(t, tc.input.Scope, tmpl.Scope)
+				assert.Equal(t, tc.input.RequiredParams, tmpl.RequiredParams)
+				assert.Equal(t, tc.input.ReservedParams, tmpl.ReservedParams)
+				assert.Equal(t, tc.input.RequiredArtifacts, tmpl.RequiredArtifacts)
+			}
+		})
+	}
+}
+
+func TestIpxeTemplateSQLDAO_Get(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+	created := testIpxeTemplateCreate(ctx, t, dao, "kernel-initrd", IpxeTemplateScopePublic)
+
+	tests := []struct {
+		desc        string
+		id          uuid.UUID
+		expectError bool
+	}{
+		{desc: "existing template", id: created.ID},
+		{desc: "not found", id: uuid.New(), expectError: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := dao.Get(ctx, nil, tc.id)
+			assert.Equal(t, tc.expectError, err != nil)
+			if !tc.expectError {
+				require.NotNil(t, got)
+				assert.Equal(t, tc.id, got.ID)
+				assert.Equal(t, "kernel-initrd", got.Name)
+			}
+		})
+	}
+}
+
+func TestIpxeTemplateSQLDAO_GetAll(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+	t1 := testIpxeTemplateCreate(ctx, t, dao, "kernel-initrd", IpxeTemplateScopePublic)
+	testIpxeTemplateCreate(ctx, t, dao, "ubuntu-autoinstall", IpxeTemplateScopePublic)
+	testIpxeTemplateCreate(ctx, t, dao, "discovery-scout-x86_64", IpxeTemplateScopeInternal)
+
+	tests := []struct {
+		desc          string
+		filter        IpxeTemplateFilterInput
+		page          paginator.PageInput
+		expectedCount int
+		expectedTotal *int
+	}{
+		{desc: "no filter returns all", expectedCount: 3, expectedTotal: cutil.GetPtr(3)},
+		{desc: "filter by id", filter: IpxeTemplateFilterInput{IDs: []uuid.UUID{t1.ID}}, expectedCount: 1},
+		{desc: "filter by name", filter: IpxeTemplateFilterInput{Names: []string{"kernel-initrd"}}, expectedCount: 1},
+		{desc: "limit applies", page: paginator.PageInput{Offset: cutil.GetPtr(0), Limit: cutil.GetPtr(2)}, expectedCount: 2, expectedTotal: cutil.GetPtr(3)},
+		{desc: "offset applies", page: paginator.PageInput{Offset: cutil.GetPtr(1)}, expectedCount: 2, expectedTotal: cutil.GetPtr(3)},
+		{desc: "unknown id returns empty", filter: IpxeTemplateFilterInput{IDs: []uuid.UUID{uuid.New()}}, expectedCount: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, total, err := dao.GetAll(ctx, nil, tc.filter, tc.page)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedCount, len(got))
+			if tc.expectedTotal != nil {
+				assert.Equal(t, *tc.expectedTotal, total)
+			}
+		})
+	}
+}
+
+func TestIpxeTemplateSQLDAO_Update(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+	created := testIpxeTemplateCreate(ctx, t, dao, "kernel-initrd", IpxeTemplateScopeInternal)
+
+	updated, err := dao.Update(ctx, nil, IpxeTemplateUpdateInput{
+		IpxeTemplateID:    created.ID,
+		Name:              cutil.GetPtr("kernel-initrd"),
+		RequiredParams:    cutil.GetPtr([]string{"kernel_params", "extra_option"}),
+		ReservedParams:    cutil.GetPtr([]string{"base_url"}),
+		RequiredArtifacts: cutil.GetPtr([]string{"kernel"}),
+		Scope:             cutil.GetPtr(IpxeTemplateScopePublic),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+
+	assert.Equal(t, created.ID, updated.ID)
+	assert.Equal(t, IpxeTemplateScopePublic, updated.Scope)
+	assert.Equal(t, []string{"kernel_params", "extra_option"}, updated.RequiredParams)
+	assert.Equal(t, []string{"base_url"}, updated.ReservedParams)
+	assert.Equal(t, []string{"kernel"}, updated.RequiredArtifacts)
+	assert.Equal(t, "kernel-initrd", updated.Name)
+
+	// Partial update: changing only Scope must leave the other fields untouched.
+	partial, err := dao.Update(ctx, nil, IpxeTemplateUpdateInput{
+		IpxeTemplateID: created.ID,
+		Scope:          cutil.GetPtr(IpxeTemplateScopeInternal),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, partial)
+
+	assert.Equal(t, IpxeTemplateScopeInternal, partial.Scope)
+	assert.Equal(t, "kernel-initrd", partial.Name)
+	assert.Equal(t, []string{"kernel_params", "extra_option"}, partial.RequiredParams)
+	assert.Equal(t, []string{"base_url"}, partial.ReservedParams)
+	assert.Equal(t, []string{"kernel"}, partial.RequiredArtifacts)
+}
+
+func TestIpxeTemplateSQLDAO_Delete(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+	t1 := testIpxeTemplateCreate(ctx, t, dao, "kernel-initrd", IpxeTemplateScopePublic)
+	testIpxeTemplateCreate(ctx, t, dao, "ubuntu-autoinstall", IpxeTemplateScopePublic)
+
+	err := dao.Delete(ctx, nil, t1.ID)
+	require.NoError(t, err)
+
+	_, err = dao.Get(ctx, nil, t1.ID)
+	assert.ErrorIs(t, err, db.ErrDoesNotExist)
+
+	remaining, total, err := dao.GetAll(ctx, nil, IpxeTemplateFilterInput{}, paginator.PageInput{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Equal(t, "ubuntu-autoinstall", remaining[0].Name)
+
+	err = dao.Delete(ctx, nil, uuid.New())
+	assert.NoError(t, err)
+}
+
+func TestIpxeTemplateSQLDAO_UniqueConstraint(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+	testIpxeTemplateCreate(ctx, t, dao, "kernel-initrd", IpxeTemplateScopePublic)
+
+	// Names are now globally unique.
+	_, err := dao.Create(ctx, nil, IpxeTemplateCreateInput{
+		ID:    uuid.New(),
+		Name:  "kernel-initrd",
+		Scope: IpxeTemplateScopePublic,
+	})
+	assert.Error(t, err)
+}
+
+func TestIpxeTemplateSQLDAO_DefaultArrayFields(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSetupSchema(t, dbSession)
+
+	dao := NewIpxeTemplateDAO(dbSession)
+
+	created, err := dao.Create(ctx, nil, IpxeTemplateCreateInput{
+		ID:    uuid.New(),
+		Name:  "ipxe-shell",
+		Scope: IpxeTemplateScopeInternal,
+	})
+	require.NoError(t, err)
+
+	retrieved, err := dao.Get(ctx, nil, created.ID)
+	require.NoError(t, err)
+	assert.NotNil(t, retrieved.RequiredParams)
+	assert.NotNil(t, retrieved.ReservedParams)
+	assert.NotNil(t, retrieved.RequiredArtifacts)
+}

--- a/rest-api/db/pkg/db/model/ipxetemplate_test.go
+++ b/rest-api/db/pkg/db/model/ipxetemplate_test.go
@@ -150,11 +150,13 @@ func TestIpxeTemplateSQLDAO_GetAll(t *testing.T) {
 		expectedTotal *int
 	}{
 		{desc: "no filter returns all", expectedCount: 3, expectedTotal: cutil.GetPtr(3)},
-		{desc: "filter by id", filter: IpxeTemplateFilterInput{IDs: []uuid.UUID{t1.ID}}, expectedCount: 1},
+		{desc: "filter by id", filter: IpxeTemplateFilterInput{IpxeTemplateIDs: []uuid.UUID{t1.ID}}, expectedCount: 1},
 		{desc: "filter by name", filter: IpxeTemplateFilterInput{Names: []string{"kernel-initrd"}}, expectedCount: 1},
 		{desc: "limit applies", page: paginator.PageInput{Offset: cutil.GetPtr(0), Limit: cutil.GetPtr(2)}, expectedCount: 2, expectedTotal: cutil.GetPtr(3)},
 		{desc: "offset applies", page: paginator.PageInput{Offset: cutil.GetPtr(1)}, expectedCount: 2, expectedTotal: cutil.GetPtr(3)},
-		{desc: "unknown id returns empty", filter: IpxeTemplateFilterInput{IDs: []uuid.UUID{uuid.New()}}, expectedCount: 0},
+		{desc: "unknown id returns empty", filter: IpxeTemplateFilterInput{IpxeTemplateIDs: []uuid.UUID{uuid.New()}}, expectedCount: 0},
+		{desc: "explicit empty ids returns empty", filter: IpxeTemplateFilterInput{IpxeTemplateIDs: []uuid.UUID{}}, expectedCount: 0, expectedTotal: cutil.GetPtr(0)},
+		{desc: "explicit empty names returns empty", filter: IpxeTemplateFilterInput{Names: []string{}}, expectedCount: 0, expectedTotal: cutil.GetPtr(0)},
 	}
 
 	for _, tc := range tests {

--- a/rest-api/db/pkg/db/model/ipxetemplatesiteassociation.go
+++ b/rest-api/db/pkg/db/model/ipxetemplatesiteassociation.go
@@ -198,6 +198,14 @@ func (itsasd IpxeTemplateSiteAssociationSQLDAO) GetAll(ctx context.Context, tx *
 
 	itsas := []IpxeTemplateSiteAssociation{}
 
+	if filter.IpxeTemplateIDs != nil && len(filter.IpxeTemplateIDs) == 0 {
+		return itsas, 0, nil
+	}
+
+	if filter.SiteIDs != nil && len(filter.SiteIDs) == 0 {
+		return itsas, 0, nil
+	}
+
 	query := db.GetIDB(tx, itsasd.dbSession).NewSelect().Model(&itsas)
 	if len(filter.IpxeTemplateIDs) > 0 {
 		query = query.Where("itsa.ipxe_template_id IN (?)", bun.In(filter.IpxeTemplateIDs))

--- a/rest-api/db/pkg/db/model/ipxetemplatesiteassociation.go
+++ b/rest-api/db/pkg/db/model/ipxetemplatesiteassociation.go
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+
+	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+)
+
+const (
+	// IpxeTemplateSiteAssociationOrderByDefault default field used for ordering when none specified
+	IpxeTemplateSiteAssociationOrderByDefault = "created"
+)
+
+var (
+	// IpxeTemplateSiteAssociationOrderByFields is a list of valid order by fields for the IpxeTemplateSiteAssociation model
+	IpxeTemplateSiteAssociationOrderByFields = []string{"created", "updated"}
+
+	// IpxeTemplateSiteAssociationRelatedEntities is a list of valid relation by fields for the IpxeTemplateSiteAssociation model
+	IpxeTemplateSiteAssociationRelatedEntities = map[string]bool{
+		IpxeTemplateRelationName: true,
+		SiteRelationName:         true,
+	}
+)
+
+// IpxeTemplateSiteAssociation records the availability of an IpxeTemplate at a Site.
+//
+// Unlike OSSA/SKGSA, REST is not the source of truth for templates (they flow from
+// the site agent into REST), so this association does not track sync status, version,
+// or controller state. The presence of a row indicates the template is available at
+// the site; the row is removed when the site agent stops reporting the template.
+type IpxeTemplateSiteAssociation struct {
+	bun.BaseModel `bun:"table:ipxe_template_site_association,alias:itsa"`
+
+	ID             uuid.UUID     `bun:"type:uuid,pk"`
+	IpxeTemplateID uuid.UUID     `bun:"ipxe_template_id,type:uuid,notnull"`
+	IpxeTemplate   *IpxeTemplate `bun:"rel:belongs-to,join:ipxe_template_id=id"`
+	SiteID         uuid.UUID     `bun:"site_id,type:uuid,notnull"`
+	Site           *Site         `bun:"rel:belongs-to,join:site_id=id"`
+	Created        time.Time     `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated        time.Time     `bun:"updated,nullzero,notnull,default:current_timestamp"`
+}
+
+// IpxeTemplateSiteAssociationCreateInput input parameters for the Create method
+type IpxeTemplateSiteAssociationCreateInput struct {
+	IpxeTemplateID uuid.UUID
+	SiteID         uuid.UUID
+}
+
+// IpxeTemplateSiteAssociationFilterInput input parameters for the GetAll method
+type IpxeTemplateSiteAssociationFilterInput struct {
+	IpxeTemplateIDs []uuid.UUID
+	SiteIDs         []uuid.UUID
+}
+
+var _ bun.BeforeAppendModelHook = (*IpxeTemplateSiteAssociation)(nil)
+
+// BeforeAppendModel is a hook called before the model is appended to the query
+func (itsa *IpxeTemplateSiteAssociation) BeforeAppendModel(ctx context.Context, query bun.Query) error {
+	switch query.(type) {
+	case *bun.InsertQuery:
+		itsa.Created = db.GetCurTime()
+		itsa.Updated = db.GetCurTime()
+	case *bun.UpdateQuery:
+		itsa.Updated = db.GetCurTime()
+	}
+	return nil
+}
+
+var _ bun.BeforeCreateTableHook = (*IpxeTemplateSiteAssociation)(nil)
+
+// BeforeCreateTable is a hook called before the table is created
+func (itsa *IpxeTemplateSiteAssociation) BeforeCreateTable(ctx context.Context, query *bun.CreateTableQuery) error {
+	query.ForeignKey(`("site_id") REFERENCES "site" ("id")`).
+		ForeignKey(`("ipxe_template_id") REFERENCES "ipxe_template" ("id") ON DELETE CASCADE`)
+	return nil
+}
+
+// IpxeTemplateSiteAssociationDAO is an interface for interacting with the IpxeTemplateSiteAssociation model
+type IpxeTemplateSiteAssociationDAO interface {
+	// Create inserts a new association row
+	Create(ctx context.Context, tx *db.Tx, input IpxeTemplateSiteAssociationCreateInput) (*IpxeTemplateSiteAssociation, error)
+	// GetByID returns a row by primary key
+	GetByID(ctx context.Context, tx *db.Tx, id uuid.UUID, includeRelations []string) (*IpxeTemplateSiteAssociation, error)
+	// GetByIpxeTemplateIDAndSiteID returns the row matching the (template, site) pair
+	GetByIpxeTemplateIDAndSiteID(ctx context.Context, tx *db.Tx, ipxeTemplateID uuid.UUID, siteID uuid.UUID, includeRelations []string) (*IpxeTemplateSiteAssociation, error)
+	// GetAll returns all rows matching the filter and page inputs
+	GetAll(ctx context.Context, tx *db.Tx, filter IpxeTemplateSiteAssociationFilterInput, page paginator.PageInput, includeRelations []string) ([]IpxeTemplateSiteAssociation, int, error)
+	// Delete removes a row by ID
+	Delete(ctx context.Context, tx *db.Tx, id uuid.UUID) error
+}
+
+// IpxeTemplateSiteAssociationSQLDAO is an implementation of the IpxeTemplateSiteAssociationDAO interface
+type IpxeTemplateSiteAssociationSQLDAO struct {
+	dbSession *db.Session
+	IpxeTemplateSiteAssociationDAO
+	tracerSpan *stracer.TracerSpan
+}
+
+// Create creates a new IpxeTemplateSiteAssociation
+func (itsasd IpxeTemplateSiteAssociationSQLDAO) Create(
+	ctx context.Context, tx *db.Tx,
+	input IpxeTemplateSiteAssociationCreateInput,
+) (*IpxeTemplateSiteAssociation, error) {
+	ctx, span := itsasd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateSiteAssociationDAO.Create")
+	if span != nil {
+		defer span.End()
+		itsasd.tracerSpan.SetAttribute(span, "ipxe_template_id", input.IpxeTemplateID.String())
+		itsasd.tracerSpan.SetAttribute(span, "site_id", input.SiteID.String())
+	}
+
+	itsa := &IpxeTemplateSiteAssociation{
+		ID:             uuid.New(),
+		IpxeTemplateID: input.IpxeTemplateID,
+		SiteID:         input.SiteID,
+	}
+
+	_, err := db.GetIDB(tx, itsasd.dbSession).NewInsert().Model(itsa).Exec(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return itsasd.GetByID(ctx, tx, itsa.ID, nil)
+}
+
+// GetByID returns an IpxeTemplateSiteAssociation by ID
+// Returns db.ErrDoesNotExist if the record is not found
+func (itsasd IpxeTemplateSiteAssociationSQLDAO) GetByID(ctx context.Context, tx *db.Tx, id uuid.UUID, includeRelations []string) (*IpxeTemplateSiteAssociation, error) {
+	ctx, span := itsasd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateSiteAssociationDAO.GetByID")
+	if span != nil {
+		defer span.End()
+		itsasd.tracerSpan.SetAttribute(span, "id", id.String())
+	}
+
+	itsa := &IpxeTemplateSiteAssociation{}
+
+	query := db.GetIDB(tx, itsasd.dbSession).NewSelect().Model(itsa).Where("itsa.id = ?", id)
+	for _, relation := range includeRelations {
+		query = query.Relation(relation)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, db.ErrDoesNotExist
+		}
+		return nil, err
+	}
+
+	return itsa, nil
+}
+
+// GetByIpxeTemplateIDAndSiteID returns an IpxeTemplateSiteAssociation by (template, site).
+// Returns db.ErrDoesNotExist if the record is not found.
+func (itsasd IpxeTemplateSiteAssociationSQLDAO) GetByIpxeTemplateIDAndSiteID(ctx context.Context, tx *db.Tx, ipxeTemplateID uuid.UUID, siteID uuid.UUID, includeRelations []string) (*IpxeTemplateSiteAssociation, error) {
+	ctx, span := itsasd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateSiteAssociationDAO.GetByIpxeTemplateIDAndSiteID")
+	if span != nil {
+		defer span.End()
+		itsasd.tracerSpan.SetAttribute(span, "ipxe_template_id", ipxeTemplateID.String())
+		itsasd.tracerSpan.SetAttribute(span, "site_id", siteID.String())
+	}
+
+	itsa := &IpxeTemplateSiteAssociation{}
+
+	query := db.GetIDB(tx, itsasd.dbSession).NewSelect().Model(itsa).
+		Where("itsa.ipxe_template_id = ?", ipxeTemplateID).
+		Where("itsa.site_id = ?", siteID)
+	for _, relation := range includeRelations {
+		query = query.Relation(relation)
+	}
+
+	err := query.Scan(ctx)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, db.ErrDoesNotExist
+		}
+		return nil, err
+	}
+
+	return itsa, nil
+}
+
+// GetAll returns all IpxeTemplateSiteAssociation rows with optional filters
+func (itsasd IpxeTemplateSiteAssociationSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter IpxeTemplateSiteAssociationFilterInput, page paginator.PageInput, includeRelations []string) ([]IpxeTemplateSiteAssociation, int, error) {
+	ctx, span := itsasd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateSiteAssociationDAO.GetAll")
+	if span != nil {
+		defer span.End()
+	}
+
+	itsas := []IpxeTemplateSiteAssociation{}
+
+	query := db.GetIDB(tx, itsasd.dbSession).NewSelect().Model(&itsas)
+	if len(filter.IpxeTemplateIDs) > 0 {
+		query = query.Where("itsa.ipxe_template_id IN (?)", bun.In(filter.IpxeTemplateIDs))
+		if span != nil {
+			itsasd.tracerSpan.SetAttribute(span, "ipxe_template_ids", filter.IpxeTemplateIDs)
+		}
+	}
+	if len(filter.SiteIDs) > 0 {
+		query = query.Where("itsa.site_id IN (?)", bun.In(filter.SiteIDs))
+		if span != nil {
+			itsasd.tracerSpan.SetAttribute(span, "site_ids", filter.SiteIDs)
+		}
+	}
+
+	for _, relation := range includeRelations {
+		query = query.Relation(relation)
+	}
+
+	if page.OrderBy == nil {
+		page.OrderBy = paginator.NewDefaultOrderBy(IpxeTemplateSiteAssociationOrderByDefault)
+	}
+
+	pager, err := paginator.NewPaginator(ctx, query, page.Offset, page.Limit, page.OrderBy, IpxeTemplateSiteAssociationOrderByFields)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	err = pager.Query.Limit(pager.Limit).Offset(pager.Offset).Scan(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return itsas, pager.Total, nil
+}
+
+// Delete removes an IpxeTemplateSiteAssociation by ID
+func (itsasd IpxeTemplateSiteAssociationSQLDAO) Delete(ctx context.Context, tx *db.Tx, id uuid.UUID) error {
+	ctx, span := itsasd.tracerSpan.CreateChildInCurrentContext(ctx, "IpxeTemplateSiteAssociationDAO.Delete")
+	if span != nil {
+		defer span.End()
+		itsasd.tracerSpan.SetAttribute(span, "id", id.String())
+	}
+
+	itsa := &IpxeTemplateSiteAssociation{ID: id}
+
+	_, err := db.GetIDB(tx, itsasd.dbSession).NewDelete().Model(itsa).Where("itsa.id = ?", id).Exec(ctx)
+	return err
+}
+
+// NewIpxeTemplateSiteAssociationDAO returns a new IpxeTemplateSiteAssociationDAO
+func NewIpxeTemplateSiteAssociationDAO(dbSession *db.Session) IpxeTemplateSiteAssociationDAO {
+	return &IpxeTemplateSiteAssociationSQLDAO{
+		dbSession:  dbSession,
+		tracerSpan: stracer.NewTracerSpan(),
+	}
+}

--- a/rest-api/db/pkg/db/model/ipxetemplatesiteassociation_test.go
+++ b/rest-api/db/pkg/db/model/ipxetemplatesiteassociation_test.go
@@ -126,4 +126,16 @@ func TestIpxeTemplateSiteAssociationSQLDAO_GetAllAndUniqueness(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, total)
 	assert.Len(t, rows, 1)
+
+	// A non-nil but empty filter slice is treated as a no-match rather than
+	// being ignored (mirrors IpxeTemplateSQLDAO.GetAll).
+	rows, total, err = dao.GetAll(ctx, nil, IpxeTemplateSiteAssociationFilterInput{IpxeTemplateIDs: []uuid.UUID{}}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Len(t, rows, 0)
+
+	rows, total, err = dao.GetAll(ctx, nil, IpxeTemplateSiteAssociationFilterInput{SiteIDs: []uuid.UUID{}}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Len(t, rows, 0)
 }

--- a/rest-api/db/pkg/db/model/ipxetemplatesiteassociation_test.go
+++ b/rest-api/db/pkg/db/model/ipxetemplatesiteassociation_test.go
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testIpxeTemplateSiteAssociationSetupSchema(t *testing.T, dbSession *db.Session) {
+	ctx := context.Background()
+	require.Nil(t, dbSession.DB.ResetModel(ctx, (*User)(nil)))
+	require.Nil(t, dbSession.DB.ResetModel(ctx, (*InfrastructureProvider)(nil)))
+	require.Nil(t, dbSession.DB.ResetModel(ctx, (*Site)(nil)))
+	require.Nil(t, dbSession.DB.ResetModel(ctx, (*IpxeTemplate)(nil)))
+	require.Nil(t, dbSession.DB.ResetModel(ctx, (*IpxeTemplateSiteAssociation)(nil)))
+
+	_, err := dbSession.DB.Exec("ALTER TABLE ipxe_template DROP CONSTRAINT IF EXISTS ipxe_template_name_key")
+	require.Nil(t, err)
+	_, err = dbSession.DB.Exec("ALTER TABLE ipxe_template ADD CONSTRAINT ipxe_template_name_key UNIQUE (name)")
+	require.Nil(t, err)
+	_, err = dbSession.DB.Exec("ALTER TABLE ipxe_template_site_association DROP CONSTRAINT IF EXISTS ipxe_template_site_association_template_id_site_id_key")
+	require.Nil(t, err)
+	_, err = dbSession.DB.Exec("ALTER TABLE ipxe_template_site_association ADD CONSTRAINT ipxe_template_site_association_template_id_site_id_key UNIQUE (ipxe_template_id, site_id)")
+	require.Nil(t, err)
+}
+
+func TestIpxeTemplateSiteAssociationSQLDAO_CreateGetDelete(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSiteAssociationSetupSchema(t, dbSession)
+
+	user := TestBuildUser(t, dbSession, "test-user", "test-org", []string{"admin"})
+	ip := TestBuildInfrastructureProvider(t, dbSession, "test-provider", "test-org", user)
+	site := TestBuildSite(t, dbSession, ip, "test-site", user)
+
+	tmplDAO := NewIpxeTemplateDAO(dbSession)
+	tmpl, err := tmplDAO.Create(ctx, nil, IpxeTemplateCreateInput{
+		ID: uuid.New(), Name: "kernel-initrd", Scope: IpxeTemplateScopePublic,
+	})
+	require.NoError(t, err)
+
+	dao := NewIpxeTemplateSiteAssociationDAO(dbSession)
+
+	itsa, err := dao.Create(ctx, nil, IpxeTemplateSiteAssociationCreateInput{
+		IpxeTemplateID: tmpl.ID,
+		SiteID:         site.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, tmpl.ID, itsa.IpxeTemplateID)
+	assert.Equal(t, site.ID, itsa.SiteID)
+
+	got, err := dao.GetByID(ctx, nil, itsa.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, itsa.ID, got.ID)
+
+	got, err = dao.GetByIpxeTemplateIDAndSiteID(ctx, nil, tmpl.ID, site.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, itsa.ID, got.ID)
+
+	_, err = dao.GetByIpxeTemplateIDAndSiteID(ctx, nil, uuid.New(), site.ID, nil)
+	assert.ErrorIs(t, err, db.ErrDoesNotExist)
+
+	require.NoError(t, dao.Delete(ctx, nil, itsa.ID))
+	_, err = dao.GetByID(ctx, nil, itsa.ID, nil)
+	assert.ErrorIs(t, err, db.ErrDoesNotExist)
+}
+
+func TestIpxeTemplateSiteAssociationSQLDAO_GetAllAndUniqueness(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testIpxeTemplateInitDB(t)
+	defer dbSession.Close()
+	testIpxeTemplateSiteAssociationSetupSchema(t, dbSession)
+
+	user := TestBuildUser(t, dbSession, "test-user", "test-org", []string{"admin"})
+	ip := TestBuildInfrastructureProvider(t, dbSession, "test-provider", "test-org", user)
+	site1 := TestBuildSite(t, dbSession, ip, "site-1", user)
+	site2 := TestBuildSite(t, dbSession, ip, "site-2", user)
+
+	tmplDAO := NewIpxeTemplateDAO(dbSession)
+	tmpl1, err := tmplDAO.Create(ctx, nil, IpxeTemplateCreateInput{ID: uuid.New(), Name: "tmpl-a", Scope: IpxeTemplateScopePublic})
+	require.NoError(t, err)
+	tmpl2, err := tmplDAO.Create(ctx, nil, IpxeTemplateCreateInput{ID: uuid.New(), Name: "tmpl-b", Scope: IpxeTemplateScopePublic})
+	require.NoError(t, err)
+
+	dao := NewIpxeTemplateSiteAssociationDAO(dbSession)
+
+	_, err = dao.Create(ctx, nil, IpxeTemplateSiteAssociationCreateInput{IpxeTemplateID: tmpl1.ID, SiteID: site1.ID})
+	require.NoError(t, err)
+	_, err = dao.Create(ctx, nil, IpxeTemplateSiteAssociationCreateInput{IpxeTemplateID: tmpl1.ID, SiteID: site2.ID})
+	require.NoError(t, err)
+	_, err = dao.Create(ctx, nil, IpxeTemplateSiteAssociationCreateInput{IpxeTemplateID: tmpl2.ID, SiteID: site1.ID})
+	require.NoError(t, err)
+
+	// Duplicate (template, site) pair must fail
+	_, err = dao.Create(ctx, nil, IpxeTemplateSiteAssociationCreateInput{IpxeTemplateID: tmpl1.ID, SiteID: site1.ID})
+	assert.Error(t, err)
+
+	rows, total, err := dao.GetAll(ctx, nil, IpxeTemplateSiteAssociationFilterInput{}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, rows, 3)
+
+	rows, total, err = dao.GetAll(ctx, nil, IpxeTemplateSiteAssociationFilterInput{SiteIDs: []uuid.UUID{site1.ID}}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, rows, 2)
+
+	rows, total, err = dao.GetAll(ctx, nil, IpxeTemplateSiteAssociationFilterInput{IpxeTemplateIDs: []uuid.UUID{tmpl1.ID}}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, rows, 2)
+
+	rows, total, err = dao.GetAll(ctx, nil, IpxeTemplateSiteAssociationFilterInput{
+		IpxeTemplateIDs: []uuid.UUID{tmpl1.ID},
+		SiteIDs:         []uuid.UUID{site2.ID},
+	}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, rows, 1)
+}

--- a/rest-api/db/pkg/db/model/operatingsystem.go
+++ b/rest-api/db/pkg/db/model/operatingsystem.go
@@ -37,10 +37,19 @@ const (
 
 	// OperatingSystemRelationName is the relation name for the OperatingSystem model
 	OperatingSystemRelationName = "OperatingSystem"
-	// OperatingSystemTypeIPXE is the ipxe based OperatingSystem type
+	// OperatingSystemTypeIPXE is the raw iPXE script based OperatingSystem type
 	OperatingSystemTypeIPXE = "iPXE"
+	// OperatingSystemTypeTemplatedIPXE is the iPXE template based OperatingSystem type
+	OperatingSystemTypeTemplatedIPXE = "Templated iPXE"
 	// OperatingSystemTypeImage is the image based OperatingSystem type
 	OperatingSystemTypeImage = "Image"
+
+	// OperatingSystemScopeLocal means single site, bidirectional sync (provider-owned OS from nico-core).
+	OperatingSystemScopeLocal = "Local"
+	// OperatingSystemScopeLimited means carbide-rest is the source of truth for a fixed list of sites.
+	OperatingSystemScopeLimited = "Limited"
+	// OperatingSystemScopeGlobal means carbide-rest is the source of truth for all owner sites.
+	OperatingSystemScopeGlobal = "Global"
 
 	// OperatingSystemOrderByDefault default field to be used for ordering when none specified
 	OperatingSystemOrderByDefault = "created"
@@ -49,6 +58,15 @@ const (
 	OperatingSystemAuthTypeBasic = "Basic"
 	// OperatingSystemAuthTypeBearer is the bearer image auth type
 	OperatingSystemAuthTypeBearer = "Bearer"
+
+	// OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded caches the artifact locally when possible.
+	OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded = "CacheAsNeeded"
+	// OperatingSystemIpxeArtifactCacheStrategyLocalOnly marks the artifact URL as usable only on-site.
+	OperatingSystemIpxeArtifactCacheStrategyLocalOnly = "LocalOnly"
+	// OperatingSystemIpxeArtifactCacheStrategyCachedOnly requires the artifact to be cached locally.
+	OperatingSystemIpxeArtifactCacheStrategyCachedOnly = "CachedOnly"
+	// OperatingSystemIpxeArtifactCacheStrategyRemoteOnly always fetches the artifact from the remote URL.
+	OperatingSystemIpxeArtifactCacheStrategyRemoteOnly = "RemoteOnly"
 )
 
 var (
@@ -71,10 +89,123 @@ var (
 	}
 	//OperatingSystemsTypeMap is a list of valid type for the OperatingSystem model
 	OperatingSystemsTypeMap = map[string]bool{
-		OperatingSystemTypeIPXE:  true,
-		OperatingSystemTypeImage: true,
+		OperatingSystemTypeIPXE:          true,
+		OperatingSystemTypeTemplatedIPXE: true,
+		OperatingSystemTypeImage:         true,
+	}
+
+	// OperatingSystemIpxeArtifactCacheStrategyFromProtoMap maps proto cache strategies to their model string values.
+	OperatingSystemIpxeArtifactCacheStrategyFromProtoMap = map[cwssaws.IpxeTemplateArtifactCacheStrategy]string{
+		cwssaws.IpxeTemplateArtifactCacheStrategy_CACHE_AS_NEEDED: OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded,
+		cwssaws.IpxeTemplateArtifactCacheStrategy_LOCAL_ONLY:      OperatingSystemIpxeArtifactCacheStrategyLocalOnly,
+		cwssaws.IpxeTemplateArtifactCacheStrategy_CACHED_ONLY:     OperatingSystemIpxeArtifactCacheStrategyCachedOnly,
+		cwssaws.IpxeTemplateArtifactCacheStrategy_REMOTE_ONLY:     OperatingSystemIpxeArtifactCacheStrategyRemoteOnly,
+	}
+
+	// OperatingSystemIpxeArtifactCacheStrategyToProtoMap maps model cache strategy strings to their proto values.
+	OperatingSystemIpxeArtifactCacheStrategyToProtoMap = map[string]cwssaws.IpxeTemplateArtifactCacheStrategy{
+		OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded: cwssaws.IpxeTemplateArtifactCacheStrategy_CACHE_AS_NEEDED,
+		OperatingSystemIpxeArtifactCacheStrategyLocalOnly:     cwssaws.IpxeTemplateArtifactCacheStrategy_LOCAL_ONLY,
+		OperatingSystemIpxeArtifactCacheStrategyCachedOnly:    cwssaws.IpxeTemplateArtifactCacheStrategy_CACHED_ONLY,
+		OperatingSystemIpxeArtifactCacheStrategyRemoteOnly:    cwssaws.IpxeTemplateArtifactCacheStrategy_REMOTE_ONLY,
+	}
+
+	// OperatingSystemTypeFromProtoMap maps nico-core OS types to their model string values.
+	OperatingSystemTypeFromProtoMap = map[cwssaws.OperatingSystemType]string{
+		cwssaws.OperatingSystemType_OS_TYPE_IPXE:           OperatingSystemTypeIPXE,
+		cwssaws.OperatingSystemType_OS_TYPE_TEMPLATED_IPXE: OperatingSystemTypeTemplatedIPXE,
+	}
+
+	// OperatingSystemStatusFromProtoMap maps nico-core tenant states to OperatingSystem status values.
+	OperatingSystemStatusFromProtoMap = map[cwssaws.TenantState]string{
+		cwssaws.TenantState_PROVISIONING: OperatingSystemStatusProvisioning,
+		cwssaws.TenantState_READY:        OperatingSystemStatusReady,
+		cwssaws.TenantState_CONFIGURING:  OperatingSystemStatusSyncing,
+		cwssaws.TenantState_TERMINATING:  OperatingSystemStatusDeleting,
+		cwssaws.TenantState_FAILED:       OperatingSystemStatusError,
 	}
 )
+
+// IsIPXEType returns true if the given OS type is any iPXE variant (raw script or templated).
+func IsIPXEType(osType string) bool {
+	return osType == OperatingSystemTypeIPXE || osType == OperatingSystemTypeTemplatedIPXE
+}
+
+// OperatingSystemIpxeParameter holds a single iPXE parameter name/value pair (stored as JSONB).
+// These are only populated for iPXE-based OS definitions synced with nico-core.
+type OperatingSystemIpxeParameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// FromProto fills the receiver from a proto IpxeTemplateParameter. A nil proto resets the receiver.
+func (osip *OperatingSystemIpxeParameter) FromProto(protoParam *cwssaws.IpxeTemplateParameter) {
+	if protoParam == nil {
+		*osip = OperatingSystemIpxeParameter{}
+		return
+	}
+	osip.Name = protoParam.Name
+	osip.Value = protoParam.Value
+}
+
+// ToProto converts the receiver to a proto IpxeTemplateParameter.
+func (osip *OperatingSystemIpxeParameter) ToProto() *cwssaws.IpxeTemplateParameter {
+	return &cwssaws.IpxeTemplateParameter{
+		Name:  osip.Name,
+		Value: osip.Value,
+	}
+}
+
+// OperatingSystemIpxeArtifact holds a single iPXE artifact descriptor (stored as JSONB).
+// These are only populated for iPXE-based OS definitions synced with nico-core.
+//
+// The proto IpxeTemplateArtifact has a cached_url field that is intentionally NOT
+// represented here: cached_url is a per-site value populated by nico-core after a
+// successful download, so there is no meaningful global value for it on the rest side.
+// The push path must therefore never emit cached_url to core (preserving per-site
+// values), and the inbound (pull) path must never store cached_url on the global row.
+type OperatingSystemIpxeArtifact struct {
+	Name          string  `json:"name"`
+	URL           string  `json:"url"`
+	SHA           *string `json:"sha"`
+	AuthType      *string `json:"authType"`
+	AuthToken     *string `json:"authToken"`
+	CacheStrategy string  `json:"cacheStrategy"`
+}
+
+// FromProto fills the receiver from a proto IpxeTemplateArtifact. A nil proto resets the receiver.
+// The proto's cached_url field is intentionally ignored; see the type doc.
+func (osia *OperatingSystemIpxeArtifact) FromProto(protoArtifact *cwssaws.IpxeTemplateArtifact) {
+	if protoArtifact == nil {
+		*osia = OperatingSystemIpxeArtifact{}
+		return
+	}
+	osia.Name = protoArtifact.Name
+	osia.URL = protoArtifact.Url
+	osia.SHA = protoArtifact.Sha
+	osia.AuthType = protoArtifact.AuthType
+	osia.AuthToken = protoArtifact.AuthToken
+
+	cacheStrategy := OperatingSystemIpxeArtifactCacheStrategyFromProtoMap[protoArtifact.CacheStrategy]
+	if cacheStrategy == "" {
+		cacheStrategy = OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded
+	}
+	osia.CacheStrategy = cacheStrategy
+}
+
+// ToProto converts the receiver to a proto IpxeTemplateArtifact. cached_url is always left
+// nil so the rest side never overwrites the per-site value managed by nico-core.
+func (osia *OperatingSystemIpxeArtifact) ToProto() *cwssaws.IpxeTemplateArtifact {
+	return &cwssaws.IpxeTemplateArtifact{
+		Name:          osia.Name,
+		Url:           osia.URL,
+		Sha:           osia.SHA,
+		AuthType:      osia.AuthType,
+		AuthToken:     osia.AuthToken,
+		CacheStrategy: OperatingSystemIpxeArtifactCacheStrategyToProtoMap[osia.CacheStrategy],
+		CachedUrl:     nil,
+	}
+}
 
 // OperatingSystem describes the attributes of the operating system
 // that can be used on instances
@@ -100,17 +231,27 @@ type OperatingSystem struct {
 	RootFsID                    *string                 `bun:"root_fs_id"`
 	RootFsLabel                 *string                 `bun:"root_fs_label"`
 	IpxeScript                  *string                 `bun:"ipxe_script"`
-	UserData                    *string                 `bun:"user_data"`
-	AllowOverride               bool                    `bun:"allow_override,notnull"`
-	EnableBlockStorage          bool                    `bun:"enable_block_storage,notnull"`
-	PhoneHomeEnabled            bool                    `bun:"phone_home_enabled,notnull"`
-	IsActive                    bool                    `bun:"is_active,notnull"`
-	DeactivationNote            *string                 `bun:"deactivation_note"` // Note for deactivation, if any
-	Status                      string                  `bun:"status,notnull"`
-	Created                     time.Time               `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated                     time.Time               `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	Deleted                     *time.Time              `bun:"deleted,soft_delete"`
-	CreatedBy                   uuid.UUID               `bun:"type:uuid,notnull"`
+	// iPXE template fields, populated for Templated iPXE OS definitions synced with nico-core.
+	IpxeTemplateId             *string                        `bun:"ipxe_template_id"`
+	IpxeTemplateParameters     []OperatingSystemIpxeParameter `bun:"ipxe_template_parameters,type:jsonb"`
+	IpxeTemplateArtifacts      []OperatingSystemIpxeArtifact  `bun:"ipxe_template_artifacts,type:jsonb"`
+	IpxeTemplateDefinitionHash *string                        `bun:"ipxe_template_definition_hash"`
+	// IpxeOsScope controls synchronization direction between carbide-rest and nico-core for
+	// iPXE OS definitions: "Local" is bidirectional/provider-owned from nico-core, while
+	// "Global" and "Limited" make carbide-rest the source of truth. nil for Image-type OS;
+	// legacy iPXE rows with nil scope are treated as "Local".
+	IpxeOsScope        *string    `bun:"ipxe_os_scope"`
+	UserData           *string    `bun:"user_data"`
+	AllowOverride      bool       `bun:"allow_override,notnull"`
+	EnableBlockStorage bool       `bun:"enable_block_storage,notnull"`
+	PhoneHomeEnabled   bool       `bun:"phone_home_enabled,notnull"`
+	IsActive           bool       `bun:"is_active,notnull"`
+	DeactivationNote   *string    `bun:"deactivation_note"` // Note for deactivation, if any
+	Status             string     `bun:"status,notnull"`
+	Created            time.Time  `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated            time.Time  `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	Deleted            *time.Time `bun:"deleted,soft_delete"`
+	CreatedBy          uuid.UUID  `bun:"type:uuid,notnull"`
 }
 
 // GetSiteID returns the OperatingSystem ID to use when communicating
@@ -165,6 +306,9 @@ func (os *OperatingSystem) ToDeletionRequestProto(tenantOrg string) *cwssaws.Del
 
 // OperatingSystemCreateInput input parameters for Create method
 type OperatingSystemCreateInput struct {
+	// ID optionally pre-specifies the primary key. When set (e.g. during inventory sync from
+	// nico-core), the same UUID is used on both sides. When zero, a new UUID is generated.
+	ID                          uuid.UUID
 	Name                        string
 	Description                 *string
 	Org                         string
@@ -181,12 +325,18 @@ type OperatingSystemCreateInput struct {
 	RootFsId                    *string
 	RootFsLabel                 *string
 	IpxeScript                  *string
-	UserData                    *string
-	AllowOverride               bool
-	EnableBlockStorage          bool
-	PhoneHomeEnabled            bool
-	Status                      string
-	CreatedBy                   uuid.UUID
+	// iPXE template definition fields (for nico-core synced iPXE OS definitions)
+	IpxeTemplateId         *string
+	IpxeTemplateParameters []OperatingSystemIpxeParameter
+	IpxeTemplateArtifacts  []OperatingSystemIpxeArtifact
+	IpxeOSHash             *string
+	IpxeOsScope            *string
+	UserData               *string
+	AllowOverride          bool
+	EnableBlockStorage     bool
+	PhoneHomeEnabled       bool
+	Status                 string
+	CreatedBy              uuid.UUID
 }
 
 // OperatingSystemUpdateInput input parameters for Update method
@@ -208,13 +358,19 @@ type OperatingSystemUpdateInput struct {
 	RootFsId                    *string
 	RootFsLabel                 *string
 	IpxeScript                  *string
-	UserData                    *string
-	AllowOverride               *bool
-	EnableBlockStorage          *bool
-	PhoneHomeEnabled            *bool
-	IsActive                    *bool
-	DeactivationNote            *string
-	Status                      *string
+	// iPXE template definition fields (for nico-core synced iPXE OS definitions)
+	IpxeTemplateId         *string
+	IpxeTemplateParameters *[]OperatingSystemIpxeParameter
+	IpxeTemplateArtifacts  *[]OperatingSystemIpxeArtifact
+	IpxeOSHash             *string
+	Scope                  *string
+	UserData               *string
+	AllowOverride          *bool
+	EnableBlockStorage     *bool
+	PhoneHomeEnabled       *bool
+	IsActive               *bool
+	DeactivationNote       *string
+	Status                 *string
 }
 
 // OperatingSystemClearInput input parameters for Clear method
@@ -235,6 +391,12 @@ type OperatingSystemClearInput struct {
 	IpxeScript                  bool
 	UserData                    bool
 	DeactivationNote            bool
+	// iPXE template definition fields (for nico-core synced iPXE OS definitions)
+	IpxeTemplateId         bool
+	IpxeTemplateParameters bool
+	IpxeTemplateArtifacts  bool
+	IpxeOSHash             bool
+	Scope                  bool
 }
 
 type OperatingSystemFilterInput struct {
@@ -248,6 +410,10 @@ type OperatingSystemFilterInput struct {
 	SearchQuery              *string
 	OperatingSystemIds       []uuid.UUID
 	IsActive                 *bool
+	// Scopes filters iPXE OS definitions by their scope (e.g. "Global", "Limited", "Local").
+	Scopes []string
+	// IncludeDeleted includes soft-deleted records (used by inventory sync to detect deletions).
+	IncludeDeleted bool
 }
 
 var _ bun.BeforeAppendModelHook = (*OperatingSystem)(nil)
@@ -309,8 +475,12 @@ func (ossd OperatingSystemSQLDAO) Create(ctx context.Context, tx *db.Tx, input O
 		ossd.tracerSpan.SetAttribute(operatingSystemSQLDAOSpan, "name", input.Name)
 	}
 
+	id := input.ID
+	if id == uuid.Nil {
+		id = uuid.New()
+	}
 	os := &OperatingSystem{
-		ID:                          uuid.New(),
+		ID:                          id,
 		Name:                        input.Name,
 		Description:                 input.Description,
 		Org:                         input.Org,
@@ -332,10 +502,15 @@ func (ossd OperatingSystemSQLDAO) Create(ctx context.Context, tx *db.Tx, input O
 		EnableBlockStorage:          input.EnableBlockStorage,
 		PhoneHomeEnabled:            input.PhoneHomeEnabled,
 		// WARNING: there is a bug in 'bun' and we cannot use non-nullable AND default=true at this time:
-		IsActive:         true, // input.IsActive,
-		DeactivationNote: nil,  //input.DeactivationNote,
-		Status:           input.Status,
-		CreatedBy:        input.CreatedBy,
+		IsActive:                   true, // input.IsActive,
+		DeactivationNote:           nil,  //input.DeactivationNote,
+		Status:                     input.Status,
+		CreatedBy:                  input.CreatedBy,
+		IpxeTemplateId:             input.IpxeTemplateId,
+		IpxeTemplateParameters:     input.IpxeTemplateParameters,
+		IpxeTemplateArtifacts:      input.IpxeTemplateArtifacts,
+		IpxeTemplateDefinitionHash: input.IpxeOSHash,
+		IpxeOsScope:                input.IpxeOsScope,
 	}
 
 	_, err := db.GetIDB(tx, ossd.dbSession).NewInsert().Model(os).Exec(ctx)
@@ -450,6 +625,20 @@ func (ossd OperatingSystemSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter 
 	if filter.IsActive != nil {
 		query = query.Where("os.is_active = ?", *filter.IsActive)
 		ossd.tracerSpan.SetAttribute(operatingSystemSQLDAOSpan, "is_active", *filter.IsActive)
+	}
+	if filter.Scopes != nil {
+		// Scope only applies to iPXE OS rows; restrict the match to iPXE types so Image rows
+		// (which have a NULL scope) are not coerced to "Local" by the COALESCE.
+		query = query.Where(
+			"os.type IN (?) AND COALESCE(os.ipxe_os_scope, ?) IN (?)",
+			bun.In([]string{OperatingSystemTypeIPXE, OperatingSystemTypeTemplatedIPXE}),
+			OperatingSystemScopeLocal,
+			bun.In(filter.Scopes),
+		)
+		ossd.tracerSpan.SetAttribute(operatingSystemSQLDAOSpan, "scopes", filter.Scopes)
+	}
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
 	}
 
 	for _, relation := range includeRelations {
@@ -607,6 +796,26 @@ func (ossd OperatingSystemSQLDAO) Update(ctx context.Context, tx *db.Tx, input O
 		updatedFields = append(updatedFields, "status")
 		ossd.tracerSpan.SetAttribute(operatingSystemSQLDAOSpan, "status", *input.Status)
 	}
+	if input.IpxeTemplateId != nil {
+		it.IpxeTemplateId = input.IpxeTemplateId
+		updatedFields = append(updatedFields, "ipxe_template_id")
+	}
+	if input.IpxeTemplateParameters != nil {
+		it.IpxeTemplateParameters = *input.IpxeTemplateParameters
+		updatedFields = append(updatedFields, "ipxe_template_parameters")
+	}
+	if input.IpxeTemplateArtifacts != nil {
+		it.IpxeTemplateArtifacts = *input.IpxeTemplateArtifacts
+		updatedFields = append(updatedFields, "ipxe_template_artifacts")
+	}
+	if input.IpxeOSHash != nil {
+		it.IpxeTemplateDefinitionHash = input.IpxeOSHash
+		updatedFields = append(updatedFields, "ipxe_template_definition_hash")
+	}
+	if input.Scope != nil {
+		it.IpxeOsScope = input.Scope
+		updatedFields = append(updatedFields, "ipxe_os_scope")
+	}
 
 	if len(updatedFields) > 0 {
 		updatedFields = append(updatedFields, "updated")
@@ -702,6 +911,26 @@ func (ossd OperatingSystemSQLDAO) Clear(ctx context.Context, tx *db.Tx, input Op
 	if input.DeactivationNote {
 		it.DeactivationNote = nil
 		updatedFields = append(updatedFields, "deactivation_note")
+	}
+	if input.IpxeTemplateId {
+		it.IpxeTemplateId = nil
+		updatedFields = append(updatedFields, "ipxe_template_id")
+	}
+	if input.IpxeTemplateParameters {
+		it.IpxeTemplateParameters = nil
+		updatedFields = append(updatedFields, "ipxe_template_parameters")
+	}
+	if input.IpxeTemplateArtifacts {
+		it.IpxeTemplateArtifacts = nil
+		updatedFields = append(updatedFields, "ipxe_template_artifacts")
+	}
+	if input.IpxeOSHash {
+		it.IpxeTemplateDefinitionHash = nil
+		updatedFields = append(updatedFields, "ipxe_template_definition_hash")
+	}
+	if input.Scope {
+		it.IpxeOsScope = nil
+		updatedFields = append(updatedFields, "ipxe_os_scope")
 	}
 
 	if len(updatedFields) > 0 {

--- a/rest-api/db/pkg/db/model/operatingsystem_ipxe_test.go
+++ b/rest-api/db/pkg/db/model/operatingsystem_ipxe_test.go
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"context"
+	"testing"
+
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperatingSystemSQLDAO_TemplatedIPXERoundTrip exercises the iPXE template definition
+// columns and the ipxe_os_scope column added for the Templated iPXE OS variant: create,
+// read-back of the JSONB parameter/artifact slices, scope update, and scope/iPXE clear.
+func TestOperatingSystemSQLDAO_TemplatedIPXERoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testOperatingSystemInitDB(t)
+	defer dbSession.Close()
+	testOperatingSystemSetupSchema(t, dbSession)
+
+	tenant := testOperatingSystemBuildTenant(t, dbSession, "testTenant")
+	user := testOperatingSystemBuildUser(t, dbSession, "testUser")
+
+	dao := NewOperatingSystemDAO(dbSession)
+
+	templateID := uuid.New().String()
+	created, err := dao.Create(ctx, nil, OperatingSystemCreateInput{
+		Name:           "templated-ipxe-os",
+		Org:            "test",
+		TenantID:       &tenant.ID,
+		OsType:         OperatingSystemTypeTemplatedIPXE,
+		IpxeTemplateId: &templateID,
+		IpxeTemplateParameters: []OperatingSystemIpxeParameter{
+			{Name: "kernel_params", Value: "quiet"},
+		},
+		IpxeTemplateArtifacts: []OperatingSystemIpxeArtifact{
+			{
+				Name:          "kernel",
+				URL:           "https://example.test/kernel",
+				AuthToken:     cutil.GetPtr("secret-token"),
+				CacheStrategy: OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded,
+			},
+		},
+		IpxeOSHash:  cutil.GetPtr("hash-1"),
+		IpxeOsScope: cutil.GetPtr(OperatingSystemScopeGlobal),
+		Status:      OperatingSystemStatusPending,
+		CreatedBy:   user.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+
+	got, err := dao.GetByID(ctx, nil, created.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, OperatingSystemTypeTemplatedIPXE, got.Type)
+	require.NotNil(t, got.IpxeOsScope)
+	assert.Equal(t, OperatingSystemScopeGlobal, *got.IpxeOsScope)
+	require.NotNil(t, got.IpxeTemplateId)
+	assert.Equal(t, templateID, *got.IpxeTemplateId)
+	require.NotNil(t, got.IpxeTemplateDefinitionHash)
+	assert.Equal(t, "hash-1", *got.IpxeTemplateDefinitionHash)
+
+	require.Len(t, got.IpxeTemplateParameters, 1)
+	assert.Equal(t, "kernel_params", got.IpxeTemplateParameters[0].Name)
+	assert.Equal(t, "quiet", got.IpxeTemplateParameters[0].Value)
+
+	require.Len(t, got.IpxeTemplateArtifacts, 1)
+	assert.Equal(t, "kernel", got.IpxeTemplateArtifacts[0].Name)
+	require.NotNil(t, got.IpxeTemplateArtifacts[0].AuthToken)
+	assert.Equal(t, "secret-token", *got.IpxeTemplateArtifacts[0].AuthToken)
+	assert.Equal(t, OperatingSystemIpxeArtifactCacheStrategyCacheAsNeeded, got.IpxeTemplateArtifacts[0].CacheStrategy)
+
+	// Update scope and artifacts.
+	updated, err := dao.Update(ctx, nil, OperatingSystemUpdateInput{
+		OperatingSystemId: created.ID,
+		Scope:             cutil.GetPtr(OperatingSystemScopeLimited),
+		IpxeTemplateArtifacts: &[]OperatingSystemIpxeArtifact{
+			{Name: "initrd", URL: "https://example.test/initrd", CacheStrategy: OperatingSystemIpxeArtifactCacheStrategyCachedOnly},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, updated.IpxeOsScope)
+	assert.Equal(t, OperatingSystemScopeLimited, *updated.IpxeOsScope)
+	require.Len(t, updated.IpxeTemplateArtifacts, 1)
+	assert.Equal(t, "initrd", updated.IpxeTemplateArtifacts[0].Name)
+	assert.Equal(t, OperatingSystemIpxeArtifactCacheStrategyCachedOnly, updated.IpxeTemplateArtifacts[0].CacheStrategy)
+
+	// Clear the iPXE definition and scope.
+	cleared, err := dao.Clear(ctx, nil, OperatingSystemClearInput{
+		OperatingSystemId:      created.ID,
+		IpxeTemplateId:         true,
+		IpxeTemplateParameters: true,
+		IpxeTemplateArtifacts:  true,
+		IpxeOSHash:             true,
+		Scope:                  true,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, cleared.IpxeOsScope)
+	assert.Nil(t, cleared.IpxeTemplateId)
+	assert.Nil(t, cleared.IpxeTemplateParameters)
+	assert.Nil(t, cleared.IpxeTemplateArtifacts)
+	assert.Nil(t, cleared.IpxeTemplateDefinitionHash)
+}
+
+// TestOperatingSystemSQLDAO_ScopeFilter verifies the Scopes filter only matches iPXE OS rows
+// and never coerces Image rows (NULL scope) into the "Local" bucket.
+func TestOperatingSystemSQLDAO_ScopeFilter(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testOperatingSystemInitDB(t)
+	defer dbSession.Close()
+	testOperatingSystemSetupSchema(t, dbSession)
+
+	ip := testOperatingSystemBuildInfrastructureProvider(t, dbSession, "testIP")
+	tenant := testOperatingSystemBuildTenant(t, dbSession, "testTenant")
+	user := testOperatingSystemBuildUser(t, dbSession, "testUser")
+
+	dao := NewOperatingSystemDAO(dbSession)
+
+	// Global-scoped Templated iPXE OS.
+	_, err := dao.Create(ctx, nil, OperatingSystemCreateInput{
+		Name: "global-ipxe", Org: "test", TenantID: &tenant.ID,
+		OsType: OperatingSystemTypeTemplatedIPXE, IpxeOsScope: cutil.GetPtr(OperatingSystemScopeGlobal),
+		Status: OperatingSystemStatusReady, CreatedBy: user.ID,
+	})
+	require.NoError(t, err)
+
+	// Raw iPXE OS with no explicit scope (treated as Local via COALESCE).
+	_, err = dao.Create(ctx, nil, OperatingSystemCreateInput{
+		Name: "local-ipxe", Org: "test", TenantID: &tenant.ID,
+		OsType: OperatingSystemTypeIPXE,
+		Status: OperatingSystemStatusReady, CreatedBy: user.ID,
+	})
+	require.NoError(t, err)
+
+	// Image OS: scope does not apply (NULL scope) and must never match a scope filter.
+	_ = testBuildImageOperatingSystem(t, dbSession, "image-os", cutil.GetPtr("img"), "test", &ip.ID, &tenant.ID, nil, false, OperatingSystemStatusReady, user.ID)
+
+	globalRows, _, err := dao.GetAll(ctx, nil, OperatingSystemFilterInput{Scopes: []string{OperatingSystemScopeGlobal}}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Len(t, globalRows, 1)
+	assert.Equal(t, "global-ipxe", globalRows[0].Name)
+
+	localRows, _, err := dao.GetAll(ctx, nil, OperatingSystemFilterInput{Scopes: []string{OperatingSystemScopeLocal}}, paginator.PageInput{}, nil)
+	require.NoError(t, err)
+	assert.Len(t, localRows, 1)
+	assert.Equal(t, "local-ipxe", localRows[0].Name)
+}

--- a/rest-api/db/pkg/db/model/operatingsystemsiteassociation.go
+++ b/rest-api/db/pkg/db/model/operatingsystemsiteassociation.go
@@ -16,6 +16,8 @@ import (
 	"github.com/uptrace/bun"
 
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 var (
@@ -56,6 +58,15 @@ var (
 		OperatingSystemSiteAssociationStatusError:    true,
 		OperatingSystemSiteAssociationStatusDeleting: true,
 	}
+
+	// OperatingSystemSiteAssociationStatusFromProtoMap maps nico-core tenant states to per-site association status values.
+	OperatingSystemSiteAssociationStatusFromProtoMap = map[cwssaws.TenantState]string{
+		cwssaws.TenantState_PROVISIONING: OperatingSystemSiteAssociationStatusSyncing,
+		cwssaws.TenantState_READY:        OperatingSystemSiteAssociationStatusSynced,
+		cwssaws.TenantState_CONFIGURING:  OperatingSystemSiteAssociationStatusSyncing,
+		cwssaws.TenantState_TERMINATING:  OperatingSystemSiteAssociationStatusDeleting,
+		cwssaws.TenantState_FAILED:       OperatingSystemSiteAssociationStatusError,
+	}
 )
 
 // OperatingSystemSiteAssociation associates an OperatingSystem with different Sites
@@ -69,11 +80,13 @@ type OperatingSystemSiteAssociation struct {
 	Site              *Site            `bun:"rel:belongs-to,join:site_id=id"`
 	Version           *string          `bun:"version"`
 	Status            string           `bun:"status,notnull"`
-	IsMissingOnSite   bool             `bun:"is_missing_on_site,notnull"`
-	Created           time.Time        `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated           time.Time        `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	Deleted           *time.Time       `bun:"deleted,soft_delete"`
-	CreatedBy         uuid.UUID        `bun:"created_by,type:uuid,notnull"`
+	// ControllerState mirrors the tenant state reported by nico-core for this OS at this site.
+	ControllerState *string    `bun:"controller_state"`
+	IsMissingOnSite bool       `bun:"is_missing_on_site,notnull"`
+	Created         time.Time  `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated         time.Time  `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	Deleted         *time.Time `bun:"deleted,soft_delete"`
+	CreatedBy       uuid.UUID  `bun:"created_by,type:uuid,notnull"`
 }
 
 // OperatingSystemSiteAssociationCreateInput input parameters for Create method
@@ -82,6 +95,7 @@ type OperatingSystemSiteAssociationCreateInput struct {
 	SiteID            uuid.UUID
 	Version           *string
 	Status            string
+	ControllerState   *string
 	CreatedBy         uuid.UUID
 }
 
@@ -92,6 +106,7 @@ type OperatingSystemSiteAssociationUpdateInput struct {
 	SiteID                           *uuid.UUID
 	Version                          *string
 	Status                           *string
+	ControllerState                  *string
 	IsMissingOnSite                  *bool
 }
 
@@ -167,6 +182,7 @@ func (ossasd OperatingSystemSiteAssociationSQLDAO) Create(
 		SiteID:            input.SiteID,
 		Version:           input.Version,
 		Status:            input.Status,
+		ControllerState:   input.ControllerState,
 		CreatedBy:         input.CreatedBy,
 	}
 
@@ -398,6 +414,11 @@ func (ossasd OperatingSystemSiteAssociationSQLDAO) Update(
 		ossa.IsMissingOnSite = *input.IsMissingOnSite
 		updatedFields = append(updatedFields, "is_missing_on_site")
 		ossasd.tracerSpan.SetAttribute(OperatingSystemSiteAssociationDAOSpan, "is_missing_on_site", *input.IsMissingOnSite)
+	}
+	if input.ControllerState != nil {
+		ossa.ControllerState = input.ControllerState
+		updatedFields = append(updatedFields, "controller_state")
+		ossasd.tracerSpan.SetAttribute(OperatingSystemSiteAssociationDAOSpan, "controller_state", *input.ControllerState)
 	}
 
 	if len(updatedFields) > 0 {

--- a/rest-api/db/pkg/migrations/20260623150000_ipxe_os_and_templates.go
+++ b/rest-api/db/pkg/migrations/20260623150000_ipxe_os_and_templates.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	"github.com/uptrace/bun"
+)
+
+// 20260623150000_ipxe_os_and_templates
+//
+// Adds the schema needed for the Templated iPXE Operating System variant and its
+// synchronization with nico-core:
+//   - ipxe_template: global iPXE script templates, keyed by the stable UUID assigned
+//     by nico-core (the same UUID is used on both sides).
+//   - ipxe_template_site_association (ITSA): tracks which sites currently report each
+//     template.
+//   - operating_system: iPXE template definition columns plus the ipxe_os_scope column
+//     that controls synchronization direction.
+//   - operating_system_site_association: controller_state column mirroring the per-site
+//     tenant state reported by nico-core.
+//
+// This migration is additive. The legacy controller_operating_system_id column is
+// intentionally left in place; consolidating on a shared OS UUID is handled separately
+// once all readers have been updated.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		tx, terr := db.BeginTx(ctx, &sql.TxOptions{})
+		if terr != nil {
+			handlePanic(terr, "failed to begin transaction")
+		}
+
+		// iPXE Template table (global). The unique name constraint and column types
+		// come from the bun model definition.
+		_, err := tx.NewCreateTable().Model((*model.IpxeTemplate)(nil)).IfNotExists().Exec(ctx)
+		handleError(tx, err)
+
+		_, err = tx.Exec("CREATE INDEX IF NOT EXISTS ipxe_template_name_idx ON ipxe_template(name)")
+		handleError(tx, err)
+		_, err = tx.Exec("CREATE INDEX IF NOT EXISTS ipxe_template_scope_idx ON ipxe_template(scope)")
+		handleError(tx, err)
+		_, err = tx.Exec("CREATE INDEX IF NOT EXISTS ipxe_template_created_idx ON ipxe_template(created)")
+		handleError(tx, err)
+		_, err = tx.Exec("CREATE INDEX IF NOT EXISTS ipxe_template_updated_idx ON ipxe_template(updated)")
+		handleError(tx, err)
+
+		// iPXE Template <-> Site association. Foreign keys are declared on the model.
+		_, err = tx.NewCreateTable().Model((*model.IpxeTemplateSiteAssociation)(nil)).IfNotExists().Exec(ctx)
+		handleError(tx, err)
+
+		_, err = tx.Exec(`
+			ALTER TABLE ipxe_template_site_association
+			DROP CONSTRAINT IF EXISTS ipxe_template_site_association_template_id_site_id_key
+		`)
+		handleError(tx, err)
+		_, err = tx.Exec(`
+			ALTER TABLE ipxe_template_site_association
+			ADD CONSTRAINT ipxe_template_site_association_template_id_site_id_key
+			UNIQUE (ipxe_template_id, site_id)
+		`)
+		handleError(tx, err)
+
+		_, err = tx.Exec("CREATE INDEX IF NOT EXISTS itsa_ipxe_template_id_idx ON ipxe_template_site_association(ipxe_template_id)")
+		handleError(tx, err)
+		_, err = tx.Exec("CREATE INDEX IF NOT EXISTS itsa_site_id_idx ON ipxe_template_site_association(site_id)")
+		handleError(tx, err)
+
+		// Operating System: iPXE template definition columns.
+		_, err = tx.Exec("ALTER TABLE operating_system ADD COLUMN IF NOT EXISTS ipxe_template_id TEXT NULL")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system ADD COLUMN IF NOT EXISTS ipxe_template_parameters JSONB NULL")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system ADD COLUMN IF NOT EXISTS ipxe_template_artifacts JSONB NULL")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system ADD COLUMN IF NOT EXISTS ipxe_template_definition_hash TEXT NULL")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system ADD COLUMN IF NOT EXISTS ipxe_os_scope TEXT NULL")
+		handleError(tx, err)
+
+		// Operating System Site Association: per-site controller state.
+		_, err = tx.Exec("ALTER TABLE operating_system_site_association ADD COLUMN IF NOT EXISTS controller_state TEXT NULL")
+		handleError(tx, err)
+
+		// Backfill ipxe_os_scope for existing iPXE-type OS records. Image rows keep a
+		// NULL scope since scope does not apply to them.
+		//   tenant-owned iPXE  -> Global (carbide-rest is the source of truth)
+		//   provider-owned iPXE -> Local  (bidirectional with nico-core)
+		_, err = tx.Exec(`
+			UPDATE operating_system
+			SET ipxe_os_scope = 'Global'
+			WHERE ipxe_os_scope IS NULL
+			  AND type = 'iPXE'
+			  AND tenant_id IS NOT NULL
+			  AND deleted IS NULL
+		`)
+		handleError(tx, err)
+		_, err = tx.Exec(`
+			UPDATE operating_system
+			SET ipxe_os_scope = 'Local'
+			WHERE ipxe_os_scope IS NULL
+			  AND type = 'iPXE'
+			  AND tenant_id IS NULL
+			  AND deleted IS NULL
+		`)
+		handleError(tx, err)
+
+		terr = tx.Commit()
+		if terr != nil {
+			handlePanic(terr, "failed to commit transaction")
+		}
+
+		fmt.Print(" [up migration] Added iPXE template tables and Operating System scope/template columns. ")
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		tx, terr := db.BeginTx(ctx, &sql.TxOptions{})
+		if terr != nil {
+			handlePanic(terr, "failed to begin transaction")
+		}
+
+		_, err := tx.Exec("ALTER TABLE operating_system_site_association DROP COLUMN IF EXISTS controller_state")
+		handleError(tx, err)
+
+		_, err = tx.Exec("ALTER TABLE operating_system DROP COLUMN IF EXISTS ipxe_os_scope")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system DROP COLUMN IF EXISTS ipxe_template_definition_hash")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system DROP COLUMN IF EXISTS ipxe_template_artifacts")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system DROP COLUMN IF EXISTS ipxe_template_parameters")
+		handleError(tx, err)
+		_, err = tx.Exec("ALTER TABLE operating_system DROP COLUMN IF EXISTS ipxe_template_id")
+		handleError(tx, err)
+
+		_, err = tx.Exec("DROP TABLE IF EXISTS ipxe_template_site_association")
+		handleError(tx, err)
+		_, err = tx.Exec("DROP TABLE IF EXISTS ipxe_template")
+		handleError(tx, err)
+
+		terr = tx.Commit()
+		if terr != nil {
+			handlePanic(terr, "failed to commit transaction")
+		}
+
+		fmt.Print(" [down migration] Dropped iPXE template tables and Operating System scope/template columns. ")
+		return nil
+	})
+}

--- a/rest-api/workflow-schema/schema/site-agent/workflows/v1/inventory.pb.go
+++ b/rest-api/workflow-schema/schema/site-agent/workflows/v1/inventory.pb.go
@@ -1230,6 +1230,170 @@ func (x *OsImageInventory) GetInventoryPage() *InventoryPage {
 	return nil
 }
 
+// OperatingSystemInventory - inventory info for all OS definitions periodically collected from carbide-core
+type OperatingSystemInventory struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// List of Operating Systems (active records only; deletions are detected by absence)
+	OperatingSystems []*OperatingSystem `protobuf:"bytes,1,rep,name=operating_systems,json=operatingSystems,proto3" json:"operating_systems,omitempty"`
+	// Reported timestamp of inventory
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// Status of Inventory
+	InventoryStatus InventoryStatus `protobuf:"varint,3,opt,name=inventory_status,json=inventoryStatus,proto3,enum=workflows.v1.InventoryStatus" json:"inventory_status,omitempty"`
+	// Message for status
+	StatusMsg string `protobuf:"bytes,4,opt,name=status_msg,json=statusMsg,proto3" json:"status_msg,omitempty"`
+	// Inventory page information
+	InventoryPage *InventoryPage `protobuf:"bytes,5,opt,name=inventory_page,json=inventoryPage,proto3" json:"inventory_page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OperatingSystemInventory) Reset() {
+	*x = OperatingSystemInventory{}
+	mi := &file_inventory_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OperatingSystemInventory) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OperatingSystemInventory) ProtoMessage() {}
+
+func (x *OperatingSystemInventory) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OperatingSystemInventory.ProtoReflect.Descriptor instead.
+func (*OperatingSystemInventory) Descriptor() ([]byte, []int) {
+	return file_inventory_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *OperatingSystemInventory) GetOperatingSystems() []*OperatingSystem {
+	if x != nil {
+		return x.OperatingSystems
+	}
+	return nil
+}
+
+func (x *OperatingSystemInventory) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *OperatingSystemInventory) GetInventoryStatus() InventoryStatus {
+	if x != nil {
+		return x.InventoryStatus
+	}
+	return InventoryStatus_INVENTORY_STATUS_UNSPECIFIED
+}
+
+func (x *OperatingSystemInventory) GetStatusMsg() string {
+	if x != nil {
+		return x.StatusMsg
+	}
+	return ""
+}
+
+func (x *OperatingSystemInventory) GetInventoryPage() *InventoryPage {
+	if x != nil {
+		return x.InventoryPage
+	}
+	return nil
+}
+
+// IpxeTemplateInventory - inventory info of all iPXE templates periodically collected from site
+type IpxeTemplateInventory struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// List of iPXE templates
+	Templates []*IpxeTemplate `protobuf:"bytes,1,rep,name=templates,proto3" json:"templates,omitempty"`
+	// Reported timestamp of iPXE template inventory
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// Status of Inventory
+	InventoryStatus InventoryStatus `protobuf:"varint,3,opt,name=inventory_status,json=inventoryStatus,proto3,enum=workflows.v1.InventoryStatus" json:"inventory_status,omitempty"`
+	// Status message
+	StatusMsg string `protobuf:"bytes,4,opt,name=status_msg,json=statusMsg,proto3" json:"status_msg,omitempty"`
+	// Inventory page information
+	InventoryPage *InventoryPage `protobuf:"bytes,5,opt,name=inventory_page,json=inventoryPage,proto3" json:"inventory_page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IpxeTemplateInventory) Reset() {
+	*x = IpxeTemplateInventory{}
+	mi := &file_inventory_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IpxeTemplateInventory) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IpxeTemplateInventory) ProtoMessage() {}
+
+func (x *IpxeTemplateInventory) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IpxeTemplateInventory.ProtoReflect.Descriptor instead.
+func (*IpxeTemplateInventory) Descriptor() ([]byte, []int) {
+	return file_inventory_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *IpxeTemplateInventory) GetTemplates() []*IpxeTemplate {
+	if x != nil {
+		return x.Templates
+	}
+	return nil
+}
+
+func (x *IpxeTemplateInventory) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *IpxeTemplateInventory) GetInventoryStatus() InventoryStatus {
+	if x != nil {
+		return x.InventoryStatus
+	}
+	return InventoryStatus_INVENTORY_STATUS_UNSPECIFIED
+}
+
+func (x *IpxeTemplateInventory) GetStatusMsg() string {
+	if x != nil {
+		return x.StatusMsg
+	}
+	return ""
+}
+
+func (x *IpxeTemplateInventory) GetInventoryPage() *InventoryPage {
+	if x != nil {
+		return x.InventoryPage
+	}
+	return nil
+}
+
 // SkuInventory - inventory info of all SKUs on Site, collected periodically
 type SkuInventory struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1249,7 +1413,7 @@ type SkuInventory struct {
 
 func (x *SkuInventory) Reset() {
 	*x = SkuInventory{}
-	mi := &file_inventory_proto_msgTypes[14]
+	mi := &file_inventory_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1261,7 +1425,7 @@ func (x *SkuInventory) String() string {
 func (*SkuInventory) ProtoMessage() {}
 
 func (x *SkuInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[14]
+	mi := &file_inventory_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1274,7 +1438,7 @@ func (x *SkuInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SkuInventory.ProtoReflect.Descriptor instead.
 func (*SkuInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{14}
+	return file_inventory_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *SkuInventory) GetInventoryStatus() InventoryStatus {
@@ -1331,7 +1495,7 @@ type SSHKeyGroupInventory struct {
 
 func (x *SSHKeyGroupInventory) Reset() {
 	*x = SSHKeyGroupInventory{}
-	mi := &file_inventory_proto_msgTypes[15]
+	mi := &file_inventory_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1343,7 +1507,7 @@ func (x *SSHKeyGroupInventory) String() string {
 func (*SSHKeyGroupInventory) ProtoMessage() {}
 
 func (x *SSHKeyGroupInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[15]
+	mi := &file_inventory_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1356,7 +1520,7 @@ func (x *SSHKeyGroupInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHKeyGroupInventory.ProtoReflect.Descriptor instead.
 func (*SSHKeyGroupInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{15}
+	return file_inventory_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *SSHKeyGroupInventory) GetTenantKeysets() []*TenantKeyset {
@@ -1413,7 +1577,7 @@ type SubnetInventory struct {
 
 func (x *SubnetInventory) Reset() {
 	*x = SubnetInventory{}
-	mi := &file_inventory_proto_msgTypes[16]
+	mi := &file_inventory_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1425,7 +1589,7 @@ func (x *SubnetInventory) String() string {
 func (*SubnetInventory) ProtoMessage() {}
 
 func (x *SubnetInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[16]
+	mi := &file_inventory_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1438,7 +1602,7 @@ func (x *SubnetInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubnetInventory.ProtoReflect.Descriptor instead.
 func (*SubnetInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{16}
+	return file_inventory_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *SubnetInventory) GetSegments() []*NetworkSegment {
@@ -1495,7 +1659,7 @@ type TenantInventory struct {
 
 func (x *TenantInventory) Reset() {
 	*x = TenantInventory{}
-	mi := &file_inventory_proto_msgTypes[17]
+	mi := &file_inventory_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1507,7 +1671,7 @@ func (x *TenantInventory) String() string {
 func (*TenantInventory) ProtoMessage() {}
 
 func (x *TenantInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[17]
+	mi := &file_inventory_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1520,7 +1684,7 @@ func (x *TenantInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TenantInventory.ProtoReflect.Descriptor instead.
 func (*TenantInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{17}
+	return file_inventory_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *TenantInventory) GetTenants() []*Tenant {
@@ -1579,7 +1743,7 @@ type VPCInventory struct {
 
 func (x *VPCInventory) Reset() {
 	*x = VPCInventory{}
-	mi := &file_inventory_proto_msgTypes[18]
+	mi := &file_inventory_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1591,7 +1755,7 @@ func (x *VPCInventory) String() string {
 func (*VPCInventory) ProtoMessage() {}
 
 func (x *VPCInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[18]
+	mi := &file_inventory_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1604,7 +1768,7 @@ func (x *VPCInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VPCInventory.ProtoReflect.Descriptor instead.
 func (*VPCInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{18}
+	return file_inventory_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *VPCInventory) GetVpcs() []*Vpc {
@@ -1668,7 +1832,7 @@ type VPCPeeringInventory struct {
 
 func (x *VPCPeeringInventory) Reset() {
 	*x = VPCPeeringInventory{}
-	mi := &file_inventory_proto_msgTypes[19]
+	mi := &file_inventory_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1680,7 +1844,7 @@ func (x *VPCPeeringInventory) String() string {
 func (*VPCPeeringInventory) ProtoMessage() {}
 
 func (x *VPCPeeringInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[19]
+	mi := &file_inventory_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1693,7 +1857,7 @@ func (x *VPCPeeringInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VPCPeeringInventory.ProtoReflect.Descriptor instead.
 func (*VPCPeeringInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{19}
+	return file_inventory_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *VPCPeeringInventory) GetVpcPeerings() []*VpcPeering {
@@ -1750,7 +1914,7 @@ type VpcPrefixInventory struct {
 
 func (x *VpcPrefixInventory) Reset() {
 	*x = VpcPrefixInventory{}
-	mi := &file_inventory_proto_msgTypes[20]
+	mi := &file_inventory_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1762,7 +1926,7 @@ func (x *VpcPrefixInventory) String() string {
 func (*VpcPrefixInventory) ProtoMessage() {}
 
 func (x *VpcPrefixInventory) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_proto_msgTypes[20]
+	mi := &file_inventory_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1775,7 +1939,7 @@ func (x *VpcPrefixInventory) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcPrefixInventory.ProtoReflect.Descriptor instead.
 func (*VpcPrefixInventory) Descriptor() ([]byte, []int) {
-	return file_inventory_proto_rawDescGZIP(), []int{20}
+	return file_inventory_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *VpcPrefixInventory) GetVpcPrefixes() []*VpcPrefix {
@@ -1918,6 +2082,20 @@ const file_inventory_proto_rawDesc = "" +
 	"\x10inventory_status\x18\x03 \x01(\x0e2\x1d.workflows.v1.InventoryStatusR\x0finventoryStatus\x12\x1d\n" +
 	"\n" +
 	"status_msg\x18\x04 \x01(\tR\tstatusMsg\x12B\n" +
+	"\x0einventory_page\x18\x05 \x01(\v2\x1b.workflows.v1.InventoryPageR\rinventoryPage\"\xc6\x02\n" +
+	"\x18OperatingSystemInventory\x12C\n" +
+	"\x11operating_systems\x18\x01 \x03(\v2\x16.forge.OperatingSystemR\x10operatingSystems\x128\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12H\n" +
+	"\x10inventory_status\x18\x03 \x01(\x0e2\x1d.workflows.v1.InventoryStatusR\x0finventoryStatus\x12\x1d\n" +
+	"\n" +
+	"status_msg\x18\x04 \x01(\tR\tstatusMsg\x12B\n" +
+	"\x0einventory_page\x18\x05 \x01(\v2\x1b.workflows.v1.InventoryPageR\rinventoryPage\"\xb1\x02\n" +
+	"\x15IpxeTemplateInventory\x121\n" +
+	"\ttemplates\x18\x01 \x03(\v2\x13.forge.IpxeTemplateR\ttemplates\x128\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12H\n" +
+	"\x10inventory_status\x18\x03 \x01(\x0e2\x1d.workflows.v1.InventoryStatusR\x0finventoryStatus\x12\x1d\n" +
+	"\n" +
+	"status_msg\x18\x04 \x01(\tR\tstatusMsg\x12B\n" +
 	"\x0einventory_page\x18\x05 \x01(\v2\x1b.workflows.v1.InventoryPageR\rinventoryPage\"\x95\x02\n" +
 	"\fSkuInventory\x12H\n" +
 	"\x10inventory_status\x18\x01 \x01(\x0e2\x1d.workflows.v1.InventoryStatusR\x0finventoryStatus\x12\x1d\n" +
@@ -1989,7 +2167,7 @@ func file_inventory_proto_rawDescGZIP() []byte {
 }
 
 var file_inventory_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_inventory_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_inventory_proto_goTypes = []any{
 	(InventoryStatus)(0),                                // 0: workflows.v1.InventoryStatus
 	(*InventoryPage)(nil),                               // 1: workflows.v1.InventoryPage
@@ -2006,128 +2184,140 @@ var file_inventory_proto_goTypes = []any{
 	(*NetworkSecurityGroupInventory)(nil),               // 12: workflows.v1.NetworkSecurityGroupInventory
 	(*NVLinkLogicalPartitionInventory)(nil),             // 13: workflows.v1.NVLinkLogicalPartitionInventory
 	(*OsImageInventory)(nil),                            // 14: workflows.v1.OsImageInventory
-	(*SkuInventory)(nil),                                // 15: workflows.v1.SkuInventory
-	(*SSHKeyGroupInventory)(nil),                        // 16: workflows.v1.SSHKeyGroupInventory
-	(*SubnetInventory)(nil),                             // 17: workflows.v1.SubnetInventory
-	(*TenantInventory)(nil),                             // 18: workflows.v1.TenantInventory
-	(*VPCInventory)(nil),                                // 19: workflows.v1.VPCInventory
-	(*VPCPeeringInventory)(nil),                         // 20: workflows.v1.VPCPeeringInventory
-	(*VpcPrefixInventory)(nil),                          // 21: workflows.v1.VpcPrefixInventory
-	(*timestamppb.Timestamp)(nil),                       // 22: google.protobuf.Timestamp
-	(*DpuExtensionService)(nil),                         // 23: forge.DpuExtensionService
-	(*ExpectedMachine)(nil),                             // 24: forge.ExpectedMachine
-	(*LinkedExpectedMachine)(nil),                       // 25: forge.LinkedExpectedMachine
-	(*ExpectedRack)(nil),                                // 26: forge.ExpectedRack
-	(*ExpectedPowerShelf)(nil),                          // 27: forge.ExpectedPowerShelf
-	(*LinkedExpectedPowerShelf)(nil),                    // 28: forge.LinkedExpectedPowerShelf
-	(*ExpectedSwitch)(nil),                              // 29: forge.ExpectedSwitch
-	(*LinkedExpectedSwitch)(nil),                        // 30: forge.LinkedExpectedSwitch
-	(*IBPartition)(nil),                                 // 31: forge.IBPartition
-	(*Instance)(nil),                                    // 32: forge.Instance
-	(*NetworkSecurityGroupPropagationObjectStatus)(nil), // 33: forge.NetworkSecurityGroupPropagationObjectStatus
-	(*InstanceType)(nil),                                // 34: forge.InstanceType
-	(*Machine)(nil),                                     // 35: forge.Machine
-	(*DiscoveryInfo)(nil),                               // 36: machine_discovery.DiscoveryInfo
-	(*NetworkSecurityGroup)(nil),                        // 37: forge.NetworkSecurityGroup
-	(*NVLinkLogicalPartition)(nil),                      // 38: forge.NVLinkLogicalPartition
-	(*OsImage)(nil),                                     // 39: forge.OsImage
-	(*Sku)(nil),                                         // 40: forge.Sku
-	(*TenantKeyset)(nil),                                // 41: forge.TenantKeyset
-	(*NetworkSegment)(nil),                              // 42: forge.NetworkSegment
-	(*Tenant)(nil),                                      // 43: forge.Tenant
-	(*Vpc)(nil),                                         // 44: forge.Vpc
-	(*VpcPeering)(nil),                                  // 45: forge.VpcPeering
-	(*VpcPrefix)(nil),                                   // 46: forge.VpcPrefix
+	(*OperatingSystemInventory)(nil),                    // 15: workflows.v1.OperatingSystemInventory
+	(*IpxeTemplateInventory)(nil),                       // 16: workflows.v1.IpxeTemplateInventory
+	(*SkuInventory)(nil),                                // 17: workflows.v1.SkuInventory
+	(*SSHKeyGroupInventory)(nil),                        // 18: workflows.v1.SSHKeyGroupInventory
+	(*SubnetInventory)(nil),                             // 19: workflows.v1.SubnetInventory
+	(*TenantInventory)(nil),                             // 20: workflows.v1.TenantInventory
+	(*VPCInventory)(nil),                                // 21: workflows.v1.VPCInventory
+	(*VPCPeeringInventory)(nil),                         // 22: workflows.v1.VPCPeeringInventory
+	(*VpcPrefixInventory)(nil),                          // 23: workflows.v1.VpcPrefixInventory
+	(*timestamppb.Timestamp)(nil),                       // 24: google.protobuf.Timestamp
+	(*DpuExtensionService)(nil),                         // 25: forge.DpuExtensionService
+	(*ExpectedMachine)(nil),                             // 26: forge.ExpectedMachine
+	(*LinkedExpectedMachine)(nil),                       // 27: forge.LinkedExpectedMachine
+	(*ExpectedRack)(nil),                                // 28: forge.ExpectedRack
+	(*ExpectedPowerShelf)(nil),                          // 29: forge.ExpectedPowerShelf
+	(*LinkedExpectedPowerShelf)(nil),                    // 30: forge.LinkedExpectedPowerShelf
+	(*ExpectedSwitch)(nil),                              // 31: forge.ExpectedSwitch
+	(*LinkedExpectedSwitch)(nil),                        // 32: forge.LinkedExpectedSwitch
+	(*IBPartition)(nil),                                 // 33: forge.IBPartition
+	(*Instance)(nil),                                    // 34: forge.Instance
+	(*NetworkSecurityGroupPropagationObjectStatus)(nil), // 35: forge.NetworkSecurityGroupPropagationObjectStatus
+	(*InstanceType)(nil),                                // 36: forge.InstanceType
+	(*Machine)(nil),                                     // 37: forge.Machine
+	(*DiscoveryInfo)(nil),                               // 38: machine_discovery.DiscoveryInfo
+	(*NetworkSecurityGroup)(nil),                        // 39: forge.NetworkSecurityGroup
+	(*NVLinkLogicalPartition)(nil),                      // 40: forge.NVLinkLogicalPartition
+	(*OsImage)(nil),                                     // 41: forge.OsImage
+	(*OperatingSystem)(nil),                             // 42: forge.OperatingSystem
+	(*IpxeTemplate)(nil),                                // 43: forge.IpxeTemplate
+	(*Sku)(nil),                                         // 44: forge.Sku
+	(*TenantKeyset)(nil),                                // 45: forge.TenantKeyset
+	(*NetworkSegment)(nil),                              // 46: forge.NetworkSegment
+	(*Tenant)(nil),                                      // 47: forge.Tenant
+	(*Vpc)(nil),                                         // 48: forge.Vpc
+	(*VpcPeering)(nil),                                  // 49: forge.VpcPeering
+	(*VpcPrefix)(nil),                                   // 50: forge.VpcPrefix
 }
 var file_inventory_proto_depIdxs = []int32{
 	0,  // 0: workflows.v1.DpuExtensionServiceInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 1: workflows.v1.DpuExtensionServiceInventory.timestamp:type_name -> google.protobuf.Timestamp
-	23, // 2: workflows.v1.DpuExtensionServiceInventory.dpu_extension_services:type_name -> forge.DpuExtensionService
+	24, // 1: workflows.v1.DpuExtensionServiceInventory.timestamp:type_name -> google.protobuf.Timestamp
+	25, // 2: workflows.v1.DpuExtensionServiceInventory.dpu_extension_services:type_name -> forge.DpuExtensionService
 	1,  // 3: workflows.v1.DpuExtensionServiceInventory.inventory_page:type_name -> workflows.v1.InventoryPage
 	0,  // 4: workflows.v1.ExpectedMachineInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 5: workflows.v1.ExpectedMachineInventory.timestamp:type_name -> google.protobuf.Timestamp
-	24, // 6: workflows.v1.ExpectedMachineInventory.expected_machines:type_name -> forge.ExpectedMachine
+	24, // 5: workflows.v1.ExpectedMachineInventory.timestamp:type_name -> google.protobuf.Timestamp
+	26, // 6: workflows.v1.ExpectedMachineInventory.expected_machines:type_name -> forge.ExpectedMachine
 	1,  // 7: workflows.v1.ExpectedMachineInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	25, // 8: workflows.v1.ExpectedMachineInventory.linked_machines:type_name -> forge.LinkedExpectedMachine
+	27, // 8: workflows.v1.ExpectedMachineInventory.linked_machines:type_name -> forge.LinkedExpectedMachine
 	0,  // 9: workflows.v1.ExpectedRackInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 10: workflows.v1.ExpectedRackInventory.timestamp:type_name -> google.protobuf.Timestamp
-	26, // 11: workflows.v1.ExpectedRackInventory.expected_racks:type_name -> forge.ExpectedRack
+	24, // 10: workflows.v1.ExpectedRackInventory.timestamp:type_name -> google.protobuf.Timestamp
+	28, // 11: workflows.v1.ExpectedRackInventory.expected_racks:type_name -> forge.ExpectedRack
 	1,  // 12: workflows.v1.ExpectedRackInventory.inventory_page:type_name -> workflows.v1.InventoryPage
 	0,  // 13: workflows.v1.ExpectedPowerShelfInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 14: workflows.v1.ExpectedPowerShelfInventory.timestamp:type_name -> google.protobuf.Timestamp
-	27, // 15: workflows.v1.ExpectedPowerShelfInventory.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
+	24, // 14: workflows.v1.ExpectedPowerShelfInventory.timestamp:type_name -> google.protobuf.Timestamp
+	29, // 15: workflows.v1.ExpectedPowerShelfInventory.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
 	1,  // 16: workflows.v1.ExpectedPowerShelfInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	28, // 17: workflows.v1.ExpectedPowerShelfInventory.linked_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
+	30, // 17: workflows.v1.ExpectedPowerShelfInventory.linked_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
 	0,  // 18: workflows.v1.ExpectedSwitchInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 19: workflows.v1.ExpectedSwitchInventory.timestamp:type_name -> google.protobuf.Timestamp
-	29, // 20: workflows.v1.ExpectedSwitchInventory.expected_switches:type_name -> forge.ExpectedSwitch
+	24, // 19: workflows.v1.ExpectedSwitchInventory.timestamp:type_name -> google.protobuf.Timestamp
+	31, // 20: workflows.v1.ExpectedSwitchInventory.expected_switches:type_name -> forge.ExpectedSwitch
 	1,  // 21: workflows.v1.ExpectedSwitchInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	30, // 22: workflows.v1.ExpectedSwitchInventory.linked_switches:type_name -> forge.LinkedExpectedSwitch
+	32, // 22: workflows.v1.ExpectedSwitchInventory.linked_switches:type_name -> forge.LinkedExpectedSwitch
 	0,  // 23: workflows.v1.InfiniBandPartitionInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 24: workflows.v1.InfiniBandPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
-	31, // 25: workflows.v1.InfiniBandPartitionInventory.ib_partitions:type_name -> forge.IBPartition
+	24, // 24: workflows.v1.InfiniBandPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
+	33, // 25: workflows.v1.InfiniBandPartitionInventory.ib_partitions:type_name -> forge.IBPartition
 	1,  // 26: workflows.v1.InfiniBandPartitionInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	32, // 27: workflows.v1.InstanceInventory.instances:type_name -> forge.Instance
-	33, // 28: workflows.v1.InstanceInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	22, // 29: workflows.v1.InstanceInventory.timestamp:type_name -> google.protobuf.Timestamp
+	34, // 27: workflows.v1.InstanceInventory.instances:type_name -> forge.Instance
+	35, // 28: workflows.v1.InstanceInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	24, // 29: workflows.v1.InstanceInventory.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 30: workflows.v1.InstanceInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
 	1,  // 31: workflows.v1.InstanceInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	34, // 32: workflows.v1.InstanceTypeInventory.instance_types:type_name -> forge.InstanceType
-	22, // 33: workflows.v1.InstanceTypeInventory.timestamp:type_name -> google.protobuf.Timestamp
+	36, // 32: workflows.v1.InstanceTypeInventory.instance_types:type_name -> forge.InstanceType
+	24, // 33: workflows.v1.InstanceTypeInventory.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 34: workflows.v1.InstanceTypeInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
 	1,  // 35: workflows.v1.InstanceTypeInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	35, // 36: workflows.v1.MachineInfo.machine:type_name -> forge.Machine
-	36, // 37: workflows.v1.MachineInfo.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	37, // 36: workflows.v1.MachineInfo.machine:type_name -> forge.Machine
+	38, // 37: workflows.v1.MachineInfo.discovery_info:type_name -> machine_discovery.DiscoveryInfo
 	10, // 38: workflows.v1.MachineInventory.machines:type_name -> workflows.v1.MachineInfo
-	22, // 39: workflows.v1.MachineInventory.timestamp:type_name -> google.protobuf.Timestamp
+	24, // 39: workflows.v1.MachineInventory.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 40: workflows.v1.MachineInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
 	1,  // 41: workflows.v1.MachineInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	37, // 42: workflows.v1.NetworkSecurityGroupInventory.network_security_groups:type_name -> forge.NetworkSecurityGroup
-	22, // 43: workflows.v1.NetworkSecurityGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
+	39, // 42: workflows.v1.NetworkSecurityGroupInventory.network_security_groups:type_name -> forge.NetworkSecurityGroup
+	24, // 43: workflows.v1.NetworkSecurityGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 44: workflows.v1.NetworkSecurityGroupInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
 	1,  // 45: workflows.v1.NetworkSecurityGroupInventory.inventory_page:type_name -> workflows.v1.InventoryPage
 	0,  // 46: workflows.v1.NVLinkLogicalPartitionInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 47: workflows.v1.NVLinkLogicalPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
-	38, // 48: workflows.v1.NVLinkLogicalPartitionInventory.partitions:type_name -> forge.NVLinkLogicalPartition
+	24, // 47: workflows.v1.NVLinkLogicalPartitionInventory.timestamp:type_name -> google.protobuf.Timestamp
+	40, // 48: workflows.v1.NVLinkLogicalPartitionInventory.partitions:type_name -> forge.NVLinkLogicalPartition
 	1,  // 49: workflows.v1.NVLinkLogicalPartitionInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	39, // 50: workflows.v1.OsImageInventory.os_images:type_name -> forge.OsImage
-	22, // 51: workflows.v1.OsImageInventory.timestamp:type_name -> google.protobuf.Timestamp
+	41, // 50: workflows.v1.OsImageInventory.os_images:type_name -> forge.OsImage
+	24, // 51: workflows.v1.OsImageInventory.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 52: workflows.v1.OsImageInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
 	1,  // 53: workflows.v1.OsImageInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	0,  // 54: workflows.v1.SkuInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	22, // 55: workflows.v1.SkuInventory.timestamp:type_name -> google.protobuf.Timestamp
-	40, // 56: workflows.v1.SkuInventory.skus:type_name -> forge.Sku
-	1,  // 57: workflows.v1.SkuInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	41, // 58: workflows.v1.SSHKeyGroupInventory.tenant_keysets:type_name -> forge.TenantKeyset
-	22, // 59: workflows.v1.SSHKeyGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 60: workflows.v1.SSHKeyGroupInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	1,  // 61: workflows.v1.SSHKeyGroupInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	42, // 62: workflows.v1.SubnetInventory.segments:type_name -> forge.NetworkSegment
-	22, // 63: workflows.v1.SubnetInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 64: workflows.v1.SubnetInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	1,  // 65: workflows.v1.SubnetInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	43, // 66: workflows.v1.TenantInventory.tenants:type_name -> forge.Tenant
-	22, // 67: workflows.v1.TenantInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 68: workflows.v1.TenantInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	1,  // 69: workflows.v1.TenantInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	44, // 70: workflows.v1.VPCInventory.vpcs:type_name -> forge.Vpc
-	33, // 71: workflows.v1.VPCInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	22, // 72: workflows.v1.VPCInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 73: workflows.v1.VPCInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	1,  // 74: workflows.v1.VPCInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	45, // 75: workflows.v1.VPCPeeringInventory.vpc_peerings:type_name -> forge.VpcPeering
-	22, // 76: workflows.v1.VPCPeeringInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 77: workflows.v1.VPCPeeringInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	1,  // 78: workflows.v1.VPCPeeringInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	46, // 79: workflows.v1.VpcPrefixInventory.vpc_prefixes:type_name -> forge.VpcPrefix
-	22, // 80: workflows.v1.VpcPrefixInventory.timestamp:type_name -> google.protobuf.Timestamp
-	0,  // 81: workflows.v1.VpcPrefixInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
-	1,  // 82: workflows.v1.VpcPrefixInventory.inventory_page:type_name -> workflows.v1.InventoryPage
-	83, // [83:83] is the sub-list for method output_type
-	83, // [83:83] is the sub-list for method input_type
-	83, // [83:83] is the sub-list for extension type_name
-	83, // [83:83] is the sub-list for extension extendee
-	0,  // [0:83] is the sub-list for field type_name
+	42, // 54: workflows.v1.OperatingSystemInventory.operating_systems:type_name -> forge.OperatingSystem
+	24, // 55: workflows.v1.OperatingSystemInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 56: workflows.v1.OperatingSystemInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 57: workflows.v1.OperatingSystemInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	43, // 58: workflows.v1.IpxeTemplateInventory.templates:type_name -> forge.IpxeTemplate
+	24, // 59: workflows.v1.IpxeTemplateInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 60: workflows.v1.IpxeTemplateInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 61: workflows.v1.IpxeTemplateInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	0,  // 62: workflows.v1.SkuInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	24, // 63: workflows.v1.SkuInventory.timestamp:type_name -> google.protobuf.Timestamp
+	44, // 64: workflows.v1.SkuInventory.skus:type_name -> forge.Sku
+	1,  // 65: workflows.v1.SkuInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	45, // 66: workflows.v1.SSHKeyGroupInventory.tenant_keysets:type_name -> forge.TenantKeyset
+	24, // 67: workflows.v1.SSHKeyGroupInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 68: workflows.v1.SSHKeyGroupInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 69: workflows.v1.SSHKeyGroupInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	46, // 70: workflows.v1.SubnetInventory.segments:type_name -> forge.NetworkSegment
+	24, // 71: workflows.v1.SubnetInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 72: workflows.v1.SubnetInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 73: workflows.v1.SubnetInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	47, // 74: workflows.v1.TenantInventory.tenants:type_name -> forge.Tenant
+	24, // 75: workflows.v1.TenantInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 76: workflows.v1.TenantInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 77: workflows.v1.TenantInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	48, // 78: workflows.v1.VPCInventory.vpcs:type_name -> forge.Vpc
+	35, // 79: workflows.v1.VPCInventory.network_security_group_propagations:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	24, // 80: workflows.v1.VPCInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 81: workflows.v1.VPCInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 82: workflows.v1.VPCInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	49, // 83: workflows.v1.VPCPeeringInventory.vpc_peerings:type_name -> forge.VpcPeering
+	24, // 84: workflows.v1.VPCPeeringInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 85: workflows.v1.VPCPeeringInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 86: workflows.v1.VPCPeeringInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	50, // 87: workflows.v1.VpcPrefixInventory.vpc_prefixes:type_name -> forge.VpcPrefix
+	24, // 88: workflows.v1.VpcPrefixInventory.timestamp:type_name -> google.protobuf.Timestamp
+	0,  // 89: workflows.v1.VpcPrefixInventory.inventory_status:type_name -> workflows.v1.InventoryStatus
+	1,  // 90: workflows.v1.VpcPrefixInventory.inventory_page:type_name -> workflows.v1.InventoryPage
+	91, // [91:91] is the sub-list for method output_type
+	91, // [91:91] is the sub-list for method input_type
+	91, // [91:91] is the sub-list for extension type_name
+	91, // [91:91] is the sub-list for extension extendee
+	0,  // [0:91] is the sub-list for field type_name
 }
 
 func init() { file_inventory_proto_init() }
@@ -2144,7 +2334,7 @@ func file_inventory_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_inventory_proto_rawDesc), len(file_inventory_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   21,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/rest-api/workflow-schema/site-agent/workflows/v1/inventory.proto
+++ b/rest-api/workflow-schema/site-agent/workflows/v1/inventory.proto
@@ -216,6 +216,34 @@ message OsImageInventory {
   InventoryPage inventory_page = 5;
 }
 
+// OperatingSystemInventory - inventory info for all OS definitions periodically collected from carbide-core
+message OperatingSystemInventory {
+  // List of Operating Systems (active records only; deletions are detected by absence)
+  repeated forge.OperatingSystem operating_systems = 1;
+  // Reported timestamp of inventory
+  google.protobuf.Timestamp timestamp = 2;
+  // Status of Inventory
+  InventoryStatus inventory_status = 3;
+  // Message for status
+  string status_msg = 4;
+  // Inventory page information
+  InventoryPage inventory_page = 5;
+}
+
+// IpxeTemplateInventory - inventory info of all iPXE templates periodically collected from site
+message IpxeTemplateInventory {
+  // List of iPXE templates
+  repeated forge.IpxeTemplate templates = 1;
+  // Reported timestamp of iPXE template inventory
+  google.protobuf.Timestamp timestamp = 2;
+  // Status of Inventory
+  InventoryStatus inventory_status = 3;
+  // Status message
+  string status_msg = 4;
+  // Inventory page information
+  InventoryPage inventory_page = 5;
+}
+
 // SkuInventory - inventory info of all SKUs on Site, collected periodically
 message SkuInventory {
   // Status of Inventory


### PR DESCRIPTION
## Summary

First PR in a clean, reviewable stack that ports the **Templated iPXE Operating System** feature onto REST API to match 'core' implementation. This PR lands only the **data-model + proto foundation**; the sync workflow and the API/SDK/OpenAPI layers follow in subsequent stacked PRs (see *Stack* below). It introduces an iPXE template–based OS variant (alongside Image and raw iPXE) with a per-OS scope (Local / Global / Limited) and the schema that lets OS definitions stay in sync with on-site NICo Core.

This PR is data-layer only: no handler, workflow, or route wiring is activated yet, so it is additive and inert on its own.

## Stack

- **PR 1 (this PR)** — DB data model + proto/inventory foundation
- **PR 2 (coming)** — cloud sync workflow (inbound reconcile + OS / iPXE-template inventory workflows)
- **PR 3 (coming)** — API handler (Core gRPC proxy push branch), iPXE-template endpoints, route wiring, OpenAPI + Go SDK, site-agent / site-workflow collectors

## What's implemented

- **DB schema** — `operating_system` scope + iPXE template columns; new `ipxe_template` and `ipxe_template_site_association` tables; `operating_system_site_association.controller_state`; additive migration (`20260623150000_ipxe_os_and_templates`).
- **DB models** — `ipxetemplate` and `ipxetemplatesiteassociation` DAOs, extended `operatingsystem` model (scope + templated-iPXE type), and proto conversions.
- **Proto** — `OperatingSystemInventory` + `IpxeTemplateInventory` added to `inventory.proto` (regenerated; only `inventory.pb.go` changed) so the downstream inbound-inventory PR has the types it needs.
- **Tests** — model tests for `ipxetemplate`, `ipxetemplatesiteassociation`, and the templated/scope additions to `operatingsystem` (table-driven).

## Verification

- Tests PASS: `cd rest-api && make test`

## Notes for review

- Migration is additive ; existing Image and raw iPXE behavior is untouched.
- `controller_state` on `operating_system_site_association` is introduced here but is exercised by the later workflow/API PRs.
- Only `inventory.pb.go` changes in the generated proto; no other generated files are touched in this PR.

## Type of Change

- [x] Feature (`feat:`)

## Services Affected

- [x] DB · [x] Proto (inventory) — Workflow / API / Site Agent land in later PRs of this stack

## Breaking Changes

None expected — additive schema + new proto messages only.