### PR TITLE
feat: introduce carbide-instrument for unified logging and metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,43 @@ and can't be exhaustively checked by the compiler. See
 `ErrorSystem`/`ErrorSubsystem` parts plus a `code`, rendered to the wire string
 in one place. Reserve raw strings for genuinely open-ended values.
 
+### Instrumentation: logs and metrics
+
+The decision rule:
+
+- **Just logging words?** Use plain `tracing::` macros with structured fields
+  (`warn!(%machine_id, error = %e, "...")`). Most log sites are and stay this.
+- **Does the event deserve a count, rate, or duration** (a failure you'd alert
+  on, an outcome you'd trend, a hot-path rate)? Declare it once as a
+  `carbide_instrument::Event` and `emit()` it — that produces the metric and
+  (optionally) the log line together, correlated by `span_id`:
+
+  ```rust
+  #[derive(carbide_instrument::Event)]
+  #[event(name = "carbide_power_control_total", component = "component_manager",
+          log = warn, metric = counter, message = "power control failed")]
+  struct PowerControlFailed {
+      #[label]   backend: Backend,  // bounded via LabelValue — enums, usually
+      #[context] error: String,     // high-cardinality — log line only
+  }
+  ```
+
+  `log = off, metric = counter` counts a hot-path event with no log line at
+  all; `metric = none` is a typed log. Never put `machine_id`/IPs/error text
+  in a `#[label]` — that's what `#[context]` is for, and `String` doesn't
+  implement `LabelValue` precisely to stop it. A bounded-but-not-enum value
+  (a vendor, a SKU) can get a manual `LabelValue` impl on a newtype — the
+  reviewed escape hatch — but only when the value is bounded *at the call
+  site*; anything caller-supplied stays in `#[context]`.
+- **Point-in-time state** ("how many machines are in state X") stays on the
+  existing observable-gauge / `SharedMetricsHolder` pattern — the kit models
+  occurrences, not state.
+
+New metric names are validated at compile time (`carbide_` prefix, `_total`
+counters, unit-suffixed histograms) and the name in the attribute is the
+exposed name, verbatim. Existing metric names never change. The full standard
+lives in [`docs/observability/instrumentation.md`](docs/observability/instrumentation.md).
+
 ## Further Reading
 
 - [`README.md`](README.md) — Project overview and getting started

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,7 @@ dependencies = [
  "carbide-host-support",
  "carbide-ib-fabric",
  "carbide-ib-partition-controller",
+ "carbide-instrument",
  "carbide-ipmi",
  "carbide-ipxe-renderer",
  "carbide-kms-provider",
@@ -2136,6 +2137,31 @@ dependencies = [
  "sqlx",
  "state-controller",
  "tracing",
+]
+
+[[package]]
+name = "carbide-instrument"
+version = "0.0.0"
+dependencies = [
+ "carbide-instrument",
+ "carbide-instrument-macros",
+ "carbide-test-support",
+ "ctor",
+ "opentelemetry 0.32.0",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
+ "prometheus",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "carbide-instrument-macros"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -41,6 +41,7 @@ carbide-dpf = { path = "../dpf" }
 carbide-firmware = { path = "../firmware" }
 carbide-health-metrics = { path = "../health-metrics" }
 carbide-health-report = { path = "../health-report" }
+carbide-instrument = { path = "../instrument" }
 carbide-host-support = { path = "../host-support", default-features = false }
 carbide-ib-fabric = { path = "../ib-fabric" }
 carbide-ib-partition-controller = { path = "../ib-partition-controller" }
@@ -224,6 +225,7 @@ carbide-api-model = { path = "../api-model", default-features = false, features 
 ] }
 carbide-firmware = { path = "../firmware", features = ["test-support"] }
 carbide-ib-fabric = { path = "../ib-fabric", features = ["test-support"] }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-machine-controller = { path = "../machine-controller", features = [
   "test-support",
 ] }

--- a/crates/api-core/src/auth/middleware.rs
+++ b/crates/api-core/src/auth/middleware.rs
@@ -25,6 +25,29 @@ use tower_http::auth::AsyncAuthorizeRequest;
 use crate::auth::internal_rbac_rules::InternalRBACRules;
 use crate::auth::{AuthContext, CasbinAuthorizer, Predicate};
 
+/// A caller was denied by the Casbin authorizer -- the canonical security
+/// signal. The denial rate is the alert; the denied method and principals
+/// ride the log line. (The method is deliberately NOT a metric label: the
+/// path segment is caller-supplied, so it would mint unbounded series. A
+/// per-method label needs a real method registry to bucket against.)
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_auth_denied_total",
+    component = "nico-api",
+    log = info,
+    metric = counter,
+    message = "Denied a call to Forge method",
+    describe = "The amount of Forge calls denied by the authorizer"
+)]
+struct AuthorizationDenied {
+    #[context]
+    method: String,
+    #[context]
+    principals: String,
+    #[context]
+    reason: String,
+}
+
 // An authorization handler to plug into tower_http::auth::AsyncAuthorizeRequest.
 // According to the docs for AsyncAuthorizeRequest, we're _supposed_ to use the
 // HTTP Authorization header to perform our custom logic, but as far as I can
@@ -89,11 +112,18 @@ where
                             true
                         }
                         Err(e) => {
-                            tracing::info!(
-                                method_name,
-                                ?principals,
-                                "Denied a call to Forge method because of authorizer result '{e}'"
-                            );
+                            carbide_instrument::emit(AuthorizationDenied {
+                                method: method_name,
+                                // as_identifier() is the authorizer's view of each
+                                // principal (e.g. external-role/<group>) and keeps
+                                // ExternalUserInfo payloads out of the log line.
+                                principals: principals
+                                    .iter()
+                                    .map(Principal::as_identifier)
+                                    .collect::<Vec<_>>()
+                                    .join(","),
+                                reason: e.to_string(),
+                            });
                             false
                         }
                     }
@@ -229,5 +259,74 @@ where
                     .unwrap()),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use futures_util::FutureExt as _;
+
+    use super::*;
+    use crate::auth::{Authorization, AuthorizationError, PolicyEngine};
+
+    /// Denies everything, standing in for a Casbin policy with no matching rule.
+    struct DenyAll;
+
+    impl PolicyEngine for DenyAll {
+        fn authorize(
+            &self,
+            _principals: &[Principal],
+            _predicate: Predicate,
+        ) -> Result<Authorization, AuthorizationError> {
+            Err(AuthorizationError::Unauthorized)
+        }
+    }
+
+    /// The denial branch is a contract: one emit writes the log line (method,
+    /// principals, reason) AND moves carbide_auth_denied_total, and the caller
+    /// gets 403.
+    #[test]
+    fn denied_forge_call_logs_and_counts() {
+        let metrics = MetricsCapture::start();
+        let mut handler = CasbinHandler::new(Arc::new(CasbinAuthorizer::new(Arc::new(DenyAll))));
+
+        let logs = capture_logs(|| {
+            let mut request = Request::builder()
+                .uri("/forge.Forge/PowerControl")
+                .body(())
+                .expect("request");
+            request.extensions_mut().insert(AuthContext {
+                principals: vec![Principal::TrustedCertificate],
+                authorization: None,
+            });
+
+            let result = handler
+                .authorize(request)
+                .now_or_never()
+                .expect("the authorization future has no awaits");
+            let response = result.expect_err("DenyAll must reject the call");
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        });
+
+        let denial = logs
+            .iter()
+            .find(|log| log.message == "Denied a call to Forge method")
+            .expect("the denial log line");
+        let field = |name: &str| {
+            denial
+                .fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.as_str())
+        };
+        assert_eq!(field("method"), Some("PowerControl"));
+        assert_eq!(field("principals"), Some("trusted-certificate"));
+        assert_eq!(
+            field("reason").expect("reason field"),
+            AuthorizationError::Unauthorized.to_string()
+        );
+
+        assert_eq!(metrics.counter_delta("carbide_auth_denied_total", &[]), 1.0);
     }
 }

--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -126,7 +126,10 @@ pub(crate) async fn cleanup_machine_completed(
             .enqueue_object(&machine_id)
             .await
     {
-        tracing::warn!(%err, %machine_id, "Failed to wake up state handler for machine");
+        carbide_instrument::emit(StateHandlerWakeupFailed {
+            machine_id,
+            err: err.to_string(),
+        });
     }
 
     Ok(Response::new(rpc::MachineCleanupResult {}))
@@ -428,6 +431,26 @@ fn record_reboot_duration_metric(
     );
 }
 
+/// A machine finished rebooting but its state handler could not be woken:
+/// the machine sits idle until the next periodic enqueue, so the rate of
+/// these is a leading "machine stuck" signal.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_state_handler_wakeup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "Failed to wake up state handler for machine",
+    describe = "The amount of times a machine's state handler could not be woken after a \
+                scout-reported event"
+)]
+struct StateHandlerWakeupFailed {
+    #[context]
+    machine_id: carbide_uuid::machine::MachineId,
+    #[context]
+    err: String,
+}
+
 // Host has rebooted
 pub(crate) async fn reboot_completed(
     api: &Api,
@@ -456,7 +479,10 @@ pub(crate) async fn reboot_completed(
             .enqueue_object(&machine_id)
             .await
     {
-        tracing::warn!(%err, %machine_id, "Failed to wake up state handler for machine");
+        carbide_instrument::emit(StateHandlerWakeupFailed {
+            machine_id,
+            err: err.to_string(),
+        });
     }
 
     Ok(Response::new(rpc::MachineRebootCompletedResponse {}))

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -168,6 +168,18 @@ fn get_tls_acceptor(tls_config: &ApiTlsConfig) -> Option<TlsAcceptor> {
     }
 }
 
+/// The five-minute TLS acceptor refresh, counted instead of logged: the
+/// steady tick is a rate, not news, so the per-refresh log line retires.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_api_tls_cert_refreshes_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Number of TLS acceptor refreshes performed by the API listener"
+)]
+struct TlsCertsRefreshed;
+
 /// Start listening for requests, spawning the listener task into `join_set`.
 ///
 /// This method will return an error if any preconditions fail (could not bind to the port, issues
