### PR TITLE
feat: apply SetBootOrder boot config once per reboot

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -2877,6 +2877,61 @@ async fn test_set_boot_order_reasserts_http_boot_device_when_reverted(pool: sqlx
         "the boot order must not be set in the same pass as the re-assert (shared BIOS job), got: {first_pass:?}"
     );
 
+    // The re-assert is committed once. While the device is still reverted (the
+    // apply reboot hasn't landed yet), the host polls in
+    // WaitForHttpBootDeviceApplied without re-running machine_setup.
+    {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert!(
+            matches!(
+                host.current_state(),
+                ManagedHostState::HostInit {
+                    machine_state: MachineState::SetBootOrder {
+                        set_boot_order_info: Some(SetBootOrderInfo {
+                            set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
+                            ..
+                        }),
+                    },
+                }
+            ),
+            "after the re-assert the host should wait for the device to apply, got: {:?}",
+            host.current_state()
+        );
+    }
+    let after_reassert = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+    let second_pass = env.redfish_sim.actions_since(&after_reassert).all_hosts();
+    assert!(
+        !second_pass
+            .iter()
+            .any(|a| matches!(a, RedfishSimAction::MachineSetup { .. })),
+        "machine_setup must not re-run while waiting for the re-asserted device to apply, got: {second_pass:?}"
+    );
+
+    // Within the wait window the host stays parked in
+    // WaitForHttpBootDeviceApplied -- it neither advances nor bounces back to
+    // SetBootOrder for another re-assert.
+    {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert!(
+            matches!(
+                host.current_state(),
+                ManagedHostState::HostInit {
+                    machine_state: MachineState::SetBootOrder {
+                        set_boot_order_info: Some(SetBootOrderInfo {
+                            set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
+                            ..
+                        }),
+                    },
+                }
+            ),
+            "the host should keep waiting for the device to apply within the wait window, got: {:?}",
+            host.current_state()
+        );
+    }
+
     // Model the reboot applying the re-asserted config: the device now verifies.
     env.redfish_sim.set_is_bios_setup(true);
 
