### PR TITLE
feat(ci): use tag for uploaded version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,21 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "Using Git describe to extract version as VERSION and HELM_VERSION"
           VERSION=$(git describe --tags --first-parent --always --long)
+
+          # check for tag trigger (ex v2.0.0-rc.1)
+          REF_NAME="${{ github.ref_name }}"
+          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            RELEASE_TAG="${REF_NAME}"
+          else
+            RELEASE_TAG=""
+          fi
+
+          # for tags, always prefer the tag for uploading
+          REF="${{ github.ref }}"
+          if [[ "${REF}" =~ ^refs/tags/ ]]; then
+            VERSION="${RELEASE_TAG}"
+          fi
+
           # HELM_VERSION strips leading 'v' for strict SemVer and replaces the last '-' with '.'
           HELM_VERSION_BASE="${VERSION#v}"
           HELM_VERSION=$(echo "$HELM_VERSION_BASE" | sed 's/\(.*\)-/\1./')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -173,25 +173,35 @@ jobs:
           SHORT_SHA=$(git rev-parse --short=7 HEAD)
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "Using Git describe to extract version as VERSION and HELM_VERSION"
-          VERSION=$(git describe --tags --first-parent --always --long)
+          # On a tagged commit this collapses to the clean tag (ex v2.0.0-rc.1);
+          # otherwise it is the long form (ex v2.0.0-3-gabc1234) for dev builds.
+          VERSION=$(git describe --tags --first-parent --always)
 
-          # check for tag trigger (ex v2.0.0-rc.1)
-          REF_NAME="${{ github.ref_name }}"
-          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
-            RELEASE_TAG="${REF_NAME}"
+          # Record whether describe returned a long (dev) tag ending in '-g<sha>' or a
+          # short/clean (pre)release tag. Only long tags need the helm suffix rewrite.
+          if [[ "$VERSION" =~ -g[0-9a-f]+$ ]]; then
+            IS_LONG_TAG="true"
           else
-            RELEASE_TAG=""
+            IS_LONG_TAG="false"
           fi
 
-          # for tags, always prefer the tag for uploading
-          REF="${{ github.ref }}"
-          if [[ "${REF}" =~ ^refs/tags/ ]]; then
-            VERSION="${RELEASE_TAG}"
+          # HELM_VERSION strips leading 'v' for strict SemVer. For long (dev) tags the
+          # git-describe suffix '-<N>-g<sha>' has its last '-' rewritten to '.'; short
+          # (pre)release tags (ex v2.0.0, v2.0.0-rc.3) are already valid SemVer as-is.
+          HELM_VERSION="${VERSION#v}"
+          if [[ "$IS_LONG_TAG" == "true" ]]; then
+            HELM_VERSION=$(echo "$HELM_VERSION" | sed 's/\(.*\)-/\1./')
           fi
 
-          # HELM_VERSION strips leading 'v' for strict SemVer and replaces the last '-' with '.'
-          HELM_VERSION_BASE="${VERSION#v}"
-          HELM_VERSION=$(echo "$HELM_VERSION_BASE" | sed 's/\(.*\)-/\1./')
+          # Strict SemVer validation. Regex adapted to POSIX ERE (non-capturing
+          # groups '(?:...)' -> '(...)', '\d' -> '[0-9]') from the official suggested
+          # SemVer regex:
+          # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+          SEMVER_STRICT='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$'
+          if [[ ! "$HELM_VERSION" =~ $SEMVER_STRICT ]]; then
+            echo "::error::HELM_VERSION '${HELM_VERSION}' (derived from VERSION '${VERSION}') failed strict SemVer validation"
+            exit 1
+          fi
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "helm_version=${HELM_VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- Describe what this PR does -->

Changes the version used for uploading artifacts to use the tag provided. One side effect is the chore PR tags to transition from one version to the next (`v2.0.0-pr` -> `v2.1.0-pr`) will instead have artifacts use the tagged version.

| change | effect |
| - | - | 
| commit on main | no change, uses `git long` for build artifacts |
| tag on main (`v2.y.z-pr`) | uploads as `v2.y.z-pr` instead of `v2.y.z-pr-0-g<sha>` |
| commit on `release/*` | no change, ci does not run on `release/*` branches |
| tag on `release/*` | uploads as `<tag>` (ex: `v2.0.0-rc.3`) |

Helm version after changes

| VERSION | git describe --long | HELM_VERSION (before) | HELM_VERSION | change |
|---|---|---|---|---|
| `v2.0.0` | `v2.0.0-0-gabc1234` | `2.0.0-0.gabc1234` | `2.0.0` | uses tag|
| `v2.0.0-rc.3` | `v2.0.0-rc.3-0-gabc1234` | `2.0.0-rc.3-0.gabc1234` | `2.0.0-rc.3` | uses tag |
| `v2.1.0-pr` | `v2.1.0-pr-0-gabc1234` | `2.1.0-pr-0.gabc1234` | `2.1.0-pr` | uses tag |
| `v2.1.0-pr-3-gabc1234` | `v2.1.0-pr-3-gabc1234` | `2.1.0-pr-3.gabc1234` | `2.1.0-pr-3.gabc1234` | unchanged |

## Related issues
<!-- Refer to existing GitHub issues here -->

- https://github.com/NVIDIA/infra-controller/issues/3230

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

