### PR TITLE
fix: validate resolved auto network configs by segment identity

### DIFF
--- a/crates/api-core/src/test_support/network_segment.rs
+++ b/crates/api-core/src/test_support/network_segment.rs
@@ -67,6 +67,11 @@ lazy_static! {
         IpNetwork::new(IpAddr::V4(Ipv4Addr::new(192, 0, 6, 1)), 24).unwrap();
 }
 
+lazy_static! {
+    pub static ref FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3: IpNetwork =
+        IpNetwork::new(IpAddr::V4(Ipv4Addr::new(192, 0, 7, 1)), 24).unwrap();
+}
+
 pub async fn create_underlay_network_segment(api: &Api) -> NetworkSegmentId {
     let prefix = IpNetwork::new(
         FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),

--- a/crates/api-core/src/tests/instance_allocate.rs
+++ b/crates/api-core/src/tests/instance_allocate.rs
@@ -35,13 +35,13 @@ use crate::tests::common;
 use crate::tests::common::api_fixtures;
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2, FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS,
-    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_admin_network_segment,
-    create_host_inband_network_segment, create_network_segment, create_tenant_network_segment,
-    create_underlay_network_segment,
+    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3,
+    FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS, FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY,
+    create_admin_network_segment, create_host_inband_network_segment, create_network_segment,
+    create_tenant_network_segment, create_underlay_network_segment,
 };
 use crate::tests::common::api_fixtures::{TestEnv, TestEnvOverrides};
