### PR TITLE
fix(devspace): load images into the current kind cluster, not the default named "kind"

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -124,7 +124,7 @@ hooks:
       case "$CONTEXT" in
         kind-*)
           echo "Loading images into kind cluster..."
-          kind load docker-image \
+          kind load docker-image --name "${CONTEXT#kind-}" \
             "${runtime.images.nico-api.image}:${runtime.images.nico-api.tag}" \
             "${runtime.images.nico-bmc-proxy.image}:${runtime.images.nico-bmc-proxy.tag}" \
             "${runtime.images.machine-a-tron.image}:${runtime.images.machine-a-tron.tag}"


### PR DESCRIPTION
Fixes the DevSpace `load-images-into-local-cluster` hook so it loads images into the kind cluster of the **current** kube context, instead of always the cluster named `kind`.

## Related issues
Fixes #3105

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] **Manual testing performed**

The hook matches any `kind-*` context but called `kind load docker-image` without `--name`, which defaults to the cluster named `kind`. On a cluster with any other name, `devspace deploy` failed with `ERROR: no nodes found for cluster "kind"`.

Reproduced and verified locally (context `kind-nico`):
- Before: `kind load docker-image <img>` → `ERROR: no nodes found for cluster "kind"`.
- After: `kind load docker-image --name "${CONTEXT#kind-}" <img>` → resolves to the `nico` cluster and proceeds to load.

## Additional Notes
One-line change. Context: evaluating NICo for DPU/bare-metal provisioning at Crusoe (NVIDIA Cloud Partner). Happy to adjust the approach.