@@ -286,11 +298,11 @@ pub async fn start(
 
     let connection_total_counter = meter
         .u64_counter("carbide-api.tls.connection_attempted")
-        .with_description("The amount of tls connections that were attempted")
+        .with_description("Number of attempted TLS connections")
         .build();
     let connection_succeeded_counter = meter
         .u64_counter("carbide-api.tls.connection_success")
-        .with_description("The amount of tls connections that were successful")
+        .with_description("Number of successful TLS connections")
         .build();
     let connection_failed_counter = meter
         .u64_counter("carbide-api.tls.connection_fail")
@@ -324,7 +336,7 @@ pub async fn start(
                 initialize_tls_acceptor
                     || tls_acceptor_created.elapsed() > tokio::time::Duration::from_secs(5 * 60),
             ) {
-                tracing::info!("Refreshing certs");
+                carbide_instrument::emit(TlsCertsRefreshed);
                 initialize_tls_acceptor = false;
                 tls_acceptor_created = Instant::now();
 

--- a/crates/instrument-macros/Cargo.toml
+++ b/crates/instrument-macros/Cargo.toml
@@ -1,0 +1,39 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-instrument-macros"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
+quote = { workspace = true, default-features = false }
+syn = { workspace = true, features = [
+  "clone-impls",
+  "derive",
+  "parsing",
+  "printing",
+  "proc-macro",
+] }
+
+[lints]
+workspace = true

--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -1,0 +1,573 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Derive macros for `carbide-instrument`: `#[derive(Event)]` and
+//! `#[derive(LabelValue)]`. See the `carbide-instrument` crate documentation
+//! for the model and usage; these macros are re-exported from there.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Field, Fields, Ident, LitStr};
+
+/// Metric-name unit suffixes a histogram may use, with the OpenTelemetry unit
+/// string each one implies.
+const UNIT_SUFFIXES: &[(&str, &str)] = &[
+    ("_seconds", "s"),
+    ("_milliseconds", "ms"),
+    ("_microseconds", "us"),
+    ("_bytes", "By"),
+];
+
+/// Derives `carbide_instrument::LabelValue` for a fieldless enum: each variant
+/// renders as its snake_case name. Enums are the only derivable label type --
+/// that is the cardinality guarantee. For a bounded-but-not-enum value,
+/// implement `LabelValue` by hand on a newtype (the reviewed escape hatch).
+#[proc_macro_derive(LabelValue)]
+pub fn derive_label_value(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    match expand_label_value(input) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_label_value(input: DeriveInput) -> syn::Result<TokenStream> {
+    let name = &input.ident;
+    let Data::Enum(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "LabelValue can only be derived for enums: metric label values must come from a \
+             closed set. For a bounded-but-not-enum value, implement LabelValue by hand on a \
+             newtype.",
+        ));
+    };
+    if data.variants.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "LabelValue needs at least one variant",
+        ));
+    }
+
+    let mut arms = Vec::new();
+    for variant in &data.variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "LabelValue variants must be unit variants (no fields): the label value set \
+                 must be closed",
+            ));
+        }
+        let ident = &variant.ident;
+        let value = snake_case(&ident.to_string());
+        arms.push(quote! { Self::#ident => #value, });
+    }
+
+    Ok(quote! {
+        impl ::carbide_instrument::LabelValue for #name {
+            fn label_value(&self) -> ::carbide_instrument::__private::opentelemetry::StringValue {
+                ::carbide_instrument::__private::opentelemetry::StringValue::from(match self {
+                    #(#arms)*
+                })
+            }
+        }
+    }
+    .into())
+}
+
+/// Derives `carbide_instrument::Event` for a struct declared with an
+/// `#[event(...)]` attribute. Every field takes exactly one of `#[label]`
+/// (enum via `LabelValue`; goes to both the log line and the metric),
+/// `#[context]` (any `Display`; log-only), or `#[observation]` (the histogram
+/// value). The metric name is validated at compile time: `carbide_` prefix,
+/// `_total` for counters, a unit suffix for histograms.
+#[proc_macro_derive(Event, attributes(event, label, context, observation))]
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as DeriveInput);
+    match expand_event(input) {
+        Ok(ts) => ts,
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum LogSpec {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum MetricSpec {
+    Counter,
+    Histogram,
+    None,
+}
+
+struct EventArgs {
+    name: Option<LitStr>,
+    component: Option<LitStr>,
+    message: Option<LitStr>,
+    describe: Option<LitStr>,
+    unit: Option<LitStr>,
+    log: LogSpec,
+    metric: MetricSpec,
+    name_unchecked: bool,
+}
+
+fn parse_event_args(input: &DeriveInput) -> syn::Result<EventArgs> {
+    let mut args = EventArgs {
+        name: None,
+        component: None,
+        message: None,
+        describe: None,
+        unit: None,
+        log: LogSpec::Info,
+        metric: MetricSpec::None,
+        name_unchecked: false,
+    };
+    let mut saw_attr = false;
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("event") {
+            continue;
+        }
+        saw_attr = true;
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name") {
+                args.name = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("component") {
+                args.component = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("message") {
+                args.message = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("describe") {
+                args.describe = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("unit") {
+                args.unit = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("name_unchecked") {
+                args.name_unchecked = true;
+            } else if meta.path.is_ident("log") {
+                let ident: Ident = meta.value()?.parse()?;
+                args.log = match ident.to_string().as_str() {
+                    "off" => LogSpec::Off,
+                    "error" => LogSpec::Error,
+                    "warn" => LogSpec::Warn,
+                    "info" => LogSpec::Info,
+                    "debug" => LogSpec::Debug,
+                    "trace" => LogSpec::Trace,
+                    other => {
+                        return Err(meta.error(format!(
+                            "unknown log level `{other}`; expected one of \
+                             error | warn | info | debug | trace | off"
+                        )));
+                    }
+                };
+            } else if meta.path.is_ident("metric") {
+                let ident: Ident = meta.value()?.parse()?;
+                args.metric = match ident.to_string().as_str() {
+                    "counter" => MetricSpec::Counter,
+                    "histogram" => MetricSpec::Histogram,
+                    "none" => MetricSpec::None,
+                    other => {
+                        return Err(meta.error(format!(
+                            "unknown metric kind `{other}`; expected counter | histogram | none"
+                        )));
+                    }
+                };
+            } else {
+                return Err(meta.error(
+                    "unknown `event` key; expected name, component, message, describe, log, \
+                     metric, unit, or name_unchecked",
+                ));
+            }
+            Ok(())
+        })?;
+    }
+
+    if !saw_attr {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "deriving Event requires an #[event(name = ..., component = ..., ...)] attribute",
+        ));
+    }
+    Ok(args)
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum FieldKind {
+    Label,
+    Context,
+    Observation,
+}
+
+fn classify_field(field: &Field) -> syn::Result<FieldKind> {
+    let mut kinds = Vec::new();
+    for attr in &field.attrs {
+        if attr.path().is_ident("label") {
+            kinds.push(FieldKind::Label);
+        } else if attr.path().is_ident("context") {
+            kinds.push(FieldKind::Context);
+        } else if attr.path().is_ident("observation") {
+            kinds.push(FieldKind::Observation);
+        }
+    }
+    match kinds.as_slice() {
+        [kind] => Ok(*kind),
+        [] => Err(syn::Error::new_spanned(
+            field,
+            "every Event field needs exactly one of #[label] (bounded, on the metric and the \
+             log), #[context] (log-only), or #[observation] (the histogram value)",
+        )),
+        _ => Err(syn::Error::new_spanned(
+            field,
+            "an Event field takes only one of #[label], #[context], #[observation]",
+        )),
+    }
+}
+
+fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
+    let struct_ident = &input.ident;
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &input.generics,
+            "Event structs must be concrete (no generics or lifetimes): declare the event with \
+             owned fields",
+        ));
+    }
+
+    let args = parse_event_args(&input)?;
+
+    let name = args.name.as_ref().ok_or_else(|| {
+        syn::Error::new_spanned(&input.ident, "#[event(...)] requires name = \"...\"")
+    })?;
+    let component = args.component.as_ref().ok_or_else(|| {
+        syn::Error::new_spanned(&input.ident, "#[event(...)] requires component = \"...\"")
+    })?;
+    let name_value = name.value();
+
+    // The metric name in the attribute is the exposed name, verbatim, so a
+    // dashboard greps straight back to this line. Validate the conventions
+    // unless the site is migrating a grandfathered pre-standard name.
+    let mut histogram_unit: Option<&'static str> = None;
+    if args.metric == MetricSpec::Histogram {
+        histogram_unit = UNIT_SUFFIXES
+            .iter()
+            .find(|(suffix, _)| name_value.ends_with(suffix))
+            .map(|(_, unit)| *unit);
+    }
+    if !args.name_unchecked {
+        if !name_value.starts_with("carbide_") {
+            return Err(syn::Error::new_spanned(
+                name,
+                "metric names use the `carbide_` prefix (use name_unchecked only to keep a \
+                 grandfathered pre-standard name)",
+            ));
+        }
+        match args.metric {
+            MetricSpec::Counter if !name_value.ends_with("_total") => {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "counter names end in `_total` (Prometheus convention)",
+                ));
+            }
+            MetricSpec::Histogram if histogram_unit.is_none() => {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "histogram names end in their unit: one of `_seconds`, `_milliseconds`, \
+                     `_microseconds`, `_bytes`",
+                ));
+            }
+            _ => {}
+        }
+        if let Some(unit) = &args.unit {
+            return Err(syn::Error::new_spanned(
+                unit,
+                "`unit` is only for name_unchecked histograms; a standard histogram name \
+                 already declares its unit as the suffix",
+            ));
+        }
+    }
+    if let Some(unit) = &args.unit
+        && args.metric != MetricSpec::Histogram
+    {
+        return Err(syn::Error::new_spanned(
+            unit,
+            "`unit` is only valid for histogram metrics",
+        ));
+    }
+    if let Some(describe) = &args.describe
+        && args.metric == MetricSpec::None
+    {
+        return Err(syn::Error::new_spanned(
+            describe,
+            "`describe` documents a metric (the Prometheus HELP text); this event has \
+             metric = none",
+        ));
+    }
+    let unit_value: String = match (&args.unit, histogram_unit) {
+        (Some(explicit), _) => explicit.value(),
+        (None, Some(from_suffix)) => from_suffix.to_string(),
+        (None, None) => String::new(),
+    };
+    if args.metric == MetricSpec::Histogram && unit_value.is_empty() {
+        return Err(syn::Error::new_spanned(
+            name,
+            "a name_unchecked histogram needs an explicit unit = \"...\"",
+        ));
+    }
+
+    if args.message.is_none() && args.log != LogSpec::Off {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "message = \"...\" is required when the event logs (or set log = off for a \
+             metric-only event)",
+        ));
+    }
+    if args.log == LogSpec::Off && args.metric == MetricSpec::None {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "an event with log = off and metric = none emits nothing; declare at least one side",
+        ));
+    }
+
+    // Classify the fields.
+    let Data::Struct(data) = &input.data else {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "Event can only be derived for structs",
+        ));
+    };
+    let fields: Vec<&Field> = match &data.fields {
+        Fields::Named(named) => named.named.iter().collect(),
+        Fields::Unit => Vec::new(),
+        Fields::Unnamed(_) => {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "Event structs use named fields (or none)",
+            ));
+        }
+    };
+
+    let mut labels: Vec<&Ident> = Vec::new();
+    let mut contexts: Vec<&Ident> = Vec::new();
+    let mut observations: Vec<&Ident> = Vec::new();
+    for field in fields {
+        let ident = field.ident.as_ref().expect("named field");
+        if ident == "message" {
+            return Err(syn::Error::new_spanned(
+                ident,
+                "`message` is reserved for the event message; pick another field name",
+            ));
+        }
+        match classify_field(field)? {
+            FieldKind::Label => labels.push(ident),
+            FieldKind::Context => contexts.push(ident),
+            FieldKind::Observation => observations.push(ident),
+        }
+    }
+
+    match (args.metric, observations.len()) {
+        (MetricSpec::Histogram, 1) => {}
+        (MetricSpec::Histogram, _) => {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "a histogram event needs exactly one #[observation] field",
+            ));
+        }
+        (_, 0) => {}
+        (_, _) => {
+            return Err(syn::Error::new_spanned(
+                observations[0],
+                "#[observation] requires metric = histogram",
+            ));
+        }
+    }
+
+    // The pieces of the generated impl.
+    let n_labels = labels.len();
+    let label_names: Vec<String> = labels.iter().map(|i| i.to_string()).collect();
+    let context_names: Vec<String> = contexts.iter().map(|i| i.to_string()).collect();
+
+    let log_const = match args.log {
+        LogSpec::Off => quote! { ::carbide_instrument::LogAt::Off },
+        LogSpec::Error => level_const(quote! { ERROR }),
+        LogSpec::Warn => level_const(quote! { WARN }),
+        LogSpec::Info => level_const(quote! { INFO }),
+        LogSpec::Debug => level_const(quote! { DEBUG }),
+        LogSpec::Trace => level_const(quote! { TRACE }),
+    };
+    let metric_const = match args.metric {
+        MetricSpec::Counter => quote! { ::carbide_instrument::MetricKind::Counter },
+        MetricSpec::Histogram => {
+            quote! { ::carbide_instrument::MetricKind::Histogram { unit: #unit_value } }
+        }
+        MetricSpec::None => quote! { ::carbide_instrument::MetricKind::None },
+    };
+    let message_value = args.message.as_ref().map(LitStr::value).unwrap_or_default();
+    let describe_value = args
+        .describe
+        .as_ref()
+        .map(LitStr::value)
+        .unwrap_or_default();
+
+    let observation_fn = observations.first().map(|obs| {
+        quote! {
+            fn observation(&self) -> f64 {
+                ::carbide_instrument::Observation::observe_as(&self.#obs, #unit_value)
+            }
+        }
+    });
+
+    // One tracing::event! per level: the macro needs a const level and static
+    // field names, so the dispatch is generated here rather than written by hand.
+    let log_fields: Vec<proc_macro2::TokenStream> = labels
+        .iter()
+        .map(|ident| {
+            quote! {
+                #ident = ::carbide_instrument::LabelValue::label_value(&self.#ident).as_str()
+            }
+        })
+        .chain(
+            contexts
+                .iter()
+                .map(|ident| quote! { #ident = %self.#ident }),
+        )
+        .collect();
+    let log_arm = |level: proc_macro2::TokenStream| {
+        quote! {
+            ::carbide_instrument::__private::tracing::event!(
+                ::carbide_instrument::__private::tracing::Level::#level,
+                #(#log_fields,)*
+                "{}",
+                __message
+            )
+        }
+    };
+    let (arm_error, arm_warn, arm_info, arm_debug, arm_trace) = (
+        log_arm(quote! { ERROR }),
+        log_arm(quote! { WARN }),
+        log_arm(quote! { INFO }),
+        log_arm(quote! { DEBUG }),
+        log_arm(quote! { TRACE }),
+    );
+
+    Ok(quote! {
+        impl ::carbide_instrument::Event for #struct_ident {
+            const NAME: &'static str = #name;
+            const COMPONENT: &'static str = #component;
+            const DESCRIBE: &'static str = #describe_value;
+            const LOG: ::carbide_instrument::LogAt = #log_const;
+            const METRIC: ::carbide_instrument::MetricKind = #metric_const;
+            type Labels = [::carbide_instrument::__private::opentelemetry::KeyValue; #n_labels];
+
+            fn message(&self) -> &'static str {
+                #message_value
+            }
+
+            fn labels(&self) -> Self::Labels {
+                [
+                    #(
+                        ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                            #label_names,
+                            ::carbide_instrument::LabelValue::label_value(&self.#labels),
+                        ),
+                    )*
+                ]
+            }
+
+            fn context(&self) -> ::std::vec::Vec<::carbide_instrument::__private::opentelemetry::KeyValue> {
+                ::std::vec![
+                    #(
+                        ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                            #context_names,
+                            ::std::string::ToString::to_string(&self.#contexts),
+                        ),
+                    )*
+                ]
+            }
+
+            #observation_fn
+
+            fn __log(&self, level: ::carbide_instrument::__private::tracing::Level) {
+                let __message = ::carbide_instrument::Event::message(self);
+                if level == ::carbide_instrument::__private::tracing::Level::ERROR {
+                    #arm_error;
+                } else if level == ::carbide_instrument::__private::tracing::Level::WARN {
+                    #arm_warn;
+                } else if level == ::carbide_instrument::__private::tracing::Level::INFO {
+                    #arm_info;
+                } else if level == ::carbide_instrument::__private::tracing::Level::DEBUG {
+                    #arm_debug;
+                } else {
+                    #arm_trace;
+                }
+            }
+
+            fn __instrument(&self) -> &'static ::carbide_instrument::__private::CachedInstrument {
+                static INSTRUMENT: ::std::sync::OnceLock<
+                    ::carbide_instrument::__private::CachedInstrument,
+                > = ::std::sync::OnceLock::new();
+                INSTRUMENT.get_or_init(::carbide_instrument::__private::new_instrument::<Self>)
+            }
+        }
+    }
+    .into())
+}
+
+fn level_const(level: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    quote! {
+        ::carbide_instrument::LogAt::Level(
+            ::carbide_instrument::__private::tracing::Level::#level,
+        )
+    }
+}
+
+/// `PowerControl` -> `power_control`, `Rms` -> `rms`, `DHCPServer` -> `dhcp_server`.
+fn snake_case(name: &str) -> String {
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, c) in chars.iter().enumerate() {
+        if c.is_uppercase() {
+            let prev_lower = i > 0 && chars[i - 1].is_lowercase();
+            let next_lower = chars.get(i + 1).is_some_and(|n| n.is_lowercase());
+            if i > 0 && (prev_lower || next_lower) {
+                out.push('_');
+            }
+            out.extend(c.to_lowercase());
+        } else {
+            out.push(*c);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::snake_case;
+
+    #[test]
+    fn snake_case_variants() {
+        assert_eq!(snake_case("Rms"), "rms");
+        assert_eq!(snake_case("PowerControl"), "power_control");
+        assert_eq!(snake_case("DHCPServer"), "dhcp_server");
+        assert_eq!(snake_case("Ok"), "ok");
+        assert_eq!(snake_case("NoDpu"), "no_dpu");
+        assert_eq!(snake_case("A"), "a");
+    }
+}

--- a/crates/instrument/Cargo.toml
+++ b/crates/instrument/Cargo.toml
@@ -1,0 +1,51 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-instrument"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+carbide-instrument-macros = { path = "../instrument-macros" }
+opentelemetry = { workspace = true }
+tracing = { workspace = true }
+
+# test-support only
+ctor = { workspace = true, optional = true }
+opentelemetry-prometheus = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+prometheus = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
+
+[features]
+# Capture helpers for asserting that an event logged and/or metered in tests.
+test-support = [
+  "dep:ctor",
+  "dep:opentelemetry-prometheus",
+  "dep:opentelemetry_sdk",
+  "dep:prometheus",
+  "dep:tracing-subscriber",
+]
+
+[dev-dependencies]
+carbide-instrument = { path = ".", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
+
+[lints]
+workspace = true

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -1,0 +1,428 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! One declaration per significant event: [`emit`] produces a structured log
+//! line and/or a Prometheus metric from the same call, correlated by the
+//! surrounding span, with metric cardinality bounded by the type system.
+//!
+//! Declare the event as a struct next to the code that emits it:
+//!
+//! ```
+//! use carbide_instrument::{Event, LabelValue, Outcome, emit};
+//!
+//! #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+//! enum Backend {
+//!     Nsm,
+//!     Psm,
+//!     Rms,
+//! }
+//!
+//! #[derive(Event)]
+//! #[event(
+//!     name      = "carbide_power_control_total", // the exposed name, verbatim
+//!     component = "component_manager",
+//!     log       = warn,                          // error|warn|info|debug|trace|off
+//!     metric    = counter,                       // counter | histogram | none
+//!     message   = "power control failed",
+//! )]
+//! struct PowerControlFailed {
+//!     #[label]
+//!     backend: Backend, // enum -> metric label backend="rms"
+//!     #[label]
+//!     outcome: Outcome, // enum -> metric label outcome="error"
+//!     #[context]
+//!     error: String, // high-cardinality -> the log line only
+//! }
+//!
+//! emit(PowerControlFailed {
+//!     backend: Backend::Rms,
+//!     outcome: Outcome::Error,
+//!     error: "deadline exceeded".to_string(),
+//! });
+//! ```
+//!
+//! The two knobs are independent: `log = off, metric = counter` counts a
+//! hot-path event without building any log line at all, and `metric = none`
+//! is a plain structured log. See `docs/observability/instrumentation.md`
+//! for the standard (naming, cardinality rules, when to use which mode).
+//!
+//! # Cardinality is enforced by the types
+//!
+//! A `#[label]` field must implement [`LabelValue`], which is derivable only
+//! for fieldless enums -- so a label's value set is closed by construction.
+//! `String` does not implement it, and high-cardinality detail belongs in
+//! `#[context]` fields, which appear on the log line only:
+//!
+//! ```compile_fail
+//! #[derive(carbide_instrument::Event)]
+//! #[event(name = "carbide_demo_total", component = "demo", log = off, metric = counter)]
+//! struct Demo {
+//!     #[label]
+//!     machine_id: String, // ERROR: String is not a LabelValue
+//! }
+//! ```
+//!
+//! The metric name is validated at compile time -- the `carbide_` prefix, the
+//! `_total` suffix for counters, a unit suffix for histograms:
+//!
+//! ```compile_fail
+//! #[derive(carbide_instrument::Event)]
+//! #[event(name = "power_control_total", component = "demo", log = off, metric = counter)]
+//! struct Demo {} // ERROR: metric names use the `carbide_` prefix
+//! ```
+//!
+//! ```compile_fail
+//! #[derive(carbide_instrument::Event)]
+//! #[event(name = "carbide_power_control", component = "demo", log = off, metric = counter)]
+//! struct Demo {} // ERROR: counter names end in `_total`
+//! ```
+//!
+//! And an event must produce something -- `log = off` with `metric = none`
+//! would make `emit()` a silent no-op:
+//!
+//! ```compile_fail
+//! #[derive(carbide_instrument::Event)]
+//! #[event(name = "carbide_demo", component = "demo", log = off, metric = none)]
+//! struct Demo {} // ERROR: declare at least one side
+//! ```
+//!
+//! `unit` belongs to histograms (and only `name_unchecked` ones -- a standard
+//! histogram name already declares its unit as the suffix), and `describe`
+//! documents a metric:
+//!
+//! ```compile_fail
+//! #[derive(carbide_instrument::Event)]
+//! #[event(name = "carbide_demo_total", component = "demo", log = off, metric = counter,
+//!         unit = "s")]
+//! struct Demo {} // ERROR: `unit` is only valid for histogram metrics
+//! ```
+//!
+//! ```compile_fail
+//! #[derive(carbide_instrument::Event)]
+//! #[event(name = "carbide_demo", component = "demo", message = "demo", describe = "demo")]
+//! struct Demo {} // ERROR: `describe` documents a metric; this event has metric = none
+//! ```
+
+use std::time::Duration;
+
+/// The derive macros: `#[derive(Event)]` and `#[derive(LabelValue)]`.
+pub use carbide_instrument_macros::{Event, LabelValue};
+use opentelemetry::{KeyValue, StringValue};
+
+/// Whether (and at which level) an event writes a log line.
+///
+/// `Off` means no `tracing` event is constructed at all -- a metric-only
+/// event has zero logging cost, not "logged then filtered".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogAt {
+    /// No log line is ever constructed.
+    Off,
+    /// Log at this level (still subject to the subscriber's filters).
+    Level(tracing::Level),
+}
+
+/// Which metric instrument an event updates, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricKind {
+    /// A monotonic counter; the event name must end in `_total`.
+    Counter,
+    /// A histogram of [`Event::observation`] values; the event name must end
+    /// in its unit (`_seconds`, `_milliseconds`, `_microseconds`, `_bytes`).
+    Histogram {
+        /// The OpenTelemetry unit string, derived from the name suffix.
+        unit: &'static str,
+    },
+    /// No metric; the event is a structured log only.
+    None,
+}
+
+/// A bounded metric label value.
+///
+/// Derivable only for fieldless enums -- that restriction is the cardinality
+/// guarantee: a metric's series count is the product of its label domains,
+/// and every derived domain is a closed set. For a value that is bounded but
+/// not an enum (an RPC method name, a vendor), implement this by hand on a
+/// newtype; the manual impl is the deliberate, greppable escape hatch and the
+/// place to justify boundedness at review. `String` never implements it.
+pub trait LabelValue {
+    /// The value as it appears on both the metric label and the log line.
+    fn label_value(&self) -> StringValue;
+}
+
+/// A value a histogram event records, converted to the unit the metric name
+/// declares (`Duration` converts; plain numbers record as-is).
+pub trait Observation {
+    /// The value in the metric's declared unit.
+    fn observe_as(&self, unit: &'static str) -> f64;
+}
+
+impl Observation for Duration {
+    fn observe_as(&self, unit: &'static str) -> f64 {
+        match unit {
+            "ms" => self.as_secs_f64() * 1_000.0,
+            "us" => self.as_secs_f64() * 1_000_000.0,
+            // Seconds, and the sensible default for anything else.
+            _ => self.as_secs_f64(),
+        }
+    }
+}
+
+impl Observation for f64 {
+    fn observe_as(&self, _unit: &'static str) -> f64 {
+        *self
+    }
+}
+
+macro_rules! lossless_observation {
+    ($($ty:ty),*) => {
+        $(
+            impl Observation for $ty {
+                fn observe_as(&self, _unit: &'static str) -> f64 {
+                    f64::from(*self)
+                }
+            }
+        )*
+    };
+}
+lossless_observation!(f32, u32, i32);
+
+macro_rules! wide_observation {
+    ($($ty:ty),*) => {
+        $(
+            impl Observation for $ty {
+                fn observe_as(&self, _unit: &'static str) -> f64 {
+                    // Counts and sizes; precision loss starts beyond 2^53.
+                    *self as f64
+                }
+            }
+        )*
+    };
+}
+wide_observation!(u64, usize, i64);
+
+/// A significant occurrence, declared once as a type.
+///
+/// Implemented with `#[derive(Event)]` (see the crate docs); hand
+/// implementations are possible but rare. Emitting an event produces a log
+/// line and/or a metric per the [`LogAt`] and [`MetricKind`] knobs -- each
+/// side independently optional.
+pub trait Event {
+    /// The exposed metric name, verbatim (derive-validated), or the event's
+    /// identity for log-only events.
+    const NAME: &'static str;
+    /// The owning subsystem, for tooling and test assertions. The logfmt
+    /// `component` key on log lines continues to come from the subscriber
+    /// configuration and span attributes, as everywhere else.
+    const COMPONENT: &'static str;
+    /// The metric's description: the Prometheus HELP text, and the row the
+    /// `core_metrics.md` catalogue picks up. Empty for log-only events.
+    const DESCRIBE: &'static str = "";
+    /// The declared log side. Default: log at INFO.
+    const LOG: LogAt = LogAt::Level(tracing::Level::INFO);
+    /// The declared metric side. Default: no metric.
+    const METRIC: MetricKind = MetricKind::None;
+    /// The label array, sized by the derive -- no heap allocation on emit.
+    type Labels: AsRef<[KeyValue]>;
+
+    /// The constant, human-readable message for the log line.
+    fn message(&self) -> &'static str;
+    /// The bounded labels, attached to both the metric and the log line.
+    fn labels(&self) -> Self::Labels;
+    /// High-cardinality detail, attached to the log line only.
+    ///
+    /// Introspection for tests and tooling: [`emit`] does not read it. The
+    /// derive renders context fields inline in the generated log call
+    /// instead, so the log path keeps static field names and allocates
+    /// nothing for them.
+    fn context(&self) -> Vec<KeyValue> {
+        Vec::new()
+    }
+    /// The value a histogram records; counters ignore it.
+    fn observation(&self) -> f64 {
+        1.0
+    }
+    /// Per-instance log control (e.g. log failures, count successes
+    /// silently). Defaults to the declared [`Self::LOG`].
+    fn log_at(&self) -> LogAt {
+        Self::LOG
+    }
+
+    #[doc(hidden)]
+    fn __log(&self, level: tracing::Level);
+    #[doc(hidden)]
+    fn __instrument(&self) -> &'static __private::CachedInstrument;
+}
+
+/// Emits an event: a log line and/or a metric, per the event's knobs.
+///
+/// Never panics. The metric side resolves its instrument once per event type
+/// (a `OnceLock`) from the global OpenTelemetry meter -- install the meter
+/// provider at startup, before the first emit, as every NICo binary already
+/// does for its existing metrics.
+pub fn emit<E: Event>(event: E) {
+    if let LogAt::Level(level) = event.log_at() {
+        event.__log(level);
+    }
+    match event.__instrument() {
+        __private::CachedInstrument::Counter(counter) => {
+            counter.add(1, event.labels().as_ref());
+        }
+        __private::CachedInstrument::Histogram(histogram) => {
+            histogram.record(event.observation(), event.labels().as_ref());
+        }
+        __private::CachedInstrument::None => {}
+    }
+}
+
+/// The success-or-failure of an operation, as a bounded label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The operation succeeded.
+    Ok,
+    /// The operation failed.
+    Error,
+}
+
+impl LabelValue for Outcome {
+    fn label_value(&self) -> StringValue {
+        StringValue::from(match self {
+            Outcome::Ok => "ok",
+            Outcome::Error => "error",
+        })
+    }
+}
+
+impl<T, E> From<&Result<T, E>> for Outcome {
+    fn from(result: &Result<T, E>) -> Self {
+        match result {
+            Ok(_) => Outcome::Ok,
+            Err(_) => Outcome::Error,
+        }
+    }
+}
+
+#[cfg(feature = "test-support")]
+pub mod testing;
+
+#[doc(hidden)]
+pub mod __private {
+    //! Support for the derive-generated code; not a public API.
+
+    pub use opentelemetry;
+    pub use tracing;
+
+    /// The per-event-type instrument, resolved once and cached in a
+    /// `OnceLock` by the generated `__instrument()`.
+    pub enum CachedInstrument {
+        Counter(opentelemetry::metrics::Counter<u64>),
+        Histogram(opentelemetry::metrics::Histogram<f64>),
+        None,
+    }
+
+    /// Builds the instrument an event type declares, from the global meter.
+    ///
+    /// `Event::NAME` is the *exposed* name, verbatim. The Prometheus exporter
+    /// appends the conventional suffix itself (`_total` for counters, the
+    /// unit for histograms), so the instrument registers under the name with
+    /// that suffix stripped -- what lands on `/metrics` is exactly `NAME`.
+    pub fn new_instrument<E: crate::Event>() -> CachedInstrument {
+        let meter = opentelemetry::global::meter("carbide-instrument");
+        match E::METRIC {
+            crate::MetricKind::Counter => {
+                let name = E::NAME.strip_suffix("_total").unwrap_or(E::NAME);
+                let mut builder = meter.u64_counter(name);
+                if !E::DESCRIBE.is_empty() {
+                    builder = builder.with_description(E::DESCRIBE);
+                }
+                CachedInstrument::Counter(builder.build())
+            }
+            crate::MetricKind::Histogram { unit } => {
+                let suffix = match unit {
+                    "s" => "_seconds",
+                    "ms" => "_milliseconds",
+                    "us" => "_microseconds",
+                    "By" => "_bytes",
+                    _ => "",
+                };
+                let name = if suffix.is_empty() {
+                    E::NAME
+                } else {
+                    E::NAME.strip_suffix(suffix).unwrap_or(E::NAME)
+                };
+                let mut builder = meter.f64_histogram(name);
+                if !unit.is_empty() {
+                    builder = builder.with_unit(unit);
+                }
+                if !E::DESCRIBE.is_empty() {
+                    builder = builder.with_description(E::DESCRIBE);
+                }
+                CachedInstrument::Histogram(builder.build())
+            }
+            crate::MetricKind::None => CachedInstrument::None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_from_result() {
+        let ok: Result<(), &str> = Ok(());
+        let err: Result<(), &str> = Err("nope");
+        assert_eq!(Outcome::from(&ok), Outcome::Ok);
+        assert_eq!(Outcome::from(&err), Outcome::Error);
+    }
+
+    #[test]
+    fn duration_observation_converts_to_the_declared_unit() {
+        use carbide_test_support::{Check, check_values};
+
+        check_values(
+            [
+                Check {
+                    scenario: "seconds",
+                    input: "s",
+                    expect: 1.5,
+                },
+                Check {
+                    scenario: "milliseconds",
+                    input: "ms",
+                    expect: 1500.0,
+                },
+                Check {
+                    scenario: "microseconds",
+                    input: "us",
+                    expect: 1_500_000.0,
+                },
+                Check {
+                    scenario: "unknown units fall back to seconds",
+                    input: "By",
+                    expect: 1.5,
+                },
+            ],
+            |unit| Duration::from_millis(1500).observe_as(unit),
+        );
+    }
+
+    #[test]
+    fn numeric_observations_ignore_the_unit() {
+        assert!((42u64.observe_as("ms") - 42.0).abs() < f64::EPSILON);
+        assert!((2.5f64.observe_as("s") - 2.5).abs() < f64::EPSILON);
+    }
+}

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -1,0 +1,253 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Capture helpers for asserting, in plain unit tests, that an event logged
+//! at the expected level *and* moved the expected metric -- the coherency
+//! guarantee is itself testable.
+//!
+//! ```
+//! use carbide_instrument::testing::{MetricsCapture, capture_logs};
+//! use carbide_instrument::{Event, emit};
+//!
+//! #[derive(Event)]
+//! #[event(name = "carbide_doc_demo_total", component = "demo",
+//!         log = warn, metric = counter, message = "demo fired")]
+//! struct Demo {}
+//!
+//! let metrics = MetricsCapture::start();
+//! let logs = capture_logs(|| emit(Demo {}));
+//!
+//! assert_eq!(logs.len(), 1);
+//! assert_eq!(logs[0].level, tracing::Level::WARN);
+//! assert_eq!(logs[0].message, "demo fired");
+//! assert_eq!(metrics.counter_delta("carbide_doc_demo_total", &[]), 1.0);
+//! ```
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use tracing_subscriber::layer::{Context, SubscriberExt};
+
+/// One captured log event: its level, message, and rendered fields.
+#[derive(Debug, Clone)]
+pub struct CapturedLog {
+    pub level: tracing::Level,
+    /// The event's `tracing` target (usually the emitting module path).
+    pub target: String,
+    pub message: String,
+    /// Field name/value pairs as strings, in emission order.
+    pub fields: Vec<(String, String)>,
+}
+
+/// Runs `f` under a capturing subscriber (this thread only) and returns every
+/// log event it emitted, at any level.
+pub fn capture_logs(f: impl FnOnce()) -> Vec<CapturedLog> {
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let layer = CaptureLayer {
+        captured: captured.clone(),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer);
+    tracing::subscriber::with_default(subscriber, f);
+    let logs = captured.lock().unwrap_or_else(|p| p.into_inner());
+    logs.clone()
+}
+
+struct CaptureLayer {
+    captured: Arc<Mutex<Vec<CapturedLog>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        // The OpenTelemetry crates emit their own internal diagnostics through
+        // `tracing`; they are not the events under test.
+        if event.metadata().target().starts_with("opentelemetry") {
+            return;
+        }
+        let mut visitor = CaptureVisitor {
+            message: String::new(),
+            fields: Vec::new(),
+        };
+        event.record(&mut visitor);
+        self.captured
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .push(CapturedLog {
+                level: *event.metadata().level(),
+                target: event.metadata().target().to_string(),
+                message: visitor.message,
+                fields: visitor.fields,
+            });
+    }
+}
+
+struct CaptureVisitor {
+    message: String,
+    fields: Vec<(String, String)>,
+}
+
+impl tracing::field::Visit for CaptureVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        // `%display` fields and the message both arrive here; their Debug
+        // rendering forwards to Display, so this is the raw string.
+        let rendered = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = rendered;
+        } else {
+            self.fields.push((field.name().to_string(), rendered));
+        }
+    }
+}
+
+/// A serialized window onto the process-global test meter.
+///
+/// The first capture installs a Prometheus-backed meter provider as the
+/// global OpenTelemetry meter (instruments are cached per event type, so
+/// tests share one provider for the whole process); the mutex serializes
+/// metric-asserting tests, and deltas are measured against the snapshot taken
+/// at [`MetricsCapture::start`].
+pub struct MetricsCapture {
+    _serialized: MutexGuard<'static, ()>,
+    baseline: Snapshot,
+}
+
+impl MetricsCapture {
+    /// Locks the test-metrics window and snapshots current values.
+    pub fn start() -> Self {
+        static SERIAL: Mutex<()> = Mutex::new(());
+        let guard = SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let registry = test_registry();
+        Self {
+            _serialized: guard,
+            baseline: snapshot(registry),
+        }
+    }
+
+    /// How much the named counter (with exactly these label pairs) moved
+    /// since [`MetricsCapture::start`]. Zero if it never appeared.
+    pub fn counter_delta(&self, name: &str, labels: &[(&str, &str)]) -> f64 {
+        let now = snapshot(test_registry());
+        now.value(name, labels) - self.baseline.value(name, labels)
+    }
+
+    /// How many observations the named histogram (with exactly these label
+    /// pairs) recorded since [`MetricsCapture::start`].
+    pub fn histogram_count_delta(&self, name: &str, labels: &[(&str, &str)]) -> u64 {
+        self.counter_delta(&format!("{name}#count"), labels) as u64
+    }
+
+    /// The sum the named histogram accumulated since [`MetricsCapture::start`].
+    pub fn histogram_sum_delta(&self, name: &str, labels: &[(&str, &str)]) -> f64 {
+        self.counter_delta(&format!("{name}#sum"), labels)
+    }
+
+    /// The current registry contents in Prometheus text exposition format --
+    /// handy for eyeballing exact rendered names and labels in a failing test.
+    pub fn render(&self) -> String {
+        use prometheus::Encoder as _;
+        let mut buffer = Vec::new();
+        prometheus::TextEncoder::new()
+            .encode(&test_registry().gather(), &mut buffer)
+            .expect("encode test registry");
+        String::from_utf8(buffer).expect("prometheus text is utf-8")
+    }
+}
+
+/// `(metric name, sorted labels) -> value`; histograms store `name#count`
+/// and `name#sum` entries.
+struct Snapshot(BTreeMap<(String, BTreeMap<String, String>), f64>);
+
+impl Snapshot {
+    fn value(&self, name: &str, labels: &[(&str, &str)]) -> f64 {
+        let labels: BTreeMap<String, String> = labels
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        self.0
+            .get(&(name.to_string(), labels))
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+fn snapshot(registry: &prometheus::Registry) -> Snapshot {
+    let mut values = BTreeMap::new();
+    for family in registry.gather() {
+        for metric in family.get_metric() {
+            let labels: BTreeMap<String, String> = metric
+                .get_label()
+                .iter()
+                .map(|pair| (pair.name().to_string(), pair.value().to_string()))
+                .collect();
+            match family.get_field_type() {
+                prometheus::proto::MetricType::COUNTER => {
+                    values.insert(
+                        (family.name().to_string(), labels),
+                        metric.get_counter().value(),
+                    );
+                }
+                prometheus::proto::MetricType::HISTOGRAM => {
+                    let histogram = metric.get_histogram();
+                    values.insert(
+                        (format!("{}#count", family.name()), labels.clone()),
+                        histogram.get_sample_count() as f64,
+                    );
+                    values.insert(
+                        (format!("{}#sum", family.name()), labels),
+                        histogram.get_sample_sum(),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+    Snapshot(values)
+}
+
+/// Installs the test meter at test-binary load, before any test (and so any
+/// `emit()`) runs. Instruments are cached per event type on first emit, so a
+/// test that emits without a `MetricsCapture` must still find the real
+/// provider installed -- otherwise that event type would bind to the no-op
+/// global meter and later counter assertions would sit at zero.
+#[ctor::ctor(unsafe)]
+fn install_test_meter_eagerly() {
+    let _ = test_registry();
+}
+
+/// The process-global test registry, installing the global meter provider on
+/// first use.
+fn test_registry() -> &'static prometheus::Registry {
+    static REGISTRY: OnceLock<prometheus::Registry> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        let registry = prometheus::Registry::new();
+        let exporter = opentelemetry_prometheus::exporter()
+            .with_registry(registry.clone())
+            .without_scope_info()
+            .without_target_info()
+            .build()
+            .expect("test meter provider");
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_reader(exporter)
+            .build();
+        opentelemetry::global::set_meter_provider(provider);
+        registry
+    })
+}

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -1,0 +1,359 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! The log/metric matrix, end to end: every knob combination produces exactly
+//! the declared outputs, with the same label values on both sides.
+
+use std::time::Duration;
+
+use carbide_instrument::testing::{MetricsCapture, capture_logs};
+use carbide_instrument::{Event, LabelValue, LogAt, MetricKind, Outcome, emit};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum Stage {
+    PreFlight,
+    Apply,
+}
+
+fn field<'a>(log: &'a carbide_instrument::testing::CapturedLog, name: &str) -> Option<&'a str> {
+    log.fields
+        .iter()
+        .find(|(k, _)| k == name)
+        .map(|(_, v)| v.as_str())
+}
+
+/// log = warn, metric = counter: one emit writes the log line AND moves the
+/// counter, with identical label values.
+#[test]
+fn both_sides_from_one_emit() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_both_total",
+        component = "matrix-test",
+        log = warn,
+        metric = counter,
+        message = "matrix both fired"
+    )]
+    struct BothSides {
+        #[label]
+        stage: Stage,
+        #[label]
+        outcome: Outcome,
+        #[context]
+        machine: String,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(BothSides {
+            stage: Stage::Apply,
+            outcome: Outcome::Error,
+            machine: "machine-1".to_string(),
+        });
+    });
+
+    assert_eq!(logs.len(), 1);
+    let log = &logs[0];
+    assert_eq!(log.level, tracing::Level::WARN);
+    assert_eq!(log.message, "matrix both fired");
+    assert_eq!(field(log, "stage"), Some("apply"));
+    assert_eq!(field(log, "outcome"), Some("error"));
+    assert_eq!(field(log, "machine"), Some("machine-1"));
+
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_both_total",
+            &[("stage", "apply"), ("outcome", "error")],
+        ),
+        1.0
+    );
+}
+
+/// log = off, metric = counter: the counter moves and no log line is built at
+/// all (message is not even required).
+#[test]
+fn metric_only_writes_no_log() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_quiet_total",
+        component = "matrix-test",
+        log = off,
+        metric = counter
+    )]
+    struct Quiet {
+        #[label]
+        stage: Stage,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(Quiet {
+            stage: Stage::PreFlight,
+        });
+        emit(Quiet {
+            stage: Stage::PreFlight,
+        });
+    });
+
+    assert!(logs.is_empty(), "log = off must not construct any log line");
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_quiet_total",
+            &[("stage", "pre_flight")]
+        ),
+        2.0
+    );
+}
+
+/// metric = none: a plain structured log, and nothing appears on the registry.
+#[test]
+fn log_only_registers_no_metric() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_logonly",
+        component = "matrix-test",
+        log = info,
+        metric = none,
+        message = "log only fired"
+    )]
+    struct LogOnly {
+        #[context]
+        detail: String,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(LogOnly {
+            detail: "just words".to_string(),
+        });
+    });
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].level, tracing::Level::INFO);
+    assert_eq!(field(&logs[0], "detail"), Some("just words"));
+    assert_eq!(
+        metrics.counter_delta("carbide_test_matrix_logonly", &[]),
+        0.0
+    );
+}
+
+/// metric = histogram: the observation records in the unit the name declares
+/// (a Duration converts), and the log still fires independently.
+#[test]
+fn histogram_records_the_observation_in_declared_units() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_copy_duration_seconds",
+        component = "matrix-test",
+        log = info,
+        metric = histogram,
+        message = "copy finished"
+    )]
+    struct CopyFinished {
+        #[label]
+        outcome: Outcome,
+        #[observation]
+        took: Duration,
+        #[context]
+        host: String,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(CopyFinished {
+            outcome: Outcome::Ok,
+            took: Duration::from_millis(1500),
+            host: "10.0.0.5".to_string(),
+        });
+    });
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(
+        metrics.histogram_count_delta(
+            "carbide_test_matrix_copy_duration_seconds",
+            &[("outcome", "ok")],
+        ),
+        1
+    );
+    let sum = metrics.histogram_sum_delta(
+        "carbide_test_matrix_copy_duration_seconds",
+        &[("outcome", "ok")],
+    );
+    assert!(
+        (sum - 1.5).abs() < 1e-9,
+        "1500ms records as 1.5s, got {sum}"
+    );
+}
+
+/// A unit struct works (zero labels), and the declared knob constants are
+/// what the derive wrote.
+#[test]
+fn unit_struct_and_declared_knobs() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_unit_total",
+        component = "matrix-test",
+        log = off,
+        metric = counter
+    )]
+    struct Tick;
+
+    assert_eq!(<Tick as Event>::LOG, LogAt::Off);
+    assert_eq!(<Tick as Event>::METRIC, MetricKind::Counter);
+    assert_eq!(<Tick as Event>::NAME, "carbide_test_matrix_unit_total");
+    assert_eq!(<Tick as Event>::COMPONENT, "matrix-test");
+
+    let metrics = MetricsCapture::start();
+    emit(Tick);
+    assert_eq!(
+        metrics.counter_delta("carbide_test_matrix_unit_total", &[]),
+        1.0
+    );
+}
+
+/// A hand-written log_at override: failures log, successes are counted
+/// silently -- the count-everything-log-only-failures idiom.
+#[test]
+fn per_instance_log_at_override() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_calls_total",
+        component = "matrix-test",
+        log = warn,
+        metric = counter,
+        message = "call finished"
+    )]
+    struct CallFinished {
+        #[label]
+        outcome: Outcome,
+    }
+
+    // The derive keeps the trait's default log_at(); a wrapper type shows the
+    // per-instance form until the derive grows dynamic support (the RED
+    // helper issue).
+    struct OnlyFailuresLog(CallFinished);
+    impl Event for OnlyFailuresLog {
+        const NAME: &'static str = <CallFinished as Event>::NAME;
+        const COMPONENT: &'static str = <CallFinished as Event>::COMPONENT;
+        const LOG: LogAt = <CallFinished as Event>::LOG;
+        const METRIC: MetricKind = <CallFinished as Event>::METRIC;
+        type Labels = <CallFinished as Event>::Labels;
+
+        fn message(&self) -> &'static str {
+            self.0.message()
+        }
+        fn labels(&self) -> Self::Labels {
+            self.0.labels()
+        }
+        fn log_at(&self) -> LogAt {
+            match self.0.outcome {
+                Outcome::Error => LogAt::Level(tracing::Level::WARN),
+                Outcome::Ok => LogAt::Off,
+            }
+        }
+        fn __log(&self, level: tracing::Level) {
+            self.0.__log(level);
+        }
+        fn __instrument(&self) -> &'static carbide_instrument::__private::CachedInstrument {
+            self.0.__instrument()
+        }
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(OnlyFailuresLog(CallFinished {
+            outcome: Outcome::Ok,
+        }));
+        emit(OnlyFailuresLog(CallFinished {
+            outcome: Outcome::Error,
+        }));
+    });
+
+    assert_eq!(logs.len(), 1, "only the failure logs");
+    assert_eq!(logs[0].level, tracing::Level::WARN);
+    assert_eq!(
+        metrics.counter_delta("carbide_test_matrix_calls_total", &[("outcome", "ok")]),
+        1.0
+    );
+    assert_eq!(
+        metrics.counter_delta("carbide_test_matrix_calls_total", &[("outcome", "error")]),
+        1.0
+    );
+}
+
+/// Every supported histogram unit round-trips: the name in the attribute is
+/// the exposed name, and the observation records in that unit.
+#[test]
+fn histogram_units_round_trip() {
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_lag_duration_milliseconds",
+        component = "matrix-test",
+        log = off,
+        metric = histogram
+    )]
+    struct LagSampled {
+        #[observation]
+        took: Duration,
+    }
+
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_poll_duration_microseconds",
+        component = "matrix-test",
+        log = off,
+        metric = histogram
+    )]
+    struct PollSampled {
+        #[observation]
+        took: Duration,
+    }
+
+    #[derive(Event)]
+    #[event(
+        name = "carbide_test_matrix_payload_bytes",
+        component = "matrix-test",
+        log = off,
+        metric = histogram
+    )]
+    struct PayloadSized {
+        #[observation]
+        size: u64,
+    }
+
+    let metrics = MetricsCapture::start();
+    emit(LagSampled {
+        took: Duration::from_millis(250),
+    });
+    emit(PollSampled {
+        took: Duration::from_micros(1500),
+    });
+    emit(PayloadSized { size: 4096 });
+
+    for (name, expected_sum) in [
+        ("carbide_test_matrix_lag_duration_milliseconds", 250.0),
+        ("carbide_test_matrix_poll_duration_microseconds", 1500.0),
+        ("carbide_test_matrix_payload_bytes", 4096.0),
+    ] {
+        assert_eq!(metrics.histogram_count_delta(name, &[]), 1, "{name}");
+        let sum = metrics.histogram_sum_delta(name, &[]);
+        assert!(
+            (sum - expected_sum).abs() < 1e-9,
+            "{name}: expected sum {expected_sum}, got {sum}"
+        );
+    }
+}

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -9,8 +9,9 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_api_db_span_query_time_milliseconds</td><td>histogram</td><td>Total time the request spent inside a span on database transactions</td></tr>
 <tr><td>carbide_api_grpc_server_duration_milliseconds</td><td>histogram</td><td>Processing time for a request on the carbide API server</td></tr>
 <tr><td>carbide_api_ready</td><td>gauge</td><td>Whether the NICo API is running</td></tr>
