### PR TITLE
build: Publish multi-arch images from Make

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,10 @@ make rest-kind-reset     # spin up the local kind dev cluster (~10 min)
 make rest-api/<target>   # pass any target through to rest-api/Makefile
 ```
 
+Published container artifacts must pin external base images by immutable
+digest. When architecture-specific targets share a base image, define one
+overridable variable so their versions cannot drift independently.
+
 ## Coding Conventions
 
 Follow the shared [Engineering Guidelines](CONTRIBUTING.md#engineering-guidelines)

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ IMAGE_TAG ?= latest
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 CI_COMMIT_SHORT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 LOCAL_REGISTRY_CONTAINER ?= nico-build-registry
+BOOT_ARTIFACTS_RUNTIME_IMAGE ?= docker.io/library/alpine:3.20.10@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 # Intermediate base containers the Core and machine-validation images build FROM.
 CORE_BUILD_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-amd64
@@ -167,10 +168,10 @@ images-machine-validation: images-base ## Build the machine-validation runner + 
 
 images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (requires mkosi + rust toolchain on the host)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-x86-host-sa
-	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
+	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_X86_64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
 		-t $(BOOT_ARTIFACTS_X86_IMAGE_AMD64) \
 		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
-	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
+	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_X86_64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
 		-t $(BOOT_ARTIFACTS_X86_IMAGE_ARM64) \
 		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) \
@@ -178,10 +179,10 @@ images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (req
 
 images-bfb: images-registry ## Build the aarch64 DPU BFB boot-artifact image (cross-arch; requires mkosi + aarch64 toolchain)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa
-	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
+	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
 		-t $(BOOT_ARTIFACTS_BFB_IMAGE_AMD64) \
 		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
-	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
+	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
 		-t $(BOOT_ARTIFACTS_BFB_IMAGE_ARM64) \
 		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ core/check-isolated-package-builds: ## Check each Rust package independently wit
 
 .PHONY: bootstrap
 
-bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, docker, cargo tooling (run once)
+bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, docker, multi-arch emulation, cargo tooling (run once)
 	./scripts/setup-build-host.sh
 
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,6 @@ IMAGE_REGISTRY ?= localhost:5000
 IMAGE_TAG ?= latest
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 CI_COMMIT_SHORT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
-IMAGE_PLATFORMS := linux/amd64,linux/arm64
 LOCAL_REGISTRY_CONTAINER ?= nico-build-registry
 
 # Intermediate base containers the Core and machine-validation images build FROM.
@@ -99,6 +98,10 @@ CORE_IMAGE_AMD64 := $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-amd64
 CORE_IMAGE_ARM64 := $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-arm64
 MACHINE_VALIDATION_IMAGE_AMD64 := $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-amd64
 MACHINE_VALIDATION_IMAGE_ARM64 := $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-arm64
+BOOT_ARTIFACTS_X86_IMAGE_AMD64 := $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG)-amd64
+BOOT_ARTIFACTS_X86_IMAGE_ARM64 := $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG)-arm64
+BOOT_ARTIFACTS_BFB_IMAGE_AMD64 := $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-amd64
+BOOT_ARTIFACTS_BFB_IMAGE_ARM64 := $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-arm64
 
 .PHONY: images images-all images-registry images-base images-core images-rest \
         images-machine-validation images-boot-artifacts images-bfb
@@ -164,15 +167,25 @@ images-machine-validation: images-base ## Build the machine-validation runner + 
 
 images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (requires mkosi + rust toolchain on the host)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-x86-host-sa
-	docker buildx build --platform $(IMAGE_PLATFORMS) --push --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
-		-t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) \
+	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
+		-t $(BOOT_ARTIFACTS_X86_IMAGE_AMD64) \
 		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
+	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
+		-t $(BOOT_ARTIFACTS_X86_IMAGE_ARM64) \
+		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) \
+		$(BOOT_ARTIFACTS_X86_IMAGE_AMD64) $(BOOT_ARTIFACTS_X86_IMAGE_ARM64)
 
 images-bfb: images-registry ## Build the aarch64 DPU BFB boot-artifact image (cross-arch; requires mkosi + aarch64 toolchain)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa
-	docker buildx build --platform $(IMAGE_PLATFORMS) --push --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
-		-t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) \
+	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
+		-t $(BOOT_ARTIFACTS_BFB_IMAGE_AMD64) \
 		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
+	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
+		-t $(BOOT_ARTIFACTS_BFB_IMAGE_ARM64) \
+		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) \
+		$(BOOT_ARTIFACTS_BFB_IMAGE_AMD64) $(BOOT_ARTIFACTS_BFB_IMAGE_ARM64)
 
 # =============================================================================
 # Rest (delegate to rest-api/Makefile)

--- a/Makefile
+++ b/Makefile
@@ -79,69 +79,98 @@ bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, 
 #   make images-core   NICo Core image (nico) only
 #   make images-rest   REST service images only
 #
-# Images are tagged $(IMAGE_REGISTRY)/<name>:$(IMAGE_TAG). Override IMAGE_REGISTRY
-# and IMAGE_TAG to build under your own registry/tag (defaults match rest-api/).
+# Images are pushed as amd64/arm64 manifests at
+# $(IMAGE_REGISTRY)/<name>:$(IMAGE_TAG). Override IMAGE_REGISTRY and IMAGE_TAG to
+# publish under your own registry/tag (defaults match rest-api/).
 
 IMAGE_REGISTRY ?= localhost:5000
 IMAGE_TAG ?= latest
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 CI_COMMIT_SHORT_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+IMAGE_PLATFORMS := linux/amd64,linux/arm64
+LOCAL_REGISTRY_CONTAINER ?= nico-build-registry
 
 # Intermediate base containers the Core and machine-validation images build FROM.
-CORE_BUILD_CONTAINER ?= nico-buildcontainer-x86_64
-CORE_RUNTIME_CONTAINER ?= nico-runtime-container-x86_64
+CORE_BUILD_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-amd64
+CORE_BUILD_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)-arm64
+CORE_RUNTIME_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-amd64
+CORE_RUNTIME_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-arm64
+CORE_IMAGE_AMD64 := $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-amd64
+CORE_IMAGE_ARM64 := $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)-arm64
+MACHINE_VALIDATION_IMAGE_AMD64 := $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-amd64
+MACHINE_VALIDATION_IMAGE_ARM64 := $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-arm64
 
-# Target platform for the deployable images. The NICo Dockerfiles are x86_64, so
-# this defaults to linux/amd64; on an arm64 host (e.g. Apple Silicon) the build
-# runs under emulation. Override PLATFORM=linux/arm64 to build native arm64.
-PLATFORM ?= linux/amd64
-
-.PHONY: images images-all images-base images-core images-rest \
+.PHONY: images images-all images-registry images-base images-core images-rest \
         images-machine-validation images-boot-artifacts images-bfb
 
 images: images-core images-rest ## Build the deployable service stack (NICo Core + REST images)
 	@echo ""
-	@echo "Deployable images built under $(IMAGE_REGISTRY) (tag: $(IMAGE_TAG)):"
+	@echo "Deployable multi-arch images pushed under $(IMAGE_REGISTRY) (tag: $(IMAGE_TAG)):"
 	@echo "  $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)   (NICo Core)"
 	@echo "  $(IMAGE_REGISTRY)/nico-rest-*:$(IMAGE_TAG)       (REST services)"
 
 images-all: images images-machine-validation images-boot-artifacts images-bfb ## Build every image (stack + machine validation + boot artifacts; needs an mkosi build host)
 
-images-base: ## Build the x86 build + runtime base containers (prerequisite for core / machine validation)
-	docker build --platform $(PLATFORM) --file dev/docker/Dockerfile.build-container-x86_64 -t $(CORE_BUILD_CONTAINER) .
-	docker build --platform $(PLATFORM) --file dev/docker/Dockerfile.runtime-container-x86_64 -t $(CORE_RUNTIME_CONTAINER) .
+images-registry:
+	@if [ "$(IMAGE_REGISTRY)" = "localhost:5000" ] && ! curl -fsS http://localhost:5000/v2/ >/dev/null 2>&1; then \
+		if docker inspect $(LOCAL_REGISTRY_CONTAINER) >/dev/null 2>&1; then \
+			docker start $(LOCAL_REGISTRY_CONTAINER); \
+		else \
+			docker run -d --rm --name $(LOCAL_REGISTRY_CONTAINER) -p 5000:5000 registry:2; \
+		fi; \
+	fi
+
+images-base: images-registry ## Build and push the amd64 + arm64 Core base containers
+	docker buildx build --platform linux/amd64 --push --file dev/docker/Dockerfile.build-container-x86_64 -t $(CORE_BUILD_CONTAINER_AMD64) .
+	docker buildx build --platform linux/arm64 --push --file dev/docker/Dockerfile.build-container-aarch64 -t $(CORE_BUILD_CONTAINER_ARM64) .
+	docker buildx build --platform linux/amd64 --push --file dev/docker/Dockerfile.runtime-container-x86_64 -t $(CORE_RUNTIME_CONTAINER_AMD64) .
+	docker buildx build --platform linux/arm64 --push --file dev/docker/Dockerfile.runtime-container-aarch64 -t $(CORE_RUNTIME_CONTAINER_ARM64) .
 
 images-core: images-base ## Build the NICo Core image (nico)
-	docker build --platform $(PLATFORM) \
-		--build-arg CONTAINER_BUILD_X86_64=$(CORE_BUILD_CONTAINER) \
-		--build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER) \
+	docker buildx build --platform linux/amd64 --push \
+		--build-arg CONTAINER_BUILD_X86_64=$(CORE_BUILD_CONTAINER_AMD64) \
+		--build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg CI_COMMIT_SHORT_SHA=$(CI_COMMIT_SHORT_SHA) \
 		--file dev/docker/Dockerfile.release-container-sa-x86_64 \
-		-t $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG) .
+		-t $(CORE_IMAGE_AMD64) .
+	docker buildx build --platform linux/arm64 --push \
+		--build-arg CONTAINER_BUILD_AARCH64=$(CORE_BUILD_CONTAINER_ARM64) \
+		--build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg CI_COMMIT_SHORT_SHA=$(CI_COMMIT_SHORT_SHA) \
+		--file dev/docker/Dockerfile.release-container-aarch64 \
+		-t $(CORE_IMAGE_ARM64) .
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG) \
+		$(CORE_IMAGE_AMD64) $(CORE_IMAGE_ARM64)
 
-images-rest: ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm)
+images-rest: images-registry ## Build the REST service images (api, workflow, site-manager, site-agent, db, cert-manager, flow, psm, nsm)
 	$(MAKE) -C rest-api docker-build IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG)
 
 images-machine-validation: images-base ## Build the machine-validation runner + config images
-	docker build --platform $(PLATFORM) --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER) \
+	docker buildx build --platform linux/amd64 --load --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
 		-t machine-validation-runner:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.machine-validation-runner .
 	mkdir -p crates/machine-validation/images
 	docker save --output crates/machine-validation/images/machine-validation-runner.tar machine-validation-runner:$(IMAGE_TAG)
-	docker build --platform $(PLATFORM) --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER) \
-		-t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) \
+	docker buildx build --platform linux/amd64 --push --build-arg CONTAINER_RUNTIME_X86_64=$(CORE_RUNTIME_CONTAINER_AMD64) \
+		-t $(MACHINE_VALIDATION_IMAGE_AMD64) \
 		--file dev/docker/Dockerfile.machine-validation-config .
+	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64) \
+		-t $(MACHINE_VALIDATION_IMAGE_ARM64) \
+		--file dev/docker/Dockerfile.machine-validation-config-aarch64 .
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) \
+		$(MACHINE_VALIDATION_IMAGE_AMD64) $(MACHINE_VALIDATION_IMAGE_ARM64)
 
-images-boot-artifacts: ## Build the x86 boot-artifact image (requires mkosi + rust toolchain on the host)
+images-boot-artifacts: images-registry ## Build the x86 boot-artifact image (requires mkosi + rust toolchain on the host)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-x86-host-sa
-	docker build --platform $(PLATFORM) --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
+	docker buildx build --platform $(IMAGE_PLATFORMS) --push --build-arg CONTAINER_RUNTIME_X86_64=alpine:latest \
 		-t $(IMAGE_REGISTRY)/boot-artifacts-x86_64:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.release-artifacts-x86_64 .
 
-images-bfb: ## Build the aarch64 DPU BFB boot-artifact image (cross-arch; requires mkosi + aarch64 toolchain)
+images-bfb: images-registry ## Build the aarch64 DPU BFB boot-artifact image (cross-arch; requires mkosi + aarch64 toolchain)
 	cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa
-	docker build --platform $(PLATFORM) --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
+	docker buildx build --platform $(IMAGE_PLATFORMS) --push --build-arg CONTAINER_RUNTIME_AARCH64=alpine:latest \
 		-t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) \
 		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,10 @@ of the bare-metal lifecycle to fast-track building next generation AI Cloud offe
 ### Quick start
 
 ```bash
