### PR TITLE
feat: make the stuck-machine mechanisms alertable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "carbide-firmware",
  "carbide-health-metrics",
  "carbide-health-report",
+ "carbide-instrument",
  "carbide-ipmi",
  "carbide-measured-boot",
  "carbide-redfish",

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -48,7 +48,7 @@ use crate::api::{Api, log_machine_id, log_request_data};
 use crate::cfg::file::VpcIsolationBehaviorType;
 use crate::handlers::astra::{get_astra_config, process_astra_config_status};
 use crate::handlers::extension_service;
-use crate::handlers::utils::convert_and_log_machine_id;
+use crate::handlers::utils::{StateHandlerWakeupFailed, WakeupTrigger, convert_and_log_machine_id};
 use crate::{CarbideError, cfg, ethernet_virtualization};
 
 /// vxlan48 is special HBN single vxlan device. It handles networking between machines on the
@@ -999,7 +999,13 @@ pub(crate) async fn record_dpu_network_status(
     if any_observed_version_changed
         && let Err(err) = wakeup_host_state_handler_by_dpu_id(api, &dpu_machine_id).await
     {
-        tracing::warn!(%err, %dpu_machine_id, "Failed to wakeup state handler for host machine");
+        // The host machine could not even be looked up, so the identity in
+        // hand is the reporting DPU rather than the host that stays asleep.
+        carbide_instrument::emit(StateHandlerWakeupFailed {
+            trigger: WakeupTrigger::DpuNetworkStatus,
+            machine_id: dpu_machine_id,
+            err: err.to_string(),
+        });
     }
 
     Ok(Response::new(()))
@@ -1009,15 +1015,21 @@ async fn wakeup_host_state_handler_by_dpu_id(
     api: &Api,
     dpu_machine_id: &MachineId,
 ) -> Result<(), DatabaseError> {
-    let mut txn = api.txn_begin().await?;
     let host_machine =
-        db::machine::lookup_host_machine_ids_by_dpu_ids(&mut txn, &[*dpu_machine_id]).await?;
-    txn.rollback().await?;
-
-    if let Some(host_machine_id) = host_machine.first() {
-        api.machine_state_handler_enqueuer
-            .enqueue_object(host_machine_id)
+        db::machine::lookup_host_machine_ids_by_dpu_ids(&mut api.db_reader(), &[*dpu_machine_id])
             .await?;
+
+    if let Some(host_machine_id) = host_machine.first()
+        && let Err(err) = api
+            .machine_state_handler_enqueuer
+            .enqueue_object(host_machine_id)
+            .await
+    {
+        carbide_instrument::emit(StateHandlerWakeupFailed {
+            trigger: WakeupTrigger::DpuNetworkStatus,
+            machine_id: *host_machine_id,
+            err: err.to_string(),
+        });
     }
 
     Ok(())

--- a/crates/api-core/src/handlers/host_reprovisioning.rs
+++ b/crates/api-core/src/handlers/host_reprovisioning.rs
@@ -24,7 +24,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data, truncate};
-use crate::handlers::utils::convert_and_log_machine_id;
+use crate::handlers::utils::{StateHandlerWakeupFailed, WakeupTrigger, convert_and_log_machine_id};
 
 pub(crate) async fn reset_host_reprovisioning(
     api: &Api,
@@ -226,7 +226,11 @@ pub async fn report_scout_firmware_upgrade_status(
         .enqueue_object(&machine_id)
         .await
     {
-        tracing::warn!(%err, %machine_id, "Failed to wake up state handler for machine");
+        carbide_instrument::emit(StateHandlerWakeupFailed {
+            trigger: WakeupTrigger::ScoutFirmwareUpgradeStatus,
+            machine_id,
+            err: err.to_string(),
+        });
     }
 
     Ok(Response::new(()))

--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -30,7 +30,7 @@ use crate::CarbideError;
 use crate::api::metrics::ApiMetricsEmitter;
 use crate::api::{Api, log_request_data};
 use crate::compat::BuildAndFillLegacyFields;
-use crate::handlers::utils::convert_and_log_machine_id;
+use crate::handlers::utils::{StateHandlerWakeupFailed, WakeupTrigger, convert_and_log_machine_id};
 
 // Records Scout cleanup success/failure and wakes the host state controller.
 // The state controller decides whether cleanup returns to discovery or deprovision flow.
@@ -127,6 +127,7 @@ pub(crate) async fn cleanup_machine_completed(
             .await
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {
+            trigger: WakeupTrigger::CleanupCompleted,
             machine_id,
             err: err.to_string(),
         });
@@ -431,26 +432,6 @@ fn record_reboot_duration_metric(
     );
 }
 
-/// A machine finished rebooting but its state handler could not be woken:
-/// the machine sits idle until the next periodic enqueue, so the rate of
-/// these is a leading "machine stuck" signal.
-#[derive(carbide_instrument::Event)]
-#[event(
-    name = "carbide_state_handler_wakeup_failures_total",
-    component = "nico-api",
-    log = warn,
-    metric = counter,
-    message = "Failed to wake up state handler for machine",
-    describe = "The amount of times a machine's state handler could not be woken after a \
-                scout-reported event"
-)]
-struct StateHandlerWakeupFailed {
-    #[context]
-    machine_id: carbide_uuid::machine::MachineId,
-    #[context]
-    err: String,
-}
-
 // Host has rebooted
 pub(crate) async fn reboot_completed(
     api: &Api,
@@ -480,6 +461,7 @@ pub(crate) async fn reboot_completed(
             .await
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {
+            trigger: WakeupTrigger::RebootCompleted,
             machine_id,
             err: err.to_string(),
         });

--- a/crates/api-core/src/handlers/utils.rs
+++ b/crates/api-core/src/handlers/utils.rs
@@ -33,3 +33,104 @@ pub fn convert_and_log_machine_id(id: Option<&MachineId>) -> Result<MachineId, C
 
     Ok(machine_id)
 }
+
+/// The agent-reported event whose processing tried to wake the machine's
+/// state handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+pub(crate) enum WakeupTrigger {
+    RebootCompleted,
+    CleanupCompleted,
+    ScoutFirmwareUpgradeStatus,
+    DpuNetworkStatus,
+}
+
+/// An agent report was recorded but the machine's state handler could not be
+/// woken: the machine sits idle until the next periodic enqueue, so the rate
+/// of these is a leading "machine stuck" signal.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_state_handler_wakeup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "Failed to wake up state handler for machine",
+    describe = "The amount of times a machine's state handler could not be woken after an \
+                agent-reported event"
+)]
+pub(crate) struct StateHandlerWakeupFailed {
+    #[label]
+    pub(crate) trigger: WakeupTrigger,
+    #[context]
+    pub(crate) machine_id: MachineId,
+    #[context]
+    pub(crate) err: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::*;
+
+    /// One emit writes the WARN line (machine id and error as fields) AND
+    /// moves the counter, with every trigger variant rendering as its
+    /// snake_case label value on both sides.
+    #[test]
+    fn wakeup_failure_logs_and_counts_by_trigger() {
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
+                .expect("a valid machine id");
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            for trigger in [
+                WakeupTrigger::RebootCompleted,
+                WakeupTrigger::CleanupCompleted,
+                WakeupTrigger::ScoutFirmwareUpgradeStatus,
+                WakeupTrigger::DpuNetworkStatus,
+            ] {
+                carbide_instrument::emit(StateHandlerWakeupFailed {
+                    trigger,
+                    machine_id,
+                    err: "enqueue failed".to_string(),
+                });
+            }
+        });
+
+        assert_eq!(logs.len(), 4);
+        for log in &logs {
+            assert_eq!(log.level, tracing::Level::WARN);
+            assert_eq!(log.message, "Failed to wake up state handler for machine");
+        }
+        let field = |log: &carbide_instrument::testing::CapturedLog, name: &str| {
+            log.fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        };
+        assert_eq!(
+            field(&logs[0], "trigger"),
+            Some("reboot_completed".to_string())
+        );
+        assert_eq!(field(&logs[0], "machine_id"), Some(machine_id.to_string()));
+        assert_eq!(field(&logs[0], "err"), Some("enqueue failed".to_string()));
+
+        for label in [
+            "reboot_completed",
+            "cleanup_completed",
+            "scout_firmware_upgrade_status",
+            "dpu_network_status",
+        ] {
+            assert_eq!(
+                metrics.counter_delta(
+                    "carbide_state_handler_wakeup_failures_total",
+                    &[("trigger", label)],
+                ),
+                1.0,
+                "counter for trigger={label}"
+            );
+        }
+    }
+}

