### PR TITLE
feat: count RBAC denials, client-cert rejections, and BMC password rotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,8 +1523,10 @@ dependencies = [
 name = "carbide-authn"
 version = "0.0.0"
 dependencies = [
+ "carbide-instrument",
  "carbide-test-support",
  "hyper",
+ "rcgen",
  "serde",
  "thiserror 2.0.18",
  "tonic",
@@ -2927,6 +2929,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-firmware",
  "carbide-health-report",
+ "carbide-instrument",
  "carbide-ipmi",
  "carbide-metrics-utils",
  "carbide-network",

--- a/crates/api-core/src/auth/middleware.rs
+++ b/crates/api-core/src/auth/middleware.rs
@@ -16,7 +16,7 @@
  */
 use std::sync::Arc;
 
-use carbide_authn::middleware::Principal;
+use carbide_authn::middleware::{ConnectionAttributes, Principal};
 use futures_util::future::BoxFuture;
 use hyper::{Request, Response, StatusCode};
 use tonic::service::AxumBody;
@@ -25,11 +25,13 @@ use tower_http::auth::AsyncAuthorizeRequest;
 use crate::auth::internal_rbac_rules::InternalRBACRules;
 use crate::auth::{AuthContext, CasbinAuthorizer, Predicate};
 
-/// A caller was denied by the Casbin authorizer -- the canonical security
-/// signal. The denial rate is the alert; the denied method and principals
-/// ride the log line. (The method is deliberately NOT a metric label: the
-/// path segment is caller-supplied, so it would mint unbounded series. A
-/// per-method label needs a real method registry to bucket against.)
+/// A caller was denied by an authorizer -- the canonical security signal.
+/// The denial rate is the alert; `authorizer` names the engine that denied
+/// and `principal_class` the strongest identity the caller presented. The
+/// denied method, principals, and client address ride the log line. (The
+/// method is deliberately NOT a metric label: the path segment is
+/// caller-supplied, so it would mint unbounded series. A per-method label
+/// needs a real method registry to bucket against.)
 #[derive(carbide_instrument::Event)]
 #[event(
     name = "carbide_auth_denied_total",
@@ -37,15 +39,75 @@ use crate::auth::{AuthContext, CasbinAuthorizer, Predicate};
     log = info,
     metric = counter,
     message = "Denied a call to Forge method",
-    describe = "The amount of Forge calls denied by the authorizer"
+    describe = "Number of Forge calls denied by the authorizer"
 )]
 struct AuthorizationDenied {
+    #[label]
+    principal_class: PrincipalClass,
+    #[label]
+    authorizer: Authorizer,
     #[context]
     method: String,
     #[context]
     principals: String,
     #[context]
+    client_address: String,
+    #[context]
     reason: String,
+}
+
+/// The strongest kind of identity among a request's principals, as the
+/// bounded `principal_class` label on [`AuthorizationDenied`]. Variants are
+/// declared weakest-first so the derived `Ord` is the precedence order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, carbide_instrument::LabelValue)]
+enum PrincipalClass {
+    Anonymous,
+    TrustedCertificate,
+    SpiffeMachine,
+    SpiffeService,
+    ExternalUser,
+}
+
+impl PrincipalClass {
+    fn classify(principals: &[Principal]) -> Self {
+        principals
+            .iter()
+            .map(|principal| match principal {
+                Principal::ExternalUser(_) => PrincipalClass::ExternalUser,
+                Principal::SpiffeServiceIdentifier(_) => PrincipalClass::SpiffeService,
+                Principal::SpiffeMachineIdentifier(_) => PrincipalClass::SpiffeMachine,
+                Principal::TrustedCertificate => PrincipalClass::TrustedCertificate,
+                Principal::Anonymous => PrincipalClass::Anonymous,
+            })
+            .max()
+            // A request that presented no principals at all is anonymous.
+            .unwrap_or(PrincipalClass::Anonymous)
+    }
+}
+
+/// Which authorization engine denied the call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+enum Authorizer {
+    Casbin,
+    InternalRbac,
+}
+
+/// The peer address of the connection a request arrived on, as recorded by
+/// the authentication middleware; `None` for a request that never passed
+/// through it (misordered layers, in-process tests).
+fn peer_address<B>(request: &Request<B>) -> Option<std::net::SocketAddr> {
+    request
+        .extensions()
+        .get::<Arc<ConnectionAttributes>>()
+        .map(|conn_attrs| conn_attrs.peer_address)
+}
+
+/// The denial log's rendering of [`peer_address`]: allocated only when a
+/// request is actually denied.
+fn client_address(peer_address: Option<std::net::SocketAddr>) -> String {
+    peer_address
+        .map(|address| address.to_string())
+        .unwrap_or_else(|| "<Unable to determine client address>".to_string())
 }
 
 // An authorization handler to plug into tower_http::auth::AsyncAuthorizeRequest.
