### PR TITLE
feat(web): add desired firmware page

### DIFF
--- a/crates/api-web/src/firmware.rs
+++ b/crates/api-web/src/firmware.rs
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use askama::Template;
+use axum::Json;
+use axum::extract::State as AxumState;
+use axum::response::{Html, IntoResponse, Response};
+use carbide_api_core::Api;
+use hyper::http::StatusCode;
+use model::firmware::DesiredFirmwareVersions;
+use sqlx::types::Json as SqlxJson;
+
+use super::Base;
+
+const DESIRED_FIRMWARE_QUERY: &str = r#"
+    SELECT vendor, model, versions, explicit_update_start_needed
+    FROM desired_firmware
+    ORDER BY vendor, model
+"#;
+
+#[derive(Template)]
+#[template(path = "firmware_show.html")]
+struct FirmwareShow {
+    desired_firmware: Vec<DesiredFirmwareDisplay>,
+}
+
+struct DesiredFirmwareDisplay {
+    vendor: String,
+    model: String,
+    versions: Vec<FirmwareVersionDisplay>,
+    explicit_update_start_needed: bool,
+}
+
+struct FirmwareVersionDisplay {
+    component: String,
+    version: String,
+}
+
+#[derive(serde::Serialize)]
+struct DesiredFirmware {
+    vendor: String,
+    model: String,
+    versions: DesiredFirmwareVersions,
+    explicit_update_start_needed: bool,
+}
+
+#[derive(sqlx::FromRow)]
+struct DesiredFirmwareRow {
+    vendor: String,
+    model: String,
+    versions: SqlxJson<DesiredFirmwareVersions>,
+    explicit_update_start_needed: bool,
+}
+
+pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+    let desired_firmware = match fetch_desired_firmware(&state).await {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::error!(%err, "fetch desired firmware");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Error loading desired firmware",
+            )
+                .into_response();
+        }
+    };
+
+    let tmpl = FirmwareShow {
+        desired_firmware: desired_firmware.iter().map(Into::into).collect(),
+    };
+    (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}
+
+pub async fn show_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+    let desired_firmware = match fetch_desired_firmware(&state).await {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::error!(%err, "fetch desired firmware");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Error loading desired firmware",
+            )
+                .into_response();
+        }
+    };
+
+    (StatusCode::OK, Json(desired_firmware)).into_response()
+}
+
+async fn fetch_desired_firmware(api: &Api) -> Result<Vec<DesiredFirmware>, sqlx::Error> {
+    sqlx::query_as::<_, DesiredFirmwareRow>(DESIRED_FIRMWARE_QUERY)
+        .fetch_all(&api.database_connection)
+        .await
+        .map(|rows| rows.into_iter().map(Into::into).collect())
+}
+
+impl From<DesiredFirmwareRow> for DesiredFirmware {
+    fn from(row: DesiredFirmwareRow) -> Self {
+        Self {
+            vendor: row.vendor,
+            model: row.model,
+            versions: row.versions.0,
+            explicit_update_start_needed: row.explicit_update_start_needed,
+        }
+    }
+}
+
+impl From<&DesiredFirmware> for DesiredFirmwareDisplay {
+    fn from(row: &DesiredFirmware) -> Self {
+        Self {
+            vendor: row.vendor.clone(),
+            model: row.model.clone(),
+            versions: display_versions(&row.versions),
+            explicit_update_start_needed: row.explicit_update_start_needed,
+        }
+    }
+}
+
+fn display_versions(versions: &DesiredFirmwareVersions) -> Vec<FirmwareVersionDisplay> {
+    let mut versions = versions
+        .versions
+        .iter()
+        .map(|(component_type, version)| FirmwareVersionDisplay {
+            component: component_type.to_string(),
+            version: version.clone(),
+        })
+        .collect::<Vec<_>>();
+    versions.sort_unstable_by(|left, right| left.component.cmp(&right.component));
+    versions
+}
+
+impl Base for FirmwareShow {}

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -243,6 +243,7 @@ mod expected_rack;
 mod expected_switch;
 mod explored_endpoint;
 mod filters;
+mod firmware;
 mod health;
 mod health_history;
 mod ib_fabric;
@@ -510,6 +511,8 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
                 "/explored-endpoint/{endpoint_ip}/enable-lockdown",
                 post(explored_endpoint::enable_lockdown),
             )
+            .route("/firmware", get(firmware::show_html))
+            .route("/firmware.json", get(firmware::show_json))
             .route("/host", get(machine::show_hosts_html))
             .route("/host.json", get(machine::show_hosts_json))
             .route("/ib-partition", get(ib_partition::show_html))

