### PR TITLE
fix: reject NVOS MACs already claimed by another expected switch

### DIFF
--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -107,6 +107,9 @@ pub enum CarbideError {
     #[error("Duplicate MAC address for expected host BMC interface: {0}")]
     ExpectedHostDuplicateMacAddress(MacAddress),
 
+    #[error("NVOS MAC address is already claimed by another expected switch: {0}")]
+    ExpectedSwitchDuplicateNvosMacAddress(MacAddress),
+
     #[error("Admin network is not configured.")]
     AdminNetworkNotConfigured,
 
@@ -287,6 +290,9 @@ impl From<DatabaseError> for CarbideError {
             }
             DatabaseError::DhcpError(e) => DhcpError(e),
             DatabaseError::ExpectedHostDuplicateMacAddress(e) => ExpectedHostDuplicateMacAddress(e),
+            DatabaseError::ExpectedSwitchDuplicateNvosMacAddress(e) => {
+                ExpectedSwitchDuplicateNvosMacAddress(e)
+            }
             DatabaseError::FailedPrecondition(e) => FailedPrecondition(e),
             DatabaseError::FindOneReturnedManyResultsError(e) => FindOneReturnedManyResultsError(e),
             DatabaseError::FindOneReturnedNoResultsError(e) => FindOneReturnedNoResultsError(e),
@@ -368,6 +374,7 @@ impl OperatorError for CarbideError {
             | CarbideError::UnhealthyHost
             | CarbideError::ConcurrentModificationError(_, _)
             | CarbideError::FailedPrecondition(_)
+            | CarbideError::ExpectedSwitchDuplicateNvosMacAddress(_)
             | CarbideError::AddressAlreadyInUse(_) => ErrorCode::nico(Api, 412),
             CarbideError::ResourceExhausted(_) | CarbideError::DhcpError(_) => {
                 ErrorCode::nico(Api, 429)
@@ -524,6 +531,9 @@ fn status_from_carbide_error(error: &CarbideError) -> Status {
             Status::failed_precondition(error.to_string())
         }
         error @ CarbideError::FailedPrecondition(_) => {
+            Status::failed_precondition(error.to_string())
+        }
+        error @ CarbideError::ExpectedSwitchDuplicateNvosMacAddress(_) => {
             Status::failed_precondition(error.to_string())
         }
         error @ CarbideError::AddressAlreadyInUse(_) => {

--- a/crates/api-core/src/handlers/expected_switch.rs
+++ b/crates/api-core/src/handlers/expected_switch.rs
@@ -254,9 +254,7 @@ pub async fn replace_all_expected_switches(
                 })?;
         db_expected_switch::create(&mut txn, switch)
             .await
-            .map_err(|e| CarbideError::Internal {
-                message: format!("Failed to create expected switch: {}", e),
-            })?;
+            .map_err(CarbideError::from)?;
     }
 
     txn.commit().await.map_err(|e| CarbideError::Internal {

--- a/crates/api-core/src/tests/expected_switch.rs
+++ b/crates/api-core/src/tests/expected_switch.rs
@@ -122,6 +122,114 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
 }
 
 #[crate::sqlx_test]
+async fn test_add_expected_switch_rejects_claimed_nvos_mac(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let mut expected_switch = rpc::forge::ExpectedSwitch {
+        expected_switch_id: None,
+        bmc_mac_address: "3A:3B:3C:3D:3E:50".to_string(),
+        nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:50".to_string()],
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        switch_serial_number: "SW-NVOS-DUP-001".into(),
+        nvos_username: None,
+        nvos_password: None,
+        metadata: None,
+        rack_id: None,
+        bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
+        nvos_ip_address: None,
+    };
+    env.api
+        .add_expected_switch(tonic::Request::new(expected_switch.clone()))
+        .await
+        .expect("unable to add expected switch");
+
+    // A second switch claiming the same NVOS MAC -- spelled with a different
+    // separator and case, which macaddr comparison canonicalizes -- is rejected.
+    expected_switch.bmc_mac_address = "3A:3B:3C:3D:3E:51".to_string();
+    expected_switch.switch_serial_number = "SW-NVOS-DUP-002".into();
+    expected_switch.nvos_mac_addresses = vec!["4a-4b-4c-4d-4e-50".to_string()];
+    let status = env
+        .api
+        .add_expected_switch(tonic::Request::new(expected_switch))
+        .await
+        .expect_err("adding a switch with a claimed NVOS MAC should fail");
+    assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+}
+
+#[crate::sqlx_test]
+async fn test_update_expected_switch_rejects_claimed_nvos_mac(pool: sqlx::PgPool) {
+    let env = create_test_env(pool.clone()).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+    txn.commit().await.unwrap();
+
+    // switches[1] tries to claim an NVOS MAC that switches[0] already holds.
+    let update = rpc::forge::ExpectedSwitch {
+        expected_switch_id: None,
+        bmc_mac_address: switches[1].bmc_mac_address.to_string(),
+        nvos_mac_addresses: switches[0]
+            .nvos_mac_addresses
+            .iter()
+            .map(|mac| mac.to_string())
+            .collect(),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        switch_serial_number: switches[1].serial_number.clone(),
+        nvos_username: None,
+        nvos_password: None,
+        metadata: None,
+        rack_id: None,
+        bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
+        nvos_ip_address: None,
+    };
+    let status = env
+        .api
+        .update_expected_switch(tonic::Request::new(update))
+        .await
+        .expect_err("claiming another switch's NVOS MAC should fail");
+    assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+}
+
+#[crate::sqlx_test]
+async fn test_replace_all_expected_switches_rejects_intra_list_nvos_dup(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let switch = |bmc: &str, serial: &str| rpc::forge::ExpectedSwitch {
+        expected_switch_id: None,
+        bmc_mac_address: bmc.to_string(),
+        nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:60".to_string()],
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        switch_serial_number: serial.into(),
+        nvos_username: None,
+        nvos_password: None,
+        metadata: None,
+        rack_id: None,
+        bmc_ip_address: String::new(),
+        bmc_retain_credentials: None,
+        nvos_ip_address: None,
+    };
+
+    // Two switches in one replace list claiming the same NVOS MAC surface a
+    // config conflict, not an internal server fault.
+    let status = env
+        .api
+        .replace_all_expected_switches(tonic::Request::new(rpc::forge::ExpectedSwitchList {
+            expected_switches: vec![
+                switch("3A:3B:3C:3D:3E:60", "SW-REPLACE-001"),
+                switch("3A:3B:3C:3D:3E:61", "SW-REPLACE-002"),
+            ],
+        }))
+        .await
+        .expect_err("intra-list NVOS MAC duplicate should fail");
+    assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+}
+
+#[crate::sqlx_test]
 async fn test_delete_expected_switch(pool: sqlx::PgPool) {
     let env = create_test_env(pool.clone()).await;
 

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -54,6 +54,64 @@ pub async fn find_by_nvos_mac_address(
         .map_err(|err| DatabaseError::query(sql, err))
 }
 
+/// Serialize expected-switch writes on a transaction-scoped advisory lock so
+/// two concurrent creates or updates can't both pass the NVOS MAC conflict
+/// check before either row lands (check-then-write under READ COMMITTED).
+/// The lock releases with the transaction; the namespaced key keeps it from
+/// colliding with other subsystems' advisory locks.
+async fn lock_expected_switch_writes(txn: &mut PgConnection) -> DatabaseResult<()> {
+    let sql = "SELECT pg_advisory_xact_lock(hashtextextended('expected_switches:write', 0))";
+    sqlx::query(sql)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|err| DatabaseError::query(sql, err))
+}
+
+/// Return an entry of `nvos_mac_addresses` that a different expected switch
+/// already claims, if any. "Different" follows the same key `update` targets:
+/// `switch.expected_switch_id` when set, otherwise `switch.bmc_mac_address`.
+/// `macaddr` comparison canonicalizes case and separator differences.
+/// `update_nvos_mac_addresses` stays unguarded on purpose -- it records
+/// hardware-observed truth from site-explorer.
+async fn find_nvos_mac_claimed_elsewhere(
+    txn: &mut PgConnection,
+    nvos_mac_addresses: &[MacAddress],
+    switch: &ExpectedSwitch,
+) -> DatabaseResult<Option<MacAddress>> {
+    if nvos_mac_addresses.is_empty() {
+        return Ok(None);
+    }
+
+    let (sql, exclude_key) = match switch.expected_switch_id {
+        Some(id) => (
+            "SELECT * FROM expected_switches WHERE expected_switch_id != $1::uuid AND nvos_mac_addresses && $2::macaddr[] LIMIT 1",
+            id.to_string(),
+        ),
+        None => (
+            "SELECT * FROM expected_switches WHERE bmc_mac_address != $1::macaddr AND nvos_mac_addresses && $2::macaddr[] LIMIT 1",
+            switch.bmc_mac_address.to_string(),
+        ),
+    };
+
+    let other: Option<ExpectedSwitch> = sqlx::query_as(sql)
+        .bind(exclude_key)
+        .bind(nvos_mac_addresses)
+        .fetch_optional(txn)
+        .await
+        .map_err(|err| DatabaseError::query(sql, err))?;
+
+    Ok(other.map(|other| {
+        nvos_mac_addresses
+            .iter()
+            .find(|mac| other.nvos_mac_addresses.contains(mac))
+            .copied()
+            // The SQL overlap guarantees a shared entry; the first requested
+            // MAC is a safe stand-in if equality ever disagrees.
+            .unwrap_or(nvos_mac_addresses[0])
+    }))
+}
+
 pub async fn find_by_serial_number(
     txn: &mut PgConnection,
     serial_number: &str,
@@ -202,6 +260,17 @@ pub async fn create(
     txn: &mut PgConnection,
     switch: ExpectedSwitch,
 ) -> DatabaseResult<ExpectedSwitch> {
+    // NVOS MACs resolve a DHCPing management port to a single expected switch
+    // (`find_by_nvos_mac_address`), so a MAC claimed by another switch is a
+    // conflict. The advisory lock makes the check-then-insert deterministic
+    // under concurrent writers.
+    lock_expected_switch_writes(&mut *txn).await?;
+    if let Some(mac) =
+        find_nvos_mac_claimed_elsewhere(&mut *txn, &switch.nvos_mac_addresses, &switch).await?
+    {
+        return Err(DatabaseError::ExpectedSwitchDuplicateNvosMacAddress(mac));
+    }
+
     let id = switch.expected_switch_id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_switches
              (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses, bmc_retain_credentials, nvos_ip_address)
@@ -320,6 +389,12 @@ pub async fn update_nvos_mac_addresses(
 }
 
 pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
+    // Take the write lock before the DELETE grabs row locks so clear-then-
+    // create flows (`replace_all_expected_switches`) acquire locks in the same
+    // order as `create`/`update` -- advisory first, rows second -- instead of
+    // forming a deadlock cycle with them.
+    lock_expected_switch_writes(&mut *txn).await?;
+
     let query = "DELETE FROM expected_switches";
 
     sqlx::query(query)
@@ -332,6 +407,41 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// update updates an existing expected switch. If expected_switch_id is set,
 /// matches by ID; otherwise matches by bmc_mac_address.
 pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> DatabaseResult<()> {
+    // The lock serializes the existence read, conflict check, and UPDATE as
+    // one unit against concurrent expected-switch writers.
+    lock_expected_switch_writes(&mut *txn).await?;
+
+    // Resolve the target first: a missing switch reports NotFound rather than
+    // a MAC conflict, and the current row bounds the conflict check to newly
+    // claimed MACs -- re-asserting a list the row already holds stays valid
+    // even when pre-existing data or site-explorer's hardware-truth writes
+    // recorded the same MAC on two switches.
+    let current = find(
+        &mut *txn,
+        &ExpectedSwitchRequest {
+            expected_switch_id: switch.expected_switch_id,
+            bmc_mac_address: Some(switch.bmc_mac_address),
+        },
+    )
+    .await?
+    .ok_or_else(|| DatabaseError::NotFoundError {
+        kind: "expected_switch",
+        id: switch
+            .expected_switch_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| switch.bmc_mac_address.to_string()),
+    })?;
+
+    let newly_claimed: Vec<MacAddress> = switch
+        .nvos_mac_addresses
+        .iter()
+        .filter(|mac| !current.nvos_mac_addresses.contains(mac))
+        .copied()
+        .collect();
+    if let Some(mac) = find_nvos_mac_claimed_elsewhere(&mut *txn, &newly_claimed, switch).await? {
+        return Err(DatabaseError::ExpectedSwitchDuplicateNvosMacAddress(mac));
+    }
+
     macro_rules! update_expected_switch_query {
         ($where_clause:literal) => {
             concat!(

--- a/crates/api-db/src/expected_switch/tests.rs
+++ b/crates/api-db/src/expected_switch/tests.rs
@@ -127,6 +127,112 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
 }
 
 #[crate::sqlx_test]
+async fn test_create_rejects_nvos_mac_claimed_by_another_switch(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+
+    let result = db::expected_switch::create(
+        &mut txn,
+        ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: expected_switch_bmc_mac_address(200),
+            nvos_mac_addresses: switches[0].nvos_mac_addresses.clone(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "hmm".into(),
+            serial_number: "NVOS-DUP".into(),
+            bmc_ip_address: None,
+            metadata: Metadata::default(),
+            rack_id: None,
+            bmc_retain_credentials: None,
+            nvos_ip_address: None,
+            nvos_username: None,
+            nvos_password: None,
+        },
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(DatabaseError::ExpectedSwitchDuplicateNvosMacAddress(_))
+    ));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_update_nvos_mac_conflicts_exclude_own_switch(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+
+    // Re-asserting a switch's own NVOS MACs is not a conflict.
+    let mut own = switches[0].clone();
+    own.bmc_username = "NEWADMIN".into();
+    db::expected_switch::update(&mut txn, &own).await?;
+
+    // Claiming another switch's NVOS MAC is.
+    own.nvos_mac_addresses = switches[1].nvos_mac_addresses.clone();
+    let result = db::expected_switch::update(&mut txn, &own).await;
+
+    assert!(matches!(
+        result,
+        Err(DatabaseError::ExpectedSwitchDuplicateNvosMacAddress(_))
+    ));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_update_missing_switch_reports_not_found(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+
+    // A target that doesn't exist reports NotFound even when the payload's
+    // NVOS MACs are claimed by some existing switch.
+    let mut ghost = switches[0].clone();
+    ghost.expected_switch_id = None;
+    ghost.bmc_mac_address = expected_switch_bmc_mac_address(201);
+    let result = db::expected_switch::update(&mut txn, &ghost).await;
+
+    assert!(matches!(result, Err(DatabaseError::NotFoundError { .. })));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_update_tolerates_preexisting_nvos_mac_overlap(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+
+    // site-explorer's hardware-truth path can record an overlap that predates
+    // the conflict guard: switch 0 ends up holding switch 1's MAC too.
+    let mut overlapped = switches[0].nvos_mac_addresses.clone();
+    overlapped.extend(switches[1].nvos_mac_addresses.iter().copied());
+    db::expected_switch::update_nvos_mac_addresses(
+        &mut txn,
+        switches[0].bmc_mac_address,
+        &overlapped,
+    )
+    .await?;
+
+    // Re-sending the list the row already holds must stay updatable -- only
+    // newly claimed MACs are checked.
+    let mut own = switches[0].clone();
+    own.nvos_mac_addresses = overlapped;
+    own.bmc_username = "NEWADMIN".into();
+    db::expected_switch::update(&mut txn, &own).await?;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_update_bmc_credentials(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = pool.begin().await.unwrap();
     let switches = create_expected_switches(&mut txn).await;

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -353,6 +353,8 @@ pub enum DatabaseError {
     InvalidArgument(String),
     #[error("Duplicate MAC address for expected host BMC interface: {0}")]
     ExpectedHostDuplicateMacAddress(MacAddress),
+    #[error("NVOS MAC address is already claimed by another expected switch: {0}")]
+    ExpectedSwitchDuplicateNvosMacAddress(MacAddress),
     #[error("Argument is missing in input: {0}")]
     MissingArgument(&'static str),
     #[error("Uuid type conversion error: {0}")]
@@ -557,6 +559,9 @@ impl From<DatabaseError> for tonic::Status {
                 Status::failed_precondition(error.to_string())
             }
             error @ DatabaseError::ExpectedHostDuplicateMacAddress(_) => {
+                Status::failed_precondition(error.to_string())
+            }
+            error @ DatabaseError::ExpectedSwitchDuplicateNvosMacAddress(_) => {
                 Status::failed_precondition(error.to_string())
             }
             error @ DatabaseError::FailedPrecondition(_) => {

--- a/rest-api/api/pkg/api/handler/expectedswitch.go
+++ b/rest-api/api/pkg/api/handler/expectedswitch.go
@@ -121,7 +121,7 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 	// Check for duplicate MAC address. The DB enforces UNIQUE (bmc_mac_address, site_id),
 	// but we pre-check here so we can return the conflicting record's ID in the response.
 	esDAO := cdbm.NewExpectedSwitchDAO(cesh.dbSession)
-	ess, count, err := esDAO.GetAll(ctx, nil, cdbm.ExpectedSwitchFilterInput{
+	ess, _, err := esDAO.GetAll(ctx, nil, cdbm.ExpectedSwitchFilterInput{
 		BmcMacAddresses: []string{apiRequest.BmcMacAddress},
 		SiteIDs:         []uuid.UUID{site.ID},
 	}, paginator.PageInput{
@@ -133,12 +133,36 @@ func (cesh CreateExpectedSwitchHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate MAC address uniqueness on Site due to DB error", nil)
 	}
 
-	if count > 0 {
+	if len(ess) > 0 {
 		logger.Warn().Str("MacAddress", apiRequest.BmcMacAddress).Msg("Expected Switch with specified MAC address already exists on Site")
 
 		return cutil.NewAPIErrorResponse(c, http.StatusConflict, "Expected Switch with specified MAC address already exists on Site", validation.Errors{
 			"id": errors.New(ess[0].ID.String()),
 		})
+	}
+
+	// NVOS MACs identify the switch's management ports during discovery, so a
+	// MAC claimed by another Expected Switch on the Site is a conflict.
+	if len(apiRequest.NvosMacAddresses) > 0 {
+		conflicts, _, derr := esDAO.GetAll(ctx, nil, cdbm.ExpectedSwitchFilterInput{
+			NvosMacAddresses: apiRequest.NvosMacAddresses,
+			SiteIDs:          []uuid.UUID{site.ID},
+		}, paginator.PageInput{
+			Limit: cutil.GetPtr(1),
+		}, nil)
+
+		if derr != nil {
+			logger.Error().Err(derr).Msg("error checking for duplicate NVOS MAC addresses on Site")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate NVOS MAC address uniqueness on Site due to DB error", nil)
+		}
+
+		if len(conflicts) > 0 {
+			logger.Warn().Strs("NvosMacAddresses", apiRequest.NvosMacAddresses).Msg("Expected Switch with specified NVOS MAC address already exists on Site")
+
+			return cutil.NewAPIErrorResponse(c, http.StatusConflict, "Expected Switch with specified NVOS MAC address already exists on Site", validation.Errors{
+				"id": errors.New(conflicts[0].ID.String()),
+			})
+		}
 	}
 
 	expectedSwitch, err := cdb.WithTxResult(ctx, cesh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedSwitch, error) {
@@ -580,6 +604,32 @@ func (uesh UpdateExpectedSwitchHandler) Handle(c echo.Context) error {
 
 	if !hasAccess {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Switch", nil)
+	}
+
+	// NVOS MACs identify the switch's management ports during discovery, so a
+	// MAC claimed by another Expected Switch on the Site is a conflict. The
+	// switch being updated is excluded so re-asserting its own MACs stays valid.
+	if len(apiRequest.NvosMacAddresses) > 0 {
+		conflicts, _, derr := esDAO.GetAll(ctx, nil, cdbm.ExpectedSwitchFilterInput{
+			NvosMacAddresses:         apiRequest.NvosMacAddresses,
+			SiteIDs:                  []uuid.UUID{site.ID},
+			ExcludeExpectedSwitchIDs: []uuid.UUID{expectedSwitch.ID},
+		}, paginator.PageInput{
+			Limit: cutil.GetPtr(1),
+		}, nil)
+
+		if derr != nil {
+			logger.Error().Err(derr).Msg("error checking for duplicate NVOS MAC addresses on Site")
+			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to validate NVOS MAC address uniqueness on Site due to DB error", nil)
+		}
+
+		if len(conflicts) > 0 {
+			logger.Warn().Strs("NvosMacAddresses", apiRequest.NvosMacAddresses).Msg("Expected Switch with specified NVOS MAC address already exists on Site")
+
+			return cutil.NewAPIErrorResponse(c, http.StatusConflict, "Expected Switch with specified NVOS MAC address already exists on Site", validation.Errors{
+				"id": errors.New(conflicts[0].ID.String()),
+			})
+		}
 	}
 
 	updatedExpectedSwitch, err := cdb.WithTxResult(ctx, uesh.dbSession, func(tx *cdb.Tx) (*cdbm.ExpectedSwitch, error) {

--- a/rest-api/api/pkg/api/handler/expectedswitch_test.go
+++ b/rest-api/api/pkg/api/handler/expectedswitch_test.go
@@ -112,7 +112,8 @@ func TestCreateExpectedSwitchHandler_Handle(t *testing.T) {
 	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
 	assert.Nil(t, err)
 
-	// Create an existing Expected Switch with a specific MAC address for duplicate test
+	// Create an existing Expected Switch with specific BMC and NVOS MAC
+	// addresses for the duplicate tests
 	esDAO := cdbm.NewExpectedSwitchDAO(dbSession)
 	existingMAC := "AA:BB:CC:DD:EE:11"
 	_, err = esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
@@ -120,6 +121,7 @@ func TestCreateExpectedSwitchHandler_Handle(t *testing.T) {
 		SiteID:             site.ID,
 		BmcMacAddress:      existingMAC,
 		SwitchSerialNumber: "EXISTING-SWITCH-001",
+		NvosMacAddresses:   []string{"AA:BB:CC:DD:EE:22"},
 		Labels:             map[string]string{"env": "existing"},
 	})
 	assert.Nil(t, err)
@@ -248,6 +250,23 @@ func TestCreateExpectedSwitchHandler_Handle(t *testing.T) {
 				DefaultBmcPassword: cutil.GetPtr("password"),
 				SwitchSerialNumber: "DUPLICATE-SWITCH-999",
 				Labels:             map[string]string{"env": "duplicate-test"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusConflict,
+		},
+		{
+			name: "NVOS MAC claimed by another switch should return 409",
+			requestBody: model.APIExpectedSwitchCreateRequest{
+				SiteID:             site.ID.String(),
+				BmcMacAddress:      "00:11:22:33:44:AA",
+				DefaultBmcUsername: cutil.GetPtr("admin"),
+				DefaultBmcPassword: cutil.GetPtr("password"),
+				SwitchSerialNumber: "NVOS-DUP-SWITCH-001",
+				NvosMacAddresses:   []string{"aa-bb-cc-dd-ee-22"},
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", createMockUser(org))
@@ -689,6 +708,18 @@ func TestUpdateExpectedSwitchHandler_Handle(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, unmanagedES)
 
+	// Create a second ExpectedSwitch on the managed site whose NVOS MAC the
+	// update conflict test tries to claim
+	conflictES, err := esDAO.Create(ctx, nil, cdbm.ExpectedSwitchCreateInput{
+		ExpectedSwitchID:   uuid.New(),
+		SiteID:             site.ID,
+		BmcMacAddress:      "00:11:22:33:44:CC",
+		SwitchSerialNumber: "CONFLICT-SWITCH-789",
+		NvosMacAddresses:   []string{"AA:BB:CC:DD:EE:33"},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, conflictES)
+
 	// Add mock temporal client for the site
 	mockTemporalClient := &tmocks.Client{}
 	mockWorkflowRun := &tmocks.WorkflowRun{}
@@ -760,6 +791,32 @@ func TestUpdateExpectedSwitchHandler_Handle(t *testing.T) {
 				c.SetParamValues(org, testES.ID.String())
 			},
 			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "update re-asserting its own NvosMacAddresses is not a conflict",
+			id:   testES.ID.String(),
+			requestBody: model.APIExpectedSwitchUpdateRequest{
+				NvosMacAddresses: []string{"00:11:22:33:44:66", "00:11:22:33:44:67"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testES.ID.String())
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "update claiming another switch's NVOS MAC should return 409",
+			id:   testES.ID.String(),
+			requestBody: model.APIExpectedSwitchUpdateRequest{
+				NvosMacAddresses: []string{"aa-bb-cc-dd-ee-33"},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testES.ID.String())
+			},
+			expectedStatus: http.StatusConflict,
 		},
 		{
 			name: "successful update clearing NvosMacAddresses with an explicit empty list",

--- a/rest-api/api/pkg/api/model/expectedswitch.go
+++ b/rest-api/api/pkg/api/model/expectedswitch.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,7 +40,7 @@ func (macs APINvosMacAddresses) Validate() error {
 
 	seen := make(map[string]bool, len(macs))
 	for _, mac := range macs {
-		key := strings.ToLower(strings.ReplaceAll(mac, "-", ":"))
+		key := cdbm.NormalizeMacAddress(mac)
 		if seen[key] {
 			return fmt.Errorf("duplicate MAC address: %s", mac)
 		}

--- a/rest-api/db/pkg/db/model/expectedswitch.go
+++ b/rest-api/db/pkg/db/model/expectedswitch.go
@@ -65,6 +65,14 @@ type ExpectedSwitch struct {
 	CreatedBy          uuid.UUID `bun:"type:uuid,notnull"`
 }
 
+// NormalizeMacAddress lowercases a MAC address and converts hyphen separators
+// to colons so equivalent spellings compare equal. It is the one home for the
+// canonical-spelling rule shared by request validation and the DAO's
+// NvosMacAddresses conflict filter.
+func NormalizeMacAddress(mac string) string {
+	return strings.ToLower(strings.ReplaceAll(mac, "-", ":"))
+}
+
 // ExpectedSwitchCredentials carries the BMC and NVOS credentials for one
 // ExpectedSwitch. They live in their own type because they aren't stored
 // in the DB record and have to be threaded through to ToProto separately.
@@ -242,9 +250,15 @@ type ExpectedSwitchClearInput struct {
 
 // ExpectedSwitchFilterInput filtering options for GetAll method
 type ExpectedSwitchFilterInput struct {
-	ExpectedSwitchIDs   []uuid.UUID
-	SiteIDs             []uuid.UUID
-	BmcMacAddresses     []string
+	ExpectedSwitchIDs []uuid.UUID
+	// ExcludeExpectedSwitchIDs drops the given switches from the result set
+	ExcludeExpectedSwitchIDs []uuid.UUID
+	SiteIDs                  []uuid.UUID
+	BmcMacAddresses          []string
+	// NvosMacAddresses matches switches whose NVOS MAC list contains any of the
+	// given addresses. Comparison ignores case and separator style since those
+	// spellings refer to the same interface.
+	NvosMacAddresses    []string
 	SwitchSerialNumbers []string
 	SearchQuery         *string
 }
@@ -396,10 +410,28 @@ func (essd ExpectedSwitchSQLDAO) setQueryWithFilter(filter ExpectedSwitchFilterI
 		}
 	}
 
+	if len(filter.ExcludeExpectedSwitchIDs) > 0 {
+		query = query.Where("es.id NOT IN (?)", bun.In(filter.ExcludeExpectedSwitchIDs))
+		if expectedSwitchDAOSpan != nil {
+			essd.tracerSpan.SetAttribute(expectedSwitchDAOSpan, "exclude_expected_switch_ids", filter.ExcludeExpectedSwitchIDs)
+		}
+	}
+
 	if filter.BmcMacAddresses != nil {
 		query = query.Where("es.bmc_mac_address IN (?)", bun.In(filter.BmcMacAddresses))
 		if expectedSwitchDAOSpan != nil {
 			essd.tracerSpan.SetAttribute(expectedSwitchDAOSpan, "bmc_mac_addresses", filter.BmcMacAddresses)
+		}
+	}
+
+	if len(filter.NvosMacAddresses) > 0 {
+		normalized := make([]string, 0, len(filter.NvosMacAddresses))
+		for _, mac := range filter.NvosMacAddresses {
+			normalized = append(normalized, NormalizeMacAddress(mac))
+		}
+		query = query.Where("EXISTS (SELECT 1 FROM unnest(es.nvos_mac_addresses) AS m(mac) WHERE lower(replace(m.mac, '-', ':')) IN (?))", bun.In(normalized))
+		if expectedSwitchDAOSpan != nil {
+			essd.tracerSpan.SetAttribute(expectedSwitchDAOSpan, "nvos_mac_addresses", filter.NvosMacAddresses)
 		}
 	}
 

--- a/rest-api/db/pkg/db/model/expectedswitch_test.go
+++ b/rest-api/db/pkg/db/model/expectedswitch_test.go
@@ -472,6 +472,31 @@ func TestExpectedSwitchSQLDAO_GetAll(t *testing.T) {
 			expectedError: false,
 		},
 		{
+			desc: "GetAll with NvosMacAddresses filter matches across separator and case",
+			filter: ExpectedSwitchFilterInput{
+				NvosMacAddresses: []string{"00-1b-44-11-3a-D1"},
+			},
+			expectedCount: 1,
+			expectedError: false,
+		},
+		{
+			desc: "GetAll with NvosMacAddresses filter returns nothing for an unclaimed MAC",
+			filter: ExpectedSwitchFilterInput{
+				NvosMacAddresses: []string{"00:1B:44:11:3A:99"},
+			},
+			expectedCount: 0,
+			expectedError: false,
+		},
+		{
+			desc: "GetAll with ExcludeExpectedSwitchIDs drops the excluded switch",
+			filter: ExpectedSwitchFilterInput{
+				NvosMacAddresses:         []string{"00:1B:44:11:3A:D1"},
+				ExcludeExpectedSwitchIDs: []uuid.UUID{created[0].ID},
+			},
+			expectedCount: 0,
+			expectedError: false,
+		},
+		{
 			desc: "GetAll with limit returns objects",
 			pageInput: paginator.PageInput{
 				Offset: cutil.GetPtr(0),


### PR DESCRIPTION
An NVOS MAC is how discovery resolves a DHCPing switch management port to its expected switch -- the lookup assumes exactly one owner, but nothing enforced that. Two expected switches could silently claim the same MAC at registration, and the mistake only surfaced much later as a mis-addressed management port or duplicated switch-search rows. This PR makes the invariant real at both entry layers: Core rejects the conflict at the source of truth, and the REST API fails fast with a friendly `409 Conflict`.

### Core (`crates/`)

- The guard lives in `db::expected_switch::create`/`update`, so every writer inherits it -- the CLI, config-driven seeding, and REST via the site workflow.
- A new `find_nvos_mac_claimed_elsewhere` overlap query backs the check; Postgres `macaddr` comparison canonicalizes case and separator differences.
- A transaction-scoped advisory lock keeps the check-then-write deterministic under concurrent registrations.
- Rejections surface as `FailedPrecondition` via the new `ExpectedSwitchDuplicateNvosMacAddress` error.
- `update_nvos_mac_addresses` stays unguarded on purpose: it records hardware-observed truth from site-explorer.
- Full-list replace (`ReplaceAllExpectedSwitches`) surfaces an intra-list duplicate as the same `FailedPrecondition` conflict.

### REST API (`rest-api/`)

- Create and update handlers run the conflict read before the transaction opens and return a `409 Conflict` naming the conflicting record's `id`.
- `ExpectedSwitchFilterInput` gains `NvosMacAddresses` (case- and separator-insensitive overlap) and `ExcludeExpectedSwitchIDs` so updates can exempt the switch being updated.

### Behavior notes

- Updates only check newly claimed MACs: re-asserting a list a switch already holds stays valid, even for overlaps that predate the guard.
- A missing update target reports not-found, not a MAC conflict.
- An omitted or empty `nvosMacAddresses` skips the checks, since nothing new is claimed.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3267


Closes #3267
