### PR TITLE
docs: document add/remove SKU admin UI action

### DIFF
--- a/docs/operations/debug_webui.md
+++ b/docs/operations/debug_webui.md
@@ -54,7 +54,7 @@ The WebUI exposes views grouped by entity type. All views are read-only unless n
 | View | Path | Description |
 |------|------|-------------|
 | Home | `/admin/` | NICo version, DPU agent upgrade policy, active log filter, dynamic feature flags, and operator-configured tool links |
-| Machines | `/admin/machine` | All managed hosts; per-machine detail, health, validation status |
+| Machines | `/admin/machine` | All managed hosts; per-machine detail, health, validation status; assign/remove SKU on hosts (write) |
 | DPUs | `/admin/dpu` | DPU inventory and per-DPU detail; DPU agent version list at `/admin/dpu/versions` |
 | DPAs | `/admin/dpa` | DPA (Data Processing Accelerator) inventory |
 | Hosts | `/admin/host` | Host-only view of managed machines |

--- a/docs/provisioning/sku-validation.md
+++ b/docs/provisioning/sku-validation.md
@@ -34,6 +34,9 @@ Generally, SKUs must be manually added a site to configure its SKUs. At some poi
 bring-up process. However, for now, SKUs are only manually added to sites. It is also expected that, generally,
 the SKU assignments for individual machines are added automatically by NICo as those machines are reconfigured.
 
+An admin can also assign or remove a SKU on an individual host manually, either with the `nico-admin-cli sku assign` /
+`nico-admin-cli sku unassign` commands or from the machine detail page of the [NICo Debug WebUI](../operations/debug_webui.md).
+
 ### BOM Validation States
 Verifying a SKU against a machine goes through several steps to acquire updated machine inventory and perform the validation.  Depending on the inventory of the machine and the SKU configuration, the state machine needs to handle several situations.  The bom validation process is broken down into the following sub-states:
 - `MatchingSku` - The state machine will attempt to find an existing SKU that matches the machine inventory.


### PR DESCRIPTION
Documents the machine-detail-page SKU assign/remove action that was added to the admin WebUI in 97b58d8d9 (#2295).

- **`docs/operations/debug_webui.md`** — the Machines row of the "Available Views" table now notes the assign/remove SKU write action on hosts, matching how other write-capable views are flagged.
- **`docs/provisioning/sku-validation.md`** — adds a note that admins can manually assign/remove a host's SKU via either the `nico-admin-cli sku assign`/`unassign` commands or the Debug WebUI machine detail page.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
Documentation-only follow-up to the SKU admin UI feature (#2295).

🤖 Generated with [Claude Code](https://claude.com/claude-code)