@@ -2893,6 +2948,103 @@ async fn test_set_boot_order_reasserts_http_boot_device_when_reverted(pool: sqlx
         .actions_since(&redfish_timepoint)
         .all_hosts();
     assert_machine_setup_precedes_reorder_for(&actions, boot_nic_mac);
+}
+
+/// When the re-asserted HTTP-boot device does not verify within the wait
+/// window (the boot NIC can drop off the BMC's Redfish inventory again on the
+/// apply reboot itself), the host returns to `SetBootOrder` for a fresh
+/// re-assert -- one `machine_setup` per window, not per pass. Once the state
+/// machine's retry budget is exhausted it stops re-asserting and surfaces the
+/// host for manual intervention.
+#[crate::sqlx_test]
+async fn test_set_boot_order_reassert_window_expiry_bounds_reapplies(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let host_id = mh.host().id;
+
+    // The device stays reverted throughout: every verify reads false.
+    env.redfish_sim.set_is_bios_setup(false);
+    env.redfish_sim.set_is_boot_order_setup(false);
+
+    let stuck_waiting = |retry_count: u32| ManagedHostState::HostInit {
+        machine_state: MachineState::SetBootOrder {
+            set_boot_order_info: Some(SetBootOrderInfo {
+                set_boot_order_jid: None,
+                set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
+                retry_count,
+            }),
+        },
+    };
+
+    // Plant the host mid-wait with the window already expired (backdated past
+    // the 10-minute apply window). Pass 1 returns it to SetBootOrder; pass 2
+    // re-asserts once and parks it back in the wait substate.
+    set_host_controller_state_stuck_in(&env, host_id, &stuck_waiting(0), 11).await;
+    let checkpoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+    env.run_machine_state_controller_iteration().await;
+    let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
+    assert_eq!(
+        actions
+            .iter()
+            .filter(|a| matches!(a, RedfishSimAction::MachineSetup { .. }))
+            .count(),
+        1,
+        "an expired wait window should produce exactly one fresh re-assert, got: {actions:?}"
+    );
+    {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert!(
+            matches!(
+                host.current_state(),
+                ManagedHostState::HostInit {
+                    machine_state: MachineState::SetBootOrder {
+                        set_boot_order_info: Some(SetBootOrderInfo {
+                            set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
+                            retry_count: 1,
+                            ..
+                        }),
+                    },
+                }
+            ),
+            "the fresh re-assert should park the host back in the wait substate with the retry spent, got: {:?}",
+            host.current_state()
+        );
+    }
+
+    // Budget exhausted: the same expired window with the retry budget spent
+    // must not re-assert again -- the host stays parked for an operator.
+    set_host_controller_state_stuck_in(&env, host_id, &stuck_waiting(3), 11).await;
+    let checkpoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+    let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a, RedfishSimAction::MachineSetup { .. })),
+        "an exhausted retry budget must not re-assert the device again, got: {actions:?}"
+    );
+    {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert!(
+            matches!(
+                host.current_state(),
+                ManagedHostState::HostInit {
+                    machine_state: MachineState::SetBootOrder {
+                        set_boot_order_info: Some(SetBootOrderInfo {
+                            set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
+                            ..
+                        }),
+                    },
+                }
+            ),
+            "the capped host should stay parked awaiting manual intervention, got: {:?}",
+            host.current_state()
+        );
+    }
 }
 
 /// When HostInit/PollingBiosSetup retry budget is exhausted, enter Failed and recover via is_bios_setup.

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1896,6 +1896,10 @@ pub struct SetBootOrderInfo {
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum SetBootOrderState {
     SetBootOrder,
+    /// A reverted HTTP-boot device was re-asserted (`machine_setup`) and the
+    /// host restarted to apply it; polls the device across that reboot, then
+    /// returns to `SetBootOrder` to set the boot order.
+    WaitForHttpBootDeviceApplied,
     WaitForSetBootOrderJobScheduled,
     RebootHost,
     WaitForSetBootOrderJobCompletion,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11247,10 +11247,13 @@ async fn set_host_boot_order(
             if !is_bios_setup {
                 // The HTTP-boot device was reverted (the boot NIC dropped off the
                 // BMC's Redfish inventory on a reboot), so re-assert it with
-                // `machine_setup` and reboot to apply it *before* setting the boot
-                // order -- the two BIOS writes never share one pass (they can't
-                // share one Dell config job). The next pass reads the device
-                // applied (`is_bios_setup` true) and continues to the order.
+                // `machine_setup` and restart the host to apply it *before*
+                // setting the boot order -- the two BIOS writes never share one
+                // pass (they can't share one Dell config job). The re-assert
+                // commits once: `WaitForHttpBootDeviceApplied` polls the device
+                // across the reboot instead of this arm re-writing the staged
+                // settings and re-creating the config job every pass while the
+                // reboot lands.
                 call_machine_setup_and_handle_no_dpu_error(
                     redfish_client,
                     Some(&boot_interface),
@@ -11260,29 +11263,15 @@ async fn set_host_boot_order(
                 .await
                 .map_err(|e| redfish_error("machine_setup", e))?;
 
-                let reboot_status = if mh_snapshot.host_snapshot.last_reboot_requested.is_none() {
-                    handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart)
-                        .await?;
-                    RebootStatus {
-                        increase_retry_count: true,
-                        status: "Restarted host to apply re-asserted HTTP boot device".to_string(),
-                    }
-                } else {
-                    trigger_reboot_if_needed(
-                        &mh_snapshot.host_snapshot,
-                        mh_snapshot,
-                        None,
-                        reachability_params,
-                        ctx,
-                    )
-                    .await?
-                };
-                if reboot_status.increase_retry_count {
-                    log_host_config(redfish_client, mh_snapshot).await;
-                }
-                return Ok(SetBootOrderOutcome::WaitingForReboot(format!(
-                    "HTTP boot device was reverted; re-asserted it and rebooting to apply before setting the boot order: {reboot_status:#?}"
-                )));
+                handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart)
+                    .await?;
+                log_host_config(redfish_client, mh_snapshot).await;
+
+                return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                    set_boot_order_jid: None,
+                    set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
+                    retry_count: set_boot_order_info.retry_count,
+                }));
             }
 
             // HTTP-boot device is already set, so `machine_setup` was not re-run
@@ -11371,6 +11360,87 @@ async fn set_host_boot_order(
                 set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
                 retry_count: set_boot_order_info.retry_count,
             }))