-# 1. Build all container images from this clone, then push them to your registry.
+# 1. Build and push amd64/arm64 container images from this clone.
 #    See docs/manuals/building_nico_containers.md for the build-host prerequisites.
 export IMAGE_REGISTRY=my-registry.example.com/infra-controller
 make images IMAGE_REGISTRY="${IMAGE_REGISTRY}"   # NICo Core (nico) + REST service images
-#    Then: docker push "${IMAGE_REGISTRY}/nico:latest"
-#          docker push "${IMAGE_REGISTRY}/nico-rest-api:latest"   # ...and the other nico-rest-* images
 
 # 2. Set environment variables
 export KUBECONFIG=/path/to/kubeconfig

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -35,7 +35,7 @@ steps on an `apt`-based distribution such as Ubuntu 24.04:
 8. `git submodule update --init --recursive`
 9. Start Docker and register cross-architecture support:
    `sudo systemctl enable --now docker.socket`, then
-   `sudo docker run --privileged --rm tonistiigi/binfmt --install all`
+   `sudo docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all`
 10. `cargo install cargo-make cargo-cache`
 11. `echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/99-userns.conf`
 12. `sudo usermod -aG docker $(id -un)`

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -87,8 +87,11 @@ for image in "${images[@]}"; do
   platforms="$(docker buildx imagetools inspect --raw \
     "${IMAGE_REGISTRY}/${image}:${IMAGE_TAG}" | \
     jq -r '[.manifests[].platform | select(.os == "linux") | "\(.os)/\(.architecture)"] | unique | sort | join(",")')"
