### PR TITLE
feat(site-explorer): default create_switches to true and log when skipping

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -305,7 +305,7 @@ flows.
 | `create_power_shelves` | `bool` | `false` | Auto-create Power Shelf state machines. |
 | `explore_power_shelves_from_static_ip` | `bool` | `false` | Discover power shelves via static IP. |
 | `power_shelves_created_per_run` | `u64` | `1` | Max power shelves created per run. |
-| `create_switches` | `bool` | `false` | Auto-create Switch state machines. |
+| `create_switches` | `bool` | `true` | Auto-create Switch state machines. |
 | `switches_created_per_run` | `u64` | `9` | Max switches created per run. |
 | `explore_mode` | `SiteExplorerExploreMode` | `LibRedfish` | Redfish backend: `libredfish`, `nv-redfish`, or `compare-result`. |
 | `dpu_mode` | `Option<DpuMode>` | — | Site-wide DPU operating mode. When set, applies to every host that doesn't declare a per-host `ExpectedMachine.dpu_mode` override. |

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -288,7 +288,7 @@ impl SiteExplorerConfig {
     }
 
     pub fn default_create_switches() -> Arc<AtomicBool> {
-        Arc::new(false.into())
+        Arc::new(true.into())
     }
 
     pub const fn default_switches_created_per_run() -> u64 {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -907,6 +907,12 @@ impl SiteExplorer {
             metrics.create_switches_latency = Some(create_switches_latency);
             metrics.record_phase_latency("create_switches", create_switches_latency);
             create_switches_res?;
+        } else if !explored_switches.is_empty() {
+            tracing::info!(
+                num_switches = explored_switches.len(),
+                "Identified switches during exploration but create_switches=false; skipping Switch creation. \
+                 Set [site_explorer] create_switches=true to ingest them."
+            );
         }
 
         // Audit after everything has been explored, identified, and created.

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -161,4 +161,5 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_vpc_prefixes_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type carbide_vpc_prefixes have spent in a certain state</td></tr>
 <tr><td>carbide_vpc_prefixes_total</td><td>gauge</td><td>The total number of carbide_vpc_prefixes in the system</td></tr>
 <tr><td>carbide_vpc_prefixes_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_vpc_prefixes in the system with a given state that failed state handling</td></tr>
+<tr><td>site_explorer_create_switches_latency_seconds</td><td>histogram</td><td>Duration of switch creation</td></tr>
 </table>


### PR DESCRIPTION
Defaults `[site_explorer] create_switches` to `true` (matching `create_machines`) and adds an info-level log when switches are identified during exploration but skipped because `create_switches = false`. Also updates the config reference default in `api-core`.

## Related issues
Implements #3152

## Type of Change
- [x] **Change** - Changes in existing functionality

## Breaking Changes
- [ ] **This PR contains breaking changes**

Note: this changes a default — explored switches now auto-create by default. This was explicitly requested in #3152 by @ajf ("we should probably default to create_switches true") and @chet ("we can probably just change the default").

## Testing
- [x] **Manual testing performed**

- `cargo check -p site-explorer` passes.
- With `create_switches = true` (now the default), explored NVOS switches ingest and appear in `switch show`. Previously the default `false` silently skipped Switch creation with no log line, while `create_machines` defaulted to `true` — the asymmetry is what made it look like a bug.
- The new log fires once per explore cycle, only when switches were identified and creation was skipped.

## Additional Notes
Per @ajf in #3152: "feel free to implement both things.. we should probably default to create_switches true as well as emit a log if it isn't creating them because of the config at info level." Context: evaluating NICo for DPU/bare-metal provisioning at Crusoe (NVIDIA Cloud Partner).
