### PR TITLE
feat(site-explorer): create power shelves by default

### DIFF
--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -338,10 +338,23 @@ plus thresholds for DPU agent compliance. Operators flip this from
 
 ### Site Explorer
 
-`[site_explorer].run_interval` controls how often background hardware
-discovery scans run. `[site_explorer].create_machines` toggles whether
-discovered hardware is auto-registered as machines (useful to disable in
-manual-onboarding environments).
+`[site_explorer]` settings:
+
+- `run_interval` — how often background hardware discovery scans run.
+- `create_machines` — whether discovered hardware is auto-registered as
+  machines (on by default; useful to disable in manual-onboarding
+  environments).
+- `create_switches` / `create_power_shelves` — the corresponding toggles for
+  switches and power shelves (both on by default).
+- `explore_power_shelves_from_static_ip` — lets a declared power shelf with
+  no DHCP lease be discovered at its static `expected_power_shelves` IP (on
+  by default).
+
+Site Explorer auto-creation is additionally gated per device on a matching
+expected-hardware record (`expected_machines`, `expected_switches`,
+`expected_power_shelves`), so it only ingests declared hardware; other
+registration paths (such as DPU agent self-registration via
+`DiscoverMachine`) are separate.
 
 ### TLS / transport — `[tls]` and `listen_mode`
 
@@ -1180,6 +1193,8 @@ on or off.
 | SPDM | siteConfig | `[spdm].enabled` | off | Hardware attestation via NRAS. |
 | Rack Management | siteConfig | `rack_management_enabled = true` | off | Standalone infrastructure manager mode (GB200/GB300/VR144). |
 | Site Explorer machine auto-creation | siteConfig | `[site_explorer].create_machines` | on | Disable for manual-onboarding environments. |
+| Site Explorer switch / power shelf auto-creation | siteConfig | `[site_explorer].create_switches` / `[site_explorer].create_power_shelves` | on | Ingests only declared hardware (`expected_switches` / `expected_power_shelves` records). Disable to pause switch or power shelf ingestion site-wide. |
+| Site Explorer power shelf static-IP discovery | siteConfig | `[site_explorer].explore_power_shelves_from_static_ip` | on | Discovers declared shelves at their `expected_power_shelves` static IP when they have no DHCP lease. Creation still requires `create_power_shelves`. |
 | Firmware autoupdate | siteConfig | `[firmware_global].autoupdate` | off | Enable once the fleet's firmware baseline is stable. |
 | Component Manager (compute trays / NvLink switches / power shelves) | siteConfig | `[component_manager]` present | off | GB200/GB300 sites with managed compute, power, and switch fabric. RMS backends require rack profile data for node type resolution. |
 | Auto-repair plugin | siteConfig | `[auto_machine_repair_plugin]` | off | Enable per fault class as fleet maturity grows. |

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -302,12 +302,12 @@ flows.
 | `reset_rate_limit` | `Duration` | `1h` | Minimum time between SiteExplorer-initiated BMC resets. |
 | `admin_segment_type_non_dpu` | `bool` | `false` | Non-DPU hosts use `HostInband` admin segment type. |
 | `allocate_secondary_vtep_ip` | `bool` | `false` | Allocate secondary VTEP IP for GENEVE traffic intercept. |
-| `create_power_shelves` | `bool` | `false` | Auto-create Power Shelf state machines. |
-| `explore_power_shelves_from_static_ip` | `bool` | `false` | Discover power shelves via static IP. |
+| `create_power_shelves` | `bool` | `true` | Auto-create Power Shelf state machines for explored shelves with a matching `expected_power_shelves` record. |
+| `explore_power_shelves_from_static_ip` | `bool` | `true` | Discover declared power shelves at their `expected_power_shelves` static IP (no DHCP lease required); creation still requires `create_power_shelves`. |
 | `power_shelves_created_per_run` | `u64` | `1` | Max power shelves created per run. |
-| `create_switches` | `bool` | `true` | Auto-create Switch state machines. |
+| `create_switches` | `bool` | `true` | Auto-create Switch state machines for explored switches with a matching `expected_switches` record. |
 | `switches_created_per_run` | `u64` | `9` | Max switches created per run. |
