### PR TITLE
chore(v2.0): Consolidate REST service DBs into shared nico-pg-cluster

### DIFF
--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -381,6 +381,36 @@ until kubectl get postgresql nico-pg-cluster -n postgres \
 done
 echo "nico-pg-cluster is Running"
 
+# Install pg_trgm on nico_rest (needed by the nico-rest-db GIN index migration).
+# Zalando's preparedDatabases conflicts with the databases section, so we install
+# the extension directly after the cluster is ready. Idempotent: IF NOT EXISTS.
+# Wait up to 120s for the Zalando operator to create the nico_rest database.
+_pg_trgm_installed=false
+for _pg_i in $(seq 1 24); do
+    _PG_PRIMARY="$(kubectl get pods -n postgres -l application=spilo \
+        -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' \
+        2>/dev/null | awk '$2=="master"{print $1}' | head -1)"
+    if [[ -z "${_PG_PRIMARY}" ]]; then
+        echo "  pg_trgm: no Patroni primary yet (${_pg_i}/24) — retrying in 5s..."
+        sleep 5
+        continue
+    fi
+    if kubectl exec -n postgres "${_PG_PRIMARY}" -- \
+        su postgres -c "psql -d nico_rest -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'" \
+        2>/dev/null; then
+        echo "pg_trgm ready"
+        _pg_trgm_installed=true
+        break
+    fi
+    echo "  pg_trgm: nico_rest not yet created by operator (${_pg_i}/24) — retrying in 5s..."
+    sleep 5
+done
+if [[ "${_pg_trgm_installed}" == "false" ]]; then
+    echo "  pg_trgm: nico_rest unavailable after 120s."
+    echo "    → If rest.enabled=false in nico-prereqs, the nico_rest database is not created — this is expected."
+    echo "    → If rest.enabled=true, the nico-rest-db migration will fail on the GIN index step."
+fi
+
 echo "Waiting for DB credentials to be synced by ESO..."
 until kubectl get secret nico-system.nico.nico-pg-cluster.credentials \
     -n nico-system &>/dev/null; do
@@ -709,11 +739,41 @@ echo "Temporal namespaces ready"
 
 _SETUP_PHASE="[7g/7] NICo REST helm chart"
 # --- 7g. NICo REST helm chart -------------------------------------------------
