### PR TITLE
fix(api): Recheck VPC prefix reference before final delete

### DIFF
--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -541,6 +541,64 @@ async fn test_deleted_vpc_prefix_cannot_allocate_new_instance_interface(
 }
 
 #[crate::sqlx_test]
+async fn test_vpc_prefix_dbdelete_returns_to_drain_when_referenced(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create a prefix covering the fixture tenant segment so it has a durable child reference.
+    let created = create_vpc_prefix(&env, vpc_id, REFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    drive_vpc_prefix_to_ready(&env, id).await;
+
+    assert!(network_prefix_ref_count(&env, id).await > 0);
+
+    // Soft-delete the prefix while retaining the child reference.
+    env.api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect("delete should soft-delete the referenced VPC prefix");
+
+    // Reproduce the durable state seen in the failure: the prefix reached
+    // DBDelete even though a network_prefix reference exists.
+    sqlx::query(
+        r#"
+        UPDATE network_vpc_prefixes
+        SET controller_state =
+            '{"state":"deleting","deletion_state":{"state":"dbdelete"}}'::json
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .execute(&env.pool)
+    .await?;
+
+    // Run the DBDelete handler once.
+    env.run_vpc_prefix_controller_iteration().await;
+
+    // The parent must remain because its child reference still exists.
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 1);
+    assert!(network_prefix_ref_count(&env, id).await > 0);
+
+    let state_after: String = sqlx::query_scalar(
+        r#"
+        SELECT controller_state->'deletion_state'->>'state'
+        FROM network_vpc_prefixes
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .fetch_one(&env.pool)
+    .await?;
+
+    assert_eq!(state_after, "drainnetworkprefixes");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_vpc_prefix_final_delete_after_generated_segment_cleanup(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-db/src/vpc_prefix.rs
+++ b/crates/api-db/src/vpc_prefix.rs
@@ -430,6 +430,20 @@ pub async fn final_delete(
     Ok(deleted_id)
 }
 
+/// Locks a VPC prefix against new foreign-key references before its final dependency check.
+pub async fn lock_for_final_delete(
+    vpc_prefix_id: VpcPrefixId,
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    let query = "SELECT id FROM network_vpc_prefixes WHERE id=$1 FOR UPDATE";
+    sqlx::query_as::<_, VpcPrefixId>(query)
+        .bind(vpc_prefix_id)
+        .fetch_one(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 /// Updates the controller-owned VPC prefix state if the version still matches.
 pub async fn try_update_controller_state(
     txn: &mut PgConnection,

--- a/crates/vpc-prefix-controller/src/handler.rs
+++ b/crates/vpc-prefix-controller/src/handler.rs
@@ -124,7 +124,28 @@ impl StateHandler for VpcPrefixStateHandler {
                 VpcPrefixDeletionState::DBDelete => {
                     let mut txn = ctx.services.db_pool.begin().await?;
 
-                    // Remove the prefix row after all network_prefix references are gone.
+                    // Serialize with in-flight allocations before rechecking dependencies. A
+                    // previous drain iteration can observe zero references while an allocation
+                    // that already locked this prefix is still uncommitted.
+                    db::vpc_prefix::lock_for_final_delete(*vpc_prefix_id, &mut txn).await?;
+                    let referenced_prefixes =
+                        db::vpc_prefix::count_network_prefixes_by_vpc_prefix_id(
+                            &mut txn,
+                            vpc_prefix_id,
+                        )
+                        .await?;
+                    if referenced_prefixes > 0 {
+                        let new_state = self.drain_state();
+                        tracing::info!(
+                            referenced_prefixes,
+                            %vpc_prefix_id,
+                            "VPC Prefix gained network prefix references before final delete; returning to drain",
+                        );
+                        tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                        return Ok(StateHandlerOutcome::transition(new_state).with_txn(txn));
+                    }
+
+                    // Remove the prefix while the lock still prevents new FK references.
                     tracing::info!(
                         %vpc_prefix_id,
                         "VPC Prefix getting removed from the database",


### PR DESCRIPTION
Fix a race condition that causes VPC-prefix final deletion to fail with a foreign-key violation when rows in `network_prefixes` still reference the prefix.

The VPC-prefix controller checks the reference count while in `DrainNetworkPrefixes` and transitions to `DBDelete` when the count reaches 0. Inside `DBDelete` state, controller trusts the earlier count and unconditionally deletes the parent `network_vpc_prefixes` row without revalidating references. However, it is possible that another writer commits a network prefix allocation after the earlier drain check. In that case, the database rejects the parent deletion with the `network_prefixes_vpc_prefix_fkey` constraint. The prefix then remains stuck in `DBDelete`. 

This change adds a final dependency check in `DBDelete`, the controller now acquires the `FOR UPDATE` lock on the VPC prefix row and rechecks the number of reference `network_prefixes` and returns back to `DrainNetworkPrefixes` if references remain. 

## Related issues
nvbug https://nvbugspro.nvidia.com/bug/6321167

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)