--- a/crates/api-core/src/machine_update_manager/host_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/host_firmware.rs
@@ -128,8 +128,16 @@ impl MachineUpdateModule for HostFirmwareUpdate {
     async fn update_metrics(
         &self,
         pool: &sqlx::Pool<sqlx::Postgres>,
-        _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<()> {
+        let exhausted_retries = snapshots
+            .values()
+            .filter(|snapshot| snapshot.managed_state.host_repro_retries_exhausted())
+            .count();
+        self.metrics
+            .exhausted_reprovision_retries
+            .store(exhausted_retries as u64, Ordering::Relaxed);
+
         let mut txn = db::Transaction::begin(pool).await?;
         match db::host_machine_update::find_upgrade_needed(
             &mut txn,
@@ -243,6 +251,7 @@ impl fmt::Display for HostFirmwareUpdate {
 pub struct HostFirmwareUpdateMetrics {
     pub pending_firmware_updates: Arc<AtomicU64>,
     pub active_firmware_updates: Arc<AtomicU64>,
+    pub exhausted_reprovision_retries: Arc<AtomicU64>,
 }
 
 impl HostFirmwareUpdateMetrics {
@@ -250,12 +259,14 @@ impl HostFirmwareUpdateMetrics {
         HostFirmwareUpdateMetrics {
             pending_firmware_updates: Arc::new(AtomicU64::new(0)),
             active_firmware_updates: Arc::new(AtomicU64::new(0)),
+            exhausted_reprovision_retries: Arc::new(AtomicU64::new(0)),
         }
     }
 
     pub fn register_callbacks(&self, meter: &Meter) {
         let pending_firmware_updates = self.pending_firmware_updates.clone();
         let active_firmware_updates = self.active_firmware_updates.clone();
+        let exhausted_reprovision_retries = self.exhausted_reprovision_retries.clone();
         meter
             .u64_observable_gauge("carbide_pending_host_firmware_update_count")
             .with_description(
@@ -272,6 +283,14 @@ impl HostFirmwareUpdateMetrics {
             )
             .with_callback(move |observer|
                 observer.observe(active_firmware_updates.load(Ordering::Relaxed), &[]))
+            .build();
+        meter
+            .u64_observable_gauge("carbide_exhausted_reprovision_retry_count")
+            .with_description(
+                "Number of host machines in the system whose host firmware upgrade retry budget is exhausted.",
+            )
+            .with_callback(move |observer|
+                observer.observe(exhausted_reprovision_retries.load(Ordering::Relaxed), &[]))
             .build();
     }
 }

--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -21,14 +21,15 @@ use std::time::Duration;
 
 use carbide_firmware::test_support::script_setup;
 use carbide_machine_controller::config::{FirmwareGlobal, TimePeriod};
-use carbide_machine_controller::handler::MAX_FIRMWARE_UPGRADE_RETRIES;
 use common::api_fixtures::instance::TestInstance;
 use common::api_fixtures::{
     self, TestEnv, TestManagedHost, create_test_env_with_overrides, get_config,
 };
 use model::firmware::{Firmware, FirmwareComponent, FirmwareComponentType, FirmwareEntry};
 use model::instance::status::tenant::TenantState;
-use model::machine::{HostReprovisionState, InstanceState, ManagedHostState};
+use model::machine::{
+    HostReprovisionState, InstanceState, MAX_FIRMWARE_UPGRADE_RETRIES, ManagedHostState,
+};
 use model::machine_update_module::HOST_FW_UPDATE_HEALTH_REPORT_SOURCE;
 use model::test_support::HardwareInfoTemplate;
 use regex::Regex;
@@ -1525,6 +1526,16 @@ async fn test_script_upgrade_failure(pool: sqlx::PgPool) -> CarbideResult<()> {
         panic!("Not in FailedFirmwareUpgrade");
     };
     txn.commit().await.unwrap();
+
+    // The machine with the exhausted retry budget surfaces on the update
+    // manager's gauge rather than in per-pass logs.
+    update_manager.run_single_iteration().await.unwrap();
+    assert_eq!(
+        env.test_meter
+            .formatted_metric("carbide_exhausted_reprovision_retry_count")
+            .unwrap(),
+        "1"
+    );
 
     Ok(())
 }

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -23,6 +23,7 @@ use ::rpc::forge::{
     InstanceDpuExtensionServiceConfig, InstanceDpuExtensionServicesConfig,
     ManagedHostNetworkConfigRequest, ManagedHostNetworkStatusRequest,
 };
+use carbide_instrument::testing::MetricsCapture;
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use carbide_uuid::machine::MachineId;
 use common::api_fixtures::network_segment::{
@@ -243,6 +244,38 @@ async fn test_record_dpu_network_status_keeps_use_admin_network_changed_without_
     assert_eq!(
         use_admin_network_changed(&env, dpu_machine_id).await,
         Some(true)
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_record_dpu_network_status_counts_failed_host_wakeup(pool: sqlx::PgPool) {
+    let env = api_fixtures::create_test_env(pool.clone()).await;
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+
+    // Remove the state-handler queue table so the host wakeup enqueue fails
+    // while the status report itself stays healthy.
+    sqlx::query("DROP TABLE machine_state_controller_queued_objects")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let metrics = MetricsCapture::start();
+    // A never-before-observed network config version registers as a change,
+    // which is what prompts the host state-handler wakeup.
+    record_dpu_network_status(
+        &env,
+        dpu_machine_id,
+        Some("wakeup-probe-version".to_string()),
+    )
+    .await;
+
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_state_handler_wakeup_failures_total",
+            &[("trigger", "dpu_network_status")],
+        ),
+        1.0
     );
 }
 

--- a/crates/api-core/tests/integration/scout_firmware_upgrade_status.rs
+++ b/crates/api-core/tests/integration/scout_firmware_upgrade_status.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_instrument::testing::MetricsCapture;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use model::firmware::FirmwareComponentType;
@@ -194,6 +195,35 @@ async fn rejects_stale_task_id(pool: PgPool) {
     };
     assert_eq!(upgrade_task_id, CURRENT_TASK_ID);
     assert!(result.is_none());
+}
+
+#[sqlx_test]
+async fn counts_failed_state_handler_wakeup(pool: PgPool) {
+    const UPGRADE_TASK_ID: &str = "scout-upgrade-task-id";
+
+    let TestContext { env, mh } = init(pool.clone()).await;
+    mh.advance_state(waiting_state(UPGRADE_TASK_ID)).await;
+
+    // Remove the state-handler queue table so the post-commit wakeup enqueue
+    // fails while the report path itself stays healthy.
+    sqlx::query("DROP TABLE machine_state_controller_queued_objects")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let metrics = MetricsCapture::start();
+    env.api()
+        .report_scout_firmware_upgrade_status(Request::new(status_request(&mh, UPGRADE_TASK_ID)))
+        .await
+        .expect("a failed state-handler wakeup must not fail the status report");
+
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_state_handler_wakeup_failures_total",
+            &[("trigger", "scout_firmware_upgrade_status")],
+        ),
+        1.0
+    );
 }
 
 #[sqlx_test]

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1303,6 +1303,11 @@ impl std::fmt::Display for ValidationState {
     }
 }
 
+/// The retry budget for a failed host firmware upgrade: once
+/// [`ManagedHostState::HostReprovision`] has consumed this many retries, the
+/// machine stays in its failure state until an operator intervenes.
+pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 5;
+
 impl ManagedHostState {
     pub fn as_reprovision_state(&self, dpu_id: &MachineId) -> Option<&ReprovisionState> {
         match self {
@@ -1328,6 +1333,17 @@ impl ManagedHostState {
             ManagedHostState::HostReprovision { retry_count, .. } => *retry_count,
             _ => 0,
         }
+    }
+
+    /// True when this machine is in host reprovisioning with no
+    /// firmware-upgrade retry budget left (see
+    /// [`MAX_FIRMWARE_UPGRADE_RETRIES`]).
+    pub fn host_repro_retries_exhausted(&self) -> bool {
+        matches!(
+            self,
+            ManagedHostState::HostReprovision { retry_count, .. }
+                if *retry_count >= MAX_FIRMWARE_UPGRADE_RETRIES
+        )
     }
 }
 

--- a/crates/machine-controller/Cargo.toml
+++ b/crates/machine-controller/Cargo.toml
@@ -38,6 +38,7 @@ carbide-health-report = { path = "../health-report", default-features = false }
 carbide-health-metrics = { path = "../health-metrics" }
 carbide-utils = { path = "../utils", default-features = false }
 carbide-firmware = { path = "../firmware", default-features = false }
+carbide-instrument = { path = "../instrument" }
 carbide-ipmi = { path = "../ipmi", default-features = false }
 carbide-measured-boot = { path = "../measured-boot", default-features = false }
 carbide-redfish = { path = "../redfish", default-features = false }
@@ -73,6 +74,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 version-compare = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-test-harness = { path = "../test-harness" }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -75,14 +75,14 @@ use model::machine::{
     CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver,
     DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
     HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
-    InstanceState, LockdownInfo, LockdownState, Machine, MachineLastRebootRequested,
-    MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState,
-    MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
-    NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
-    PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext, SecureEraseBossState,
-    SetBootOrderInfo, SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
-    UefiSetupInfo, UefiSetupState, UnlockHostState, ValidationState,
-    dpf_based_dpu_provisioning_possible, get_display_ids,
+    InstanceState, LockdownInfo, LockdownState, MAX_FIRMWARE_UPGRADE_RETRIES, Machine,
+    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineNextStateResolver,
+    MachineState, MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot,
+    MeasuringState, NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation,
+    PowerDrainState, PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext,
+    SecureEraseBossState, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
+    SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState, UnlockHostState,
+    ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
 };
 use model::power_manager::PowerHandlingOutcome;
 use model::predicted_machine_interface::PredictedMachineInterface;
@@ -144,16 +144,33 @@ use crate::write_ops::MachineWriteOp;
 const NOT_FOUND: u16 = 404;
 
 #[cfg(not(test))]
-pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 5;
-
-#[cfg(test)]
-pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 2; // Faster for tests
-
-#[cfg(not(test))]
 pub const MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES: u32 = 5;
 
 #[cfg(test)]
 pub const MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES: u32 = 2; // Faster for tests
+
+/// A failed host firmware upgrade is being retried. `attempt` is the retry
+/// about to run (1-based), out of a budget of [`MAX_FIRMWARE_UPGRADE_RETRIES`].
+/// Machines whose budget ran out are visible on the
+/// `carbide_exhausted_reprovision_retry_count` gauge instead.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_host_reprovision_retries_total",
+    component = "machine-controller",
+    log = info,
+    metric = counter,
+    message = "Retrying the host firmware upgrade",
+    describe = "Number of times a failed host firmware upgrade was retried during host \
+                reprovisioning"
+)]
+struct HostFirmwareUpgradeRetried {
+    #[context]
+    machine_id: MachineId,
+    #[context]
+    attempt: u32,
+    #[context]
+    error: String,
+}
 
 // Compute the API-side deadline for a scout firmware upgrade from scout's
 // timeout envelope: fixed script download timeout, script execution timeout,
