### PR TITLE
fix: box large futures in explore_site to reduce stack usage

### DIFF
--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -818,6 +818,7 @@ impl SiteExplorer {
         self.check_preconditions(metrics).await?;
 
         let update_explored_endpoints_start = Instant::now();
+        // Boxed to keep this large future off explore_site's stack frame (see #2303).
         let expected_endpoint_index = Box::pin(self.update_explored_endpoints(metrics)).await?;
         metrics.record_phase_latency(
             "update_explored_endpoints",
@@ -845,6 +846,7 @@ impl SiteExplorer {
         // However since host information rarely changes (we never reassign MachineInterfaces),
         // this should be ok. The most noticeable effect is that ManagedHost population might be delayed a bit.
         let identify_managed_hosts_start = Instant::now();
+        // Boxed to keep this large future off explore_site's stack frame (see #2303).
         let mut identified_hosts = Box::pin(self
             .identify_managed_hosts(
                 metrics,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -818,7 +818,7 @@ impl SiteExplorer {
         self.check_preconditions(metrics).await?;
 
         let update_explored_endpoints_start = Instant::now();
-        let expected_endpoint_index = self.update_explored_endpoints(metrics).await?;
+        let expected_endpoint_index = Box::pin(self.update_explored_endpoints(metrics)).await?;
         metrics.record_phase_latency(
             "update_explored_endpoints",
             update_explored_endpoints_start.elapsed(),
@@ -845,13 +845,13 @@ impl SiteExplorer {
         // However since host information rarely changes (we never reassign MachineInterfaces),
         // this should be ok. The most noticeable effect is that ManagedHost population might be delayed a bit.
         let identify_managed_hosts_start = Instant::now();
-        let mut identified_hosts = self
+        let mut identified_hosts = Box::pin(self
             .identify_managed_hosts(
                 metrics,
                 &expected_endpoint_index,
                 explored_dpus,
                 explored_hosts,
-            )
+            ))
             .await?;
         metrics.record_phase_latency(
             "identify_managed_hosts",


### PR DESCRIPTION
Boxes the two largest unboxed async calls inside `explore_site`
(`update_explored_endpoints`, `identify_managed_hosts`) so their
generated futures are heap-allocated instead of inlined into
`explore_site`'s own stack frame.

Addresses #2303.

Note: I could not independently reproduce the exact stack overflow
described in the issue's repro steps in my local environment (see
comment on #2303) — the fix targets the code path named in the
original CI crash log (`explore_site`, `carbide_site_explorer`), but
full verification against the original crash is still open. Flagging
this clearly rather than claiming the fix is fully verified.