### PR TITLE
perf(bmc-explorer): explore independent Redfish subtrees concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "bmc-vendor",
  "carbide-api-model",
  "carbide-network",
+ "futures",
  "itertools 0.14.0",
  "lazy_static",
  "mac_address",
@@ -856,6 +857,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -2968,6 +2968,10 @@ mod tests {
                 .load(AtomicOrdering::Relaxed)
         );
         assert_eq!(
+            config.site_explorer.max_concurrent_bmc_requests,
+            SiteExplorerConfig::default_max_concurrent_bmc_requests()
+        );
+        assert_eq!(
             config.machine_state_controller,
             MachineStateControllerConfig::default()
         );
@@ -3064,6 +3068,8 @@ mod tests {
                 run_interval: std::time::Duration::from_secs(120),
                 concurrent_explorations: 10,
                 explorations_per_run: 12,
+                max_concurrent_bmc_requests:
+                    SiteExplorerConfig::default_max_concurrent_bmc_requests(),
                 create_machines: Arc::new(false.into()),
                 machines_created_per_run: 1,
                 override_target_ip: None,
@@ -3261,6 +3267,8 @@ mod tests {
                 run_interval: std::time::Duration::from_secs(100),
                 concurrent_explorations: 30,
                 explorations_per_run: 11,
+                max_concurrent_bmc_requests:
+                    SiteExplorerConfig::default_max_concurrent_bmc_requests(),
                 create_machines: Arc::new(true.into()),
                 machines_created_per_run: 2,
                 override_target_ip: Some("1.2.3.4".to_owned()),
@@ -3605,6 +3613,8 @@ mod tests {
                 run_interval: std::time::Duration::from_secs(100),
                 concurrent_explorations: 10,
                 explorations_per_run: 12,
+                max_concurrent_bmc_requests:
+                    SiteExplorerConfig::default_max_concurrent_bmc_requests(),
                 create_machines: Arc::new(false.into()),
                 machines_created_per_run: 2,
                 override_target_ip: Some("1.2.3.4".to_owned()),

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -469,6 +469,7 @@ pub async fn start_api(
     let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
         shared_redfish_pool.clone(),
         shared_nv_redfish_pool,
+        carbide_config.site_explorer.max_concurrent_bmc_requests,
         ipmi_tool.clone(),
         credential_manager.clone(),
         carbide_config

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -229,6 +229,7 @@ impl TestApiBuilder {
         let real_endpoint_explorer = carbide_site_explorer::new_bmc_explorer(
             redfish_pool.clone(),
             nv_redfish_pool,
+            runtime_config.site_explorer.max_concurrent_bmc_requests,
             carbide_ipmi::test_support(),
             credential_manager.clone(),
             Arc::new(std::sync::atomic::AtomicBool::new(false)),

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1710,6 +1710,7 @@ pub async fn create_test_env_with_overrides(
             run_interval: Duration::seconds(0).to_std().unwrap(),
             concurrent_explorations: 100,
             explorations_per_run: 100,
+            max_concurrent_bmc_requests: SiteExplorerConfig::default_max_concurrent_bmc_requests(),
             create_machines: Arc::new(true.into()),
             machines_created_per_run: 1,
             override_target_ip: None,

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -24,7 +24,7 @@ use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use carbide_secrets::credentials::Credentials;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_site_explorer::BmcEndpointExplorer;
-use carbide_site_explorer::config::SiteExplorerExploreMode;
+use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
 use clap::Parser;
 use mac_address::MacAddress;
 use tracing_subscriber::fmt;
@@ -106,6 +106,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let explorer = BmcEndpointExplorer::new(
         redfish_client_pool,
         Arc::new(NvRedfishClientPool::new(proxy_address)),
+        // Standalone debug tool: no site config, so it explores with the
+        // default per-BMC request cap.
+        SiteExplorerConfig::default_max_concurrent_bmc_requests(),
         carbide_ipmi::test_support(),
         credential_provider.clone(),
         rotate_switch_nvos_credentials,

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -30,6 +30,7 @@ carbide-network = { path = "../network", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 
+futures = { workspace = true }
 itertools = { workspace = true }
 mac_address = { workspace = true }
 nv-redfish = { workspace = true, features = [
@@ -76,6 +77,7 @@ bmc-mock = { path = "../bmc-mock" }
 bmc-explorer = { path = ".", features = ["test-support"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+url = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -19,6 +19,7 @@ use std::convert::identity;
 use std::fmt;
 
 use carbide_network::BaseMac;
+use futures::stream::{self, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::site_explorer::{Chassis, PowerState as ModelPowerState};
@@ -29,9 +30,10 @@ use nv_redfish::hardware_id::{Manufacturer, Model};
 use nv_redfish::pcie_device::PcieDevice;
 use nv_redfish::resource::ResourceIdRef;
 use nv_redfish::{Bmc, Resource, ServiceRoot};
+use tokio::sync::Semaphore;
 
 use crate::network_adapter::ExploredNetworkAdapterCollection;
-use crate::{Error, network_adapter};
+use crate::{DEFAULT_MAX_CONCURRENT_BMC_REQUESTS, Error, limited, network_adapter};
 
 type AssemblyModelFilterFn = fn(Option<AssemblyModel<&str>>) -> bool;
 const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
@@ -46,41 +48,44 @@ pub struct ExploredChassisCollection<B: Bmc> {
 }
 
 impl<B: Bmc> ExploredChassisCollection<B> {
-    pub async fn explore(root: &ServiceRoot<B>, config: &Config) -> Result<Self, Error<B>> {
-        let mut members = Vec::new();
-        for m in Self::fetch_members(root, config).await? {
-            members.push(ExploredChassis::explore(m, config).await?);
-        }
+    pub async fn explore(
+        root: &ServiceRoot<B>,
+        config: &Config,
+        limiter: &Semaphore,
+    ) -> Result<Self, Error<B>> {
+        let members = stream::iter(Self::fetch_members(root, config, limiter).await?)
+            .map(|m| ExploredChassis::explore(m, config, limiter))
+            .buffered(DEFAULT_MAX_CONCURRENT_BMC_REQUESTS)
+            .try_collect()
+            .await?;
         Ok(Self { members })
     }
 
     async fn fetch_members(
         root: &ServiceRoot<B>,
         config: &Config,
+        limiter: &Semaphore,
     ) -> Result<Vec<NvChassis<B>>, Error<B>> {
         if let Some(filter) = config.lazy_fetch {
-            let links = root
-                .chassis_links()
+            let links = limited(limiter, root.chassis_links())
                 .await
                 .map_err(Error::nv_redfish("chassis collection"))?
                 .ok_or_else(Error::bmc_not_provided("chassis collection"))?;
-            let mut result = Vec::with_capacity(links.len());
-            for l in links {
-                if filter(l.odata_id()) {
-                    result.push(
-                        l.upgrade()
-                            .await
-                            .map_err(Error::nv_redfish("chassis collection member"))?,
-                    )
-                }
-            }
-            Ok(result)
+            stream::iter(links.into_iter().filter(|l| filter(l.odata_id())))
+                .map(|l| async move {
+                    limited(limiter, l.upgrade())
+                        .await
+                        .map_err(Error::nv_redfish("chassis collection member"))
+                })
+                .buffered(DEFAULT_MAX_CONCURRENT_BMC_REQUESTS)
+                .try_collect()
+                .await
         } else {
-            root.chassis()
+            let collection = limited(limiter, root.chassis())
                 .await
                 .map_err(Error::nv_redfish("chassis collection"))?
-                .ok_or_else(Error::bmc_not_provided("chassis collection"))?
-                .members()
+                .ok_or_else(Error::bmc_not_provided("chassis collection"))?;
+            limited(limiter, collection.members())
                 .await
                 .map_err(Error::nv_redfish("chassis collection members"))
         }
@@ -198,24 +203,33 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     pub async fn pcie_devices(
         &self,
         chassis_filter: impl Fn(&ExploredChassis<B>) -> bool,
+        limiter: &Semaphore,
     ) -> Result<Vec<PcieDevice<B>>, Error<B>> {
-        let mut pcie_devices = Vec::new();
-        for c in &self.members {
-            if chassis_filter(c)
-                && let Some(collection) = c
-                    .chassis
-                    .pcie_devices()
+        // The per-chassis fetch futures are collected eagerly instead of
+        // streamed through a `buffered` adapter: adapters over borrowed items
+        // embed their closure types in the awaited future, which defeats
+        // rustc's `Send` proof for the whole exploration ("implementation of
+        // `FnOnce` is not general enough"). The shared limiter bounds the
+        // real request fan-out either way.
+        let fetches: Vec<_> = self
+            .members
+            .iter()
+            .filter(|c| chassis_filter(c))
+            .map(|c| async move {
+                if let Some(collection) = limited(limiter, c.chassis.pcie_devices())
                     .await
                     .map_err(Error::nv_redfish("chassis pcie devices"))?
-            {
-                let mut chassis_pcie_devices = collection
-                    .members()
-                    .await
-                    .map_err(Error::nv_redfish("chassis pcie devices members"))?;
-                pcie_devices.append(&mut chassis_pcie_devices);
-            }
-        }
-        Ok(pcie_devices)
+                {
+                    limited(limiter, collection.members())
+                        .await
+                        .map_err(Error::nv_redfish("chassis pcie devices members"))
+                } else {
+                    Ok(Vec::new())
+                }
+            })
+            .collect();
+        let per_chassis: Vec<Vec<PcieDevice<B>>> = futures::future::try_join_all(fetches).await?;
+        Ok(per_chassis.into_iter().flatten().collect())
     }
 }
 
@@ -238,57 +252,73 @@ pub struct ExploredChassis<B: Bmc> {
 }
 
 impl<B: Bmc> ExploredChassis<B> {
-    async fn explore(chassis: NvChassis<B>, config: &Config) -> Result<Self, Error<B>> {
-        let network_adapters =
-            ExploredNetworkAdapterCollection::explore(&chassis, &config.network_adapter).await?;
-        let assembly_sn = if let Some(model_check_fn) = (config.need_assembly_sn)(chassis.id()) {
-            match chassis.assembly().await {
-                Ok(Some(assembly)) => {
-                    let assembly_data = assembly
-                        .assemblies()
-                        .await
-                        .map_err(Error::nv_redfish("chassis assemblies"))?;
-                    assembly_data
-                        .iter()
-                        .find(|asm| model_check_fn(asm.hardware_id().model))
-                        .and_then(|asm| asm.hardware_id().serial_number)
-                        .map(|v| v.to_string())
-                }
-                Ok(None) => None,
-                Err(err) => {
-                    return Err(Error::NvRedfish {
+    async fn explore(
+        chassis: NvChassis<B>,
+        config: &Config,
+        limiter: &Semaphore,
+    ) -> Result<Self, Error<B>> {
+        // The network-adapter, assembly, and LiteOn power-supply subtrees of
+        // one chassis are independent, so they proceed concurrently.
+        let network_adapters_branch =
+            ExploredNetworkAdapterCollection::explore(&chassis, &config.network_adapter, limiter);
+
+        let assembly_branch = async {
+            if let Some(model_check_fn) = (config.need_assembly_sn)(chassis.id()) {
+                match limited(limiter, chassis.assembly()).await {
+                    Ok(Some(assembly)) => {
+                        let assembly_data = limited(limiter, assembly.assemblies())
+                            .await
+                            .map_err(Error::nv_redfish("chassis assemblies"))?;
+                        Ok(assembly_data
+                            .iter()
+                            .find(|asm| model_check_fn(asm.hardware_id().model))
+                            .and_then(|asm| asm.hardware_id().serial_number)
+                            .map(|v| v.to_string()))
+                    }
+                    Ok(None) => Ok(None),
+                    Err(err) => Err(Error::NvRedfish {
                         context: "chassis assembly",
                         err,
-                    });
+                    }),
                 }
+            } else {
+                Ok(None)
             }
-        } else {
-            None
         };
+
         // Here we rely on the fact that
         // Chassis::oem_liteon_power_supply_links returns None
         // immediately if chassis is not LiteOn.
-        let oem_liteon_power_supplies = if let Some(ps_links) = chassis
-            .oem_liteon_power_supply_links()
-            .await
-            .map_err(Error::nv_redfish("LiteOn power supply links"))?
-        {
-            let mut power_supplies = Vec::new();
-            for l in ps_links {
-                let ps = l
-                    .fetch()
-                    .await
-                    .map_err(Error::nv_redfish("LiteOn power supply"))?;
-                power_supplies.push(LiteOnPowerSupply {
-                    id: ps.base.id.clone(),
-                    serial_number: ps.serial_number.clone().and_then(std::convert::identity),
-                    power_state: ps.power_state,
-                });
+        let liteon_branch = async {
+            if let Some(ps_links) = limited(limiter, chassis.oem_liteon_power_supply_links())
+                .await
+                .map_err(Error::nv_redfish("LiteOn power supply links"))?
+            {
+                let power_supplies = stream::iter(ps_links)
+                    .map(|l| async move {
+                        let ps = limited(limiter, l.fetch())
+                            .await
+                            .map_err(Error::nv_redfish("LiteOn power supply"))?;
+                        Ok(LiteOnPowerSupply {
+                            id: ps.base.id.clone(),
+                            serial_number: ps
+                                .serial_number
+                                .clone()
+                                .and_then(std::convert::identity),
+                            power_state: ps.power_state,
+                        })
+                    })
+                    .buffered(DEFAULT_MAX_CONCURRENT_BMC_REQUESTS)
+                    .try_collect()
+                    .await?;
+                Ok(Some(power_supplies))
+            } else {
+                Ok(None)
             }
-            Some(power_supplies)
-        } else {
-            None
         };
+
+        let (network_adapters, assembly_sn, oem_liteon_power_supplies) =
+            tokio::try_join!(network_adapters_branch, assembly_branch, liteon_branch)?;
 
         Ok(Self {
             chassis,

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -36,9 +36,11 @@ use nv_redfish::pcie_device::PcieDevice;
 use nv_redfish::resource::PowerState;
 use nv_redfish::{Bmc, Resource, ResourceProvidesStatus};
 use regex::Regex;
+use tokio::sync::Semaphore;
 
 use crate::{
-    Config as ExploreConfig, Error, ErrorClass, ExploredChassisCollection, compare_boot_options, hw,
+    Config as ExploreConfig, Error, ErrorClass, ExploredChassisCollection, compare_boot_options,
+    hw, limited,
 };
 
 const UEFI_MAC_PATTERN_CAPTURE: &str = "mac";
@@ -74,40 +76,56 @@ impl<B: Bmc> ExploredComputerSystem<B> {
     pub async fn explore(
         system: ComputerSystem<B>,
         config: &Config<'_, B>,
+        limiter: &Semaphore,
     ) -> Result<Self, Error<B>> {
-        let boot_options = if config.need_boot_options
-            && let Some(collection) = system
-                .boot_options()
-                .await
-                .map_err(Error::nv_redfish("boot options"))?
-        {
-            collection
-                .members()
-                .await
-                .map_err(Error::nv_redfish("boot options members"))?
-        } else {
-            vec![]
+        // The boot-option, BIOS, ethernet-interface, OEM, and secure-boot
+        // subtrees of one computer system are independent, so they proceed
+        // concurrently.
+        let boot_options_branch = async {
+            if config.need_boot_options
+                && let Some(collection) = limited(limiter, system.boot_options())
+                    .await
+                    .map_err(Error::nv_redfish("boot options"))?
+            {
+                limited(limiter, collection.members())
+                    .await
+                    .map_err(Error::nv_redfish("boot options members"))
+            } else {
+                Ok(vec![])
+            }
         };
 
-        let bios = Self::fetch_bios(&system, config).await?;
+        let bios_branch = Self::fetch_bios(&system, config, limiter);
 
-        let ethernet_interfaces = Self::fetch_eth_interfaces(&system, config)
-            .await
-            .map_err(Error::nv_redfish("system ethernet interfaces"))?;
-
-        let oem_nvidia_bluefield = if config.need_oem_nvidia_bluefield {
-            system
-                .oem_nvidia_bluefield()
+        let eth_interfaces_branch = async {
+            Self::fetch_eth_interfaces(&system, config, limiter)
                 .await
-                .map_err(Error::nv_redfish("NVIDIA system Bluefield OEM"))?
-        } else {
-            None
+                .map_err(Error::nv_redfish("system ethernet interfaces"))
         };
 
-        let secure_boot = system
-            .secure_boot()
-            .await
-            .map_err(Error::nv_redfish("secure boot"))?;
+        let oem_nvidia_bluefield_branch = async {
+            if config.need_oem_nvidia_bluefield {
+                limited(limiter, system.oem_nvidia_bluefield())
+                    .await
+                    .map_err(Error::nv_redfish("NVIDIA system Bluefield OEM"))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let secure_boot_branch = async {
+            limited(limiter, system.secure_boot())
+                .await
+                .map_err(Error::nv_redfish("secure boot"))
+        };
+
+        let (boot_options, bios, ethernet_interfaces, oem_nvidia_bluefield, secure_boot) = tokio::try_join!(
+            boot_options_branch,
+            bios_branch,
+            eth_interfaces_branch,
+            oem_nvidia_bluefield_branch,
+            secure_boot_branch,
+        )?;
 
         Ok(Self {
             system,
@@ -122,8 +140,9 @@ impl<B: Bmc> ExploredComputerSystem<B> {
     async fn fetch_bios(
         system: &ComputerSystem<B>,
         config: &Config<'_, B>,
+        limiter: &Semaphore,
     ) -> Result<Option<Bios<B>>, Error<B>> {
-        match system.bios().await {
+        match limited(limiter, system.bios()).await {
             Ok(bios) => Ok(bios),
             Err(err) if config.ignore_500_on_bios_fetch => {
                 if let nv_redfish::Error::Bmc(bmc_error) = &err
@@ -144,15 +163,21 @@ impl<B: Bmc> ExploredComputerSystem<B> {
     async fn fetch_eth_interfaces(
         system: &ComputerSystem<B>,
         config: &Config<'_, B>,
+        limiter: &Semaphore,
     ) -> Result<Vec<EthernetInterface<B>>, nv_redfish::Error<B>> {
         // Total tries: 3 (initial + 2 retries).
         let mut retries_remaining = 2;
         loop {
-            let result = match system.ethernet_interfaces().await {
-                Ok(Some(ifaces)) => ifaces.members().await,
-                Ok(None) => Ok(vec![]),
-                Err(err) => Err(err),
-            };
+            // One permit spans the collection + members pair of one attempt;
+            // it is released before any retry sleep below.
+            let result = limited(limiter, async {
+                match system.ethernet_interfaces().await {
+                    Ok(Some(ifaces)) => ifaces.members().await,
+                    Ok(None) => Ok(vec![]),
+                    Err(err) => Err(err),
+                }
+            })
+            .await;
             match result {
                 Ok(v) => break Ok(v),
                 Err(err) if config.retry_404_on_eth_interfaces && retries_remaining != 0 => {

--- a/crates/bmc-explorer/src/inventories.rs
+++ b/crates/bmc-explorer/src/inventories.rs
@@ -18,22 +18,22 @@
 use model::site_explorer::{Inventory as ModelInventory, Service as ModelService};
 use nv_redfish::update_service::SoftwareInventory;
 use nv_redfish::{Bmc, Resource, ServiceRoot};
+use tokio::sync::Semaphore;
 
-use crate::{Error, hw};
+use crate::{Error, hw, limited};
 
 pub struct ExploredInventories<B: Bmc> {
     members: Vec<SoftwareInventory<B>>,
 }
 
 impl<B: Bmc> ExploredInventories<B> {
-    pub async fn explore(root: &ServiceRoot<B>) -> Result<Self, Error<B>> {
+    pub async fn explore(root: &ServiceRoot<B>, limiter: &Semaphore) -> Result<Self, Error<B>> {
+        let update_service = limited(limiter, root.update_service())
+            .await
+            .map_err(Error::nv_redfish("update service"))?
+            .ok_or_else(Error::bmc_not_provided("update service"))?;
         Ok(Self {
-            members: root
-                .update_service()
-                .await
-                .map_err(Error::nv_redfish("update service"))?
-                .ok_or_else(Error::bmc_not_provided("update service"))?
-                .firmware_inventories()
+            members: limited(limiter, update_service.firmware_inventories())
                 .await
                 .map_err(Error::nv_redfish("firmware inventories"))?
                 .unwrap_or_default(),

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -26,6 +26,7 @@ mod network_adapter;
 pub mod test_support;
 use std::collections::HashMap;
 use std::convert::identity;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -53,6 +54,38 @@ use nv_redfish::oem::supermicro::Privilege as SupermicroPrivilege;
 use nv_redfish::resource::ResourceNameRef;
 use nv_redfish::service_root::{Product, Vendor};
 use nv_redfish::{Bmc, Resource, ServiceRoot};
+use tokio::sync::Semaphore;
+
+/// Default cap on concurrent requests one exploration keeps in flight against
+/// a BMC (the default for [`Config::max_concurrent_bmc_requests`]).
+///
+/// Exploration fetches independent Redfish subtrees concurrently, but BMC
+/// firmware is fragile under request bursts, so every fetch in this crate
+/// takes a permit from one shared per-exploration semaphore (see [`limited`]).
+/// Nested concurrent constructs therefore never multiply the fan-out beyond
+/// the configured bound. The reqwest connection pool used against real BMCs
+/// retains this many idle connections (`crates/redfish`), so the default
+/// fan-out reuses warm sockets instead of reopening them.
+///
+/// Some BMC firmware dislikes concurrent access altogether — pre-iLO-7 HPE
+/// BMCs, for example, drop connections aggressively enough that
+/// `crates/redfish` forces `Connection: Close` on them — so operators may
+/// lower the cap for such a site, down to 1 to explore one request at a
+/// time. The cap is floored at 1: the limiter never starts without permits.
+pub const DEFAULT_MAX_CONCURRENT_BMC_REQUESTS: usize = 4;
+
+/// Runs one BMC fetch while holding a permit on the shared request limiter.
+///
+/// Permits are taken only around direct BMC fetches, never around composite
+/// explorations that themselves acquire, so the limiter is deadlock-free by
+/// construction.
+pub(crate) async fn limited<F: Future>(limiter: &Semaphore, fetch: F) -> F::Output {
+    let _permit = limiter
+        .acquire()
+        .await
+        .expect("BMC request limiter is never closed");
+    fetch.await
+}
 
 #[derive(PartialEq, Eq)]
 pub enum ErrorClass {
@@ -66,6 +99,11 @@ pub struct Config<'a, B: Bmc> {
     pub boot_interface_mac: Option<MacAddress>,
     pub error_classifier: ErrorClassifier<'a, B>,
     pub retry_timeout: Duration,
+    /// Cap on concurrent requests this exploration keeps in flight against
+    /// the BMC. [`DEFAULT_MAX_CONCURRENT_BMC_REQUESTS`] unless an operator
+    /// lowered it for BMCs that dislike concurrent access; floored at 1,
+    /// which explores one request at a time.
+    pub max_concurrent_bmc_requests: usize,
 }
 
 /// Builds the chassis exploration config shared by [`nv_generate_exploration_report`]
@@ -103,54 +141,75 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
     mut root: Arc<ServiceRoot<B>>,
     config: &Config<'_, B>,
 ) -> Result<EndpointExplorationReport, Error<B>> {
+    let limiter = Semaphore::new(config.max_concurrent_bmc_requests.max(1));
     let chassis_explore_config = build_chassis_explore_config(&root);
-    let explored_chassis =
-        ExploredChassisCollection::explore(&root, &chassis_explore_config).await?;
-    let explored_inventories = ExploredInventories::explore(&root).await?;
+
+    // The chassis and firmware-inventory subtrees are independent reads of
+    // the (unrestricted) service root, so they proceed concurrently. The
+    // system/manager subtrees wait for the chassis result: a BlueField-2
+    // chassis restricts `$expand` for every fetch after this point.
+    let (explored_chassis, explored_inventories) = tokio::try_join!(
+        ExploredChassisCollection::explore(&root, &chassis_explore_config, &limiter),
+        ExploredInventories::explore(&root, &limiter),
+    )?;
 
     if explored_chassis.is_bluefield2() {
         root = root.as_ref().clone().restrict_expand().into();
     }
 
-    let mut systems_iter = root
-        .systems()
-        .await
-        .map_err(Error::nv_redfish("systems"))?
-        .ok_or_else(Error::bmc_not_provided("systems"))?
-        .members()
-        .await
-        .map_err(Error::nv_redfish("systems members"))?
+    // The computer-system subtree and the manager-collection fetch are
+    // independent. Exploring the manager itself waits for the system: its
+    // configuration is selected by the platform type, which is detected from
+    // the explored system and chassis.
+    let system_branch = async {
+        let mut systems_iter = limited(&limiter, async {
+            root.systems()
+                .await
+                .map_err(Error::nv_redfish("systems"))?
+                .ok_or_else(Error::bmc_not_provided("systems"))?
+                .members()
+                .await
+                .map_err(Error::nv_redfish("systems members"))
+        })
+        .await?
         .into_iter();
 
-    let first_system = systems_iter
-        .next()
-        .ok_or_else(Error::bmc_not_provided("at least one computer system"))?;
-    let other_system_with_bios = systems_iter.find(|system| system.raw().bios.is_some());
-    let system = other_system_with_bios.unwrap_or(first_system);
+        let first_system = systems_iter
+            .next()
+            .ok_or_else(Error::bmc_not_provided("at least one computer system"))?;
+        let other_system_with_bios = systems_iter.find(|system| system.raw().bios.is_some());
+        let system = other_system_with_bios.unwrap_or(first_system);
 
-    let manager = root
-        .managers()
-        .await
-        .map_err(Error::nv_redfish("managers"))?
-        .ok_or_else(Error::bmc_not_provided("managers"))?
-        .members()
-        .await
-        .map_err(Error::nv_redfish("managers members"))?
+        let is_bluefield_system = system.id().into_inner() == "Bluefield";
+        let system_explore_config = computer_system::Config {
+            need_oem_nvidia_bluefield: is_bluefield_system,
+            ignore_500_on_bios_fetch: is_bluefield_system,
+            retry_404_on_eth_interfaces: is_bluefield_system,
+            // BlueField-4 returns null in the Members field in
+            // BootOptions. This is a workaround for this bug.
+            need_boot_options: !explored_chassis.is_bluefield4(),
+            explore: config,
+        };
+        ExploredComputerSystem::explore(system, &system_explore_config, &limiter).await
+    };
+
+    let manager_branch = async {
+        limited(&limiter, async {
+            root.managers()
+                .await
+                .map_err(Error::nv_redfish("managers"))?
+                .ok_or_else(Error::bmc_not_provided("managers"))?
+                .members()
+                .await
+                .map_err(Error::nv_redfish("managers members"))
+        })
+        .await?
         .into_iter()
         .next()
-        .ok_or_else(Error::bmc_not_provided("at least one manager"))?;
-
-    let is_bluefield_system = system.id().into_inner() == "Bluefield";
-    let system_explore_config = computer_system::Config {
-        need_oem_nvidia_bluefield: is_bluefield_system,
-        ignore_500_on_bios_fetch: is_bluefield_system,
-        retry_404_on_eth_interfaces: is_bluefield_system,
-        // BlueField-4 returns null in the Members field in
-        // BootOptions. This is a workaround for this bug.
-        need_boot_options: !explored_chassis.is_bluefield4(),
-        explore: config,
+        .ok_or_else(Error::bmc_not_provided("at least one manager"))
     };
-    let explored_system = ExploredComputerSystem::explore(system, &system_explore_config).await?;
+
+    let (explored_system, manager) = tokio::try_join!(system_branch, manager_branch)?;
 
     let hw_type = hw_type(&root, &explored_system, &explored_chassis);
     let manager_explore_config = hw_type
@@ -185,40 +244,45 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
         })
         .unwrap_or_default();
 
-    let explored_manager = ExploredManager::explore(manager, &manager_explore_config).await?;
-
-    let pcie_devices = explored_chassis
-        .pcie_devices(|chassis| match hw_type {
-            Some(hw::HwType::Viking) => {
-                let chassis_id = chassis.chassis.id().into_inner();
-                chassis_id.starts_with("HGX_GPU_SXM") || chassis_id.starts_with("HGX_NVSwitch")
-            }
-            // When needed Chassis Id is equal to System Id.
-            Some(
-                hw::HwType::Ami
-                | hw::HwType::Dell
-                | hw::HwType::Hpe
-                | hw::HwType::Lenovo
-                | hw::HwType::Supermicro,
-            ) => chassis.chassis.id().into_inner() == explored_system.system.id().into_inner(),
-            // Provides only one Chassis.
-            Some(hw::HwType::LenovoAmi) => true,
-            Some(
-                hw::HwType::LenovoGb300
-                | hw::HwType::DgxGb300
-                | hw::HwType::SupermicroGb300
-                | hw::HwType::VeraRubin,
-            ) => chassis.chassis.id().into_inner().starts_with("HGX_GPU_"),
-            // No meaningful PCIeDevices.
-            Some(
-                hw::HwType::Bluefield
-                | hw::HwType::Gb200
-                | hw::HwType::LiteonPowerShelf
-                | hw::HwType::NvSwitch,
-            ) => false,
-            None => false,
-        })
-        .await?;
+    // The manager exploration and the PCIe-device sweep both depend only on
+    // the platform type (and already-fetched chassis/system data), so they
+    // proceed concurrently.
+    let (explored_manager, pcie_devices) = tokio::try_join!(
+        ExploredManager::explore(manager, &manager_explore_config, &limiter),
+        explored_chassis.pcie_devices(
+            |chassis| match hw_type {
+                Some(hw::HwType::Viking) => {
+                    let chassis_id = chassis.chassis.id().into_inner();
+                    chassis_id.starts_with("HGX_GPU_SXM") || chassis_id.starts_with("HGX_NVSwitch")
+                }
+                // When needed Chassis Id is equal to System Id.
+                Some(
+                    hw::HwType::Ami
+                    | hw::HwType::Dell
+                    | hw::HwType::Hpe
+                    | hw::HwType::Lenovo
+                    | hw::HwType::Supermicro,
+                ) => chassis.chassis.id().into_inner() == explored_system.system.id().into_inner(),
+                // Provides only one Chassis.
+                Some(hw::HwType::LenovoAmi) => true,
+                Some(
+                    hw::HwType::LenovoGb300
+                    | hw::HwType::DgxGb300
+                    | hw::HwType::SupermicroGb300
+                    | hw::HwType::VeraRubin,
+                ) => chassis.chassis.id().into_inner().starts_with("HGX_GPU_"),
+                // No meaningful PCIeDevices.
+                Some(
+                    hw::HwType::Bluefield
+                    | hw::HwType::Gb200
+                    | hw::HwType::LiteonPowerShelf
+                    | hw::HwType::NvSwitch,
+                ) => false,
+                None => false,
+            },
+            &limiter,
+        ),
+    )?;
 
     let lockdown_status = hw_type
         .map(|hw_type| lockdown_status(&hw_type, &explored_system, &explored_manager))

--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -29,8 +29,9 @@ use nv_redfish::oem::dell::attributes::DellAttributes;
 use nv_redfish::oem::lenovo::security_service::LenovoSecurityService;
 use nv_redfish::oem::supermicro::{KcsInterface, SysLockdown};
 use nv_redfish::{Bmc, Resource};
+use tokio::sync::Semaphore;
 
-use crate::Error;
+use crate::{Error, limited};
 
 #[derive(Default)]
 pub struct Config {
@@ -54,87 +55,119 @@ pub struct ExploredManager<B: Bmc> {
 }
 
 impl<B: Bmc> ExploredManager<B> {
-    pub async fn explore(manager: Manager<B>, config: &Config) -> Result<Self, Error<B>> {
-        let eth_interfaces = manager
-            .ethernet_interfaces()
-            .await
-            .map_err(Error::nv_redfish("manager ethernet interfaces"))?
-            .ok_or_else(Error::bmc_not_provided("manager ethernet interfaces"))?
-            .members()
-            .await
-            .map_err(Error::nv_redfish("manager ethernet interfaces members"))?;
-
-        let host_interfaces = if config.need_host_interfaces {
-            if let Some(collection) = manager
-                .host_interfaces()
+    pub async fn explore(
+        manager: Manager<B>,
+        config: &Config,
+        limiter: &Semaphore,
+    ) -> Result<Self, Error<B>> {
+        // The ethernet-interface, host-interface, and OEM subtrees of one
+        // manager are independent, so they proceed concurrently.
+        let eth_interfaces_branch = async {
+            let collection = limited(limiter, manager.ethernet_interfaces())
                 .await
-                .map_err(Error::nv_redfish("host interfaces collection"))?
-            {
-                Some(
-                    collection
-                        .members()
-                        .await
-                        .map_err(Error::nv_redfish("host interfaces collection members"))?,
-                )
+                .map_err(Error::nv_redfish("manager ethernet interfaces"))?
+                .ok_or_else(Error::bmc_not_provided("manager ethernet interfaces"))?;
+            limited(limiter, collection.members())
+                .await
+                .map_err(Error::nv_redfish("manager ethernet interfaces members"))
+        };
+
+        let host_interfaces_branch = async {
+            if config.need_host_interfaces {
+                if let Some(collection) = limited(limiter, manager.host_interfaces())
+                    .await
+                    .map_err(Error::nv_redfish("host interfaces collection"))?
+                {
+                    Ok(Some(limited(limiter, collection.members()).await.map_err(
+                        Error::nv_redfish("host interfaces collection members"),
+                    )?))
+                } else {
+                    Ok(None)
+                }
             } else {
-                None
+                Ok(None)
             }
-        } else {
-            None
         };
 
-        let oem_dell_attributes = if config.need_oem_dell_attributes {
-            manager
-                .oem_dell_attributes()
-                .await
-                .map_err(Error::nv_redfish("Dell OEM Attributes"))?
-        } else {
-            None
-        };
-
-        let oem_lenovo_security_service = if config.need_oem_lenovo_security_service
-            && let Some(oem_lenovo) = manager
-                .oem_lenovo()
-                .map_err(Error::nv_redfish("Lenovo manager OEM"))?
-        {
-            oem_lenovo
-                .security()
-                .await
-                .map_err(Error::nv_redfish("Lenovo OEM security service"))?
-        } else {
-            None
-        };
-
-        let mut oem_supermicro_kcs_interface = None;
-        let mut oem_supermicro_sys_lockdown = None;
-        if (config.need_oem_supermicro_kcs_interface || config.need_oem_supermicro_sys_lockdown)
-            && let Some(oem_supermicro) = manager
-                .oem_supermicro()
-                .map_err(Error::nv_redfish("Supermicro OEM"))?
-        {
-            if config.need_oem_supermicro_kcs_interface {
-                oem_supermicro_kcs_interface = oem_supermicro
-                    .kcs_interface()
+        let oem_dell_attributes_branch = async {
+            if config.need_oem_dell_attributes {
+                limited(limiter, manager.oem_dell_attributes())
                     .await
-                    .map_err(Error::nv_redfish("Supermicro KCS Interface"))?
-            };
-
-            if config.need_oem_supermicro_sys_lockdown {
-                oem_supermicro_sys_lockdown = oem_supermicro
-                    .sys_lockdown()
-                    .await
-                    .map_err(Error::nv_redfish("Supermicro SysLockdown"))?
+                    .map_err(Error::nv_redfish("Dell OEM Attributes"))
+            } else {
+                Ok(None)
             }
-        }
-
-        let oem_ami_config_bmc = if config.need_oem_ami_config_bmc {
-            manager
-                .oem_ami_config_bmc()
-                .await
-                .map_err(Error::nv_redfish("AMI manager ConfigBMC OEM"))?
-        } else {
-            None
         };
+
+        let oem_lenovo_security_service_branch = async {
+            if config.need_oem_lenovo_security_service
+                && let Some(oem_lenovo) = manager
+                    .oem_lenovo()
+                    .map_err(Error::nv_redfish("Lenovo manager OEM"))?
+            {
+                limited(limiter, oem_lenovo.security())
+                    .await
+                    .map_err(Error::nv_redfish("Lenovo OEM security service"))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let oem_supermicro_branch = async {
+            if (config.need_oem_supermicro_kcs_interface || config.need_oem_supermicro_sys_lockdown)
+                && let Some(oem_supermicro) = manager
+                    .oem_supermicro()
+                    .map_err(Error::nv_redfish("Supermicro OEM"))?
+            {
+                let kcs_interface_branch = async {
+                    if config.need_oem_supermicro_kcs_interface {
+                        limited(limiter, oem_supermicro.kcs_interface())
+                            .await
+                            .map_err(Error::nv_redfish("Supermicro KCS Interface"))
+                    } else {
+                        Ok(None)
+                    }
+                };
+                let sys_lockdown_branch = async {
+                    if config.need_oem_supermicro_sys_lockdown {
+                        limited(limiter, oem_supermicro.sys_lockdown())
+                            .await
+                            .map_err(Error::nv_redfish("Supermicro SysLockdown"))
+                    } else {
+                        Ok(None)
+                    }
+                };
+                tokio::try_join!(kcs_interface_branch, sys_lockdown_branch)
+            } else {
+                Ok((None, None))
+            }
+        };
+
+        let oem_ami_config_bmc_branch = async {
+            if config.need_oem_ami_config_bmc {
+                limited(limiter, manager.oem_ami_config_bmc())
+                    .await
+                    .map_err(Error::nv_redfish("AMI manager ConfigBMC OEM"))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let (
+            eth_interfaces,
+            host_interfaces,
+            oem_dell_attributes,
+            oem_lenovo_security_service,
+            (oem_supermicro_kcs_interface, oem_supermicro_sys_lockdown),
+            oem_ami_config_bmc,
+        ) = tokio::try_join!(
+            eth_interfaces_branch,
+            host_interfaces_branch,
+            oem_dell_attributes_branch,
+            oem_lenovo_security_service_branch,
+            oem_supermicro_branch,
+            oem_ami_config_bmc_branch,
+        )?;
 
         Ok(Self {
             manager,

--- a/crates/bmc-explorer/src/network_adapter.rs
+++ b/crates/bmc-explorer/src/network_adapter.rs
@@ -15,13 +15,15 @@
  * limitations under the License.
  */
 
+use futures::stream::{self, StreamExt, TryStreamExt};
 use mac_address::MacAddress;
 use model::site_explorer::NetworkAdapter as ModelNetworkAdapter;
 use nv_redfish::chassis::{Chassis, NetworkAdapter};
 use nv_redfish::network_device_function::NetworkDeviceFunction;
 use nv_redfish::{Bmc, Resource};
+use tokio::sync::Semaphore;
 
-use crate::Error;
+use crate::{DEFAULT_MAX_CONCURRENT_BMC_REQUESTS, Error, limited};
 
 pub struct Config {
     pub need_network_device_fns: bool,
@@ -32,13 +34,18 @@ pub struct ExploredNetworkAdapterCollection<B: Bmc> {
 }
 
 impl<B: Bmc> ExploredNetworkAdapterCollection<B> {
-    pub async fn explore(chassis: &Chassis<B>, config: &Config) -> Result<Self, Error<B>> {
-        match chassis.network_adapters().await {
+    pub async fn explore(
+        chassis: &Chassis<B>,
+        config: &Config,
+        limiter: &Semaphore,
+    ) -> Result<Self, Error<B>> {
+        match limited(limiter, chassis.network_adapters()).await {
             Ok(Some(network_adapters)) => {
-                let mut members = Vec::new();
-                for na in network_adapters {
-                    members.push(ExploredNetworkAdapter::explore(na, config).await?);
-                }
+                let members = stream::iter(network_adapters)
+                    .map(|na| ExploredNetworkAdapter::explore(na, config, limiter))
+                    .buffered(DEFAULT_MAX_CONCURRENT_BMC_REQUESTS)
+                    .try_collect()
+                    .await?;
                 Ok(Self { members })
             }
             Ok(None) => Ok(Self { members: vec![] }),
@@ -75,22 +82,26 @@ pub struct ExploredNetworkAdapter<B: Bmc> {
 }
 
 impl<B: Bmc> ExploredNetworkAdapter<B> {
-    pub async fn explore(adapter: NetworkAdapter<B>, config: &Config) -> Result<Self, Error<B>> {
-        let functions = if config.need_network_device_fns {
-            if let Some(collection) = adapter
-                .network_device_functions()
-                .await
-                .map_err(Error::nv_redfish("network device function collection"))?
-            {
-                Some(collection.members().await.map_err(Error::nv_redfish(
-                    "network device function collection members",
-                ))?)
+    pub async fn explore(
+        adapter: NetworkAdapter<B>,
+        config: &Config,
+        limiter: &Semaphore,
+    ) -> Result<Self, Error<B>> {
+        let functions =
+            if config.need_network_device_fns {
+                if let Some(collection) = limited(limiter, adapter.network_device_functions())
+                    .await
+                    .map_err(Error::nv_redfish("network device function collection"))?
+                {
+                    Some(limited(limiter, collection.members()).await.map_err(
+                        Error::nv_redfish("network device function collection members"),
+                    )?)
+                } else {
+                    None
+                }
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
         Ok(Self { adapter, functions })
     }
 

--- a/crates/bmc-explorer/src/test_support.rs
+++ b/crates/bmc-explorer/src/test_support.rs
@@ -21,6 +21,7 @@
 use std::sync::Arc;
 
 use nv_redfish::{Bmc, Resource, ServiceRoot};
+use tokio::sync::Semaphore;
 
 use crate::chassis::ExploredChassisCollection;
 use crate::computer_system::{self, ExploredComputerSystem};
@@ -43,9 +44,10 @@ pub async fn detect_hw_type<B: Bmc>(
     mut root: Arc<ServiceRoot<B>>,
     config: &Config<'_, B>,
 ) -> Result<Option<hw::HwType>, Error<B>> {
+    let limiter = Semaphore::new(config.max_concurrent_bmc_requests.max(1));
     let chassis_explore_config = build_chassis_explore_config(&root);
     let explored_chassis =
-        ExploredChassisCollection::explore(&root, &chassis_explore_config).await?;
+        ExploredChassisCollection::explore(&root, &chassis_explore_config, &limiter).await?;
 
     if explored_chassis.is_bluefield2() {
         root = root.as_ref().clone().restrict_expand().into();
@@ -75,7 +77,8 @@ pub async fn detect_hw_type<B: Bmc>(
         need_boot_options: !explored_chassis.is_bluefield4(),
         explore: config,
     };
-    let explored_system = ExploredComputerSystem::explore(system, &system_explore_config).await?;
+    let explored_system =
+        ExploredComputerSystem::explore(system, &system_explore_config, &limiter).await?;
 
     Ok(hw_type(&root, &explored_system, &explored_chassis))
 }

--- a/crates/bmc-explorer/tests/common.rs
+++ b/crates/bmc-explorer/tests/common.rs
@@ -38,5 +38,6 @@ pub fn explorer_config() -> bmc_explorer::Config<'static, TestBmc> {
         boot_interface_mac: None,
         error_classifier: &error_classifier,
         retry_timeout: Duration::from_millis(0),
+        max_concurrent_bmc_requests: bmc_explorer::DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
     }
 }

--- a/crates/bmc-explorer/tests/exploration_concurrency.rs
+++ b/crates/bmc-explorer/tests/exploration_concurrency.rs
@@ -1,0 +1,392 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Guards the concurrency contract of `nv_generate_exploration_report`:
+//!
+//! 1. Independent Redfish fetches overlap (max in-flight >= 2), so a full
+//!    exploration is bounded by the critical path instead of the sum of all
+//!    round-trips.
+//! 2. The fan-out never exceeds the per-BMC request cap (BMCs are fragile).
+//! 3. Concurrency changes only the schedule, not the semantics: the same run
+//!    against a transport-serialized mock (one request at a time) must issue
+//!    the exact same request multiset and produce an identical report.
+//! 4. `Config::max_concurrent_bmc_requests = 1` is the operator escape hatch
+//!    for BMCs that dislike concurrent access: it must restore
+//!    one-request-at-a-time behavior (max in-flight == 1) while still issuing
+//!    the same request multiset and producing the same report.
+//!
+//! The mock BMC router is wrapped with an observing middleware that injects a
+//! fixed per-request delay (so overlap is observable in wall-clock time) and
+//! tracks in-flight/max-in-flight request counts plus the log of requested
+//! paths.
+
+mod common;
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::extract::{Request, State};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use bmc_explorer::{DEFAULT_MAX_CONCURRENT_BMC_REQUESTS, nv_generate_exploration_report};
+use bmc_mock::test_support::axum_http_client::AxumRouterHttpClient;
+use bmc_mock::test_support::{NoopCallbacks, TEST_MAC_POOL, TestBmc};
+use bmc_mock::{
+    DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo, MachineInfo, machine_router,
+};
+use model::site_explorer::EndpointExplorationReport;
+use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
+use tokio::test;
+use url::Url;
+
+/// Injected latency for every mock BMC request. Large enough that overlapping
+/// requests dominate the wall clock, small enough to keep the test fast.
+const PER_REQUEST_DELAY: Duration = Duration::from_millis(25);
+
+/// Tracks the concurrency profile of requests flowing through the mock BMC.
+#[derive(Clone, Default)]
+struct RequestObserver {
+    in_flight: Arc<AtomicUsize>,
+    max_in_flight: Arc<AtomicUsize>,
+    paths: Arc<Mutex<Vec<String>>>,
+}
+
+impl RequestObserver {
+    /// Clears counters, so measurement covers only the exploration itself
+    /// (not the `ServiceRoot` bootstrap).
+    fn reset(&self) {
+        self.in_flight.store(0, Ordering::SeqCst);
+        self.max_in_flight.store(0, Ordering::SeqCst);
+        self.paths.lock().unwrap().clear();
+    }
+
+    fn max_in_flight(&self) -> usize {
+        self.max_in_flight.load(Ordering::SeqCst)
+    }
+
+    fn request_count(&self) -> usize {
+        self.paths.lock().unwrap().len()
+    }
+
+    /// The requested paths as a multiset (path -> occurrence count).
+    fn multiset(&self) -> BTreeMap<String, usize> {
+        let mut multiset = BTreeMap::new();
+        for path in self.paths.lock().unwrap().iter() {
+            *multiset.entry(path.clone()).or_insert(0) += 1;
+        }
+        multiset
+    }
+}
+
+/// Middleware: records the requested path, tracks in-flight/max-in-flight, and
+/// injects [`PER_REQUEST_DELAY`] while the request counts as in-flight.
+async fn observe(
+    State(observer): State<RequestObserver>,
+    request: Request,
+    next: Next,
+) -> Response {
+    observer
+        .paths
+        .lock()
+        .unwrap()
+        .push(request.uri().path().to_string());
+    let now_in_flight = observer.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+    observer
+        .max_in_flight
+        .fetch_max(now_in_flight, Ordering::SeqCst);
+    tokio::time::sleep(PER_REQUEST_DELAY).await;
+    let response = next.run(request).await;
+    observer.in_flight.fetch_sub(1, Ordering::SeqCst);
+    response
+}
+
+/// Middleware: admits one request at a time. Wrapping the observer with this
+/// gate yields the serial reference run: the same exploration code, forced to
+/// execute its requests sequentially at the transport.
+async fn serialize_requests(
+    State(gate): State<Arc<tokio::sync::Semaphore>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let _permit = gate
+        .acquire()
+        .await
+        .expect("serialization gate is never closed");
+    next.run(request).await
+}
+
+struct InstrumentedBmc {
+    service_root: Arc<nv_redfish::ServiceRoot<TestBmc>>,
+    observer: RequestObserver,
+}
+
+async fn instrumented_bmc(
+    machine_info: &MachineInfo,
+    machine_id: &str,
+    serialized: bool,
+) -> InstrumentedBmc {
+    let (router, _state) = machine_router(
+        machine_info,
+        Arc::new(NoopCallbacks),
+        machine_id.to_string(),
+        false,
+    );
+    let observer = RequestObserver::default();
+    let mut router = router.layer(middleware::from_fn_with_state(observer.clone(), observe));
+    if serialized {
+        // Applied after (thus outside of) the observer, so the gate is held
+        // across the observer's whole span: a serialized run must report
+        // max_in_flight == 1, which doubles as proof the observer works.
+        router = router.layer(middleware::from_fn_with_state(
+            Arc::new(tokio::sync::Semaphore::new(1)),
+            serialize_requests,
+        ));
+    }
+
+    let client = AxumRouterHttpClient::new(router);
+    let endpoint = Url::parse("https://bmc-mock.local").expect("valid URL");
+    let credentials = BmcCredentials::new("root".to_string(), "password".to_string());
+    let bmc = Arc::new(HttpBmc::new(
+        client,
+        endpoint,
+        credentials,
+        CacheSettings::with_capacity(32),
+    ));
+    let service_root = nv_redfish::ServiceRoot::new(bmc)
+        .await
+        .expect("service root")
+        .into();
+    // Measure the exploration only, not the ServiceRoot bootstrap.
+    observer.reset();
+    InstrumentedBmc {
+        service_root,
+        observer,
+    }
+}
+
+struct Measurement {
+    report: EndpointExplorationReport,
+    wall_clock: Duration,
+    max_in_flight: usize,
+    request_count: usize,
+    multiset: BTreeMap<String, usize>,
+}
+
+/// Compile-time guard: the exploration future must stay `Send` for a `Send`
+/// transport — site-explorer awaits it from spawned (Send-checked) tasks.
+/// Stream adapters whose closures take borrowed items embed closure types in
+/// the future and break this proof (rustc "implementation of `FnOnce`/`Send`
+/// is not general enough"), so a regression fails compilation right here.
+fn require_send<T: Send>(value: T) -> T {
+    value
+}
+
+async fn measure(
+    machine_info: &MachineInfo,
+    machine_id: &str,
+    serialized: bool,
+    max_concurrent_bmc_requests: usize,
+) -> Measurement {
+    let bmc = instrumented_bmc(machine_info, machine_id, serialized).await;
+    let config = bmc_explorer::Config {
+        max_concurrent_bmc_requests,
+        ..common::explorer_config()
+    };
+    let started = Instant::now();
+    let report = require_send(nv_generate_exploration_report(bmc.service_root, &config))
+        .await
+        .expect("exploration must succeed");
+    let wall_clock = started.elapsed();
+    Measurement {
+        report,
+        wall_clock,
+        max_in_flight: bmc.observer.max_in_flight(),
+        request_count: bmc.observer.request_count(),
+        multiset: bmc.observer.multiset(),
+    }
+}
+
+fn print_measurements(
+    label: &str,
+    serialized: &Measurement,
+    free: &Measurement,
+    capped_to_one: &Measurement,
+) {
+    println!(
+        "[measure:{label}] serialized: wall_clock={:?} requests={} max_in_flight={}",
+        serialized.wall_clock, serialized.request_count, serialized.max_in_flight,
+    );
+    println!(
+        "[measure:{label}] free:       wall_clock={:?} requests={} max_in_flight={}",
+        free.wall_clock, free.request_count, free.max_in_flight,
+    );
+    println!(
+        "[measure:{label}] cap=1:      wall_clock={:?} requests={} max_in_flight={}",
+        capped_to_one.wall_clock, capped_to_one.request_count, capped_to_one.max_in_flight,
+    );
+    println!(
+        "[measure:{label}] request multiset ({} paths): {:?}",
+        free.request_count, free.multiset,
+    );
+}
+
+fn assert_concurrent_run_matches_serial_reference(
+    label: &str,
+    serialized: &Measurement,
+    free: &Measurement,
+    capped_to_one: &Measurement,
+) {
+    print_measurements(label, serialized, free, capped_to_one);
+
+    // The gated run proves the observer detects serial execution: exactly one
+    // request may be in flight.
+    assert_eq!(
+        serialized.max_in_flight, 1,
+        "transport-serialized run must never overlap requests",
+    );
+    assert!(
+        serialized.request_count > 0,
+        "observer must have seen the exploration requests",
+    );
+
+    // Deterministic concurrency proof: independent fetches must overlap.
+    assert!(
+        free.max_in_flight >= 2,
+        "exploration must overlap independent requests, max_in_flight={}",
+        free.max_in_flight,
+    );
+    // ... but never beyond the per-BMC cap.
+    assert!(
+        free.max_in_flight <= DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
+        "exploration must respect the default per-BMC request cap of \
+         {DEFAULT_MAX_CONCURRENT_BMC_REQUESTS}, max_in_flight={}",
+        free.max_in_flight,
+    );
+
+    // Semantic parity: concurrency changes the schedule, not the requests
+    // issued nor the report produced.
+    assert_eq!(
+        serialized.multiset, free.multiset,
+        "concurrent exploration must issue exactly the requests of a serial run",
+    );
+    assert_eq!(
+        serialized.report, free.report,
+        "concurrent exploration must produce the identical report",
+    );
+
+    // The operator escape hatch: a cap of 1 must restore one-request-at-a-time
+    // behavior at the client (for BMCs that dislike concurrent access), while
+    // still issuing the same requests and producing the same report.
+    assert_eq!(
+        capped_to_one.max_in_flight, 1,
+        "cap=1 exploration must never overlap requests",
+    );
+    assert_eq!(
+        capped_to_one.multiset, free.multiset,
+        "cap=1 exploration must issue exactly the requests of the free run",
+    );
+    assert_eq!(
+        capped_to_one.report, free.report,
+        "cap=1 exploration must produce the identical report",
+    );
+
+    // Wall clocks are diagnostic output only: the deterministic guards above
+    // (max-in-flight, request multiset, report equality) prove the overlap,
+    // and any timing comparison could flake on a loaded runner.
+    println!(
+        "wall clocks -- serialized: {:?}, free: {:?}, cap=1: {:?}",
+        serialized.wall_clock, free.wall_clock, capped_to_one.wall_clock,
+    );
+}
+
+fn dell_r750_host_info() -> MachineInfo {
+    let hw_type = HostHardwareType::DellPowerEdgeR750;
+    let mut pool = TEST_MAC_POOL.lock().unwrap();
+    let ranges_config = pool.allocate_range_config().expect("range config");
+    let dpu_count = hw_type.fixed_number_of_dpu().unwrap_or(0);
+    MachineInfo::Host(HostMachineInfo::new(
+        hw_type,
+        (0..dpu_count)
+            .map(|_| DpuMachineInfo::new(hw_type, &mut pool, DpuSettings::default()))
+            .collect(),
+        &mut pool,
+        ranges_config,
+    ))
+}
+
+fn bluefield3_dpu_info() -> MachineInfo {
+    let mut pool = TEST_MAC_POOL.lock().unwrap();
+    MachineInfo::Dpu(DpuMachineInfo::new(
+        HostHardwareType::DellPowerEdgeR750,
+        &mut pool,
+        DpuSettings::default(),
+    ))
+}
+
+/// Dell host BMC: exercises the network-device-function fan-out (Dell explores
+/// adapters with `need_network_device_fns`) and the Dell manager OEM branch.
+#[test]
+async fn exploration_overlaps_requests_with_parity_dell_r750() {
+    let machine_info = dell_r750_host_info();
+    let serialized = measure(
+        &machine_info,
+        "test-host-id",
+        true,
+        DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
+    )
+    .await;
+    let free = measure(
+        &machine_info,
+        "test-host-id",
+        false,
+        DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
+    )
+    .await;
+    let capped_to_one = measure(&machine_info, "test-host-id", false, 1).await;
+    assert_concurrent_run_matches_serial_reference("dell_r750", &serialized, &free, &capped_to_one);
+}
+
+/// BlueField-3 DPU BMC: exercises the lazily-fetched chassis links (with the
+/// ERoT skip filter) and the BlueField computer-system branches (OEM +
+/// secure-boot + eth-interface retry path).
+#[test]
+async fn exploration_overlaps_requests_with_parity_bluefield3_dpu() {
+    let machine_info = bluefield3_dpu_info();
+    let serialized = measure(
+        &machine_info,
+        "test-dpu-id",
+        true,
+        DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
+    )
+    .await;
+    let free = measure(
+        &machine_info,
+        "test-dpu-id",
+        false,
+        DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
+    )
+    .await;
+    let capped_to_one = measure(&machine_info, "test-dpu-id", false, 1).await;
+    assert_concurrent_run_matches_serial_reference(
+        "bluefield3_dpu",
+        &serialized,
+        &free,
+        &capped_to_one,
+    );
+}

--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -35,6 +35,18 @@ pub type RedfishBmc = HttpBmc<RedfishReqwestClient>;
 pub type ServiceRoot = NvServiceRoot<RedfishBmc>;
 pub type Error = NvError<RedfishBmc>;
 
+/// Idle connections the reqwest pool retains per BMC.
+///
+/// BMC exploration fetches independent Redfish subtrees concurrently, keeping
+/// up to `Config::max_concurrent_bmc_requests` (bmc-explorer) requests in
+/// flight against one endpoint. Retaining as many idle connections as that
+/// cap's default (`DEFAULT_MAX_CONCURRENT_BMC_REQUESTS`, also 4) lets the
+/// default fan-out reuse warm sockets instead of opening (and dropping) a
+/// fresh connection per concurrent request; the nv-redfish default retains
+/// only one. A site configured with a lower per-BMC cap simply leaves idle
+/// capacity unused.
+const POOL_MAX_IDLE_PER_HOST: usize = 4;
+
 pub fn new_pool(proxy_address: Arc<ArcSwap<Option<HostPortPair>>>) -> Arc<NvRedfishClientPool> {
     NvRedfishClientPool::new(proxy_address).into()
 }
@@ -171,7 +183,9 @@ impl NvRedfishClientPool {
         }
 
         let client = RedfishReqwestClient::with_params(
-            RedfishReqwestClientParams::new().accept_invalid_certs(true),
+            RedfishReqwestClientParams::new()
+                .accept_invalid_certs(true)
+                .pool_max_idle_per_host(POOL_MAX_IDLE_PER_HOST),
         )
         .map_err(|err| Error::Bmc(err.into()))?;
         Ok(Arc::new(RedfishBmc::with_custom_headers(

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -61,9 +61,11 @@ pub struct BmcEndpointExplorer {
 }
 
 impl BmcEndpointExplorer {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         redfish_client_pool: Arc<dyn RedfishClientPool>,
         nv_redfish_client_pool: Arc<NvRedfishClientPool>,
+        max_concurrent_bmc_requests: usize,
         ipmi_tool: Arc<dyn IPMITool>,
         credential_manager: Arc<dyn CredentialManager>,
         rotate_switch_nvos_credentials: Arc<AtomicBool>,
@@ -71,7 +73,11 @@ impl BmcEndpointExplorer {
         database_connection: Option<PgPool>,
     ) -> Self {
         Self {
-            redfish_client: RedfishClient::new(redfish_client_pool, nv_redfish_client_pool),
+            redfish_client: RedfishClient::new(
+                redfish_client_pool,
+                nv_redfish_client_pool,
+                max_concurrent_bmc_requests,
+            ),
             ipmi_tool,
             credential_client: CredentialClient::new(credential_manager),
             rotate_switch_nvos_credentials,

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -73,6 +73,12 @@ pub struct SiteExplorerConfig {
     #[serde(default = "SiteExplorerConfig::default_explorations_per_run")]
     pub explorations_per_run: u64,
 
+    /// The maximum number of in-flight Redfish requests to a single BMC
+    /// during exploration. `1` explores one request at a time, for BMCs that
+    /// dislike concurrent access. Default is 4.
+    #[serde(default = "SiteExplorerConfig::default_max_concurrent_bmc_requests")]
+    pub max_concurrent_bmc_requests: usize,
+
     /// When false, SiteExplorer skips creating ManagedHost state machines; the DPU agent (scout) must self-register via DiscoverMachine gRPC endpoint with create_machine=true
     #[serde(
         default = "SiteExplorerConfig::default_create_machines",
@@ -203,6 +209,7 @@ impl Default for SiteExplorerConfig {
             run_interval: Self::default_run_interval(),
             concurrent_explorations: Self::default_concurrent_explorations(),
             explorations_per_run: Self::default_explorations_per_run(),
+            max_concurrent_bmc_requests: Self::default_max_concurrent_bmc_requests(),
             create_machines: Arc::new(true.into()),
             machines_created_per_run: Self::default_machines_created_per_run(),
             override_target_ip: None,
@@ -230,6 +237,7 @@ impl PartialEq for SiteExplorerConfig {
             && self.run_interval == other.run_interval
             && self.concurrent_explorations == other.concurrent_explorations
             && self.explorations_per_run == other.explorations_per_run
+            && self.max_concurrent_bmc_requests == other.max_concurrent_bmc_requests
             && self.create_machines.load(AtomicOrdering::Relaxed)
                 == other.create_machines.load(AtomicOrdering::Relaxed)
             && self.override_target_ip == other.override_target_ip
@@ -256,6 +264,10 @@ impl SiteExplorerConfig {
 
     pub const fn default_explorations_per_run() -> u64 {
         90
+    }
+
+    pub const fn default_max_concurrent_bmc_requests() -> usize {
+        bmc_explorer::DEFAULT_MAX_CONCURRENT_BMC_REQUESTS
     }
 
     pub const fn default_machines_created_per_run() -> u64 {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -103,9 +103,11 @@ use self::metrics::{DpuMigrationSignal, PairingBlockerReason, exploration_error_
 use crate::config::SiteExplorerExploreMode;
 use crate::explored_endpoint_index::ExploredEndpointIndex;
 
+#[allow(clippy::too_many_arguments)]
 pub fn new_bmc_explorer(
     redfish_client_pool: Arc<dyn RedfishClientPool>,
     nv_redfish_client_pool: Arc<NvRedfishClientPool>,
+    max_concurrent_bmc_requests: usize,
     ipmi_tool: Arc<dyn IPMITool>,
     credential_manager: Arc<dyn CredentialManager>,
     rotate_switch_nvos_credentials: Arc<AtomicBool>,
@@ -115,6 +117,7 @@ pub fn new_bmc_explorer(
     BmcEndpointExplorer::new(
         redfish_client_pool,
         nv_redfish_client_pool,
+        max_concurrent_bmc_requests,
         ipmi_tool,
         credential_manager,
         rotate_switch_nvos_credentials,

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -51,16 +51,21 @@ const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
 pub struct RedfishClient {
     redfish_client_pool: Arc<dyn RedfishClientPool>,
     nv_redfish_client_pool: Arc<NvRedfishClientPool>,
+    /// Cap on in-flight Redfish requests one exploration keeps against a
+    /// single BMC (`[site_explorer] max_concurrent_bmc_requests`).
+    max_concurrent_bmc_requests: usize,
 }
 
 impl RedfishClient {
     pub fn new(
         redfish_client_pool: Arc<dyn RedfishClientPool>,
         nv_redfish_client_pool: Arc<NvRedfishClientPool>,
+        max_concurrent_bmc_requests: usize,
     ) -> Self {
         Self {
             redfish_client_pool,
             nv_redfish_client_pool,
+            max_concurrent_bmc_requests,
         }
     }
 
@@ -345,7 +350,7 @@ impl RedfishClient {
 
         bmc_explorer::nv_generate_exploration_report(
             service_root,
-            &nv_bmc_explore_config(boot_interface_mac),
+            &nv_bmc_explore_config(boot_interface_mac, self.max_concurrent_bmc_requests),
         )
         .await
         .map_err(map_nv_redfish_explore_error)
@@ -1365,6 +1370,7 @@ fn nv_error_classifier(
 
 fn nv_bmc_explore_config(
     boot_interface_mac: Option<MacAddress>,
+    max_concurrent_bmc_requests: usize,
 ) -> bmc_explorer::Config<'static, carbide_redfish::nv_redfish::RedfishBmc> {
     bmc_explorer::Config {
         boot_interface_mac,
@@ -1373,6 +1379,7 @@ fn nv_bmc_explore_config(
         // but not for too long relative to the total exploration
         // time.
         retry_timeout: Duration::from_millis(1000),
+        max_concurrent_bmc_requests,
     }
 }
 
@@ -1480,7 +1487,11 @@ mod tests {
     fn build_redfish_client(sim: Arc<RedfishSim>) -> RedfishClient {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let nv_pool = Arc::new(NvRedfishClientPool::new(proxy_address));
-        RedfishClient::new(sim, nv_pool)
+        RedfishClient::new(
+            sim,
+            nv_pool,
+            bmc_explorer::DEFAULT_MAX_CONCURRENT_BMC_REQUESTS,
+        )
     }
 
     /// Rotate a BMC's root password against the sim and report the vendor

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -1628,6 +1628,7 @@ async fn test_site_explorer_audit_exploration_results(
         retained_boot_interface_window: None,
         explorations_per_run: 7,
         concurrent_explorations: 1,
+        max_concurrent_bmc_requests: SiteExplorerConfig::default_max_concurrent_bmc_requests(),
         run_interval: std::time::Duration::from_secs(1),
         create_machines: Arc::new(true.into()),
         machines_created_per_run: 1,


### PR DESCRIPTION
Exploring a BMC walked its whole Redfish tree one request at a time: chassis, firmware inventory, systems, managers, and every collection member waited on the previous fetch, so a full exploration cost the sum of every round-trip. Against real BMC latencies that is seconds per endpoint, paid for every host, DPU, and switch on the provisioning path.

Independent subtrees and collection members now fetch concurrently under a per-exploration cap of four in-flight requests by default. The cap is a site setting -- `[site_explorer] max_concurrent_bmc_requests` -- and a value of one explores one request at a time, for BMCs that dislike concurrent access (the way pre-iLO-7 HPE BMCs already need `Connection: Close`). Ordering-sensitive steps stay sequential: the chassis sweep still precedes systems and managers (a BlueField-2 chassis result reconfigures the service root's expand behavior), manager exploration still follows the system's hardware-type detection, and collection results keep their member order. The Redfish client retains as many idle connections as the default fan-out so concurrent fetches reuse warm sockets.

- `try_join!` independent top-level subtrees and the per-resource sub-fetches inside system and manager exploration.
- Order-preserving `buffered` member loops under one shared semaphore bounding the whole exploration.
- The cap plumbs from site config through `site-explorer` to the exploration semaphore; the CLI uses the default.

A mock-BMC test drives the same exploration serialized, free, and at a cap of one, and asserts the request multisets and resulting reports are identical in every mode, that free-run concurrency reaches the cap, and that a cap of one observes one request at a time. With 25ms injected latency the sample host and DPU explore 1.8-2.0x faster at the default cap; wider real topologies have more parallel breadth.

This supports https://github.com/NVIDIA/infra-controller/issues/3209