@@ -79,6 +141,10 @@ where
             let request_permitted = match RequestClass::from(&request) {
                 // Forge-owned endpoints must go through access control.
                 ForgeMethod(method_name) => {
+                    // Read before AuthContext borrows the extensions mutably;
+                    // the denial emit below needs it. Copy, not a String: the
+                    // allowed path -- almost every request -- never formats it.
+                    let peer_address = peer_address(&request);
                     let req_auth_context = request
                         .extensions_mut()
                         .get_mut::<AuthContext>()
@@ -113,15 +179,18 @@ where
                         }
                         Err(e) => {
                             carbide_instrument::emit(AuthorizationDenied {
+                                principal_class: PrincipalClass::classify(principals),
+                                authorizer: Authorizer::Casbin,
                                 method: method_name,
-                                // as_identifier() is the authorizer's view of each
-                                // principal (e.g. external-role/<group>) and keeps
+                                // audit_identity() keeps each principal's concrete
+                                // identity (which machine was denied) while keeping
                                 // ExternalUserInfo payloads out of the log line.
                                 principals: principals
                                     .iter()
-                                    .map(Principal::as_identifier)
+                                    .map(Principal::audit_identity)
                                     .collect::<Vec<_>>()
                                     .join(","),
+                                client_address: client_address(peer_address),
                                 reason: e.to_string(),
                             });
                             false
@@ -210,37 +279,39 @@ where
     type ResponseBody = AxumBody;
     type Future = BoxFuture<'static, Result<Request<B>, Response<Self::ResponseBody>>>;
 
-    fn authorize(&mut self, mut request: Request<B>) -> Self::Future {
+    fn authorize(&mut self, request: Request<B>) -> Self::Future {
         Box::pin(async move {
             let request_permitted = match RequestClass::from(&request) {
                 // Forge-owned endpoints must go through access control.
                 RequestClass::ForgeMethod(method_name) => {
-                    let extensions = request.extensions_mut();
-                    let req_auth_context = extensions.get::<AuthContext>().ok_or_else(|| {
-                        tracing::warn!(
-                            "InternalRBACHandler::authorize() found a request with \
+                    let req_auth_context =
+                        request.extensions().get::<AuthContext>().ok_or_else(|| {
+                            tracing::warn!(
+                                "InternalRBACHandler::authorize() found a request with \
                                 no AuthContext in its extensions. This may mean \
                                 the authentication middleware didn't run \
                                 successfully, or the middleware layers are \
                                 nested in the wrong order."
-                        );
-                        empty_response_with_status(StatusCode::INTERNAL_SERVER_ERROR)
-                    })?;
+                            );
+                            empty_response_with_status(StatusCode::INTERNAL_SERVER_ERROR)
+                        })?;
                     let principals = &req_auth_context.principals;
 
                     let allowed = InternalRBACRules::allowed_from_static(&method_name, principals);
 
                     if !allowed {
-                        let client_address = if let Some(conn_attrs) =
-                            extensions.get::<Arc<carbide_authn::middleware::ConnectionAttributes>>()
-                        {
-                            conn_attrs.peer_address.to_string()
-                        } else {
-                            "<Unable to determine client address>".to_string()
-                        };
-                        tracing::info!(
-                            "Request denied: {client_address} {method_name} {principals:?}",
-                        );
+                        carbide_instrument::emit(AuthorizationDenied {
+                            principal_class: PrincipalClass::classify(principals),
+                            authorizer: Authorizer::InternalRbac,
+                            method: method_name,
+                            principals: principals
+                                .iter()
+                                .map(Principal::audit_identity)
+                                .collect::<Vec<_>>()
+                                .join(","),
+                            client_address: client_address(peer_address(&request)),
+                            reason: "no internal RBAC rule permits these principals".to_string(),
+                        });
                     }
                     allowed
                 }
@@ -264,7 +335,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_authn::middleware::ExternalUserInfo;
+    use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use futures_util::FutureExt as _;
 
     use super::*;
@@ -283,23 +356,44 @@ mod tests {
         }
     }
 
+    /// A Forge-method request presenting `principals`, arriving from
+    /// `peer_address` per the connection middleware's attributes.
+    fn forge_request(uri: &str, principals: Vec<Principal>, peer_address: &str) -> Request<()> {
+        let mut request = Request::builder().uri(uri).body(()).expect("request");
+        request.extensions_mut().insert(AuthContext {
+            principals,
+            authorization: None,
+        });
+        request
+            .extensions_mut()
+            .insert(Arc::new(ConnectionAttributes {
+                peer_address: peer_address.parse().expect("socket address"),
+                peer_certificates: Vec::new(),
+            }));
+        request
+    }
+
+    fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
+        log.fields
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+    }
+
     /// The denial branch is a contract: one emit writes the log line (method,
-    /// principals, reason) AND moves carbide_auth_denied_total, and the caller
-    /// gets 403.
+    /// principals, client address, reason) AND moves carbide_auth_denied_total
+    /// under the caller's principal class, and the caller gets 403.
     #[test]
     fn denied_forge_call_logs_and_counts() {
         let metrics = MetricsCapture::start();
         let mut handler = CasbinHandler::new(Arc::new(CasbinAuthorizer::new(Arc::new(DenyAll))));
 
         let logs = capture_logs(|| {
-            let mut request = Request::builder()
-                .uri("/forge.Forge/PowerControl")
-                .body(())
-                .expect("request");
-            request.extensions_mut().insert(AuthContext {
-                principals: vec![Principal::TrustedCertificate],
-                authorization: None,
-            });
+            let request = forge_request(
+                "/forge.Forge/PowerControl",
+                vec![Principal::TrustedCertificate],
+                "203.0.113.9:52011",
+            );
 
             let result = handler
                 .authorize(request)
@@ -313,20 +407,131 @@ mod tests {
             .iter()
             .find(|log| log.message == "Denied a call to Forge method")
             .expect("the denial log line");
-        let field = |name: &str| {
-            denial
-                .fields
-                .iter()
-                .find(|(key, _)| key == name)
-                .map(|(_, value)| value.as_str())
-        };
-        assert_eq!(field("method"), Some("PowerControl"));
-        assert_eq!(field("principals"), Some("trusted-certificate"));
         assert_eq!(
-            field("reason").expect("reason field"),
+            field(denial, "principal_class"),
+            Some("trusted_certificate")
+        );
+        assert_eq!(field(denial, "authorizer"), Some("casbin"));
+        assert_eq!(field(denial, "method"), Some("PowerControl"));
+        assert_eq!(field(denial, "principals"), Some("trusted-certificate"));
+        assert_eq!(field(denial, "client_address"), Some("203.0.113.9:52011"));
+        assert_eq!(
+            field(denial, "reason").expect("reason field"),
             AuthorizationError::Unauthorized.to_string()
         );
 
-        assert_eq!(metrics.counter_delta("carbide_auth_denied_total", &[]), 1.0);
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_auth_denied_total",
+                &[
+                    ("principal_class", "trusted_certificate"),
+                    ("authorizer", "casbin"),
+                ],
+            ),
+            1.0
+        );
+    }
+
+    /// The internal RBAC denial path emits the same event as the Casbin path,
+    /// distinguished by the authorizer label, and the caller gets 403.
+    #[test]
+    fn denied_internal_rbac_call_logs_and_counts() {
+        let metrics = MetricsCapture::start();
+        let mut handler = InternalRBACHandler::new();
+
+        let logs = capture_logs(|| {
+            // MachineSetup permits only the admin CLI, never a bare trusted
+            // certificate.
+            let request = forge_request(
+                "/forge.Forge/MachineSetup",
+                vec![Principal::TrustedCertificate],
+                "198.51.100.4:40000",
+            );
+
+            let result = handler
+                .authorize(request)
+                .now_or_never()
+                .expect("the authorization future has no awaits");
+            let response = result.expect_err("the internal RBAC rules must reject the call");
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        });
+
+        let denial = logs
+            .iter()
+            .find(|log| log.message == "Denied a call to Forge method")
+            .expect("the denial log line");
+        assert_eq!(
+            field(denial, "principal_class"),
+            Some("trusted_certificate")
+        );
+        assert_eq!(field(denial, "authorizer"), Some("internal_rbac"));
+        assert_eq!(field(denial, "method"), Some("MachineSetup"));
+        assert_eq!(field(denial, "principals"), Some("trusted-certificate"));
+        assert_eq!(field(denial, "client_address"), Some("198.51.100.4:40000"));
+
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_auth_denied_total",
+                &[
+                    ("principal_class", "trusted_certificate"),
+                    ("authorizer", "internal_rbac"),
+                ],
+            ),
+            1.0
+        );
+    }
+
+    /// principal_class is the strongest identity present; an empty principal
+    /// set is anonymous.
+    #[test]
+    fn principal_class_is_the_strongest_principal() {
+        let spiffe_service = || Principal::SpiffeServiceIdentifier("machine-a-tron".to_string());
+        let spiffe_machine = || Principal::SpiffeMachineIdentifier("fm100".to_string());
+        let external_user =
+            || Principal::ExternalUser(ExternalUserInfo::new(None, "admins".to_string(), None));
+
+        check_values(
+            [
+                Check {
+                    scenario: "no principals at all",
+                    input: vec![],
+                    expect: PrincipalClass::Anonymous,
+                },
+                Check {
+                    scenario: "an explicit anonymous principal",
+                    input: vec![Principal::Anonymous],
+                    expect: PrincipalClass::Anonymous,
+                },
+                Check {
+                    scenario: "a trusted certificate outranks anonymous",
+                    input: vec![Principal::Anonymous, Principal::TrustedCertificate],
+                    expect: PrincipalClass::TrustedCertificate,
+                },
+                Check {
+                    scenario: "a machine identity outranks its trusted certificate",
+                    input: vec![spiffe_machine(), Principal::TrustedCertificate],
+                    expect: PrincipalClass::SpiffeMachine,
+                },
+                Check {
+                    scenario: "a service identity outranks a machine identity",
+                    input: vec![
+                        Principal::TrustedCertificate,
+                        spiffe_machine(),
+                        spiffe_service(),
+                    ],
+                    expect: PrincipalClass::SpiffeService,
+                },
+                Check {
+                    scenario: "an external user outranks everything",
+                    input: vec![
+                        spiffe_service(),
+                        external_user(),
+                        Principal::TrustedCertificate,
+                    ],
+                    expect: PrincipalClass::ExternalUser,
+                },
+            ],
+            |principals| PrincipalClass::classify(&principals),
+        );
     }
 }

--- a/crates/authn/Cargo.toml
+++ b/crates/authn/Cargo.toml
@@ -26,6 +26,8 @@ description = "Helpers for interacting with TLS authentication, client certs, SP
 name = "carbide_authn"
 
 [dependencies]
+carbide-instrument = { path = "../instrument" }
+
 thiserror = { workspace = true }
 x509-parser = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -35,7 +37,9 @@ tower = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+rcgen = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/authn/src/middleware.rs
+++ b/crates/authn/src/middleware.rs
@@ -152,6 +152,19 @@ impl Principal {
         }
     }
 
+    /// The audit-log rendering of this principal: like [`Self::as_identifier`]
+    /// but keeping the machine's concrete SPIFFE identity -- an audit line
+    /// must say which machine was denied, while authorization only cares that
+    /// it is a machine. External-user payloads stay redacted to the group.
+    pub fn audit_identity(&self) -> String {
+        match self {
+            Principal::SpiffeMachineIdentifier(identifier) => {
+                format!("spiffe-machine-id/{identifier}")
+            }
+            other => other.as_identifier(),
+        }
+    }
+
     // Note: no certificate verification is performed here!
     pub fn try_from_client_certificate<AZ: Authorization>(
         certificate: &CertificateDer,
@@ -452,6 +465,46 @@ pub struct ConnectionAttributes {
     pub peer_certificates: Vec<CertificateDer<'static>>,
 }
 
+/// A request whose presented certificate chain minted no principal, counted
+/// once per request with the end-entity certificate's error. A healthy chain
+/// whose intermediates don't map -- CA certificates never do -- is not a
+/// rejection. The peer and the exact error ride the log line at the DEBUG
+/// level this site has always logged at.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_authn_client_cert_rejected_total",
+    component = "authn",
+    log = debug,
+    metric = counter,
+    message = "Rejected a client certificate",
+    describe = "Number of client certificates rejected during authentication"
+)]
+struct ClientCertRejected {
+    #[label]
+    reason: RejectReason,
+    #[context]
+    peer_address: SocketAddr,
+    #[context]
+    error: String,
+}
+
+/// Which stage of certificate-to-principal mapping rejected the certificate,
+/// mirroring [`SpiffeError`]'s variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+enum RejectReason {
+    Validation,
+    Recognition,
+}
+
+impl From<&SpiffeError> for RejectReason {
+    fn from(error: &SpiffeError) -> Self {
+        match error {
+            SpiffeError::Validation(_) => RejectReason::Validation,
+            SpiffeError::Recognition(_) => RejectReason::Recognition,
+        }
+    }
+}
+
 impl<S, B, AZ> Service<Request<B>> for CertDescriptionService<S, AZ>
 where
     B: tonic::codegen::Body,