-  test "${platforms}" = "linux/amd64,linux/arm64"
-  printf '%s: %s\n' "${image}" "${platforms}"
+  if [ "${platforms}" != "linux/amd64,linux/arm64" ]; then
+    printf 'FAIL %s: %s\n' "${image}" "${platforms}" >&2
+    exit 1
+  fi
+  printf 'PASS %s: %s\n' "${image}" "${platforms}"
 done
 ```
 
@@ -111,10 +114,11 @@ The loop should print exactly 14 successful checks:
 | `boot-artifacts-x86_64` | `images-boot-artifacts` |
 | `boot-artifacts-aarch64` | `images-bfb` |
 
-If fewer than 14 checks run, the missing image indicates which sub-target failed. The three
-boot/validation images (`machine-validation`, `boot-artifacts-x86_64`,
-`boot-artifacts-aarch64`) require the full mkosi + Rust toolchain. Use `make images` instead
-of `make images-all` to build only the 11-image deployable stack.
+If the loop exits early, the `FAIL` line identifies which image has an incomplete
+manifest. The three boot/validation images (`machine-validation`,
+`boot-artifacts-x86_64`, `boot-artifacts-aarch64`) require the full mkosi + Rust
+toolchain. Use `make images` instead of `make images-all` to build only the 11-image
+deployable stack.
 
 The architecture-specific Core base images and `-amd64`/`-arm64` service tags are build
 inputs for the bare multi-arch tags. `machine-validation-runner` is the only local-only

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -8,7 +8,8 @@ An Ubuntu 24.04 host or VM with at least 150GB of free disk space is required, a
 
 Clone the repo and run the build-host bootstrap. It installs everything needed to build
 the containers and boot artifacts -- system packages, rustup, the mkosi/ipxe git
-submodules, Docker, and the cargo build tooling -- in one idempotent step:
+submodules, Docker with cross-architecture emulation, and the cargo build tooling --
+in one idempotent step:
 
 ```sh
 git clone git@github.com:NVIDIA/infra-controller.git