-<tr><td>carbide_api_tls_connection_attempted_total</td><td>counter</td><td>The amount of tls connections that were attempted</td></tr>
-<tr><td>carbide_api_tls_connection_success_total</td><td>counter</td><td>The amount of tls connections that were successful</td></tr>
+<tr><td>carbide_api_tls_cert_refreshes_total</td><td>counter</td><td>Number of TLS acceptor refreshes performed by the API listener</td></tr>
+<tr><td>carbide_api_tls_connection_attempted_total</td><td>counter</td><td>Number of attempted TLS connections</td></tr>
+<tr><td>carbide_api_tls_connection_success_total</td><td>counter</td><td>Number of successful TLS connections</td></tr>
 <tr><td>carbide_api_tracing_spans_open</td><td>gauge</td><td>Number of open logging/tracing spans</td></tr>
 <tr><td>carbide_api_vault_request_duration_milliseconds</td><td>histogram</td><td>the duration of outbound vault requests, in milliseconds</td></tr>
 <tr><td>carbide_api_vault_requests_attempted_total</td><td>counter</td><td>The amount of tls connections that were attempted</td></tr>

--- a/docs/observability/instrumentation.md
+++ b/docs/observability/instrumentation.md
@@ -1,0 +1,251 @@
+# NICo Instrumentation
+
+How to instrument significant events with `carbide-instrument`: this kit provides a single declaration that
+produces a structured log line, a Prometheus metric, or both -- correlated, consistently
+named, and with metric cardinality bounded by the type system.
+
+---
+
+## TL;DR
+
+- **Just logging words? Keep using `tracing::`.** `info!`/`warn!`/`error!` with structured
+  fields stays the right tool for plain logs; nothing migrates for its own sake.
+- **Need a count, rate, or duration? Declare an `Event` and `emit()` it.** The event's two
+  options -- `log = error|warn|info|debug|trace|off` and `metric = counter|histogram|none` --
+  cover metric-only, log-only, or both from the same call.
+- **Cardinality is enforced by the types.** `#[label]` fields must be bounded via
+  `LabelValue` -- usually a fieldless enum, with a manual impl on a bounded newtype as the
+  reviewed escape hatch; high-cardinality detail (`machine_id`, IPs, error text) goes in
+  `#[context]` fields, which appear on the log line only and *cannot* become a metric label.
+- **The metric name in the attribute is the exposed name, verbatim** -- what you grep on a
+  dashboard is the string in the source. The derive validates it at compile time
+  (`carbide_` prefix, `_total` for counters, a unit suffix for histograms).
+- **Point-in-time state (gauges) is unchanged.** The kit models *occurrences*; observable
+  gauges and `SharedMetricsHolder` snapshots stay exactly as they are.
+
+Part of the instrumentation-coherency initiative
+([#3169](https://github.com/NVIDIA/infra-controller/issues/3169)).
+
+---
+
+## When to use carbide-instrument
+
+| You want | Use | Why |
+|---|---|---|
+| A plain log line | `tracing::info!(%machine_id, "...")` | No metric required. Most log sites stay exactly like this. |
+| A failure you'd alert on | `emit(...)` with `log = warn, metric = counter` | The counter is the alert; the log line (same labels + context) provides the details. |
+| A hot-path rate (per packet / per request) | `emit(...)` with `log = off, metric = counter` | The rate is the signal; no log line is built at all -- zero logging cost, and the noise is gone. |
+| A duration or size distribution | `emit(...)` with `metric = histogram` | `#[observation]` supplies the value; the unit comes from the metric name. |
+| "How many are in state X right now" | An observable gauge (existing pattern) | State is not an occurrence. Keep `SharedMetricsHolder` + `u64_observable_gauge`. |
+
+**Adoption is opt-in** and call-site-by-call-site. Existing `tracing::` sites and existing
+metric emitter structs keep working unchanged; when a site *does* migrate, its log line
+keeps the same level, message, and fields (labels and context render as ordinary logfmt
+fields), so greps and dashboards keep working -- it just also gains the metric.
+
+## Quick start
+
+Declare the event next to the code that emits it:
+
+```rust
+use carbide_instrument::{emit, Event, LabelValue, Outcome};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum Backend {
+    Nsm,
+    Psm,
+    Rms,
+}
+
+#[derive(Event)]
+#[event(
+    name      = "carbide_power_control_total", // the exposed name, verbatim
+    component = "component_manager",
+    log       = warn,                          // error|warn|info|debug|trace|off
+    metric    = counter,                       // counter | histogram | none
+    message   = "power control failed",
+    describe  = "Power control has failed.",
+)]
+struct PowerControlFailed {
+    #[label]
+    backend: Backend, // enum -> label backend="rms" (metric AND log)
+    #[label]
+    outcome: Outcome, // the kit's shared ok|error vocabulary
+    #[context]
+    bmc_ip: std::net::IpAddr, // log-only, never a metric label
+    #[context]
+    error: String, // log-only
+}
+
+if let Err(e) = backend.power_control(&target, action).await {
+    emit(PowerControlFailed {
+        backend: Backend::Rms,
+        outcome: Outcome::Error,
+        bmc_ip,
+        error: e.to_string(),
+    });
+}
+```
+
+One `emit()` writes both the log line and the metric. The log line carries the surrounding
+span's `span_id`; the metric is an aggregate with no per-request identity, so correlation
+runs the other way: pivot from the moving metric to the matching log lines by metric name
+and label values, and `span_id` then ties each line to its request:
+
+```logfmt
+level=WARN component=nico-api span_id=0x4f... msg="power control failed" backend=rms outcome=error bmc_ip=10.0.0.5 error="deadline exceeded" location="..."
+```
+
+```text
+carbide_power_control_total{backend="rms",outcome="error"} 1
+```
+
+Install the meter provider at startup **before the first emit** (every NICo binary
+already does, for its existing metrics); instruments resolve from the global meter once
+per event type.
+
+## Log and metric options
+
+Every event declares its log side and its metric side independently:
+
+| `#[event(...)]` | Log line? | Metric? | Use for |
+|---|---|---|---|
+| `log = warn, metric = none` | Yes | No | A typed structured log (rare; plain `tracing::` is usually fine) |
+| `log = warn, metric = counter` | Yes | Yes | A failure you alert on *and* read |
+| `log = off, metric = counter` | No | Yes | Hot paths where the rate is the signal |
+| `log = off, metric = histogram` | No | Yes | High-frequency latency as a distribution only |
+
+`log = off` constructs no `tracing` event at all -- it is not "logged then filtered".
+
+For per-instance control (count everything, log only failures), implement
+`Event::log_at()` by hand; derive support for dynamic levels arrives with the
+outbound-call RED helper ([#3172](https://github.com/NVIDIA/infra-controller/issues/3172)).
+
+## Rules for labels and context
+
+A metric's time-series count is the product of its label domains, so every label domain
+must be small and closed. The kit makes that structural instead of a review checklist:
+
+- **`#[label]` fields must implement `LabelValue`**, which is derivable **only for
+  fieldless enums**. A derived label value is the variant's snake_case name.
+  `String` never implements it.
+- **`#[context]` fields take anything `Display`** and appear on the log line only. This is
+  where `machine_id`, addresses, and error text belong. A context field cannot
+  become a metric label.
+- **Bounded-but-not-enumerated values** such as vendor strings or SKUs can go through a
+  **manual `impl LabelValue` on a newtype** -- the deliberate, greppable escape hatch, and
+  the place to justify boundedness at review. The deciding factor should be real boundedness *at the call
+  site*: a raw request-path segment is not bounded even when a proto surface suggests it
+  should be -- caller-supplied values mint unbounded series. When in doubt, keep the value
+  in `#[context]` and count without it.
+- Per-object metric series remain the exception, and they stay on the opt-in,
+  hold-time-bounded `PerObjectMetricsRegistry` -- not on event labels.
+
+## Histograms and observations
+
+A histogram event carries exactly one `#[observation]` field: a `Duration` (converted to
+the unit the metric name declares) or a plain number (recorded as-is).
+
+```rust
+#[derive(Event)]
+#[event(
+    name = "carbide_preingestion_bfb_copy_duration_seconds",
+    component = "preingestion-manager",
+    log = info,
+    metric = histogram,
+    message = "BFB copy finished",
+)]
+struct BfbCopyFinished {
+    #[label]
+    outcome: Outcome,
+    #[observation]
+    took: std::time::Duration, // recorded in seconds -- checked against the name
+    #[context]
+    host_ip: std::net::IpAddr,
+}
+```
+
+A histogram already exports a `_count` series, so it never needs a twin counter.
+
+## Naming conventions
+
+The `name` in the attribute is the exposed Prometheus name, verbatim, and the derive
+enforces the conventions at compile time:
+
+- All new metrics use the `carbide_` prefix.
+- Counter names have a `_total` suffix.
+- Histograms end in their unit: `_seconds`, `_milliseconds`, `_microseconds`, `_bytes`.
+- Gauge names (existing pattern, not the kit) are mixed legacy forms; follow established
+  neighboring names rather than a single suffix rule.
+
+The name in the attribute is what lands on `/metrics`, byte for byte -- a dashboard name
+greps straight back to the declaring line. (Implementation detail: the Prometheus exporter
+appends the conventional suffix, so the kit registers the instrument
+without the suffix; the two cancel out to exactly the attribute string.)
+
+**Existing metric names never change.** Migrating a pre-standard site onto the kit keeps
+its frozen name via `name_unchecked` (plus an explicit `unit = "..."` for histograms);
+a search for `name_unchecked` finds every grandfathered site, and new metrics cannot
+use the opt-out silently.
+
+Give every metric a `describe = "..."` attribute -- it becomes the Prometheus HELP text and the
+Description column of the [core_metrics.md](core_metrics.md) catalogue, which is
+regenerated by `test_integration` and checked in CI.
+
+## Derivation outputs and costs
+
+`#[derive(Event)]` is [thiserror](https://docs.rs/thiserror/latest/thiserror/)-style: a plain struct you can construct, test, and match,
+with the semantics in attributes. The generated code:
+
+- Builds labels as a fixed-size array (no heap allocation on emit) with enum values
+  rendering as `&'static str`
+- Caches the OTel instrument in a per-event-type `OnceLock` -- a metric-only emit is an
+  atomic load plus an `add()`
+- Emits the log via `tracing::event!` with real static field names, so `logfmt`, the
+  admin-UI log stream, and every other subscriber layer see an ordinary tracing event in
+  the surrounding span
+- Never panics
+
+## Testing the coherency
+
+The `test-support` feature provides capture helpers, so "this event logged at WARN *and*
+ticked the counter" is a plain unit test:
+
+```rust
+use carbide_instrument::testing::{capture_logs, MetricsCapture};
+
+let metrics = MetricsCapture::start();
+let logs = capture_logs(|| emit(PowerControlFailed { ... }));
+
+assert_eq!(logs[0].level, tracing::Level::WARN);
+assert_eq!(
+    metrics.counter_delta("carbide_power_control_total", &[("backend", "rms"), ("outcome", "error")]),
+    1.0,
+);
+```
+
+`MetricsCapture` serializes metric-asserting tests behind a process-global registry;
+`capture_logs` is per-thread. `render()` prints the raw exposition text when a test needs
+inspection.
+
+## Potential hazards
+
+- **`LogLimiter`-gated sites**: before migration, the limiter suppresses the log call
+  before any event fires, so the true rate is invisible to everything -- including the
+  kit. After migration onto an `Event`, the metric ticks on every occurrence and the
+  limiter gates only the log line.
+- **The logfmt `component` key** continues to come from the subscriber configuration and
+  span attributes (as everywhere else); the event's `component` names the subsystem for
+  tooling and tests and is not written as a log field.
+- **Events are occurrences.** Do not model state with counters; keep gauges on the
+  existing observable-gauge pattern.
+- **Don't name a field `message`** -- that name is reserved for the event message.
+
+## References
+
+- The initiative: [#3169](https://github.com/NVIDIA/infra-controller/issues/3169)
+  (unify logging and metrics behind a single instrumentation standard).
+- The crate: `crates/instrument` (rustdoc on `Event`, `emit`, `LabelValue`, `testing`).
+- The catalogue: [core_metrics.md](core_metrics.md) -- every new metric lands there.
+- Conventions: [Prometheus metric and label naming](https://prometheus.io/docs/practices/naming/).
+- Neighbors: [logging.md](logging.md), [tracing.md](tracing.md).


### PR DESCRIPTION
Logs and metrics have been two separate worlds: a warn! moves no counter, a
counter writes no log, and the places where the two agree were each hand-built.
carbide-instrument makes the coherent path the easy one -- declare a significant
event once as a struct, emit() it, and get a structured log line and a
Prometheus metric together (or either alone), correlated by span_id, with metric
cardinality bounded by the type system: #[label] fields must be enums, while
high-cardinality detail rides in #[context] fields that appear on the log line
only. Metric names are validated at compile time (carbide_ prefix, _total
counters, unit-suffixed histograms), and the name in the attribute is the
exposed name, verbatim -- a dashboard name greps straight back to its declaring
line.

The kit lands with its documentation and three first conversions that show the
modes side by side: authorizer denials now count per method
(carbide_auth_denied_total) while keeping their log line, state-handler wake-up
failures gain a leading "machine stuck" counter
(carbide_state_handler_wakeup_failures_total), and the five-minute TLS cert
refresh becomes a metric-only counter (carbide_api_tls_cert_refreshes_total)
with the per-refresh log line retired. Adoption is opt-in: plain tracing:: call
sites stay exactly as they are, and existing metric emitters keep working
unchanged.

- crates/instrument + crates/instrument-macros: the Event trait, emit(), the
  log/metric knobs (each side independently optional, including metric-only via
  log = off), #[derive(Event)] / #[derive(LabelValue)], and a test-support
  feature with capture helpers so "logged at WARN and ticked the counter" is a
  plain unit test.
- docs/observability/instrumentation.md plus an AGENTS.md section: the standard
  -- when to reach for emit() vs plain tracing::, the cardinality rules, naming,
  and occurrences-vs-state.
- Three showcase conversions in api-core (auth middleware, machine_scout,
  listener), each a small diff with the log fields preserved.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3170
