### PR TITLE
fix(helm): make legacyAlias createNamespace truly opt-in and fuse chart namespaces against Argo CD pruning

### DIFF
--- a/helm-prereqs/templates/namespace.yaml
+++ b/helm-prereqs/templates/namespace.yaml
@@ -6,5 +6,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+  annotations:
+    # Namespace deletion cascades; never allow automated deletion.
+    # keep covers helm-CLI uninstalls, Prune=false covers Argo CD pruning.
+    "helm.sh/resource-policy": keep
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     nico.nvidia.com/managed: "true"

--- a/helm/charts/nico-api/templates/legacy-alias-service.yaml
+++ b/helm/charts/nico-api/templates/legacy-alias-service.yaml
@@ -32,6 +32,8 @@ metadata:
   name: {{ $alias.namespace }}
   annotations:
     "helm.sh/resource-policy": keep
+    # Argo CD ignores helm.sh/resource-policy; this is its equivalent fuse.
+    argocd.argoproj.io/sync-options: Prune=false
     nico.nvidia.com/purpose: "legacy-compat namespace for nico-api aliases"
   labels:
     {{- include "nico-api.labels" $ | nindent 4 }}

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -39,9 +39,10 @@ namespaceOverride: ""
 ## share the same pods. Disable when running an all-modern fleet.
 ##
 ## Each entry creates:
-##   - the alias namespace (if `createNamespace: true`, with
-##     `helm.sh/resource-policy: keep` so a helm uninstall does not delete
-##     it).
+##   - the alias namespace, only if `createNamespace: true`. Opt in only
+##     when nothing else owns the target namespace: a second renderer makes
+##     GitOps controllers fight over ownership, and disabling it later can
+##     prune the whole namespace.
 ##   - an ExternalName Service `<name>.<namespace>` that CNAMEs to
 ##     `nico-api.<this-namespace>.svc.cluster.local`.
 ##
@@ -59,7 +60,8 @@ legacyAlias:
   aliases:
     - name: carbide-api
       namespace: forge-system
-      createNamespace: true
+      # Off by default: helm-prereqs already owns this namespace (see note above).
+      createNamespace: false
 
 replicas: 1
 automountServiceAccountToken: true


### PR DESCRIPTION
## Problem

With `legacyAlias.aliases[].createNamespace` defaulting to `true`, this chart renders a Namespace that `helm-prereqs/templates/namespace.yaml` already renders. Under Argo CD, two Applications then fight over the resource's tracking-id - every self-heal sync re-stamps it, so both apps flap OutOfSync indefinitely. The failure mode is worse than churn: if the second renderer is later disabled while it happens to hold the tracking-id, automated pruning deletes the entire namespace, cascading every pod, secret, and cert in it. We hit exactly this on a dev site; GitOps self-healed most of it, but it cost hours.

The alias namespace's existing `helm.sh/resource-policy: keep` implies deletion protection, but Argo CD does not honor helm resource policies when pruning, so that protection never applies under Argo CD.

## Changes

1. `legacyAlias.aliases[].createNamespace` default -> `false` (values + docs). The alias feature was introduced as opt-in; this makes the namespace part actually opt-in. Standard deployments install nico into the same namespace the alias targets (already owned by helm-prereqs) and get the hazard with zero benefit. Cross-namespace installs can opt in explicitly.
2. `argocd.argoproj.io/sync-options: Prune=false` on both chart-rendered Namespaces (legacy-alias template and helm-prereqs), alongside the existing `helm.sh/resource-policy: keep`. Namespace deletion cascades to everything in it, so it should never be a candidate for automated pruning - with the fuse, Argo CD can flag it out-of-sync but never auto-delete it.

Verified with `helm template`: default renders only the alias Service; opt-in renders the Namespace with both annotations; the prereqs namespace carries the fuse.

cc @shayan1995
