### PR TITLE
fix(dpu-otel-agent): support logfmt format

### DIFF
--- a/crates/dpu-otel-agent/src/main.rs
+++ b/crates/dpu-otel-agent/src/main.rs
@@ -17,10 +17,8 @@
 
 use std::time::Duration;
 
-use tracing_subscriber::fmt;
-
 fn main() -> eyre::Result<()> {
-    fmt().init();
+    carbide_host_support::init_logging("forge-dpu-otel-agent")?;
     // We need a multi-threaded runtime since background threads will queue work
     // on it, and the foreground thread might not be blocked onto the runtime
     // at all points in time


### PR DESCRIPTION
Replaced `forge-dpu-otel-agent` binary logging with logfmt support to match other NICo DPU components.

## Related issues
- Closes #3151

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Before:
```
$ RUST_LOG=debug cargo run -p carbide-dpu-otel-agent run
2026-07-07T01:23:45.511074Z  INFO otel_agent: Using configuration from default: AgentConfig { XXX }
2026-07-07T01:23:45.511345Z  INFO otel_agent::main_loop: Started forge-dpu-otel-agent options=RunOptions
2026-07-07T01:23:45.511470Z  INFO otel_agent::main_loop: main cert renewal loop iteration=1us 417ns uptime=115us 83ns
```
After:
```
$ RUST_LOG=debug cargo run -p carbide-dpu-otel-agent run
level=INFO component=forge-dpu-otel-agent msg="Using configuration from default: AgentConfig { XXX }
level=DEBUG component=forge-dpu-otel-agent msg="ignore_mgmt_vrf is false using mgmt vrf: mgmt" log_file=crates/rpc/src/forge_tls_client.rs log_line=150 log_module_path=rpc::forge_tls_client log_target=rpc::forge_tls_client location=":0"
level=DEBUG component=forge-dpu-otel-agent msg="ForgeClientConfig ForgeClientConfig { XXX }
level=INFO component=forge-dpu-otel-agent msg="Started forge-dpu-otel-agent" options=RunOptions location="crates/dpu-otel-agent/src/main_loop.rs:38"
level=INFO component=forge-dpu-otel-agent msg="main cert renewal loop" iteration="1us 916ns" uptime="134us 250ns" location="crates/dpu-otel-agent/src/main_loop.rs:113"
```

## Additional Notes