--- a/crates/api-web/src/tests/firmware.rs
+++ b/crates/api-web/src/tests/firmware.rs
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use axum::body::Body;
+use axum::response::Response;
+use http_body_util::BodyExt;
+use hyper::http::StatusCode;
+use sqlx::types::Json;
+use tower::ServiceExt;
+
+use crate::tests::env::TestEnv;
+use crate::tests::{make_test_app, web_request_builder};
+
+async fn response_body(response: Response) -> String {
+    let body_bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("empty response body")
+        .to_bytes();
+
+    String::from_utf8(body_bytes.to_vec()).expect("invalid UTF-8 in response body")
+}
+
+async fn insert_desired_firmware(pool: &sqlx::PgPool) {
+    sqlx::query(
+        r#"
+            INSERT INTO desired_firmware (
+                vendor,
+                model,
+                versions,
+                explicit_update_start_needed
+            )
+            VALUES ($1, $2, $3, $4)
+        "#,
+    )
+    .bind("Acme")
+    .bind("RackServer 9000")
+    .bind(Json(serde_json::json!({
+        "Versions": {
+            "bmc": "1.2.3",
+            "uefi": "4.5.6"
+        }
+    })))
+    .bind(true)
+    .execute(pool)
+    .await
+    .expect("insert desired firmware row");
+}
+
+#[crate::sqlx_test]
+async fn firmware_page_shows_desired_firmware_table(pool: sqlx::PgPool) {
+    let env = TestEnv::new(pool.clone()).await;
+    insert_desired_firmware(&pool).await;
+    let app = make_test_app(&env.test_harness);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/firmware")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_body(response).await;
+    assert!(body.contains("Desired Firmware"));
+    assert!(body.contains("Acme"));
+    assert!(body.contains("RackServer 9000"));
+    assert!(body.contains("true"));
+    assert!(body.contains("<b>BMC</b>: 1.2.3"));
+    assert!(body.contains("<b>UEFI</b>: 4.5.6"));
+    assert!(body.contains("1.2.3"));
+    assert!(body.contains("4.5.6"));
+}
+
+#[crate::sqlx_test]
+async fn firmware_json_preserves_versions_as_json(pool: sqlx::PgPool) {
+    let env = TestEnv::new(pool.clone()).await;
+    insert_desired_firmware(&pool).await;
+    let app = make_test_app(&env.test_harness);
+
+    let response = app
+        .oneshot(
+            web_request_builder()
+                .uri("/admin/firmware.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(&response_body(response).await).expect("valid JSON response");
+    let row = rows
+        .iter()
+        .find(|row| row["vendor"] == "Acme" && row["model"] == "RackServer 9000")
+        .expect("inserted desired firmware row");
+
+    assert_eq!(row["explicit_update_start_needed"], true);
+    assert_eq!(row["versions"]["Versions"]["bmc"], "1.2.3");
+    assert_eq!(row["versions"]["Versions"]["uefi"], "4.5.6");
+}

--- a/crates/api-web/src/tests/mod.rs
+++ b/crates/api-web/src/tests/mod.rs
@@ -23,6 +23,7 @@ use crate::routes;
 
 mod env;
 mod explored_endpoint;
+mod firmware;
 mod health;
 mod managed_host;
 mod vpc;

--- a/crates/api-web/templates/base.html
+++ b/crates/api-web/templates/base.html
@@ -64,6 +64,7 @@
 				<li><a href="/admin/attestation-summary">Attestations</a></li>
 				<li><a href="/admin/instance-type">Instance Types</a></li>
 				<li><a href="/admin/dpa">DPAs</a></li>
+				<li><a href="/admin/firmware">Firmware</a></li>
 			</ul>
 			<hr/>
 			<h3>BMCs and Site Explorer</h3>

--- a/crates/api-web/templates/firmware_show.html
+++ b/crates/api-web/templates/firmware_show.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}Firmware{% endblock %}
+
+{% block content %}
+<div id="json"><a id="json-link" href="">JSON</a></div>
+<h1>Firmware</h1>
+
+<h2>Desired Firmware ({{ desired_firmware.len() }})</h2>
+<table class="sortable overview">
+	<thead>
+	<tr>
+		<th>Vendor</th>
+		<th>Model</th>
+		<th>Explicit Update Start Needed</th>
+		<th>Versions</th>
+	</tr>
+	</thead>
+	<tbody>
+	{% for row in desired_firmware %}
+		<tr>
+			<td>{{ row.vendor }}</td>
+			<td>{{ row.model }}</td>
+			<td>{{ row.explicit_update_start_needed }}</td>
+			<td>
+				{% if row.versions.is_empty() %}
+					No versions
+				{% else %}
+					{% for version in row.versions %}
+						<span style="display: inline-block; margin-right: 0.75rem; white-space: nowrap;"><b>{{ version.component }}</b>: {{ version.version }}</span>
+					{% endfor %}
+				{% endif %}
+			</td>
+		</tr>
+	{% endfor %}
+	</tbody>
+</table>
+
+{% endblock %}


### PR DESCRIPTION
Adding firmware tab to the admin web ui. With the changes, it will look like this:

<img width="4046" height="1362" alt="image" src="https://github.com/user-attachments/assets/7a53ae9e-d26c-4f3d-8c0d-16718a1c83e0" />

I will later add a form to create/update firmware configuration to make host firmware upgrades easier.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