@@ -32,7 +33,9 @@ steps on an `apt`-based distribution such as Ubuntu 24.04:
 6. `cd infra-controller`
 7. `direnv allow`
 8. `git submodule update --init --recursive`
-9. `sudo systemctl enable docker.socket`
+9. Start Docker and register cross-architecture support:
+   `sudo systemctl enable --now docker.socket`, then
+   `sudo docker run --privileged --rm tonistiigi/binfmt --install all`
 10. `cargo install cargo-make cargo-cache`
 11. `echo "kernel.apparmor_restrict_unprivileged_userns=0" | sudo tee /etc/sysctl.d/99-userns.conf`
 12. `sudo usermod -aG docker $(id -un)`

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -46,20 +46,22 @@ top of the repo with a single `make` command:
 
 ```sh
 make images          # deployable stack: NICo Core (nico) + the REST service images
-make images-all      # the above plus the machine-validation and x86 boot-artifact images
+make images-all      # the above plus machine-validation and both boot-artifact images
 ```
 
-Images are tagged `localhost:5000/<name>:latest` by default. Override the registry and
-tag to build under your own registry:
+Images are pushed as `linux/amd64` and `linux/arm64` manifests at
+`localhost:5000/<name>:latest` by default. The Makefile starts a local registry named
+`nico-build-registry` when that default is used. Override the registry and tag to publish
+under your own registry; authenticate Docker to that registry before running the build:
 
 ```sh
 make images IMAGE_REGISTRY=my-registry.example.com/nico IMAGE_TAG=v1.0.0
 ```
 
