### PR TITLE
Update nicocli site list validation step in documentation

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -475,6 +475,7 @@ This is a **one-to-one deployment**: one site per NICo installation. The site is
 To verify the site was registered correctly:
 
 ```bash
+export NICO_API_NAME=nico
 nicocli site list
 ```
 


### PR DESCRIPTION
This PR updates the `nicocli site list` command by setting the following env variable correctly to `export NICO_API_NAME=nico`.  The env variable seems to get set without the users knowledge to "carbide" which causes a 404 error.  Setting the value to "nico" before running the command resolves this.

## Related issues
None

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