@@ -8287,7 +8304,11 @@ impl HostUpgradeState {
                     Ok(StateHandlerOutcome::do_nothing())
                 }
             }
-            HostReprovisionState::FailedFirmwareUpgrade { report_time, .. } => {
+            HostReprovisionState::FailedFirmwareUpgrade {
+                report_time,
+                reason,
+                ..
+            } => {
                 // A special case in Rackfirmware upgrade to handle FailedFirmwareUpgrade
                 // Accept a freshly-issued Host Reprovision request that arrives while we are
                 // sitting in FailedFirmwareUpgrade. `trigger_host_reprovisioning_request`
@@ -8324,10 +8345,13 @@ impl HostUpgradeState {
                         .site_config
                         .firmware_global
                         .host_firmware_upgrade_retry_interval;
-                let should_retry = can_retry && waited_enough;
 
-                if should_retry {
-                    tracing::info!("Retrying firmware upgrade on {}", state.host_snapshot.id);
+                if can_retry && waited_enough {
+                    carbide_instrument::emit(HostFirmwareUpgradeRetried {
+                        machine_id: *machine_id,
+                        attempt: retry_count + 1,
+                        error: reason.clone().unwrap_or_default(),
+                    });
 
                     let reprovision_state = HostReprovisionState::CheckingFirmwareV2 {
                         firmware_type: None,
@@ -8336,8 +8360,14 @@ impl HostUpgradeState {
                     Ok(StateHandlerOutcome::transition(
                         scenario.actual_new_state(reprovision_state, retry_count + 1),
                     ))
+                } else if can_retry {
+                    // Still inside the retry interval; a later pass decides.
+                    Ok(StateHandlerOutcome::do_nothing())
                 } else {
-                    // doesn't make sense to retry anymore, remain in this failure state
+                    // No retry budget left; remain in this failure state until
+                    // an operator intervenes. Exhausted machines are counted
+                    // by the carbide_exhausted_reprovision_retry_count gauge,
+                    // so nothing is logged per pass.
                     Ok(StateHandlerOutcome::do_nothing())
                 }
             }
@@ -11901,6 +11931,7 @@ async fn get_power_state(redfish_client: &dyn Redfish) -> Result<PowerState, Sta
 mod tests {
     use std::str::FromStr;
 
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use model::firmware::FirmwareComponent;
     use model::site_explorer::{
         EndpointExplorationReport, EndpointType, Inventory, PreingestionState, Service,
@@ -11908,6 +11939,43 @@ mod tests {
     use regex::Regex;
 
     use super::*;
+
+    /// One emit per actual retry: the INFO line carries the machine, the
+    /// 1-based attempt, and the failure it recovers from, and the unlabeled
+    /// counter moves by one.
+    #[test]
+    fn host_firmware_upgrade_retry_logs_and_counts() {
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
+                .unwrap();
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            carbide_instrument::emit(HostFirmwareUpgradeRetried {
+                machine_id,
+                attempt: 1,
+                error: "scout upgrade failed".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::INFO);
+        assert_eq!(logs[0].message, "Retrying the host firmware upgrade");
+        let field = |name: &str| {
+            logs[0]
+                .fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        };
+        assert_eq!(field("machine_id"), Some(machine_id.to_string()));
+        assert_eq!(field("attempt"), Some("1".to_string()));
+        assert_eq!(field("error"), Some("scout upgrade failed".to_string()));
+        assert_eq!(
+            metrics.counter_delta("carbide_host_reprovision_retries_total", &[]),
+            1.0
+        );
+    }
 
     #[test]
     fn scout_firmware_upgrade_deadline_accounts_for_each_artifact() {

--- a/crates/machine-controller/tests/integration/firmware_upgrade_completion.rs
+++ b/crates/machine-controller/tests/integration/firmware_upgrade_completion.rs
@@ -15,11 +15,15 @@
  * limitations under the License.
  */
 
+use carbide_instrument::testing::MetricsCapture;
 use carbide_machine_controller::handler::MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES;
+use carbide_test_harness::CarbideConfig;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use model::firmware::FirmwareComponentType;
-use model::machine::{HostReprovisionState, ManagedHostState, ScoutUpgradeResult};
+use model::machine::{
+    HostReprovisionState, MAX_FIRMWARE_UPGRADE_RETRIES, ManagedHostState, ScoutUpgradeResult,
+};
 use model::test_support::ManagedHostConfig;
 
 use crate::env::Env;
@@ -31,7 +35,14 @@ struct TestContext {
 
 impl TestContext {
     async fn init(pool: PgPool) -> Self {
-        let env = Env::builder(pool).build().await;
+        Self::init_with_runtime(pool, |_| {}).await
+    }
+
+    async fn init_with_runtime(pool: PgPool, configure: impl FnOnce(&mut CarbideConfig)) -> Self {
+        let env = Env::builder(pool)
+            .configure_runtime(configure)
+            .build()
+            .await;
         let domain = env.test_harness.test_domain().await;
         let network_controller = env.test_harness.network_controller();
         let underlay_segment = network_controller.create_underlay_segment(&domain).await;
@@ -60,6 +71,12 @@ trait TestManagedHostFirmwareExt {
         &self,
         previous_reset_time: i64,
         reset_retry_count: u32,
+    );
+
+    async fn put_in_failed_firmware_upgrade(
+        &self,
+        report_time: chrono::DateTime<chrono::Utc>,
+        retry_count: u32,
     );
 }
 
@@ -100,6 +117,22 @@ impl TestManagedHostFirmwareExt for TestManagedHost {
                 reset_retry_count,
             },
             retry_count: 0,
+        })
+        .await;
+    }
+
+    async fn put_in_failed_firmware_upgrade(
+        &self,
+        report_time: chrono::DateTime<chrono::Utc>,
+        retry_count: u32,
+    ) {
+        self.advance_state(ManagedHostState::HostReprovision {
+            reprovision_state: HostReprovisionState::FailedFirmwareUpgrade {
+                firmware_type: FirmwareComponentType::Bmc,
+                report_time: Some(report_time),
+                reason: Some("scout upgrade failed".to_string()),
+            },
+            retry_count,
         })
         .await;
     }
@@ -318,4 +351,92 @@ async fn scout_upgrade_before_deadline_waits(pool: PgPool) {
         ),
         "expected to remain in WaitingForScoutUpgrade, got {reprovision_state:?}",
     );
+}
+
+/// Drives the `FailedFirmwareUpgrade` arm through all three of its retry
+/// outcomes: inside the retry interval nothing moves, past the interval one
+/// retry is consumed and counted, and with the budget exhausted the machine
+/// parks in the failure state without another count. The log side of the
+/// retry emit is covered by the unit test next to the event declaration.
+#[sqlx_test]
+async fn failed_firmware_upgrade_retries_until_the_budget_is_exhausted(pool: PgPool) {
+    const RETRIES_TOTAL: &str = "carbide_host_reprovision_retries_total";
+    let retry_interval = chrono::TimeDelta::hours(1);
+    let TestContext { mut env, mh } = TestContext::init_with_runtime(pool, |config| {
+        config.firmware_global.host_firmware_upgrade_retry_interval = retry_interval;
+    })
+    .await;
+    let metrics = MetricsCapture::start();
+
+    // Still inside the retry interval: the machine stays put and nothing is
+    // counted.
+    mh.put_in_failed_firmware_upgrade(chrono::Utc::now(), 0)
+        .await;
+    env.run_single_iteration().await;
+    let machine = mh.host.machine().await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state,
+        retry_count,
+    } = machine.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    assert!(
+        matches!(
+            reprovision_state,
+            HostReprovisionState::FailedFirmwareUpgrade { .. }
+        ),
+        "expected to remain in FailedFirmwareUpgrade, got {reprovision_state:?}",
+    );
+    assert_eq!(*retry_count, 0);
+    assert_eq!(metrics.counter_delta(RETRIES_TOTAL, &[]), 0.0);
+
+    // Past the retry interval with budget left: one retry is taken and
+    // counted, and the consumed attempt lands in the state's retry_count.
+    mh.put_in_failed_firmware_upgrade(chrono::Utc::now() - retry_interval * 2, 0)
+        .await;
+    env.run_single_iteration().await;
+    let machine = mh.host.machine().await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state,
+        retry_count,
+    } = machine.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    assert!(
+        matches!(
+            reprovision_state,
+            HostReprovisionState::CheckingFirmwareV2 { .. }
+        ),
+        "expected CheckingFirmwareV2, got {reprovision_state:?}",
+    );
+    assert_eq!(*retry_count, 1);
+    assert_eq!(metrics.counter_delta(RETRIES_TOTAL, &[]), 1.0);
+
+    // Past the retry interval with the budget exhausted: the machine parks in
+    // the failure state and the counter does not move again.
+    mh.put_in_failed_firmware_upgrade(
+        chrono::Utc::now() - retry_interval * 2,
+        MAX_FIRMWARE_UPGRADE_RETRIES,
+    )
+    .await;
+    env.run_single_iteration().await;
+    let machine = mh.host.machine().await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state,
+        retry_count,
+    } = machine.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    assert!(
+        matches!(
+            reprovision_state,
+            HostReprovisionState::FailedFirmwareUpgrade { .. }
+        ),
+        "expected to remain in FailedFirmwareUpgrade, got {reprovision_state:?}",
+    );
+    assert_eq!(*retry_count, MAX_FIRMWARE_UPGRADE_RETRIES);
+    assert_eq!(metrics.counter_delta(RETRIES_TOTAL, &[]), 1.0);
 }

--- a/crates/state-controller/src/controller/processor.rs
+++ b/crates/state-controller/src/controller/processor.rs
@@ -564,6 +564,9 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         self.stats_since_last_log.num_completed_tasks += 1;
         if task_result.metrics.common.error.is_some() {
             self.stats_since_last_log.num_errored_tasks += 1;
+            if let Some(emitter) = &self.metric_emitter {
+                emitter.errored_tasks_counter.add(1, &[]);
+            }
         }
 
         self.in_flight.remove(&task_result.object_id);
@@ -789,6 +792,7 @@ pub(super) struct ProcessorMetricsEmitter {
     dispatched_tasks_counter: Counter<u64>,
     completed_tasks_counter: Counter<u64>,
     requeued_tasks_counter: Counter<u64>,
+    errored_tasks_counter: Counter<u64>,
     db: sqlx_query_tracing::DatabaseMetricEmitters,
 }
 
@@ -825,12 +829,20 @@ impl ProcessorMetricsEmitter {
             ))
             .build();
 
+        let errored_tasks_counter = meter
+            .u64_counter(format!("{object_type}_object_tasks_errored"))
+            .with_description(format!(
+                "Number of object handling tasks that have completed with an error for objects of type {object_type}"
+            ))
+            .build();
+
         Self {
             iteration_latency,
             db,
             dispatched_tasks_counter,
             completed_tasks_counter,
             requeued_tasks_counter,
+            errored_tasks_counter,
         }
     }
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -39,6 +39,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_endpoint_exploration_step_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one endpoint exploration step</td></tr>
 <tr><td>carbide_endpoint_exploration_success_count</td><td>gauge</td><td>The amount of endpoint explorations that have been successful</td></tr>
 <tr><td>carbide_endpoint_explorations_count</td><td>gauge</td><td>The amount of endpoint explorations that have been attempted</td></tr>
+<tr><td>carbide_exhausted_reprovision_retry_count</td><td>gauge</td><td>Number of host machines in the system whose host firmware upgrade retry budget is exhausted.</td></tr>
 <tr><td>carbide_external_call_duration_milliseconds</td><td>histogram</td><td>Duration of outbound calls by backend, operation, and outcome; the _count series, split by outcome, gives the request and error rates.</td></tr>
 <tr><td>carbide_gpus_in_use_count</td><td>gauge</td><td>The total number of GPUs that are actively used by tenants in instances in the NICo deployment</td></tr>
 <tr><td>carbide_gpus_total_count</td><td>gauge</td><td>The total number of GPUs available in the NICo deployment</td></tr>
@@ -76,6 +77,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_machines_object_tasks_completed_total</td><td>counter</td><td>The amount of object handling tasks that have been completed for objects of type carbide_machines</td></tr>
 <tr><td>carbide_machines_object_tasks_dispatched_total</td><td>counter</td><td>The amount of types that object handling tasks that have been dequeued and dispatched for processing for objects of type carbide_machines</td></tr>
 <tr><td>carbide_machines_object_tasks_enqueued_total</td><td>counter</td><td>The amount of types that object handling tasks that have been freshly enqueued for objects of type carbide_machines</td></tr>
+<tr><td>carbide_machines_object_tasks_errored_total</td><td>counter</td><td>Number of object handling tasks that have completed with an error for objects of type carbide_machines</td></tr>
 <tr><td>carbide_machines_object_tasks_requeued_total</td><td>counter</td><td>The amount of object handling tasks that have been requeued for objects of type carbide_machines</td></tr>
 <tr><td>carbide_machines_per_state</td><td>gauge</td><td>The number of carbide_machines in the system with a given state</td></tr>
 <tr><td>carbide_machines_per_state_above_sla</td><td>gauge</td><td>The number of carbide_machines in the system which had been longer in a state than allowed per SLA</td></tr>


### PR DESCRIPTION
The two mechanisms that strand a machine are invisible to alerting today: a failed state-handler wake-up means the machine silently stops being driven, and a host that exhausts its firmware-upgrade retry budget just sits there -- both are log lines at warn or quieter. This makes both visible to Prometheus, and completes the state-controller counter family with the error count that was always logged but never metered.

Three signals, split by the framework's occurrences-versus-state rule:
- `carbide_state_handler_wakeup_failures_total{trigger}` -- gains a `trigger` label saying which path failed to wake the machine (reboot completion, cleanup completion, scout firmware status, DPU network status) and now covers every failure class at all four sites; the DPU path previously logged without counting.
- `carbide_host_reprovision_retries_total` -- counts each actual retry as it happens, logged at the site's historical info level with the attempt number.
- `carbide_exhausted_reprovision_retry_count` -- "how many hosts are out of retry budget right now" is state, so it's an observable gauge refreshed beside the other firmware-update gauges the update manager already maintains. A gauge keeps reporting stuck hosts even if the controller that would retry them wedges -- a per-pass counter would read zero at exactly the wrong moment.
- ..and every state controller now exports `<object>_object_tasks_errored_total` beside its dispatched/completed/requeued siblings; the per-iteration log always had an `errored_tasks` field, now the metric family does too.

Notable details:
- `machine-controller`'s `FailedFirmwareUpgrade` arm splits three ways -- retried, exhausted, still waiting out the retry interval -- and only the retry emits: waiting and exhausted passes are silent, with the gauge holding the stuck-state signal, so a stranded host no longer means a warn line on every handler pass.
- The wake-up event is shared from `handlers/utils.rs`; the DPU path's host lookup now reads through `db_reader()` directly instead of opening a transaction it only ever rolled back.
- `MAX_FIRMWARE_UPGRADE_RETRIES` moves to `api-model` beside the state it governs, so the controller and the update manager share one budget definition (`host_repro_retries_exhausted()`).
- Coverage: emit-level unit tests, two DB-backed wake-up site tests, an arm-level test driving still-waiting, retried, and exhausted passes through the real handler, and a gauge assertion after exhaustion.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3175