-| `explore_mode` | `SiteExplorerExploreMode` | `LibRedfish` | Redfish backend: `libredfish`, `nv-redfish`, or `compare-result`. |
+| `explore_mode` | `SiteExplorerExploreMode` | `NvRedfish` | Redfish backend: `libredfish`, `nv-redfish`, or `compare-result`. |
 | `dpu_mode` | `Option<DpuMode>` | — | Site-wide DPU operating mode. When set, applies to every host that doesn't declare a per-host `ExpectedMachine.dpu_mode` override. |
 
 ### `StateControllerConfig`

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3267,7 +3267,7 @@ mod tests {
                 concurrent_explorations: 10,
                 explorations_per_run: 12,
                 create_machines: Arc::new(false.into()),
-                machines_created_per_run: 1,
+                machines_created_per_run: 4,
                 override_target_ip: None,
                 override_target_port: None,
                 bmc_proxy: carbide_site_explorer::config::bmc_proxy(None),
@@ -3282,7 +3282,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
-                explore_mode: SiteExplorerExploreMode::LibRedfish,
+                explore_mode: SiteExplorerExploreMode::NvRedfish,
             }
         );
         assert_eq!(
@@ -3479,7 +3479,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
-                explore_mode: SiteExplorerExploreMode::LibRedfish,
+                explore_mode: SiteExplorerExploreMode::NvRedfish,
             }
         );
 
@@ -3823,7 +3823,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
-                explore_mode: SiteExplorerExploreMode::LibRedfish,
+                explore_mode: SiteExplorerExploreMode::NvRedfish,
             }
         );
 
@@ -3995,6 +3995,25 @@ mod tests {
         // Make sure that if we let serde pick the defaults, it matches Default::default().
         let deserialized = serde_json::from_str::<SiteExplorerConfig>("{}")?;
         assert_eq!(deserialized, SiteExplorerConfig::default());
+        Ok(())
+    }
+
+    /// Every hardware class SiteExplorer can identify is ingested by default:
+    /// a config whose `[site_explorer]` section omits the creation flags gets
+    /// the same behavior as one with no section at all. Creation stays gated
+    /// per device on a matching expected-hardware record, so these defaults
+    /// only ingest declared hardware.
+    #[test]
+    fn site_explorer_creation_flags_default_on() -> eyre::Result<()> {
+        let config = serde_json::from_str::<SiteExplorerConfig>("{}")?;
+        assert!(config.create_machines.load(AtomicOrdering::Relaxed));
+        assert!(config.create_switches.load(AtomicOrdering::Relaxed));
+        assert!(config.create_power_shelves.load(AtomicOrdering::Relaxed));
+        assert!(
+            config
+                .explore_power_shelves_from_static_ip
+                .load(AtomicOrdering::Relaxed)
+        );
         Ok(())
     }
 

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -145,7 +145,9 @@ pub struct SiteExplorerConfig {
     #[serde(default)]
     pub allocate_secondary_vtep_ip: bool,
 
-    /// Whether SiteExplorer should create Power Shelf state machine
+    /// Whether SiteExplorer should create PowerShelf objects for explored power
+    /// shelves that match an `expected_power_shelves` record. Defaults to true;
+    /// set false to disable power shelf ingestion site-wide.
     #[serde(
         default = "SiteExplorerConfig::default_create_power_shelves",
         deserialize_with = "deserialize_arc_atomic_bool",
@@ -153,7 +155,10 @@ pub struct SiteExplorerConfig {
     )]
     pub create_power_shelves: Arc<AtomicBool>,
 
-    /// Whether SiteExplorer should create Power Shelf state machine from static IP
+    /// Whether SiteExplorer should explore power shelves reachable only at
+    /// their `expected_power_shelves` static IP (no DHCP lease) and mark
+    /// them eligible for ingestion. Creation stays gated by
+    /// `create_power_shelves`. Defaults to true.
     #[serde(
         default = "SiteExplorerConfig::default_explore_power_shelves_from_static_ip",
         deserialize_with = "deserialize_arc_atomic_bool",
