### PR TITLE
fix: Preserve admin segment lock order during discovery

### DIFF
--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -116,6 +116,12 @@ pub(crate) async fn discover_machine(
     };
 
     let mut txn = api.txn_begin().await?;
+    if hardware_info.is_dpu() {
+        // Discovery updates machine-interface rows before reconciliation. Take the segment locks
+        // first so the outer transaction preserves the allocator's advisory-lock-before-row-lock
+        // order instead of relying on reconciliation's inner savepoint to establish it later.
+        db::machine_interface::load_and_lock_all_admin_segments(&mut txn).await?;
+    }
     tracing::debug!(
         ?remote_ip,
         ?interface_id,

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -283,6 +283,10 @@ async fn set_primary_interface_core(
     if current_primary_is_admin {
         db::machine_interface::reconcile_admin_addresses_for_host(&mut txn, &host_machine_id)
             .await?;
+    } else {
+        // The repair path has no current admin primary to reconcile, but it still must acquire
+        // segment locks before the primary-interface row updates below.
+        db::machine_interface::load_and_lock_all_admin_segments(&mut txn).await?;
     }
 
     // update the primary interface: clear the old primary (if any), then set the new.

--- a/crates/api-core/src/tests/set_primary_interface.rs
+++ b/crates/api-core/src/tests/set_primary_interface.rs
@@ -402,14 +402,64 @@ async fn test_set_primary_interface_repairs_dpu_host_with_no_admin_primary(
         .execute(&env.pool)
         .await?;
 
-    // Promoting the Admin interface must succeed (repair), not error after the BMC call.
-    env.api
-        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+    // Hold the admin segment lock while the repair starts. The handler must wait for this lock
+    // before updating the interface row, or it can deadlock with DPU discovery's segment-first
+    // transaction.
+    let mut blocker_txn = db::Transaction::begin(&env.pool).await?;
+    let blocker_pid = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+        .fetch_one(blocker_txn.as_pgconn())
+        .await?;
+    db::machine_interface::load_and_lock_all_admin_segments(&mut blocker_txn).await?;
+
+    let api = env.api.clone();
+    let set_primary_task = tokio::spawn(async move {
+        api.set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
             host_machine_id: Some(host_id),
             interface_id: Some(promote_id),
             reboot: false,
         }))
-        .await?;
+        .await
+    });
+
+    let wait_result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS (\
+                     SELECT 1 FROM pg_locks \
+                     WHERE locktype = 'advisory' AND NOT granted \
+                       AND $1 = ANY(pg_blocking_pids(pid))\
+                 )",
+            )
+            .bind(blocker_pid)
+            .fetch_one(&env.pool)
+            .await?;
+            if waiting {
+                return Ok::<(), sqlx::Error>(());
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .map_err(|_| {
+        std::io::Error::other("set-primary-interface did not wait for the admin segment lock")
+    });
+
+    let row_lock_result =
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1::uuid FOR UPDATE NOWAIT")
+            .bind(promote_id)
+            .fetch_one(&env.pool)
+            .await;
+
+    blocker_txn.commit().await?;
+    let set_primary_result = set_primary_task.await?;
+
+    wait_result??;
+    row_lock_result.map_err(|err| {
+        std::io::Error::other(format!(
+            "set-primary-interface locked the target row before the admin segment: {err}",
+        ))
+    })?;
+    set_primary_result?;
 
     // The promoted interface is now the only primary.
     let primaries_now: Vec<_> = {

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2627,7 +2627,7 @@ FOR UPDATE"#;
 /// This intentionally locks more broadly than the specific host touches so reconciliation follows
 /// the same high-level lock order as address allocation: segment advisory lock first, then
 /// machine interface/address row locks.
-async fn load_and_lock_all_admin_segments(
+pub async fn load_and_lock_all_admin_segments(
     txn: &mut Transaction<'_>,
 ) -> DatabaseResult<Vec<NetworkSegment>> {
     let mut segment_ids =


### PR DESCRIPTION
### Summary

Prevent a PostgreSQL deadlock in DPU discovery by making the discovery transaction acquire admin-network-segment advisory locks before it updates or locks machine-interface rows. Address allocation already uses this segment-lock-before-row-lock order.

### Root cause

The 18-tray machine-a-tron lifecycle in #3207 exposed a pre-existing lock inversion:

- DPU discovery updated machine-interface rows, then waited for the admin-segment advisory lock during address reconciliation.
- Concurrent address allocation held the admin-segment advisory lock, then waited for machine-interface rows.

PostgreSQL repeatedly reported `deadlock detected` from the `FOR UPDATE OF mi` query in `reconcile_admin_addresses_for_host`, paired with another transaction waiting on `pg_advisory_xact_lock`.

### Fix

The DPU discovery transaction now calls the existing `load_and_lock_all_admin_segments` helper before any machine-interface work. The helper is made public within the database crate so both paths use the same lock order.

No new locking primitive, abstraction, or dependency is introduced.

### Before and after evidence

Removing only this two-file change reproduced repeated deadlocks in the 18-tray lifecycle. Restoring it made the same rack-scale path complete in 83.85 seconds:

```text
test result: ok. 1 passed; 0 failed; finished in 83.85s
machine-a-tron-nvl72 | NVL72 | 18 expected | 18 managed | 18 Ready
```

The passing run contained no `deadlock detected` entry.

### Verification

Hotfix revision: `2fcc29b83052d745d2fb39374cc2e812c342cd5b`

Base revision: upstream `main` at `b7154872b`

Supporting checks passed:

```sh
cargo check -p carbide-api-core --no-default-features --lib
cargo fmt --all --check
git diff --check
```

Hands-on regression exercise:

```sh
REPO_ROOT="$PWD" \
DATABASE_URL=postgresql://postgres@127.0.0.1:55433 \
cargo test --release -p carbide-api-integration-tests --test lib \
  test_machine_a_tron_rack_integration -- --exact --nocapture
```

The focused lifecycle test currently lives in #3207. Its copy of this two-file fix has the same stable Git patch ID as this hotfix: `76226037bcbdaef26b31592f98bb7f3e6c1d8741`.

The direct `carbide-api-core` unit-test target cannot build on this Apple Silicon host because its circular test-harness dev dependency re-enables the Linux-only default TPM feature. The no-default-features library check verifies the hotfix build without that unsupported target; the real PostgreSQL lifecycle above exercises the changed lock path.

### Relationship to #3207

#3207 exposed the deadlock but does not own the production lock-order behavior. This hotfix is separate so the concurrency fix has a focused review, merge, and rollback path. #3207 remains draft and depends on this PR merging first.

### Risk and scope

- Two production files: seven insertions and one visibility change.
- DPU discovery takes the existing admin-segment locks earlier in its transaction, which can move contention earlier but removes the observed lock inversion.
- No rack or simulator behavior changes.
- No API, schema, configuration, or dependency changes.
