### PR TITLE
fix: don't set multicast limit for nvl partitions

### DIFF
--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -224,7 +224,7 @@ pub(crate) async fn re_explore_endpoint(
 
 // Short-circuited: adhoc endpoint refresh is temporarily disabled. The probe
 // path below is retained but unreachable until the feature is re-enabled.
-#[allow(unreachable_code, unused_variables)]
+#[allow(unreachable_code, unused_variables, txn_without_commit)]
 pub(crate) async fn refresh_endpoint_report(
     api: &Api,
     request: Request<rpc::RefreshEndpointReportRequest>,

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -20,8 +20,8 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
 use carbide_site_explorer::SiteExplorer;
+use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
 use carbide_utils::test_support::test_meter::TestMeter;
 use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::TestEnv;

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -62,11 +62,6 @@ use tracing::Instrument;
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
 
-/// Multicast groups limit for new NMX-C partitions. Must be a multiple of 4. Assuming at most 2
-/// partitions per tray and 18 tray default partitions, this is floor(1024 / (36+18)) rounded down
-/// to the nearest multiple of 4.
-const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 16;
-
 fn rack_id_from_chassis_snapshots(
     chassis_snapshots: &[&ManagedHostStateSnapshot],
 ) -> Option<RackId> {
@@ -193,19 +188,9 @@ fn populate_machine_nvlink_info_if_needed(
     updates
 }
 
-fn nmx_c_partition_create_attr_with_multicast_groups_limit(
-    multicast_groups_limit: u32,
-) -> libnmxc::nmxc_model::PartitionAttr {
-    libnmxc::nmxc_model::PartitionAttr {
-        resiliency_mode: libnmxc::nmxc_model::ResiliencyMode::NmxResiliencyModeUndefined as i32,
-        multicast_groups_limit,
-    }
-}
-
 fn nmx_c_create_partition_request(
     name: String,
     gpu_uids: &[u64],
-    multicast_groups_limit: u32,
 ) -> libnmxc::nmxc_model::CreatePartitionRequest {
     libnmxc::nmxc_model::CreatePartitionRequest {
         context: None,
@@ -218,9 +203,7 @@ fn nmx_c_create_partition_request(
                 )),
             })
             .collect(),
-        attr: Some(nmx_c_partition_create_attr_with_multicast_groups_limit(
-            multicast_groups_limit,
-        )),
+        attr: None,
         partition_id: None,
         gateway_id: NMX_C_GATEWAY_ID.into(),
     }
@@ -1839,11 +1822,7 @@ impl NvlPartitionMonitor {
                                 .join(",")
                         );
                         let name: String = name.chars().take(240).collect();
-                        let request = nmx_c_create_partition_request(
-                            name,
-                            &operation.gpu_uids,
-                            NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT,
-                        );
+                        let request = nmx_c_create_partition_request(name, &operation.gpu_uids);
                         match nmxc_client.create_partition(request).await {
                             Ok(_) => true,
                             Err(e) => {


### PR DESCRIPTION
To set multicast limits for partitions we need to implement tray default partitions, and remove the current default partitions. This code is not in v0.10 so for now remove the multicast code.

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

