### PR TITLE
fix(rest-api): Revise response for invalid Site ID sent in ExpectedMachine creation

### DIFF
--- a/rest-api/api/pkg/api/handler/expectedmachine.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine.go
@@ -158,6 +158,9 @@ func (cemh CreateExpectedMachineHandler) Handle(c echo.Context) error {
 	// Retrieve the Site from the DB
 	site, err := common.GetSiteFromIDString(ctx, nil, apiRequest.SiteID, cemh.dbSession)
 	if err != nil {
+		if errors.Is(err, common.ErrInvalidID) {
+			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Site ID specified in request data is not valid", nil)
+		}
 		if errors.Is(err, cdb.ErrDoesNotExist) {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Site specified in request data does not exist", nil)
 		}

--- a/rest-api/api/pkg/api/handler/expectedmachine_test.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine_test.go
@@ -194,10 +194,11 @@ func TestCreateExpectedMachineHandler_Handle(t *testing.T) {
 
 	// Test cases
 	tests := []struct {
-		name           string
-		requestBody    model.APIExpectedMachineCreateRequest
-		setupContext   func(c echo.Context)
-		expectedStatus int
+		name             string
+		requestBody      model.APIExpectedMachineCreateRequest
+		setupContext     func(c echo.Context)
+		expectedStatus   int
+		expectedErrorMsg *string
 	}{
 		{
 			name: "successful creation",
@@ -283,6 +284,21 @@ func TestCreateExpectedMachineHandler_Handle(t *testing.T) {
 				c.SetParamValues(org)
 			},
 			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "site ID is empty",
+			requestBody: model.APIExpectedMachineCreateRequest{
+				SiteID:              "",
+				BmcMacAddress:       "00:11:22:33:44:88",
+				ChassisSerialNumber: "CHASSIS127",
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus:   http.StatusBadRequest,
+			expectedErrorMsg: cutil.GetPtr("Site ID specified in request data is not valid"),
 		},
 		{
 			name: "cannot create on unmanaged site",
@@ -402,6 +418,8 @@ func TestCreateExpectedMachineHandler_Handle(t *testing.T) {
 						assert.Equal(t, *tt.requestBody.BmcIpAddress, *response.BmcIpAddress, "BmcIpAddress in response should match request")
 					}
 				}
+			} else if tt.expectedErrorMsg != nil {
+				assert.Contains(t, rec.Body.String(), *tt.expectedErrorMsg, fmt.Sprintf("Expected: %s, got: %s", *tt.expectedErrorMsg, rec.Body.String()))
 			}
 		})
 	}


### PR DESCRIPTION
Individual Expected Machine creation request expects a Site ID, but omitting the Site ID results in HTTP 500 response. This PR changes the response code to 400 and identifies the issue in response.

## Related issues
Internal

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