-The deployable images are built for `linux/amd64` (the NICo Dockerfiles are x86_64).
-On an arm64 host such as Apple Silicon they build under emulation, which is slow — a
-native `linux/amd64` build host is recommended. Pass `PLATFORM=linux/arm64` to build
-native arm64 images instead.
+Each architecture is built separately before the bare tag is assembled. This matches CI
+and is required for the REST Dockerfiles: a single combined Buildx invocation would reuse
+one builder stage and could copy an amd64 binary into the arm64 image. Building the
+non-native architecture uses the platforms configured on the active Docker Buildx builder.
 
 Run `make help` from the repo root to list the individual image targets (`images-core`,
 `images-rest`, `images-machine-validation`, `images-boot-artifacts`, `images-bfb`). The
@@ -68,14 +70,26 @@ need to build or debug a single image.
 
 ### Verifying the build
 
-After `make images-all` completes, verify that all 14 deployable images were produced:
+After `make images-all` completes, verify that all 14 deployable image tags contain both
+platforms:
 
-```sh
-docker images --filter "reference=${IMAGE_REGISTRY}/*:${IMAGE_TAG}" \
-  --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+```bash
+images=(
+  nico nico-rest-api nico-rest-workflow nico-rest-site-manager
+  nico-rest-site-agent nico-rest-db nico-rest-cert-manager nico-flow
+  nico-psm nico-nsm nico-mcp machine-validation
+  boot-artifacts-x86_64 boot-artifacts-aarch64
+)
+for image in "${images[@]}"; do
+  platforms="$(docker buildx imagetools inspect --raw \
+    "${IMAGE_REGISTRY}/${image}:${IMAGE_TAG}" | \
+    jq -r '[.manifests[].platform | select(.os == "linux") | "\(.os)/\(.architecture)"] | unique | sort | join(",")')"
+  test "${platforms}" = "linux/amd64,linux/arm64"
+  printf '%s: %s\n' "${image}" "${platforms}"
+done
 ```
 
-The count should be exactly 14:
+The loop should print exactly 14 successful checks:
 
 | Image | Target |
 |---|---|
@@ -94,15 +108,14 @@ The count should be exactly 14:
 | `boot-artifacts-x86_64` | `images-boot-artifacts` |
 | `boot-artifacts-aarch64` | `images-bfb` |
 
-```sh
-# Quick count — should print 14
-docker images --filter "reference=${IMAGE_REGISTRY}/*:${IMAGE_TAG}" \
-  --format "{{.Repository}}" | wc -l
-```
+If fewer than 14 checks run, the missing image indicates which sub-target failed. The three
+boot/validation images (`machine-validation`, `boot-artifacts-x86_64`,
+`boot-artifacts-aarch64`) require the full mkosi + Rust toolchain. Use `make images` instead
+of `make images-all` to build only the 11-image deployable stack.
 
-If the count is less than 14, the missing images indicate which sub-target failed. The three boot/validation images (`machine-validation`, `boot-artifacts-x86_64`, `boot-artifacts-aarch64`) require the full mkosi + Rust toolchain — if only 11 images appear, use `make images` instead of `make images-all` to build the deployable stack without them.
-
-Three intermediate images are also created locally but are not tagged under `IMAGE_REGISTRY`: `nico-buildcontainer-x86_64`, `nico-runtime-container-x86_64`, and `machine-validation-runner`. These are build-time dependencies only and do not need to be pushed.
+The architecture-specific Core base images and `-amd64`/`-arm64` service tags are build
+inputs for the bare multi-arch tags. `machine-validation-runner` is the only local-only
+intermediate image.
 
 ## Building X86_64 Containers
 

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -13,6 +13,11 @@ BUILD_DIR := build/binaries
 IMAGE_REGISTRY := localhost:5000
 IMAGE_TAG := latest
 DOCKERFILE_DIR := docker/production
+DOCKER_ARCHES := amd64 arm64
+LOCAL_REGISTRY_CONTAINER := nico-build-registry
+REST_IMAGES := nico-rest-api nico-rest-workflow nico-rest-site-manager \
+	nico-rest-site-agent nico-rest-db nico-rest-cert-manager nico-flow \
+	nico-psm nico-nsm nico-mcp
 
 # PostgreSQL container configuration
 POSTGRES_CONTAINER_NAME := project-test
@@ -249,16 +254,25 @@ nico-mcp:
 	@echo "Installed nico-mcp to $(INSTALL_DIR)/nico-mcp"
 
 docker-build:
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-api:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-rest-api .
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-workflow:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-rest-workflow .
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-site-manager:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-rest-site-manager .
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-site-agent:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-rest-site-agent .
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-db:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-rest-db .
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-cert-manager:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-rest-cert-manager .
-	docker build -t $(IMAGE_REGISTRY)/nico-flow:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-flow .
-	docker build -t $(IMAGE_REGISTRY)/nico-psm:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-psm .
-	docker build -t $(IMAGE_REGISTRY)/nico-nsm:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-nsm .
-	docker build -t $(IMAGE_REGISTRY)/nico-mcp:$(IMAGE_TAG) -f $(DOCKERFILE_DIR)/Dockerfile.nico-mcp .
+	@if [ "$(IMAGE_REGISTRY)" = "localhost:5000" ] && ! curl -fsS http://localhost:5000/v2/ >/dev/null 2>&1; then \
+		if docker inspect $(LOCAL_REGISTRY_CONTAINER) >/dev/null 2>&1; then \
+			docker start $(LOCAL_REGISTRY_CONTAINER); \
+		else \
+			docker run -d --rm --name $(LOCAL_REGISTRY_CONTAINER) -p 5000:5000 registry:2; \
+		fi; \
+	fi
+	@set -e; \
+	for image in $(REST_IMAGES); do \
+		for arch in $(DOCKER_ARCHES); do \
+			docker buildx build --platform linux/$$arch --push \
+				--build-arg TARGETOS=linux --build-arg TARGETARCH=$$arch \
+				-t $(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-$$arch \
+				-f $(DOCKERFILE_DIR)/Dockerfile.$$image .; \
+		done; \
+		docker buildx imagetools create -t $(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG) \
+			$(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-amd64 \
+			$(IMAGE_REGISTRY)/$$image:$(IMAGE_TAG)-arm64; \
+	done
 
 core-proto:
 	$(MAKE) core-proto-clean

--- a/scripts/setup-build-host.sh
+++ b/scripts/setup-build-host.sh
@@ -90,7 +90,7 @@ ${SUDO} systemctl enable --now docker.socket
 
 # --- 7. Cross-architecture container support ---------------------------------
 echo "=== [7/9] Registering cross-architecture container support ==="
-${SUDO} docker run --privileged --rm tonistiigi/binfmt --install all
+${SUDO} docker run --privileged --rm tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 --install all
 
 # --- 8. Cargo build tooling ---------------------------------------------------
 echo "=== [8/9] Installing cargo build tooling (cargo-make, cargo-cache) ==="

--- a/scripts/setup-build-host.sh
+++ b/scripts/setup-build-host.sh
@@ -34,7 +34,7 @@ fi
 DOCKER_USER="${SUDO_USER:-$(id -un)}"
 
 # --- 1. System packages -------------------------------------------------------
-echo "=== [1/8] Installing system packages via apt ==="
+echo "=== [1/9] Installing system packages via apt ==="
 ${SUDO} apt-get update
 ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential cpio direnv mkosi uidmap curl file fakeroot git \
@@ -43,7 +43,7 @@ ${SUDO} DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libtss2-dev kea-dev systemd-boot systemd-ukify jq zip
 
 # --- 2. Rust toolchain --------------------------------------------------------
-echo "=== [2/8] Installing rustup + Rust toolchain ==="
+echo "=== [2/9] Installing rustup + Rust toolchain ==="
 if command -v rustup >/dev/null 2>&1; then
     echo "rustup already installed -- skipping"
 else
@@ -56,7 +56,7 @@ if [[ -f "${HOME}/.cargo/env" ]]; then
 fi
 
 # --- 3. direnv shell hook -----------------------------------------------------
-echo "=== [3/8] Configuring the direnv shell hook ==="
+echo "=== [3/9] Configuring the direnv shell hook ==="
 _shell="$(basename "${SHELL:-bash}")"
 case "${_shell}" in
     bash) _rc="${HOME}/.bashrc"; _hook='eval "$(direnv hook bash)"' ;;
@@ -76,25 +76,29 @@ else
 fi
 
 # --- 4. Allow direnv for this repo --------------------------------------------
-echo "=== [4/8] Allowing direnv for this repo ==="
+echo "=== [4/9] Allowing direnv for this repo ==="
 direnv allow .
 
 # --- 5. Git submodules (mkosi + ipxe) -----------------------------------------
 # The pinned mkosi and ipxe sources live under pxe/ as git submodules.
-echo "=== [5/8] Fetching git submodules (mkosi, ipxe) ==="
+echo "=== [5/9] Fetching git submodules (mkosi, ipxe) ==="
 git submodule update --init --recursive
 
 # --- 6. Docker socket ---------------------------------------------------------
-echo "=== [6/8] Enabling the docker socket ==="
-${SUDO} systemctl enable docker.socket
+echo "=== [6/9] Enabling the docker socket ==="
+${SUDO} systemctl enable --now docker.socket
 
-# --- 7. Cargo build tooling ---------------------------------------------------
-echo "=== [7/8] Installing cargo build tooling (cargo-make, cargo-cache) ==="
+# --- 7. Cross-architecture container support ---------------------------------
+echo "=== [7/9] Registering cross-architecture container support ==="
+${SUDO} docker run --privileged --rm tonistiigi/binfmt --install all
+
+# --- 8. Cargo build tooling ---------------------------------------------------
+echo "=== [8/9] Installing cargo build tooling (cargo-make, cargo-cache) ==="
 command -v cargo-make  >/dev/null 2>&1 || cargo install cargo-make
 command -v cargo-cache >/dev/null 2>&1 || cargo install cargo-cache
 
-# --- 8. Host configuration ----------------------------------------------------
-echo "=== [8/8] Configuring host (unprivileged userns + docker group) ==="
+# --- 9. Host configuration ----------------------------------------------------
+echo "=== [9/9] Configuring host (unprivileged userns + docker group) ==="
 echo "kernel.apparmor_restrict_unprivileged_userns=0" \
     | ${SUDO} tee /etc/sysctl.d/99-userns.conf >/dev/null
 ${SUDO} usermod -aG docker "${DOCKER_USER}"


### PR DESCRIPTION
Resolves #3028

### What this PR does

Publishes deployable NICo images as `linux/amd64` and `linux/arm64` image indexes from the normal Make targets.

- builds and pushes architecture-specific Core base and release images before creating the bare `nico` tag
- builds each REST image separately for amd64 and arm64, then creates the bare multi-architecture tag
- starts a local registry automatically when the default `localhost:5000` registry is used
- applies the same publication pattern to machine-validation and boot-artifact image targets
- updates the build documentation with manifest verification steps

### How we verified it

Current revision: `2c6304a807e90753476ef5a8b6c98c3c475c5c55`

Image publication and runtime evidence was produced from implementation commit
`3f57554cad43398794ecfd06c5a62fbc6cd62914`. The follow-up commits update the
fresh-host bootstrap and its documentation, make boot-image publication work with
the default Docker driver, and pin the privileged binfmt installer by digest.

Environment: Apple Silicon macOS, isolated Colima Virtualization Framework profile with Rosetta, 10 CPUs, 16 GiB RAM, 120 GiB disk, Docker 28.3.3, BuildKit 0.23.2, and a local registry on `localhost:5001`.

Hands-on verification used the real Make recipes from a clean isolated checkout:

```sh
export DOCKER_HOST="unix://${HOME}/.colima/pr3257-rosetta/docker.sock"
export IMAGE_REGISTRY=localhost:5001
export IMAGE_TAG=verify-3257-3f57554c-rosetta

