### PR TITLE
fix: Surface NICo CLI config errors and correct usage help

### DIFF
--- a/rest-api/cli/pkg/auth.go
+++ b/rest-api/cli/pkg/auth.go
@@ -58,7 +58,10 @@ func LoginCommand() *cli.Command {
 			},
 		},
 		Action: func(c *cli.Context) error {
-			cfg, _ := LoadConfig()
+			cfg, err := LoadConfig()
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
 			ApplyEnvOverrides(cfg)
 
 			tokenCommand := c.String("token-command")

--- a/rest-api/cli/pkg/auth_test.go
+++ b/rest-api/cli/pkg/auth_test.go
@@ -161,6 +161,18 @@ func TestSaveOIDCTokenErrorsWhenAccessTokenMissing(t *testing.T) {
 	require.Equal(t, "2026-01-01T00:00:00Z", oidc.ExpiresAt)
 }
 
+func TestLoginCommandReturnsConfigReadError(t *testing.T) {
+	configPath := t.TempDir()
+	SetConfigPath(configPath)
+	defer SetConfigPath("")
+
+	ctx := cli.NewContext(cli.NewApp(), flag.NewFlagSet("login", flag.ContinueOnError), nil)
+	err := LoginCommand().Action(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "loading config:")
+	require.Contains(t, err.Error(), configPath)
+}
+
 func TestLoginCommandExplicitAPIKeyWinsOverOIDCFlags(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "ApiKey explicit-key", r.Header.Get("Authorization"))

--- a/rest-api/cli/pkg/commands.go
+++ b/rest-api/cli/pkg/commands.go
@@ -412,7 +412,7 @@ func buildActionCommand(spec *Spec, ro resolvedOp, subResource string) *cli.Comm
 	if subResource != "" {
 		usageText += " " + subResource
 	}
-	usageText += " " + ro.action
+	usageText += " " + ro.action + " [command options]"
 	for _, ap := range argParams {
 		usageText += " <" + ap + ">"
 	}
@@ -535,23 +535,11 @@ func detectMisorderedFlagsInArgs(args, argParams []string, usageText string) err
 		return nil
 	}
 
-	// Rewrite the usage line so the hint shows exactly where flags belong.
-	hint := usageText
-	if len(argParams) > 0 {
-		tail := ""
-		for _, ap := range argParams {
-			tail += " <" + ap + ">"
-		}
-		if idx := strings.Index(usageText, tail); idx >= 0 {
-			hint = usageText[:idx] + " [flags...]" + tail
-		}
-	}
-
 	var msg strings.Builder
 	if len(misplacedFlags) > 0 {
 		fmt.Fprintf(&msg, "flag(s) %s placed after a positional argument; urfave/cli (stdlib flag) stops parsing flags at the first positional, so these flags are being ignored.\n",
 			strings.Join(misplacedFlags, ", "))
-		fmt.Fprintf(&msg, "Move all flags before positionals, e.g.\n  %s\n", hint)
+		fmt.Fprintf(&msg, "Move all flags before positionals, e.g.\n  %s\n", usageText)
 	}
 	if len(extraPositionals) > 0 {
 		if msg.Len() > 0 {
@@ -742,7 +730,10 @@ func coerceValue(v string, schemaType SchemaType) (interface{}, error) {
 }
 
 func clientFromContext(c *cli.Context) (*Client, error) {
-	cfg, _ := LoadConfig()
+	cfg, err := LoadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
 	ApplyEnvOverrides(cfg)
 
 	tokenCommand := c.String("token-command")

--- a/rest-api/cli/pkg/commands_test.go
+++ b/rest-api/cli/pkg/commands_test.go
@@ -4,7 +4,9 @@
 package cli
 
 import (
+	"bytes"
 	"flag"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -88,6 +90,25 @@ func TestClientFromContextExplicitTokenCommandOverridesCachedConfigToken(t *test
 	client, err := clientFromContext(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "explicit-token", client.Token)
+}
+
+func TestClientFromContextReturnsMalformedConfigError(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("auth:\n  token:missing-space\n  token_command: echo token\n"), 0600))
+	SetConfigPath(configPath)
+	defer SetConfigPath("")
+
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	flags.String("token", "", "")
+	flags.String("token-command", "", "")
+	flags.String("base-url", "", "")
+	flags.String("org", "", "")
+	flags.Bool("debug", false, "")
+
+	ctx := cli.NewContext(cli.NewApp(), flags, nil)
+	_, err := clientFromContext(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "loading config: parsing config "+configPath)
 }
 
 func TestOperationAction(t *testing.T) {
@@ -493,9 +514,21 @@ func TestBuildActionCommand_UsageTextUsesBinaryName(t *testing.T) {
 	}
 
 	cmd := buildActionCommand(spec, ro, "")
-	assert.Equal(t, "nicocli site get <siteId>", cmd.UsageText)
+	assert.Equal(t, "nicocli site get [command options] <siteId>", cmd.UsageText)
 	assert.False(t, strings.HasPrefix(cmd.UsageText, "cli "),
 		"UsageText must not start with the literal word 'cli '; got %q", cmd.UsageText)
+}
+
+func TestNewApp_RackGetUsageShowsOptionsBeforeID(t *testing.T) {
+	app, err := NewApp(openapi.Spec)
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	app.Writer = &output
+	require.NoError(t, app.Run([]string{"nicocli", "rack", "get", "--help"}))
+
+	assert.Contains(t, output.String(), "USAGE:\n   nicocli rack get [command options] <id>")
+	assert.NotContains(t, output.String(), "nicocli rack get <id>")
 }
 
 // TestBuildCommands_AllUsageTextStartsWithBinaryName walks every dynamically
@@ -527,7 +560,7 @@ func TestBuildCommands_AllUsageTextStartsWithBinaryName(t *testing.T) {
 }
 
 func TestDetectMisorderedFlags(t *testing.T) {
-	usage := "nicocli machine update <machineId>"
+	usage := "nicocli machine update [command options] <machineId>"
 	tests := []struct {
 		name         string
 		args         []string
@@ -552,7 +585,7 @@ func TestDetectMisorderedFlags(t *testing.T) {
 			args:         []string{"fm100htq", "--data", "{}"},
 			argParams:    []string{"machineId"},
 			wantErr:      true,
-			wantContains: []string{"--data", "placed after a positional", "Move all flags before positionals", "[flags...] <machineId>"},
+			wantContains: []string{"--data", "placed after a positional", "Move all flags before positionals", "[command options] <machineId>"},
 		},
 		{
 			name:         "flag=value form after positional",


### PR DESCRIPTION
Improve CLI user experience by correctly identifying malformed CLI config files, and producing better helptext when parameters can be passed into the commands.