### PR TITLE
docs(logs): address review findings for logging and machine-dpu-logs

### DIFF
--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -46,13 +46,17 @@ sidecar - just configure your collector to read pod logs.
 |-----------|--------|------------|-------|
 | **nico-api** | `carbide-api` | logfmt | Primary control plane. Supports runtime level changes. |
 | **nico-dns** | `carbide-dns` | JSON | DNS resolution service. |
-| **nico-dhcp** | `carbide-dhcp-server` | logfmt | DHCP server for PXE boot. |
-| **nico-pxe** | `carbide-pxe` | plain text | iPXE boot service. Minimal logging. |
+| **nico-dhcp** | Kea + `libdhcp.so` | Kea format | See section 2.6 below. |
+| **nico-pxe** | `carbide` | plain text | iPXE boot service. Hand-rolled `println!`, no log levels. |
 | **nico-bmc-proxy** | `carbide-bmc-proxy` | logfmt | BMC credential proxy. |
-| **nico-hardware-health** | `carbide-hw-health` | logfmt | Hardware health monitoring. |
-| **nico-ssh-console** | `carbide-ssh-console-rs` | compact | SSH console access service. Also captures machine/DPU console output to files (see 2.5). |
+| **nico-hardware-health** | `forge-hw-health` | logfmt | Hardware health monitoring. |
+| **nico-ssh-console** | `ssh-console` | compact | SSH console access. Also captures machine/DPU console output to files (see 2.5). |
 | **nico-dsx-exchange-consumer** | `carbide-dsx-exchange-consumer` | logfmt | DSX message consumer. |