-use crate::tests::common::rpc_builder::VpcCreationRequest;
+use crate::tests::common::rpc_builder::{DhcpDiscovery, VpcCreationRequest};
 
 #[derive(Debug, Default)]
 struct TestEnvOptions {
@@ -73,6 +73,11 @@ async fn create_test_env_for_instance_allocation(
         IpNetwork::new(
             FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2.network(),
             FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2.prefix(),
+        )
+        .unwrap(),
+        IpNetwork::new(
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3.network(),
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3.prefix(),
         )
         .unwrap(),
         IpNetwork::new(
@@ -1007,6 +1012,199 @@ async fn test_zero_dpu_instance_allocation_auto_multi_segment(
         .await?
         .expect("zero-DPU allocation should persist an instance address per HostInband segment");
         assert_eq!(address.vpc_id, flat_vpc_id);
+    }
+
+    Ok(())
+}
+
+/// Updating an auto-networked instance re-resolves its interface set from the
+/// host's current HostInband segments, so an operator-added segment (with the
+/// host DHCP'ing a NIC on it) flows into the instance on its next config
+/// update. The re-resolved multi-interface config must pass validation: a
+/// resolved auto interface is identified by its segment, not by a shared
+/// per-device function-id bucket.
+#[crate::sqlx_test]
+async fn test_zero_dpu_auto_update_absorbs_added_host_inband_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    let config = ManagedHostConfig {
+        dpus: vec![],
+        non_dpu_macs: vec![
+            HOST_NON_DPU_MAC_ADDRESS_POOL.allocate(),
+            HOST_NON_DPU_MAC_ADDRESS_POOL.allocate(),
+            HOST_NON_DPU_MAC_ADDRESS_POOL.allocate(),
+        ],
+        ..ManagedHostConfig::default()
+    };
+
+    // Ingest a zero-DPU host with NICs on both fixture HostInband segments.
+    // The third NIC stays segment-less for now; its segment arrives mid-test.
+    let zero_dpu_host = api_fixtures::site_explorer::new_mock_host(&env, config.clone())
+        .await?
+        .discover_dhcp_host_secondary_iface(
+            1,
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_2
+                .ip()
+                .to_string(),
+            |result, _| {
+                assert!(result.is_ok());
+                Ok(())
+            },
+        )
+        .await?
+        .finish(|mock| async move {
+            let machine_id = mock.discovered_machine_id().unwrap();
+
+            Ok::<ManagedHostStateSnapshot, eyre::Report>(
+                db::managed_host::load_snapshot(
+                    mock.test_env.pool.begin().await?.deref_mut(),
+                    &machine_id,
+                    Default::default(),
+                )
+                .await
+                .transpose()
+                .unwrap()?,
+            )
+        })
+        .await?;
+    let flat_vpc_id = default_flat_vpc_id(&env).await;
+
+    let instance = crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(zero_dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: FIXTURE_TENANT_ORG_ID.to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                        },
+                    )),
+                }),
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![],
+                    #[allow(deprecated)]
+                    auto: true,
+                    auto_config: Some(forge::InstanceNetworkAutoConfig {
+                        vpc_id: Some(flat_vpc_id),
+                    }),
+                }),
+                infiniband: None,
+                nvlink: None,
+                spxconfig: None,
+                network_security_group_id: None,
+                dpu_extension_services: None,
+            }),
+            instance_id: None,
+            metadata: Some(Metadata {
+                name: "zero-dpu-auto-absorbs-segment".to_string(),
+                ..Default::default()
+            }),
+            allow_unhealthy_machine: false,
+        }),
+    )
+    .await
+    .expect("initial zero-DPU auto allocation should succeed on a multi-NIC host")
+    .into_inner();
+    let instance_id = instance.id.expect("allocated instance should have an id");
+
+    // Network config updates only run against a Ready instance.
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &zero_dpu_host.host_snapshot.id,
+        30,
+        ManagedHostState::Assigned {
+            instance_state: model::machine::InstanceState::Ready,
+        },
+    )
+    .await;
+
+    // The operator adds a third HostInband segment, and the host gets a
+    // lease on it with its spare NIC.
+    let host_inband_3_id = create_network_segment(
+        &env.api,
+        "HOST_INBAND_3",
+        &format!(
+            "{}/{}",
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3.network(),
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3.prefix()
+        ),
+        &FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3
+            .ip()
+            .to_string(),
+        forge::NetworkSegmentType::HostInband,
+        None,
+        true,
+    )
+    .await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    env.api
+        .discover_dhcp(
+            DhcpDiscovery::builder(
+                config.non_dpu_macs[2],
+                FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3.ip(),
+            )
+            .vendor_string("Bluefield")
+            .tonic_request(),
+        )
+        .await
+        .expect("the spare host NIC should get a lease on the new HostInband segment");
+
+    // Re-send the instance's own external-view config (`auto` + empty
+    // interfaces); the update re-resolves it from the host's current
+    // segments and stages the three-interface config.
+    env.api
+        .update_instance_config(tonic::Request::new(forge::InstanceConfigUpdateRequest {
+            instance_id: instance.id,
+            if_version_match: None,
+            config: instance.config.clone(),
+            metadata: instance.metadata.clone(),
+        }))
+        .await
+        .expect("the auto update must absorb the added HostInband segment");
+
+    let mut txn = env.db_txn().await;
+    let db_instance = db::instance::find_by_id(txn.as_mut(), instance_id)
+        .await?
+        .expect("instance should still exist after the update");
+    let pending = db_instance
+        .update_network_config_request
+        .expect("the auto update should stage a re-resolved network config");
+    assert_eq!(
+        pending.new_config.interfaces.len(),
+        3,
+        "the staged config should resolve one interface per HostInband segment"
+    );
+    let (host_inband_segment_1, host_inband_segment_2) = (
+        db::network_segment::find_by_name(txn.as_mut(), "HOST_INBAND").await?,
+        db::network_segment::find_by_name(txn.as_mut(), "HOST_INBAND_2").await?,
+    );
+    for segment_id in [
+        host_inband_segment_1.id,
+        host_inband_segment_2.id,
+        host_inband_3_id,
+    ] {
+        assert_eq!(
+            pending
+                .new_config
+                .interfaces
+                .iter()
+                .filter(|i| i.network_segment_id == Some(segment_id))
+                .count(),
+            1,
+            "the staged config should hold exactly one interface for segment {segment_id}"
+        );
     }
 
     Ok(())

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -310,7 +310,10 @@ impl InstanceNetworkConfig {
     /// underlying interfaces), so it must not reject the combination
     /// `auto: true` + non-empty interfaces here. The "auto must arrive with
     /// empty interfaces" rule is enforced in RPC <-> model conversion, which
-    /// only runs on user input.
+    /// only runs on user input. A resolved `auto` interface is identified by
+    /// its HostInband segment (one bare `Physical {}` per segment), so those
+    /// configs are validated against that rule rather than the per-device
+    /// function-id bucketing.
     pub fn validate(&self, allow_instance_vf: bool) -> Result<(), ConfigValidationError> {
         if !allow_instance_vf
             && self
@@ -323,12 +326,33 @@ impl InstanceNetworkConfig {
             ));
         }
 
-        validate_interface_function_ids(
-            &self.interfaces,
-            |iface| &iface.function_id,
-            |iface| iface.device_locator.as_ref(),
-        )
-        .map_err(ConfigValidationError::InvalidValue)?;
+        if self.auto_config.is_some() {
+            // Resolved `auto` interfaces are system-injected by
+            // `add_inband_interfaces_to_config`: one bare `Physical {}` per
+            // HostInband segment on the host, with no `device_locator` (a
+            // zero-DPU host has no DPU to locate). Their identity is the
+            // network segment itself -- enforced by the uniqueness check
+            // below -- so the per-device function-id bucketing doesn't apply
+            // here; it would read every injected PF beyond the first as a
+            // duplicate of one device.
+            if let Some(iface) = self.interfaces.iter().find(|iface| {
+                !matches!(iface.function_id, InterfaceFunctionId::Physical {})
+                    || iface.device_locator.is_some()
+            }) {
+                return Err(ConfigValidationError::InvalidValue(format!(
+                    "auto network configs hold only system-resolved physical host-inband \
+                     interfaces; found function {:?} with device locator {:?}",
+                    iface.function_id, iface.device_locator,
+                )));
+            }
+        } else {
+            validate_interface_function_ids(
+                &self.interfaces,
+                |iface| &iface.function_id,
+                |iface| iface.device_locator.as_ref(),
+            )
+            .map_err(ConfigValidationError::InvalidValue)?;
+        }
 
         // Note: We can't fully validate the network segment IDs here
         // We validate that the ID is not duplicated, but not whether it actually exists
