### PR TITLE
feat(nvlink): enhance MNNVL capability detection logic to work for GB300 and VR systems as well

### DIFF
--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -590,12 +590,12 @@ async fn group_machine_ids_by_rack(
     Ok(targets)
 }
 
-/// Returns whether the machine is a rack-scale server (today just GB200, but will later include other SKUs)
+/// Returns whether the machine is a rack-scale MNNVL server (GB200, GB300, etc.).
 fn is_rack_scale_server(machine: &Machine) -> bool {
     machine
         .hardware_info
         .as_ref()
-        .is_some_and(|hw| hw.is_gbx00())
+        .is_some_and(|hw| hw.is_mnnvl_capable())
 }
 
 /// Splits the requested compute machines into two lists: rack-scale and standalone servers.

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -102,7 +102,7 @@ pub(crate) async fn discover_machine(
         .filter_map(|gpu| gpu.platform_info.as_ref())
         .collect();
 
-    let nvlink_info = if hardware_info.is_gbx00()
+    let nvlink_info = if hardware_info.is_mnnvl_capable()
         && !gpu_platform_infos.is_empty()
         && api
             .runtime_config

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -35,7 +35,9 @@ use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::expected_machine::ExpectedMachineData;
-use model::hardware_info::{MachineInventory, MachineNvLinkInfo};
+use model::hardware_info::{
+    MachineInventory, MachineNvLinkInfo, mnnvl_gpu_name_sql_like_conditions,
+};
 use model::machine::infiniband::MachineInfinibandStatusObservation;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::{
@@ -1955,9 +1957,20 @@ pub async fn find_machine_ids(
         qb.push("->'alerts') > 0");
     }
     if search_config.mnnvl_only {
-        qb.push(
-            " AND mt.topology->'discovery_data'->'Info'->'dmi_data'->>'product_name' LIKE '%GB200%'",
-        );
+        qb.push(format!(
+            " AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements(
+                    COALESCE(mt.topology->'discovery_data'->'Info'->'gpus', '[]'::jsonb)
+                ) AS gpu
+                WHERE gpu->'platform_info' IS NOT NULL
+                  AND gpu->'platform_info' <> 'null'::jsonb
+                  AND (
+                      {}
+                  )
+            )",
+            mnnvl_gpu_name_sql_like_conditions()
+        ));
     }
 
     if let Some(id) = search_config.instance_type_id {

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -210,14 +210,6 @@ pub struct Gpu {
     pub platform_info: Option<GpuPlatformInfo>,
 }
 
-impl Gpu {
-    /// Returns true when this GPU reports NVLink platform metadata and an MNNVL family
-    /// name on the GPU or, when absent there, in DMI `product_name`.
-    pub fn is_mnnvl_capable_with_dmi(&self, dmi_product_name: Option<&str>) -> bool {
-        is_mnnvl_capable_gpu(self, dmi_product_name)
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GpuPlatformInfo {
     pub chassis_serial: String,
@@ -351,7 +343,7 @@ impl HardwareInfo {
 }
 
 /// Substrings matched against GPU `name` or DMI `product_name` to identify MNNVL-capable hardware.
-pub const MNNVL_KNOWN_GPU_NAMES: &[&str] = &["GB200", "GB300", "VR"];
+pub const MNNVL_KNOWN_GPU_NAMES: &[&str] = &["GB200", "GB300", "VR NVL"];
 
 /// Returns true when `name` contains any [`MNNVL_KNOWN_GPU_NAMES`] entry.
 pub fn gpu_name_indicates_mnnvl(name: &str) -> bool {

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -16,7 +16,6 @@
  */
 
 //! Describes hardware that is discovered by Forge
-
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
@@ -211,6 +210,13 @@ pub struct Gpu {
     pub platform_info: Option<GpuPlatformInfo>,
 }
 
+impl Gpu {
+    /// Returns true when this GPU reports NVLink platform metadata and an MNNVL family name.
+    pub fn is_mnnvl_capable(&self) -> bool {
+        self.platform_info.is_some() && gpu_name_indicates_mnnvl(&self.name)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GpuPlatformInfo {
     pub chassis_serial: String,
@@ -327,10 +333,10 @@ impl HardwareInfo {
             .collect()
     }
 
-    pub fn is_gbx00(&self) -> bool {
-        self.dmi_data
-            .as_ref()
-            .is_some_and(|dmi| dmi.product_name.contains("GB200")) // TODO: for now just do GB200
+    /// Returns true when hardware reports at least one GPU with NVLink platform metadata
+    /// and an MNNVL family name (GB200, GB300, etc.).
+    pub fn is_mnnvl_capable(&self) -> bool {
+        self.gpus.iter().any(|gpu| gpu.is_mnnvl_capable())
     }
 
     pub fn is_dgx_h100(&self) -> bool {
@@ -338,6 +344,25 @@ impl HardwareInfo {
             .as_ref()
             .is_some_and(|dmi| dmi.sys_vendor == "NVIDIA" && dmi.product_name == "DGXH100")
     }
+}
+
+/// Substrings matched against discovered GPU `name` values to identify MNNVL-capable hardware.
+pub const MNNVL_KNOWN_GPU_NAMES: &[&str] = &["GB200", "GB300", "VR"];
+
+/// Returns true when `name` contains any [`MNNVL_KNOWN_GPU_NAMES`] entry.
+pub fn gpu_name_indicates_mnnvl(name: &str) -> bool {
+    MNNVL_KNOWN_GPU_NAMES
+        .iter()
+        .any(|marker| name.contains(marker))
+}
+
+/// Builds the SQL `LIKE` conditions used to match GPU names against [`MNNVL_KNOWN_GPU_NAMES`].
+pub fn mnnvl_gpu_name_sql_like_conditions() -> String {
+    MNNVL_KNOWN_GPU_NAMES
+        .iter()
+        .map(|marker| format!("gpu->>'name' LIKE '%{marker}%'"))
+        .collect::<Vec<_>>()
+        .join("\n                      OR ")
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -911,41 +936,92 @@ mod tests {
         );
     }
 
-    // `is_gbx00()` checks for a "GB200" substring in the product name; `is_dgx_h100()`
-    // wants an exact NVIDIA / DGXH100 pairing.
+    fn gpu_with_platform_info(name: &str) -> Gpu {
+        Gpu {
+            name: name.to_string(),
+            serial: String::new(),
+            driver_version: String::new(),
+            vbios_version: String::new(),
+            inforom_version: String::new(),
+            total_memory: String::new(),
+            frequency: String::new(),
+            pci_bus_id: String::new(),
+            platform_info: Some(GpuPlatformInfo {
+                chassis_serial: "chassis-1".to_string(),
+                slot_number: 1,
+                tray_index: 1,
+                host_id: 1,
+                module_id: 1,
+                fabric_guid: "0x1".to_string(),
+            }),
+        }
+    }
+
     #[test]
-    fn hardware_info_product_predicates() {
+    fn hardware_info_is_mnnvl_capable() {
         value_scenarios!(
-            run = |(product_name, _)| {
-                info_with_dmi(
-                    CpuArchitecture::Aarch64,
-                    DmiData {
-                        product_name: product_name.to_string(),
-                        ..Default::default()
-                    },
-                )
-                .is_gbx00()
+            run = |(gpu_name, has_platform_info)| {
+                let mut info = HardwareInfo::default();
+                if has_platform_info {
+                    info.gpus.push(gpu_with_platform_info(gpu_name));
+                } else {
+                    info.gpus.push(Gpu {
+                        name: gpu_name.to_string(),
+                        serial: String::new(),
+                        driver_version: String::new(),
+                        vbios_version: String::new(),
+                        inforom_version: String::new(),
+                        total_memory: String::new(),
+                        frequency: String::new(),
+                        pci_bus_id: String::new(),
+                        platform_info: None,
+                    });
+                }
+                info.is_mnnvl_capable()
             };
-            "exact GB200 product name" {
-                ("GB200", false) => true,
+            "GB200 GPU with platform_info is MNNVL capable" {
+                ("NVIDIA GB200", true) => true,
             }
 
-            "GB200 as a substring" {
-                ("NVIDIA GB200 NVL72", false) => true,
+            "GB300 GPU with platform_info is MNNVL capable" {
+                ("NVIDIA GB300", true) => true,
             }
 
-            "different product is not gbx00" {
-                ("GB300", false) => false,
+            "VR GPU with platform_info is MNNVL capable" {
+                ("NVIDIA VR NVL72 ES", true) => true,
             }
 
-            "empty product name is not gbx00" {
-                ("", false) => false,
+            "GPU name without platform_info is not MNNVL capable" {
+                ("NVIDIA GB200", false) => false,
             }
 
-            "case-sensitive: lowercase gb200 is not gbx00" {
-                ("gb200", false) => false,
+            "platform_info without MNNVL GPU name is not MNNVL capable" {
+                ("NVIDIA H100 PCIe", true) => false,
             }
         );
+    }
+
+    #[test]
+    fn hardware_info_is_mnnvl_capable_ignores_dmi_product_name() {
+        let info = info_with_dmi(
+            CpuArchitecture::Aarch64,
+            DmiData {
+                product_name: "GB200 NVL".to_string(),
+                ..Default::default()
+            },
+        );
+        assert!(!info.is_mnnvl_capable());
+    }
+
+    #[test]
+    fn mnnvl_gpu_name_sql_like_conditions_match_markers() {
+        let sql = mnnvl_gpu_name_sql_like_conditions();
+        for marker in MNNVL_KNOWN_GPU_NAMES {
+            assert!(
+                sql.contains(marker),
+                "expected SQL filter to include marker {marker:?}, got: {sql}"
+            );
+        }
     }
 
     // `is_dgx_h100()` requires both sys_vendor == "NVIDIA" and product_name == "DGXH100".

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -211,9 +211,10 @@ pub struct Gpu {
 }
 
 impl Gpu {
-    /// Returns true when this GPU reports NVLink platform metadata and an MNNVL family name.
-    pub fn is_mnnvl_capable(&self) -> bool {
-        self.platform_info.is_some() && gpu_name_indicates_mnnvl(&self.name)
+    /// Returns true when this GPU reports NVLink platform metadata and an MNNVL family
+    /// name on the GPU or, when absent there, in DMI `product_name`.
+    pub fn is_mnnvl_capable_with_dmi(&self, dmi_product_name: Option<&str>) -> bool {
+        is_mnnvl_capable_gpu(self, dmi_product_name)
     }
 }
 
@@ -334,9 +335,12 @@ impl HardwareInfo {
     }
 
     /// Returns true when hardware reports at least one GPU with NVLink platform metadata
-    /// and an MNNVL family name (GB200, GB300, etc.).
+    /// and an MNNVL family name on the GPU or, when absent there, in DMI `product_name`.
     pub fn is_mnnvl_capable(&self) -> bool {
-        self.gpus.iter().any(|gpu| gpu.is_mnnvl_capable())
+        let dmi_product_name = self.dmi_data.as_ref().map(|dmi| dmi.product_name.as_str());
+        self.gpus
+            .iter()
+            .any(|gpu| is_mnnvl_capable_gpu(gpu, dmi_product_name))
     }
 
     pub fn is_dgx_h100(&self) -> bool {
@@ -346,7 +350,7 @@ impl HardwareInfo {
     }
 }
 
-/// Substrings matched against discovered GPU `name` values to identify MNNVL-capable hardware.
+/// Substrings matched against GPU `name` or DMI `product_name` to identify MNNVL-capable hardware.
 pub const MNNVL_KNOWN_GPU_NAMES: &[&str] = &["GB200", "GB300", "VR"];
 
 /// Returns true when `name` contains any [`MNNVL_KNOWN_GPU_NAMES`] entry.
@@ -356,13 +360,36 @@ pub fn gpu_name_indicates_mnnvl(name: &str) -> bool {
         .any(|marker| name.contains(marker))
 }
 
-/// Builds the SQL `LIKE` conditions used to match GPU names against [`MNNVL_KNOWN_GPU_NAMES`].
+/// Returns true when a GPU has `platform_info` and its name matches an MNNVL marker, or when
+/// the GPU name does not match and DMI `product_name` does.
+pub fn is_mnnvl_capable_gpu(gpu: &Gpu, dmi_product_name: Option<&str>) -> bool {
+    if gpu.platform_info.is_none() {
+        return false;
+    }
+    if gpu_name_indicates_mnnvl(&gpu.name) {
+        return true;
+    }
+    dmi_product_name.is_some_and(gpu_name_indicates_mnnvl)
+}
+
+/// Builds SQL `LIKE` conditions matching GPU `name` or DMI `product_name` against
+/// [`MNNVL_KNOWN_GPU_NAMES`].
 pub fn mnnvl_gpu_name_sql_like_conditions() -> String {
-    MNNVL_KNOWN_GPU_NAMES
+    let gpu_name_conditions = MNNVL_KNOWN_GPU_NAMES
         .iter()
         .map(|marker| format!("gpu->>'name' LIKE '%{marker}%'"))
         .collect::<Vec<_>>()
-        .join("\n                      OR ")
+        .join("\n                      OR ");
+    let dmi_product_name_conditions = MNNVL_KNOWN_GPU_NAMES
+        .iter()
+        .map(|marker| {
+            format!(
+                "mt.topology->'discovery_data'->'Info'->'dmi_data'->>'product_name' LIKE '%{marker}%'"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n                      OR ");
+    format!("{gpu_name_conditions}\n                      OR {dmi_product_name_conditions}")
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -1002,15 +1029,16 @@ mod tests {
     }
 
     #[test]
-    fn hardware_info_is_mnnvl_capable_ignores_dmi_product_name() {
-        let info = info_with_dmi(
+    fn hardware_info_is_mnnvl_capable_falls_back_to_dmi_product_name() {
+        let mut info = info_with_dmi(
             CpuArchitecture::Aarch64,
             DmiData {
                 product_name: "GB200 NVL".to_string(),
                 ..Default::default()
             },
         );
-        assert!(!info.is_mnnvl_capable());
+        info.gpus.push(gpu_with_platform_info("NVIDIA H100 PCIe"));
+        assert!(info.is_mnnvl_capable());
     }
 
     #[test]
@@ -1018,8 +1046,12 @@ mod tests {
         let sql = mnnvl_gpu_name_sql_like_conditions();
         for marker in MNNVL_KNOWN_GPU_NAMES {
             assert!(
-                sql.contains(marker),
-                "expected SQL filter to include marker {marker:?}, got: {sql}"
+                sql.contains(&format!("gpu->>'name' LIKE '%{marker}%'")),
+                "expected SQL filter to include GPU name marker {marker:?}, got: {sql}"
+            );
+            assert!(
+                sql.contains(&format!("dmi_data'->>'product_name' LIKE '%{marker}%'")),
+                "expected SQL filter to include DMI product_name marker {marker:?}, got: {sql}"
             );
         }
     }

--- a/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_1_info.json
+++ b/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_1_info.json
@@ -234,7 +234,7 @@
     "tpm_ek_certificate": "U29tZSBhcmJpdHJhcnkgYmFzZTY0",
     "gpus": [
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1654422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -252,7 +252,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1754422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -270,7 +270,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1854422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -288,7 +288,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1954422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",

--- a/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_2_info.json
+++ b/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_2_info.json
@@ -234,7 +234,7 @@
     "tpm_ek_certificate": "U29tZSBhcmJpdHJhcnkgYmFzZTY0",
     "gpus": [
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1654422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -252,7 +252,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1754422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -270,7 +270,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1854422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -288,7 +288,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1954422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",

--- a/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_3_info.json
+++ b/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_3_info.json
@@ -234,7 +234,7 @@
     "tpm_ek_certificate": "U29tZSBhcmJpdHJhcnkgYmFzZTY0",
     "gpus": [
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1654422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -252,7 +252,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1754422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -270,7 +270,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1854422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -288,7 +288,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1954422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",

--- a/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_4_info.json
+++ b/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_4_info.json
@@ -234,7 +234,7 @@
     "tpm_ek_certificate": "U29tZSBhcmJpdHJhcnkgYmFzZTY0",
     "gpus": [
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1654422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -252,7 +252,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1754422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -270,7 +270,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1854422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -288,7 +288,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "1954422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",

--- a/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_5_info.json
+++ b/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_5_info.json
@@ -234,7 +234,7 @@
     "tpm_ek_certificate": "U29tZSBhcmJpdHJhcnkgYmFzZTY0",
     "gpus": [
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "2054422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -252,7 +252,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "2154422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -270,7 +270,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "2254422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",
@@ -288,7 +288,7 @@
             }
         },
         {
-            "name": "NVIDIA H100 PCIe",
+            "name": "NVIDIA GB200",
             "serial": "2354422005699",
             "driver_version": "530.30.02",
             "vbios_version": "96.00.30.00.01",

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -302,8 +302,12 @@ impl MachineCapabilitiesSet {
 
         let mut gpu_map = HashMap::<String, MachineCapabilityGpu>::new();
 
-        let is_gbx00 = hardware_info.is_gbx00();
         for gpu_info in hardware_info.gpus.into_iter() {
+            let device_type = if gpu_info.is_mnnvl_capable() {
+                Some(MachineCapabilityDeviceType::NvLink)
+            } else {
+                Some(MachineCapabilityDeviceType::Unknown)
+            };
             match gpu_map.get_mut(&gpu_info.name) {
                 None => {
                     gpu_map.insert(
@@ -316,11 +320,7 @@ impl MachineCapabilitiesSet {
                             cores: None,   // hardware_info doesn't provide this.
                             threads: None, // hardware_info doesn't provide this.
                             memory_capacity: Some(gpu_info.total_memory),
-                            device_type: if is_gbx00 {
-                                Some(MachineCapabilityDeviceType::NvLink)
-                            } else {
-                                Some(MachineCapabilityDeviceType::Unknown)
-                            },
+                            device_type,
                         },
                     );
                 }

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -22,7 +22,7 @@ use carbide_uuid::machine::MachineId;
 use serde::{Deserialize, Serialize};
 
 use super::infiniband::MachineInfinibandStatusObservation;
-use crate::hardware_info::{CpuInfo, InfinibandInterface};
+use crate::hardware_info::{CpuInfo, InfinibandInterface, is_mnnvl_capable_gpu};
 use crate::machine::{HardwareInfo, MachineInterfaceSnapshot};
 
 lazy_static::lazy_static! {
@@ -302,8 +302,13 @@ impl MachineCapabilitiesSet {
 
         let mut gpu_map = HashMap::<String, MachineCapabilityGpu>::new();
 
+        let dmi_product_name = hardware_info
+            .dmi_data
+            .as_ref()
+            .map(|dmi| dmi.product_name.as_str());
+
         for gpu_info in hardware_info.gpus.into_iter() {
-            let device_type = if gpu_info.is_mnnvl_capable() {
+            let device_type = if is_mnnvl_capable_gpu(&gpu_info, dmi_product_name) {
                 Some(MachineCapabilityDeviceType::NvLink)
             } else {
                 Some(MachineCapabilityDeviceType::Unknown)

--- a/crates/api-model/src/machine/machine_search_config.rs
+++ b/crates/api-model/src/machine/machine_search_config.rs
@@ -40,7 +40,8 @@ pub struct MachineSearchConfig {
     /// and any joined tables.  The value is *not*
     /// propagated to any additional underlying queries.
     pub for_update: bool,
-    /// Only include NVLink capable machines (GB200/GB300 etc)
+    /// Only include NVLink capable machines (GB200/GB300 etc), identified by GPU
+    /// `name` on entries with `platform_info` in discovered topology.
     pub mnnvl_only: bool,
     pub only_with_power_state: Option<String>,
     pub only_with_health_alert: Option<String>,

--- a/crates/api-model/src/machine/machine_search_config.rs
+++ b/crates/api-model/src/machine/machine_search_config.rs
@@ -40,8 +40,8 @@ pub struct MachineSearchConfig {
     /// and any joined tables.  The value is *not*
     /// propagated to any additional underlying queries.
     pub for_update: bool,
-    /// Only include NVLink capable machines (GB200/GB300 etc), identified by GPU
-    /// `name` on entries with `platform_info` in discovered topology.
+    /// Only include NVLink capable machines (GB200/GB300/VR etc), identified by GPU
+    /// `name` or DMI `product_name` on entries with `platform_info` in discovered topology.
     pub mnnvl_only: bool,
     pub only_with_power_state: Option<String>,
     pub only_with_health_alert: Option<String>,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -9794,14 +9794,13 @@ fn requires_manual_firmware_upgrade(
         return false;
     }
 
-    let is_gb200 = state
+    let is_mnnvl_capable = state
         .host_snapshot
         .hardware_info
         .as_ref()
-        .map(|hi| hi.is_gbx00())
-        .unwrap_or(false);
+        .is_some_and(|hi| hi.is_mnnvl_capable());
 
-    if !is_gb200 {
+    if !is_mnnvl_capable {
         return false;
     }
 


### PR DESCRIPTION
Detect MNNVL machines from GPU platform_info and known GPU names. As there is no canonical way to check for MNNVL capability, If GPU name does not contain one of the know MNNVL name markers, fallback to scan dmi_data.product_name for mnnvl name markers (for ex. on a VR system, GPU name doesn't contain VR, but dmi_data.product_name contains "VR NVL").

## Related issues
[(https://github.com/NVIDIA/infra-controller/issues/3011)]
## Type of Change
<!-- Check one that best describes this PR -->
- [ X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

