### PR TITLE
chore: quiet the repeating firmware-mismatch warning + fix its typo

### DIFF
--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -511,12 +511,12 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
             );
             if let Some(job_id) = redfish.set_boot_order_dpu_first(boot_interface).await? {
                 tracing::info!(
-                    "succesfully configured BIOS job {job_id} to set {} first in the server's boot order",
+                    "successfully configured BIOS job {job_id} to set {} first in the server's boot order",
                     args.boot_interface_mac
                 )
             } else {
                 tracing::info!(
-                    "succesfully set {} first in the server's boot order",
+                    "successfully set {} first in the server's boot order",
                     args.boot_interface_mac
                 )
             }

--- a/crates/api-core/src/handlers/attestation.rs
+++ b/crates/api-core/src/handlers/attestation.rs
@@ -145,7 +145,7 @@ pub(crate) async fn list_attestation_machines(
     // if selector is not selected AND machine id is None,
     // just list all machines + their attestation status
     // if machine id not None, print the attestation status for this machine only
-    // if machine id is None AND selector is unsucessful, print failed attestations
+    // if machine id is None AND selector is unsuccessful, print failed attestations
     // if machine is None AND selector is in progress, print all machines that are in progress
 
     let mut txn = api.txn_begin().await?;

--- a/crates/api-core/src/tests/tpm_ca.rs
+++ b/crates/api-core/src/tests/tpm_ca.rs
@@ -952,7 +952,7 @@ pub mod tests {
         });
         env.api.tpm_delete_ca_cert(delete_ca_certs_request).await?;
 
-        // verify - the delete must be succesful and the matched ek should become unmatched
+        // verify - the delete must be successful and the matched ek should become unmatched
         // make sure we have two unmatched eks
         let show_unmatched_ek_certs_request = tonic::Request::new(());
         let ek_statuses = env

--- a/crates/host-support/src/hardware_enumeration/dpu.rs
+++ b/crates/host-support/src/hardware_enumeration/dpu.rs
@@ -134,7 +134,7 @@ pub fn wait_until_all_ports_available() {
         }
     }
 
-    debug!("lldp: Ports {:?} are read succesfully.", ports_read);
+    debug!("lldp: Ports {:?} are read successfully.", ports_read);
 }
 
 // LLDP was broken in multiple forge versions. It was fixed in HBN 2.1/ doca 2.6, as per

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3827,9 +3827,9 @@ async fn check_fw_component_version(
                 return Ok(None);
             }
 
-            tracing::warn!(
+            tracing::debug!(
                 machine_id=%dpu_snapshot.id,
-                "{:#?} FW didn't update succesfully. Expected version: {}, Current version: {}",
+                "{:#?} FW not yet at the expected version. Expected: {}, Current: {}",
                 component,
                 expected_version,
                 cur_version,
@@ -3839,14 +3839,14 @@ async fn check_fw_component_version(
             // This will cause continuous reboot of machine after first failure_retry_time is
             // passed.
             return Ok(Some(StateHandlerOutcome::wait(format!(
-                "{:#?} FW didn't update succesfully. Expected version: {}, Current version: {}",
+                "{:#?} FW not yet at the expected version. Expected: {}, Current: {}",
                 component, expected_version, cur_version,
             ))));
         }
 
         tracing::info!(
             machine_id=%dpu_snapshot.id,
-            "{:#?} FW updated succesfully to {}",
+            "{:#?} FW updated successfully to {}",
             component,
             expected_version,
         );

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -296,7 +296,7 @@ impl MachineValidation {
         for image_name in list.images {
             match Self::import_container(&image_name, MACHINE_VALIDATION_RUNNER_TAG).await {
                 Ok(data) => {
-                    trace!("Import successfull '{}'", data)
+                    trace!("Import successful '{}'", data)
                 }
                 Err(e) => error!("Failed to import '{}'", e.to_string()),
             };

--- a/crates/ssh-console/tests/util/ssh_client.rs
+++ b/crates/ssh-console/tests/util/ssh_client.rs
@@ -159,7 +159,7 @@ pub async fn assert_connection_works(
             _ = tokio::time::sleep_until(assertion_timeout.into()) => {
                 match test_state {
                     ConnectionTestState::TryingCtrlBackslash => {
-                        tracing::info!("Succesfully prevented ctrl+\\ from triggering escape, now simulating dropping to BMC prompt from other means");
+                        tracing::info!("Successfully prevented ctrl+\\ from triggering escape, now simulating dropping to BMC prompt from other means");
                         test_state = ConnectionTestState::TryingBackdoorEscape;
                         assertion_timeout = Instant::now().add(Duration::from_secs(3));
                     }


### PR DESCRIPTION
While a DPU's firmware converges, `check_fw_component_version` warned on every
reconcile that the FW "didn't update succesfully" -- an in-progress update
masquerading as a repeating failure (~82/hr in dev3), misspelled to boot. The
per-tick log drops to debug and now reads as what it is ("FW not yet at the
expected version"); the same text still rides the persisted `wait(..)` reason,
and a genuinely stuck update keeps escalating through the state SLA machinery.

Also sweeps the "succesfully" family of misspellings across the tree -- log
messages in admin-cli, host-support, machine-validation, ssh-console, and the
firmware messages here, plus two comments. `ReprovisionState::VerifyFirmareVersions`
stays as-is deliberately: it's a serialized state variant, so renaming it is a
persisted-state migration, not a typo fix.

This supports https://github.com/NVIDIA/infra-controller/issues/3157

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

