### PR TITLE
fix: host serial number from assembly

### DIFF
--- a/crates/bmc-explorer/src/hw/vera_rubin.rs
+++ b/crates/bmc-explorer/src/hw/vera_rubin.rs
@@ -53,5 +53,6 @@ mod tests {
         ));
         assert!(!chassis_assembly_serial_model("GB200 NVL"));
         assert!(!chassis_assembly_serial_model("1331226010330"));
+        assert!(!chassis_assembly_serial_model("2101326000053"));
     }
 }

--- a/crates/bmc-explorer/src/hw/vera_rubin.rs
+++ b/crates/bmc-explorer/src/hw/vera_rubin.rs
@@ -20,8 +20,38 @@ use crate::hw::BiosAttr;
 // Vera Rubin compute-tray host BMC: Systems/System_0, ServiceRoot Product "VR NVL72".
 // Shares TPM / EmbeddedUefiShell with GB200; uses GpuExposeAsPcie instead of GB200's
 // Socket{0,1}Pcie6DisableOptionROM knobs.
+
+/// `Model` value reported for the Power Distribution Board (PDB) chassis FRU under
+/// `/redfish/v1/Chassis/Chassis_0/Assembly` on a Vera Rubin compute tray. `P4107` is
+/// NVIDIA's board/PCA design code (the same FRU carries `Name` "PDB_0 Chassis FRU
+/// Assembly0" and `PartNumber` "675-24109-...."). `Model` is the stable, machine-readable
+/// key we match on; its `SerialNumber` is the compute-tray serial the inventory
+/// (Nautobot / expected-machine) tracks -- the raw `Chassis_0.SerialNumber` is a
+/// different, internal board serial that must NOT be used for matching.
+pub const VERA_RUBIN_PDB_CHASSIS_FRU_ASSEMBLY_MODEL: &str = "P4107";
+
+/// Assembly `Model` on `Chassis_0` whose `SerialNumber` is the source of truth for
+/// Vera Rubin expected-machine matching.
+pub fn chassis_assembly_serial_model(model: &str) -> bool {
+    matches!(model, VERA_RUBIN_PDB_CHASSIS_FRU_ASSEMBLY_MODEL)
+}
+
 pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 3] = [
     BiosAttr::new_str("TPM", "Enabled"),
     BiosAttr::new_str("EmbeddedUefiShell", "Disabled"),
     BiosAttr::new_bool("GpuExposeAsPcie", true),
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chassis_assembly_serial_model_matches_vera_rubin() {
+        assert!(chassis_assembly_serial_model(
+            VERA_RUBIN_PDB_CHASSIS_FRU_ASSEMBLY_MODEL
+        ));
+        assert!(!chassis_assembly_serial_model("GB200 NVL"));
+        assert!(!chassis_assembly_serial_model("1331226010330"));
+    }
+}

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -76,9 +76,13 @@ fn build_chassis_explore_config<B: Bmc>(root: &ServiceRoot<B>) -> chassis::Confi
             need_network_device_fns: root.vendor() == Some(Vendor::new("Dell")),
         },
         need_assembly_sn: |id| {
-            // For GB200s, use the Chassis_0 assembly serial number to match Nautobot.
-            (*id.inner() == "Chassis_0")
-                .then_some(|model| model == Some(AssemblyModel::new("GB200 NVL")))
+            // For GB200 and Vera Rubin hosts, use the Chassis_0 assembly serial
+            // number to match Nautobot / expected-machine inventory serials.
+            (*id.inner() == "Chassis_0").then_some(|model| {
+                model.is_some_and(|model| {
+                    hw::vera_rubin::chassis_assembly_serial_model(model.into_inner())
+                }) || model == Some(AssemblyModel::new("GB200 NVL"))
+            })
         },
         // BlueField-3 DPU (Tested on BF-25.10-9 firmware) has issue
         // with ERoT chassis. It stucks sometimes until next request

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -1129,7 +1129,8 @@ async fn fetch_chassis(client: &dyn Redfish) -> Result<Vec<Chassis>, RedfishErro
             net_adapters.push(net_adapter);
         }
 
-        // For GB200s, use the Chassis_0 assembly serial number to match Nautobot.
+        // For GB200 and Vera Rubin hosts, use the Chassis_0 assembly serial number to
+        // match Nautobot / expected-machine inventory serials.
         let serial_number = if chassis_id == "Chassis_0" {
             client
                 .get_chassis_assembly("Chassis_0")
@@ -1139,7 +1140,12 @@ async fn fetch_chassis(client: &dyn Redfish) -> Result<Vec<Chassis>, RedfishErro
                     assembly
                         .assemblies
                         .iter()
-                        .find(|asm| asm.model.as_deref() == Some("GB200 NVL"))
+                        .find(|asm| {
+                            let model = asm.model.as_deref();
+                            model.is_some_and(
+                                bmc_explorer::hw::vera_rubin::chassis_assembly_serial_model,
+                            ) || model == Some("GB200 NVL")
+                        })
                         .and_then(|asm| asm.serial_number.clone())
                 })
                 .or(desc.serial_number)


### PR DESCRIPTION
Get the host serial number to compare with the expected serial numbers from the following path for VeraRubin similar to GB200:


## Related issues
VeraRubin host serial mismatch with expected. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Testing
<!-- How was this tested? Check all that apply -->
- [ x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
`"@odata.id": "[/redfish/v1/Chassis/Chassis_0/Assembly]",
    "@odata.type": "#Assembly.v1_3_0.Assembly",
    "Assemblies": [
        {
            "@odata.id": "[/redfish/v1/Chassis/Chassis_0/Assembly#/Assemblies/0]",
            "Location": {
                "PartLocation": {
                    "LocationType": "Embedded"
                }
            },
            "MemberId": "0",
            "Model": "P4107",
            "Name": "PDB_0 Chassis FRU Assembly0",
            "PartNumber": "675-24109-0005-TS3",
            "SerialNumber": "2101326000053",
            "Vendor": "NVIDIA"
        },`
       