@@ -967,6 +991,81 @@ mod tests {
 
             "duplicate network segment" {
                 (duplicate_network_segment, true) => Fails,
+            }
+        );
+    }
+
+    /// A resolved `auto` config as `add_inband_interfaces_to_config` produces
+    /// it: one bare `Physical {}` interface per HostInband segment, no
+    /// `device_locator`. Interface identity is the segment.
+    fn create_resolved_auto_network_config(segment_count: u8) -> InstanceNetworkConfig {
+        InstanceNetworkConfig {
+            interfaces: (0..segment_count)
+                .map(|idx| InstanceInterfaceConfig {
+                    function_id: InterfaceFunctionId::Physical {},
+                    network_segment_id: Some(offset_segment_id(idx)),
+                    network_details: None,
+                    ip_addrs: HashMap::default(),
+                    requested_ip_addr: None,
+                    ipv6_interface_config: None,
+                    routing_profile: None,
+                    interface_prefixes: HashMap::default(),
+                    network_segment_gateways: HashMap::default(),
+                    host_inband_mac_address: None,
+                    device_locator: None,
+                    internal_uuid: uuid::Uuid::new_v4(),
+                    vpc_id: None,
+                })
+                .collect(),
+            auto_config: Some(InstanceNetworkAutoConfig {
+                vpc_id: VpcId::new(),
+            }),
+        }
+    }
+
+    // InstanceNetworkConfig::validate over resolved `auto` configs (the
+    // output of `add_inband_interfaces_to_config`). A multi-NIC zero-DPU
+    // host resolves to several bare `Physical {}` interfaces -- one per
+    // HostInband segment -- and must validate; the per-device function-id
+    // bucketing would read those as duplicates of one device.
+    #[test]
+    fn validate_resolved_auto_network_config() {
+        let single_segment = create_resolved_auto_network_config(1);
+        let multi_segment = create_resolved_auto_network_config(3);
+
+        let mut duplicate_segment = create_resolved_auto_network_config(2);
+        duplicate_segment.interfaces[1].network_segment_id =
+            duplicate_segment.interfaces[0].network_segment_id;
+
+        let mut virtual_function = create_resolved_auto_network_config(2);
+        virtual_function.interfaces[1].function_id = InterfaceFunctionId::Virtual { id: 0 };
+
+        let mut located_interface = create_resolved_auto_network_config(2);
+        located_interface.interfaces[1].device_locator = Some(DeviceLocator {
+            device: "DPU".to_string(),
+            device_instance: 0,
+        });
+
+        scenarios!(
+            run = |(config, allow_instance_vf)| config.validate(allow_instance_vf).map_err(drop);
+            "single resolved host-inband interface" {
+                (single_segment, false) => Yields(()),
+            }
+
+            "one interface per HostInband segment on a multi-NIC host" {
+                (multi_segment, false) => Yields(()),
+            }
+
+            "duplicate segments are still rejected for auto configs" {
+                (duplicate_segment, false) => Fails,
+            }
+
+            "virtual functions cannot appear in an auto config" {
+                (virtual_function, true) => Fails,
+            }
+
+            "device-located interfaces cannot appear in an auto config" {
+                (located_interface, false) => Fails,
             }
         );
     }


### PR DESCRIPTION
A multi-NIC zero-DPU host resolves an `auto: true` network config into several bare `Physical {}` interfaces -- one per `HostInband` segment, none of them device-located. `InstanceNetworkConfig::validate()` read that through its per-device function-id bucketing as duplicate PFs of one device and rejected the config, which broke instance config updates on multi-segment hosts (the update path re-resolves the auto config and validates the result). Resolved auto configs are now validated against their own invariant: every interface a bare physical function, identified by its segment.

Primary callouts are:

- `InstanceNetworkConfig::validate()` branches on `auto_config`: resolved auto interfaces must be bare `Physical {}` with no `device_locator` (their identity is the segment, whose uniqueness was already enforced); manual configs keep the per-device bucketing unchanged.
- Virtual functions and device-located interfaces are now rejected inside auto configs -- nothing legitimate ever puts them there.
- New `FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY_3` fixture prefix (and a third site prefix in the instance-allocation test env) so a test can grow a host's segment set mid-test.

Tests added! `validate_resolved_auto_network_config` covers multi-segment acceptance plus the new rejections at the model layer, and `test_zero_dpu_auto_update_absorbs_added_host_inband_segment` drives the end-to-end story: a three-NIC zero-DPU host allocates on two `HostInband` segments, the operator adds a third, the spare NIC leases onto it, and `update_instance_config` re-resolves and stages the three-interface config. Both fail without the fix.

This supports https://github.com/NVIDIA/infra-controller/issues/1688




Closes #1688