@@ -166,7 +171,9 @@ pub struct SiteExplorerConfig {
     #[serde(default = "SiteExplorerConfig::default_power_shelves_created_per_run")]
     pub power_shelves_created_per_run: u64,
 
-    /// Whether SiteExplorer should create Switch state machine
+    /// Whether SiteExplorer should create Switch objects for explored switches
+    /// that match an `expected_switches` record. Defaults to true; set false to
+    /// disable switch ingestion site-wide.
     #[serde(
         default = "SiteExplorerConfig::default_create_switches",
         deserialize_with = "deserialize_arc_atomic_bool",
@@ -199,12 +206,12 @@ pub struct SiteExplorerConfig {
 impl Default for SiteExplorerConfig {
     fn default() -> Self {
         SiteExplorerConfig {
-            enabled: Arc::new(true.into()),
+            enabled: Self::default_enabled(),
             retained_boot_interface_window: None,
             run_interval: Self::default_run_interval(),
             concurrent_explorations: Self::default_concurrent_explorations(),
             explorations_per_run: Self::default_explorations_per_run(),
-            create_machines: Arc::new(true.into()),
+            create_machines: Self::default_create_machines(),
             machines_created_per_run: Self::default_machines_created_per_run(),
             override_target_ip: None,
             override_target_port: None,
@@ -213,10 +220,11 @@ impl Default for SiteExplorerConfig {
             reset_rate_limit: Self::default_reset_rate_limit(),
             admin_segment_type_non_dpu: Self::default_admin_segment_type_non_dpu(),
             allocate_secondary_vtep_ip: false,
-            create_power_shelves: Arc::new(true.into()),
-            explore_power_shelves_from_static_ip: Arc::new(true.into()),
+            create_power_shelves: Self::default_create_power_shelves(),
+            explore_power_shelves_from_static_ip:
+                Self::default_explore_power_shelves_from_static_ip(),
             power_shelves_created_per_run: Self::default_power_shelves_created_per_run(),
-            create_switches: Arc::new(true.into()),
+            create_switches: Self::default_create_switches(),
             switches_created_per_run: Self::default_switches_created_per_run(),
             rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
             dpu_mode: None,
@@ -227,14 +235,67 @@ impl Default for SiteExplorerConfig {
 
 impl PartialEq for SiteExplorerConfig {
     fn eq(&self, other: &SiteExplorerConfig) -> bool {
-        self.enabled.load(AtomicOrdering::Relaxed) == other.enabled.load(AtomicOrdering::Relaxed)
-            && self.run_interval == other.run_interval
-            && self.concurrent_explorations == other.concurrent_explorations
-            && self.explorations_per_run == other.explorations_per_run
-            && self.create_machines.load(AtomicOrdering::Relaxed)
+        // Destructured without `..` so adding a field to the struct without
+        // deciding how it compares here is a compile error, not a silent gap.
+        let Self {
+            enabled,
+            retained_boot_interface_window,
+            run_interval,
+            concurrent_explorations,
+            explorations_per_run,
+            create_machines,
+            machines_created_per_run,
+            rotate_switch_nvos_credentials,
+            override_target_ip,
+            override_target_port,
+            bmc_proxy,
+            allow_changing_bmc_proxy,
+            reset_rate_limit,
+            admin_segment_type_non_dpu,
+            allocate_secondary_vtep_ip,
+            create_power_shelves,
+            explore_power_shelves_from_static_ip,
+            power_shelves_created_per_run,
+            create_switches,
+            switches_created_per_run,
+            dpu_mode,
+            explore_mode,
+        } = self;
+
+        enabled.load(AtomicOrdering::Relaxed) == other.enabled.load(AtomicOrdering::Relaxed)
+            && *retained_boot_interface_window == other.retained_boot_interface_window
+            && *run_interval == other.run_interval
+            && *concurrent_explorations == other.concurrent_explorations
+            && *explorations_per_run == other.explorations_per_run
+            && create_machines.load(AtomicOrdering::Relaxed)
                 == other.create_machines.load(AtomicOrdering::Relaxed)
-            && self.override_target_ip == other.override_target_ip
-            && self.override_target_port == other.override_target_port
+            && *machines_created_per_run == other.machines_created_per_run
+            && rotate_switch_nvos_credentials.load(AtomicOrdering::Relaxed)
+                == other
+                    .rotate_switch_nvos_credentials
+                    .load(AtomicOrdering::Relaxed)
+            && *override_target_ip == other.override_target_ip
+            && *override_target_port == other.override_target_port
+            && bmc_proxy.load_full() == other.bmc_proxy.load_full()
+            && *allow_changing_bmc_proxy == other.allow_changing_bmc_proxy
+            && *reset_rate_limit == other.reset_rate_limit
+            && admin_segment_type_non_dpu.load(AtomicOrdering::Relaxed)
+                == other
+                    .admin_segment_type_non_dpu
+                    .load(AtomicOrdering::Relaxed)
+            && *allocate_secondary_vtep_ip == other.allocate_secondary_vtep_ip
+            && create_power_shelves.load(AtomicOrdering::Relaxed)
+                == other.create_power_shelves.load(AtomicOrdering::Relaxed)
+            && explore_power_shelves_from_static_ip.load(AtomicOrdering::Relaxed)
+                == other
+                    .explore_power_shelves_from_static_ip
+                    .load(AtomicOrdering::Relaxed)
+            && *power_shelves_created_per_run == other.power_shelves_created_per_run
+            && create_switches.load(AtomicOrdering::Relaxed)
+                == other.create_switches.load(AtomicOrdering::Relaxed)
+            && *switches_created_per_run == other.switches_created_per_run
+            && *dpu_mode == other.dpu_mode
+            && *explore_mode == other.explore_mode
     }
 }
 
@@ -276,11 +337,11 @@ impl SiteExplorerConfig {
     }
 
     pub fn default_create_power_shelves() -> Arc<AtomicBool> {
-        Arc::new(false.into())
+        Arc::new(true.into())
     }
 
     pub fn default_explore_power_shelves_from_static_ip() -> Arc<AtomicBool> {
-        Arc::new(false.into())
+        Arc::new(true.into())
     }
 
     pub const fn default_power_shelves_created_per_run() -> u64 {
@@ -306,7 +367,7 @@ pub fn bmc_proxy(s: Option<HostPortPair>) -> Arc<ArcSwap<Option<HostPortPair>>> 
 
 /// Selects the Redfish client backend used by SiteExplorer
 /// for BMC discovery.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum SiteExplorerExploreMode {
     /// Use the libredfish Rust client.
     #[serde(rename = "libredfish")]

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -887,6 +887,12 @@ impl SiteExplorer {
             metrics.create_power_shelves_latency = Some(create_power_shelves_latency);
             metrics.record_phase_latency("create_power_shelves", create_power_shelves_latency);
             create_power_shelves_res?;
+        } else if !explored_power_shelves.is_empty() {
+            tracing::info!(
+                num_power_shelves = explored_power_shelves.len(),
+                "Identified power shelves during exploration but create_power_shelves=false; skipping PowerShelf creation. \
+                 Set [site_explorer] create_power_shelves=true and declare matching expected_power_shelves records to ingest them."
+            );
         }
 
         // Identify and create switches
@@ -911,7 +917,7 @@ impl SiteExplorer {
             tracing::info!(
                 num_switches = explored_switches.len(),
                 "Identified switches during exploration but create_switches=false; skipping Switch creation. \
-                 Set [site_explorer] create_switches=true to ingest them."
+                 Set [site_explorer] create_switches=true and declare matching expected_switches records to ingest them."
             );
         }
 

--- a/crates/site-explorer/src/switch_creator.rs
+++ b/crates/site-explorer/src/switch_creator.rs
@@ -50,7 +50,13 @@ impl SwitchCreator {
                 .matched_expected_switch(&explored_managed_switch.bmc_ip)
             {
                 Some(expected_switch) => expected_switch,
-                None => continue,
+                None => {
+                    tracing::info!(
+                        bmc_ip = %explored_managed_switch.bmc_ip,
+                        "No expected switch found for explored switch endpoint"
+                    );
+                    continue;
+                }
             };
 
             match self

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -169,5 +169,6 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_vpc_prefixes_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type carbide_vpc_prefixes have spent in a certain state</td></tr>
 <tr><td>carbide_vpc_prefixes_total</td><td>gauge</td><td>The total number of carbide_vpc_prefixes in the system</td></tr>
 <tr><td>carbide_vpc_prefixes_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_vpc_prefixes in the system with a given state that failed state handling</td></tr>
+<tr><td>site_explorer_create_power_shelves_latency_seconds</td><td>histogram</td><td>Duration of power shelf creation</td></tr>
 <tr><td>site_explorer_create_switches_latency_seconds</td><td>histogram</td><td>Duration of switch creation</td></tr>
 </table>


### PR DESCRIPTION
Completes what #3280 started for switches: explored power shelves that match an `expected_power_shelves` record are now ingested out of the box too -- `create_power_shelves` and `explore_power_shelves_from_static_ip` default to true instead of false. The expected-hardware records remain the per-device gate, so these defaults only ever ingest hardware an operator has declared, and the flags stay available as site-wide kill switches.

Primary callouts are:

- The power shelf creation defaults flip to true, matching `create_machines` (true all along) and `create_switches` (true since #3280).
- The two default paths now agree by construction: `Default::default()` delegates to the serde default fns, and `SiteExplorerConfig`'s `PartialEq` compares every field, destructuring `Self` without `..` so a future field is a compile error rather than a silent comparison gap. Previously a config with no `[site_explorer]` section at all ran with these flags on while a config with the section got false -- and the parity test couldn't see it because `PartialEq` skipped the creation flags.
- The now-exhaustive comparison made three full-config fixture tests assert their `site_explorer` fields for real, surfacing stale values that predate the `nv-redfish` default (`explore_mode: LibRedfish`, one old `machines_created_per_run`); the fixtures now match the parsed config.
- Skipped-creation visibility rounds out: the power shelf skip log mirrors the switch one from #3280 (`num_power_shelves`, same actionable wording), both skip logs now name the full prerequisite (the creation flag plus a matching expected-hardware record), and an explored switch with no `expected_switches` record now logs per endpoint instead of silently vanishing (power shelves and machines already logged this case).
- Docs follow: the configurability book page records all three creation defaults and the expected-record gating, and the config reference README gets fuller row descriptions plus a stale `explore_mode` default fix (it said `libredfish`; the code default is `nv-redfish`). The auto-generated metrics reference gains `site_explorer_create_power_shelves_latency_seconds`, which the now-default-on shelf creation phase emits.

Upgrade note: a site that declares `expected_power_shelves` records but never set the creation flags starts ingesting those shelves on upgrade (switches got this behavior in #3280). Setting the flags to false keeps ingestion off, exactly as before.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3152


Closes #3152
