### PR TITLE
docs: Sync Fern docs for recent changes

### DIFF
--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -72,7 +72,7 @@ abbreviated as `…/nico/...` thereafter.
 |---|---|---|
 | Put hosts in NIC / no-DPU mode (site-wide `dpu_mode`, per-host `ExpectedMachine.dpu_mode`) | Operator | **TOML** — Day 0 / rare; API restart |
 | Declare `HostInband` underlay segments | Operator | **TOML** (`[networks.<name>]`, `type = "hostinband"`) — Day 0 |
-| Create an additional `HostInband` segment after Day 0 | Operator | **TOML** (`[networks]`) + API restart, or **`nico-admin-cli`** (`network-segment create`) — see [Configuring HostInband Segments](#2-configuring-hostinband-network-segments) |
+| Create an additional `HostInband` segment after initial setup | Operator | **Restart-applied TOML** (`[networks]`), or runtime **`nico-admin-cli`** (`network-segment create`) — see [Configuring HostInband Segments](#2-configuring-hostinband-network-segments) |
 | Inspect / delete a `HostInband` segment | Operator | **`nico-admin-cli`** (`network-segment show` / `delete`) |
 | Create an instance type and associate zero-DPU machines | Operator | **REST** `…/nico/instance-type` · `nicocli` |
 | Bind a `HostInband` segment to a Flat VPC | Tenant *(VPC owner)* | Set the VPC on the segment (see below) |
@@ -197,13 +197,15 @@ after Day 0 in either of two ways:
 
 Note the current CLI surface for the runtime path:
 
-- `nico-admin-cli network-segment create` creates a segment at runtime. For a
-  `HostInband` segment pass `--segment-type host-inband` with `--name`,
-  `--prefix`, and `--gateway` (host-inband segments also need `--subdomain-id`);
-  run `nico-admin-cli network-segment create --help` for the full flag set. The
-  REST API / `nicocli` do not expose operator network-segment management (the
-  REST `/subnet` endpoints are the tenant subnet surface, not operator
-  `HostInband` segments).
+- `nico-admin-cli --cloud-unsafe-op=<username> network-segment create` creates a
+  segment at runtime. The global `--cloud-unsafe-op` acknowledgment is required
+  and must not be used against a production site. For a `HostInband` segment,
+  pass `--segment-type host-inband` with `--name`, `--prefix`, and
+  `--subdomain-id`; add `--gateway` when the IPv4 prefix has a gateway. Run
+  `nico-admin-cli network-segment create --help` for the full flag set. The REST
+  API / `nicocli` do not expose operator network-segment management (the REST
+  `/subnet` endpoints are the tenant subnet surface, not operator `HostInband`
+  segments).
 - `nico-admin-cli network-segment show` and `nico-admin-cli network-segment delete`
   exist for inspecting and removing segments.
 

--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -72,7 +72,7 @@ abbreviated as `…/nico/...` thereafter.
 |---|---|---|
 | Put hosts in NIC / no-DPU mode (site-wide `dpu_mode`, per-host `ExpectedMachine.dpu_mode`) | Operator | **TOML** — Day 0 / rare; API restart |
 | Declare `HostInband` underlay segments | Operator | **TOML** (`[networks.<name>]`, `type = "hostinband"`) — Day 0 |
-| Create an additional `HostInband` segment after Day 0 | Operator | **TOML** (`[networks]`) + API restart, or **`nico-admin-cli`** (gRPC `CreateNetworkSegment`) — see [Configuring HostInband Segments](#2-configuring-hostinband-network-segments) |
+| Create an additional `HostInband` segment after Day 0 | Operator | **TOML** (`[networks]`) + API restart, or **`nico-admin-cli`** (`network-segment create`) — see [Configuring HostInband Segments](#2-configuring-hostinband-network-segments) |
 | Inspect / delete a `HostInband` segment | Operator | **`nico-admin-cli`** (`network-segment show` / `delete`) |
 | Create an instance type and associate zero-DPU machines | Operator | **REST** `…/nico/instance-type` · `nicocli` |
 | Bind a `HostInband` segment to a Flat VPC | Tenant *(VPC owner)* | Set the VPC on the segment (see below) |
@@ -197,14 +197,15 @@ after Day 0 in either of two ways:
 
 Note the current CLI surface for the runtime path:
 
+- `nico-admin-cli network-segment create` creates a segment at runtime. For a
+  `HostInband` segment pass `--segment-type host-inband` with `--name`,
+  `--prefix`, and `--gateway` (host-inband segments also need `--subdomain-id`);
+  run `nico-admin-cli network-segment create --help` for the full flag set. The
+  REST API / `nicocli` do not expose operator network-segment management (the
+  REST `/subnet` endpoints are the tenant subnet surface, not operator
+  `HostInband` segments).
 - `nico-admin-cli network-segment show` and `nico-admin-cli network-segment delete`
   exist for inspecting and removing segments.
-- There is **no `network-segment create` CLI subcommand**, and the REST API /
-  `nicocli` do not expose operator network-segment management (the REST
-  `/subnet` endpoints are the tenant subnet surface, not operator `HostInband`
-  segments). Runtime creation is therefore done by calling the
-  `CreateNetworkSegment` gRPC endpoint directly. If a wrapped create command is
-  needed operationally, file a bug.
 
 Deleting a `HostInband` segment follows the standard segment lifecycle: the
 segment is drained (it is not removed while any host interface or instance

--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -198,16 +198,23 @@ after Day 0 in either of two ways:
 Note the current CLI surface for the runtime path:
 
 - `nico-admin-cli --cloud-unsafe-op=<username> network-segment create` creates a
-  segment at runtime. The global `--cloud-unsafe-op` acknowledgment is required
-  and must not be used against a production site. For a `HostInband` segment,
-  pass `--segment-type host-inband` with `--name`, `--prefix`, and
-  `--subdomain-id`; add `--gateway` when the IPv4 prefix has a gateway. Run
-  `nico-admin-cli network-segment create --help` for the full flag set. The REST
-  API / `nicocli` do not expose operator network-segment management (the REST
-  `/subnet` endpoints are the tenant subnet surface, not operator `HostInband`
-  segments).
-- `nico-admin-cli network-segment show` and `nico-admin-cli network-segment delete`
-  exist for inspecting and removing segments.
+  segment at runtime.
+
+  The global `--cloud-unsafe-op` acknowledgment is required and must not be used
+  against a production site.
+
+  For a `HostInband` segment, pass `--segment-type host-inband` with `--name`,
+  `--prefix`, and `--subdomain-id`; add `--gateway` when the IPv4 prefix has a
+  gateway.
+
+  Run `nico-admin-cli network-segment create --help` for the full flag set.
+- `nico-admin-cli network-segment show` lists segments. To remove one, use
+  `nico-admin-cli --cloud-unsafe-op=<username> network-segment delete`; the same
+  global acknowledgment is required and must not be used against production.
+
+<Tip>
+The REST API and `nicocli` do not expose operator network-segment management. The REST `/subnet` endpoints are the tenant subnet surface, not operator `HostInband` segments.
+</Tip>
 
 Deleting a `HostInband` segment follows the standard segment lifecycle: the
 segment is drained (it is not removed while any host interface or instance


### PR DESCRIPTION
### What this PR does

Correct `docs/manuals/vpc/flat_vpcs_zero_dpu.md` to reflect the
`nico-admin-cli network-segment create` subcommand. The guide previously stated
that no such subcommand existed and that runtime `HostInband` segment creation
required calling the `CreateNetworkSegment` gRPC endpoint directly.

The updated page now gives operators the real CLI command and the required
`host-inband` inputs.

### Source PRs reviewed

Reviewed the 80 PRs merged in `NVIDIA/infra-controller` between 2026-07-02 and
2026-07-09. This docs change is driven by:

- #3143 `feat(cli): Support network segment creation from CLI` (adds
  `network-segment create`).

Considered but not requiring a docs edit here: #3145 (`vpc create` on the admin
CLI; the guide's `nicocli` coverage-gap note is about the tenant REST wrapper,
not the admin CLI) and #3150 (REST endpoint restructure; the OpenAPI spec is
regenerated in-PR and no prose docs reference the old routes).

### How we verified it

Tested revision `cdd338a5a2a2f119e5aaeb401d5e3980a3a03421` from a clean
checkout on macOS 26.5.1 arm64 with the repository-pinned Rust 1.96.0 toolchain
and Node.js 25.5.0.

Hands-on verification:

- Compiled and ran
  `cargo run --package nico-admin-cli -- network-segment create --help`.
  The real help output listed `host-inband` as a `--segment-type` value,
  showed `--gateway` as optional, and exposed `--name`, `--prefix`, and
  `--subdomain-id`. The command's runtime dispatch requires the global
  `--cloud-unsafe-op` acknowledgment, whose help explicitly warns against
  production use.
- Started the local Fern preview with the repository-pinned
  `fern-api@4.81.0` package. The changed page returned HTTP 200 and rendered
  the restart-applied TOML/runtime CLI distinction, the required
  `--cloud-unsafe-op=<username>` warning, conditional `--gateway` guidance,
  and the `2-configuring-hostinband-network-segments` section anchor. The
  stale "no create command" and mandatory-gateway wording were absent.

Supporting checks:

- `fern check`: 0 errors.
- `rumdl` 0.2.29 reported the same seven pre-existing MD040/MD029 findings on
  both `origin/main` and the PR revision; the edited region added no finding.
- `git diff --check origin/main...HEAD`: passed.
- `fern docs broken-links --strict` still reports 27 pre-existing errors in
  other pages; none are in the changed Flat VPC page.

### How to reproduce the verification

Prerequisites: macOS arm64, Rustup, Node.js/npm, and `rg`.

```bash
git clone https://github.com/kfelternv/infra-controller.git
cd infra-controller
git checkout cdd338a5a2a2f119e5aaeb401d5e3980a3a03421

CARGO_TERM_COLOR=never NO_COLOR=1 \
  cargo run --package nico-admin-cli -- network-segment create --help
```

Expected CLI checkpoints:

- `--segment-type` lists `host-inband`.
- Help includes `--name`, `--prefix`, `--gateway`, and `--subdomain-id`;
  `--gateway` is not part of the required usage set.
- `nico-admin-cli --help` documents `--cloud-unsafe-op <USERNAME>` and its
  non-production warning.

Validate and render the documentation:

```bash
npx -y fern-api@4.81.0 check
npx -y fern-api@4.81.0 docs dev --port 4173
```

In another shell:

```bash
URL=http://127.0.0.1:4173/infra-controller/documentation/operations-day-2/managing-vp-cs/flat-vp-cs-and-zero-dpu-hosts

curl -sSL -o /dev/null -w '%{http_code}\n' "$URL"
curl -sSL "$URL" | rg -o -F -- 'Restart-applied TOML'
curl -sSL "$URL" | rg -o -F -- 'cloud-unsafe-op'
curl -sSL "$URL" | rg -o -F -- 'must not be used against a production site'
curl -sSL "$URL" | rg -o -F -- 'add <code>--gateway</code> when the IPv4 prefix has a gateway'
curl -sSL "$URL" | rg -o -F -- 'id="2-configuring-hostinband-network-segments"'
```

Expected result: HTTP 200 and one match from each content check.

### Risk / notes

- Docs-only change; no code or generated specs touched.
- Possible follow-up (out of scope): `docs/playbooks/force_delete.md` still uses
  the old `-c` API-URL flag in one example; #3114 renamed it to `-a` everywhere
  else. A separate one-line fix.