@@ -478,19 +531,33 @@ where
         let mut auth_context = AuthContext::<AZ>::default();
         if let Some(conn_attrs) = extensions.get::<Arc<ConnectionAttributes>>() {
             let peer_certs = &conn_attrs.peer_certificates;
+            // rustls presents the end-entity certificate first, intermediates
+            // after -- and an intermediate CA certificate never maps to a
+            // principal, so counting per certificate would brand every
+            // healthy chain-presenting client a rejection on every request.
+            // Failures are collected instead, and the rejection counts once
+            // per request, only when the whole chain minted no principal.
+            let mut rejections = Vec::new();
+            let minted_before = auth_context.principals.len();
             let peer_cert_principals = peer_certs.iter().filter_map(|cert| {
                 match Principal::try_from_client_certificate(cert, &self.authorization_context) {
                     Ok(x) => Some(x),
                     Err(e) => {
-                        tracing::debug!(
-                            "Saw bad certificate from {:?}: {e}",
-                            conn_attrs.peer_address,
-                        );
+                        rejections.push(e);
                         None
                     }
                 }
             });
             auth_context.principals.extend(peer_cert_principals);
+            if auth_context.principals.len() == minted_before
+                && let Some(leaf_error) = rejections.first()
+            {
+                carbide_instrument::emit(ClientCertRejected {
+                    reason: RejectReason::from(leaf_error),
+                    peer_address: conn_attrs.peer_address,
+                    error: leaf_error.to_string(),
+                });
+            }
             // Regardless of whether we were able to get a specific Principal
             // flavor out of the certificate, having a trusted certificate
             // presented by the client is worth recording on its own.
@@ -503,5 +570,167 @@ where
 
         extensions.insert(auth_context);
         self.inner.call(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::task::{Context, Poll};
+
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::*;
+    use crate::spiffe_id::TrustDomain;
+    use crate::{SpiffeContextError, SpiffeValidationError};
+
+    /// A terminal service for driving the middleware. The middleware does all
+    /// of its certificate work synchronously inside `call` before delegating
+    /// here, so the test never needs to poll the returned future.
+    #[derive(Clone)]
+    struct Terminal;
+
+    impl<B> Service<Request<B>> for Terminal {
+        type Response = ();
+        type Error = std::convert::Infallible;
+        type Future = std::future::Ready<Result<(), Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _request: Request<B>) -> Self::Future {
+            std::future::ready(Ok(()))
+        }
+    }
+
+    fn spiffe_context() -> SpiffeContext {
+        SpiffeContext {
+            trust_domain: TrustDomain::new("example.test").expect("trust domain"),
+            service_base_paths: vec!["/carbide-system/sa/".to_string()],
+            machine_base_path: "/carbide-system/machine/".to_string(),
+            additional_issuer_cns: HashSet::new(),
+        }
+    }
+
+    /// A self-signed leaf whose URI SAN is a service SPIFFE id under the test
+    /// trust domain: `try_from_client_certificate` performs no signature
+    /// verification, so this maps to a real principal.
+    fn spiffe_leaf_certificate(path: &str) -> CertificateDer<'static> {
+        let mut params = rcgen::CertificateParams::default();
+        params.subject_alt_names = vec![rcgen::SanType::URI(
+            rcgen::string::Ia5String::try_from(format!("spiffe://example.test{path}"))
+                .expect("uri"),
+        )];
+        let key = rcgen::KeyPair::generate().expect("key pair");
+        params.self_signed(&key).expect("certificate").der().clone()
+    }
+
+    /// A healthy chain -- a mapping leaf plus a non-mapping second
+    /// certificate -- is not a rejection: the counter must not move.
+    #[test]
+    fn valid_chain_with_unmappable_intermediate_counts_no_rejection() {
+        let metrics = MetricsCapture::start();
+        let middleware = CertDescriptionMiddleware::<NoAuthorization>::new(None, spiffe_context());
+        let mut service = middleware.layer(Terminal);
+
+        capture_logs(|| {
+            let mut request = Request::builder()
+                .uri("/forge.Forge/Anything")
+                .body(String::new())
+                .expect("request");
+            request
+                .extensions_mut()
+                .insert(Arc::new(ConnectionAttributes {
+                    peer_address: "192.0.2.8:4433".parse().expect("socket address"),
+                    peer_certificates: vec![
+                        spiffe_leaf_certificate("/carbide-system/sa/test-service"),
+                        CertificateDer::from(b"not a certificate".to_vec()),
+                    ],
+                }));
+            let _response_future = service.call(request);
+        });
+
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_authn_client_cert_rejected_total",
+                &[("reason", "validation")]
+            ),
+            0.0,
+            "a chain that minted a principal is not a rejection"
+        );
+    }
+
+    /// A certificate that maps to no principal is dropped, and the drop is
+    /// counted: one emit writes the DEBUG log line (reason, peer, error) AND
+    /// moves carbide_authn_client_cert_rejected_total.
+    #[test]
+    fn rejected_client_cert_logs_and_counts() {
+        let metrics = MetricsCapture::start();
+        let middleware = CertDescriptionMiddleware::<NoAuthorization>::new(None, spiffe_context());
+        let mut service = middleware.layer(Terminal);
+
+        let logs = capture_logs(|| {
+            let mut request = Request::builder()
+                .uri("/forge.Forge/Anything")
+                .body(String::new())
+                .expect("request");
+            request
+                .extensions_mut()
+                .insert(Arc::new(ConnectionAttributes {
+                    peer_address: "192.0.2.7:4433".parse().expect("socket address"),
+                    peer_certificates: vec![CertificateDer::from(b"not a certificate".to_vec())],
+                }));
+            let _response_future = service.call(request);
+        });
+
+        let rejection = logs
+            .iter()
+            .find(|log| log.message == "Rejected a client certificate")
+            .expect("the rejection log line");
+        assert_eq!(rejection.level, tracing::Level::DEBUG);
+        let field = |name: &str| {
+            rejection
+                .fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.as_str())
+        };
+        assert_eq!(field("reason"), Some("validation"));
+        assert_eq!(field("peer_address"), Some("192.0.2.7:4433"));
+        assert!(
+            field("error").is_some_and(|error| !error.is_empty()),
+            "the rejection carries the certificate error"
+        );
+
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_authn_client_cert_rejected_total",
+                &[("reason", "validation")]
+            ),
+            1.0
+        );
+    }
+
+    /// Both SpiffeError variants map onto the bounded reason label.
+    #[test]
+    fn reject_reason_maps_the_spiffe_error_variants() {
+        use carbide_instrument::LabelValue as _;
+
+        let validation =
+            SpiffeError::Validation(SpiffeValidationError::ValidationError("bad".to_string()));
+        let recognition =
+            SpiffeError::Recognition(SpiffeContextError::ContextError("unknown".to_string()));
+
+        assert_eq!(RejectReason::from(&validation), RejectReason::Validation);
+        assert_eq!(RejectReason::from(&recognition), RejectReason::Recognition);
+        assert_eq!(
+            RejectReason::Validation.label_value().as_str(),
+            "validation"
+        );
+        assert_eq!(
+            RejectReason::Recognition.label_value().as_str(),
+            "recognition"
+        );
     }
 }

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -23,6 +23,7 @@ carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
 carbide-firmware = { path = "../firmware" }
 carbide-health-report = { path = "../health-report" }