+# Wait for ESO to sync the Zalando-generated REST DB credentials into nico-rest.
+# nico-rest-db-eso ClusterExternalSecret creates nico-rest-pg-creds once the
+# nico-rest namespace (created in 7a) is visible to ESO. The nico-rest-db
+# pre-install hook will fail immediately if the secret is missing.
+echo "Waiting for REST DB credentials to be synced by ESO (nico-rest-pg-creds in nico-rest)..."
+for _rdc_i in $(seq 1 24); do
+    if kubectl get secret nico-rest-pg-creds -n nico-rest &>/dev/null; then
+        break
+    fi
+    if [[ "${_rdc_i}" -eq 24 ]]; then
+        echo "ERROR: nico-rest-pg-creds not synced after 120s." >&2
+        echo "  Check: kubectl describe clusterexternalsecret nico-rest-db-eso" >&2
+        echo "  Ensure the nico-rest namespace exists and rest.enabled=true in nico-prereqs." >&2
+        exit 1
+    fi
+    echo "  nico-rest-pg-creds not yet synced (${_rdc_i}/24) — retrying in 5s..."
+    sleep 5
+done
+echo "REST DB credentials ready"
+
+# Write credentials to a temp file rather than --set so they are not visible
+# in process arguments and are not subject to Helm's --set special-char escaping.
+_NICO_REST_CREDS_FILE="$(mktemp)"
+chmod 600 "${_NICO_REST_CREDS_FILE}"
+printf 'nico-rest-common:\n  secrets:\n    dbCreds:\n      username: "%s"\n      password: "%s"\n' \
+    "$(kubectl get secret nico-rest-pg-creds -n nico-rest -o jsonpath='{.data.username}' | base64 -d)" \
+    "$(kubectl get secret nico-rest-pg-creds -n nico-rest -o jsonpath='{.data.password}' | base64 -d)" \
+    > "${_NICO_REST_CREDS_FILE}"
+
 NICO_HELM_CHART="${NICO_REST_HELM_DIR}/nico-rest"
 NICO_REST_CMD=(
     helm upgrade --install nico-rest "${NICO_HELM_CHART}"
     --namespace nico-rest
     -f "${SCRIPT_DIR}/values/nico-rest.yaml"
+    -f "${_NICO_REST_CREDS_FILE}"
     --set global.image.repository="${NICO_IMAGE_REGISTRY}"
     --set global.image.tag="${NICO_REST_IMAGE_TAG}"
     --timeout 600s --wait
@@ -752,7 +812,9 @@ else
 fi
 if [[ "${_nico_reply:-Y}" =~ ^[Yy]$ ]]; then
     "${NICO_REST_CMD[@]}"
+    rm -f "${_NICO_REST_CREDS_FILE}"
 else
+    rm -f "${_NICO_REST_CREDS_FILE}"
     echo "Skipped NICo REST. Re-run with -y or answer Y to deploy."
     echo ""
     echo "=== Setup complete (NICo REST skipped) ==="

--- a/helm-prereqs/templates/eso-external-secrets.yaml
+++ b/helm-prereqs/templates/eso-external-secrets.yaml
@@ -67,6 +67,45 @@ spec:
           version: v1
 {{- end }}
 
+## =============================================================================
+## nico-rest-db-eso — sync operator-generated REST DB credentials → nico-rest.
+## Source: nico-rest.nico.nico-pg-cluster.credentials.postgresql.acid.zalan.do
+##         in postgres namespace (created automatically by Zalando operator).
+## Target: nico-rest-pg-creds Secret in nico-rest namespace.
+##
+## Named nico-rest-pg-creds (not db-creds) to avoid a collision with the
+## db-creds Secret that nico-rest-common creates as a weight-10 pre-install
+## hook: that hook has hook-delete-policy before-hook-creation, so Helm would
+## delete ESO's copy just before recreating it from chart values. setup.sh
+## reads nico-rest-pg-creds and injects the Zalando-generated password into
+## nico-rest-common.secrets.dbCreds.password at helm install time.
+## =============================================================================
+{{- if and .Values.postgresql.enabled .Values.rest.enabled }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterExternalSecret
+metadata:
+  name: nico-rest-db-eso
+spec:
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: ["{{ .Values.rest.namespace }}"]
+  refreshTime: 30s
+  externalSecretSpec:
+    secretStoreRef:
+      name: postgres-ns-secretstore
+      kind: ClusterSecretStore
+    target:
+      name: nico-rest-pg-creds
+      deletionPolicy: Retain
+    dataFrom:
+      - extract:
+          key: nico-rest.nico.nico-pg-cluster.credentials.postgresql.acid.zalan.do
+          version: v1
+{{- end }}
+
 {{/*
   flow/psm/nsm DB credential syncs.
   The Zalando operator generates one Secret per (user, cluster) pair in the

--- a/helm-prereqs/templates/postgresql.yaml
+++ b/helm-prereqs/templates/postgresql.yaml
@@ -45,6 +45,11 @@ spec:
     nico-system.nico:
       - superuser
       - createdb
+    {{- if .Values.rest.enabled }}
+    nico-rest.nico:
+      - superuser
+      - createdb
+    {{- end }}
     {{- if .Values.flow.enabled }}
     flow.nico:
       - superuser
@@ -58,6 +63,9 @@ spec:
     {{- end }}
   databases:
     nico_system_nico: nico-system.nico
+    {{- if .Values.rest.enabled }}
+    nico_rest: nico-rest.nico
+    {{- end }}
     {{- if .Values.flow.enabled }}
     flow: flow.nico
     psm: psm.nico

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -123,6 +123,24 @@ imagePullSecrets:
   ngcNvidianKey: ""      # nvcr.io/nvidian/nvforge (optional, for unbound)
 
 ## ---------------------------------------------------------------------------
+## rest — NICo REST API database prerequisites.
+##
+## When enabled, creates a dedicated postgres user (nico-rest.nico) and database
+## (nico_rest) on nico-pg-cluster, and an ESO ClusterExternalSecret that syncs
+## the Zalando-generated credentials into the rest namespace as the
+## `nico-rest-pg-creds` Secret. setup.sh reads this secret and injects the
+## credentials into nico-rest-common.secrets.dbCreds at helm install time.
+##
+## Enable when deploying nico-rest against the shared nico-pg-cluster.
+## Disable only when nico-rest uses its own external Postgres instance.
+## ---------------------------------------------------------------------------
+rest:
+  enabled: true
+  ## Namespace the nico-rest helm release deploys into.
+  ## ESO targets this namespace when syncing the nico-rest-pg-creds secret.
+  namespace: nico-rest
+
+## ---------------------------------------------------------------------------
 ## flow — NICo Flow (rack lifecycle orchestrator, formerly RLA).
 ##
 ## This toggle controls only the helm-prereqs side of Flow:

--- a/helm-prereqs/values/nico-site-agent.yaml
+++ b/helm-prereqs/values/nico-site-agent.yaml
@@ -7,7 +7,7 @@
 # Dynamic values (image tags, site UUID) are passed via --set in setup.sh.
 #
 # Key fields to customize for non-dev environments:
-#   envConfig.DB_DATABASE / DB_ADDR               — match your postgres instance
+#   envConfig.DB_DATABASE / DB_ADDR               — consolidated nico-pg-cluster by default
 #   secrets.dbCreds                               — name of Secret with DB_USER and DB_PASSWORD
 #   certificate.uris                               — SPIFFE URI for this site
 #   global.certificate.issuerRef.name             — CA issuer for mTLS certs
@@ -63,10 +63,10 @@ envConfig:
   CARBIDE_ADDRESS: "nico-api.nico-system.svc.cluster.local:1079"
   CARBIDE_SEC_OPT: "2"
 
-  # DB connection config — DEV ONLY, matches the dev postgres instance in setup.sh.
+  # DB connection — nico-pg-cluster (Zalando-managed, shared with nico-rest-api).
   # DB_USER and DB_PASSWORD are injected from the db-creds Secret (secrets.dbCreds).
-  DB_ADDR: "postgres.postgres.svc.cluster.local"
-  DB_DATABASE: "elektratest"
+  DB_ADDR: "nico-pg-cluster.postgres.svc.cluster.local"
+  DB_DATABASE: "nico_rest"
   DB_PORT: "5432"
 
   TEMPORAL_HOST: "temporal-frontend.temporal"

--- a/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
@@ -33,7 +33,8 @@ secrets:
   keycloakClientSecret: keycloak-client-secret
   # -- Secret containing DB password at key "password". When set, db.password is ignored
   # and the password is read from /var/secrets/db/password (supports live rotation).
-  dbCreds: ""
+  # Created by nico-prereqs ESO (nico-rest-db-eso) when rest.enabled=true.
+  dbCreds: db-creds
 
 config:
   env:
@@ -48,12 +49,12 @@ config:
     sentry:
       dsn: ""
   db:
-    host: postgres.postgres
+    host: nico-pg-cluster.postgres.svc.cluster.local
     port: 5432
-    name: nico
-    user: nico
+    name: nico_rest
+    user: nico-rest.nico
     # -- Plain-text password. Ignored when secrets.dbCreds is set.
-    password: nico
+    password: ""
   temporal:
     host: temporal-frontend.temporal
     port: 7233

--- a/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
@@ -11,10 +11,10 @@ waitForPostgres:
   image: postgres:14.4-alpine
 
 db:
-  host: postgres.postgres
+  host: nico-pg-cluster.postgres.svc.cluster.local
   port: "5432"
-  name: nico
-  user: nico
+  name: nico_rest
+  user: nico-rest.nico
 
 secrets:
   dbCreds: db-creds


### PR DESCRIPTION
<!-- Describe what this PR does -->
 Cherry-pick of #3081 (12ef832de) onto `release/v2.0`, following the same process as #3181

Move the NICo REST API database from the standalone `postgres.postgres` StatefulSet onto the Zalando-managed `nico-pg-cluster`, eliminating the separate REST database instance.

## Changes
- **`postgresql.yaml`**: add `nico-rest.nico` user and `nico_rest` database, gated on `rest.enabled` (default: `true`)
- **`eso-external-secrets.yaml`**: add `nico-rest-db-eso` ClusterExternalSecret syncing Zalando credentials to the `nico-rest` namespace as `nico-rest-pg-creds` — named to avoid collision with the `db-creds` hook managed by `nico-rest-common` (`hook-delete-policy: before-hook-creation` causes a Helm/ESO race if ESO targets `db-creds` directly)
- **`values.yaml`**: add `rest.enabled` / `rest.namespace` toggles with documentation
- **`setup.sh`**:
- Wait (up to 120 s) for `nico-rest-pg-creds` to be synced by ESO; extract Zalando credentials and write to a `chmod 600` temp file; pass via `-f` to `helm upgrade --install` to populate
`nico-rest-common.secrets.dbCreds.*` at install time (avoids `--set` credential exposure and Helm special-char escaping issues)
- Install `pg_trgm` extension on `nico_rest` after the cluster reaches `Running` state, with a 120 s bounded retry loop
- **`nico-rest-db/values.yaml`**: update `db.host` / `db.name` / `db.user` defaults to `nico-pg-cluster.postgres.svc.cluster.local` / `nico_rest` / `nico-rest.nico`
- **`nico-rest-api/values.yaml`**: same db defaults plus `secrets.dbCreds: db-creds` to enable the secret-based password path for live rotation

## Related Issues
N/A

## Type of Change
Change - Changes in existing functionality

## Breaking Changes
**This PR contains breaking changes.**

## Testing

Manual end-to-end validation performed on dev6 (rg-forge-dev6, 3-node cluster).