-| **nico-dpu-otel-agent** | `forge-dpu-otel-agent` | compact | DPU certificate renewal agent. |
+| **nico-dpu-otel-agent** | `forge-dpu-otel-agent` | full | mTLS cert renewal agent on DPUs. See note below. |
+
+> **Note**: `nico-dpu-otel-agent` currently ignores `RUST_LOG` due to a source bug
+> (`fmt().init()` instead of `fmt::init()`). It logs at INFO level only until this is fixed.
+> See [#3151](https://github.com/NVIDIA/infra-controller/issues/3151).
 
 ### 2.1 logfmt format
 
@@ -60,12 +64,12 @@ Most NICo components use [logfmt](https://brandur.org/logfmt) - a line-oriented 
 space-separated `key=value` pairs, easy for both humans and machines to parse.
 
 **Event lines** — one per log call:
-```logfmt
+```
 level=INFO component=nico-api span_id=0x4f… msg="Starting reconciliation" location="handlers/machine.rs:142"
 ```
 
 **Span lines** — emitted when a unit of work closes (`level=SPAN`), carrying timing data:
-```logfmt
+```
 level=SPAN component=site-explorer span_id=0xf7… span_name=explore_site timing_elapsed_us=1523 timing_busy_ns=1200000 timing_idle_ns=323000
 ```
 
@@ -88,7 +92,7 @@ without enabling full distributed tracing.
 
 On logfmt lines, NICo sets the `component` field to identify the emitting service or subsystem:
 
-```text
+```
 nico-api                       — API handlers, DB, startup: anything not in a subsystem below
 ├── site-explorer
 ├── machine_state_controller
@@ -124,12 +128,13 @@ This enables filtering logs by component in your backend. For example, with Loki
 
 Components that **do not** use the logfmt layer and carry no `component` field:
 
-| Component | Format | Notes |
-|-----------|--------|-------|
-| nico-dns | JSON | Uses tracing-subscriber JSON formatter |
-| nico-pxe | plain text | Hand-rolled `println!` logging |
-| nico-ssh-console | compact | Uses tracing-subscriber compact formatter |
-| nico-dpu-otel-agent | compact | Certificate renewal agent |
+| Component | Binary | Format | Notes |
+|-----------|--------|--------|-------|
+| nico-dns | `carbide-dns` | JSON | Uses tracing-subscriber JSON formatter |
+| nico-pxe | `carbide` | plain text | Hand-rolled `println!`, no log levels |
+| nico-ssh-console | `ssh-console` | compact | Uses tracing-subscriber compact formatter |
+| nico-dpu-otel-agent | `forge-dpu-otel-agent` | full | Default tracing-subscriber formatter. Ignores `RUST_LOG`. |
+| nico-dhcp | Kea + `libdhcp.so` | Kea | Production uses Kea logger, not Rust tracing (see 2.6) |
 
 ### 2.2 JSON format (nico-dns)
 
@@ -144,7 +149,7 @@ nico-dns uses `tracing-subscriber`'s JSON formatter. Each line is a self-contain
 nico-ssh-console uses `tracing-subscriber`'s compact formatter - a human-readable single-line
 format similar to traditional log output:
 
-```text
+```
 2026-01-15T10:23:45.123Z  INFO carbide_ssh_console: Session started session_id=abc-123
 ```
 
@@ -162,7 +167,7 @@ tracing output.
 When a BMC console session is established, nico-ssh-console streams the serial output to a
 per-machine log file:
 
-```text
+```
 /var/log/consoles/<machine-id>_<bmc-ip>.log
 ```
 
@@ -187,8 +192,50 @@ hardware issues.
 > OpenTelemetry Collector sidecar (`lokiLogCollector.enabled: true`) that ships console logs
 > to Loki. The sidecar reads from `/var/log/consoles/*.log`, extracts the machine ID and BMC
 > IP from filenames, and exports to your Loki endpoint. To use a different backend, customize
-> the `configFiles.otelcolConfig` value in the chart. A separate document covers machine log
-> collection workflows in detail.
+> the `configFiles.otelcolConfig` value in the chart. See [Machine and DPU Logs](machine-dpu-logs.md)
+> for detailed collection workflows.
+
+### 2.6 Kea DHCP format (nico-dhcp)
+
+The nico-dhcp Helm chart runs [Kea DHCP](https://www.isc.org/kea/), with NICo's DHCP logic
+loaded as a Kea hook library (`libdhcp.so`). All logging from the hook routes through Kea's
+logger, meaning:
+
+- Log format follows **Kea's format**, not logfmt
+- Log levels are configured via **Kea's `loggers` config**, not `RUST_LOG`
+- Output goes to Kea's configured destinations (stdout by default in the container)
+
+Example Kea log output:
+```
+2026-07-06 10:15:23.456 INFO  [kea-dhcp4.hooks/12345] DHCP4_SUBNET_SELECTED [hwtype=1 ...] subnet selected
+```
+
+To adjust log levels, modify the Kea configuration in the Helm chart's ConfigMap. The
+`loggers` section controls verbosity:
+
+```json
+{
+  "Dhcp4": {
+    "loggers": [
+      {
+        "name": "kea-dhcp4",
+        "severity": "INFO",
+        "debuglevel": 0,
+        "output_options": [
+          { "output": "stdout" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Set `severity` to `DEBUG` and increase `debuglevel` (0-99) for more verbose output from
+the NICo hook. The hook maps Rust log levels to Kea severity: `info` → INFO, `debug` →
+DEBUG/10, `trace` → DEBUG/99.
+
+> **Dev environment**: The standalone `forge-dhcp-server` binary uses logfmt output and
+> respects `RUST_LOG`. It is used for local development and testing only.
 
 ---
 
@@ -196,7 +243,8 @@ hardware issues.
 
 ### 3.1 At startup: RUST_LOG and --debug
 
-All components respect the `RUST_LOG` environment variable, which uses `tracing-subscriber`'s
+Most tracing-based components respect the `RUST_LOG` environment variable, which uses
+`tracing-subscriber`'s
 [`EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html)
 syntax:
 
@@ -211,12 +259,21 @@ RUST_LOG=info,carbide_api_core::handlers=debug,sqlx=warn
 RUST_LOG=info,carbide=debug,hyper=error
 ```
 
-Several binaries also accept a `--debug` flag that sets the default level to DEBUG (equivalent
-to `RUST_LOG=debug` if `RUST_LOG` is unset):
+**Exceptions**: nico-pxe uses hand-rolled `println!` with no level concept. nico-dpu-otel-agent
+currently ignores `RUST_LOG` due to a source bug (logs at INFO only). nico-dhcp uses Kea's
+logger config instead (see section 2.6).
+
+Three binaries accept a `--debug` flag that sets the default level to DEBUG:
 
 ```bash
-carbide-api run --debug -c /etc/carbide/config.toml
+# carbide-api: --debug is a parent flag, must precede subcommand
+carbide-api --debug run --config-path /etc/carbide/config.toml
+
+# carbide-bmc-proxy
 carbide-bmc-proxy --debug --config-path /etc/carbide/bmc-proxy.toml
+
+# ssh-console
+ssh-console --debug --config /etc/ssh-console/config.toml
 ```
 
 **Default log level** is INFO for all components.
@@ -226,7 +283,7 @@ carbide-bmc-proxy --debug --config-path /etc/carbide/bmc-proxy.toml
 NICo components automatically suppress verbose output from common dependencies. For example,
 nico-api applies these directives by default:
 
-```text
+```
 sqlxmq::runner=warn,sqlx::query=warn,rustify=off,hyper=error,rustls=warn,h2=warn,vaultrs=error
 ```
 
@@ -251,6 +308,9 @@ nico-admin-cli set log-filter -f "trace,h2=warn,hyper=warn" --expiry 5min
 
 When the expiry elapses, the log filter **automatically reverts** to the startup value. This
 prevents accidentally leaving debug logging on and filling your storage.
+
+> **Note**: Expiry is checked every 15 minutes by an internal poll. A filter with `--expiry 5min`
+> will actually revert at the next 15-minute poll cycle, not exactly at 5 minutes.
 
 #### How it works
 
@@ -295,26 +355,28 @@ reads pod log files and exports them to your backend. This is the standard Kuber
 and works with any OTLP-compatible backend: Grafana Loki, Elasticsearch, VictoriaLogs, Datadog,
 Splunk, etc.
 
-```text
-┌─────────────────────────────────────────────────────────────────────────┐
-│  Node                                                                   │
-│  ┌──────────────┐    stdout    ┌──────────────┐                         │
-│  │   NICo Pod   │ ──────────▶  │  /var/log/   │                         │
-│  │  (nico-api)  │              │   pods/...   │                         │
-│  └──────────────┘              └──────┬───────┘                         │
-│                                       │                                 │
-│                                       ▼ filelog receiver                │
-│                              ┌────────────────────┐                     │
-│                              │   otel-collector   │                     │
-│                              │    (DaemonSet)     │                     │
-│                              └─────────┬──────────┘                     │
-└────────────────────────────────────────┼────────────────────────────────┘
-                                         │ OTLP / Loki API / etc.
-                                         ▼
-                              ┌────────────────────┐
-                              │   Logs Backend     │
-                              │ (Loki, ES, VL...)  │
-                              └────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Node["Node"]
+        subgraph NicoPod["NICo Pod"]
+            nicoApi["nico-api"]
+        end
+
+        logs["/var/log/pods/..."]
+
+        subgraph OtelDS["otel-collector (DaemonSet)"]
+            filelog["filelog receiver"]
+        end
+
+        nicoApi -->|"stdout"| logs
+        logs --> filelog
+    end
+
+    subgraph Backend["Logs Backend (Loki, ES, VL...)"]
+        storage["Log storage"]
+    end
+
+    filelog -->|"OTLP / Loki API / etc."| storage
 ```
 
 ### 4.1 Collector configuration
@@ -322,9 +384,6 @@ Splunk, etc.
 Below is a reference Helm values file for deploying the
 [OpenTelemetry Collector Helm chart](https://opentelemetry.io/docs/platforms/kubernetes/helm/collector/) to collect NICo logs.
 Adapt the exporter section for your backend.
-
-The `logsCollection` preset parses the Kubernetes container log format; the explicit
-`filelog` receiver below controls which pod log files are collected.
 
 ```yaml
 # values.yaml for opentelemetry-collector Helm chart
@@ -343,11 +402,11 @@ config:
   receivers:
     filelog:
       include:
-        # Adjust this pattern if your NICo namespace uses a different prefix
-        - /var/log/pods/nico-*/*/*.log
+        - /var/log/pods/*/*/*.log
       exclude:
         # Exclude collector's own logs to avoid feedback loops
         - /var/log/pods/*/opentelemetry-collector*/*.log
+      # The logsCollection preset configures parsing of container log format
 
   processors:
     memory_limiter:
@@ -359,12 +418,13 @@ config:
       send_batch_size: 1024
       timeout: 5s
 
-    # Add labels for collected NICo logs
+    # Add component label for NICo pods
     resource:
       attributes:
         - action: insert
           key: component
           value: "nico"
+          # Only apply to NICo namespaces (adjust pattern as needed)
         - action: insert
           key: service.name
           from_attribute: k8s.container.name
@@ -424,9 +484,7 @@ processors:
             where IsMatch(body, "^level=")
 ```
 
-If you cannot use the transform processor, a minimal `filelog` receiver regex can extract
-`level` and `msg` while keeping the remaining key-value pairs in `rest`. Use the
-`ParseKeyValue` approach above for full field extraction.
+Or use the `logfmt` parser in the filelog receiver for nico components specifically:
 
 ```yaml
 receivers:
@@ -486,10 +544,10 @@ easier maintenance. There are two approaches:
 
 **Option A: Patterns in chart files**
 
-Place patterns in a file within your chart package at `files/drop-patterns.txt`:
+Place patterns in a file within your chart package at `files/logs-drop-patterns.txt`:
 
 ```text
-# files/drop-patterns.txt
+# files/logs-drop-patterns.txt
 # Noisy DHCP messages from cross-network relay
 No network segment defined for relay address
 # DPU mlx5_core noise
@@ -590,10 +648,6 @@ service:
 
 For extremely high-volume logs where you only need a statistical sample:
 
-Log support in the OpenTelemetry `probabilistic_sampler` processor is alpha. Verify that
-your collector distribution supports log pipelines for this processor before relying on it
-in production.
-
 ```yaml
 processors:
   probabilistic_sampler:
@@ -654,7 +708,7 @@ Use the Datadog exporter or OTLP endpoint. Datadog automatically parses common l
 |---------|-------|-----|
 | No logs from a component | Container not running, or stdout not captured | `kubectl logs <pod>` to verify. Check container status. |
 | Logs not reaching backend | Collector not running, or exporter misconfigured | Check collector logs: `kubectl logs -l app=opentelemetry-collector`. Verify exporter endpoint. |
-| Missing fields in backend | logfmt not parsed | Add a transform processor to parse logfmt, or use Loki's `logfmt` parser in queries. |
+| Missing fields in backend | logfmt not parsed | Add a transform processor to parse logfmt, or query with `| logfmt` in Loki. |
 | Too many DEBUG logs | `RUST_LOG` set too verbose, or runtime filter left on | Check `RUST_LOG` env var. For nico-api, runtime filter auto-expires; wait or set a less verbose filter. |
 | Log level change didn't take effect | Changed wrong component, or typo in filter | Runtime changes only work for nico-api. Verify filter syntax matches `EnvFilter` rules. |
 | Logs are truncated | Log line too long for collector buffer | Increase `max_log_size` in filelog receiver config. |
@@ -695,11 +749,15 @@ components at once.
 
 ### Checking current log level (nico-api)
 
-The current log filter is visible in nico-api's startup log and via the admin API. Look for:
+The startup log shows the initial log level. Look for lines like:
 
-```logfmt
-level=INFO msg="current log level: info,carbide=debug" location="setup.rs:142"
 ```
+level=INFO msg="current log level: INFO" location="setup.rs:142"
+```
+
+Note that this shows the coarse `LevelFilter` (e.g., INFO), not the full directive string.
+There is currently no `get log-filter` command in nico-admin-cli to query the active filter
+at runtime.
 
 ---
 

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -36,7 +36,9 @@ sidecar - just configure your collector to read pod logs.
 
 > **Note**: nico-ssh-console is an exception - in addition to stdout, it writes **machine
 > console output** (BMC serial console streams) to local files. These are not service logs
-> but captured output from managed machines. See section 2.5 for details.
+<Note>
+nico-ssh-console is an exception - in addition to stdout, it writes **machine console output** (BMC serial console streams) to local files. These are not service logs but captured output from managed machines. See [Machine console logs](#25-machine-console-logs-nico-ssh-console) for details.
+</Note>
 
 ---
 
@@ -46,17 +48,17 @@ sidecar - just configure your collector to read pod logs.
 |-----------|--------|------------|-------|
 | **nico-api** | `carbide-api` | logfmt | Primary control plane. Supports runtime level changes. |
 | **nico-dns** | `carbide-dns` | JSON | DNS resolution service. |
-| **nico-dhcp** | Kea + `libdhcp.so` | Kea format | See section 2.6 below. |
+| **nico-dhcp** | Kea + `libdhcp.so` | Kea format | See [Kea DHCP format](#26-kea-dhcp-format-nico-dhcp). |
 | **nico-pxe** | `carbide` | plain text | iPXE boot service. Hand-rolled `println!`, no log levels. |
 | **nico-bmc-proxy** | `carbide-bmc-proxy` | logfmt | BMC credential proxy. |
 | **nico-hardware-health** | `forge-hw-health` | logfmt | Hardware health monitoring. |
-| **nico-ssh-console** | `ssh-console` | compact | SSH console access. Also captures machine/DPU console output to files (see 2.5). |
+| **nico-ssh-console** | `ssh-console` | compact | SSH console access. Also captures machine/DPU console output to files (see [Machine console logs](#25-machine-console-logs-nico-ssh-console)). |
 | **nico-dsx-exchange-consumer** | `carbide-dsx-exchange-consumer` | logfmt | DSX message consumer. |
 | **nico-dpu-otel-agent** | `forge-dpu-otel-agent` | full | mTLS cert renewal agent on DPUs. See note below. |
 
-> **Note**: `nico-dpu-otel-agent` currently ignores `RUST_LOG` due to a source bug
-> (`fmt().init()` instead of `fmt::init()`). It logs at INFO level only until this is fixed.
-> See [#3151](https://github.com/NVIDIA/infra-controller/issues/3151).
+<Note>
+`nico-dpu-otel-agent` currently ignores `RUST_LOG` due to a source bug (`fmt().init()` instead of `fmt::init()`). It logs at INFO level only until this is fixed. See [#3151](https://github.com/NVIDIA/infra-controller/issues/3151).
+</Note>
 
 ### 2.1 logfmt format
 
@@ -134,7 +136,7 @@ Components that **do not** use the logfmt layer and carry no `component` field:
 | nico-pxe | `carbide` | plain text | Hand-rolled `println!`, no log levels |
 | nico-ssh-console | `ssh-console` | compact | Uses tracing-subscriber compact formatter |
 | nico-dpu-otel-agent | `forge-dpu-otel-agent` | full | Default tracing-subscriber formatter. Ignores `RUST_LOG`. |
-| nico-dhcp | Kea + `libdhcp.so` | Kea | Production uses Kea logger, not Rust tracing (see 2.6) |
+| nico-dhcp | Kea + `libdhcp.so` | Kea | Production uses Kea logger, not Rust tracing (see [Kea DHCP format](#26-kea-dhcp-format-nico-dhcp)) |
 
 ### 2.2 JSON format (nico-dns)
 
@@ -193,7 +195,9 @@ hardware issues.
 > to Loki. The sidecar reads from `/var/log/consoles/*.log`, extracts the machine ID and BMC
 > IP from filenames, and exports to your Loki endpoint. To use a different backend, customize
 > the `configFiles.otelcolConfig` value in the chart. See [Machine and DPU Logs](machine-dpu-logs.md)
-> for detailed collection workflows.
+<Tip title="Centralizing console logs">
+The nico-ssh-console Helm chart includes an optional OpenTelemetry Collector sidecar (`lokiLogCollector.enabled: true`) that ships console logs to Loki. The sidecar reads from `/var/log/consoles/*.log`, extracts the machine ID and BMC IP from filenames, and exports to your Loki endpoint. To use a different backend, customize the `configFiles.otelcolConfig` value in the chart. See [Machine and DPU Logs](machine-dpu-logs.md) for detailed collection workflows.
+</Tip>
 
 ### 2.6 Kea DHCP format (nico-dhcp)
 
@@ -206,9 +210,7 @@ logger, meaning:
 - Output goes to Kea's configured destinations (stdout by default in the container)
 
 Example Kea log output:
-```text
-2026-07-06 10:15:23.456 INFO  [kea-dhcp4.hooks/12345] DHCP4_SUBNET_SELECTED [hwtype=1 ...] subnet selected
-```
+
 
 To adjust log levels, modify the Kea configuration in the Helm chart's ConfigMap. The
 `loggers` section controls verbosity:
@@ -234,8 +236,9 @@ Set `severity` to `DEBUG` and increase `debuglevel` (0-99) for more verbose outp
 the NICo hook. The hook maps Rust log levels to Kea severity: `info` → INFO, `debug` →
 DEBUG/10, `trace` → DEBUG/99.
 
-> **Dev environment**: The standalone `forge-dhcp-server` binary uses logfmt output and
-> respects `RUST_LOG`. It is used for local development and testing only.
+<Tip title="Dev environment">
+The standalone `forge-dhcp-server` binary uses logfmt output and respects `RUST_LOG`. Use the standalone binary for local development and testing only.
+</Tip>
 
 ---
 
@@ -304,8 +307,9 @@ nico-admin-cli set log-filter -f "trace,h2=warn,hyper=warn" --expiry 5min
 When the expiry elapses, the log filter **automatically reverts** to the startup value. This
 prevents accidentally leaving debug logging on and filling your storage.
 
-> **Note**: Expiry is checked every 15 minutes by an internal poll. A filter with `--expiry 5min`
-> will actually revert at the next 15-minute poll cycle, not exactly at 5 minutes.
+<Note>
+Expiry is checked every 15 minutes by an internal poll. A filter with `--expiry 5min` will actually revert at the next 15-minute poll cycle, not exactly at 5 minutes.
+</Note>
 
 #### How it works
 
@@ -749,7 +753,7 @@ The startup log shows the initial log level. Look for lines like:
 level=INFO msg="current log level: INFO" location="setup.rs:142"
 ```
 
-Note that this shows the coarse `LevelFilter` (e.g., INFO), not the full directive string.
+Note that this shows the coarse `LevelFilter` (such as INFO), not the full directive string.
 There is currently no `get log-filter` command in nico-admin-cli to query the active filter
 at runtime.
 

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -64,12 +64,12 @@ Most NICo components use [logfmt](https://brandur.org/logfmt) - a line-oriented 
 space-separated `key=value` pairs, easy for both humans and machines to parse.
 
 **Event lines** — one per log call:
-```
+```text
 level=INFO component=nico-api span_id=0x4f… msg="Starting reconciliation" location="handlers/machine.rs:142"
 ```
 
 **Span lines** — emitted when a unit of work closes (`level=SPAN`), carrying timing data:
-```
+```text
 level=SPAN component=site-explorer span_id=0xf7… span_name=explore_site timing_elapsed_us=1523 timing_busy_ns=1200000 timing_idle_ns=323000
 ```
 
@@ -92,7 +92,7 @@ without enabling full distributed tracing.
 
 On logfmt lines, NICo sets the `component` field to identify the emitting service or subsystem:
 
-```
+```text
 nico-api                       — API handlers, DB, startup: anything not in a subsystem below
 ├── site-explorer
 ├── machine_state_controller
@@ -149,7 +149,7 @@ nico-dns uses `tracing-subscriber`'s JSON formatter. Each line is a self-contain
 nico-ssh-console uses `tracing-subscriber`'s compact formatter - a human-readable single-line
 format similar to traditional log output:
 
-```
+```text
 2026-01-15T10:23:45.123Z  INFO carbide_ssh_console: Session started session_id=abc-123
 ```
 
@@ -167,7 +167,7 @@ tracing output.
 When a BMC console session is established, nico-ssh-console streams the serial output to a
 per-machine log file:
 
-```
+```text
 /var/log/consoles/<machine-id>_<bmc-ip>.log
 ```
 
@@ -206,7 +206,7 @@ logger, meaning:
 - Output goes to Kea's configured destinations (stdout by default in the container)
 
 Example Kea log output:
-```
+```text
 2026-07-06 10:15:23.456 INFO  [kea-dhcp4.hooks/12345] DHCP4_SUBNET_SELECTED [hwtype=1 ...] subnet selected
 ```
 
@@ -266,13 +266,8 @@ logger config instead (see section 2.6).
 Three binaries accept a `--debug` flag that sets the default level to DEBUG:
 
 ```bash
-# carbide-api: --debug is a parent flag, must precede subcommand
 carbide-api --debug run --config-path /etc/carbide/config.toml
-
-# carbide-bmc-proxy
 carbide-bmc-proxy --debug --config-path /etc/carbide/bmc-proxy.toml
-
-# ssh-console
 ssh-console --debug --config /etc/ssh-console/config.toml
 ```
 
@@ -283,7 +278,7 @@ ssh-console --debug --config /etc/ssh-console/config.toml
 NICo components automatically suppress verbose output from common dependencies. For example,
 nico-api applies these directives by default:
 
-```
+```text
 sqlxmq::runner=warn,sqlx::query=warn,rustify=off,hyper=error,rustls=warn,h2=warn,vaultrs=error
 ```
 
@@ -686,7 +681,7 @@ processors:
 ```
 
 Query example:
-```logql
+```text
 {k8s_container_name="nico-api"} | logfmt | level="ERROR"
 ```
 
@@ -750,7 +745,7 @@ components at once.
 
 The startup log shows the initial log level. Look for lines like:
 
-```
+```text
 level=INFO msg="current log level: INFO" location="setup.rs:142"
 ```
 

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -402,7 +402,8 @@ config:
   receivers:
     filelog:
       include:
-        - /var/log/pods/*/*/*.log
+        # Collect only NICo namespace logs
+        - /var/log/pods/nico-*/*/*.log
       exclude:
         # Exclude collector's own logs to avoid feedback loops
         - /var/log/pods/*/opentelemetry-collector*/*.log
@@ -418,13 +419,12 @@ config:
       send_batch_size: 1024
       timeout: 5s
 
-    # Add component label for NICo pods
+    # Add component label for NICo logs
     resource:
       attributes:
         - action: insert
           key: component
           value: "nico"
-          # Only apply to NICo namespaces (adjust pattern as needed)
         - action: insert
           key: service.name
           from_attribute: k8s.container.name
@@ -484,7 +484,7 @@ processors:
             where IsMatch(body, "^level=")
 ```
 
-Or use the `logfmt` parser in the filelog receiver for nico components specifically:
+Or use the `key_value_parser` operator in the filelog receiver for NICo components specifically:
 
 ```yaml
 receivers:
@@ -493,9 +493,8 @@ receivers:
       - /var/log/pods/nico-*/*/*.log
     operators:
       - type: container
-      - type: regex_parser
+      - type: key_value_parser
         if: 'body matches "^level="'
-        regex: 'level=(?P<level>\w+)\s+(?:msg="(?P<msg>[^"]*)")?\s*(?P<rest>.*)'
         parse_to: attributes
 ```
 
@@ -708,7 +707,7 @@ Use the Datadog exporter or OTLP endpoint. Datadog automatically parses common l
 |---------|-------|-----|
 | No logs from a component | Container not running, or stdout not captured | `kubectl logs <pod>` to verify. Check container status. |
 | Logs not reaching backend | Collector not running, or exporter misconfigured | Check collector logs: `kubectl logs -l app=opentelemetry-collector`. Verify exporter endpoint. |
-| Missing fields in backend | logfmt not parsed | Add a transform processor to parse logfmt, or query with `| logfmt` in Loki. |
+| Missing fields in backend | logfmt not parsed | Add a transform processor to parse logfmt, or use `\| logfmt` operator in Loki queries. |
 | Too many DEBUG logs | `RUST_LOG` set too verbose, or runtime filter left on | Check `RUST_LOG` env var. For nico-api, runtime filter auto-expires; wait or set a less verbose filter. |
 | Log level change didn't take effect | Changed wrong component, or typo in filter | Runtime changes only work for nico-api. Verify filter syntax matches `EnvFilter` rules. |
 | Logs are truncated | Log line too long for collector buffer | Increase `max_log_size` in filelog receiver config. |

--- a/docs/observability/machine-dpu-logs.md
+++ b/docs/observability/machine-dpu-logs.md
@@ -341,13 +341,13 @@ exporters:
 
 DPU logs are sent over mTLS using machine certificates provisioned by NICo.
 
-> **Note on DPU services**: Two separate services handle telemetry on the DPU:
-> - **`otelcol-contrib`** — The OpenTelemetry Collector that collects and exports logs/metrics
-> - **`forge-dpu-otel-agent`** — A Rust helper service that periodically renews the mTLS
->   certificates used by otelcol-contrib to authenticate with the site controller
->
-> The cert renewal agent is *not* a custom OTel build — it's a sidecar that manages certificate
-> lifecycle so otelcol-contrib can maintain secure connections.
+<Note title="DPU services">
+Two separate services handle telemetry on the DPU:
+- **`otelcol-contrib`** — The OpenTelemetry Collector that collects and exports logs/metrics
+- **`forge-dpu-otel-agent`** — A Rust helper service that periodically renews the mTLS certificates used by otelcol-contrib to authenticate with the site controller
+
+The cert renewal agent is *not* a custom OTel build — it's a sidecar that manages certificate lifecycle so otelcol-contrib can maintain secure connections.
+</Note>
 
 ### 3.3 Site collector receiver
 
@@ -386,8 +386,9 @@ processors:
         value: raw
 ```
 
-> **Note**: The routing/pipeline configuration depends on your deployment and may require
-> customization for your environment.
+<Note>
+The routing/pipeline configuration depends on your deployment. It may require customization for your environment.
+</Note>
 
 ### 3.4 Querying DPU logs
 

--- a/docs/observability/machine-dpu-logs.md
+++ b/docs/observability/machine-dpu-logs.md
@@ -37,28 +37,29 @@ flowchart TB
             files --> sidecar
         end
 
-        subgraph siteOtel["otel-collector (DaemonSet)"]
+        subgraph siteOtel["otel-collector"]
             otlpRecv["OTLP receiver"]
-            routing["routing/otlp-logs"]
-            logsConsole["logs/console"]
-            logsDPU["logs/dpu"]
-            otlpRecv --> routing
-            routing --> logsConsole
-            routing --> logsDPU
+            routing["routing"]
+            logsDPU["logs/dpu pipeline"]
+            otlpRecv --> routing --> logsDPU
         end
-
-        sidecar --> otlpRecv
     end
 
-    subgraph Backend["Backend (Loki, VL, ES, etc.)"]
+    subgraph Backend["Backend (Loki, VL, etc.)"]
         storage["Log storage"]
     end
 
     serial -->|"SSH/BMC"| files
+    sidecar -->|"Loki API (default)"| storage
     otelDPU -->|"OTLP (mTLS)"| otlpRecv
-    logsConsole --> storage
     logsDPU --> storage
 ```
+
+**Log flow:**
+- **Console logs**: The default sidecar ships directly to Loki via Loki API. This can be
+  reconfigured to export via OTLP to a site collector if needed.
+- **DPU logs**: Always flow via OTLP over mTLS to the site otel-collector, which routes
+  them through processing pipelines to the backend.
 
 ---
 
@@ -338,13 +339,20 @@ exporters:
       max_elapsed_time: 1h
 ```
 
-DPU logs are sent over mTLS using machine certificates provisioned by NICo. The
-`forge-dpu-otel-agent` service handles certificate renewal.
+DPU logs are sent over mTLS using machine certificates provisioned by NICo.
 
-### 3.3 Site controller receiver
+> **Note on DPU services**: Two separate services handle telemetry on the DPU:
+> - **`otelcol-contrib`** — The OpenTelemetry Collector that collects and exports logs/metrics
+> - **`forge-dpu-otel-agent`** — A Rust helper service that periodically renews the mTLS
+>   certificates used by otelcol-contrib to authenticate with the site controller
+>
+> The cert renewal agent is *not* a custom OTel build — it's a sidecar that manages certificate
+> lifecycle so otelcol-contrib can maintain secure connections.
 
-The site controller's otel-collector receives DPU logs via OTLP and routes them through
-processing pipelines:
+### 3.3 Site collector receiver
+
+The site otel-collector receives DPU logs via OTLP and routes them to the backend. Example
+configuration (adapt to your deployment):
 
 ```yaml
 receivers:
@@ -352,33 +360,16 @@ receivers:
     protocols:
       grpc:
         endpoint: ${env:MY_POD_IP}:4317
-      http:
-        endpoint: ${env:MY_POD_IP}:4318
-
-connectors:
-  routing/otlp-logs:
-    default_pipelines:
-      - logs/dpu
-    table:
-      # Route console logs separately
-      - statement: route() where attributes["component"] == "nico-ssh-console-rs"
-        pipelines:
-          - logs/console
 
 service:
   pipelines:
-    logs/otlp-in:
-      receivers: [otlp]
-      exporters: [routing/otlp-logs]
-
     logs/dpu:
-      receivers: [routing/otlp-logs]
+      receivers: [otlp]
       processors:
         - memory_limiter
         - resource/dpu-logs-loki
-        - transform/dpu-logs-loki
         - batch
-      exporters: [loki]
+      exporters: [loki]  # or otlphttp for VictoriaLogs
 ```
 
 **Resource labels for Loki indexing:**
@@ -394,6 +385,9 @@ processors:
         key: loki.format
         value: raw
 ```
+
+> **Note**: The routing/pipeline configuration depends on your deployment and may require
+> customization for your environment.
 
 ### 3.4 Querying DPU logs
 


### PR DESCRIPTION
Address review findings for `logging.md` and `machine-dpu-logs.md`. Fixes incorrect binary names, CLI examples, log format descriptions and architecture diagrams to match actual NICo implementation.

## Related issues
- Fixes documentation issues from #2299 and #2526 reviews
- References #3151 (nico-dpu-otel-agent RUST_LOG bug)

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
All changes verified against current nico repo source code. Binary names match `Dockerfile.release-container-x86_64`, CLI flags verified against clap definitions, log formats verified against tracing initialization code.