+        }
+        SetBootOrderState::WaitForHttpBootDeviceApplied => {
+            // The SetBootOrder substate re-asserted the reverted HTTP-boot device
+            // and restarted the host; the staged BIOS settings apply across that
+            // reboot. Poll until the device verifies, then return to SetBootOrder
+            // to set the boot order. If it still hasn't applied once the reboot
+            // has had time to land (the boot NIC can drop off the BMC's Redfish
+            // inventory again on the apply reboot itself), return to SetBootOrder
+            // for a fresh re-assert -- re-commits stay bounded to one per wait
+            // window instead of one per pass.
+            const HTTP_BOOT_DEVICE_APPLY_WAIT_MINUTES: i64 = 10;
+            const MAX_HTTP_BOOT_DEVICE_APPLY_RETRIES: u32 = 3;
+
+            let boot_interface = match resolve_boot_interface(mh_snapshot, &predictions) {
+                BootInterfaceResolution::Ready(target) => target,
+                BootInterfaceResolution::AwaitingNic => {
+                    return Ok(SetBootOrderOutcome::Wait(format!(
+                        "Waiting for zero-DPU host {} to discover its boot NIC before verifying the re-asserted HTTP boot device.",
+                        mh_snapshot.host_snapshot.id
+                    )));
+                }
+                BootInterfaceResolution::Missing => {
+                    return Err(StateHandlerError::GenericError(eyre::eyre!(
+                        "Missing boot interface for host: {}",
+                        mh_snapshot.host_snapshot.id
+                    )));
+                }
+            };
+
+            let is_bios_setup = boot_interface
+                .run(|bi| redfish_client.is_bios_setup(Some(bi)))
+                .await
+                .map_err(|e| redfish_error("is_bios_setup", e))?;
+
+            if is_bios_setup {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Re-asserted HTTP boot device applied; returning to SetBootOrder to set the boot order",
+                );
+                return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                    set_boot_order_jid: None,
+                    set_boot_order_state: SetBootOrderState::SetBootOrder,
+                    retry_count: set_boot_order_info.retry_count,
+                }));
+            }
+
+            let minutes_waiting = mh_snapshot
+                .host_snapshot
+                .state
+                .version
+                .since_state_change()
+                .num_minutes();
+
+            if minutes_waiting >= HTTP_BOOT_DEVICE_APPLY_WAIT_MINUTES {
+                // Each expired window spends one retry from the SetBootOrder
+                // state machine's shared budget. Once it's exhausted the device
+                // is not coming back on its own -- stop re-asserting and surface
+                // the host for an operator, the same terminal escalation the
+                // reboot pacer applies to a host that never comes up.
+                if set_boot_order_info.retry_count >= MAX_HTTP_BOOT_DEVICE_APPLY_RETRIES {
+                    return Err(StateHandlerError::ManualInterventionRequired(format!(
+                        "HTTP boot device on host {} still not applied after {} re-asserts; manual intervention required",
+                        mh_snapshot.host_snapshot.id, MAX_HTTP_BOOT_DEVICE_APPLY_RETRIES
+                    )));
+                }
+                tracing::warn!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    minutes_waiting,
+                    "Re-asserted HTTP boot device still not applied after the wait window; returning to SetBootOrder to re-assert",
+                );
+                return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                    set_boot_order_jid: None,
+                    set_boot_order_state: SetBootOrderState::SetBootOrder,
+                    retry_count: set_boot_order_info.retry_count + 1,
+                }));
+            }
+
+            Ok(SetBootOrderOutcome::WaitingForReboot(format!(
+                "Waiting for the re-asserted HTTP boot device to apply on host {} ({minutes_waiting}m of {HTTP_BOOT_DEVICE_APPLY_WAIT_MINUTES}m)",
+                mh_snapshot.host_snapshot.id
+            )))
         }
         SetBootOrderState::WaitForSetBootOrderJobScheduled => {
             if let Some(job_id) = &set_boot_order_info.set_boot_order_jid {


### PR DESCRIPTION
When SetBootOrder finds the HTTP-boot device reverted (the boot NIC dropped
off the BMC's Redfish inventory on a reboot), it restores the device with
`machine_setup` and restarts the host to apply it. That restore now happens
once per revert: a new `WaitForHttpBootDeviceApplied` substate polls the
device across the reboot -- the same wait choreography the boot-order job
already has -- instead of the SetBootOrder pass re-writing the staged BIOS
settings and re-creating the config job on every pass until the reboot lands.

- While the reboot is in flight, the host waits in
  `WaitForHttpBootDeviceApplied`; once the device verifies, the flow returns
  to `SetBootOrder` to set the boot order.
- A device still reverted after the wait window (it can drop off again on the
  apply reboot itself) returns to `SetBootOrder` for a fresh restore, so
  re-applies stay bounded to one per window rather than one per pass.
- The restore path drops its two-way reboot branch for the unconditional
  restart the `RebootHost` substate already uses.

Tests updated!

This supports https://github.com/NVIDIA/infra-controller/issues/3166

Signed-off-by: Chet Nichols III <chetn@nvidia.com>



Closes #3166