+carbide-instrument = { path = "../instrument" }
 carbide-ipmi = { path = "../ipmi" }
 carbide-metrics-utils = { path = "../metrics-utils" }
 carbide-network = { path = "../network" }
@@ -66,6 +67,7 @@ bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-model = { path = "../api-model", default-features = false, features = [
   "test-support",
 ] }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-harness = { path = "../test-harness" }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-rpc = { path = "../rpc", features = ["test-support"] }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -45,6 +45,35 @@ use super::redfish::RedfishClient;
 
 const BMC_AUTH_RETRY_DURATION: Duration = Duration::from_secs(3);
 
+/// The site explorer moved a device's BMC root password onto the site-wide
+/// credential during ingestion (or failed to). Rotations are infrequent and
+/// security-relevant: the counter is the audit signal by outcome, and the log
+/// line carries the device address plus the error when one occurred.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_site_explorer_bmc_password_rotations_total",
+    component = "site-explorer",
+    log = info,
+    metric = counter,
+    message = "BMC root password rotation finished",
+    describe = "Number of BMC root password rotations onto the site-wide credential, by \
+                outcome"
+)]
+struct BmcPasswordRotationFinished {
+    #[label]
+    outcome: carbide_instrument::Outcome,
+    #[context]
+    bmc_ip_address: SocketAddr,
+    /// The device's stable identity (it keys the vault credential entry).
+    #[context]
+    bmc_mac_address: MacAddress,
+    #[context]
+    vendor: RedfishVendor,
+    /// The rotation failure, when there was one; empty on success.
+    #[context]
+    error: String,
+}
+
 /// An `EndpointExplorer` which uses redfish APIs to query the endpoint
 pub struct BmcEndpointExplorer {
     redfish_client: RedfishClient,
@@ -329,20 +358,26 @@ impl BmcEndpointExplorer {
             // match Forge's sitewide BMC root password (from the factory default).
             // return an error if we cannot log into the machine's BMC using current credentials
             let sitewide_bmc_password = self.get_sitewide_bmc_password().await?;
-            let rotated = self
+            let rotation = self
                 .set_bmc_root_password(
                     bmc_ip_address,
                     vendor,
                     current_bmc_credentials,
                     sitewide_bmc_password,
                 )
-                .await?;
-
-            tracing::info!(
-                %bmc_ip_address, %bmc_mac_address, %vendor,
-                "Site explorer successfully updated the root password for {bmc_mac_address} to the sitewide BMC root password"
-            );
-            rotated
+                .await;
+            carbide_instrument::emit(BmcPasswordRotationFinished {
+                outcome: carbide_instrument::Outcome::from(&rotation),
+                bmc_ip_address,
+                bmc_mac_address,
+                vendor,
+                error: rotation
+                    .as_ref()
+                    .err()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            });
+            rotation?
         };
 
         // set the BMC root credentials in vault for this machine
@@ -1585,5 +1620,76 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
             report1.revision_id,
             report2.revision_id
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::Outcome;
+    use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+
+    use super::*;
+
+    /// One emit per rotation attempt writes the INFO log line and moves
+    /// carbide_site_explorer_bmc_password_rotations_total, split by outcome.
+    #[test]
+    fn bmc_password_rotation_counts_both_outcomes() {
+        let metrics = MetricsCapture::start();
+        let bmc_ip_address: SocketAddr = "10.2.3.4:443".parse().expect("socket address");
+        let bmc_mac_address: MacAddress = "aa:bb:cc:dd:ee:ff".parse().expect("mac address");
+
+        let logs = capture_logs(|| {
+            carbide_instrument::emit(BmcPasswordRotationFinished {
+                outcome: Outcome::Ok,
+                bmc_ip_address,
+                bmc_mac_address,
+                vendor: RedfishVendor::Dell,
+                error: String::new(),
+            });
+            carbide_instrument::emit(BmcPasswordRotationFinished {
+                outcome: Outcome::Error,
+                bmc_ip_address,
+                bmc_mac_address,
+                vendor: RedfishVendor::Dell,
+                error: "unable to log into the BMC".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 2);
+        for log in &logs {
+            assert_eq!(log.level, tracing::Level::INFO);
+            assert_eq!(log.message, "BMC root password rotation finished");
+        }
+        let field = |log: &CapturedLog, name: &str| {
+            log.fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        };
+        assert_eq!(field(&logs[0], "outcome"), Some("ok".to_string()));
+        assert_eq!(
+            field(&logs[0], "bmc_ip_address"),
+            Some("10.2.3.4:443".to_string())
+        );
+        assert_eq!(field(&logs[1], "outcome"), Some("error".to_string()));
+        assert_eq!(
+            field(&logs[1], "error"),
+            Some("unable to log into the BMC".to_string())
+        );
+
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_site_explorer_bmc_password_rotations_total",
+                &[("outcome", "ok")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_site_explorer_bmc_password_rotations_total",
+                &[("outcome", "error")]
+            ),
+            1.0
+        );
     }
 }

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -19,6 +19,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_api_vault_requests_succeeded_total</td><td>counter</td><td>The amount of tls connections that were successful</td></tr>
 <tr><td>carbide_api_vault_token_time_until_refresh_seconds</td><td>gauge</td><td>The amount of time, in seconds, until the vault token is required to be refreshed</td></tr>
 <tr><td>carbide_api_version</td><td>gauge</td><td>Version (git sha, build date, etc) of this service</td></tr>
+<tr><td>carbide_authn_client_cert_rejected_total</td><td>counter</td><td>Number of client certificates rejected during authentication</td></tr>
 <tr><td>carbide_available_ips_count</td><td>gauge</td><td>The total number of available ips in the site</td></tr>
 <tr><td>carbide_client_tcp_connect_attempts_total</td><td>counter</td><td>Number of outbound TCP connect attempts across all HTTP connectors</td></tr>
 <tr><td>carbide_client_tcp_connect_errors_total</td><td>counter</td><td>Number of failed outbound TCP connect attempts across all HTTP connectors</td></tr>
@@ -132,6 +133,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>The number of machines in the system that are running a firmware update.</td></tr>
 <tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>The total count of expected machines by SKU ID and device type</td></tr>
 <tr><td>carbide_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>The amount of Host+DPU pairs that has been identified in the last SiteExplorer run</td></tr>
+<tr><td>carbide_site_explorer_bmc_password_rotations_total</td><td>counter</td><td>Number of BMC root password rotations onto the site-wide credential, by outcome</td></tr>
 <tr><td>carbide_site_explorer_bmc_reset_count</td><td>gauge</td><td>The amount of BMC resets initiated in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_create_machines</td><td>gauge</td><td>Whether site-explorer machine creation is enabled (1) or disabled (0)</td></tr>
 <tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it took to perform create_machines inside site-explorer</td></tr>


### PR DESCRIPTION
You can't alert on a 403 spike today: RBAC denials, bad client certificates, and BMC credential rotations live only in logs -- some only at debug level. This makes those three security signals countable in Prometheus, each paired with the log line it already had.

Three counters from `carbide-instrument`:
- `carbide_auth_denied_total{principal_class, authorizer}` -- now counts both denial paths: the Casbin policy engine and the internal RBAC handler, which previously only logged. The gRPC method stays as log-only context rather than a label, because the path segment is caller-supplied and labeling it would hand external callers control over the metric's series count.
- `carbide_authn_client_cert_rejected_total{reason}` -- a bad client cert was a debug-level log and nothing else, invisible at the fleet's effective log level. Counted once per request, and only when the whole presented chain minted no principal -- a healthy chain's intermediate CA certificates never register false rejections.
- `carbide_site_explorer_bmc_password_rotations_total{outcome}` -- rotations were recorded to the database and the log, counted nowhere.

Notable details:
- Denial audit lines use the new `Principal::audit_identity()`: the concrete machine SPIFFE id stays in the log (which machine was denied), while external-user payloads stay redacted to their group.
- `PrincipalClass` classifies a request's principals by strength: external user > SPIFFE service > SPIFFE machine > trusted certificate > anonymous.
- The rotation event keeps the predecessor log line's `bmc_mac_address` and `vendor` fields -- the MAC is the device's stable identity.
- The Casbin path captures the peer address as a `Copy` `SocketAddr` and formats it only on deny, so the allowed path -- nearly every request -- never allocates for it.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3176
