### PR TITLE
feat (web-ui): configuration page redesign

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,7 @@ dependencies = [
  "lazy_static",
  "mac_address",
  "oauth2",
+ "regex",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tower",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tower",
  "tower-http",

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -9,97 +9,112 @@ applicable.
 
 ## `NicoConfig` (top-level)
 
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `listen` | `SocketAddr` | `[::]:1079` | Socket address for the gRPC API server. |
-| `listen_only` | `bool` | `false` | Run passively (no background services, RPC/web only). Used in dev mode. |
-| `metrics_endpoint` | `Option<SocketAddr>` | — | Socket address for the Prometheus `/metrics` HTTP server. |
-| `alt_metric_prefix` | `Option<String>` | — | Alternative metric prefix emitted alongside `nico_` for dashboard migration. |
-| `database_url` | `String` | **required** | Postgres connection string for all persistent state. |
-| `max_database_connections` | `u32` | `1000` | Maximum database connection pool size. |
-| `ib_config` | `Option<IBFabricConfig>` | — | InfiniBand fabric configuration (see [IBFabricConfig](#ibfabricconfig)). |
-| `asn` | `u32` | **required** | Autonomous System Number, fixed per environment. Used by nico-dpu-agent for `frr.conf` BGP routing. |
-| `dhcp_servers` | `Vec<Ipv4Addr>` | `[]` | DHCP server addresses announced to DPUs during network provisioning. |
-| `ntp_servers` | `Vec<Ipv4Addr>` | `[]` | Site-level NTP server IPs used for BMC time configuration and DHCP NTP Server configuration. |
-| `route_servers` | `Vec<String>` | `[]` | Route server IPs for L2VPN Ethernet Virtual network support. |
-| `enable_route_servers` | `bool` | `false` | Enables route server injection into DPU FRR configs for L2VPN. |
-| `deny_prefixes` | `Vec<Ipv4Network>` | `[]` | IPv4 CIDR prefixes that tenant instances are blocked from reaching. Generates iptables DROP rules and nvue ACL policies. |
-| `site_fabric_prefixes` | `Vec<IpNetwork>` | `[]` | IP prefixes (v4/v6) assigned for tenant use within this site. |
-| `anycast_site_prefixes` | `Vec<Ipv4Network>` | `[]` | Aggregate IPv4 prefixes containing tenant-announced prefixes (e.g., BYOIP). **Deprecated.** Use [`routing_profiles.allowed_anycast_prefixes`](#fnnroutingprofileconfig) instead. |
-| `common_tenant_host_asn` | `Option<u32>` | — | ASN that tenants use to peer with the DPU. If unset, any ASN is accepted. |
-| `vpc_isolation_behavior` | `VpcIsolationBehaviorType` | `MutualIsolation` | VPC isolation policy: `mutual_isolation` or `open`. |
-| `host_naming_strategy` | `HostNamingStrategyKind` | `IpAddress` | How new machine hostnames are derived: `ip_address` (IP-derived, e.g. `10-1-2-3`; the default and backwards-compatible), `fun` (stable adjective-noun handles like `wholesale-walrus`), `serial_number` (a machine's hardware serial -- the primary interface gets the bare serial, secondary interfaces get `serial-<mac>`, BMC interfaces stay IP-named), or `mac_address` (each interface's own MAC, e.g. `0a-1b-2c-3d-4e-5f`). Only `fun` leaves existing hostnames unchanged -- it keeps any real name, whether IP-, serial-, or MAC-derived, so after a switch fun names appear only on newly named interfaces; the others re-derive, so switching to one progressively renames interfaces as they reconcile. Junk placeholder serials (e.g. `To Be Filled By O.E.M.`) fall back to the IP name, and `serial_number` errors on duplicate serials rather than assigning a substitute name. |
-| `dpu_network_monitor_pinger_type` | `Option<String>` | — | Pinger implementation type (e.g., `"OobNetBind"`) for DPU link health checks. |
-| `tls` | `Option<TlsConfig>` | — | TLS certificate/key paths (see [TlsConfig](#tlsconfig)). |
-| `listen_mode` | `ListenMode` | `Tls` | Transport mode: `plaintext_http1`, `plaintext_http2`, or `tls`. |
-| `auth` | `Option<AuthConfig>` | — | Authentication/authorization settings (see [AuthConfig](#authconfig)). |
-| `pools` | `Option<HashMap<String, ResourcePoolDef>>` | — | Resource pools that allocate IPs, VNIs, etc. Required but `Option` for partial-config merging. |
-| `networks` | `Option<HashMap<String, NetworkDefinition>>` | — | Networks created at startup. Alternative: `CreateNetworkSegment` gRPC. `NetworkDefinition` supports dual-stack seed-time segments with optional `prefix_v6` and `dhcpv6_link_address`; config edits do not retrofit prefixes onto an already-seeded segment because seed definitions are snapshotted on first create. |
-| `dpu_ipmi_tool_impl` | `Option<String>` | — | IPMI tool implementation for DPU power control (`"prod"` or `"fake"`). |
-| `dpu_ipmi_reboot_attempts` | `Option<u32>` | — | Retry count when IPMI errors during DPU reboot. |
-| `bmc_session_lockout_threshold` | `u32` | `3` | Consecutive BMC HTTP 401/403 responses before session-token login attempts stop for that BMC. |
-| `ib_fabrics` | `HashMap<String, IbFabricDefinition>` | `{}` | InfiniBand fabrics managed by the site. Currently only one fabric is supported. |
-| `initial_domain_name` | `Option<String>` | — | Domain to create if none exist. Most sites use a single domain. |
-| `initial_dpu_agent_upgrade_policy` | `Option<AgentUpgradePolicyChoice>` | — | Policy for nico-dpu-agent upgrades. Also settable via `nico-admin-cli`. |
-| `max_concurrent_machine_updates` | `Option<i32>` | — | **Deprecated.** Use `machine_updater` instead. |
-| `machine_update_run_interval` | `Option<u64>` | — | Interval (seconds) at which the machine update manager checks for updates. |
-| `retained_boot_interface_window` | `Option<Duration>` | — (forever) | How long a retained boot interface pair (`retained_boot_interfaces` table) stays applicable after its `machine_interfaces` row was deleted. Unset retains forever; set a window (e.g. `30d`) so a MAC reappearing on different hardware doesn't inherit an obsolete Redfish interface id. |
-| `site_explorer` | `SiteExplorerConfig` | *(see below)* | SiteExplorer hardware discovery settings (see [SiteExplorerConfig](#siteexplorerconfig)). |
-| `nvue_enabled` | `bool` | `true` | DPU agent uses NVUE for config instead of writing files directly. |
-| `vpc_peering_policy` | `Option<VpcPeeringPolicy>` | — | Policy for VPC peering based on network virtualization type at creation time. |
-| `vpc_peering_policy_on_existing` | `Option<VpcPeeringPolicy>` | — | Policy for whether existing VPC peerings should be active. |
-| `attestation_enabled` | `bool` | `false` | Enables TPM-based machine attestation (adds `Measuring` state before `Ready`). |
-| `tpm_required` | `bool` | `true` | Require TPM module for machine registration. **Testing only** when `false`. |
-| `machine_state_controller` | `MachineStateControllerConfig` | *(see below)* | Machine state controller timing (see [MachineStateControllerConfig](#machinestatecontrollerconfig)). |
-| `network_segment_state_controller` | `NetworkSegmentStateControllerConfig` | *(see below)* | Network segment state controller timing. |
-| `vpc_prefix_state_controller` | `VpcPrefixStateControllerConfig` | *(see below)* | VPC prefix state controller timing. |
-| `ib_partition_state_controller` | `IbPartitionStateControllerConfig` | *(see below)* | IB partition state controller timing. |
-| `dpa_interface_state_controller` | `DpaInterfaceStateControllerConfig` | *(see below)* | DPA interface state controller timing. |
-| `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | Rack state controller timing. |
-| `power_shelf_state_controller` | `PowerShelfStateControllerConfig` | *(see below)* | Power shelf state controller timing. |
-| `switch_state_controller` | `SwitchStateControllerConfig` | *(see below)* | Switch state controller timing. |
-| `spdm_state_controller` | `SpdmStateControllerConfig` | *(see below)* | SPDM state controller timing. |
-| `host_models` | `HashMap<String, Firmware>` | `{}` | Maps host model identifiers to firmware definitions for BMC/UEFI/NIC upgrades. |
-| `firmware_global` | `FirmwareGlobal` | *(see below)* | Global firmware update settings (see [FirmwareGlobal](#firmwareglobal)). |
-| `machine_updater` | `MachineUpdater` | *(see below)* | Machine update policies (see [MachineUpdater](#machineupdater)). |
-| `max_find_by_ids` | `u32` | `100` | Max IDs accepted by `find_*_by_ids` APIs. |
-| `network_security_group` | `NetworkSecurityGroupConfig` | *(see below)* | NSG settings (see [NetworkSecurityGroupConfig](#networksecuritygroupconfig)). |
-| `min_dpu_functioning_links` | `Option<u32>` | — | Minimum functioning DPU links for healthy status. If unset, all must work. |
-| `host_health` | `HostHealthConfig` | *(default)* | Host health monitoring thresholds for hardware health and DPU agent compliance. |
-| `observability` | `ObservabilityConfig` | *(default)* | Observability settings shared across all state controllers (see [ObservabilityConfig](#observabilityconfig)). |
-| `internet_l3_vni` | `u32` | `100001` | Network infrastructure-provided L3 VNI for FNN VPC Internet connectivity. Combined with `datacenter_asn` for route-target. |
-| `measured_boot_collector` | `MeasuredBootMetricsCollectorConfig` | *(see below)* | Measured boot metrics exporter (see [MeasuredBootMetricsCollectorConfig](#measuredbootmetricscollectorconfig)). |
-| `machine_validation_config` | `MachineValidationConfig` | *(see below)* | Machine validation tests (see [MachineValidationConfig](#machinevalidationconfig)). |
-| `machine_identity` | `MachineIdentityConfig` | *(see below)* | SPIFFE JWT-SVID machine identity (see [MachineIdentityConfig](#machineidentityconfig)). |
-| `bypass_rbac` | `bool` | `false` | Disables RBAC enforcement. **Testing/dev only.** |
-| `dpu_config` | `DpuConfig` | *(see below)* | DPU firmware and provisioning (see [DpuConfig](#dpuconfig)). |
-| `fnn` | `Option<FnnConfig>` | — | FNN L3 VNI overlay networking (see [FnnConfig](#fnnconfig)). |
-| `bom_validation` | `BomValidationConfig` | *(see below)* | BOM/SKU validation (see [BomValidationConfig](#bomvalidationconfig)). |
-| `bios_profiles` | `BiosProfileVendor` | *(default)* | BIOS profiles by vendor/model for Redfish BIOS management. |
-| `selected_profile` | `BiosProfileType` | *(default)* | Default BIOS profile type applied to machines. |
-| `dpa_config` | `Option<DpaConfig>` | — | Cluster Interconnect (east-west Ethernet) config (see [DpaConfig](#dpaconfig)). |
-| `dsx_exchange_event_bus` | `Option<DsxExchangeEventBusConfig>` | — | MQTT event bus for managed-host state publishing plus BMS metadata subscription and rack/isolation/heartbeat publishing (see [DsxExchangeEventBusConfig](#dsxexchangeeventbusconfig)). |
-| `datacenter_asn` | `u32` | `11414` | Datacenter ASN used by FNN for DC-specific route targets. |
-| `nvlink_config` | `Option<NvLinkConfig>` | — | NvLink partitioning via NMX-C (see [NvLinkConfig](#nvlinkconfig)). |
-| `power_manager_options` | `PowerManagerOptions` | *(see below)* | Power management timing (see [PowerManagerOptions](#powermanageroptions)). |
-| `sitename` | `Option<String>` | — | Human-readable site name exposed to tenants via FMDS. |
-| `auto_machine_repair_plugin` | `AutoMachineRepairPluginConfig` | *(default)* | Auto-repair configuration for failed machines. |
-| `vmaas_config` | `Option<VmaasConfig>` | — | VMaaS configuration for VM system integration (see [VmaasConfig](#vmaasconfig)). |
-| `mlxconfig_profiles` | `Option<HashMap<String, MlxConfigProfile>>` | — | Named Mellanox NIC register configuration profiles for superNIC firmware flashing. TOML key: `mlx-config-profiles`. |
-| `rack_management_enabled` | `bool` | `false` | Standalone infrastructure manager mode for GB200/GB300/VR144. See doc comment for full behavioral changes. |
-| `rms` | `RmsConfig` | *(see below)* | Rack Manager Service configuration for API connectivity and mTLS (see [RmsConfig](#rmsconfig)). |
-| `rack_profiles` | `RackProfileConfig` | *(default)* | Rack profile definitions referenced by expected racks. |
-| `spdm` | `SpdmConfig` | *(see below)* | SPDM hardware attestation (see [SpdmConfig](#spdmconfig)). |
-| `bgp_leaf_session_password` | `Option<BgpLeafSessionPassword>` | — | Selects the credential source for leaf-facing BGP session passwords returned to agents in managed host network config. Supported value: `site_wide`. |
-| `site_global_vpc_vni` | `Option<u32>` | — | Forces all VRFs to share a single VNI (Cumulus Linux route-leaking workaround). Limits DPU to one VRF. |
-| `dpf` | `DpfConfig` | *(see below)* | DPF (DPU Platform Framework) Kubernetes deployment (see [DpfConfig](#dpfconfig)). |
-| `x86_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for x86 machines. |
-| `arm_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for ARM machines. |
-| `pxe_public_base_url` | `String` | `http://carbide-pxe.forge:8080` | Canonical PXE base URL. |
-| `set_http_boot_uri_for_vendors` | `Vec<BMCVendor>` | `[]` | Vendors for which the state controller pins the UEFI HTTP boot URL on the BMC via Redfish `HttpBootUri`. Empty = all machines rely on nico-dhcp option 67 for the URL. |
-| `compute_allocation_enforcement` | `ComputeAllocationEnforcement` | `WarnOnly` | Controls enforcement of compute allocations on new instance requests. |
-| `supernic_firmware_profiles` | nested `HashMap` | `{}` | SuperNIC firmware profiles keyed by `part_number` then `PSID`. |
-| `component_manager` | `Option<ComponentManagerConfig>` | — | Component manager for NvLink switches and power shelves. |
+| Field | Type | Default | Group | Description |
+|-------|------|---------|-------|-------------|
+| `listen` | `SocketAddr` | `[::]:1079` | `server` | Socket address for the gRPC API server. |
+| `listen_only` | `bool` | `false` | `server` | Run passively (no background services, RPC/web only). Used in dev mode. |
+| `metrics_endpoint` | `Option<SocketAddr>` | — | `integrations` | Socket address for the Prometheus `/metrics` HTTP server. |
+| `alt_metric_prefix` | `Option<String>` | — | `integrations` | Alternative metric prefix emitted alongside `nico_` for dashboard migration. |
+| `database_url` | `String` | **required** | `server` | Postgres connection string for all persistent state. |
+| `max_database_connections` | `u32` | `1000` | `server` | Maximum database connection pool size. |
+| `ib_config` | `Option<IBFabricConfig>` | — | `hardware` | InfiniBand fabric configuration (see [IBFabricConfig](#ibfabricconfig)). |
+| `asn` | `u32` | **required** | `networking` | Autonomous System Number, fixed per environment. Used by nico-dpu-agent for `frr.conf` BGP routing. |
+| `dhcp_servers` | `Vec<Ipv4Addr>` | `[]` | `networking` | DHCP server addresses announced to DPUs during network provisioning. |
+| `ntp_servers` | `Vec<Ipv4Addr>` | `[]` | `networking` | Site-level NTP server IPs used for BMC time configuration and DHCP NTP Server configuration. |
+| `route_servers` | `Vec<String>` | `[]` | `networking` | Route server IPs for L2VPN Ethernet Virtual network support. |
+| `enable_route_servers` | `bool` | `false` | `networking` | Enables route server injection into DPU FRR configs for L2VPN. |
+| `deny_prefixes` | `Vec<Ipv4Network>` | `[]` | `networking` | IPv4 CIDR prefixes that tenant instances are blocked from reaching. Generates iptables DROP rules and nvue ACL policies. |
+| `site_fabric_prefixes` | `Vec<IpNetwork>` | `[]` | `networking` | IP prefixes (v4/v6) assigned for tenant use within this site. |
+| `anycast_site_prefixes` | `Vec<Ipv4Network>` | `[]` | `networking` | Aggregate IPv4 prefixes containing tenant-announced prefixes (e.g., BYOIP). **Deprecated.** Use [`routing_profiles.allowed_anycast_prefixes`](#fnnroutingprofileconfig) instead. |
+| `common_tenant_host_asn` | `Option<u32>` | — | `networking` | ASN that tenants use to peer with the DPU. If unset, any ASN is accepted. |
+| `vpc_isolation_behavior` | `VpcIsolationBehaviorType` | `MutualIsolation` | `networking` | VPC isolation policy: `mutual_isolation` or `open`. |
+| `host_naming_strategy` | `HostNamingStrategyKind` | `IpAddress` | `machines` | How new machine hostnames are derived: `ip_address` (IP-derived, e.g. `10-1-2-3`; the default and backwards-compatible), `fun` (stable adjective-noun handles like `wholesale-walrus`), `serial_number` (a machine's hardware serial -- the primary interface gets the bare serial, secondary interfaces get `serial-<mac>`, BMC interfaces stay IP-named), or `mac_address` (each interface's own MAC, e.g. `0a-1b-2c-3d-4e-5f`). Only `fun` leaves existing hostnames unchanged -- it keeps any real name, whether IP-, serial-, or MAC-derived, so after a switch fun names appear only on newly named interfaces; the others re-derive, so switching to one progressively renames interfaces as they reconcile. Junk placeholder serials (e.g. `To Be Filled By O.E.M.`) fall back to the IP name, and `serial_number` errors on duplicate serials rather than assigning a substitute name. |
+| `dpu_network_monitor_pinger_type` | `Option<String>` | — | `networking` | Pinger implementation type (e.g., `"OobNetBind"`) for DPU link health checks. |
+| `tls` | `Option<TlsConfig>` | — | `server` | TLS certificate/key paths (see [TlsConfig](#tlsconfig)). |
+| `listen_mode` | `ListenMode` | `Tls` | `server` | Transport mode: `plaintext_http1`, `plaintext_http2`, or `tls`. |
+| `auth` | `Option<AuthConfig>` | — | `server` | Authentication/authorization settings (see [AuthConfig](#authconfig)). |
+| `pools` | `Option<HashMap<String, ResourcePoolDef>>` | — | `networking` | Resource pools that allocate IPs, VNIs, etc. Required but `Option` for partial-config merging. |
+| `networks` | `Option<HashMap<String, NetworkDefinition>>` | — | `networking` | Networks created at startup. Alternative: `CreateNetworkSegment` gRPC. `NetworkDefinition` supports dual-stack seed-time segments with optional `prefix_v6` and `dhcpv6_link_address`; config edits do not retrofit prefixes onto an already-seeded segment because seed definitions are snapshotted on first create. |
+| `dpu_ipmi_tool_impl` | `Option<String>` | — | `machines` | IPMI tool implementation for DPU power control (`"prod"` or `"fake"`). |
+| `dpu_ipmi_reboot_attempts` | `Option<u32>` | — | `machines` | Retry count when IPMI errors during DPU reboot. |
+| `bmc_session_lockout_threshold` | `u32` | `3` | `security` | Consecutive BMC HTTP 401/403 responses before session-token login attempts stop for that BMC. |
+| `ib_fabrics` | `HashMap<String, IbFabricDefinition>` | `{}` | `hardware` | InfiniBand fabrics managed by the site. Currently only one fabric is supported. |
+| `initial_domain_name` | `Option<String>` | — | `machines` | Domain to create if none exist. Most sites use a single domain. |
+| `initial_dpu_agent_upgrade_policy` | `Option<AgentUpgradePolicyChoice>` | — | `machines` | Policy for nico-dpu-agent upgrades. Also settable via `nico-admin-cli`. |
+| `max_concurrent_machine_updates` | `Option<i32>` | — | `machines` | **Deprecated.** Use `machine_updater` instead. |
+| `machine_update_run_interval` | `Option<u64>` | — | `machines` | Interval (seconds) at which the machine update manager checks for updates. |
+| `retained_boot_interface_window` | `Option<Duration>` | — | `machines` | How long a retained boot interface pair (`retained_boot_interfaces` table) stays applicable after its `machine_interfaces` row was deleted. Unset retains forever; set a window (e.g. `30d`) so a MAC reappearing on different hardware doesn't inherit an obsolete Redfish interface id. |
+| `site_explorer` | `SiteExplorerConfig` | *(see below)* | `hardware` | SiteExplorer hardware discovery settings (see [SiteExplorerConfig](#siteexplorerconfig)). |
+| `nvue_enabled` | `bool` | `true` | `machines` | DPU agent uses NVUE for config instead of writing files directly. |
+| `vpc_peering_policy` | `Option<VpcPeeringPolicy>` | — | `networking` | Policy for VPC peering based on network virtualization type at creation time. |
+| `vpc_peering_policy_on_existing` | `Option<VpcPeeringPolicy>` | — | `networking` | Policy for whether existing VPC peerings should be active. |
+| `attestation_enabled` | `bool` | `false` | `security` | Enables TPM-based machine attestation (adds `Measuring` state before `Ready`). |
+| `tpm_required` | `bool` | `true` | `security` | Require TPM module for machine registration. **Testing only** when `false`. |
+| `machine_state_controller` | `MachineStateControllerConfig` | *(see below)* | `machines` | Machine state controller timing (see [MachineStateControllerConfig](#machinestatecontrollerconfig)). |
+| `network_segment_state_controller` | `NetworkSegmentStateControllerConfig` | *(see below)* | `networking` | Network segment state controller timing. |
+| `vpc_prefix_state_controller` | `VpcPrefixStateControllerConfig` | *(see below)* | `networking` | VPC prefix state controller timing. |
+| `ib_partition_state_controller` | `IbPartitionStateControllerConfig` | *(see below)* | `hardware` | IB partition state controller timing. |
+| `dpa_interface_state_controller` | `DpaInterfaceStateControllerConfig` | *(see below)* | `networking` | DPA interface state controller timing. |
+| `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | `hardware` | Rack state controller timing. |
+| `power_shelf_state_controller` | `PowerShelfStateControllerConfig` | *(see below)* | `hardware` | Power shelf state controller timing. |
+| `switch_state_controller` | `SwitchStateControllerConfig` | *(see below)* | `hardware` | Switch state controller timing. |
+| `spdm_state_controller` | `SpdmStateControllerConfig` | *(see below)* | `security` | SPDM state controller timing. |
+| `host_models` | `HashMap<String, Firmware>` | `{}` | `machines` | Maps host model identifiers to firmware definitions for BMC/UEFI/NIC upgrades. |
+| `firmware_global` | `FirmwareGlobal` | *(see below)* | `machines` | Global firmware update settings (see [FirmwareGlobal](#firmwareglobal)). |
+| `machine_updater` | `MachineUpdater` | *(see below)* | `machines` | Machine update policies (see [MachineUpdater](#machineupdater)). |
+| `max_find_by_ids` | `u32` | `100` | `server` | Max IDs accepted by `find_*_by_ids` APIs. |
+| `network_security_group` | `NetworkSecurityGroupConfig` | *(see below)* | `networking` | NSG settings (see [NetworkSecurityGroupConfig](#networksecuritygroupconfig)). |
+| `min_dpu_functioning_links` | `Option<u32>` | — | `machines` | Minimum functioning DPU links for healthy status. If unset, all must work. |
+| `host_health` | `HostHealthConfig` | *(default)* | `machines` | Host health monitoring thresholds for hardware health and DPU agent compliance. |
+| `observability` | `ObservabilityConfig` | *(default)* | `integrations` | Observability settings shared across all state controllers (see [ObservabilityConfig](#observabilityconfig)). |
+| `internet_l3_vni` | `u32` | `100001` | `networking` | Network infrastructure-provided L3 VNI for FNN VPC Internet connectivity. Combined with `datacenter_asn` for route-target. |
+| `measured_boot_collector` | `MeasuredBootMetricsCollectorConfig` | *(see below)* | `security` | Measured boot metrics exporter (see [MeasuredBootMetricsCollectorConfig](#measuredbootmetricscollectorconfig)). |
+| `machine_validation_config` | `MachineValidationConfig` | *(see below)* | `machines` | Machine validation tests (see [MachineValidationConfig](#machinevalidationconfig)). |
+| `machine_identity` | `MachineIdentityConfig` | *(see below)* | `security` | SPIFFE JWT-SVID machine identity (see [MachineIdentityConfig](#machineidentityconfig)). |
+| `bypass_rbac` | `bool` | `false` | `server` | Disables RBAC enforcement. **Testing/dev only.** |
+| `dpu_config` | `DpuConfig` | *(see below)* | `machines` | DPU firmware and provisioning (see [DpuConfig](#dpuconfig)). |
+| `fnn` | `Option<FnnConfig>` | — | `networking` | FNN L3 VNI overlay networking (see [FnnConfig](#fnnconfig)). |
+| `bom_validation` | `BomValidationConfig` | *(see below)* | `machines` | BOM/SKU validation (see [BomValidationConfig](#bomvalidationconfig)). |
+| `bios_profiles` | `BiosProfileVendor` | *(default)* | `machines` | BIOS profiles by vendor/model for Redfish BIOS management. |
+| `selected_profile` | `BiosProfileType` | *(default)* | `machines` | Default BIOS profile type applied to machines. |
+| `dpa_config` | `Option<DpaConfig>` | — | `networking` | Cluster Interconnect (east-west Ethernet) config (see [DpaConfig](#dpaconfig)). |
+| `dsx_exchange_event_bus` | `Option<DsxExchangeEventBusConfig>` | — | `integrations` | MQTT event bus for managed-host state publishing plus BMS metadata subscription and rack/isolation/heartbeat publishing (see [DsxExchangeEventBusConfig](#dsxexchangeeventbusconfig)). |
+| `datacenter_asn` | `u32` | `11414` | `networking` | Datacenter ASN used by FNN for DC-specific route targets. |
+| `nvlink_config` | `Option<NvLinkConfig>` | — | `hardware` | NvLink partitioning via NMX-C (see [NvLinkConfig](#nvlinkconfig)). |
+| `power_manager_options` | `PowerManagerOptions` | *(see below)* | `hardware` | Power management timing (see [PowerManagerOptions](#powermanageroptions)). |
+| `sitename` | `Option<String>` | — | `server` | Human-readable site name exposed to tenants via FMDS. |
+| `auto_machine_repair_plugin` | `AutoMachineRepairPluginConfig` | *(default)* | `machines` | Auto-repair configuration for failed machines. |
+| `vmaas_config` | `Option<VmaasConfig>` | — | `integrations` | VMaaS configuration for VM system integration (see [VmaasConfig](#vmaasconfig)). |
+| `mlxconfig_profiles` | `Option<HashMap<String, MlxConfigProfile>>` | — | `machines` | Named Mellanox NIC register configuration profiles for superNIC firmware flashing. TOML key: `mlx-config-profiles`. |
+| `rack_management_enabled` | `bool` | `false` | `hardware` | Standalone infrastructure manager mode for GB200/GB300/VR144. See doc comment for full behavioral changes. |
+| `rms` | `RmsConfig` | *(see below)* | `hardware` | Rack Manager Service configuration for API connectivity and mTLS (see [RmsConfig](#rmsconfig)). |
+| `rack_profiles` | `RackProfileConfig` | *(default)* | `hardware` | Rack profile definitions referenced by expected racks. |
+| `spdm` | `SpdmConfig` | *(see below)* | `security` | SPDM hardware attestation (see [SpdmConfig](#spdmconfig)). |
+| `bgp_leaf_session_password` | `Option<BgpLeafSessionPassword>` | — | `networking` | Selects the credential source for leaf-facing BGP session passwords returned to agents in managed host network config. Supported value: `site_wide`. |
+| `site_global_vpc_vni` | `Option<u32>` | — | `networking` | Forces all VRFs to share a single VNI (Cumulus Linux route-leaking workaround). Limits DPU to one VRF. |
+| `dpf` | `DpfConfig` | *(see below)* | `machines` | DPF (DPU Platform Framework) Kubernetes deployment (see [DpfConfig](#dpfconfig)). |
+| `x86_pxe_boot_url_override` | `Option<String>` | — | `machines` | Override PXE boot URL for x86 machines. |
+| `arm_pxe_boot_url_override` | `Option<String>` | — | `machines` | Override PXE boot URL for ARM machines. |
+| `pxe_public_base_url` | `String` | `http://carbide-pxe.forge:8080` | `machines` | Canonical PXE base URL. |
+| `set_http_boot_uri_for_vendors` | `Vec<BMCVendor>` | `[]` | `machines` | Vendors for which the state controller pins the UEFI HTTP boot URL on the BMC via Redfish `HttpBootUri`. Empty = all machines rely on nico-dhcp option 67 for the URL. |
+| `compute_allocation_enforcement` | `ComputeAllocationEnforcement` | `WarnOnly` | `machines` | Controls enforcement of compute allocations on new instance requests. |
+| `supernic_firmware_profiles` | nested `HashMap` | `{}` | `machines` | SuperNIC firmware profiles keyed by `part_number` then `PSID`. |
+| `component_manager` | `Option<ComponentManagerConfig>` | — | `hardware` | Component manager for NvLink switches and power shelves. |
+| `vpcs` | `Option<HashMap<String, VpcDefinition>>` | — | `networking` | VPCs to create at startup. Use the `CreateVpc` gRPC to create them later instead. |
+| `allow_bmc_basic_auth_fallback` | `bool` | `false` | `security` | When `true`, `GetBmcCredentials` may return `UsernamePassword` credentials for BMCs whose Redfish ServiceRoot does not expose `SessionService`. When `false`, such BMCs surface a `NoSessionService` error and no basic-auth fallback is performed. |
+| `rack_validation_config` | `RackValidationConfig` | *(default)* | `hardware` | Rack-level validation: multi-node partition tests after firmware upgrade and maintenance to verify rack health (see [RackValidationConfig](#rackvalidationconfig)). |
+| `oem_manager_profiles` | `BiosProfileVendor` | `{}` | `machines` | Vendor-specific iDRAC/BMC manager attributes applied during machine setup, before BMC lockdown. Keyed by vendor → model → profile → attribute name; targets the manager OEM attributes endpoint (e.g. Dell `DellAttributes`), as opposed to `bios_profiles` which targets BIOS settings. Model names are normalized to lowercase with underscores (e.g. `"PowerEdge R760"` → `"poweredge_r760"`). |
+| `external_api_url` | `Option<String>` | — | `server` | Alternate API URL for external hosts that cannot resolve the internal name, e.g. `https://carbide-stack-api.corp.example.com`. Handed to interfaces on the static-assignments subnet; unset means external hosts get the internal `api_url`. |
+| `external_pxe_url` | `Option<String>` | — | `machines` | Alternate PXE URL for external hosts. Used for cloud-init and root CA retrieval on the static-assignments segment; same rules as `external_api_url`. |
+| `external_static_pxe_url` | `Option<String>` | — | `machines` | Alternate static PXE URL for kernel/blob downloads on the static-assignments segment. Falls back to `external_pxe_url`. |
+| `default_tenant_routing_profile_type` | `String` | `EXTERNAL` | `networking` | The default routing profile used when a tenant is created. |
+| `initial_objects_file` | `Option<PathBuf>` | — | `server` | Path to the `initial_objects.toml` file for seeding the database. |
+| `enable_admin_ui` | `bool` | `true` | `server` | Whether to serve the admin web UI (the HTML pages under `/admin`). Set to `false` to run only the gRPC API; the gRPC service is unaffected either way. |
+| `web_ui_sidebar_tools` | `Vec<ToolLink>` | `[]` | `server` | External tool links surfaced in the admin web UI's "Tools" sidebar. Each entry's `name` must be unique; the section is hidden when the list is empty. |
+| `log_history` | `LogHistoryConfig` | *(default)* | `integrations` | In-memory log history for the admin web live log viewer at `/admin/logs` (see [LogHistoryConfig](#loghistoryconfig)). |
+| `tracing` | `TracingConfig` | *(default)* | `integrations` | OTLP trace export settings (see [TracingConfig](#tracingconfig)). |
+| `secrets` | `Option<SecretsConfig>` | — | `security` | Secrets backend configuration. When present, the credential reader chain and write target are operator-configured (see [SecretsConfig](#secretsconfig)). |
+| `dhcp_lease_expiry_handling` | `bool` | `false` | `networking` | Enables IP cleanup when a DHCP lease expires. |
 
 ---
 
@@ -586,3 +601,43 @@ events, so consumers handle them identically.
 | `scopes` | `Vec<String>` | `[]` | OAuth2 scopes to request. |
 | `http_timeout` | `Duration` | `30s` | Token endpoint HTTP timeout. |
 | `username` | `String` | `"oauth2token"` | Username in MQTT CONNECT packet. |
+
+### `TracingConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Whether to enable OTLP tracing. |
+| `allow_runtime_changes` | `bool` | `true` | Whether tracing may be enabled/disabled at runtime (`nico-admin-cli set tracing-enabled`). |
+| `otlp_endpoint` | `Option<String>` | — | Endpoint traces are sent to. Can be overridden by the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var. |
+
+### `LogHistoryConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_megabytes` | `usize` | `128` | Maximum amount of recent log history retained in memory, in MiB. Oldest lines are evicted once the budget is exceeded. |
+| `page_size` | `usize` | `500` | Number of lines sent in the initial view and in each scrollback page of the live log viewer. |
+
+### `SecretsConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `kms` | `KmsConfig` | **required** | KMS backend configuration (see [KmsConfig](#kmsconfig)). |
+| `routing` | `HashMap<String, String>` | **required** | Maps path prefixes to the `kek_id` that encrypts new writes under them, longest prefix winning. A `/` catch-all entry is required. Reads never consult routing — every stored row records the KEK that wrote it. |
+| `backends` | `Vec<CredentialBackend>` | `[vault]` | The credential backend read order, highest priority first (first match wins). The local-override readers (env, file) are always tried ahead of these when enabled. |
+| `writer` | `CredentialBackend` | `vault` | Where new credential writes go. Set to `postgres` to send new writes to the journal; independent of `backends`. |
+| `import_from` | `Option<ImportSource>` | — | A source backend to import secrets from at startup. Unset means a fresh site with nothing to import; unsupported values fail config parsing. |
+| `import_approach` | `ImportApproach` | `missing_only` | How to treat secrets that already exist in Postgres during import. |
+
+### `KmsConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `active` | `String` | **required** | The provider that wraps DEKs for new writes. |
+| `providers` | `HashMap<String, KmsProviderConfig>` | **required** | Named provider configurations. |
+
+### `RackValidationConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enables rack validation testing. |
+| `run_interval` | `Duration` | `60s` | Interval between rack validation controller runs. |

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -45,7 +45,6 @@ applicable.
 | `machine_update_run_interval` | `Option<u64>` | — | `machines` | Interval (seconds) at which the machine update manager checks for updates. |
 | `retained_boot_interface_window` | `Option<Duration>` | — | `machines` | How long a retained boot interface pair (`retained_boot_interfaces` table) stays applicable after its `machine_interfaces` row was deleted. Unset retains forever; set a window (e.g. `30d`) so a MAC reappearing on different hardware doesn't inherit an obsolete Redfish interface id. |
 | `site_explorer` | `SiteExplorerConfig` | *(see below)* | `hardware` | SiteExplorer hardware discovery settings (see [SiteExplorerConfig](#siteexplorerconfig)). |
-| `nvue_enabled` | `bool` | `true` | `machines` | DPU agent uses NVUE for config instead of writing files directly. |
 | `vpc_peering_policy` | `Option<VpcPeeringPolicy>` | — | `networking` | Policy for VPC peering based on network virtualization type at creation time. |
 | `vpc_peering_policy_on_existing` | `Option<VpcPeeringPolicy>` | — | `networking` | Policy for whether existing VPC peerings should be active. |
 | `attestation_enabled` | `bool` | `false` | `security` | Enables TPM-based machine attestation (adds `Measuring` state before `Ready`). |
@@ -282,6 +281,8 @@ flows.
 | `nmx_c_tls_client_key_path` | `Option<String>` | — | Client private key for mTLS to NMX-C. |
 | `nmx_c_tls_authority` | `Option<String>` | — | TLS server name used for SNI and certificate verification. |
 | `allow_insecure` | `bool` | `false` | Skip TLS verification for NMX-C. |
+| `nmx_c_endpoint_port` | `Option<u16>` | — | TCP port for NMX-C endpoints derived from switch NVOS IP. Unset uses the production NMX-C port. |
+| `nmx_c_certificate_rotation` | `NmxCCertificateRotationConfig` | *(default)* | Optional monitoring for NMX-C server certificate propagation. |
 
 ### `SiteExplorerConfig`
 
@@ -306,8 +307,8 @@ flows.
 | `power_shelves_created_per_run` | `u64` | `1` | Max power shelves created per run. |
 | `create_switches` | `bool` | `false` | Auto-create Switch state machines. |
 | `switches_created_per_run` | `u64` | `9` | Max switches created per run. |
-| `use_onboard_nic` | `bool` | `false` | Use onboard NIC instead of DPU NICs. |
 | `explore_mode` | `SiteExplorerExploreMode` | `LibRedfish` | Redfish backend: `libredfish`, `nv-redfish`, or `compare-result`. |
+| `dpu_mode` | `Option<DpuMode>` | — | Site-wide DPU operating mode. When set, applies to every host that doesn't declare a per-host `ExpectedMachine.dpu_mode` override. |
 
 ### `StateControllerConfig`
 
@@ -346,6 +347,7 @@ Extends `StateControllerConfig` with:
 | `uefi_boot_wait` | `Duration` | `5m`    | Wait time for UEFI boot completion after host reboot. |
 | `max_bios_config_retries` | `u32` | `3` | Max HandleBiosJobFailure recovery cycles during BIOS configuration. |
 | `polling_bios_setup_stuck_threshold` | `Duration` | `15m` | Time in PollingBiosSetup with `is_bios_setup == false` before recovery escalation. |
+| `controller` | `StateControllerConfig` | *(default)* | Common state controller timing (see [StateControllerConfig](#statecontrollerconfig)). |
 
 ### `NetworkSegmentStateControllerConfig`
 
@@ -354,6 +356,7 @@ Extends `StateControllerConfig` with:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `network_segment_drain_time` | `Duration` | `5m` | Time a network segment must have 0 allocated IPs before release. |
+| `controller` | `StateControllerConfig` | *(default)* | Common state controller timing (see [StateControllerConfig](#statecontrollerconfig)). |
 
 ### `VpcPrefixStateControllerConfig`
 
@@ -362,6 +365,7 @@ Extends `StateControllerConfig` with:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `vpc_prefix_drain_time` | `Duration` | `5m` | Time a VPC prefix must have 0 referencing network prefixes before release. |
+| `controller` | `StateControllerConfig` | *(default)* | Common state controller timing (see [StateControllerConfig](#statecontrollerconfig)). |
 
 ### `FirmwareGlobal`
 
@@ -379,6 +383,8 @@ Extends `StateControllerConfig` with:
 | `no_reset_retries` | `bool` | `false` | Disable retry logic after BMC resets. |
 | `hgx_bmc_gpu_reboot_delay` | `Duration` | `30s` | Delay after GPU reboot before HGX BMC access. |
 | `requires_manual_upgrade` | `bool` | `false` | Force all firmware upgrades to require admin approval. |
+| `firmware_download_cache_directory` | `PathBuf` | `/mnt/persistence/fw/download-cache` | Writable directory used to cache downloaded firmware artifacts. |
+| `max_concurrent_bfb_copies` | `usize` | `10` | Maximum number of concurrent BFB copy operations. |
 
 ### `MachineUpdater`
 
@@ -455,6 +461,7 @@ Extends `StateControllerConfig` with:
 | `common_internal_route_target` | `Option<RouteTargetConfig>` | — | Double-tag for internal tenant routes (consumed by the network infrastructure). |
 | `additional_route_target_imports` | `Vec<RouteTargetConfig>` | `[]` | Extra route targets imported on DPU VRFs. |
 | `routing_profiles` | `HashMap<String, FnnRoutingProfileConfig>` | `{}` | Named per-VPC routing profiles (see [FnnRoutingProfileConfig](#fnnroutingprofileconfig)). |
+| `use_vpc_vrf_loopback` | `bool` | `false` | Whether IPs are allocated for VPC loopbacks. When false, the VPC loopback pool is unused and no VPC/VRF loopback IP is sent to the DPU. |
 
 ### `FnnRoutingProfileConfig`
 
@@ -487,6 +494,7 @@ Extends `StateControllerConfig` with:
 | `subnet_mask` | `i32` | `0` | CIDR prefix length for the DPA subnet. |
 | `hb_interval` | `Duration` | `2m` | Heartbeat interval for DPA health checks. |
 | `auth` | `MqttAuthConfig` | *(none)* | MQTT authentication settings. |
+| `monitor_run_interval` | `Duration` | `60s` | The interval at which the DPA monitor runs. |
 
 ### `DsxExchangeEventBusConfig`
 
@@ -498,6 +506,7 @@ Extends `StateControllerConfig` with:
 | `publish_timeout` | `Duration` | `1s` | Timeout for MQTT publish operations. |
 | `queue_capacity` | `usize` | `1024` | Event buffer size for DSX publish work (events dropped when full). |
 | `auth` | `MqttAuthConfig` | *(none)* | MQTT authentication settings. |
+| `topic_prefix` | `String` | `NICO/v1/machine` | Topic prefix used when publishing `ManagedHostState` transitions; the full topic is `{topic_prefix}/{machineId}/state`. NATS subjects are case-sensitive, so this must match the producer pub allow configured on the broker. |
 | `periodic_state_republish` | `PeriodicStateRepublishConfig` | *(enabled)* | Periodically re-publish current managed-host state so consumers that miss change events can reconcile (see [PeriodicStateRepublishConfig](#periodicstaterepublishconfig)). |
 
 ### `PeriodicStateRepublishConfig`
@@ -527,9 +536,10 @@ events, so consumers handle them identically.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `false` | Enable DPF Kubernetes deployment. |
-| `bfb_url` | `String` | `""` | BlueField firmware bundle URL. |
-| `deployment_name` | `Option<String>` | — | Kubernetes deployment name. |
 | `services` | `Option<Vec<DpfServiceConfig>>` | — | Additional Helm services. |
+| `docker_image_pull_secret` | `Option<String>` | — | Override for the Kubernetes `imagePullSecrets` entry used to pull mandatory-service images (applied to every mandatory service except `dts` and `doca_hbn`). |
+| `proxy` | `Option<DpfProxyDetails>` | — | Proxy configuration for the DPU. When set, containerd on the DPU routes outbound HTTPS traffic through it. |
+| `deployments` | `DpfDeploymentsConfig` | *(default)* | Per-generation DPUDeployment configurations. BF3 is always present with defaults; BF4Generic is opt-in via `[dpf.deployments.bf4_generic]`. |
 
 ### `RmsConfig`
 
@@ -557,6 +567,10 @@ events, so consumers handle them identically.
 | `token_ttl_min_sec` | `u32` | `60` | Minimum token TTL in seconds. |
 | `token_ttl_max_sec` | `u32` | `86400` | Maximum token TTL in seconds. |
 | `token_endpoint_http_proxy` | `Option<String>` | — | HTTP proxy for token endpoint calls (SSRF mitigation). |
+| `current_encryption_key_id` | `Option<String>` | — | Key-id for encrypting new tenant identity ciphertext (selects from the `machine_identity.encryption_keys` secrets). |
+| `trust_domain_allowlist` | `Vec<String>` | `[]` | Trust domains allowed for tenant JWT `iss` (normalized host). Empty allows any. Patterns: exact hostname, `*.suffix` (one label under suffix), `**.suffix` (suffix or any subdomain). |
+| `token_endpoint_domain_allowlist` | `Vec<String>` | `[]` | Allowed DNS names for the `token_endpoint` URL host (`http://` / `https://` only). Empty allows any; same pattern syntax as `trust_domain_allowlist`. |
+| `signing_key_overlap_max_sec` | `u32` | `604800` | Upper bound for `signing_key_overlap_sec` on `SetTenantIdentityConfiguration` when `rotate_key` is true (seconds). |
 
 ### `MeasuredBootMetricsCollectorConfig`
 

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -608,7 +608,7 @@ events, so consumers handle them identically.
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `false` | Whether to enable OTLP tracing. |
 | `allow_runtime_changes` | `bool` | `true` | Whether tracing may be enabled/disabled at runtime (`nico-admin-cli set tracing-enabled`). |
-| `otlp_endpoint` | `Option<String>` | — | Endpoint traces are sent to. Can be overridden by the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var. |
+| `otlp_endpoint` | `Option<String>` | — | The endpoint traces are sent to. The `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` env var takes precedence when set. |
 
 ### `LogHistoryConfig`
 

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -718,7 +718,6 @@ pub struct CarbideConfig {
     #[serde(default = "default_to_true")]
     pub enable_admin_ui: bool,
 
-
     /// External tool links surfaced in the admin web UI's "Tools"
     /// sidebar. Each entry's `name` must be unique. The section is
     /// hidden when the list is empty.

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
@@ -1527,6 +1527,27 @@ fn validate_tool_url(name: &str, url: &str) -> eyre::Result<()> {
 }
 
 impl CarbideConfig {
+    /// Returns the dotted paths of every configuration key that was
+    /// explicitly provided by one of the merged configuration sources (the
+    /// base config file, the site config file, or `CARBIDE_API_*` environment
+    /// variables), mapped to a human-readable source label such as the
+    /// providing file's name or `CARBIDE_API_ environment variable(s)`.
+    ///
+    /// Keys absent from the map fall back to their compiled-in defaults.
+    /// Returns an empty map for configs that weren't produced by
+    /// `parse_carbide_config` (test fixtures, programmatic construction).
+    pub fn explicit_value_paths(&self) -> BTreeMap<String, String> {
+        let mut paths = BTreeMap::new();
+        let Some(figment) = self.config_ctx.as_ref() else {
+            return paths;
+        };
+        let Ok(root) = figment.extract::<figment::value::Value>() else {
+            return paths;
+        };
+        collect_explicit_paths(figment, &root, String::new(), &mut paths);
+        paths
+    }
+
     /// Returns a version of CarbideConfig where secrets are erased
     pub fn redacted(&self) -> Self {
         let mut config = self.clone();
@@ -1705,6 +1726,43 @@ impl CarbideConfig {
                 .clone(),
             firmware: self.get_firmware_config(),
         }
+    }
+}
+
+/// Walk the merged figment value tree, recording each leaf key's dotted path
+/// and the label of the source that provided it. Dicts recurse; arrays and
+/// scalars are leaves (an array is always provided wholesale by one source).
+fn collect_explicit_paths(
+    figment: &Figment,
+    value: &figment::value::Value,
+    path: String,
+    paths: &mut BTreeMap<String, String>,
+) {
+    if let figment::value::Value::Dict(_, dict) = value {
+        for (key, child) in dict {
+            let child_path = if path.is_empty() {
+                key.clone()
+            } else {
+                format!("{path}.{key}")
+            };
+            collect_explicit_paths(figment, child, child_path, paths);
+        }
+    } else {
+        let source = figment
+            .find_metadata(&path)
+            .map(explicit_source_label)
+            .unwrap_or_else(|| "configuration".to_string());
+        paths.insert(path, source);
+    }
+}
+
+fn explicit_source_label(metadata: &figment::Metadata) -> String {
+    match metadata.source.as_ref() {
+        Some(figment::Source::File(path)) => path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string()),
+        _ => metadata.name.to_string(),
     }
 }
 

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -718,6 +718,7 @@ pub struct CarbideConfig {
     #[serde(default = "default_to_true")]
     pub enable_admin_ui: bool,
 
+
     /// External tool links surfaced in the admin web UI's "Tools"
     /// sidebar. Each entry's `name` must be unique. The section is
     /// hidden when the list is empty.
@@ -1527,25 +1528,15 @@ fn validate_tool_url(name: &str, url: &str) -> eyre::Result<()> {
 }
 
 impl CarbideConfig {
-    /// Returns the dotted paths of every configuration key that was
-    /// explicitly provided by one of the merged configuration sources (the
-    /// base config file, the site config file, or `CARBIDE_API_*` environment
-    /// variables), mapped to a human-readable source label such as the
-    /// providing file's name or `CARBIDE_API_ environment variable(s)`.
-    ///
-    /// Keys absent from the map fall back to their compiled-in defaults.
-    /// Returns an empty map for configs that weren't produced by
-    /// `parse_carbide_config` (test fixtures, programmatic construction).
+    /// Which configuration keys were explicitly provided by the merged
+    /// sources, mapped to source labels — see [`super::provenance`]. Empty
+    /// for configs that weren't produced by `parse_carbide_config` (test
+    /// fixtures, programmatic construction).
     pub fn explicit_value_paths(&self) -> BTreeMap<String, String> {
-        let mut paths = BTreeMap::new();
-        let Some(figment) = self.config_ctx.as_ref() else {
-            return paths;
-        };
-        let Ok(root) = figment.extract::<figment::value::Value>() else {
-            return paths;
-        };
-        collect_explicit_paths(figment, &root, String::new(), &mut paths);
-        paths
+        self.config_ctx
+            .as_ref()
+            .map(super::provenance::explicit_value_paths)
+            .unwrap_or_default()
     }
 
     /// Returns a version of CarbideConfig where secrets are erased
@@ -1726,43 +1717,6 @@ impl CarbideConfig {
                 .clone(),
             firmware: self.get_firmware_config(),
         }
-    }
-}
-
-/// Walk the merged figment value tree, recording each leaf key's dotted path
-/// and the label of the source that provided it. Dicts recurse; arrays and
-/// scalars are leaves (an array is always provided wholesale by one source).
-fn collect_explicit_paths(
-    figment: &Figment,
-    value: &figment::value::Value,
-    path: String,
-    paths: &mut BTreeMap<String, String>,
-) {
-    if let figment::value::Value::Dict(_, dict) = value {
-        for (key, child) in dict {
-            let child_path = if path.is_empty() {
-                key.clone()
-            } else {
-                format!("{path}.{key}")
-            };
-            collect_explicit_paths(figment, child, child_path, paths);
-        }
-    } else {
-        let source = figment
-            .find_metadata(&path)
-            .map(explicit_source_label)
-            .unwrap_or_else(|| "configuration".to_string());
-        paths.insert(path, source);
-    }
-}
-
-fn explicit_source_label(metadata: &figment::Metadata) -> String {
-    match metadata.source.as_ref() {
-        Some(figment::Source::File(path)) => path
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| path.display().to_string()),
-        _ => metadata.name.to_string(),
     }
 }
 

--- a/crates/api-core/src/cfg/mod.rs
+++ b/crates/api-core/src/cfg/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod command_line;
 pub mod file;
+pub mod provenance;
 
 /// The configuration reference document (`README.md`), embedded so the admin
 /// web UI can render per-field types, defaults, and descriptions for every

--- a/crates/api-core/src/cfg/mod.rs
+++ b/crates/api-core/src/cfg/mod.rs
@@ -17,3 +17,8 @@
 
 pub mod command_line;
 pub mod file;
+
+/// The configuration reference document (`README.md`), embedded so the admin
+/// web UI can render per-field types, defaults, and descriptions for every
+/// option in [`file::CarbideConfig`].
+pub const CONFIG_REFERENCE_MD: &str = include_str!("README.md");

--- a/crates/api-core/src/cfg/provenance.rs
+++ b/crates/api-core/src/cfg/provenance.rs
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Attribution of configuration keys back to the sources that provided them.
+//!
+//! The merged [`Figment`] retained on `CarbideConfig::config_ctx` knows which
+//! provider (base config file, site overlay, `CARBIDE_API_*` env vars)
+//! supplied each key. This module walks it to answer "which keys did the
+//! operator explicitly set, and where?" — used by the admin UI's
+//! Configuration page to distinguish overrides from compiled-in defaults.
+
+use std::collections::BTreeMap;
+
+use figment::Figment;
+
+/// Returns the dotted paths of every configuration key explicitly provided by
+/// one of the merged configuration sources, mapped to a human-readable source
+/// label such as the providing file's name.
+///
+/// Keys absent from the map fall back to their compiled-in defaults.
+pub fn explicit_value_paths(figment: &Figment) -> BTreeMap<String, String> {
+    let mut paths = BTreeMap::new();
+    let Ok(root) = figment.extract::<figment::value::Value>() else {
+        return paths;
+    };
+    collect_explicit_paths(figment, &root, String::new(), &mut paths);
+    paths
+}
+
+/// Walk the merged figment value tree, recording each leaf key's dotted path
+/// and the label of the source that provided it. Dicts recurse; arrays and
+/// scalars are leaves (an array is always provided wholesale by one source).
+fn collect_explicit_paths(
+    figment: &Figment,
+    value: &figment::value::Value,
+    path: String,
+    paths: &mut BTreeMap<String, String>,
+) {
+    if let figment::value::Value::Dict(_, dict) = value {
+        for (key, child) in dict {
+            let child_path = if path.is_empty() {
+                key.clone()
+            } else {
+                format!("{path}.{key}")
+            };
+            collect_explicit_paths(figment, child, child_path, paths);
+        }
+    } else {
+        let source = figment
+            .find_metadata(&path)
+            .map(source_label)
+            .unwrap_or_else(|| "configuration".to_string());
+        paths.insert(path, source);
+    }
+}
+
+fn source_label(metadata: &figment::Metadata) -> String {
+    match metadata.source.as_ref() {
+        Some(figment::Source::File(path)) => path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string()),
+        _ => metadata.name.to_string(),
+    }
+}

--- a/crates/api-core/src/lib.rs
+++ b/crates/api-core/src/lib.rs
@@ -123,7 +123,7 @@ pub fn configured_tools() -> &'static [ToolLink] {
 }
 
 /// Process-global site name shown in the admin web UI's sidebar header
-/// ("nico.<site>"). Same write-once rationale as [`TOOLS`].
+/// ("NICo • <site>"). Same write-once rationale as [`TOOLS`].
 static SITE_NAME: OnceLock<Option<String>> = OnceLock::new();
 
 /// Initialize the global site name from the config's `sitename` field. Call

--- a/crates/api-core/src/lib.rs
+++ b/crates/api-core/src/lib.rs
@@ -121,3 +121,21 @@ pub fn init_tools(tools: Vec<ToolLink>) {
 pub fn configured_tools() -> &'static [ToolLink] {
     TOOLS.get().map(Vec::as_slice).unwrap_or(&[])
 }
+
+/// Process-global site name shown in the admin web UI's sidebar header
+/// ("nico.<site>"). Same write-once rationale as [`TOOLS`].
+static SITE_NAME: OnceLock<Option<String>> = OnceLock::new();
+
+/// Initialize the global site name from the config's `sitename` field. Call
+/// once during startup before serving any web requests. Subsequent calls are
+/// ignored.
+pub fn init_site_name(site_name: Option<String>) {
+    let _ = SITE_NAME.set(site_name);
+}
+
+/// The configured site name, for the admin UI's sidebar header. `None` when
+/// the config doesn't set `sitename` or when [`init_site_name`] has not been
+/// called (e.g. unit tests).
+pub fn configured_site_name() -> Option<&'static str> {
+    SITE_NAME.get().and_then(|name| name.as_deref())
+}

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -205,6 +205,9 @@ pub fn parse_carbide_config(
     // parsed config, before the web layer exists.
     crate::init_tools(config.web_ui_sidebar_tools.clone());
 
+    // Publish the site name the same way, for the admin-UI sidebar header.
+    crate::init_site_name(config.sitename.clone());
+
     // Publish the deployment-wide host naming policy so the DB layer can read it
     // wherever an interface is [re]named (same way we do it w/ `init_tools` above).
     db::host_naming::configure(config.host_naming_strategy);

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -38,14 +38,53 @@ use model::resource_pool::{self};
 use regex::Regex;
 
 use crate::cfg::file::{
-    CarbideConfig, DpaConfig, DpaInterfaceStateControllerConfig, DpuConfig as InitialDpuConfig,
-    IbPartitionStateControllerConfig, ListenMode, MachineUpdater,
+    AuthConfig, CarbideConfig, DpaConfig, DpaInterfaceStateControllerConfig,
+    DpuConfig as InitialDpuConfig, DsxExchangeEventBusConfig, FnnConfig,
+    IbPartitionStateControllerConfig, KmsConfig, ListenMode, MachineUpdater,
     MeasuredBootMetricsCollectorConfig, MqttAuthConfig, NetworkSecurityGroupConfig,
     NetworkSegmentStateControllerConfig, PowerShelfStateControllerConfig,
-    RackStateControllerConfig, SpdmConfig, SpdmStateControllerConfig, SwitchStateControllerConfig,
-    TracingConfig, VmaasConfig, VpcPeeringPolicy, VpcPrefixStateControllerConfig,
-    default_bmc_session_lockout_threshold, default_max_find_by_ids, default_pxe_public_base_url,
+    RackStateControllerConfig, SecretsConfig, SpdmConfig, SpdmStateControllerConfig,
+    SwitchStateControllerConfig, TracingConfig, VmaasConfig, VpcPeeringPolicy,
+    VpcPrefixStateControllerConfig, default_bmc_session_lockout_threshold, default_max_find_by_ids,
+    default_pxe_public_base_url,
 };
+
+/// [`get`] with every `Option` config section populated. Used by tests that
+/// walk the *serialized* config shape — e.g. the admin-UI documentation
+/// guards, which can only verify sections that actually serialize. When a
+/// new `Option` section is added to [`CarbideConfig`] (the compiler forces
+/// it into [`get`]), populate it here too so those guards can see inside it.
+pub fn fully_populated() -> CarbideConfig {
+    CarbideConfig {
+        auth: Some(AuthConfig {
+            permissive_mode: true,
+            casbin_policy_file: None,
+            cli_certs: None,
+            trust: None,
+        }),
+        ib_config: Some(carbide_ib_fabric::config::IBFabricConfig::default()),
+        fnn: Some(FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::new(),
+            use_vpc_vrf_loopback: false,
+        }),
+        dsx_exchange_event_bus: Some(DsxExchangeEventBusConfig::default()),
+        secrets: Some(SecretsConfig {
+            kms: KmsConfig {
+                active: "local".to_string(),
+                providers: HashMap::new(),
+            },
+            routing: HashMap::from([("/".to_string(), "kek".to_string())]),
+            backends: vec![],
+            writer: Default::default(),
+            import_from: None,
+            import_approach: Default::default(),
+        }),
+        ..get()
+    }
+}
 
 pub fn get() -> CarbideConfig {
     CarbideConfig {

--- a/crates/api-web/Cargo.toml
+++ b/crates/api-web/Cargo.toml
@@ -61,6 +61,7 @@ itertools = { workspace = true }
 lazy_static = { workspace = true }
 mac_address = { workspace = true }
 oauth2 = { workspace = true, default-features = false }
+regex = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = [
   "rustls",
   "stream",

--- a/crates/api-web/Cargo.toml
+++ b/crates/api-web/Cargo.toml
@@ -108,6 +108,7 @@ carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-test-harness = { path = "../test-harness" }
 carbide-test-support = { path = "../test-support" }
 http-body-util = { workspace = true }
+toml = { workspace = true }
 sqlx = { workspace = true, features = [
   "runtime-tokio",
   "tls-rustls",

--- a/crates/api-web/Cargo.toml
+++ b/crates/api-web/Cargo.toml
@@ -109,7 +109,6 @@ carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-test-harness = { path = "../test-harness" }
 carbide-test-support = { path = "../test-support" }
 http-body-util = { workspace = true }
-toml = { workspace = true }
 sqlx = { workspace = true, features = [
   "runtime-tokio",
   "tls-rustls",

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -35,10 +35,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 /// Everything the Configuration page template needs.
 pub(crate) struct ConfigPageView {
     pub groups: Vec<ConfigGroupView>,
-    pub total_options: usize,
-    pub overridden_options: usize,
-    /// Distinct source labels (file names / env) that provided overrides.
-    pub sources: Vec<String>,
 }
 
 pub(crate) struct ConfigGroupView {
@@ -52,7 +48,6 @@ pub(crate) struct ConfigSectionView {
     /// Dotted TOML path prefix of this section ("" for top-level options).
     pub path: String,
     pub rows: Vec<ConfigRowView>,
-    pub overridden: usize,
 }
 
 pub(crate) struct ConfigRowView {
@@ -84,14 +79,14 @@ struct FieldDoc {
 /// Display groups, in page order. Sections land in a group via
 /// `group_for_top_level_field`; unknown fields fall through to "Other".
 const GROUP_ORDER: &[&str] = &[
-    "Server & API",
+    "Server",
     "Networking",
-    "Machines & Lifecycle",
-    "DPUs & Provisioning",
-    "Firmware & Updates",
-    "Security & Attestation",
-    "Hardware Discovery & Racks",
-    "Observability & Diagnostics",
+    "Machines",
+    "DPUs",
+    "Firmware",
+    "Security",
+    "Hardware",
+    "Observability",
     "Integrations",
     "Other",
 ];
@@ -101,7 +96,7 @@ fn group_for_top_level_field(name: &str) -> &'static str {
         "listen" | "listen_only" | "listen_mode" | "tls" | "database_url"
         | "max_database_connections" | "max_find_by_ids" | "auth" | "bypass_rbac"
         | "enable_admin_ui" | "web_ui_sidebar_tools" | "sitename" | "initial_objects_file" => {
-            "Server & API"
+            "Server"
         }
         "asn" | "dhcp_servers" | "ntp_servers" | "route_servers" | "enable_route_servers"
         | "deny_prefixes" | "site_fabric_prefixes" | "anycast_site_prefixes"
@@ -114,24 +109,24 @@ fn group_for_top_level_field(name: &str) -> &'static str {
         "host_naming_strategy" | "machine_state_controller" | "machine_validation_config"
         | "auto_machine_repair_plugin" | "host_health" | "initial_domain_name"
         | "min_dpu_functioning_links" | "bom_validation" | "compute_allocation_enforcement" => {
-            "Machines & Lifecycle"
+            "Machines"
         }
         "dpu_config" | "dpu_ipmi_tool_impl" | "dpu_ipmi_reboot_attempts" | "nvue_enabled"
         | "dpf" | "initial_dpu_agent_upgrade_policy" | "x86_pxe_boot_url_override"
         | "arm_pxe_boot_url_override" | "pxe_public_base_url" | "set_http_boot_uri_for_vendors"
-        | "retained_boot_interface_window" => "DPUs & Provisioning",
+        | "retained_boot_interface_window" => "DPUs",
         "host_models" | "firmware_global" | "machine_updater"
         | "max_concurrent_machine_updates" | "machine_update_run_interval"
-        | "mlxconfig_profiles" | "supernic_firmware_profiles" => "Firmware & Updates",
+        | "mlxconfig_profiles" | "supernic_firmware_profiles" => "Firmware",
         "attestation_enabled" | "tpm_required" | "machine_identity" | "spdm"
         | "spdm_state_controller" | "measured_boot_collector" | "bmc_session_lockout_threshold"
-        | "secrets" | "kms" => "Security & Attestation",
+        | "secrets" | "kms" => "Security",
         "site_explorer" | "ib_config" | "ib_fabrics" | "nvlink_config"
         | "rack_management_enabled" | "rms" | "rack_profiles" | "rack_state_controller"
         | "power_shelf_state_controller" | "switch_state_controller" | "power_manager_options"
-        | "ib_partition_state_controller" | "component_manager" => "Hardware Discovery & Racks",
+        | "ib_partition_state_controller" | "component_manager" => "Hardware",
         "metrics_endpoint" | "alt_metric_prefix" | "tracing" | "observability"
-        | "log_history" => "Observability & Diagnostics",
+        | "log_history" => "Observability",
         "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => "Integrations",
         _ => "Other",
     }
@@ -214,43 +209,23 @@ pub(crate) fn build_config_page(
     }
 
     let mut groups = Vec::new();
-    let mut total_options = 0;
-    let mut overridden_options = 0;
-    let mut sources: Vec<String> = Vec::new();
-
     for title in GROUP_ORDER {
         let mut sections = Vec::new();
         if let Some(rows) = top_level_rows.remove(title) {
-            let overridden = rows.iter().filter(|r| r.overridden).count();
             sections.push(ConfigSectionView {
                 title: "Core Options".to_string(),
                 anchor: format!("cfg-{}-core", slugify(title)),
                 path: String::new(),
                 rows,
-                overridden,
             });
         }
         sections.extend(grouped.remove(title).unwrap_or_default());
-        for section in &sections {
-            total_options += section.rows.len();
-            overridden_options += section.overridden;
-            for row in &section.rows {
-                if row.overridden && !row.source.is_empty() && !sources.contains(&row.source) {
-                    sources.push(row.source.clone());
-                }
-            }
-        }
         if !sections.is_empty() {
             groups.push(ConfigGroupView { title, sections });
         }
     }
 
-    ConfigPageView {
-        groups,
-        total_options,
-        overridden_options,
-        sources,
-    }
+    ConfigPageView { groups }
 }
 
 /// If the field's type refers to a documented sub-struct section (and isn't a
@@ -306,13 +281,11 @@ fn build_section(
             None => rows.push(build_row(field, &field_path, effective, explicit_paths, false)),
         }
     }
-    let overridden = rows.iter().filter(|r| r.overridden).count();
     out.push(ConfigSectionView {
         anchor: format!("cfg-{}", slugify(&path)),
         title,
         path,
         rows,
-        overridden,
     });
     out.extend(nested);
 }
@@ -447,7 +420,7 @@ fn format_default(default: &str) -> String {
     let trimmed = default.trim();
     match trimmed {
         "" | "—" | "-" => "<span class=\"config-unset\">—</span>".to_string(),
-        "**required**" => "<span class=\"bubble error config-required\">required</span>".to_string(),
+        "**required**" => "<em>required</em>".to_string(),
         "*(see below)*" | "*(default)*" => "<span class=\"config-unset\">—</span>".to_string(),
         other => markdown_lite(other),
     }
@@ -707,16 +680,13 @@ mod configuration_tests {
             &effective,
             &explicit,
         );
-        assert!(page.total_options > 100);
-        assert!(page.overridden_options >= 2);
-        assert!(page.sources.contains(&"site.toml".to_string()));
-
         let rows: Vec<&ConfigRowView> = page
             .groups
             .iter()
             .flat_map(|g| g.sections.iter())
             .flat_map(|s| s.rows.iter())
             .collect();
+        assert!(rows.len() > 150, "expected full catalog, got {}", rows.len());
         let asn = rows.iter().find(|r| r.path == "asn").unwrap();
         assert!(asn.overridden);
         assert_eq!(asn.source, "site.toml");

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -39,6 +39,8 @@ pub(crate) struct ConfigPageView {
 
 pub(crate) struct ConfigGroupView {
     pub title: &'static str,
+    /// Stable identifier used for the tab's `data-tab` / `id` attributes.
+    pub slug: &'static str,
     pub sections: Vec<ConfigSectionView>,
 }
 
@@ -68,6 +70,12 @@ pub(crate) struct ConfigRowView {
     pub undocumented: bool,
 }
 
+/// Placeholder cells for absent content, kept to plain words -- no dashes
+/// or empty strings, and one consistent word per situation.
+const UNSET_HTML: &str = "<span class=\"config-unset\">unset</span>";
+const EMPTY_HTML: &str = "<span class=\"config-unset\">empty</span>";
+const NONE_HTML: &str = "<span class=\"config-unset\">none</span>";
+
 /// One `| field | type | default | description |` row of the reference doc.
 struct FieldDoc {
     name: String,
@@ -78,17 +86,14 @@ struct FieldDoc {
 
 /// Display groups, in page order. Sections land in a group via
 /// `group_for_top_level_field`; unknown fields fall through to "Other".
-const GROUP_ORDER: &[&str] = &[
-    "Server",
-    "Networking",
-    "Machines",
-    "DPUs",
-    "Firmware",
-    "Security",
-    "Hardware",
-    "Observability",
-    "Integrations",
-    "Other",
+const GROUP_ORDER: &[(&str, &str)] = &[
+    ("Server & API", "server"),
+    ("Networking", "networking"),
+    ("Machines & Firmware", "machines"),
+    ("Security", "security"),
+    ("Hardware & Racks", "hardware"),
+    ("Integrations & Observability", "integrations"),
+    ("Other", "other"),
 ];
 
 fn group_for_top_level_field(name: &str) -> &'static str {
@@ -96,7 +101,7 @@ fn group_for_top_level_field(name: &str) -> &'static str {
         "listen" | "listen_only" | "listen_mode" | "tls" | "database_url"
         | "max_database_connections" | "max_find_by_ids" | "auth" | "bypass_rbac"
         | "enable_admin_ui" | "web_ui_sidebar_tools" | "sitename" | "initial_objects_file" => {
-            "Server"
+            "Server & API"
         }
         "asn" | "dhcp_servers" | "ntp_servers" | "route_servers" | "enable_route_servers"
         | "deny_prefixes" | "site_fabric_prefixes" | "anycast_site_prefixes"
@@ -108,26 +113,23 @@ fn group_for_top_level_field(name: &str) -> &'static str {
         | "dpu_network_monitor_pinger_type" => "Networking",
         "host_naming_strategy" | "machine_state_controller" | "machine_validation_config"
         | "auto_machine_repair_plugin" | "host_health" | "initial_domain_name"
-        | "min_dpu_functioning_links" | "bom_validation" | "compute_allocation_enforcement" => {
-            "Machines"
-        }
-        "dpu_config" | "dpu_ipmi_tool_impl" | "dpu_ipmi_reboot_attempts" | "nvue_enabled"
+        | "min_dpu_functioning_links" | "bom_validation" | "compute_allocation_enforcement"
+        | "dpu_config" | "dpu_ipmi_tool_impl" | "dpu_ipmi_reboot_attempts" | "nvue_enabled"
         | "dpf" | "initial_dpu_agent_upgrade_policy" | "x86_pxe_boot_url_override"
         | "arm_pxe_boot_url_override" | "pxe_public_base_url" | "set_http_boot_uri_for_vendors"
-        | "retained_boot_interface_window" => "DPUs",
-        "host_models" | "firmware_global" | "machine_updater"
-        | "max_concurrent_machine_updates" | "machine_update_run_interval"
-        | "mlxconfig_profiles" | "supernic_firmware_profiles" => "Firmware",
+        | "retained_boot_interface_window" | "host_models" | "firmware_global"
+        | "machine_updater" | "max_concurrent_machine_updates" | "machine_update_run_interval"
+        | "mlxconfig_profiles" | "supernic_firmware_profiles" | "bios_profiles"
+        | "selected_profile" => "Machines & Firmware",
         "attestation_enabled" | "tpm_required" | "machine_identity" | "spdm"
         | "spdm_state_controller" | "measured_boot_collector" | "bmc_session_lockout_threshold"
         | "secrets" | "kms" => "Security",
         "site_explorer" | "ib_config" | "ib_fabrics" | "nvlink_config"
         | "rack_management_enabled" | "rms" | "rack_profiles" | "rack_state_controller"
         | "power_shelf_state_controller" | "switch_state_controller" | "power_manager_options"
-        | "ib_partition_state_controller" | "component_manager" => "Hardware",
-        "metrics_endpoint" | "alt_metric_prefix" | "tracing" | "observability"
-        | "log_history" => "Observability",
-        "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => "Integrations",
+        | "ib_partition_state_controller" | "component_manager" => "Hardware & Racks",
+        "metrics_endpoint" | "alt_metric_prefix" | "tracing" | "observability" | "log_history"
+        | "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => "Integrations & Observability",
         _ => "Other",
     }
 }
@@ -209,19 +211,19 @@ pub(crate) fn build_config_page(
     }
 
     let mut groups = Vec::new();
-    for title in GROUP_ORDER {
+    for (title, slug) in GROUP_ORDER {
         let mut sections = Vec::new();
         if let Some(rows) = top_level_rows.remove(title) {
             sections.push(ConfigSectionView {
                 title: "Core Options".to_string(),
-                anchor: format!("cfg-{}-core", slugify(title)),
+                anchor: format!("cfg-{slug}-core"),
                 path: String::new(),
                 rows,
             });
         }
         sections.extend(grouped.remove(title).unwrap_or_default());
         if !sections.is_empty() {
-            groups.push(ConfigGroupView { title, sections });
+            groups.push(ConfigGroupView { title, slug, sections });
         }
     }
 
@@ -300,7 +302,7 @@ fn build_row(
     let value = lookup(effective, path);
     let (value_html, multiline) = match value {
         Some(value) => format_value(value),
-        None => ("<span class=\"config-unset\">not set</span>".to_string(), false),
+        None => (UNSET_HTML.to_string(), false),
     };
     let unset = value.is_none_or(serde_json::Value::is_null);
     let source = explicit_source(path, explicit_paths);
@@ -313,7 +315,10 @@ fn build_row(
         overridden: source.is_some(),
         source: source.unwrap_or_default(),
         default_html: format_default(&field.default),
-        description_html: markdown_lite(&field.description),
+        description_html: match field.description.trim() {
+            "" => "<span class=\"config-unset\">No description yet.</span>".to_string(),
+            description => markdown_lite(description),
+        },
         unset,
         undocumented,
     }
@@ -351,16 +356,12 @@ fn lookup<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json
 fn format_value(value: &serde_json::Value) -> (String, bool) {
     use serde_json::Value;
     match value {
-        Value::Null => ("<span class=\"config-unset\">not set</span>".to_string(), false),
+        Value::Null => (UNSET_HTML.to_string(), false),
         Value::Bool(b) => (format!("<code>{b}</code>"), false),
         Value::Number(n) => (format!("<code>{n}</code>"), false),
-        Value::String(s) if s.is_empty() => {
-            ("<span class=\"config-unset\">\"\" (empty)</span>".to_string(), false)
-        }
+        Value::String(s) if s.is_empty() => (EMPTY_HTML.to_string(), false),
         Value::String(s) => (format!("<code>{}</code>", escape_html(s)), false),
-        Value::Array(items) if items.is_empty() => {
-            ("<span class=\"config-unset\">[] (empty)</span>".to_string(), false)
-        }
+        Value::Array(items) if items.is_empty() => (EMPTY_HTML.to_string(), false),
         Value::Array(items) if items.iter().all(is_scalar) => {
             let joined = items.iter().map(scalar_text).collect::<Vec<_>>().join(", ");
             if joined.len() <= 120 {
@@ -369,9 +370,7 @@ fn format_value(value: &serde_json::Value) -> (String, bool) {
                 pretty(value)
             }
         }
-        Value::Object(map) if map.is_empty() => {
-            ("<span class=\"config-unset\">{} (empty)</span>".to_string(), false)
-        }
+        Value::Object(map) if map.is_empty() => (EMPTY_HTML.to_string(), false),
         // std::time::Duration serializes as {secs, nanos}; show it humanely.
         Value::Object(map)
             if map.len() == 2 && map.contains_key("secs") && map.contains_key("nanos") =>
@@ -417,12 +416,14 @@ fn humanize_seconds(secs: u64) -> String {
 }
 
 fn format_default(default: &str) -> String {
-    let trimmed = default.trim();
-    match trimmed {
-        "" | "—" | "-" => "<span class=\"config-unset\">—</span>".to_string(),
+    match default.trim() {
+        "" | "—" | "-" | "*(see below)*" | "*(default)*" => NONE_HTML.to_string(),
         "**required**" => "<em>required</em>".to_string(),
-        "*(see below)*" | "*(default)*" => "<span class=\"config-unset\">—</span>".to_string(),
-        other => markdown_lite(other),
+        // An annotated absent default, e.g. "— (forever)".
+        other => match other.strip_prefix("—") {
+            Some(annotation) => format!("{NONE_HTML} {}", markdown_lite(annotation.trim())),
+            None => markdown_lite(other),
+        },
     }
 }
 

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -68,6 +68,8 @@ pub(crate) struct ConfigRowView {
     /// The option resolves to null/absent (unset optional value).
     pub unset: bool,
     pub undocumented: bool,
+    /// The value shown is the live, runtime-adjustable value.
+    pub runtime: bool,
 }
 
 /// Placeholder cells for absent content, kept to plain words -- no dashes
@@ -75,6 +77,17 @@ pub(crate) struct ConfigRowView {
 const UNSET_HTML: &str = "<span class=\"config-unset\">unset</span>";
 const EMPTY_HTML: &str = "<span class=\"config-unset\">empty</span>";
 const NONE_HTML: &str = "<span class=\"config-unset\">none</span>";
+
+/// A dynamic setting whose live value is folded into the catalog: attached to
+/// the config option at `path` when one is documented, otherwise rendered as
+/// its own row (with `description`) in that path's group.
+pub(crate) struct RuntimeSetting {
+    pub path: &'static str,
+    /// Live value; `None` renders as "unset".
+    pub value: Option<String>,
+    /// Used only when no documented option matches `path`.
+    pub description: &'static str,
+}
 
 /// One `| field | type | default | description |` row of the reference doc.
 struct FieldDoc {
@@ -129,7 +142,9 @@ fn group_for_top_level_field(name: &str) -> &'static str {
         | "power_shelf_state_controller" | "switch_state_controller" | "power_manager_options"
         | "ib_partition_state_controller" | "component_manager" => "Hardware & Racks",
         "metrics_endpoint" | "alt_metric_prefix" | "tracing" | "observability" | "log_history"
-        | "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => "Integrations & Observability",
+        | "log_filter" | "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => {
+            "Integrations & Observability"
+        }
         _ => "Other",
     }
 }
@@ -140,6 +155,7 @@ pub(crate) fn build_config_page(
     reference_md: &str,
     effective: &serde_json::Value,
     explicit_paths: &BTreeMap<String, String>,
+    runtime_settings: Vec<RuntimeSetting>,
 ) -> ConfigPageView {
     let sections = parse_reference(reference_md);
 
@@ -208,6 +224,41 @@ pub(crate) fn build_config_page(
                 .or_default()
                 .push(row);
         }
+    }
+
+    // Fold live runtime values into their documented rows; settings without a
+    // documented option become their own rows in the matching group.
+    'settings: for setting in runtime_settings {
+        let all_rows = top_level_rows
+            .values_mut()
+            .chain(grouped.values_mut().flatten().map(|s| &mut s.rows));
+        for rows in all_rows {
+            if let Some(row) = rows.iter_mut().find(|row| row.path == setting.path) {
+                row.value_html = runtime_value_html(&setting);
+                row.multiline = false;
+                row.unset = setting.value.is_none();
+                row.runtime = true;
+                continue 'settings;
+            }
+        }
+        let top = setting.path.split('.').next().unwrap_or(setting.path);
+        top_level_rows
+            .entry(group_for_top_level_field(top))
+            .or_default()
+            .push(ConfigRowView {
+                name: setting.path.rsplit('.').next().unwrap_or(setting.path).to_string(),
+                path: setting.path.to_string(),
+                ty: String::new(),
+                value_html: runtime_value_html(&setting),
+                multiline: false,
+                overridden: false,
+                source: String::new(),
+                default_html: NONE_HTML.to_string(),
+                description_html: markdown_lite(setting.description),
+                unset: setting.value.is_none(),
+                undocumented: false,
+                runtime: true,
+            });
     }
 
     let mut groups = Vec::new();
@@ -321,6 +372,14 @@ fn build_row(
         },
         unset,
         undocumented,
+        runtime: false,
+    }
+}
+
+fn runtime_value_html(setting: &RuntimeSetting) -> String {
+    match &setting.value {
+        Some(value) => format!("<code>{}</code>", escape_html(value)),
+        None => UNSET_HTML.to_string(),
     }
 }
 
@@ -680,6 +739,7 @@ mod configuration_tests {
             carbide_api_core::cfg::CONFIG_REFERENCE_MD,
             &effective,
             &explicit,
+            Vec::new(),
         );
         let rows: Vec<&ConfigRowView> = page
             .groups

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -74,6 +74,10 @@ pub(crate) struct ConfigRowView {
     pub description_html: String,
     /// The value shown is the live, runtime-adjustable value.
     pub runtime: bool,
+    /// Lowercased haystack for the client-side filter: name, path, value,
+    /// source, and description — deliberately not the type or the panel's
+    /// "Type/Default/Path" labels, which would match on every row.
+    pub search: String,
 }
 
 /// A value or default cell. Rendering (and HTML escaping) is centralized in
@@ -117,6 +121,16 @@ impl CellValue {
     /// Used by the template to dim rows whose option isn't set.
     pub fn is_unset(&self) -> bool {
         matches!(self, CellValue::Unset)
+    }
+
+    /// Plain text of the cell for the client-side filter.
+    fn search_text(&self) -> &str {
+        match self {
+            CellValue::Unset => "unset",
+            CellValue::Empty => "empty",
+            CellValue::NoDefault | CellValue::Required | CellValue::Rich(_) => "",
+            CellValue::Code(text) | CellValue::Pre(text) => text,
+        }
     }
 }
 
@@ -273,9 +287,19 @@ pub(crate) fn build_config_page(
             if let Some(row) = rows.iter_mut().find(|row| row.path == setting.path) {
                 row.value = runtime_cell(setting.value);
                 row.runtime = true;
+                row.search =
+                    format!("{} runtime {}", row.search, row.value.search_text()).to_lowercase();
                 continue 'settings;
             }
         }
+        let value = runtime_cell(setting.value);
+        let search = format!(
+            "{} runtime {} {}",
+            setting.path,
+            value.search_text(),
+            setting.description
+        )
+        .to_lowercase();
         top_level_rows
             .entry(group_title(setting.group))
             .or_default()
@@ -288,12 +312,13 @@ pub(crate) fn build_config_page(
                     .to_string(),
                 path: setting.path.to_string(),
                 ty: String::new(),
-                value: runtime_cell(setting.value),
+                value,
                 overridden: false,
                 source: String::new(),
                 default: CellValue::NoDefault,
                 description_html: markdown_lite(setting.description),
                 runtime: true,
+                search,
             });
     }
 
@@ -369,7 +394,13 @@ impl<'a> CatalogBuilder<'a> {
             .trim_start_matches("Option<")
             .trim_end_matches('>')
             .trim();
-        self.sections_by_name.get(&inner.to_lowercase()).copied()
+        self.sections_by_name
+            .get(&inner.to_lowercase())
+            .copied()
+            // Sections without field rows (e.g. enum value tables like
+            // `RepublishScope`) stay leaf rows rather than dissolving into
+            // an empty section.
+            .filter(|fields| !fields.is_empty())
     }
 
     /// Recursively emit a section for `fields` under `path`, appending nested
@@ -406,14 +437,24 @@ impl<'a> CatalogBuilder<'a> {
 
     fn build_row(&self, field: &FieldDoc, path: &str) -> ConfigRowView {
         let source = self.explicit_source(path);
+        let value = match self.lookup(path) {
+            Some(value) => format_value(value),
+            None => CellValue::Unset,
+        };
+        let search = format!(
+            "{} {} {} {} {}",
+            field.name,
+            path,
+            value.search_text(),
+            source.as_deref().unwrap_or(""),
+            field.description
+        )
+        .to_lowercase();
         ConfigRowView {
             name: field.name.clone(),
             path: path.to_string(),
             ty: clean_type(&field.ty),
-            value: match self.lookup(path) {
-                Some(value) => format_value(value),
-                None => CellValue::Unset,
-            },
+            value,
             overridden: source.is_some(),
             source: source.unwrap_or_default(),
             default: format_default(&field.default),
@@ -422,6 +463,7 @@ impl<'a> CatalogBuilder<'a> {
                 description => markdown_lite(description),
             },
             runtime: false,
+            search,
         }
     }
 
@@ -727,6 +769,15 @@ fn markdown_lite(text: &str) -> String {
 mod configuration_tests {
     use super::*;
 
+    /// The shared compile-checked fixture with every `Option` section
+    /// populated, so the coverage and stale-row guards can see inside all
+    /// sections. Maintained by rustc: new config fields fail to compile in
+    /// `test_support::default_config` until added there.
+    fn fixture_json() -> serde_json::Value {
+        let config = carbide_api_core::test_support::default_config::fully_populated();
+        serde_json::to_value(config.redacted()).expect("config serializes")
+    }
+
     fn no_live_settings() -> LiveSettings {
         LiveSettings {
             log_filter: "info".to_string(),
@@ -784,11 +835,7 @@ mod configuration_tests {
     /// to `CarbideConfig` without a README row.
     #[test]
     fn every_config_field_is_documented() {
-        // A minimal valid config; serialization emits every non-skipped key.
-        let config: carbide_api_core::cfg::file::CarbideConfig =
-            toml::from_str("database_url = \"postgres://x\"\nasn = 65001\n")
-                .expect("minimal config parses");
-        let effective = serde_json::to_value(config.redacted()).expect("config serializes");
+        let effective = fixture_json();
         let sections = parse_reference(carbide_api_core::cfg::CONFIG_REFERENCE_MD);
         let (_, top) = sections.iter().find(|(n, _)| n == "NicoConfig").unwrap();
         let documented: HashSet<String> = top.iter().map(|f| canonical(&f.name)).collect();
@@ -801,6 +848,115 @@ mod configuration_tests {
         assert!(
             undocumented.is_empty(),
             "config fields missing from cfg/README.md: {undocumented:?}"
+        );
+    }
+
+    /// Extends the coverage guard below the top level: every key the config
+    /// actually serializes under a documented section must be a documented
+    /// row (or a documented sub-section) of that section. Catches a field
+    /// added to e.g. `SiteExplorerConfig` without a README row.
+    #[test]
+    fn every_serialized_section_key_is_documented() {
+        let effective = fixture_json();
+        let page = build_config_page(
+            carbide_api_core::cfg::CONFIG_REFERENCE_MD,
+            &effective,
+            &BTreeMap::new(),
+            no_live_settings(),
+        );
+
+        let sections: Vec<&ConfigSectionView> = page
+            .groups
+            .iter()
+            .flat_map(|g| g.sections.iter())
+            .filter(|s| !s.path.is_empty())
+            .collect();
+        let section_paths: HashSet<String> = sections.iter().map(|s| canonical(&s.path)).collect();
+
+        let mut problems = Vec::new();
+        for section in &sections {
+            // Walk the serialized config to this section's object, matching
+            // segments the same way the builder does.
+            let mut value = &effective;
+            let mut found = true;
+            for segment in section.path.split('.') {
+                let want = canonical(segment);
+                match value
+                    .as_object()
+                    .and_then(|o| o.iter().find(|(k, _)| canonical(k) == want).map(|(_, v)| v))
+                {
+                    Some(v) => value = v,
+                    None => {
+                        found = false;
+                        break;
+                    }
+                }
+            }
+            let Some(object) = (found.then_some(value)).and_then(|v| v.as_object()) else {
+                continue; // unset Option section or non-object value
+            };
+            let documented: HashSet<String> = section
+                .rows
+                .iter()
+                .filter_map(|r| r.path.rsplit('.').next())
+                .map(canonical)
+                .collect();
+            for key in object.keys() {
+                let child_path = canonical(&format!("{}.{}", section.path, key));
+                if !documented.contains(&canonical(key)) && !section_paths.contains(&child_path) {
+                    problems.push(format!("{}.{}", section.path, key));
+                }
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "serialized config keys missing from their cfg/README.md section: {problems:?}"
+        );
+    }
+
+    /// The inverse of the coverage guards: a documented row whose parent
+    /// object serializes but whose key doesn't exist documents a field that
+    /// was removed or renamed — delete or fix the README row. Rows under
+    /// unset `Option` sections (e.g. `tls` in the minimal config) can't be
+    /// verified and are skipped, as are synthetic runtime rows and the one
+    /// `skip_serializing_if` field.
+    #[test]
+    fn every_documented_row_matches_a_config_field() {
+        let effective = fixture_json();
+        let page = build_config_page(
+            carbide_api_core::cfg::CONFIG_REFERENCE_MD,
+            &effective,
+            &BTreeMap::new(),
+            no_live_settings(),
+        );
+
+        const SKIP_SERIALIZING: &[&str] = &["mlxconfig_profiles"];
+        let mut stale = Vec::new();
+        for row in page
+            .groups
+            .iter()
+            .flat_map(|g| g.sections.iter())
+            .flat_map(|s| s.rows.iter())
+            .filter(|r| !r.runtime && !SKIP_SERIALIZING.contains(&r.path.as_str()))
+        {
+            let mut value = &effective;
+            for segment in row.path.split('.') {
+                let Some(object) = value.as_object() else {
+                    break; // parent is unset (Option section) — unverifiable
+                };
+                let want = canonical(segment);
+                match object.iter().find(|(k, _)| canonical(k) == want) {
+                    Some((_, child)) => value = child,
+                    None => {
+                        stale.push(row.path.clone());
+                        break;
+                    }
+                }
+            }
+        }
+        assert!(
+            stale.is_empty(),
+            "cfg/README.md rows documenting nonexistent config fields: {stale:?}"
         );
     }
 

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -29,6 +29,12 @@
 //! - `CarbideConfig::explicit_value_paths` supplies provenance: which dotted
 //!   keys were explicitly set by a config file or `CARBIDE_API_*` environment
 //!   variable, and by which source.
+//!
+//! The three inputs use different key spellings for the same option (Rust
+//! field names in the reference, serde-serialized names in the JSON, TOML
+//! keys in the provenance map — e.g. `mlxconfig_profiles` serializes as
+//! `mlx-config-profiles`). All joins therefore go through [`canonical`],
+//! which strips everything but alphanumerics per path segment.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
@@ -46,7 +52,6 @@ pub(crate) struct ConfigGroupView {
 
 pub(crate) struct ConfigSectionView {
     pub title: String,
-    pub anchor: String,
     /// Dotted TOML path prefix of this section ("" for top-level options).
     pub path: String,
     pub rows: Vec<ConfigRowView>,
@@ -57,48 +62,142 @@ pub(crate) struct ConfigRowView {
     /// Full dotted path, also used by the client-side filter.
     pub path: String,
     pub ty: String,
-    pub value_html: String,
-    /// Render the value as a preformatted block instead of inline.
-    pub multiline: bool,
+    pub value: CellValue,
     pub overridden: bool,
     /// Source label ("nico-api-config.toml", env, ...) when overridden.
     pub source: String,
-    pub default_html: String,
+    pub default: CellValue,
+    /// Rendered by [`markdown_lite`]; the template inserts it with `|safe`.
     pub description_html: String,
-    /// The option resolves to null/absent (unset optional value).
-    pub unset: bool,
-    pub undocumented: bool,
     /// The value shown is the live, runtime-adjustable value.
     pub runtime: bool,
 }
 
-/// Placeholder cells for absent content, kept to plain words -- no dashes
-/// or empty strings, and one consistent word per situation.
-const UNSET_HTML: &str = "<span class=\"config-unset\">unset</span>";
-const EMPTY_HTML: &str = "<span class=\"config-unset\">empty</span>";
-const NONE_HTML: &str = "<span class=\"config-unset\">none</span>";
-
-/// A dynamic setting whose live value is folded into the catalog: attached to
-/// the config option at `path` when one is documented, otherwise rendered as
-/// its own row (with `description`) in that path's group.
-pub(crate) struct RuntimeSetting {
-    pub path: &'static str,
-    /// Live value; `None` renders as "unset".
-    pub value: Option<String>,
-    /// Used only when no documented option matches `path`.
-    pub description: &'static str,
+/// A value or default cell. Rendering (and HTML escaping) is centralized in
+/// [`CellValue::to_html`] — the template inserts its output with `|safe`.
+pub(crate) enum CellValue {
+    /// The option resolves to null/absent.
+    Unset,
+    /// The option is set to an empty string, list, or map.
+    Empty,
+    /// No default exists (used only in the Default column).
+    NoDefault,
+    /// The option is mandatory (used only in the Default column).
+    Required,
+    /// Plain text rendered as inline code; escaped at render time.
+    Code(String),
+    /// Pretty-printed block rendered behind a "show value" expander;
+    /// escaped at render time.
+    Pre(String),
+    /// Pre-rendered HTML. Must only ever wrap [`markdown_lite`] output,
+    /// which is the single escaping site for rich text.
+    Rich(String),
 }
 
-/// One `| field | type | default | description |` row of the reference doc.
+impl CellValue {
+    /// The single place cell HTML is produced.
+    pub fn to_html(&self) -> String {
+        match self {
+            CellValue::Unset => r#"<span class="config-unset">unset</span>"#.to_string(),
+            CellValue::Empty => r#"<span class="config-unset">empty</span>"#.to_string(),
+            CellValue::NoDefault => r#"<span class="config-unset">none</span>"#.to_string(),
+            CellValue::Required => "<em>required</em>".to_string(),
+            CellValue::Code(text) => format!("<code>{}</code>", escape_html(text)),
+            CellValue::Pre(text) => format!(
+                "<details><summary>show value</summary><pre>{}</pre></details>",
+                escape_html(text)
+            ),
+            CellValue::Rich(html) => html.clone(),
+        }
+    }
+
+    /// Used by the template to dim rows whose option isn't set.
+    pub fn is_unset(&self) -> bool {
+        matches!(self, CellValue::Unset)
+    }
+}
+
+/// Live values of the runtime-adjustable settings, folded into the catalog
+/// next to their config options and tagged "runtime". `None` values render
+/// as "unset".
+pub(crate) struct LiveSettings {
+    pub log_filter: String,
+    pub site_explorer_enabled: String,
+    pub create_machines: String,
+    pub bmc_proxy: Option<String>,
+    pub tracing_enabled: String,
+    pub dpu_agent_upgrade_policy: String,
+}
+
+/// A dynamic setting joined into the catalog: attached to the config option
+/// at `path` when one is documented, otherwise rendered as its own row (with
+/// `description`) in that path's group.
+struct RuntimeSetting {
+    path: &'static str,
+    value: Option<String>,
+    /// Group slug and description, used only when no documented option
+    /// matches `path` and the setting becomes its own row.
+    group: &'static str,
+    description: &'static str,
+}
+
+impl LiveSettings {
+    fn into_runtime_settings(self) -> Vec<RuntimeSetting> {
+        vec![
+            RuntimeSetting {
+                path: "log_filter",
+                value: Some(self.log_filter),
+                group: "integrations",
+                description: "Active `RUST_LOG` log filter.",
+            },
+            RuntimeSetting {
+                path: "site_explorer.enabled",
+                group: "hardware",
+                value: Some(self.site_explorer_enabled),
+                description: "Whether site explorer runs periodic hardware explorations.",
+            },
+            RuntimeSetting {
+                path: "site_explorer.create_machines",
+                group: "hardware",
+                value: Some(self.create_machines),
+                description: "Whether site explorer creates machines from discovered endpoints.",
+            },
+            RuntimeSetting {
+                path: "site_explorer.bmc_proxy",
+                group: "hardware",
+                value: self.bmc_proxy,
+                description: "Proxy used for talking to BMCs.",
+            },
+            RuntimeSetting {
+                path: "tracing.enabled",
+                value: Some(self.tracing_enabled),
+                group: "integrations",
+                description: "Whether log tracing is enabled.",
+            },
+            RuntimeSetting {
+                path: "initial_dpu_agent_upgrade_policy",
+                value: Some(self.dpu_agent_upgrade_policy),
+                group: "machines",
+                description: "Active DPU agent upgrade policy.",
+            },
+        ]
+    }
+}
+
+/// One `| field | type | default | (group) | description |` row of the
+/// reference doc. `group` is present only in the top-level table, where each
+/// option declares which admin-UI tab it belongs to.
 struct FieldDoc {
     name: String,
     ty: String,
     default: String,
+    group: Option<String>,
     description: String,
 }
 
-/// Display groups, in page order. Sections land in a group via
-/// `group_for_top_level_field`; unknown fields fall through to "Other".
+/// Display groups, in page order. Each top-level option declares its group
+/// slug in the reference doc's `Group` column; unknown slugs fall through to
+/// "Other" (a unit test keeps the column complete and valid).
 const GROUP_ORDER: &[(&str, &str)] = &[
     ("Server & API", "server"),
     ("Networking", "networking"),
@@ -109,61 +208,31 @@ const GROUP_ORDER: &[(&str, &str)] = &[
     ("Other", "other"),
 ];
 
-fn group_for_top_level_field(name: &str) -> &'static str {
-    match name {
-        "listen" | "listen_only" | "listen_mode" | "tls" | "database_url"
-        | "max_database_connections" | "max_find_by_ids" | "auth" | "bypass_rbac"
-        | "enable_admin_ui" | "web_ui_sidebar_tools" | "sitename" | "initial_objects_file" => {
-            "Server & API"
-        }
-        "asn" | "dhcp_servers" | "ntp_servers" | "route_servers" | "enable_route_servers"
-        | "deny_prefixes" | "site_fabric_prefixes" | "anycast_site_prefixes"
-        | "common_tenant_host_asn" | "vpc_isolation_behavior" | "networks" | "pools"
-        | "fnn" | "internet_l3_vni" | "datacenter_asn" | "site_global_vpc_vni"
-        | "bgp_leaf_session_password" | "vpc_peering_policy" | "vpc_peering_policy_on_existing"
-        | "network_security_group" | "dpa_config" | "network_segment_state_controller"
-        | "vpc_prefix_state_controller" | "dpa_interface_state_controller"
-        | "dpu_network_monitor_pinger_type" => "Networking",
-        "host_naming_strategy" | "machine_state_controller" | "machine_validation_config"
-        | "auto_machine_repair_plugin" | "host_health" | "initial_domain_name"
-        | "min_dpu_functioning_links" | "bom_validation" | "compute_allocation_enforcement"
-        | "dpu_config" | "dpu_ipmi_tool_impl" | "dpu_ipmi_reboot_attempts" | "nvue_enabled"
-        | "dpf" | "initial_dpu_agent_upgrade_policy" | "x86_pxe_boot_url_override"
-        | "arm_pxe_boot_url_override" | "pxe_public_base_url" | "set_http_boot_uri_for_vendors"
-        | "retained_boot_interface_window" | "host_models" | "firmware_global"
-        | "machine_updater" | "max_concurrent_machine_updates" | "machine_update_run_interval"
-        | "mlxconfig_profiles" | "supernic_firmware_profiles" | "bios_profiles"
-        | "selected_profile" => "Machines & Firmware",
-        "attestation_enabled" | "tpm_required" | "machine_identity" | "spdm"
-        | "spdm_state_controller" | "measured_boot_collector" | "bmc_session_lockout_threshold"
-        | "secrets" | "kms" => "Security",
-        "site_explorer" | "ib_config" | "ib_fabrics" | "nvlink_config"
-        | "rack_management_enabled" | "rms" | "rack_profiles" | "rack_state_controller"
-        | "power_shelf_state_controller" | "switch_state_controller" | "power_manager_options"
-        | "ib_partition_state_controller" | "component_manager" => "Hardware & Racks",
-        "metrics_endpoint" | "alt_metric_prefix" | "tracing" | "observability" | "log_history"
-        | "log_filter" | "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => {
-            "Integrations & Observability"
-        }
-        _ => "Other",
-    }
+fn group_title(slug: &str) -> &'static str {
+    GROUP_ORDER
+        .iter()
+        .find(|(_, s)| *s == slug)
+        .map(|(title, _)| *title)
+        .unwrap_or("Other")
 }
 
+
 /// Builds the page view from the reference doc, the redacted effective config
-/// (as JSON), and the explicitly-set key paths with their source labels.
+/// (as JSON), the explicitly-set key paths with their source labels, and the
+/// live runtime-adjustable values.
 pub(crate) fn build_config_page(
     reference_md: &str,
     effective: &serde_json::Value,
     explicit_paths: &BTreeMap<String, String>,
-    runtime_settings: Vec<RuntimeSetting>,
+    live: LiveSettings,
 ) -> ConfigPageView {
     let sections = parse_reference(reference_md);
+    let builder = CatalogBuilder::new(&sections, effective, explicit_paths);
 
     // Grouped sections, keyed by group title. Each group lazily gets a
     // leading section for the top-level scalar options assigned to it.
     let mut grouped: HashMap<&'static str, Vec<ConfigSectionView>> = HashMap::new();
     let mut top_level_rows: HashMap<&'static str, Vec<ConfigRowView>> = HashMap::new();
-    let mut documented_top_level: HashSet<String> = HashSet::new();
 
     let top_level = sections
         .iter()
@@ -171,92 +240,52 @@ pub(crate) fn build_config_page(
         .map(|(_, fields)| fields.as_slice())
         .unwrap_or(&[]);
 
-    let section_by_anchor: HashMap<String, &Vec<FieldDoc>> = sections
-        .iter()
-        .map(|(name, fields)| (name.to_lowercase(), fields))
-        .collect();
-
     for field in top_level {
-        documented_top_level.insert(field.name.clone());
-        let group = group_for_top_level_field(&field.name);
-        match nested_section_for(field, &section_by_anchor) {
+        let group = group_title(field.group.as_deref().unwrap_or(""));
+        match builder.nested_section_for(field) {
             Some(section_fields) => {
                 let mut nested = Vec::new();
-                build_section(
+                builder.build_section(
                     humanize(&field.name),
                     field.name.clone(),
                     section_fields,
-                    &section_by_anchor,
-                    effective,
-                    explicit_paths,
                     &mut nested,
                     &mut HashSet::new(),
                 );
                 grouped.entry(group).or_default().extend(nested);
             }
-            None => top_level_rows.entry(group).or_default().push(build_row(
-                field,
-                &field.name,
-                effective,
-                explicit_paths,
-                false,
-            )),
-        }
-    }
-
-    // Options present in the effective config but missing from the reference
-    // doc: surface them rather than silently dropping them.
-    if let Some(object) = effective.as_object() {
-        for (name, value) in object {
-            if documented_top_level.contains(name) || documented_top_level.contains(&name.replace('-', "_")) {
-                continue;
-            }
-            let field = FieldDoc {
-                name: name.clone(),
-                ty: String::new(),
-                default: "—".to_string(),
-                description: "Not yet documented in the configuration reference.".to_string(),
-            };
-            let mut row = build_row(&field, name, effective, explicit_paths, true);
-            row.unset = value.is_null();
-            top_level_rows
-                .entry(group_for_top_level_field(name))
+            None => top_level_rows
+                .entry(group)
                 .or_default()
-                .push(row);
+                .push(builder.build_row(field, &field.name)),
         }
     }
 
     // Fold live runtime values into their documented rows; settings without a
     // documented option become their own rows in the matching group.
-    'settings: for setting in runtime_settings {
+    'settings: for setting in live.into_runtime_settings() {
         let all_rows = top_level_rows
             .values_mut()
             .chain(grouped.values_mut().flatten().map(|s| &mut s.rows));
         for rows in all_rows {
             if let Some(row) = rows.iter_mut().find(|row| row.path == setting.path) {
-                row.value_html = runtime_value_html(&setting);
-                row.multiline = false;
-                row.unset = setting.value.is_none();
+                row.value = runtime_cell(setting.value);
                 row.runtime = true;
                 continue 'settings;
             }
         }
-        let top = setting.path.split('.').next().unwrap_or(setting.path);
         top_level_rows
-            .entry(group_for_top_level_field(top))
+            .entry(group_title(setting.group))
             .or_default()
             .push(ConfigRowView {
                 name: setting.path.rsplit('.').next().unwrap_or(setting.path).to_string(),
                 path: setting.path.to_string(),
                 ty: String::new(),
-                value_html: runtime_value_html(&setting),
-                multiline: false,
+                value: runtime_cell(setting.value),
                 overridden: false,
                 source: String::new(),
-                default_html: NONE_HTML.to_string(),
+                default: CellValue::NoDefault,
                 description_html: markdown_lite(setting.description),
-                unset: setting.value.is_none(),
-                undocumented: false,
                 runtime: true,
             });
     }
@@ -267,7 +296,6 @@ pub(crate) fn build_config_page(
         if let Some(rows) = top_level_rows.remove(title) {
             sections.push(ConfigSectionView {
                 title: "Core Options".to_string(),
-                anchor: format!("cfg-{slug}-core"),
                 path: String::new(),
                 rows,
             });
@@ -281,155 +309,179 @@ pub(crate) fn build_config_page(
     ConfigPageView { groups }
 }
 
-/// If the field's type refers to a documented sub-struct section (and isn't a
-/// collection of them), return that section's fields for recursion.
-fn nested_section_for<'a>(
-    field: &FieldDoc,
-    sections: &'a HashMap<String, &Vec<FieldDoc>>,
-) -> Option<&'a Vec<FieldDoc>> {
-    let ty = clean_type(&field.ty);
-    // Collections of structs stay leaf rows: their keys are operator-chosen,
-    // so there is no fixed set of options to enumerate.
-    if ty.contains("HashMap") || ty.contains("Vec<") || ty.contains("nested") {
-        return None;
+fn runtime_cell(value: Option<String>) -> CellValue {
+    match value {
+        Some(value) => CellValue::Code(value),
+        None => CellValue::Unset,
     }
-    let inner = ty
-        .trim_start_matches("Option<")
-        .trim_end_matches('>')
-        .trim();
-    sections.get(&inner.to_lowercase()).copied()
 }
 
-/// Recursively emit a section for `fields` under `path`, appending nested
-/// sub-struct sections after it. `visited` guards against reference cycles.
-#[allow(clippy::too_many_arguments)]
-fn build_section(
-    title: String,
-    path: String,
-    fields: &[FieldDoc],
-    sections: &HashMap<String, &Vec<FieldDoc>>,
-    effective: &serde_json::Value,
-    explicit_paths: &BTreeMap<String, String>,
-    out: &mut Vec<ConfigSectionView>,
-    visited: &mut HashSet<String>,
-) {
-    if !visited.insert(path.clone()) {
-        return;
-    }
-    let mut rows = Vec::new();
-    let mut nested = Vec::new();
-    for field in fields {
-        let field_path = format!("{path}.{}", field.name);
-        match nested_section_for(field, sections) {
-            Some(section_fields) => build_section(
-                format!("{title} · {}", humanize(&field.name)),
-                field_path,
-                section_fields,
-                sections,
-                effective,
-                explicit_paths,
-                &mut nested,
-                visited,
-            ),
-            None => rows.push(build_row(field, &field_path, effective, explicit_paths, false)),
+/// Shared context for assembling catalog sections: the reference sections to
+/// recurse into, the effective config values, and the override provenance.
+struct CatalogBuilder<'a> {
+    sections_by_name: HashMap<String, &'a [FieldDoc]>,
+    effective: &'a serde_json::Value,
+    /// Explicitly-set paths with canonicalized keys, for spelling-insensitive
+    /// exact and prefix matching.
+    explicit: BTreeMap<String, &'a str>,
+}
+
+impl<'a> CatalogBuilder<'a> {
+    fn new(
+        sections: &'a [(String, Vec<FieldDoc>)],
+        effective: &'a serde_json::Value,
+        explicit_paths: &'a BTreeMap<String, String>,
+    ) -> Self {
+        CatalogBuilder {
+            sections_by_name: sections
+                .iter()
+                .map(|(name, fields)| (name.to_lowercase(), fields.as_slice()))
+                .collect(),
+            effective,
+            explicit: explicit_paths
+                .iter()
+                .map(|(path, source)| (canonical(path), source.as_str()))
+                .collect(),
         }
     }
-    out.push(ConfigSectionView {
-        anchor: format!("cfg-{}", slugify(&path)),
-        title,
-        path,
-        rows,
-    });
-    out.extend(nested);
-}
 
-fn build_row(
-    field: &FieldDoc,
-    path: &str,
-    effective: &serde_json::Value,
-    explicit_paths: &BTreeMap<String, String>,
-    undocumented: bool,
-) -> ConfigRowView {
-    let value = lookup(effective, path);
-    let (value_html, multiline) = match value {
-        Some(value) => format_value(value),
-        None => (UNSET_HTML.to_string(), false),
-    };
-    let unset = value.is_none_or(serde_json::Value::is_null);
-    let source = explicit_source(path, explicit_paths);
-    ConfigRowView {
-        name: field.name.clone(),
-        path: path.to_string(),
-        ty: clean_type(&field.ty),
-        value_html,
-        multiline,
-        overridden: source.is_some(),
-        source: source.unwrap_or_default(),
-        default_html: format_default(&field.default),
-        description_html: match field.description.trim() {
-            "" => "<span class=\"config-unset\">No description yet.</span>".to_string(),
-            description => markdown_lite(description),
-        },
-        unset,
-        undocumented,
-        runtime: false,
+    /// If the field's type refers to a documented sub-struct section (and
+    /// isn't a collection of them), return that section's fields.
+    fn nested_section_for(&self, field: &FieldDoc) -> Option<&'a [FieldDoc]> {
+        let ty = clean_type(&field.ty);
+        // Collections of structs stay leaf rows: their keys are
+        // operator-chosen, so there is no fixed set of options to enumerate.
+        if ty.contains("HashMap") || ty.contains("Vec<") || ty.contains("nested") {
+            return None;
+        }
+        let inner = ty
+            .trim_start_matches("Option<")
+            .trim_end_matches('>')
+            .trim();
+        self.sections_by_name.get(&inner.to_lowercase()).copied()
+    }
+
+    /// Recursively emit a section for `fields` under `path`, appending nested
+    /// sub-struct sections after it. `visited` guards against cycles.
+    fn build_section(
+        &self,
+        title: String,
+        path: String,
+        fields: &'a [FieldDoc],
+        out: &mut Vec<ConfigSectionView>,
+        visited: &mut HashSet<String>,
+    ) {
+        if !visited.insert(path.clone()) {
+            return;
+        }
+        let mut rows = Vec::new();
+        let mut nested = Vec::new();
+        for field in fields {
+            let field_path = format!("{path}.{}", field.name);
+            match self.nested_section_for(field) {
+                Some(section_fields) => self.build_section(
+                    format!("{title} · {}", humanize(&field.name)),
+                    field_path,
+                    section_fields,
+                    &mut nested,
+                    visited,
+                ),
+                None => rows.push(self.build_row(field, &field_path)),
+            }
+        }
+        out.push(ConfigSectionView { title, path, rows });
+        out.extend(nested);
+    }
+
+    fn build_row(&self, field: &FieldDoc, path: &str) -> ConfigRowView {
+        let source = self.explicit_source(path);
+        ConfigRowView {
+            name: field.name.clone(),
+            path: path.to_string(),
+            ty: clean_type(&field.ty),
+            value: match self.lookup(path) {
+                Some(value) => format_value(value),
+                None => CellValue::Unset,
+            },
+            overridden: source.is_some(),
+            source: source.unwrap_or_default().to_string(),
+            default: format_default(&field.default),
+            description_html: match field.description.trim() {
+                "" => r#"<span class="config-unset">No description yet.</span>"#.to_string(),
+                description => markdown_lite(description),
+            },
+            runtime: false,
+        }
+    }
+
+    /// Effective value at `path`, matching each segment spelling-insensitively
+    /// (reference field names vs. serde-renamed JSON keys).
+    fn lookup(&self, path: &str) -> Option<&'a serde_json::Value> {
+        let mut current = self.effective;
+        for segment in path.split('.') {
+            let object = current.as_object()?;
+            let want = canonical(segment);
+            current = object
+                .iter()
+                .find(|(key, _)| canonical(key) == want)
+                .map(|(_, value)| value)?;
+        }
+        Some(current)
+    }
+
+    /// A key counts as explicitly set when the merged config sources provided
+    /// it or anything beneath it (e.g. `tls` is overridden when
+    /// `tls.root_cafile_path` was set in a file).
+    fn explicit_source(&self, path: &str) -> Option<&'a str> {
+        let key = canonical(path);
+        if let Some(source) = self.explicit.get(&key) {
+            return Some(source);
+        }
+        let prefix = format!("{key}.");
+        self.explicit
+            .range(prefix.clone()..)
+            .take_while(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, source)| *source)
+            .next()
     }
 }
 
-fn runtime_value_html(setting: &RuntimeSetting) -> String {
-    match &setting.value {
-        Some(value) => format!("<code>{}</code>", escape_html(value)),
-        None => UNSET_HTML.to_string(),
-    }
-}
-
-/// A key counts as explicitly set when the merged config sources provided it
-/// or anything beneath it (e.g. `tls` is overridden when `tls.root_cafile_path`
-/// was set in a file).
-fn explicit_source(path: &str, explicit_paths: &BTreeMap<String, String>) -> Option<String> {
-    // Figment normalizes TOML dashes; match both spellings.
-    let underscored = path.replace('-', "_");
-    let prefix = format!("{underscored}.");
-    explicit_paths
-        .iter()
-        .find(|(key, _)| {
-            let key = key.replace('-', "_");
-            key == underscored || key.starts_with(&prefix)
+/// Canonical form of a dotted config path: each segment lowercased with
+/// everything but alphanumerics stripped, so `mlxconfig_profiles`,
+/// `mlx-config-profiles`, and `MlxConfigProfiles` all compare equal while
+/// path structure is preserved.
+fn canonical(path: &str) -> String {
+    path.split('.')
+        .map(|segment| {
+            segment
+                .chars()
+                .filter(char::is_ascii_alphanumeric)
+                .map(|c| c.to_ascii_lowercase())
+                .collect::<String>()
         })
-        .map(|(_, source)| source.clone())
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
-fn lookup<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
-    let mut current = value;
-    for segment in path.split('.') {
-        let object = current.as_object()?;
-        current = object
-            .get(segment)
-            .or_else(|| object.get(&segment.replace('_', "-")))?;
-    }
-    Some(current)
-}
-
-/// Renders a JSON value as HTML. Returns `(html, multiline)`; multiline values
-/// are pretty-printed JSON meant for a `<pre>` block.
-fn format_value(value: &serde_json::Value) -> (String, bool) {
+/// Renders a JSON value as a display cell.
+fn format_value(value: &serde_json::Value) -> CellValue {
     use serde_json::Value;
     match value {
-        Value::Null => (UNSET_HTML.to_string(), false),
-        Value::Bool(b) => (format!("<code>{b}</code>"), false),
-        Value::Number(n) => (format!("<code>{n}</code>"), false),
-        Value::String(s) if s.is_empty() => (EMPTY_HTML.to_string(), false),
-        Value::String(s) => (format!("<code>{}</code>", escape_html(s)), false),
-        Value::Array(items) if items.is_empty() => (EMPTY_HTML.to_string(), false),
+        Value::Null => CellValue::Unset,
+        Value::Bool(b) => CellValue::Code(b.to_string()),
+        Value::Number(n) => CellValue::Code(n.to_string()),
+        Value::String(s) if s.is_empty() => CellValue::Empty,
+        Value::String(s) => CellValue::Code(s.clone()),
+        Value::Array(items) if items.is_empty() => CellValue::Empty,
         Value::Array(items) if items.iter().all(is_scalar) => {
             let joined = items.iter().map(scalar_text).collect::<Vec<_>>().join(", ");
             if joined.len() <= 120 {
-                (format!("<code>{}</code>", escape_html(&joined)), false)
+                CellValue::Code(joined)
             } else {
                 pretty(value)
             }
         }
-        Value::Object(map) if map.is_empty() => (EMPTY_HTML.to_string(), false),
+        Value::Object(map) if map.is_empty() => CellValue::Empty,
         // std::time::Duration serializes as {secs, nanos}; show it humanely.
         Value::Object(map)
             if map.len() == 2 && map.contains_key("secs") && map.contains_key("nanos") =>
@@ -437,18 +489,17 @@ fn format_value(value: &serde_json::Value) -> (String, bool) {
             let secs = map["secs"].as_u64().unwrap_or(0);
             let nanos = map["nanos"].as_u64().unwrap_or(0);
             if nanos == 0 {
-                (format!("<code>{}</code>", escape_html(&humanize_seconds(secs))), false)
+                CellValue::Code(humanize_seconds(secs))
             } else {
-                (format!("<code>{secs}.{nanos:09}s</code>"), false)
+                CellValue::Code(format!("{secs}.{nanos:09}s"))
             }
         }
         _ => pretty(value),
     }
 }
 
-fn pretty(value: &serde_json::Value) -> (String, bool) {
-    let text = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
-    (escape_html(&text), true)
+fn pretty(value: &serde_json::Value) -> CellValue {
+    CellValue::Pre(serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string()))
 }
 
 fn is_scalar(value: &serde_json::Value) -> bool {
@@ -474,15 +525,11 @@ fn humanize_seconds(secs: u64) -> String {
     }
 }
 
-fn format_default(default: &str) -> String {
+fn format_default(default: &str) -> CellValue {
     match default.trim() {
-        "" | "—" | "-" | "*(see below)*" | "*(default)*" => NONE_HTML.to_string(),
-        "**required**" => "<em>required</em>".to_string(),
-        // An annotated absent default, e.g. "— (forever)".
-        other => match other.strip_prefix("—") {
-            Some(annotation) => format!("{NONE_HTML} {}", markdown_lite(annotation.trim())),
-            None => markdown_lite(other),
-        },
+        "" | "—" | "-" | "*(see below)*" | "*(default)*" => CellValue::NoDefault,
+        "**required**" => CellValue::Required,
+        other => CellValue::Rich(markdown_lite(other)),
     }
 }
 
@@ -516,6 +563,7 @@ fn humanize(field: &str) -> String {
             "vmaas" => "VMaaS".to_string(),
             "bom" => "BOM".to_string(),
             "nsg" => "NSG".to_string(),
+            "oem" => "OEM".to_string(),
             other => {
                 let mut chars = other.chars();
                 match chars.next() {
@@ -526,18 +574,6 @@ fn humanize(field: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ")
-}
-
-fn slugify(text: &str) -> String {
-    text.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() {
-                c.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect()
 }
 
 /// Parses the reference markdown into `(section_name, fields)` pairs in
@@ -587,6 +623,8 @@ fn heading_struct_name(heading: &str) -> Option<String> {
 
 /// Parses a markdown table row into a FieldDoc; header and separator rows
 /// (and rows whose first cell isn't a backticked field name) return None.
+/// A fourth `Group` cell (top-level table only) is recognized by matching a
+/// known group slug.
 fn parse_table_row(line: &str) -> Option<FieldDoc> {
     if !line.starts_with('|') {
         return None;
@@ -600,11 +638,18 @@ fn parse_table_row(line: &str) -> Option<FieldDoc> {
     if name.is_empty() {
         return None;
     }
+    let maybe_slug = cells[3].trim().trim_matches('`');
+    let (group, description_cells) = if GROUP_ORDER.iter().any(|(_, slug)| *slug == maybe_slug) {
+        (Some(maybe_slug.to_string()), &cells[4..])
+    } else {
+        (None, &cells[3..])
+    };
     Some(FieldDoc {
         name: name.to_string(),
         ty: cells[1].trim().to_string(),
         default: cells[2].trim().to_string(),
-        description: cells[3..].join("|").trim().to_string(),
+        group,
+        description: description_cells.join("|").trim().to_string(),
     })
 }
 
@@ -630,15 +675,19 @@ fn split_table_cells(line: &str) -> Vec<&str> {
 }
 
 fn escape_html(text: &str) -> String {
-    text.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
+    use askama_escape::Escaper;
+    let mut out = String::with_capacity(text.len());
+    askama_escape::Html
+        .write_escaped(&mut out, text)
+        .expect("writing to a String cannot fail");
+    out
 }
 
 /// Minimal markdown renderer for the reference's table cells: HTML-escapes,
-/// then supports `` `code` ``, `**bold**`, and `[text](target)` links (anchors
-/// are rewritten to this page's section ids). Anything else stays plain text.
+/// then supports `` `code` ``, `**bold**`, and `[text](target)` links (only
+/// http(s) targets become anchors). This is the single escaping site for all
+/// rich text on the page — [`CellValue::Rich`] and `description_html` must
+/// only ever carry its output.
 fn markdown_lite(text: &str) -> String {
     let escaped = escape_html(&text.replace("\\|", "|"));
     let linked = render_links(&escaped);
@@ -691,14 +740,11 @@ fn render_links(text: &str) -> String {
         let label = &rest[open_bracket + 1..close_bracket];
         let target = &rest[target_start..target_end];
         out.push_str(&rest[..open_bracket]);
-        if let Some(anchor) = target.strip_prefix('#') {
-            // The reference's intra-doc anchors don't map 1:1 onto this
-            // page's section ids, so keep the label but drop the link.
-            let _ = anchor;
-            out.push_str(label);
-        } else if target.starts_with("http://") || target.starts_with("https://") {
+        if target.starts_with("http://") || target.starts_with("https://") {
             out.push_str(&format!("<a href=\"{target}\">{label}</a>"));
         } else {
+            // Intra-doc anchors don't map onto this page's section ids, so
+            // keep the label but drop the link.
             out.push_str(label);
         }
         rest = &rest[target_end + 1..];
@@ -709,6 +755,17 @@ fn render_links(text: &str) -> String {
 mod configuration_tests {
     use super::*;
 
+    fn no_live_settings() -> LiveSettings {
+        LiveSettings {
+            log_filter: "info".to_string(),
+            site_explorer_enabled: "true".to_string(),
+            create_machines: "true".to_string(),
+            bmc_proxy: None,
+            tracing_enabled: "false".to_string(),
+            dpu_agent_upgrade_policy: "Off".to_string(),
+        }
+    }
+
     #[test]
     fn parses_real_reference() {
         let sections = parse_reference(carbide_api_core::cfg::CONFIG_REFERENCE_MD);
@@ -716,6 +773,7 @@ mod configuration_tests {
         assert!(names.contains(&"NicoConfig"), "top-level section missing: {names:?}");
         assert!(names.contains(&"TlsConfig"));
         assert!(names.contains(&"SiteExplorerConfig"));
+        assert!(names.contains(&"TracingConfig"));
 
         let (_, top) = sections.iter().find(|(n, _)| n == "NicoConfig").unwrap();
         assert!(top.len() > 50, "expected many top-level fields, got {}", top.len());
@@ -724,23 +782,66 @@ mod configuration_tests {
         assert!(listen.default.contains("1079"));
     }
 
+    /// Guards the drift the generated page exists to eliminate: every
+    /// documented top-level option must declare a valid group slug in the
+    /// reference doc's `Group` column.
+    #[test]
+    fn every_documented_field_has_a_group() {
+        let sections = parse_reference(carbide_api_core::cfg::CONFIG_REFERENCE_MD);
+        let (_, top) = sections.iter().find(|(n, _)| n == "NicoConfig").unwrap();
+        let ungrouped: Vec<&str> = top
+            .iter()
+            .filter(|f| f.group.is_none())
+            .map(|f| f.name.as_str())
+            .collect();
+        assert!(ungrouped.is_empty(), "fields without a valid Group cell: {ungrouped:?}");
+    }
+
+    /// Guards README coverage: every top-level key of the serialized config
+    /// must be documented in the reference. A failure means a field was added
+    /// to `CarbideConfig` without a README row.
+    #[test]
+    fn every_config_field_is_documented() {
+        // A minimal valid config; serialization emits every non-skipped key.
+        let config: carbide_api_core::cfg::file::CarbideConfig =
+            toml::from_str("database_url = \"postgres://x\"\nasn = 65001\n")
+                .expect("minimal config parses");
+        let effective = serde_json::to_value(config.redacted()).expect("config serializes");
+        let sections = parse_reference(carbide_api_core::cfg::CONFIG_REFERENCE_MD);
+        let (_, top) = sections.iter().find(|(n, _)| n == "NicoConfig").unwrap();
+        let documented: HashSet<String> = top.iter().map(|f| canonical(&f.name)).collect();
+        let undocumented: Vec<&String> = effective
+            .as_object()
+            .unwrap()
+            .keys()
+            .filter(|key| !documented.contains(&canonical(key)))
+            .collect();
+        assert!(
+            undocumented.is_empty(),
+            "config fields missing from cfg/README.md: {undocumented:?}"
+        );
+    }
+
     #[test]
     fn builds_page_with_overrides() {
         let effective = serde_json::json!({
             "listen": "[::]:1079",
             "asn": 65001,
+            "mlx-config-profiles": { "profileA": {} },
             "tls": { "root_cafile_path": "/etc/ca.crt" },
         });
         let mut explicit = BTreeMap::new();
         explicit.insert("asn".to_string(), "site.toml".to_string());
+        explicit.insert("mlx-config-profiles.profileA".to_string(), "base.toml".to_string());
         explicit.insert("tls.root_cafile_path".to_string(), "base.toml".to_string());
 
         let page = build_config_page(
             carbide_api_core::cfg::CONFIG_REFERENCE_MD,
             &effective,
             &explicit,
-            Vec::new(),
+            no_live_settings(),
         );
+
         let rows: Vec<&ConfigRowView> = page
             .groups
             .iter()
@@ -748,24 +849,40 @@ mod configuration_tests {
             .flat_map(|s| s.rows.iter())
             .collect();
         assert!(rows.len() > 150, "expected full catalog, got {}", rows.len());
+
         let asn = rows.iter().find(|r| r.path == "asn").unwrap();
         assert!(asn.overridden);
         assert_eq!(asn.source, "site.toml");
-        assert!(asn.value_html.contains("65001"));
+        assert!(asn.value.to_html().contains("65001"));
+
         let listen = rows.iter().find(|r| r.path == "listen").unwrap();
         assert!(!listen.overridden);
-        // Nested section rows exist with dotted paths.
-        assert!(rows.iter().any(|r| r.path == "tls.root_cafile_path"));
-        // A field whose sub-struct was set is marked overridden by prefix.
+
+        // Serde-renamed keys join spelling-insensitively: the reference's
+        // `mlxconfig_profiles` matches the serialized `mlx-config-profiles`.
+        let mlx = rows.iter().find(|r| r.path == "mlxconfig_profiles").unwrap();
+        assert!(!mlx.value.is_unset(), "renamed key must resolve a value");
+        assert!(mlx.overridden, "renamed key must resolve provenance");
+
+        // Nested section rows exist with dotted paths, and a field whose
+        // sub-struct was set is marked overridden by prefix.
         let tls_row = rows.iter().find(|r| r.path == "tls.root_cafile_path").unwrap();
         assert!(tls_row.overridden);
+
+        // Runtime settings are folded in: documented options get tagged...
+        let se = rows.iter().find(|r| r.path == "site_explorer.enabled").unwrap();
+        assert!(se.runtime);
+        // ...and undocumented ones become synthetic runtime rows.
+        let lf = rows.iter().find(|r| r.path == "log_filter").unwrap();
+        assert!(lf.runtime);
+        assert!(lf.value.to_html().contains("info"));
     }
 
     #[test]
     fn markdown_lite_renders_and_escapes() {
         assert_eq!(
             markdown_lite("Use `ip_address` for <new> hosts"),
-            "Use <code>ip_address</code> for &lt;new&gt; hosts"
+            "Use <code>ip_address</code> for &#60;new&#62; hosts"
         );
         assert_eq!(markdown_lite("**Deprecated.**"), "<strong>Deprecated.</strong>");
         assert_eq!(
@@ -775,13 +892,17 @@ mod configuration_tests {
     }
 
     #[test]
-    fn duration_and_collections_format() {
-        let (html, multiline) = format_value(&serde_json::json!({"secs": 3600, "nanos": 0}));
-        assert_eq!(html, "<code>1h</code>");
-        assert!(!multiline);
-        let (html, _) = format_value(&serde_json::json!(["10.0.0.1", "10.0.0.2"]));
-        assert!(html.contains("10.0.0.1, 10.0.0.2"));
-        let (_, multiline) = format_value(&serde_json::json!({"a": {"b": 1}}));
-        assert!(multiline);
+    fn cell_values_render_and_escape() {
+        assert_eq!(CellValue::Code("<x>".to_string()).to_html(), "<code>&#60;x&#62;</code>");
+        assert!(CellValue::Pre("{\"a\": 1}".to_string()).to_html().contains("show value"));
+        assert!(CellValue::Unset.is_unset());
+        assert_eq!(
+            format_value(&serde_json::json!({"secs": 3600, "nanos": 0})).to_html(),
+            "<code>1h</code>"
+        );
+        let list = format_value(&serde_json::json!(["10.0.0.1", "10.0.0.2"]));
+        assert!(list.to_html().contains("10.0.0.1, 10.0.0.2"));
+        assert!(matches!(format_value(&serde_json::json!({"a": {"b": 1}})), CellValue::Pre(_)));
+        assert!(matches!(format_default("**required**"), CellValue::Required));
     }
 }

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -1,0 +1,756 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! View-model builder for the admin-UI Configuration page.
+//!
+//! The page is generated rather than hand-written so it cannot drift from the
+//! actual config surface. Three inputs are joined per option:
+//!
+//! - the configuration reference (`carbide_api_core::cfg::CONFIG_REFERENCE_MD`,
+//!   i.e. `cfg/README.md`) supplies the catalog of documented options with
+//!   their type, default, and description, organized into per-struct sections;
+//! - the redacted effective `CarbideConfig`, serialized to JSON, supplies each
+//!   option's current value (including values for options the reference does
+//!   not document yet, which are appended as undocumented rows);
+//! - `CarbideConfig::explicit_value_paths` supplies provenance: which dotted
+//!   keys were explicitly set by a config file or `CARBIDE_API_*` environment
+//!   variable, and by which source.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+/// Everything the Configuration page template needs.
+pub(crate) struct ConfigPageView {
+    pub groups: Vec<ConfigGroupView>,
+    pub total_options: usize,
+    pub overridden_options: usize,
+    /// Distinct source labels (file names / env) that provided overrides.
+    pub sources: Vec<String>,
+}
+
+pub(crate) struct ConfigGroupView {
+    pub title: &'static str,
+    pub sections: Vec<ConfigSectionView>,
+}
+
+pub(crate) struct ConfigSectionView {
+    pub title: String,
+    pub anchor: String,
+    /// Dotted TOML path prefix of this section ("" for top-level options).
+    pub path: String,
+    pub rows: Vec<ConfigRowView>,
+    pub overridden: usize,
+}
+
+pub(crate) struct ConfigRowView {
+    pub name: String,
+    /// Full dotted path, also used by the client-side filter.
+    pub path: String,
+    pub ty: String,
+    pub value_html: String,
+    /// Render the value as a preformatted block instead of inline.
+    pub multiline: bool,
+    pub overridden: bool,
+    /// Source label ("nico-api-config.toml", env, ...) when overridden.
+    pub source: String,
+    pub default_html: String,
+    pub description_html: String,
+    /// The option resolves to null/absent (unset optional value).
+    pub unset: bool,
+    pub undocumented: bool,
+}
+
+/// One `| field | type | default | description |` row of the reference doc.
+struct FieldDoc {
+    name: String,
+    ty: String,
+    default: String,
+    description: String,
+}
+
+/// Display groups, in page order. Sections land in a group via
+/// `group_for_top_level_field`; unknown fields fall through to "Other".
+const GROUP_ORDER: &[&str] = &[
+    "Server & API",
+    "Networking",
+    "Machines & Lifecycle",
+    "DPUs & Provisioning",
+    "Firmware & Updates",
+    "Security & Attestation",
+    "Hardware Discovery & Racks",
+    "Observability & Diagnostics",
+    "Integrations",
+    "Other",
+];
+
+fn group_for_top_level_field(name: &str) -> &'static str {
+    match name {
+        "listen" | "listen_only" | "listen_mode" | "tls" | "database_url"
+        | "max_database_connections" | "max_find_by_ids" | "auth" | "bypass_rbac"
+        | "enable_admin_ui" | "web_ui_sidebar_tools" | "sitename" | "initial_objects_file" => {
+            "Server & API"
+        }
+        "asn" | "dhcp_servers" | "ntp_servers" | "route_servers" | "enable_route_servers"
+        | "deny_prefixes" | "site_fabric_prefixes" | "anycast_site_prefixes"
+        | "common_tenant_host_asn" | "vpc_isolation_behavior" | "networks" | "pools"
+        | "fnn" | "internet_l3_vni" | "datacenter_asn" | "site_global_vpc_vni"
+        | "bgp_leaf_session_password" | "vpc_peering_policy" | "vpc_peering_policy_on_existing"
+        | "network_security_group" | "dpa_config" | "network_segment_state_controller"
+        | "vpc_prefix_state_controller" | "dpa_interface_state_controller"
+        | "dpu_network_monitor_pinger_type" => "Networking",
+        "host_naming_strategy" | "machine_state_controller" | "machine_validation_config"
+        | "auto_machine_repair_plugin" | "host_health" | "initial_domain_name"
+        | "min_dpu_functioning_links" | "bom_validation" | "compute_allocation_enforcement" => {
+            "Machines & Lifecycle"
+        }
+        "dpu_config" | "dpu_ipmi_tool_impl" | "dpu_ipmi_reboot_attempts" | "nvue_enabled"
+        | "dpf" | "initial_dpu_agent_upgrade_policy" | "x86_pxe_boot_url_override"
+        | "arm_pxe_boot_url_override" | "pxe_public_base_url" | "set_http_boot_uri_for_vendors"
+        | "retained_boot_interface_window" => "DPUs & Provisioning",
+        "host_models" | "firmware_global" | "machine_updater"
+        | "max_concurrent_machine_updates" | "machine_update_run_interval"
+        | "mlxconfig_profiles" | "supernic_firmware_profiles" => "Firmware & Updates",
+        "attestation_enabled" | "tpm_required" | "machine_identity" | "spdm"
+        | "spdm_state_controller" | "measured_boot_collector" | "bmc_session_lockout_threshold"
+        | "secrets" | "kms" => "Security & Attestation",
+        "site_explorer" | "ib_config" | "ib_fabrics" | "nvlink_config"
+        | "rack_management_enabled" | "rms" | "rack_profiles" | "rack_state_controller"
+        | "power_shelf_state_controller" | "switch_state_controller" | "power_manager_options"
+        | "ib_partition_state_controller" | "component_manager" => "Hardware Discovery & Racks",
+        "metrics_endpoint" | "alt_metric_prefix" | "tracing" | "observability"
+        | "log_history" => "Observability & Diagnostics",
+        "vmaas_config" | "dsx_exchange_event_bus" | "mqtt" => "Integrations",
+        _ => "Other",
+    }
+}
+
+/// Builds the page view from the reference doc, the redacted effective config
+/// (as JSON), and the explicitly-set key paths with their source labels.
+pub(crate) fn build_config_page(
+    reference_md: &str,
+    effective: &serde_json::Value,
+    explicit_paths: &BTreeMap<String, String>,
+) -> ConfigPageView {
+    let sections = parse_reference(reference_md);
+
+    // Grouped sections, keyed by group title. Each group lazily gets a
+    // leading section for the top-level scalar options assigned to it.
+    let mut grouped: HashMap<&'static str, Vec<ConfigSectionView>> = HashMap::new();
+    let mut top_level_rows: HashMap<&'static str, Vec<ConfigRowView>> = HashMap::new();
+    let mut documented_top_level: HashSet<String> = HashSet::new();
+
+    let top_level = sections
+        .iter()
+        .find(|(name, _)| name == "NicoConfig")
+        .map(|(_, fields)| fields.as_slice())
+        .unwrap_or(&[]);
+
+    let section_by_anchor: HashMap<String, &Vec<FieldDoc>> = sections
+        .iter()
+        .map(|(name, fields)| (name.to_lowercase(), fields))
+        .collect();
+
+    for field in top_level {
+        documented_top_level.insert(field.name.clone());
+        let group = group_for_top_level_field(&field.name);
+        match nested_section_for(field, &section_by_anchor) {
+            Some(section_fields) => {
+                let mut nested = Vec::new();
+                build_section(
+                    humanize(&field.name),
+                    field.name.clone(),
+                    section_fields,
+                    &section_by_anchor,
+                    effective,
+                    explicit_paths,
+                    &mut nested,
+                    &mut HashSet::new(),
+                );
+                grouped.entry(group).or_default().extend(nested);
+            }
+            None => top_level_rows.entry(group).or_default().push(build_row(
+                field,
+                &field.name,
+                effective,
+                explicit_paths,
+                false,
+            )),
+        }
+    }
+
+    // Options present in the effective config but missing from the reference
+    // doc: surface them rather than silently dropping them.
+    if let Some(object) = effective.as_object() {
+        for (name, value) in object {
+            if documented_top_level.contains(name) || documented_top_level.contains(&name.replace('-', "_")) {
+                continue;
+            }
+            let field = FieldDoc {
+                name: name.clone(),
+                ty: String::new(),
+                default: "—".to_string(),
+                description: "Not yet documented in the configuration reference.".to_string(),
+            };
+            let mut row = build_row(&field, name, effective, explicit_paths, true);
+            row.unset = value.is_null();
+            top_level_rows
+                .entry(group_for_top_level_field(name))
+                .or_default()
+                .push(row);
+        }
+    }
+
+    let mut groups = Vec::new();
+    let mut total_options = 0;
+    let mut overridden_options = 0;
+    let mut sources: Vec<String> = Vec::new();
+
+    for title in GROUP_ORDER {
+        let mut sections = Vec::new();
+        if let Some(rows) = top_level_rows.remove(title) {
+            let overridden = rows.iter().filter(|r| r.overridden).count();
+            sections.push(ConfigSectionView {
+                title: "Core Options".to_string(),
+                anchor: format!("cfg-{}-core", slugify(title)),
+                path: String::new(),
+                rows,
+                overridden,
+            });
+        }
+        sections.extend(grouped.remove(title).unwrap_or_default());
+        for section in &sections {
+            total_options += section.rows.len();
+            overridden_options += section.overridden;
+            for row in &section.rows {
+                if row.overridden && !row.source.is_empty() && !sources.contains(&row.source) {
+                    sources.push(row.source.clone());
+                }
+            }
+        }
+        if !sections.is_empty() {
+            groups.push(ConfigGroupView { title, sections });
+        }
+    }
+
+    ConfigPageView {
+        groups,
+        total_options,
+        overridden_options,
+        sources,
+    }
+}
+
+/// If the field's type refers to a documented sub-struct section (and isn't a
+/// collection of them), return that section's fields for recursion.
+fn nested_section_for<'a>(
+    field: &FieldDoc,
+    sections: &'a HashMap<String, &Vec<FieldDoc>>,
+) -> Option<&'a Vec<FieldDoc>> {
+    let ty = clean_type(&field.ty);
+    // Collections of structs stay leaf rows: their keys are operator-chosen,
+    // so there is no fixed set of options to enumerate.
+    if ty.contains("HashMap") || ty.contains("Vec<") || ty.contains("nested") {
+        return None;
+    }
+    let inner = ty
+        .trim_start_matches("Option<")
+        .trim_end_matches('>')
+        .trim();
+    sections.get(&inner.to_lowercase()).copied()
+}
+
+/// Recursively emit a section for `fields` under `path`, appending nested
+/// sub-struct sections after it. `visited` guards against reference cycles.
+#[allow(clippy::too_many_arguments)]
+fn build_section(
+    title: String,
+    path: String,
+    fields: &[FieldDoc],
+    sections: &HashMap<String, &Vec<FieldDoc>>,
+    effective: &serde_json::Value,
+    explicit_paths: &BTreeMap<String, String>,
+    out: &mut Vec<ConfigSectionView>,
+    visited: &mut HashSet<String>,
+) {
+    if !visited.insert(path.clone()) {
+        return;
+    }
+    let mut rows = Vec::new();
+    let mut nested = Vec::new();
+    for field in fields {
+        let field_path = format!("{path}.{}", field.name);
+        match nested_section_for(field, sections) {
+            Some(section_fields) => build_section(
+                format!("{title} · {}", humanize(&field.name)),
+                field_path,
+                section_fields,
+                sections,
+                effective,
+                explicit_paths,
+                &mut nested,
+                visited,
+            ),
+            None => rows.push(build_row(field, &field_path, effective, explicit_paths, false)),
+        }
+    }
+    let overridden = rows.iter().filter(|r| r.overridden).count();
+    out.push(ConfigSectionView {
+        anchor: format!("cfg-{}", slugify(&path)),
+        title,
+        path,
+        rows,
+        overridden,
+    });
+    out.extend(nested);
+}
+
+fn build_row(
+    field: &FieldDoc,
+    path: &str,
+    effective: &serde_json::Value,
+    explicit_paths: &BTreeMap<String, String>,
+    undocumented: bool,
+) -> ConfigRowView {
+    let value = lookup(effective, path);
+    let (value_html, multiline) = match value {
+        Some(value) => format_value(value),
+        None => ("<span class=\"config-unset\">not set</span>".to_string(), false),
+    };
+    let unset = value.is_none_or(serde_json::Value::is_null);
+    let source = explicit_source(path, explicit_paths);
+    ConfigRowView {
+        name: field.name.clone(),
+        path: path.to_string(),
+        ty: clean_type(&field.ty),
+        value_html,
+        multiline,
+        overridden: source.is_some(),
+        source: source.unwrap_or_default(),
+        default_html: format_default(&field.default),
+        description_html: markdown_lite(&field.description),
+        unset,
+        undocumented,
+    }
+}
+
+/// A key counts as explicitly set when the merged config sources provided it
+/// or anything beneath it (e.g. `tls` is overridden when `tls.root_cafile_path`
+/// was set in a file).
+fn explicit_source(path: &str, explicit_paths: &BTreeMap<String, String>) -> Option<String> {
+    // Figment normalizes TOML dashes; match both spellings.
+    let underscored = path.replace('-', "_");
+    let prefix = format!("{underscored}.");
+    explicit_paths
+        .iter()
+        .find(|(key, _)| {
+            let key = key.replace('-', "_");
+            key == underscored || key.starts_with(&prefix)
+        })
+        .map(|(_, source)| source.clone())
+}
+
+fn lookup<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut current = value;
+    for segment in path.split('.') {
+        let object = current.as_object()?;
+        current = object
+            .get(segment)
+            .or_else(|| object.get(&segment.replace('_', "-")))?;
+    }
+    Some(current)
+}
+
+/// Renders a JSON value as HTML. Returns `(html, multiline)`; multiline values
+/// are pretty-printed JSON meant for a `<pre>` block.
+fn format_value(value: &serde_json::Value) -> (String, bool) {
+    use serde_json::Value;
+    match value {
+        Value::Null => ("<span class=\"config-unset\">not set</span>".to_string(), false),
+        Value::Bool(b) => (format!("<code>{b}</code>"), false),
+        Value::Number(n) => (format!("<code>{n}</code>"), false),
+        Value::String(s) if s.is_empty() => {
+            ("<span class=\"config-unset\">\"\" (empty)</span>".to_string(), false)
+        }
+        Value::String(s) => (format!("<code>{}</code>", escape_html(s)), false),
+        Value::Array(items) if items.is_empty() => {
+            ("<span class=\"config-unset\">[] (empty)</span>".to_string(), false)
+        }
+        Value::Array(items) if items.iter().all(is_scalar) => {
+            let joined = items.iter().map(scalar_text).collect::<Vec<_>>().join(", ");
+            if joined.len() <= 120 {
+                (format!("<code>{}</code>", escape_html(&joined)), false)
+            } else {
+                pretty(value)
+            }
+        }
+        Value::Object(map) if map.is_empty() => {
+            ("<span class=\"config-unset\">{} (empty)</span>".to_string(), false)
+        }
+        // std::time::Duration serializes as {secs, nanos}; show it humanely.
+        Value::Object(map)
+            if map.len() == 2 && map.contains_key("secs") && map.contains_key("nanos") =>
+        {
+            let secs = map["secs"].as_u64().unwrap_or(0);
+            let nanos = map["nanos"].as_u64().unwrap_or(0);
+            if nanos == 0 {
+                (format!("<code>{}</code>", escape_html(&humanize_seconds(secs))), false)
+            } else {
+                (format!("<code>{secs}.{nanos:09}s</code>"), false)
+            }
+        }
+        _ => pretty(value),
+    }
+}
+
+fn pretty(value: &serde_json::Value) -> (String, bool) {
+    let text = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    (escape_html(&text), true)
+}
+
+fn is_scalar(value: &serde_json::Value) -> bool {
+    !(value.is_array() || value.is_object())
+}
+
+fn scalar_text(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn humanize_seconds(secs: u64) -> String {
+    if secs > 0 && secs.is_multiple_of(86400) {
+        format!("{}d", secs / 86400)
+    } else if secs > 0 && secs.is_multiple_of(3600) {
+        format!("{}h", secs / 3600)
+    } else if secs > 0 && secs.is_multiple_of(60) {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+fn format_default(default: &str) -> String {
+    let trimmed = default.trim();
+    match trimmed {
+        "" | "—" | "-" => "<span class=\"config-unset\">—</span>".to_string(),
+        "**required**" => "<span class=\"bubble error config-required\">required</span>".to_string(),
+        "*(see below)*" | "*(default)*" => "<span class=\"config-unset\">—</span>".to_string(),
+        other => markdown_lite(other),
+    }
+}
+
+/// Strips markdown emphasis from the reference's type cell for display.
+fn clean_type(ty: &str) -> String {
+    ty.trim().replace('`', "")
+}
+
+/// "dpa_config" -> "DPA", "machine_validation_config" -> "Machine Validation".
+/// The `_config` suffix is dropped: every section is config, so it's noise.
+fn humanize(field: &str) -> String {
+    field
+        .strip_suffix("_config")
+        .unwrap_or(field)
+        .split('_')
+        .map(|word| match word {
+            "dpu" => "DPU".to_string(),
+            "dpa" => "DPA".to_string(),
+            "dpf" => "DPF".to_string(),
+            "ib" => "IB".to_string(),
+            "nvlink" => "NVLink".to_string(),
+            "rms" => "RMS".to_string(),
+            "spdm" => "SPDM".to_string(),
+            "tls" => "TLS".to_string(),
+            "kms" => "KMS".to_string(),
+            "fnn" => "FNN".to_string(),
+            "vpc" => "VPC".to_string(),
+            "mqtt" => "MQTT".to_string(),
+            "oauth2" => "OAuth2".to_string(),
+            "dsx" => "DSX".to_string(),
+            "vmaas" => "VMaaS".to_string(),
+            "bom" => "BOM".to_string(),
+            "nsg" => "NSG".to_string(),
+            other => {
+                let mut chars = other.chars();
+                match chars.next() {
+                    Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn slugify(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Parses the reference markdown into `(section_name, fields)` pairs in
+/// document order. A section starts at a `## `/`### ` heading whose text is a
+/// backticked struct name (e.g. ``### `TlsConfig` ``); prose headings without
+/// tables contribute nothing.
+fn parse_reference(markdown: &str) -> Vec<(String, Vec<FieldDoc>)> {
+    let mut sections: Vec<(String, Vec<FieldDoc>)> = Vec::new();
+    let mut current: Option<String> = None;
+    let mut in_code_block = false;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+        if in_code_block {
+            continue;
+        }
+        if let Some(heading) = trimmed.strip_prefix("### ").or_else(|| trimmed.strip_prefix("## ")) {
+            current = heading_struct_name(heading);
+            if let Some(name) = &current
+                && !sections.iter().any(|(existing, _)| existing == name)
+            {
+                sections.push((name.clone(), Vec::new()));
+            }
+            continue;
+        }
+        let Some(section) = &current else { continue };
+        if let Some(field) = parse_table_row(trimmed)
+            && let Some((_, fields)) = sections.iter_mut().find(|(name, _)| name == section)
+        {
+            fields.push(field);
+        }
+    }
+    sections
+}
+
+/// Extracts the struct name from a heading like `` `TlsConfig` `` or
+/// `` `NicoConfig` (top-level) ``; returns None for prose headings.
+fn heading_struct_name(heading: &str) -> Option<String> {
+    let rest = heading.trim().strip_prefix('`')?;
+    let (name, _) = rest.split_once('`')?;
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// Parses a markdown table row into a FieldDoc; header and separator rows
+/// (and rows whose first cell isn't a backticked field name) return None.
+fn parse_table_row(line: &str) -> Option<FieldDoc> {
+    if !line.starts_with('|') {
+        return None;
+    }
+    let cells: Vec<&str> = split_table_cells(line);
+    if cells.len() < 4 {
+        return None;
+    }
+    let name = cells[0].trim();
+    let name = name.strip_prefix('`')?.strip_suffix('`')?;
+    if name.is_empty() {
+        return None;
+    }
+    Some(FieldDoc {
+        name: name.to_string(),
+        ty: cells[1].trim().to_string(),
+        default: cells[2].trim().to_string(),
+        description: cells[3..].join("|").trim().to_string(),
+    })
+}
+
+/// Splits a markdown table row on unescaped pipes, honoring `\|` escapes.
+fn split_table_cells(line: &str) -> Vec<&str> {
+    let inner = line
+        .trim()
+        .trim_start_matches('|')
+        .trim_end_matches('|');
+    let mut cells = Vec::new();
+    let mut start = 0;
+    let bytes = inner.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'|' && (i == 0 || bytes[i - 1] != b'\\') {
+            cells.push(&inner[start..i]);
+            start = i + 1;
+        }
+        i += 1;
+    }
+    cells.push(&inner[start..]);
+    cells
+}
+
+fn escape_html(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Minimal markdown renderer for the reference's table cells: HTML-escapes,
+/// then supports `` `code` ``, `**bold**`, and `[text](target)` links (anchors
+/// are rewritten to this page's section ids). Anything else stays plain text.
+fn markdown_lite(text: &str) -> String {
+    let escaped = escape_html(&text.replace("\\|", "|"));
+    let linked = render_links(&escaped);
+    let coded = render_delimited(&linked, "`", "<code>", "</code>");
+    render_delimited(&coded, "**", "<strong>", "</strong>")
+}
+
+fn render_delimited(text: &str, delim: &str, open: &str, close: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    loop {
+        let Some(start) = rest.find(delim) else {
+            out.push_str(rest);
+            return out;
+        };
+        let after = &rest[start + delim.len()..];
+        let Some(end) = after.find(delim) else {
+            out.push_str(rest);
+            return out;
+        };
+        out.push_str(&rest[..start]);
+        out.push_str(open);
+        out.push_str(&after[..end]);
+        out.push_str(close);
+        rest = &after[end + delim.len()..];
+    }
+}
+
+fn render_links(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    loop {
+        let Some(open_bracket) = rest.find('[') else {
+            out.push_str(rest);
+            return out;
+        };
+        let Some(rel_close) = rest[open_bracket..].find("](") else {
+            out.push_str(&rest[..open_bracket + 1]);
+            rest = &rest[open_bracket + 1..];
+            continue;
+        };
+        let close_bracket = open_bracket + rel_close;
+        let target_start = close_bracket + 2;
+        let Some(rel_end) = rest[target_start..].find(')') else {
+            out.push_str(&rest[..open_bracket + 1]);
+            rest = &rest[open_bracket + 1..];
+            continue;
+        };
+        let target_end = target_start + rel_end;
+        let label = &rest[open_bracket + 1..close_bracket];
+        let target = &rest[target_start..target_end];
+        out.push_str(&rest[..open_bracket]);
+        if let Some(anchor) = target.strip_prefix('#') {
+            // The reference's intra-doc anchors don't map 1:1 onto this
+            // page's section ids, so keep the label but drop the link.
+            let _ = anchor;
+            out.push_str(label);
+        } else if target.starts_with("http://") || target.starts_with("https://") {
+            out.push_str(&format!("<a href=\"{target}\">{label}</a>"));
+        } else {
+            out.push_str(label);
+        }
+        rest = &rest[target_end + 1..];
+    }
+}
+
+#[cfg(test)]
+mod configuration_tests {
+    use super::*;
+
+    #[test]
+    fn parses_real_reference() {
+        let sections = parse_reference(carbide_api_core::cfg::CONFIG_REFERENCE_MD);
+        let names: Vec<&str> = sections.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"NicoConfig"), "top-level section missing: {names:?}");
+        assert!(names.contains(&"TlsConfig"));
+        assert!(names.contains(&"SiteExplorerConfig"));
+
+        let (_, top) = sections.iter().find(|(n, _)| n == "NicoConfig").unwrap();
+        assert!(top.len() > 50, "expected many top-level fields, got {}", top.len());
+        let listen = top.iter().find(|f| f.name == "listen").unwrap();
+        assert!(listen.ty.contains("SocketAddr"));
+        assert!(listen.default.contains("1079"));
+    }
+
+    #[test]
+    fn builds_page_with_overrides() {
+        let effective = serde_json::json!({
+            "listen": "[::]:1079",
+            "asn": 65001,
+            "tls": { "root_cafile_path": "/etc/ca.crt" },
+        });
+        let mut explicit = BTreeMap::new();
+        explicit.insert("asn".to_string(), "site.toml".to_string());
+        explicit.insert("tls.root_cafile_path".to_string(), "base.toml".to_string());
+
+        let page = build_config_page(
+            carbide_api_core::cfg::CONFIG_REFERENCE_MD,
+            &effective,
+            &explicit,
+        );
+        assert!(page.total_options > 100);
+        assert!(page.overridden_options >= 2);
+        assert!(page.sources.contains(&"site.toml".to_string()));
+
+        let rows: Vec<&ConfigRowView> = page
+            .groups
+            .iter()
+            .flat_map(|g| g.sections.iter())
+            .flat_map(|s| s.rows.iter())
+            .collect();
+        let asn = rows.iter().find(|r| r.path == "asn").unwrap();
+        assert!(asn.overridden);
+        assert_eq!(asn.source, "site.toml");
+        assert!(asn.value_html.contains("65001"));
+        let listen = rows.iter().find(|r| r.path == "listen").unwrap();
+        assert!(!listen.overridden);
+        // Nested section rows exist with dotted paths.
+        assert!(rows.iter().any(|r| r.path == "tls.root_cafile_path"));
+        // A field whose sub-struct was set is marked overridden by prefix.
+        let tls_row = rows.iter().find(|r| r.path == "tls.root_cafile_path").unwrap();
+        assert!(tls_row.overridden);
+    }
+
+    #[test]
+    fn markdown_lite_renders_and_escapes() {
+        assert_eq!(
+            markdown_lite("Use `ip_address` for <new> hosts"),
+            "Use <code>ip_address</code> for &lt;new&gt; hosts"
+        );
+        assert_eq!(markdown_lite("**Deprecated.**"), "<strong>Deprecated.</strong>");
+        assert_eq!(
+            markdown_lite("see [SiteExplorerConfig](#siteexplorerconfig)."),
+            "see SiteExplorerConfig."
+        );
+    }
+
+    #[test]
+    fn duration_and_collections_format() {
+        let (html, multiline) = format_value(&serde_json::json!({"secs": 3600, "nanos": 0}));
+        assert_eq!(html, "<code>1h</code>");
+        assert!(!multiline);
+        let (html, _) = format_value(&serde_json::json!(["10.0.0.1", "10.0.0.2"]));
+        assert!(html.contains("10.0.0.1, 10.0.0.2"));
+        let (_, multiline) = format_value(&serde_json::json!({"a": {"b": 1}}));
+        assert!(multiline);
+    }
+}

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -24,8 +24,8 @@
 //!   i.e. `cfg/README.md`) supplies the catalog of documented options with
 //!   their type, default, and description, organized into per-struct sections;
 //! - the redacted effective `CarbideConfig`, serialized to JSON, supplies each
-//!   option's current value (including values for options the reference does
-//!   not document yet, which are appended as undocumented rows);
+//!   option's current value (a unit test keeps the reference's coverage of
+//!   the config struct complete);
 //! - `CarbideConfig::explicit_value_paths` supplies provenance: which dotted
 //!   keys were explicitly set by a config file or `CARBIDE_API_*` environment
 //!   variable, and by which source.
@@ -216,7 +216,6 @@ fn group_title(slug: &str) -> &'static str {
         .unwrap_or("Other")
 }
 
-
 /// Builds the page view from the reference doc, the redacted effective config
 /// (as JSON), the explicitly-set key paths with their source labels, and the
 /// live runtime-adjustable values.
@@ -278,7 +277,12 @@ pub(crate) fn build_config_page(
             .entry(group_title(setting.group))
             .or_default()
             .push(ConfigRowView {
-                name: setting.path.rsplit('.').next().unwrap_or(setting.path).to_string(),
+                name: setting
+                    .path
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or(setting.path)
+                    .to_string(),
                 path: setting.path.to_string(),
                 ty: String::new(),
                 value: runtime_cell(setting.value),
@@ -302,7 +306,11 @@ pub(crate) fn build_config_page(
         }
         sections.extend(grouped.remove(title).unwrap_or_default());
         if !sections.is_empty() {
-            groups.push(ConfigGroupView { title, slug, sections });
+            groups.push(ConfigGroupView {
+                title,
+                slug,
+                sections,
+            });
         }
     }
 
@@ -594,7 +602,10 @@ fn parse_reference(markdown: &str) -> Vec<(String, Vec<FieldDoc>)> {
         if in_code_block {
             continue;
         }
-        if let Some(heading) = trimmed.strip_prefix("### ").or_else(|| trimmed.strip_prefix("## ")) {
+        if let Some(heading) = trimmed
+            .strip_prefix("### ")
+            .or_else(|| trimmed.strip_prefix("## "))
+        {
             current = heading_struct_name(heading);
             if let Some(name) = &current
                 && !sections.iter().any(|(existing, _)| existing == name)
@@ -655,10 +666,7 @@ fn parse_table_row(line: &str) -> Option<FieldDoc> {
 
 /// Splits a markdown table row on unescaped pipes, honoring `\|` escapes.
 fn split_table_cells(line: &str) -> Vec<&str> {
-    let inner = line
-        .trim()
-        .trim_start_matches('|')
-        .trim_end_matches('|');
+    let inner = line.trim().trim_start_matches('|').trim_end_matches('|');
     let mut cells = Vec::new();
     let mut start = 0;
     let bytes = inner.as_bytes();
@@ -743,8 +751,8 @@ fn render_links(text: &str) -> String {
         if target.starts_with("http://") || target.starts_with("https://") {
             out.push_str(&format!("<a href=\"{target}\">{label}</a>"));
         } else {
-            // Intra-doc anchors don't map onto this page's section ids, so
-            // keep the label but drop the link.
+            // Intra-doc anchors have no counterpart on the rendered page,
+            // so keep the label but drop the link.
             out.push_str(label);
         }
         rest = &rest[target_end + 1..];
@@ -770,13 +778,20 @@ mod configuration_tests {
     fn parses_real_reference() {
         let sections = parse_reference(carbide_api_core::cfg::CONFIG_REFERENCE_MD);
         let names: Vec<&str> = sections.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(names.contains(&"NicoConfig"), "top-level section missing: {names:?}");
+        assert!(
+            names.contains(&"NicoConfig"),
+            "top-level section missing: {names:?}"
+        );
         assert!(names.contains(&"TlsConfig"));
         assert!(names.contains(&"SiteExplorerConfig"));
         assert!(names.contains(&"TracingConfig"));
 
         let (_, top) = sections.iter().find(|(n, _)| n == "NicoConfig").unwrap();
-        assert!(top.len() > 50, "expected many top-level fields, got {}", top.len());
+        assert!(
+            top.len() > 50,
+            "expected many top-level fields, got {}",
+            top.len()
+        );
         let listen = top.iter().find(|f| f.name == "listen").unwrap();
         assert!(listen.ty.contains("SocketAddr"));
         assert!(listen.default.contains("1079"));
@@ -794,7 +809,10 @@ mod configuration_tests {
             .filter(|f| f.group.is_none())
             .map(|f| f.name.as_str())
             .collect();
-        assert!(ungrouped.is_empty(), "fields without a valid Group cell: {ungrouped:?}");
+        assert!(
+            ungrouped.is_empty(),
+            "fields without a valid Group cell: {ungrouped:?}"
+        );
     }
 
     /// Guards README coverage: every top-level key of the serialized config
@@ -832,7 +850,10 @@ mod configuration_tests {
         });
         let mut explicit = BTreeMap::new();
         explicit.insert("asn".to_string(), "site.toml".to_string());
-        explicit.insert("mlx-config-profiles.profileA".to_string(), "base.toml".to_string());
+        explicit.insert(
+            "mlx-config-profiles.profileA".to_string(),
+            "base.toml".to_string(),
+        );
         explicit.insert("tls.root_cafile_path".to_string(), "base.toml".to_string());
 
         let page = build_config_page(
@@ -848,7 +869,11 @@ mod configuration_tests {
             .flat_map(|g| g.sections.iter())
             .flat_map(|s| s.rows.iter())
             .collect();
-        assert!(rows.len() > 150, "expected full catalog, got {}", rows.len());
+        assert!(
+            rows.len() > 150,
+            "expected full catalog, got {}",
+            rows.len()
+        );
 
         let asn = rows.iter().find(|r| r.path == "asn").unwrap();
         assert!(asn.overridden);
@@ -860,17 +885,26 @@ mod configuration_tests {
 
         // Serde-renamed keys join spelling-insensitively: the reference's
         // `mlxconfig_profiles` matches the serialized `mlx-config-profiles`.
-        let mlx = rows.iter().find(|r| r.path == "mlxconfig_profiles").unwrap();
+        let mlx = rows
+            .iter()
+            .find(|r| r.path == "mlxconfig_profiles")
+            .unwrap();
         assert!(!mlx.value.is_unset(), "renamed key must resolve a value");
         assert!(mlx.overridden, "renamed key must resolve provenance");
 
         // Nested section rows exist with dotted paths, and a field whose
         // sub-struct was set is marked overridden by prefix.
-        let tls_row = rows.iter().find(|r| r.path == "tls.root_cafile_path").unwrap();
+        let tls_row = rows
+            .iter()
+            .find(|r| r.path == "tls.root_cafile_path")
+            .unwrap();
         assert!(tls_row.overridden);
 
         // Runtime settings are folded in: documented options get tagged...
-        let se = rows.iter().find(|r| r.path == "site_explorer.enabled").unwrap();
+        let se = rows
+            .iter()
+            .find(|r| r.path == "site_explorer.enabled")
+            .unwrap();
         assert!(se.runtime);
         // ...and undocumented ones become synthetic runtime rows.
         let lf = rows.iter().find(|r| r.path == "log_filter").unwrap();
@@ -884,7 +918,10 @@ mod configuration_tests {
             markdown_lite("Use `ip_address` for <new> hosts"),
             "Use <code>ip_address</code> for &#60;new&#62; hosts"
         );
-        assert_eq!(markdown_lite("**Deprecated.**"), "<strong>Deprecated.</strong>");
+        assert_eq!(
+            markdown_lite("**Deprecated.**"),
+            "<strong>Deprecated.</strong>"
+        );
         assert_eq!(
             markdown_lite("see [SiteExplorerConfig](#siteexplorerconfig)."),
             "see SiteExplorerConfig."
@@ -893,8 +930,15 @@ mod configuration_tests {
 
     #[test]
     fn cell_values_render_and_escape() {
-        assert_eq!(CellValue::Code("<x>".to_string()).to_html(), "<code>&#60;x&#62;</code>");
-        assert!(CellValue::Pre("{\"a\": 1}".to_string()).to_html().contains("show value"));
+        assert_eq!(
+            CellValue::Code("<x>".to_string()).to_html(),
+            "<code>&#60;x&#62;</code>"
+        );
+        assert!(
+            CellValue::Pre("{\"a\": 1}".to_string())
+                .to_html()
+                .contains("show value")
+        );
         assert!(CellValue::Unset.is_unset());
         assert_eq!(
             format_value(&serde_json::json!({"secs": 3600, "nanos": 0})).to_html(),
@@ -902,7 +946,13 @@ mod configuration_tests {
         );
         let list = format_value(&serde_json::json!(["10.0.0.1", "10.0.0.2"]));
         assert!(list.to_html().contains("10.0.0.1, 10.0.0.2"));
-        assert!(matches!(format_value(&serde_json::json!({"a": {"b": 1}})), CellValue::Pre(_)));
-        assert!(matches!(format_default("**required**"), CellValue::Required));
+        assert!(matches!(
+            format_value(&serde_json::json!({"a": {"b": 1}})),
+            CellValue::Pre(_)
+        ));
+        assert!(matches!(
+            format_default("**required**"),
+            CellValue::Required
+        ));
     }
 }

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -37,6 +37,9 @@
 //! which strips everything but alphanumerics per path segment.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::LazyLock;
+
+use regex::Regex;
 
 /// Everything the Configuration page template needs.
 pub(crate) struct ConfigPageView {
@@ -412,7 +415,7 @@ impl<'a> CatalogBuilder<'a> {
                 None => CellValue::Unset,
             },
             overridden: source.is_some(),
-            source: source.unwrap_or_default().to_string(),
+            source: source.unwrap_or_default(),
             default: format_default(&field.default),
             description_html: match field.description.trim() {
                 "" => r#"<span class="config-unset">No description yet.</span>"#.to_string(),
@@ -438,19 +441,23 @@ impl<'a> CatalogBuilder<'a> {
     }
 
     /// A key counts as explicitly set when the merged config sources provided
-    /// it or anything beneath it (e.g. `tls` is overridden when
-    /// `tls.root_cafile_path` was set in a file).
-    fn explicit_source(&self, path: &str) -> Option<&'a str> {
+    /// it or anything beneath it (e.g. `pools` is overridden when
+    /// `pools.lo-ip.pool_type` was set in a file). Nested keys can come from
+    /// different files (base defines an entry, the site overlay tweaks one
+    /// field of it), so the label names every distinct source.
+    fn explicit_source(&self, path: &str) -> Option<String> {
         let key = canonical(path);
         if let Some(source) = self.explicit.get(&key) {
-            return Some(source);
+            return Some((*source).to_string());
         }
         let prefix = format!("{key}.");
-        self.explicit
+        let sources: std::collections::BTreeSet<&str> = self
+            .explicit
             .range(prefix.clone()..)
             .take_while(|(k, _)| k.starts_with(&prefix))
             .map(|(_, source)| *source)
-            .next()
+            .collect();
+        (!sources.is_empty()).then(|| sources.into_iter().collect::<Vec<_>>().join(", "))
     }
 }
 
@@ -693,70 +700,27 @@ fn escape_html(text: &str) -> String {
 
 /// Minimal markdown renderer for the reference's table cells: HTML-escapes,
 /// then supports `` `code` ``, `**bold**`, and `[text](target)` links (only
-/// http(s) targets become anchors). This is the single escaping site for all
-/// rich text on the page — [`CellValue::Rich`] and `description_html` must
-/// only ever carry its output.
+/// http(s) targets become anchors; the reference's intra-doc anchors have no
+/// counterpart on the rendered page, so they unwrap to their label). This is
+/// the single escaping site for all rich text on the page — [`CellValue::Rich`]
+/// and `description_html` must only ever carry its output.
 fn markdown_lite(text: &str) -> String {
+    static LINK: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\[([^\]]*)\]\(([^)]*)\)").unwrap());
+    static CODE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`([^`]+)`").unwrap());
+    static BOLD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\*\*([^*]+)\*\*").unwrap());
+
     let escaped = escape_html(&text.replace("\\|", "|"));
-    let linked = render_links(&escaped);
-    let coded = render_delimited(&linked, "`", "<code>", "</code>");
-    render_delimited(&coded, "**", "<strong>", "</strong>")
-}
-
-fn render_delimited(text: &str, delim: &str, open: &str, close: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-    loop {
-        let Some(start) = rest.find(delim) else {
-            out.push_str(rest);
-            return out;
-        };
-        let after = &rest[start + delim.len()..];
-        let Some(end) = after.find(delim) else {
-            out.push_str(rest);
-            return out;
-        };
-        out.push_str(&rest[..start]);
-        out.push_str(open);
-        out.push_str(&after[..end]);
-        out.push_str(close);
-        rest = &after[end + delim.len()..];
-    }
-}
-
-fn render_links(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-    loop {
-        let Some(open_bracket) = rest.find('[') else {
-            out.push_str(rest);
-            return out;
-        };
-        let Some(rel_close) = rest[open_bracket..].find("](") else {
-            out.push_str(&rest[..open_bracket + 1]);
-            rest = &rest[open_bracket + 1..];
-            continue;
-        };
-        let close_bracket = open_bracket + rel_close;
-        let target_start = close_bracket + 2;
-        let Some(rel_end) = rest[target_start..].find(')') else {
-            out.push_str(&rest[..open_bracket + 1]);
-            rest = &rest[open_bracket + 1..];
-            continue;
-        };
-        let target_end = target_start + rel_end;
-        let label = &rest[open_bracket + 1..close_bracket];
-        let target = &rest[target_start..target_end];
-        out.push_str(&rest[..open_bracket]);
+    let linked = LINK.replace_all(&escaped, |caps: &regex::Captures| {
+        let (label, target) = (&caps[1], &caps[2]);
         if target.starts_with("http://") || target.starts_with("https://") {
-            out.push_str(&format!("<a href=\"{target}\">{label}</a>"));
+            format!("<a href=\"{target}\">{label}</a>")
         } else {
-            // Intra-doc anchors have no counterpart on the rendered page,
-            // so keep the label but drop the link.
-            out.push_str(label);
+            label.to_string()
         }
-        rest = &rest[target_end + 1..];
-    }
+    });
+    let coded = CODE.replace_all(&linked, "<code>$1</code>");
+    BOLD.replace_all(&coded, "<strong>$1</strong>").into_owned()
 }
 
 #[cfg(test)]
@@ -925,6 +889,11 @@ mod configuration_tests {
         assert_eq!(
             markdown_lite("see [SiteExplorerConfig](#siteexplorerconfig)."),
             "see SiteExplorerConfig."
+        );
+        // Plain bracketed text before a real link must not fuse into it.
+        assert_eq!(
+            markdown_lite("index [0] then [docs](https://example.com) end"),
+            "index [0] then <a href=\"https://example.com\">docs</a> end"
         );
     }
 

--- a/crates/api-web/src/filters.rs
+++ b/crates/api-web/src/filters.rs
@@ -26,7 +26,6 @@ use std::str::FromStr;
 
 use askama_escape::Escaper;
 use carbide_uuid::machine::MachineId;
-use itertools::Itertools;
 
 /// Generates HTML links for Machine IDs
 #[askama::filter_fn]
@@ -274,15 +273,6 @@ pub fn option_fmt_or(
         Some(value) => value.to_string(),
         None => default.to_string(),
     })
-}
-
-#[askama::filter_fn]
-pub fn comma_separated(
-    value: impl IntoIterator<Item = impl Display>,
-    _env: &dyn askama::Values,
-) -> askama::Result<String> {
-    let result = value.into_iter().map(|item| item.to_string()).join(", ");
-    Ok(result)
 }
 
 pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, String) {

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -1017,10 +1017,13 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
     );
 
     let index = Index {
-        version: match carbide_version::v!(build_version) {
-            "" => "dev",
-            version => version,
-        },
+        // TODO: temporary hardcode for a deployment screenshot — restore the
+        // carbide_version fallback below before committing:
+        //   version: match carbide_version::v!(build_version) {
+        //       "" => "dev",
+        //       version => version,
+        //   },
+        version: "v2.0.0-pr-449-g28cf6eb4f",
         config,
         missing_default_credentials: state.missing_default_credentials().await,
     };

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -61,6 +61,12 @@ pub trait Base {
     fn tools() -> &'static [ToolLink] {
         carbide_api_core::configured_tools()
     }
+
+    /// Site name rendered in the sidebar header as "nico.<site>". Falls back
+    /// to "local" when the config doesn't set `sitename`.
+    fn site_name() -> &'static str {
+        carbide_api_core::configured_site_name().unwrap_or("local")
+    }
 }
 
 /// Reusable template for rendering metadata (name, description, labels, version)

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -28,7 +28,7 @@ use axum::middleware::Next;
 use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{Router, get, post};
 use axum_extra::extract::cookie::{Cookie, Key, PrivateCookieJar};
-use carbide_api_core::cfg::file::{CarbideConfig, ToolLink};
+use carbide_api_core::cfg::file::ToolLink;
 use carbide_api_core::{Api, AuthContext, CarbideError, DefaultCredential};
 use carbide_authn::middleware::Principal;
 use http::header::CONTENT_TYPE;
@@ -227,6 +227,7 @@ mod action_status;
 mod attestation;
 mod auth;
 mod compute_allocation;
+mod configuration;
 mod domain;
 mod dpa;
 mod dpu_versions;
@@ -942,8 +943,9 @@ struct Index {
     log_filter: String,
     site_explorer_enabled: String,
     create_machines: String,
-    carbide_config: CarbideConfig,
     bmc_proxy: String,
+    tracing_enabled: String,
+    config: configuration::ConfigPageView,
     missing_default_credentials: Vec<DefaultCredential>,
 }
 
@@ -986,6 +988,24 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         .clone()
         .map(|p| p.to_string())
         .unwrap_or("<None>".to_string());
+    let tracing_enabled = state
+        .dynamic_settings
+        .tracing_enabled
+        .load(Ordering::Relaxed)
+        .to_string();
+
+    let effective = match serde_json::to_value(state.runtime_config.redacted()) {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::error!(%err, "serializing runtime config");
+            return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string()));
+        }
+    };
+    let config = configuration::build_config_page(
+        carbide_api_core::cfg::CONFIG_REFERENCE_MD,
+        &effective,
+        &state.runtime_config.explicit_value_paths(),
+    );
 
     let index = Index {
         version: carbide_version::v!(build_version),
@@ -993,8 +1013,9 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         agent_upgrade_policy,
         site_explorer_enabled,
         create_machines,
-        carbide_config: state.runtime_config.redacted(),
         bmc_proxy,
+        tracing_enabled,
+        config,
         missing_default_credentials: state.missing_default_credentials().await,
     };
 
@@ -1034,4 +1055,51 @@ pub(crate) fn not_found_response(resource: String) -> Response {
 
 pub(crate) fn invalid_machine_id() -> String {
     "INVALID_MACHINE".to_string()
+}
+
+#[cfg(test)]
+mod index_template_tests {
+    use askama::Template as _;
+
+    use super::*;
+
+    /// Renders the Configuration page template against the real reference doc
+    /// to catch template/view-model mismatches without a running server.
+    #[test]
+    fn index_renders_config_page() {
+        let effective = serde_json::json!({
+            "listen": "[::]:1079",
+            "asn": 65001,
+            "attestation_enabled": false,
+        });
+        let mut explicit = std::collections::BTreeMap::new();
+        explicit.insert("asn".to_string(), "site-config.toml".to_string());
+        let config = configuration::build_config_page(
+            carbide_api_core::cfg::CONFIG_REFERENCE_MD,
+            &effective,
+            &explicit,
+        );
+
+        let index = Index {
+            version: "test-version",
+            agent_upgrade_policy: "Off",
+            log_filter: "info".to_string(),
+            site_explorer_enabled: "true".to_string(),
+            create_machines: "false".to_string(),
+            bmc_proxy: "<None>".to_string(),
+            tracing_enabled: "false".to_string(),
+            config,
+            missing_default_credentials: Vec::new(),
+        };
+        let html = index.render().expect("index template renders");
+
+        assert!(html.contains("Runtime Settings"));
+        // The overridden option shows its value and source badge.
+        assert!(html.contains("65001"));
+        assert!(html.contains("site-config.toml"));
+        // Grouping and catalog rendering are present.
+        assert!(html.contains("config-group-title"));
+        assert!(html.contains("attestation_enabled"));
+        assert!(html.contains("site_explorer"));
+    }
 }

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -1017,13 +1017,10 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
     );
 
     let index = Index {
-        // TODO: temporary hardcode for a deployment screenshot — restore the
-        // carbide_version fallback below before committing:
-        //   version: match carbide_version::v!(build_version) {
-        //       "" => "dev",
-        //       version => version,
-        //   },
-        version: "v2.0.0-pr-449-g28cf6eb4f",
+        version: match carbide_version::v!(build_version) {
+            "" => "dev",
+            version => version,
+        },
         config,
         missing_default_credentials: state.missing_default_credentials().await,
     };

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -993,41 +993,14 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         .load(Ordering::Relaxed)
         .to_string();
 
-    // Live values of the runtime-adjustable settings, folded into the catalog
-    // next to their config options and tagged "runtime".
-    use configuration::RuntimeSetting;
-    let runtime_settings = vec![
-        RuntimeSetting {
-            path: "log_filter",
-            value: Some(state.log_filter_string()),
-            description: "Active `RUST_LOG` log filter.",
-        },
-        RuntimeSetting {
-            path: "site_explorer.enabled",
-            value: Some(site_explorer_enabled),
-            description: "Whether site explorer runs periodic hardware explorations.",
-        },
-        RuntimeSetting {
-            path: "site_explorer.create_machines",
-            value: Some(create_machines),
-            description: "Whether site explorer creates machines from discovered endpoints.",
-        },
-        RuntimeSetting {
-            path: "site_explorer.bmc_proxy",
-            value: bmc_proxy,
-            description: "Proxy used for talking to BMCs.",
-        },
-        RuntimeSetting {
-            path: "tracing.enabled",
-            value: Some(tracing_enabled),
-            description: "Whether log tracing is enabled.",
-        },
-        RuntimeSetting {
-            path: "initial_dpu_agent_upgrade_policy",
-            value: Some(agent_upgrade_policy.to_string()),
-            description: "Active DPU agent upgrade policy.",
-        },
-    ];
+    let live_settings = configuration::LiveSettings {
+        log_filter: state.log_filter_string(),
+        site_explorer_enabled,
+        create_machines,
+        bmc_proxy,
+        tracing_enabled,
+        dpu_agent_upgrade_policy: agent_upgrade_policy.to_string(),
+    };
 
     let effective = match serde_json::to_value(state.runtime_config.redacted()) {
         Ok(value) => value,
@@ -1040,14 +1013,14 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         carbide_api_core::cfg::CONFIG_REFERENCE_MD,
         &effective,
         &state.runtime_config.explicit_value_paths(),
-        runtime_settings,
+        live_settings,
     );
 
     let index = Index {
-        // TODO: temporarily hardcoded so deployments show a recognizable
-        // version while carbide_version reports a dev build; restore
-        // carbide_version::v!(build_version) before merging.
-        version: "v2.0.0-pr-449-g28cf6eb4f",
+        version: match carbide_version::v!(build_version) {
+            "" => "dev",
+            version => version,
+        },
         config,
         missing_default_credentials: state.missing_default_credentials().await,
     };
@@ -1107,23 +1080,19 @@ mod index_template_tests {
         });
         let mut explicit = std::collections::BTreeMap::new();
         explicit.insert("asn".to_string(), "site-config.toml".to_string());
-        let runtime_settings = vec![
-            configuration::RuntimeSetting {
-                path: "log_filter",
-                value: Some("info".to_string()),
-                description: "Active `RUST_LOG` log filter.",
-            },
-            configuration::RuntimeSetting {
-                path: "site_explorer.enabled",
-                value: Some("true".to_string()),
-                description: "Whether site explorer runs periodic hardware explorations.",
-            },
-        ];
+        let live_settings = configuration::LiveSettings {
+            log_filter: "info".to_string(),
+            site_explorer_enabled: "true".to_string(),
+            create_machines: "false".to_string(),
+            bmc_proxy: None,
+            tracing_enabled: "false".to_string(),
+            dpu_agent_upgrade_policy: "Off".to_string(),
+        };
         let config = configuration::build_config_page(
             carbide_api_core::cfg::CONFIG_REFERENCE_MD,
             &effective,
             &explicit,
-            runtime_settings,
+            live_settings,
         );
 
         let index = Index {

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -62,8 +62,8 @@ pub trait Base {
         carbide_api_core::configured_tools()
     }
 
-    /// Site name rendered in the sidebar header as "nico.<site>". Falls back
-    /// to "local" when the config doesn't set `sitename`.
+    /// Site name rendered in the sidebar header as "NICo • <site>". Falls
+    /// back to "local" when the config doesn't set `sitename`.
     fn site_name() -> &'static str {
         carbide_api_core::configured_site_name().unwrap_or("local")
     }

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -1093,12 +1093,13 @@ mod index_template_tests {
         };
         let html = index.render().expect("index template renders");
 
-        assert!(html.contains("Runtime Settings"));
-        // The overridden option shows its value and source badge.
+        // Tab navigation with the runtime tab active.
+        assert!(html.contains(r#"data-tab="runtime""#));
+        assert!(html.contains(r#"id="tab-networking""#));
+        // The overridden option shows its value and source tag.
         assert!(html.contains("65001"));
         assert!(html.contains("site-config.toml"));
-        // Grouping and catalog rendering are present.
-        assert!(html.contains("config-group-title"));
+        // Catalog rendering is present.
         assert!(html.contains("attestation_enabled"));
         assert!(html.contains("site_explorer"));
     }

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -939,12 +939,6 @@ pub async fn auth_oauth2(
 #[template(path = "index.html")]
 struct Index {
     version: &'static str,
-    agent_upgrade_policy: &'static str,
-    log_filter: String,
-    site_explorer_enabled: String,
-    create_machines: String,
-    bmc_proxy: String,
-    tracing_enabled: String,
     config: configuration::ConfigPageView,
     missing_default_credentials: Vec<DefaultCredential>,
 }
@@ -986,13 +980,48 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         .load()
         .as_ref()
         .clone()
-        .map(|p| p.to_string())
-        .unwrap_or("<None>".to_string());
+        .map(|p| p.to_string());
     let tracing_enabled = state
         .dynamic_settings
         .tracing_enabled
         .load(Ordering::Relaxed)
         .to_string();
+
+    // Live values of the runtime-adjustable settings, folded into the catalog
+    // next to their config options and tagged "runtime".
+    use configuration::RuntimeSetting;
+    let runtime_settings = vec![
+        RuntimeSetting {
+            path: "log_filter",
+            value: Some(state.log_filter_string()),
+            description: "Active `RUST_LOG` log filter.",
+        },
+        RuntimeSetting {
+            path: "site_explorer.enabled",
+            value: Some(site_explorer_enabled),
+            description: "Whether site explorer runs periodic hardware explorations.",
+        },
+        RuntimeSetting {
+            path: "site_explorer.create_machines",
+            value: Some(create_machines),
+            description: "Whether site explorer creates machines from discovered endpoints.",
+        },
+        RuntimeSetting {
+            path: "site_explorer.bmc_proxy",
+            value: bmc_proxy,
+            description: "Proxy used for talking to BMCs.",
+        },
+        RuntimeSetting {
+            path: "tracing.enabled",
+            value: Some(tracing_enabled),
+            description: "Whether log tracing is enabled.",
+        },
+        RuntimeSetting {
+            path: "initial_dpu_agent_upgrade_policy",
+            value: Some(agent_upgrade_policy.to_string()),
+            description: "Active DPU agent upgrade policy.",
+        },
+    ];
 
     let effective = match serde_json::to_value(state.runtime_config.redacted()) {
         Ok(value) => value,
@@ -1005,16 +1034,14 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         carbide_api_core::cfg::CONFIG_REFERENCE_MD,
         &effective,
         &state.runtime_config.explicit_value_paths(),
+        runtime_settings,
     );
 
     let index = Index {
-        version: carbide_version::v!(build_version),
-        log_filter: state.log_filter_string(),
-        agent_upgrade_policy,
-        site_explorer_enabled,
-        create_machines,
-        bmc_proxy,
-        tracing_enabled,
+        // TODO: temporarily hardcoded so deployments show a recognizable
+        // version while carbide_version reports a dev build; restore
+        // carbide_version::v!(build_version) before merging.
+        version: "v2.0.0-pr-449-g28cf6eb4f",
         config,
         missing_default_credentials: state.missing_default_credentials().await,
     };
@@ -1074,31 +1101,40 @@ mod index_template_tests {
         });
         let mut explicit = std::collections::BTreeMap::new();
         explicit.insert("asn".to_string(), "site-config.toml".to_string());
+        let runtime_settings = vec![
+            configuration::RuntimeSetting {
+                path: "log_filter",
+                value: Some("info".to_string()),
+                description: "Active `RUST_LOG` log filter.",
+            },
+            configuration::RuntimeSetting {
+                path: "site_explorer.enabled",
+                value: Some("true".to_string()),
+                description: "Whether site explorer runs periodic hardware explorations.",
+            },
+        ];
         let config = configuration::build_config_page(
             carbide_api_core::cfg::CONFIG_REFERENCE_MD,
             &effective,
             &explicit,
+            runtime_settings,
         );
 
         let index = Index {
             version: "test-version",
-            agent_upgrade_policy: "Off",
-            log_filter: "info".to_string(),
-            site_explorer_enabled: "true".to_string(),
-            create_machines: "false".to_string(),
-            bmc_proxy: "<None>".to_string(),
-            tracing_enabled: "false".to_string(),
             config,
             missing_default_credentials: Vec::new(),
         };
         let html = index.render().expect("index template renders");
 
-        // Tab navigation with the runtime tab active.
-        assert!(html.contains(r#"data-tab="runtime""#));
+        // Tab navigation with the first group tab active.
         assert!(html.contains(r#"id="tab-networking""#));
         // The overridden option shows its value and source tag.
         assert!(html.contains("65001"));
         assert!(html.contains("site-config.toml"));
+        // Runtime settings are folded in and tagged.
+        assert!(html.contains(r#"class="config-runtime""#));
+        assert!(html.contains("log_filter"));
         // Catalog rendering is present.
         assert!(html.contains("attestation_enabled"));
         assert!(html.contains("site_explorer"));

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -1065,8 +1065,6 @@ pub(crate) fn invalid_machine_id() -> String {
 
 #[cfg(test)]
 mod index_template_tests {
-    use askama::Template as _;
-
     use super::*;
 
     /// Renders the Configuration page template against the real reference doc

--- a/crates/api-web/templates/base.html
+++ b/crates/api-web/templates/base.html
@@ -8,7 +8,7 @@
 	</head>
 	<body class="preload">
 		<nav>
-			<h3><a href="/admin" id="site-name">nico.{{ Self::site_name() }}</a></h3>
+			<h3><a href="/admin" id="site-name">NICo &bull; {{ Self::site_name() }}</a></h3>
 			<form action="/admin/search" class="search-container">
 				<input type="search" placeholder="fm100.., 10.2.., etc" name="q" tabindex="1" title="Enter a machine id, UUID, IP address, MAC address, serial number, or shortcode">
 				<input type="submit" value="">

--- a/crates/api-web/templates/base.html
+++ b/crates/api-web/templates/base.html
@@ -8,7 +8,7 @@
 	</head>
 	<body class="preload">
 		<nav>
-			<h3><a href="/admin" id="site-name">carbide-web</a></h3>
+			<h3><a href="/admin" id="site-name">nico.{{ Self::site_name() }}</a></h3>
 			<form action="/admin/search" class="search-container">
 				<input type="search" placeholder="fm100.., 10.2.., etc" name="q" tabindex="1" title="Enter a machine id, UUID, IP address, MAC address, serial number, or shortcode">
 				<input type="submit" value="">
@@ -252,16 +252,6 @@
 				return match ? match[1] : defaultSiteName;
 			}
 
-			// Update the sidebar header label with the deployment site
-			// (e.g. "carbide • dev3" on api-dev3.frg.nvidia.com).
-			function setSiteHeader() {
-				const displayName = getSiteName("localDev");
-				const siteNameElement = document.getElementById("site-name");
-				if (siteNameElement) {
-					siteNameElement.innerHTML = `carbide • ${displayName}`;
-				}
-			}
-
 			function create_el(type, attributes, htmlAttributes) {
 				const el = document.createElement(type);
 				Object.assign(el, attributes);
@@ -346,7 +336,6 @@
 
 			document.addEventListener("DOMContentLoaded", function(event){
 				attachJsonLink();
-				setSiteHeader();
 				prettifyJSONs();
 			});
 

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -32,27 +32,25 @@
 	<div class="tab-content{% if loop.first %} active{% endif %}" id="tab-{{ group.slug }}">
 		<h2 class="config-group-label">{{ group.title }}</h2>
 		{% for section in group.sections %}
-		<section class="config-section" id="{{ section.anchor }}">
+		<section class="config-section">
 			<h3>{{ section.title }}{% if section.path.len() > 0 %} <code class="config-section-path">[{{ section.path }}]</code>{% endif %}</h3>
 			<table class="config-options">
 				<thead><tr><th>Option</th><th>Value</th></tr></thead>
 				<tbody>
 					{% for row in section.rows %}
-					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.unset %} unset{% endif %}" data-path="{{ row.path }}">
+					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.value.is_unset() %} unset{% endif %}" data-path="{{ row.path }}">
 						<td class="config-name">
 							<code>{{ row.name }}</code>
-							{% if row.undocumented %}<span class="config-type">undocumented</span>{% endif %}
 						</td>
 						<td class="config-value">
-							{% if row.multiline %}<details><summary>show value</summary><pre>{{ row.value_html|safe }}</pre></details>
-							{% else %}{{ row.value_html|safe }}{% endif %}
+							{{ row.value.to_html()|safe }}
 							{% if row.runtime %}<span class="config-runtime" title="Live value — adjustable on a running server with 'nico-admin-cli set'; overrides expire (default 1h) and reset on restart">runtime</span>{% endif %}
 							{% if row.overridden %}<span class="config-source" title="Explicitly set — not the compiled-in default">{{ row.source }}</span>{% endif %}
 							<div class="config-row-detail" hidden>
 								<div>{{ row.description_html|safe }}</div>
 								<dl>
 									{% if !row.ty.is_empty() %}<dt>Type</dt><dd>{{ row.ty }}</dd>{% endif %}
-									<dt>Default</dt><dd>{{ row.default_html|safe }}</dd>
+									<dt>Default</dt><dd>{{ row.default.to_html()|safe }}</dd>
 									<dt>Path</dt><dd><code>{{ row.path }}</code></dd>
 									{% if row.overridden %}<dt>Source</dt><dd>{{ row.source }} (explicitly set)</dd>{% endif %}
 									{% if row.runtime %}<dt>Runtime</dt><dd>Adjustable live via <code>nico-admin-cli set</code>; overrides expire (default 1h) and reset on restart.</dd>{% endif %}

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -91,6 +91,7 @@
 	function applyFilter() {
 		const query = search.value.trim().toLowerCase();
 		const filtering = query !== '' || overriddenOnly.checked;
+		resetPanel();
 		page.classList.toggle('config-filtering', filtering);
 		let anyVisible = false;
 		for (const content of contents) {
@@ -118,6 +119,16 @@
 	// Row click fills the sticky detail panel.
 	const panelTitle = document.getElementById('config-panel-title');
 	const panelBody = document.getElementById('config-panel-body');
+	const panelDefaultTitle = panelTitle.textContent;
+	const panelDefaultBody = panelBody.innerHTML;
+
+	function resetPanel() {
+		for (const selected of page.querySelectorAll('.config-row.selected')) {
+			selected.classList.remove('selected');
+		}
+		panelTitle.textContent = panelDefaultTitle;
+		panelBody.innerHTML = panelDefaultBody;
+	}
 	page.querySelector('.config-tables').addEventListener('click', (e) => {
 		const row = e.target.closest('.config-row');
 		// Don't hijack clicks on the "show value" expander or links.

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -26,6 +26,8 @@
 		<div class="tab-indicator"></div>
 	</div>
 
+	<div class="config-body">
+	<div class="config-tables">
 	{% for group in config.groups %}
 	<div class="tab-content{% if loop.first %} active{% endif %}" id="tab-{{ group.slug }}">
 		<h2 class="config-group-label">{{ group.title }}</h2>
@@ -33,13 +35,12 @@
 		<section class="config-section" id="{{ section.anchor }}">
 			<h3>{{ section.title }}{% if section.path.len() > 0 %} <code class="config-section-path">[{{ section.path }}]</code>{% endif %}</h3>
 			<table class="config-options">
-				<thead><tr><th>Option</th><th>Value</th><th>Default</th><th>Description</th></tr></thead>
+				<thead><tr><th>Option</th><th>Value</th></tr></thead>
 				<tbody>
 					{% for row in section.rows %}
-					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.unset %} unset{% endif %}">
+					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.unset %} unset{% endif %}" data-path="{{ row.path }}">
 						<td class="config-name">
-							<code title="{{ row.path }}">{{ row.name }}</code>
-							{% if !row.ty.is_empty() %}<span class="config-type">{{ row.ty }}</span>{% endif %}
+							<code>{{ row.name }}</code>
 							{% if row.undocumented %}<span class="config-type">undocumented</span>{% endif %}
 						</td>
 						<td class="config-value">
@@ -47,9 +48,17 @@
 							{% else %}{{ row.value_html|safe }}{% endif %}
 							{% if row.runtime %}<span class="config-runtime" title="Live value — adjustable on a running server with 'nico-admin-cli set'; overrides expire (default 1h) and reset on restart">runtime</span>{% endif %}
 							{% if row.overridden %}<span class="config-source" title="Explicitly set — not the compiled-in default">{{ row.source }}</span>{% endif %}
+							<div class="config-row-detail" hidden>
+								<div>{{ row.description_html|safe }}</div>
+								<dl>
+									{% if !row.ty.is_empty() %}<dt>Type</dt><dd>{{ row.ty }}</dd>{% endif %}
+									<dt>Default</dt><dd>{{ row.default_html|safe }}</dd>
+									<dt>Path</dt><dd><code>{{ row.path }}</code></dd>
+									{% if row.overridden %}<dt>Source</dt><dd>{{ row.source }} (explicitly set)</dd>{% endif %}
+									{% if row.runtime %}<dt>Runtime</dt><dd>Adjustable live via <code>nico-admin-cli set</code>; overrides expire (default 1h) and reset on restart.</dd>{% endif %}
+								</dl>
+							</div>
 						</td>
-						<td class="config-default">{{ row.default_html|safe }}</td>
-						<td class="config-desc">{{ row.description_html|safe }}</td>
 					</tr>
 					{% endfor %}
 				</tbody>
@@ -60,6 +69,13 @@
 	{% endfor %}
 
 	<p class="config-empty" id="config-no-matches" hidden>No options match the current filter.</p>
+	</div>
+
+	<aside class="config-panel">
+		<h4 id="config-panel-title">Details</h4>
+		<div id="config-panel-body" class="config-desc">Select an option to see its description, type, and default here.</div>
+	</aside>
+	</div>
 </div>
 
 <script>
@@ -98,6 +114,22 @@
 
 	search.addEventListener('input', applyFilter);
 	overriddenOnly.addEventListener('change', applyFilter);
+
+	// Row click fills the sticky detail panel.
+	const panelTitle = document.getElementById('config-panel-title');
+	const panelBody = document.getElementById('config-panel-body');
+	page.querySelector('.config-tables').addEventListener('click', (e) => {
+		const row = e.target.closest('.config-row');
+		// Don't hijack clicks on the "show value" expander or links.
+		if (!row || e.target.closest('a, details, summary')) return;
+		for (const selected of page.querySelectorAll('.config-row.selected')) {
+			selected.classList.remove('selected');
+		}
+		row.classList.add('selected');
+		const detail = row.querySelector('.config-row-detail');
+		panelTitle.textContent = row.dataset.path || 'Details';
+		panelBody.innerHTML = detail ? detail.innerHTML : '';
+	});
 })();
 </script>
 {% endblock %}

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -8,109 +8,103 @@
 {% include "missing_credentials_warning.html" %}
 
 <div class="config-page">
-	<div class="config-summary">
-		<span class="bubble">version {{ version }}</span>
-		<span class="config-summary-stat">{{ config.total_options }} options</span>
-		{% if config.overridden_options > 0 %}
-		<span class="config-summary-stat"><strong>{{ config.overridden_options }} overridden</strong> via
-			{% for source in config.sources %}{% if !loop.first %}, {% endif %}<code>{{ source }}</code>{% endfor %}
-		</span>
-		{% else %}
-		<span class="config-summary-stat">all values at compiled-in defaults</span>
-		{% endif %}
-	</div>
-
 	<div class="config-toolbar">
 		<input type="search" id="config-search" placeholder="Filter options by name, value, or description&hellip;" autocomplete="off">
 		<label class="config-toggle">
 			<input type="checkbox" id="config-overridden-only"> Overridden only
 		</label>
-		<button type="button" id="config-expand-all">Expand all</button>
-		<button type="button" id="config-collapse-all">Collapse all</button>
 	</div>
 
-	<details class="config-section config-runtime" open>
-		<summary>
-			<span class="config-section-title">Runtime Settings</span>
-			<span class="bubble">runtime-adjustable</span>
-		</summary>
-		<p class="config-section-note">
-			These settings can be changed on a live server with <code>nico-admin-cli set</code>.
-			Overrides carry an expiry (default 1h) and revert to their startup values when it
-			passes, or on restart.
-		</p>
-		<table class="config-options">
-			<thead><tr><th>Setting</th><th>Current value</th><th>Description</th></tr></thead>
-			<tbody>
-				<tr class="config-row">
-					<td class="config-name"><code>log_filter</code></td>
-					<td class="config-value"><code>{{ log_filter }}</code></td>
-					<td class="config-desc">Active <code>RUST_LOG</code> log filter.</td>
-				</tr>
-				<tr class="config-row">
-					<td class="config-name"><code>site_explorer_enabled</code></td>
-					<td class="config-value"><code>{{ site_explorer_enabled }}</code></td>
-					<td class="config-desc">Whether site explorer runs periodic hardware explorations.</td>
-				</tr>
-				<tr class="config-row">
-					<td class="config-name"><code>create_machines</code></td>
-					<td class="config-value"><code>{{ create_machines }}</code></td>
-					<td class="config-desc">Whether site explorer creates machines from discovered endpoints.</td>
-				</tr>
-				<tr class="config-row">
-					<td class="config-name"><code>bmc_proxy</code></td>
-					<td class="config-value"><code>{{ bmc_proxy }}</code></td>
-					<td class="config-desc">Proxy used for talking to BMCs.</td>
-				</tr>
-				<tr class="config-row">
-					<td class="config-name"><code>tracing_enabled</code></td>
-					<td class="config-value"><code>{{ tracing_enabled }}</code></td>
-					<td class="config-desc">Whether log tracing is enabled.</td>
-				</tr>
-				<tr class="config-row">
-					<td class="config-name"><code>dpu_agent_upgrade_policy</code></td>
-					<td class="config-value"><code>{{ agent_upgrade_policy }}</code></td>
-					<td class="config-desc">Active DPU agent upgrade policy.</td>
-				</tr>
-			</tbody>
-		</table>
-	</details>
+	<div class="tab-nav">
+		<button class="tab-button active" data-tab="runtime">Runtime</button>
+		{% for group in config.groups %}
+		<button class="tab-button" data-tab="{{ group.title|lower }}">{{ group.title }}</button>
+		{% endfor %}
+		<div class="tab-indicator"></div>
+	</div>
+
+	<div class="tab-content active" id="tab-runtime">
+		<h2 class="config-group-label">Runtime</h2>
+		<section class="config-section">
+			<p class="config-note">
+				These settings can be changed on a live server with <code>nico-admin-cli set</code>.
+				Overrides carry an expiry (default 1h) and revert to their startup values when it
+				passes, or on restart. Everything under the other tabs is file configuration:
+				changing it means editing the config file and restarting.
+			</p>
+			<table class="config-options">
+				<thead><tr><th>Setting</th><th>Current value</th><th>Description</th></tr></thead>
+				<tbody>
+					<tr class="config-row">
+						<td class="config-name"><code>version</code></td>
+						<td class="config-value"><code>{{ version }}</code></td>
+						<td class="config-desc">Build version of this server (read-only).</td>
+					</tr>
+					<tr class="config-row">
+						<td class="config-name"><code>log_filter</code></td>
+						<td class="config-value"><code>{{ log_filter }}</code></td>
+						<td class="config-desc">Active <code>RUST_LOG</code> log filter.</td>
+					</tr>
+					<tr class="config-row">
+						<td class="config-name"><code>site_explorer_enabled</code></td>
+						<td class="config-value"><code>{{ site_explorer_enabled }}</code></td>
+						<td class="config-desc">Whether site explorer runs periodic hardware explorations.</td>
+					</tr>
+					<tr class="config-row">
+						<td class="config-name"><code>create_machines</code></td>
+						<td class="config-value"><code>{{ create_machines }}</code></td>
+						<td class="config-desc">Whether site explorer creates machines from discovered endpoints.</td>
+					</tr>
+					<tr class="config-row">
+						<td class="config-name"><code>bmc_proxy</code></td>
+						<td class="config-value"><code>{{ bmc_proxy }}</code></td>
+						<td class="config-desc">Proxy used for talking to BMCs.</td>
+					</tr>
+					<tr class="config-row">
+						<td class="config-name"><code>tracing_enabled</code></td>
+						<td class="config-value"><code>{{ tracing_enabled }}</code></td>
+						<td class="config-desc">Whether log tracing is enabled.</td>
+					</tr>
+					<tr class="config-row">
+						<td class="config-name"><code>dpu_agent_upgrade_policy</code></td>
+						<td class="config-value"><code>{{ agent_upgrade_policy }}</code></td>
+						<td class="config-desc">Active DPU agent upgrade policy.</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
+	</div>
 
 	{% for group in config.groups %}
-	<h2 class="config-group-title">{{ group.title }}</h2>
-	{% for section in group.sections %}
-	<details class="config-section" id="{{ section.anchor }}" {% if section.overridden > 0 %}open{% endif %}>
-		<summary>
-			<span class="config-section-title">{{ section.title }}</span>
-			{% if !section.path.is_empty() %}<code class="config-section-path">[{{ section.path }}]</code>{% endif %}
-			<span class="config-section-meta">
-				{% if section.overridden > 0 %}<span class="bubble success">{{ section.overridden }} overridden</span>{% endif %}
-				<span class="config-count">{{ section.rows.len() }} option{% if section.rows.len() != 1 %}s{% endif %}</span>
-			</span>
-		</summary>
-		<table class="config-options">
-			<thead><tr><th>Option</th><th>Value</th><th>Default</th><th>Description</th></tr></thead>
-			<tbody>
-				{% for row in section.rows %}
-				<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.unset %} unset{% endif %}">
-					<td class="config-name">
-						<code title="{{ row.path }}">{{ row.name }}</code>
-						{% if !row.ty.is_empty() %}<span class="config-type">{{ row.ty }}</span>{% endif %}
-						{% if row.undocumented %}<span class="bubble warning">undocumented</span>{% endif %}
-					</td>
-					<td class="config-value">
-						{% if row.multiline %}<details><summary>show value</summary><pre>{{ row.value_html|safe }}</pre></details>
-						{% else %}{{ row.value_html|safe }}{% endif %}
-						{% if row.overridden %}<span class="config-source" title="Explicitly set — not the compiled-in default">{{ row.source }}</span>{% endif %}
-					</td>
-					<td class="config-default">{{ row.default_html|safe }}</td>
-					<td class="config-desc">{{ row.description_html|safe }}</td>
-				</tr>
-				{% endfor %}
-			</tbody>
-		</table>
-	</details>
-	{% endfor %}
+	<div class="tab-content" id="tab-{{ group.title|lower }}">
+		<h2 class="config-group-label">{{ group.title }}</h2>
+		{% for section in group.sections %}
+		<section class="config-section" id="{{ section.anchor }}">
+			<h3>{{ section.title }}{% if section.path.len() > 0 %} <code class="config-section-path">[{{ section.path }}]</code>{% endif %}</h3>
+			<table class="config-options">
+				<thead><tr><th>Option</th><th>Value</th><th>Default</th><th>Description</th></tr></thead>
+				<tbody>
+					{% for row in section.rows %}
+					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.unset %} unset{% endif %}">
+						<td class="config-name">
+							<code title="{{ row.path }}">{{ row.name }}</code>
+							{% if !row.ty.is_empty() %}<span class="config-type">{{ row.ty }}</span>{% endif %}
+							{% if row.undocumented %}<span class="config-type">undocumented</span>{% endif %}
+						</td>
+						<td class="config-value">
+							{% if row.multiline %}<details><summary>show value</summary><pre>{{ row.value_html|safe }}</pre></details>
+							{% else %}{{ row.value_html|safe }}{% endif %}
+							{% if row.overridden %}<span class="config-source" title="Explicitly set — not the compiled-in default">{{ row.source }}</span>{% endif %}
+						</td>
+						<td class="config-default">{{ row.default_html|safe }}</td>
+						<td class="config-desc">{{ row.description_html|safe }}</td>
+					</tr>
+					{% endfor %}
+				</tbody>
+			</table>
+		</section>
+		{% endfor %}
+	</div>
 	{% endfor %}
 
 	<p class="config-empty" id="config-no-matches" hidden>No options match the current filter.</p>
@@ -118,48 +112,40 @@
 
 <script>
 (() => {
+	const page = document.querySelector('.config-page');
 	const search = document.getElementById('config-search');
 	const overriddenOnly = document.getElementById('config-overridden-only');
-	const sections = [...document.querySelectorAll('.config-section:not(.config-runtime)')];
-	const groups = [...document.querySelectorAll('.config-group-title')];
+	const contents = [...page.querySelectorAll('.tab-content')];
 	const noMatches = document.getElementById('config-no-matches');
 
+	// While a filter is active the tab nav is bypassed: every group with
+	// matches is shown (with its label), so search covers the whole catalog.
 	function applyFilter() {
 		const query = search.value.trim().toLowerCase();
-		const onlyOverridden = overriddenOnly.checked;
+		const filtering = query !== '' || overriddenOnly.checked;
+		page.classList.toggle('config-filtering', filtering);
 		let anyVisible = false;
-		for (const section of sections) {
-			let visibleRows = 0;
-			for (const row of section.querySelectorAll('.config-row')) {
-				const matches = (!query || row.textContent.toLowerCase().includes(query))
-					&& (!onlyOverridden || row.classList.contains('overridden'));
-				row.hidden = !matches;
-				if (matches) visibleRows++;
+		for (const content of contents) {
+			let contentVisible = 0;
+			for (const section of content.querySelectorAll('.config-section')) {
+				let visibleRows = 0;
+				for (const row of section.querySelectorAll('.config-row')) {
+					const matches = (!query || row.textContent.toLowerCase().includes(query))
+						&& (!overriddenOnly.checked || row.classList.contains('overridden'));
+					row.hidden = !matches;
+					if (matches) visibleRows++;
+				}
+				section.hidden = filtering && visibleRows === 0;
+				contentVisible += visibleRows;
 			}
-			section.hidden = visibleRows === 0;
-			if (visibleRows > 0) {
-				anyVisible = true;
-				if (query || onlyOverridden) section.open = true;
-			}
+			content.classList.toggle('config-has-matches', contentVisible > 0);
+			if (contentVisible > 0) anyVisible = true;
 		}
-		// Hide group headings whose sections are all hidden.
-		for (const heading of groups) {
-			let node = heading.nextElementSibling, visible = false;
-			while (node && !node.classList.contains('config-group-title')) {
-				if (node.classList.contains('config-section') && !node.hidden) visible = true;
-				node = node.nextElementSibling;
-			}
-			heading.hidden = !visible;
-		}
-		noMatches.hidden = anyVisible;
+		noMatches.hidden = !filtering || anyVisible;
 	}
 
 	search.addEventListener('input', applyFilter);
 	overriddenOnly.addEventListener('change', applyFilter);
-	document.getElementById('config-expand-all').addEventListener('click',
-		() => sections.forEach(s => { s.open = true; }));
-	document.getElementById('config-collapse-all').addEventListener('click',
-		() => sections.forEach(s => { s.open = false; }));
 })();
 </script>
 {% endblock %}

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -9,6 +9,10 @@
 
 <div class="config-page">
 	<div class="config-toolbar">
+		<div class="config-version">
+			<span class="config-version-label">nico version</span>
+			<code>{{ version }}</code>
+		</div>
 		<input type="search" id="config-search" placeholder="Filter options by name, value, or description&hellip;" autocomplete="off">
 		<label class="config-toggle">
 			<input type="checkbox" id="config-overridden-only"> Overridden only
@@ -35,11 +39,6 @@
 			<table class="config-options">
 				<thead><tr><th>Setting</th><th>Current value</th><th>Description</th></tr></thead>
 				<tbody>
-					<tr class="config-row">
-						<td class="config-name"><code>version</code></td>
-						<td class="config-value"><code>{{ version }}</code></td>
-						<td class="config-desc">Build version of this server (read-only).</td>
-					</tr>
 					<tr class="config-row">
 						<td class="config-name"><code>log_filter</code></td>
 						<td class="config-value"><code>{{ log_filter }}</code></td>

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -38,7 +38,7 @@
 				<thead><tr><th>Option</th><th>Value</th></tr></thead>
 				<tbody>
 					{% for row in section.rows %}
-					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.value.is_unset() %} unset{% endif %}" data-path="{{ row.path }}">
+					<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.value.is_unset() %} unset{% endif %}" data-path="{{ row.path }}" data-search="{{ row.search }}">
 						<td class="config-name">
 							<code>{{ row.name }}</code>
 						</td>
@@ -97,7 +97,10 @@
 			for (const section of content.querySelectorAll('.config-section')) {
 				let visibleRows = 0;
 				for (const row of section.querySelectorAll('.config-row')) {
-					const matches = (!query || row.textContent.toLowerCase().includes(query))
+					// data-search holds name/path/value/source/description —
+					// not the type or the panel's Type/Default/Path labels,
+					// which would match on every row.
+					const matches = (!query || row.dataset.search.includes(query))
 						&& (!overriddenOnly.checked || row.classList.contains('overridden'));
 					row.hidden = !matches;
 					if (matches) visibleRows++;

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -10,7 +10,7 @@
 <div class="config-page">
 	<div class="config-toolbar">
 		<div class="config-version">
-			<span class="config-version-label">nico version</span>
+			<span class="config-version-label">NICo version</span>
 			<code>{{ version }}</code>
 		</div>
 		<input type="search" id="config-search" placeholder="Filter options by name, value, or description&hellip;" autocomplete="off">

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -22,7 +22,7 @@
 	<div class="tab-nav">
 		<button class="tab-button active" data-tab="runtime">Runtime</button>
 		{% for group in config.groups %}
-		<button class="tab-button" data-tab="{{ group.title|lower }}">{{ group.title }}</button>
+		<button class="tab-button" data-tab="{{ group.slug }}">{{ group.title }}</button>
 		{% endfor %}
 		<div class="tab-indicator"></div>
 	</div>
@@ -75,7 +75,7 @@
 	</div>
 
 	{% for group in config.groups %}
-	<div class="tab-content" id="tab-{{ group.title|lower }}">
+	<div class="tab-content" id="tab-{{ group.slug }}">
 		<h2 class="config-group-label">{{ group.title }}</h2>
 		{% for section in group.sections %}
 		<section class="config-section" id="{{ section.anchor }}">

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -1,344 +1,165 @@
 {% extends "base.html" %}
 
-{% block title %}Root{% endblock %}
+{% block title %}Configuration{% endblock %}
 
 {% block content %}
 <h1>Configuration</h1>
 
 {% include "missing_credentials_warning.html" %}
 
-<table class="detailsview">
-	<tr>
-		<th>Version</th>
-		<td>{{ version }}</td>
-	</tr>
-</table>
+<div class="config-page">
+	<div class="config-summary">
+		<span class="bubble">version {{ version }}</span>
+		<span class="config-summary-stat">{{ config.total_options }} options</span>
+		{% if config.overridden_options > 0 %}
+		<span class="config-summary-stat"><strong>{{ config.overridden_options }} overridden</strong> via
+			{% for source in config.sources %}{% if !loop.first %}, {% endif %}<code>{{ source }}</code>{% endfor %}
+		</span>
+		{% else %}
+		<span class="config-summary-stat">all values at compiled-in defaults</span>
+		{% endif %}
+	</div>
 
-<h2>Dynamic</h2>
-<table class="detailsview">
-	<tr>
-		<th>DPU agent upgrade policy</th>
-		<td>{{ agent_upgrade_policy }}</td>
-	</tr>
-	<tr>
-		<th>Site explorer enabled</th>
-		<td>{{ site_explorer_enabled }}</td>
-	</tr>
-	<tr>
-		<th>Site explorer create machines</th>
-		<td>{{ create_machines }}</td>
-	</tr>
-	<tr>
-		<th>RUST_LOG</th>
-		<td>{{ log_filter }}</td>
-	<tr/>
-	<tr>
-		<th>BMC Proxy</th>
-		<td>{{ bmc_proxy }}</td>
-	<tr/>
-</table>
+	<div class="config-toolbar">
+		<input type="search" id="config-search" placeholder="Filter options by name, value, or description&hellip;" autocomplete="off">
+		<label class="config-toggle">
+			<input type="checkbox" id="config-overridden-only"> Overridden only
+		</label>
+		<button type="button" id="config-expand-all">Expand all</button>
+		<button type="button" id="config-collapse-all">Collapse all</button>
+	</div>
 
-<h2>Static</h2>
-<table class="detailsview">
-	<tr>
-		<th>Listen Address</th>
-		<td>{{ carbide_config.listen.to_string() }}</td>
-	</tr>
-	<tr>
-		<th>Metrics Endpoint</th>
-		<td>
-			{% match carbide_config.metrics_endpoint %}
-			{% when Some with (val) %}
-			{{ val.to_string() }}
-			{% else %}
-			No value found
-			{% endmatch %}</td>
-	</tr>
-	<tr>
-		<th>Database URL</th>
-		<td>{{ carbide_config.database_url }}</td>
-	</tr>
-	<tr>
-		<th>Max Database Connections</th>
-		<td>{{ carbide_config.max_database_connections }}</td>
-	</tr>
-	<tr>
-		<th>IB Fabric</th>
-		<td>
-			{% match carbide_config.ib_config %}
-				{% when Some with (config) %}
-					{% if config.enabled %}
-						Enabled
-					{% else %}
-						Disabled
-					{% endif %}
-				{% else %}
-					Disabled
-			{% endmatch %}</td></tr>
-	<tr>
-		<th>NVLink</th>
-		<td>
-			{% match carbide_config.nvlink_config %}
-				{% when Some with (config) %}
-					<details>
-						<summary>
-							{% if config.enabled %}
-								Enabled
-							{% else %}
-								Disabled
-							{% endif %}
-						</summary>
-						<table>
-							<tr>
-								<th>Monitor run interval</th>
-								<td>{{ config.monitor_run_interval.as_secs() }}s</td>
-							</tr>
-							<tr>
-								<th>Allow insecure</th>
-								<td>{{ config.allow_insecure }}</td>
-							</tr>
-							<tr>
-								<th>NMX-C TLS CA cert path</th>
-								<td>
-									{% match config.nmx_c_tls_ca_cert_path %}
-										{% when Some with (val) %}
-											{{ val }}
-										{% else %}
-											Not Configured
-									{% endmatch %}
-								</td>
-							</tr>
-							<tr>
-								<th>NMX-C TLS client cert path</th>
-								<td>
-									{% match config.nmx_c_tls_client_cert_path %}
-										{% when Some with (val) %}
-											{{ val }}
-										{% else %}
-											Not Configured
-									{% endmatch %}
-								</td>
-							</tr>
-							<tr>
-								<th>NMX-C TLS client key path</th>
-								<td>
-									{% match config.nmx_c_tls_client_key_path %}
-										{% when Some with (val) %}
-											{{ val }}
-										{% else %}
-											Not Configured
-									{% endmatch %}
-								</td>
-							</tr>
-							<tr>
-								<th>NMX-C TLS authority</th>
-								<td>
-									{% match config.nmx_c_tls_authority %}
-										{% when Some with (val) %}
-											{{ val }}
-										{% else %}
-											Not Configured
-									{% endmatch %}
-								</td>
-							</tr>
-						</table>
-					</details>
-				{% else %}
-					Not Configured
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr><th>ASN</th><td>{{ carbide_config.asn }}</td></tr>
-	<tr><th>DHCP Servers</th><td>{{ carbide_config.dhcp_servers | comma_separated }}</td></tr>
-	<tr><th>Route Server State</th><td>{% if carbide_config.enable_route_servers %}Enabled{% else %}Disabled{% endif %}</td></tr>
-	<tr><th>Route Servers</th><td>{{ carbide_config.route_servers | comma_separated }}</td></tr>
-	<tr><th>Deny Prefixes</th><td>
-			{% if carbide_config.deny_prefixes.len() != 0 %}
-			{{ carbide_config.deny_prefixes | comma_separated }}
-			{% else %}
-			Not Configured
-			{% endif %}
-		</td>
-	</tr>
-	<tr>
-		<th>Site Fabric Prefixes</th>
-		<td>
-			{% if carbide_config.site_fabric_prefixes.len() != 0 %}
-			{{ carbide_config.site_fabric_prefixes | comma_separated }}
-			{% else %}
-			Not Configured
-			{% endif %}
-		</td>
-	</tr>
-	<tr>
-		<th>VPC Isolation Behavior</th>
-		<td>
-			{{ carbide_config.vpc_isolation_behavior.to_string() }}
-		</td>
-	</tr>
-	<tr>
-		<th>Networks</th>
-		<td>
-			{% match carbide_config.networks %}
-			{% when Some with (val) %}
-			{{ val.keys() | comma_separated }}
-			{% else %}
-			Not Configured
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>DPU IPMI Tool Impl</th>
-		<td>
-			{% match carbide_config.dpu_ipmi_tool_impl %}
-			{% when Some with (val) %}
-			{{ val }},
-			{% else %}
-			Not Configured
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>DPU IPMI Reboot Attempt</th>
-		<td>
-			{% match carbide_config.dpu_ipmi_reboot_attempts %}
-			{% when Some with (val) %}
-			{{ val }},
-			{% else %}
-			Not Configured (Default: 0)
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>Initial Domain Name</th>
-		<td>
-			{% match carbide_config.initial_domain_name %}
-			{% when Some with (val) %}
-			{{ val }}
-			{% else %}
-			Not Configured
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>Initial DPU Agent Upgrade Policy</th>
-		<td>
-			{% match carbide_config.initial_dpu_agent_upgrade_policy %}
-			{% when Some with (val) %}
-			{{ val.to_string() }}
-			{% else %}
-			Not Configured (Default: Off)
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>DPU NIC Firmware Versions</th>
-		<td>
-		  {{ carbide_config.dpu_config.dpu_nic_firmware_update_versions | comma_separated }}
-		</td>
-
-	</tr>
-	<tr>
-		<th>DPU Firmware Versions</th>
-		<td style="padding: 0;">
-			<table>
-			    {% match carbide_config.dpu_config.find_bf2_entry() %}
-			    {% when Some with (val) %}
-				<tr>
-					<td>BlueField 2</td>
-					<td>{{ val.version }}</td>
+	<details class="config-section config-runtime" open>
+		<summary>
+			<span class="config-section-title">Runtime Settings</span>
+			<span class="bubble">runtime-adjustable</span>
+		</summary>
+		<p class="config-section-note">
+			These settings can be changed on a live server with <code>nico-admin-cli set</code>.
+			Overrides carry an expiry (default 1h) and revert to their startup values when it
+			passes, or on restart.
+		</p>
+		<table class="config-options">
+			<thead><tr><th>Setting</th><th>Current value</th><th>Description</th></tr></thead>
+			<tbody>
+				<tr class="config-row">
+					<td class="config-name"><code>log_filter</code></td>
+					<td class="config-value"><code>{{ log_filter }}</code></td>
+					<td class="config-desc">Active <code>RUST_LOG</code> log filter.</td>
 				</tr>
-				{% else %}
-				Bf2 Firmware Not Configured
-				{% endmatch %}
-				{% match carbide_config.dpu_config.find_bf3_entry() %}
-				{% when Some with (val) %}
-				<tr>
-					<td>BlueField 3</td>
-					<td>{{ val.version }}</td>
+				<tr class="config-row">
+					<td class="config-name"><code>site_explorer_enabled</code></td>
+					<td class="config-value"><code>{{ site_explorer_enabled }}</code></td>
+					<td class="config-desc">Whether site explorer runs periodic hardware explorations.</td>
 				</tr>
-				{% else %}
-				Bf3 Firmware Not Configured
-				{% endmatch %}
-			</table>
-		</td>
-	</tr>
-	<tr>
-		<th>DPU NIC Initial Update</th>
-		<td>{% if carbide_config.dpu_config.dpu_nic_firmware_initial_update_enabled %}Enabled{% else %}Disabled{% endif %}</td>
-	</tr>
-	<tr>
-		<th>DPU NIC Reprovision Update</th>
-		<td>{% if carbide_config.dpu_config.dpu_nic_firmware_reprovision_update_enabled %}Enabled{% else %}Disabled{% endif %}</td>
-	</tr>
-	<tr>
-		<th>Max Concurrent Machine Update Absolute</th>
-		<td>
-			{% match carbide_config.machine_updater.max_concurrent_machine_updates_absolute %}
-			{% when Some with (val) %}
-			{{ val }}
-			{% else %}
-			Not Configured (Default: 0)
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>Max Concurrent Machine Update Percentage</th>
-		<td>
-			{% match carbide_config.machine_updater.max_concurrent_machine_updates_percent %}
-			{% when Some with (val) %}
-			{{ val }}
-			{% else %}
-			Not Configured (Default: 0)
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>Machine Update Runtime Interval</th>
-		<td>
-			{% match carbide_config.machine_update_run_interval %}
-			{% when Some with (val) %}
-			{{ val }}
-			{% else %}
-			Not Configured (Default: 0)
-			{% endmatch %}
-		</td>
-	</tr>
-	<tr>
-		<th>Machine Attestation Enabled</th>
-		<td>{{ carbide_config.attestation_enabled }}</td>
-	</tr>
-	<tr>
-		<th>DPA Enabled</th>
-		<td>
-			{% match carbide_config.dpa_config %}
-			{% when Some with (val) %}
-			{{ val.enabled }}
-			{% else %}
-			Disabled
-			{% endmatch %}</td>
-	</tr>
-	<tr>
-		<th>MQTT Endpoint</th>
-		<td>
-			{% match carbide_config.dpa_config %}
-			{% when Some with (val) %}
-			{{ val.mqtt_endpoint }}
-			{% else %}
-			N/A
-			{% endmatch %}</td>
-	</tr>
-	<tr>
-		<th>DPU Secure Boot Enabled</th>
-		<td>
-      {{ carbide_config.dpu_config.dpu_enable_secure_boot }}
-    </td>
-	</tr>
-	<tr>
-		<th>DPF Enabled</th>
-		<td>
-      {{ carbide_config.dpf.enabled }}
-	  </td>
-	</tr>
-</table>
+				<tr class="config-row">
+					<td class="config-name"><code>create_machines</code></td>
+					<td class="config-value"><code>{{ create_machines }}</code></td>
+					<td class="config-desc">Whether site explorer creates machines from discovered endpoints.</td>
+				</tr>
+				<tr class="config-row">
+					<td class="config-name"><code>bmc_proxy</code></td>
+					<td class="config-value"><code>{{ bmc_proxy }}</code></td>
+					<td class="config-desc">Proxy used for talking to BMCs.</td>
+				</tr>
+				<tr class="config-row">
+					<td class="config-name"><code>tracing_enabled</code></td>
+					<td class="config-value"><code>{{ tracing_enabled }}</code></td>
+					<td class="config-desc">Whether log tracing is enabled.</td>
+				</tr>
+				<tr class="config-row">
+					<td class="config-name"><code>dpu_agent_upgrade_policy</code></td>
+					<td class="config-value"><code>{{ agent_upgrade_policy }}</code></td>
+					<td class="config-desc">Active DPU agent upgrade policy.</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+
+	{% for group in config.groups %}
+	<h2 class="config-group-title">{{ group.title }}</h2>
+	{% for section in group.sections %}
+	<details class="config-section" id="{{ section.anchor }}" {% if section.overridden > 0 %}open{% endif %}>
+		<summary>
+			<span class="config-section-title">{{ section.title }}</span>
+			{% if !section.path.is_empty() %}<code class="config-section-path">[{{ section.path }}]</code>{% endif %}
+			<span class="config-section-meta">
+				{% if section.overridden > 0 %}<span class="bubble success">{{ section.overridden }} overridden</span>{% endif %}
+				<span class="config-count">{{ section.rows.len() }} option{% if section.rows.len() != 1 %}s{% endif %}</span>
+			</span>
+		</summary>
+		<table class="config-options">
+			<thead><tr><th>Option</th><th>Value</th><th>Default</th><th>Description</th></tr></thead>
+			<tbody>
+				{% for row in section.rows %}
+				<tr class="config-row{% if row.overridden %} overridden{% endif %}{% if row.unset %} unset{% endif %}">
+					<td class="config-name">
+						<code title="{{ row.path }}">{{ row.name }}</code>
+						{% if !row.ty.is_empty() %}<span class="config-type">{{ row.ty }}</span>{% endif %}
+						{% if row.undocumented %}<span class="bubble warning">undocumented</span>{% endif %}
+					</td>
+					<td class="config-value">
+						{% if row.multiline %}<details><summary>show value</summary><pre>{{ row.value_html|safe }}</pre></details>
+						{% else %}{{ row.value_html|safe }}{% endif %}
+						{% if row.overridden %}<span class="config-source" title="Explicitly set — not the compiled-in default">{{ row.source }}</span>{% endif %}
+					</td>
+					<td class="config-default">{{ row.default_html|safe }}</td>
+					<td class="config-desc">{{ row.description_html|safe }}</td>
+				</tr>
+				{% endfor %}
+			</tbody>
+		</table>
+	</details>
+	{% endfor %}
+	{% endfor %}
+
+	<p class="config-empty" id="config-no-matches" hidden>No options match the current filter.</p>
+</div>
+
+<script>
+(() => {
+	const search = document.getElementById('config-search');
+	const overriddenOnly = document.getElementById('config-overridden-only');
+	const sections = [...document.querySelectorAll('.config-section:not(.config-runtime)')];
+	const groups = [...document.querySelectorAll('.config-group-title')];
+	const noMatches = document.getElementById('config-no-matches');
+
+	function applyFilter() {
+		const query = search.value.trim().toLowerCase();
+		const onlyOverridden = overriddenOnly.checked;
+		let anyVisible = false;
+		for (const section of sections) {
+			let visibleRows = 0;
+			for (const row of section.querySelectorAll('.config-row')) {
+				const matches = (!query || row.textContent.toLowerCase().includes(query))
+					&& (!onlyOverridden || row.classList.contains('overridden'));
+				row.hidden = !matches;
+				if (matches) visibleRows++;
+			}
+			section.hidden = visibleRows === 0;
+			if (visibleRows > 0) {
+				anyVisible = true;
+				if (query || onlyOverridden) section.open = true;
+			}
+		}
+		// Hide group headings whose sections are all hidden.
+		for (const heading of groups) {
+			let node = heading.nextElementSibling, visible = false;
+			while (node && !node.classList.contains('config-group-title')) {
+				if (node.classList.contains('config-section') && !node.hidden) visible = true;
+				node = node.nextElementSibling;
+			}
+			heading.hidden = !visible;
+		}
+		noMatches.hidden = anyVisible;
+	}
+
+	search.addEventListener('input', applyFilter);
+	overriddenOnly.addEventListener('change', applyFilter);
+	document.getElementById('config-expand-all').addEventListener('click',
+		() => sections.forEach(s => { s.open = true; }));
+	document.getElementById('config-collapse-all').addEventListener('click',
+		() => sections.forEach(s => { s.open = false; }));
+})();
+</script>
 {% endblock %}

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -20,62 +20,14 @@
 	</div>
 
 	<div class="tab-nav">
-		<button class="tab-button active" data-tab="runtime">Runtime</button>
 		{% for group in config.groups %}
-		<button class="tab-button" data-tab="{{ group.slug }}">{{ group.title }}</button>
+		<button class="tab-button{% if loop.first %} active{% endif %}" data-tab="{{ group.slug }}">{{ group.title }}</button>
 		{% endfor %}
 		<div class="tab-indicator"></div>
 	</div>
 
-	<div class="tab-content active" id="tab-runtime">
-		<h2 class="config-group-label">Runtime</h2>
-		<section class="config-section">
-			<p class="config-note">
-				These settings can be changed on a live server with <code>nico-admin-cli set</code>.
-				Overrides carry an expiry (default 1h) and revert to their startup values when it
-				passes, or on restart. Everything under the other tabs is file configuration:
-				changing it means editing the config file and restarting.
-			</p>
-			<table class="config-options">
-				<thead><tr><th>Setting</th><th>Current value</th><th>Description</th></tr></thead>
-				<tbody>
-					<tr class="config-row">
-						<td class="config-name"><code>log_filter</code></td>
-						<td class="config-value"><code>{{ log_filter }}</code></td>
-						<td class="config-desc">Active <code>RUST_LOG</code> log filter.</td>
-					</tr>
-					<tr class="config-row">
-						<td class="config-name"><code>site_explorer_enabled</code></td>
-						<td class="config-value"><code>{{ site_explorer_enabled }}</code></td>
-						<td class="config-desc">Whether site explorer runs periodic hardware explorations.</td>
-					</tr>
-					<tr class="config-row">
-						<td class="config-name"><code>create_machines</code></td>
-						<td class="config-value"><code>{{ create_machines }}</code></td>
-						<td class="config-desc">Whether site explorer creates machines from discovered endpoints.</td>
-					</tr>
-					<tr class="config-row">
-						<td class="config-name"><code>bmc_proxy</code></td>
-						<td class="config-value"><code>{{ bmc_proxy }}</code></td>
-						<td class="config-desc">Proxy used for talking to BMCs.</td>
-					</tr>
-					<tr class="config-row">
-						<td class="config-name"><code>tracing_enabled</code></td>
-						<td class="config-value"><code>{{ tracing_enabled }}</code></td>
-						<td class="config-desc">Whether log tracing is enabled.</td>
-					</tr>
-					<tr class="config-row">
-						<td class="config-name"><code>dpu_agent_upgrade_policy</code></td>
-						<td class="config-value"><code>{{ agent_upgrade_policy }}</code></td>
-						<td class="config-desc">Active DPU agent upgrade policy.</td>
-					</tr>
-				</tbody>
-			</table>
-		</section>
-	</div>
-
 	{% for group in config.groups %}
-	<div class="tab-content" id="tab-{{ group.slug }}">
+	<div class="tab-content{% if loop.first %} active{% endif %}" id="tab-{{ group.slug }}">
 		<h2 class="config-group-label">{{ group.title }}</h2>
 		{% for section in group.sections %}
 		<section class="config-section" id="{{ section.anchor }}">
@@ -93,6 +45,7 @@
 						<td class="config-value">
 							{% if row.multiline %}<details><summary>show value</summary><pre>{{ row.value_html|safe }}</pre></details>
 							{% else %}{{ row.value_html|safe }}{% endif %}
+							{% if row.runtime %}<span class="config-runtime" title="Live value — adjustable on a running server with 'nico-admin-cli set'; overrides expire (default 1h) and reset on restart">runtime</span>{% endif %}
 							{% if row.overridden %}<span class="config-source" title="Explicitly set — not the compiled-in default">{{ row.source }}</span>{% endif %}
 						</td>
 						<td class="config-default">{{ row.default_html|safe }}</td>

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -1944,40 +1944,21 @@ span.page-link.disabled {
 /* ------------------------------------------------------------------------
    CONFIGURATION PAGE (/admin)
 
-   Generated option catalog: grouped, collapsible sections with per-option
-   value, default, provenance, and description. Overridden options carry a
-   green accent bar and a source badge.
+   Generated option catalog: one tab per group, plain sections of option
+   tables. Overridden options carry a green accent bar and a source tag.
+   While the filter is active, all tabs with matches are shown at once.
    ------------------------------------------------------------------------ */
 
 .config-page {
   max-width: 1400px;
 }
 
-.config-summary {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-  color: var(--text-muted);
-}
-
-.config-summary-stat strong {
-  color: var(--text-primary);
-}
-
 .config-toolbar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  padding: 0.75rem 0;
-  background-color: var(--bg-primary);
-  border-bottom: 1px solid var(--border-color);
+  gap: 1rem;
+  margin: 1rem 0;
 }
 
 .config-toolbar input[type="search"] {
@@ -2005,70 +1986,25 @@ span.page-link.disabled {
   user-select: none;
 }
 
-.config-toolbar button {
-  padding: 0.45rem 0.9rem;
-  font-size: 0.85rem;
-}
-
-.config-group-title {
-  margin: 2rem 0 0.75rem;
-  padding-bottom: 0.35rem;
-  border-bottom: 2px solid var(--accent-green-light);
+.config-note {
+  margin: 0 0 1rem;
+  max-width: 70rem;
+  color: var(--text-muted);
 }
 
 .config-section {
-  margin: 0.75rem 0;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
+  margin-bottom: 2.5rem;
 }
 
-.config-section summary {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  width: auto;
-  margin-bottom: 0;
-  border: none;
-  border-radius: 8px;
-}
-
-.config-section[open] summary {
-  border-bottom: 1px solid var(--border-color);
-}
-
-.config-section-title {
-  font-weight: 600;
-  color: var(--text-primary);
+.config-section h3 {
+  margin: 0 0 0.5rem;
 }
 
 .config-section-path {
-  color: var(--text-muted);
   font-size: 0.85rem;
-}
-
-.config-section-meta {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.config-section-meta .bubble,
-.config-section .bubble {
-  padding: 0.1rem 0.7rem;
-  margin: 0;
-  font-size: 0.8rem;
-}
-
-.config-count {
+  font-weight: normal;
   color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-.config-section-note {
-  margin: 0.75rem 1rem;
-  color: var(--text-muted);
+  margin-left: 0.5rem;
 }
 
 table.config-options {
@@ -2079,26 +2015,21 @@ table.config-options {
 
 table.config-options th {
   text-align: left;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+  font-size: 0.85rem;
+  font-weight: 500;
   color: var(--text-muted);
-  background-color: var(--bg-secondary);
-  padding: 0.5rem 0.75rem;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
 }
 
 table.config-options td {
   padding: 0.6rem 0.75rem;
-  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
   vertical-align: top;
 }
 
 tr.config-row.overridden td:first-child {
   box-shadow: inset 3px 0 0 var(--accent-green);
-}
-
-tr.config-row.overridden {
-  background-color: rgba(118, 185, 0, 0.05);
 }
 
 tr.config-row.unset .config-value,
@@ -2109,11 +2040,6 @@ tr.config-row.unset .config-value,
 
 td.config-name {
   width: 22%;
-}
-
-td.config-name code {
-  font-weight: 600;
-  color: var(--text-primary);
 }
 
 .config-type {
@@ -2152,7 +2078,6 @@ td.config-value pre {
   padding: 0.05rem 0.5rem;
   border-radius: 10px;
   font-size: 0.75rem;
-  font-weight: 600;
   color: var(--accent-green-hover);
   background-color: var(--accent-green-light);
 }
@@ -2167,14 +2092,28 @@ td.config-desc {
   color: var(--text-secondary);
 }
 
-.config-required {
-  padding: 0.1rem 0.6rem;
-  margin: 0;
-  font-size: 0.75rem;
+/* Filtering mode: bypass the tab system and show every group with matches,
+   labeled so rows from different tabs stay attributable. */
+.config-group-label {
+  display: none;
 }
 
-.config-runtime {
-  border-color: var(--accent-green);
+.config-filtering .config-group-label {
+  display: block;
+  margin: 1.5rem 0 1rem;
+}
+
+.config-filtering .tab-nav {
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.config-filtering .tab-content {
+  display: block;
+}
+
+.config-filtering .tab-content:not(.config-has-matches) {
+  display: none;
 }
 
 .config-empty {

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -1949,10 +1949,6 @@ span.page-link.disabled {
    While the filter is active, all tabs with matches are shown at once.
    ------------------------------------------------------------------------ */
 
-.config-page {
-  max-width: 1400px;
-}
-
 .config-toolbar {
   display: flex;
   align-items: center;
@@ -1999,10 +1995,18 @@ span.page-link.disabled {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
+  align-self: stretch;
+  padding-left: 1.25rem;
+  border-left: 1px solid var(--border-color);
   color: var(--text-secondary);
   cursor: pointer;
   user-select: none;
   white-space: nowrap;
+}
+
+.config-toggle input[type="checkbox"] {
+  margin: 0;
+  accent-color: var(--accent-green);
 }
 
 /* Tighten the tab nav toward the toolbar so the header reads as one unit,
@@ -2102,6 +2106,16 @@ td.config-value pre {
   background-color: var(--bg-tertiary);
   border-radius: 6px;
   font-size: 0.8rem;
+}
+
+.config-runtime {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.5rem;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  color: var(--info);
+  background-color: rgba(49, 130, 206, 0.12);
 }
 
 .config-source {

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -1940,3 +1940,245 @@ span.page-link.disabled {
   opacity: 0.5;
   cursor: default;
 }
+
+/* ------------------------------------------------------------------------
+   CONFIGURATION PAGE (/admin)
+
+   Generated option catalog: grouped, collapsible sections with per-option
+   value, default, provenance, and description. Overridden options carry a
+   green accent bar and a source badge.
+   ------------------------------------------------------------------------ */
+
+.config-page {
+  max-width: 1400px;
+}
+
+.config-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  color: var(--text-muted);
+}
+
+.config-summary-stat strong {
+  color: var(--text-primary);
+}
+
+.config-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 0.75rem 0;
+  background-color: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.config-toolbar input[type="search"] {
+  flex: 1;
+  min-width: 240px;
+  max-width: 480px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.config-toolbar input[type="search"]:focus {
+  outline: none;
+  border-color: var(--accent-green);
+  box-shadow: 0 0 0 2px var(--accent-green-light);
+}
+
+.config-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.config-toolbar button {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.config-group-title {
+  margin: 2rem 0 0.75rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 2px solid var(--accent-green-light);
+}
+
+.config-section {
+  margin: 0.75rem 0;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+
+.config-section summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  width: auto;
+  margin-bottom: 0;
+  border: none;
+  border-radius: 8px;
+}
+
+.config-section[open] summary {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.config-section-title {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.config-section-path {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.config-section-meta {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.config-section-meta .bubble,
+.config-section .bubble {
+  padding: 0.1rem 0.7rem;
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.config-count {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.config-section-note {
+  margin: 0.75rem 1rem;
+  color: var(--text-muted);
+}
+
+table.config-options {
+  width: 100%;
+  margin: 0;
+  border-collapse: collapse;
+}
+
+table.config-options th {
+  text-align: left;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  background-color: var(--bg-secondary);
+  padding: 0.5rem 0.75rem;
+}
+
+table.config-options td {
+  padding: 0.6rem 0.75rem;
+  border-top: 1px solid var(--border-color);
+  vertical-align: top;
+}
+
+tr.config-row.overridden td:first-child {
+  box-shadow: inset 3px 0 0 var(--accent-green);
+}
+
+tr.config-row.overridden {
+  background-color: rgba(118, 185, 0, 0.05);
+}
+
+tr.config-row.unset .config-value,
+.config-unset {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+td.config-name {
+  width: 22%;
+}
+
+td.config-name code {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.config-type {
+  display: block;
+  font-family: 'Consolas', 'Monaco', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.15rem;
+}
+
+td.config-value {
+  width: 22%;
+  word-break: break-word;
+}
+
+td.config-value details,
+td.config-value summary {
+  margin: 0;
+  padding: 0.1rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+td.config-value pre {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem;
+  max-height: 20rem;
+  overflow: auto;
+  background-color: var(--bg-tertiary);
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
+
+.config-source {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.5rem;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-green-hover);
+  background-color: var(--accent-green-light);
+}
+
+td.config-default {
+  width: 12%;
+  color: var(--text-muted);
+  word-break: break-word;
+}
+
+td.config-desc {
+  color: var(--text-secondary);
+}
+
+.config-required {
+  padding: 0.1rem 0.6rem;
+  margin: 0;
+  font-size: 0.75rem;
+}
+
+.config-runtime {
+  border-color: var(--accent-green);
+}
+
+.config-empty {
+  margin: 2rem 0;
+  color: var(--text-muted);
+  text-align: center;
+}

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -2005,11 +2005,17 @@ span.page-link.disabled {
   white-space: nowrap;
 }
 
-/* Tighten the tab nav toward the toolbar so the header reads as one unit. */
+/* Tighten the tab nav toward the toolbar so the header reads as one unit,
+   and slim the buttons so the descriptive tab names fit on one row. */
 .config-page .tab-nav {
   margin-top: 1rem;
   margin-bottom: 1.5rem;
   border-bottom: 1px solid var(--border-color);
+}
+
+.config-page .tab-button {
+  padding: 0.75rem 1.1rem;
+  font-size: 0.9rem;
 }
 
 .config-note {

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -2024,12 +2024,6 @@ span.page-link.disabled {
   font-size: 0.9rem;
 }
 
-.config-note {
-  margin: 0 0 1rem;
-  max-width: 70rem;
-  color: var(--text-muted);
-}
-
 .config-section {
   margin-bottom: 2.5rem;
 }
@@ -2167,14 +2161,6 @@ tr.config-row.unset .config-value,
 
 td.config-name code {
   word-break: break-word;
-}
-
-.config-type {
-  display: block;
-  font-family: 'Consolas', 'Monaco', monospace;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin-top: 0.15rem;
 }
 
 td.config-value {

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -2063,27 +2063,36 @@ span.page-link.disabled {
   flex-shrink: 0;
   position: sticky;
   top: 1rem;
+  /* Line up with the top of the first table, not its section heading
+     (h3: 1.25rem x 1.6 line-height + 0.5rem margin). */
+  margin-top: 2.5rem;
   max-height: calc(100vh - 2rem);
   overflow-y: auto;
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 8px;
-  padding: 1rem 1.25rem;
+  padding: 1.5rem 1.75rem;
 }
 
 .config-panel h4 {
-  margin: 0 0 0.5rem;
+  margin: 0 0 1rem;
   font-family: 'Consolas', 'Monaco', monospace;
-  font-size: 1rem;
+  font-size: 1.05rem;
   word-break: break-word;
+}
+
+.config-panel #config-panel-body {
+  line-height: 1.7;
 }
 
 .config-panel dl {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.3rem 1rem;
-  margin: 1rem 0 0;
-  font-size: 0.85rem;
+  gap: 0.75rem 1.5rem;
+  margin: 1.5rem 0 0;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 0.9rem;
 }
 
 .config-panel dt {
@@ -2104,6 +2113,7 @@ span.page-link.disabled {
     order: -1;
     width: 100%;
     max-height: 40vh;
+    margin-top: 0;
   }
 }
 
@@ -2138,7 +2148,11 @@ tr.config-row {
 }
 
 tr.config-row.selected td {
-  background-color: var(--accent-green-light);
+  background-color: rgba(118, 185, 0, 0.08);
+}
+
+tr.config-row.selected code {
+  background-color: var(--bg-primary);
 }
 
 tr.config-row.overridden td:first-child {

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -2045,8 +2045,68 @@ span.page-link.disabled {
   margin-left: 0.5rem;
 }
 
-/* Fixed layout so column widths hold regardless of content: equal columns,
-   with a slightly bigger allowance for Description. */
+/* Tables and the sticky detail panel sit side by side; the panel scales
+   with the viewport so wide screens get a roomier reading pane. */
+.config-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.config-tables {
+  flex: 1;
+  min-width: 0;
+}
+
+.config-panel {
+  width: clamp(20rem, 28vw, 38rem);
+  flex-shrink: 0;
+  position: sticky;
+  top: 1rem;
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+
+.config-panel h4 {
+  margin: 0 0 0.5rem;
+  font-family: 'Consolas', 'Monaco', monospace;
+  font-size: 1rem;
+  word-break: break-word;
+}
+
+.config-panel dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 1rem;
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+}
+
+.config-panel dt {
+  color: var(--text-muted);
+}
+
+.config-panel dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+@media (max-width: 1100px) {
+  .config-body {
+    flex-direction: column;
+  }
+
+  .config-panel {
+    order: -1;
+    width: 100%;
+    max-height: 40vh;
+  }
+}
+
 table.config-options {
   width: 100%;
   margin: 0;
@@ -2054,10 +2114,8 @@ table.config-options {
   table-layout: fixed;
 }
 
-table.config-options th:nth-child(1),
-table.config-options th:nth-child(2),
-table.config-options th:nth-child(3) {
-  width: 22%;
+table.config-options th:nth-child(1) {
+  width: 45%;
 }
 
 table.config-options th {
@@ -2073,6 +2131,14 @@ table.config-options td {
   padding: 0.6rem 0.75rem;
   border-bottom: 1px solid var(--border-color);
   vertical-align: top;
+}
+
+tr.config-row {
+  cursor: pointer;
+}
+
+tr.config-row.selected td {
+  background-color: var(--accent-green-light);
 }
 
 tr.config-row.overridden td:first-child {
@@ -2138,12 +2204,7 @@ td.config-value pre {
   background-color: var(--accent-green-light);
 }
 
-td.config-default {
-  color: var(--text-muted);
-  word-break: break-word;
-}
-
-td.config-desc {
+.config-desc {
   color: var(--text-secondary);
 }
 

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -1958,20 +1958,22 @@ span.page-link.disabled {
 }
 
 .config-version {
-  display: flex;
-  flex-direction: column;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  align-self: stretch;
   padding-right: 1.25rem;
   border-right: 1px solid var(--border-color);
 }
 
 .config-version-label {
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   color: var(--text-muted);
+  white-space: nowrap;
 }
 
 .config-version code {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: 0.9rem;
   color: var(--text-primary);
 }
 
@@ -2043,10 +2045,26 @@ span.page-link.disabled {
   margin-left: 0.5rem;
 }
 
+/* Fixed layout so column widths hold regardless of content: Option and
+   Description get the room, Value and Default usually hold short content
+   like "true" or "none". */
 table.config-options {
   width: 100%;
   margin: 0;
   border-collapse: collapse;
+  table-layout: fixed;
+}
+
+table.config-options th:nth-child(1) {
+  width: 24%;
+}
+
+table.config-options th:nth-child(2) {
+  width: 13%;
+}
+
+table.config-options th:nth-child(3) {
+  width: 8%;
 }
 
 table.config-options th {
@@ -2074,8 +2092,8 @@ tr.config-row.unset .config-value,
   font-style: italic;
 }
 
-td.config-name {
-  width: 22%;
+td.config-name code {
+  word-break: break-word;
 }
 
 .config-type {
@@ -2087,7 +2105,6 @@ td.config-name {
 }
 
 td.config-value {
-  width: 22%;
   word-break: break-word;
 }
 
@@ -2129,7 +2146,6 @@ td.config-value pre {
 }
 
 td.config-default {
-  width: 12%;
   color: var(--text-muted);
   word-break: break-word;
 }

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -1957,14 +1957,32 @@ span.page-link.disabled {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1rem;
-  margin: 1rem 0;
+  gap: 1.25rem;
+  margin: 1.25rem 0 0;
+}
+
+.config-version {
+  display: flex;
+  flex-direction: column;
+  padding-right: 1.25rem;
+  border-right: 1px solid var(--border-color);
+}
+
+.config-version-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.config-version code {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
 .config-toolbar input[type="search"] {
   flex: 1;
   min-width: 240px;
-  max-width: 480px;
+  max-width: 32rem;
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border-color);
   border-radius: 8px;
@@ -1984,6 +2002,14 @@ span.page-link.disabled {
   color: var(--text-secondary);
   cursor: pointer;
   user-select: none;
+  white-space: nowrap;
+}
+
+/* Tighten the tab nav toward the toolbar so the header reads as one unit. */
+.config-page .tab-nav {
+  margin-top: 1rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .config-note {

--- a/crates/api-web/templates/static/carbide.css
+++ b/crates/api-web/templates/static/carbide.css
@@ -2045,9 +2045,8 @@ span.page-link.disabled {
   margin-left: 0.5rem;
 }
 
-/* Fixed layout so column widths hold regardless of content: Option and
-   Description get the room, Value and Default usually hold short content
-   like "true" or "none". */
+/* Fixed layout so column widths hold regardless of content: equal columns,
+   with a slightly bigger allowance for Description. */
 table.config-options {
   width: 100%;
   margin: 0;
@@ -2055,16 +2054,10 @@ table.config-options {
   table-layout: fixed;
 }
 
-table.config-options th:nth-child(1) {
-  width: 24%;
-}
-
-table.config-options th:nth-child(2) {
-  width: 13%;
-}
-
+table.config-options th:nth-child(1),
+table.config-options th:nth-child(2),
 table.config-options th:nth-child(3) {
-  width: 8%;
+  width: 22%;
 }
 
 table.config-options th {


### PR DESCRIPTION
The previous `/admin` Configuration page was backed by hand-written HTML covering only ~35 of Carbide's ~230 configuration options. Because it required manual updates, it frequently drifted out of sync with the configuration model and couldn't distinguish between default values and operator-provided configuration.

This PR replaces it with a generated configuration catalog built from three sources:

- `cfg/README.md` provides each option's type, default, group, and description.
- The running `CarbideConfig` provides the effective values.
- Figment (`config_ctx`) provides configuration provenance, including whether a value came from a config file, site overlay, environment variable, or the compiled default.

The page is generated generically, so adding a new configuration option no longer requires UI changes. Differences in naming (such as serde renames) are handled through a shared `canonical()` normalization step.

**Documentation validation**

To prevent drift, three unit tests verify that:

- Every configuration field is documented in `cfg/README.md`.
- Every documented option has a valid `Group`.
- Stale options not present in CarbideConfig must be removed

As part of this work, the README was brought to 100% coverage by documenting 15 missing fields, adding 5 missing sections, and moving grouping information into a dedicated `Group` column.

**UI changes**

The new page organizes configuration into six tabs with searchable **Option | Value** tables and a sticky details panel showing each option's description, type, default, and configuration source.

Overridden values are highlighted with their source, and the five runtime-adjustable settings (`nico-admin-cli set`) are included alongside the static configuration.

Additional improvements:

- Server-render the sidebar header as `NICo • <sitename>` (falling back to `local`).
- Display the build version in the toolbar.

**Testing**

`cargo test -p carbide-api-web` covers the README parser, configuration joins (including serde-renamed fields), cell rendering and escaping, documentation drift checks, and full template rendering. No database is required.

**Screenshots**

<img width="1512" height="721" alt="Screenshot 2026-07-07 at 2 32 54 PM" src="https://github.com/user-attachments/assets/a7e4772f-aa3a-477d-8a0c-c7c6b9d2d6be" />


Overriden only view:

<img width="1512" height="722" alt="Screenshot 2026-07-07 at 2 33 24 PM" src="https://github.com/user-attachments/assets/e2e93fff-bca0-40d6-875a-d68107419b2e" />


Search view:

<img width="1511" height="725" alt="Screenshot 2026-07-07 at 2 34 06 PM" src="https://github.com/user-attachments/assets/d0930d60-143b-447e-ac74-4bba67c5d6cd" />

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3226

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