make -C rest-api docker-build \
  IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
  IMAGE_TAG="${IMAGE_TAG}" \
  REST_IMAGES=nico-mcp

make images-core \
  IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
  IMAGE_TAG="${IMAGE_TAG}" \
  VERSION=verify-3257 \
  CI_COMMIT_SHORT_SHA=3f57554c
```

The long Core build required restarting the isolated Docker VM and resuming the exact remaining arm64 Buildx and index-creation steps after local Docker storage/runtime instability. No source changes were made during that recovery.

Expected result: each bare tag resolves to both Linux platforms, and each selected platform runs the binary built for that architecture.

Actual result:

```text
localhost:5001/nico:verify-3257-3f57554c-rosetta
  digest: sha256:6c5df269ff9a83abe7e79ce01f349429d48452426a03512bf8cde69bcdec9ddc
  platforms: linux/amd64,linux/arm64

localhost:5001/nico-mcp:verify-3257-3f57554c-rosetta
  digest: sha256:5718f3622e55c386f19652cc0ef441ff8de7568c812ab9925072cd3a0842a871
  platforms: linux/amd64,linux/arm64

nico amd64: x86_64; nico-admin-cli --version succeeded
nico arm64: aarch64; nico-admin-cli --version succeeded
nico-mcp amd64: --help succeeded
nico-mcp arm64: --help succeeded
```

The platform and runtime checks were repeated against the preserved registry after restarting the isolated VM. This is hands-on image publication and execution evidence; it is separate from GitHub checks.

The fresh-host bootstrap follow-up was exercised separately in the same isolated Linux VM:

```text
tonistiigi/binfmt@sha256:400a4873... --install all: linux/amd64 and linux/arm64 registered
docker buildx inspect: linux/amd64 and linux/arm64 available
docker run --platform linux/amd64 alpine:3.20 uname -m: x86_64
docker run --platform linux/arm64 alpine:3.20 uname -m: aarch64
```

`bash -n` passed, ShellCheck reported only the two pre-existing SC2016 informational findings, `git diff --check` passed, and the changed manual retained the same 15 pre-existing rumdl findings as the prior revision.

The default Docker driver was also used to exercise the boot-image publication pattern added in the final follow-up: separate amd64 and arm64 builds were pushed, `imagetools create` assembled the bare tag, and inspection returned `linux/amd64,linux/arm64`. The documented verification loop printed `PASS` for that index and exited nonzero with `FAIL` for a forced single-platform result. `make -n images-boot-artifacts` and `make -n images-bfb` confirmed both targets use the same per-architecture sequence. The full mkosi artifact generation is covered by CI rather than this local packaging check.

### How to reproduce the verification

Prerequisites: Docker with Buildx, an active builder that can build and run both `linux/amd64` and `linux/arm64`, `curl`, `jq`, and enough local Docker storage for the Core build.

```sh
git clone https://github.com/kfelternv/infra-controller.git
cd infra-controller
git checkout 2c6304a807e90753476ef5a8b6c98c3c475c5c55

