### PR TITLE
remove(build): Remove rust min stack size workaround

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,10 +28,6 @@ CARBIDE_ENVIRONMENT = { value = "local", condition = { env_not_set = [
 FORGE_CA = { value = "nonprod", condition = { env_not_set = ["FORGE_CA"] } }
 FORGE_CA_PATH = { value = "${REPO_ROOT}/dev/forge_${FORGE_CA}root.pem" }
 
-# Temporary: increase Rust test thread stack to avoid stack overflows in tests.
-# TODO: remove after stack-heavy tests/code paths are refactored.
-RUST_MIN_STACK = { value = "8388608", condition = { env_not_set = ["RUST_MIN_STACK"] } }
-
 BUILD_CONTAINER_X86_URL = { value = "urm.nvidia.com/swngc-ngcc-docker-local/forge/carbide/x86-64/build-container:latest", condition = { env_not_set = [
   "BUILD_CONTAINER_X86_URL",
 ] } }


### PR DESCRIPTION
This workaround was introduced when we build / run tests in both types of containers arm and x86.
Issue was with arm container. Now we build / run tests only on x86, so workarounds is not relevant anymore.

## Related issues

Closes: #2303 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