docker run -d --rm --name nico-build-registry -p 5001:5000 registry:2
export IMAGE_REGISTRY=localhost:5001
export IMAGE_TAG=verify-3257

make -C rest-api docker-build \
  IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
  IMAGE_TAG="${IMAGE_TAG}" \
  REST_IMAGES=nico-mcp

make images-core \
  IMAGE_REGISTRY="${IMAGE_REGISTRY}" \
  IMAGE_TAG="${IMAGE_TAG}" \
  VERSION=verify-3257 \
  CI_COMMIT_SHORT_SHA=3f57554c

for image in nico nico-mcp; do
  platforms="$(docker buildx imagetools inspect --raw \
    "${IMAGE_REGISTRY}/${image}:${IMAGE_TAG}" | \
    jq -r '[.manifests[].platform | select(.os == "linux") | "\(.os)/\(.architecture)"] | unique | sort | join(",")')"
  test "${platforms}" = "linux/amd64,linux/arm64"
  printf '%s: %s\n' "${image}" "${platforms}"
done

for arch in amd64 arm64; do
  docker run --rm --platform "linux/${arch}" \
    --entrypoint /opt/carbide/nico-admin-cli \
    "${IMAGE_REGISTRY}/nico:${IMAGE_TAG}" --version
  docker run --rm --platform "linux/${arch}" \
    "${IMAGE_REGISTRY}/nico-mcp:${IMAGE_TAG}" --help
done
```

The two platform checks must print `linux/amd64,linux/arm64`; all four runtime commands must exit successfully.
