### PR TITLE
feat: complete the Kea hook's DHCP drop census and count replies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,6 +1608,7 @@ dependencies = [
 name = "carbide-dhcp"
 version = "0.0.0"
 dependencies = [
+ "carbide-instrument",
  "carbide-rpc",
  "carbide-test-support",
  "carbide-tls",

--- a/crates/dhcp/Cargo.toml
+++ b/crates/dhcp/Cargo.toml
@@ -30,6 +30,7 @@ tokio-util = { workspace = true }
 tonic = { workspace = true }
 
 # [local-dependencies]
+carbide-instrument = { path = "../instrument" }
 carbide-rpc = { path = "../rpc" }
 carbide-tls = { path = "../tls" }
 metrics-endpoint = { path = "../metrics-endpoint" }
@@ -40,6 +41,7 @@ dhcproto = { workspace = true }
 serde_json = { workspace = true }
 test-cdylib = { workspace = true }
 tempfile = { workspace = true }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-rpc = { path = "../rpc" }
 carbide-test-support = { path = "../test-support" }
 prometheus = { workspace = true }

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -133,6 +133,11 @@ void update_option(CalloutHandle &handle, Pkt4Ptr response4_ptr,
                       "[%1]. Exception: %2")
         .arg(option)
         .arg(e.what());
+    // Several options are updated per reply and each failing update throws;
+    // count the packet's drop once, on the throw that marks it dropped.
+    if (handle.getStatus() != CalloutHandle::NEXT_STEP_DROP) {
+      carbide_increment_dropped_requests("OptionEncodingFailed");
+    }
     handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
   }
 }
@@ -519,6 +524,7 @@ int pkt4_send(CalloutHandle &handle) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_PKT4_SEND)
         .arg("Missing machine object from handle context");
     handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    carbide_increment_dropped_requests("MissingMachineContext");
     return 1;
   }
 
@@ -542,6 +548,14 @@ int pkt4_send(CalloutHandle &handle) {
 
   LOG_INFO(logger, isc::log::LOG_CARBIDE_PKT4_SEND)
       .arg(response4_ptr->toText());
+
+  /*
+   * The reply is fully assembled; count it by DHCP message type unless an
+   * option failure above already marked the exchange dropped (and counted).
+   */
+  if (handle.getStatus() != CalloutHandle::NEXT_STEP_DROP) {
+    carbide_increment_reply_sent(response4_ptr->getType());
+  }
 
   return 0;
 }
@@ -603,6 +617,7 @@ int lease4_select(CalloutHandle &handle) {
         .arg("Missing lease4 argument");
     // At lease4_select, SKIP means Kea will not assign its selected lease.
     handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    carbide_increment_dropped_requests("AllocationRefused");
     return 1;
   }
 
@@ -620,6 +635,7 @@ int lease4_select(CalloutHandle &handle) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
         .arg("Missing machine object from handle context");
     handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    carbide_increment_dropped_requests("AllocationRefused");
     return 1;
   }
 
@@ -631,6 +647,7 @@ int lease4_select(CalloutHandle &handle) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
         .arg("Carbide returned no usable IPv4 address; refusing to allocate");
     handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    carbide_increment_dropped_requests("AllocationRefused");
     return 1;
   }
 
@@ -683,6 +700,7 @@ int lease4_renew(CalloutHandle &handle) {
         .arg("Missing lease4 argument");
     // At lease4_renew, SKIP means Kea will not update the lease database.
     handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    carbide_increment_dropped_requests("RenewalRefused");
     return 1;
   }
 
@@ -692,6 +710,7 @@ int lease4_renew(CalloutHandle &handle) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
         .arg("Missing machine object from handle context");
     handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    carbide_increment_dropped_requests("RenewalRefused");
     return 1;
   }
 
@@ -700,6 +719,7 @@ int lease4_renew(CalloutHandle &handle) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
         .arg("Carbide returned no usable IPv4 address; refusing to renew");
     handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    carbide_increment_dropped_requests("RenewalRefused");
     return 1;
   }
 

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -24,7 +24,6 @@ use forge_tls::default as tls_default;
 use libc::c_char;
 use metrics_endpoint::HealthController;
 use once_cell::sync::Lazy;
-use opentelemetry::metrics::Counter;
 use rpc::forge_tls_client::ForgeClientConfig;
 use tokio::runtime::{Builder, Runtime};
 
@@ -62,10 +61,11 @@ pub struct CarbideDhcpContext {
     startup_time: chrono::DateTime<chrono::Utc>,
 }
 
+// The request/drop/reply counters are `carbide-instrument` events declared in
+// `metrics.rs` and resolve from the global meter; this struct holds only the
+// state the certificate-expiry gauge reports.
 #[derive(Debug, Clone)]
 pub struct CarbideDhcpMetrics {
-    total_requests_counter: Counter<u64>,
-    dropped_requests_counter: Counter<u64>,
     forge_client_config: ForgeClientConfig,
     certificate_expiration_value: Arc<AtomicI64>,
 }
@@ -238,17 +238,37 @@ pub unsafe extern "C" fn carbide_increment_total_requests() {
     metrics::increment_total_requests();
 }
 
-/// Increments counter for number of dropped requests
+/// Increments counter for number of dropped or refused requests. The reason
+/// string is mapped onto the bounded [`metrics::DropReason`] taxonomy; a
+/// string outside the taxonomy (or a null / non-UTF-8 input) is bucketed as
+/// `Unknown` so the metric's label domain stays closed.
+///
+/// # Safety
+/// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
+/// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_increment_dropped_requests(reason: *const c_char) {
+    let reason = if reason.is_null() {
+        metrics::DropReason::Unknown
+    } else {
+        unsafe { CStr::from_ptr(reason) }
+            .to_str()
+            .map_or(metrics::DropReason::Unknown, metrics::DropReason::from)
+    };
+    metrics::increment_dropped_requests(reason);
+}
+
+/// Increments counter for number of DHCP replies sent, labelled by the
+/// reply's message type. `message_type` is the raw RFC 2131 message-type code
+/// from the response packet (`Pkt4::getType()`); the mapping onto the bounded
+/// label lives in [`metrics::ReplyMessageType`].
 ///
 /// # Safety
 ///
 /// None
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn carbide_increment_dropped_requests(reason: *const c_char) {
-    unsafe {
-        let reason_value = CStr::from_ptr(reason).to_str().unwrap().to_owned();
-        metrics::increment_dropped_requests(reason_value);
-    }
+pub extern "C" fn carbide_increment_reply_sent(message_type: u8) {
+    metrics::increment_reply_sent(metrics::ReplyMessageType::from(message_type));
 }
 
 #[cfg(test)]

--- a/crates/dhcp/src/metrics.rs
+++ b/crates/dhcp/src/metrics.rs
@@ -15,15 +15,28 @@
  * limitations under the License.
  */
 
+//! Packet-level counters for the Kea hook, plus the metrics endpoint, health
+//! plumbing, and the certificate-expiry gauge.
+//!
+//! The counters are `carbide-instrument` events declared with `log = off`:
+//! the Kea process installs no tracing subscriber, so the C++ `LOG_ERROR`
+//! lines in `callouts.cc` remain the log side and the events move only the
+//! metric. The two request counters keep their pre-standard names via
+//! `name_unchecked` -- the names and the `reason` label key existing
+//! dashboards select on stay byte-identical. The certificate-expiry gauge is
+//! point-in-time state, not an occurrence, and stays on the observable-gauge
+//! pattern.
+
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
+use carbide_instrument::{Event, LabelValue, emit};
 use metrics_endpoint::{
     HealthController, MetricsEndpointConfig, MetricsSetup, new_metrics_setup, run_metrics_endpoint,
 };
-use opentelemetry::KeyValue;
+use opentelemetry::StringValue;
 use rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
 use tokio::runtime::Runtime;
 use tokio::time::{interval, timeout};
@@ -32,6 +45,196 @@ use crate::{CONFIG, CarbideDhcpContext, CarbideDhcpMetrics, tls};
 
 const METRICS_CAPTURE_FREQUENCY: Duration = Duration::from_secs(30);
 const READINESS_CHECK_FREQUENCY: Duration = Duration::from_secs(30);
+
+/// The DHCP message type of an outgoing reply, as a bounded metric label.
+///
+/// Built from the raw RFC 2131 message-type code Kea reports for the response
+/// (`Pkt4::getType()`): DHCPOFFER = 2, DHCPACK = 5, DHCPNAK = 6. Those three
+/// are the only types a DHCPv4 server sends, so any other code counts as
+/// `other`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum ReplyMessageType {
+    Offer,
+    Ack,
+    Nak,
+    Other,
+}
+
+impl From<u8> for ReplyMessageType {
+    fn from(message_type_code: u8) -> Self {
+        match message_type_code {
+            2 => Self::Offer, // DHCPOFFER
+            5 => Self::Ack,   // DHCPACK
+            6 => Self::Nak,   // DHCPNAK
+            _ => Self::Other,
+        }
+    }
+}
+
+/// Why the hook dropped or refused a DHCP request, as the bounded `reason`
+/// label on the grandfathered `carbide-dhcp.dropped_requests` counter.
+///
+/// The rendered strings are part of the metric's contract: the long-counted
+/// reasons render byte-identically to the strings their sites have always
+/// reported (including every `DiscoveryBuilderResult` name, which
+/// `pkt4_receive` passes through verbatim on a discovery failure), and the
+/// newer refusal reasons follow the same PascalCase style.
+/// [`DropReason::Unknown`] closes the domain: a reason string outside this
+/// taxonomy buckets there instead of minting a new time series.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropReason {
+    /// `pkt4_receive` refuses packets that did not arrive through a relay.
+    NonRelayedPacket,
+    /// `pkt4_receive` drops packets whose machine carries no usable IPv4
+    /// address.
+    NoUsableIPv4Address,
+    // One variant per `DiscoveryBuilderResult` name: on a machine-discovery
+    // failure, `pkt4_receive` reports the result's name verbatim as the
+    // reason. `Success` covers the defensive edge where discovery reported
+    // success yet returned no machine object.
+    Success,
+    InvalidDiscoveryBuilderPointer,
+    InvalidMacAddress,
+    InvalidVendorClass,
+    InvalidMachinePointer,
+    BuilderError,
+    FetchMachineError,
+    InvalidCircuitId,
+    TooManyFailuresError,
+    InvalidDesiredAddress,
+    /// `pkt4_send` hit an exception while encoding a response option.
+    OptionEncodingFailed,
+    /// `pkt4_send` found no machine object on the callout context.
+    MissingMachineContext,
+    /// `lease4_select` refused to let Kea assign its selected lease (missing
+    /// hook state, or no usable address from Carbide).
+    AllocationRefused,
+    /// `lease4_renew` refused to let Kea extend an existing lease (missing
+    /// hook state, or no usable address from Carbide).
+    RenewalRefused,
+    /// The FFI reason string was not part of this taxonomy; bucketing keeps
+    /// the label domain closed.
+    Unknown,
+}
+
+impl DropReason {
+    /// Every variant, as the single source for the string mapping and tests.
+    // Every variant must appear here: `From<&str>` resolves FFI strings by
+    // scanning this table, so a variant missing from it buckets to `Unknown`.
+    const ALL: [Self; 17] = [
+        Self::NonRelayedPacket,
+        Self::NoUsableIPv4Address,
+        Self::Success,
+        Self::InvalidDiscoveryBuilderPointer,
+        Self::InvalidMacAddress,
+        Self::InvalidVendorClass,
+        Self::InvalidMachinePointer,
+        Self::BuilderError,
+        Self::FetchMachineError,
+        Self::InvalidCircuitId,
+        Self::TooManyFailuresError,
+        Self::InvalidDesiredAddress,
+        Self::OptionEncodingFailed,
+        Self::MissingMachineContext,
+        Self::AllocationRefused,
+        Self::RenewalRefused,
+        Self::Unknown,
+    ];
+
+    /// The exact string exposed as the metric's `reason` label value, and
+    /// accepted back across the FFI. PascalCase by contract: dashboards
+    /// select on these bytes.
+    const fn as_label(self) -> &'static str {
+        match self {
+            Self::NonRelayedPacket => "NonRelayedPacket",
+            Self::NoUsableIPv4Address => "NoUsableIPv4Address",
+            Self::Success => "Success",
+            Self::InvalidDiscoveryBuilderPointer => "InvalidDiscoveryBuilderPointer",
+            Self::InvalidMacAddress => "InvalidMacAddress",
+            Self::InvalidVendorClass => "InvalidVendorClass",
+            Self::InvalidMachinePointer => "InvalidMachinePointer",
+            Self::BuilderError => "BuilderError",
+            Self::FetchMachineError => "FetchMachineError",
+            Self::InvalidCircuitId => "InvalidCircuitId",
+            Self::TooManyFailuresError => "TooManyFailuresError",
+            Self::InvalidDesiredAddress => "InvalidDesiredAddress",
+            Self::OptionEncodingFailed => "OptionEncodingFailed",
+            Self::MissingMachineContext => "MissingMachineContext",
+            Self::AllocationRefused => "AllocationRefused",
+            Self::RenewalRefused => "RenewalRefused",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+/// Manual rather than derived: the derive renders variant names in
+/// snake_case, and this label's values are the grandfathered PascalCase
+/// strings existing dashboards already select on. The fieldless enum itself
+/// keeps the domain closed.
+impl LabelValue for DropReason {
+    fn label_value(&self) -> StringValue {
+        StringValue::from(self.as_label())
+    }
+}
+
+impl From<&str> for DropReason {
+    /// Maps an FFI reason string onto the taxonomy; anything unrecognized
+    /// buckets to [`DropReason::Unknown`].
+    fn from(reason: &str) -> Self {
+        Self::ALL
+            .into_iter()
+            .find(|candidate| candidate.as_label() == reason)
+            .unwrap_or(Self::Unknown)
+    }
+}
+
+/// A DHCP request reached the hook's `pkt4_receive` callout, whatever becomes
+/// of it next.
+#[derive(Event)]
+#[event(
+    name = "carbide-dhcp.requests",
+    name_unchecked,
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCP requests received."
+)]
+pub struct DhcpRequestReceived;
+
+/// The hook dropped or refused a DHCP request. This counts refusal events,
+/// not packets: an exchange that fails at more than one callout (a refused
+/// lease selection and then a missing machine at send time) counts each site.
+#[derive(Event)]
+#[event(
+    name = "carbide-dhcp.dropped_requests",
+    name_unchecked,
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCP requests dropped or refused, by reason."
+)]
+pub struct DhcpRequestDropped {
+    #[label]
+    pub reason: DropReason,
+}
+
+/// A fully assembled DHCP reply left `pkt4_send` for transmission: an `offer`
+/// proposes a lease, an `ack` commits one, a `nak` refuses one.
+///
+/// Unlike the two request counters this metric is new, so it uses the
+/// standard name rather than a grandfathered one.
+#[derive(Event)]
+#[event(
+    name = "carbide_dhcp_replies_sent_total",
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCP replies sent, by reply message type."
+)]
+pub struct DhcpReplySent {
+    #[label]
+    pub message_type: ReplyMessageType,
+}
 
 pub async fn certificate_loop() {
     let mut interval = tokio::time::interval(METRICS_CAPTURE_FREQUENCY);
@@ -54,18 +257,7 @@ pub async fn certificate_loop() {
 
 fn initialize_metrics(mconf: &MetricsSetup) -> CarbideDhcpMetrics {
     let certificate_expiration_value = Arc::new(AtomicI64::new(0));
-    // initialize metrics.
     let metrics = CarbideDhcpMetrics {
-        total_requests_counter: mconf
-            .meter
-            .u64_counter("carbide-dhcp.requests")
-            .with_description("The total number of DHCP requests")
-            .build(),
-        dropped_requests_counter: mconf
-            .meter
-            .u64_counter("carbide-dhcp.dropped_requests")
-            .with_description("The number of dropped DHCP requests")
-            .build(),
         forge_client_config: tls::build_forge_client_config(),
         certificate_expiration_value: certificate_expiration_value.clone(),
     };
@@ -184,17 +376,36 @@ pub async fn start_readiness_monitoring() {
     }
 }
 
+/// True once [`metrics_server`] has installed the global meter provider and
+/// stored the initialized metrics state.
+///
+/// Event instruments resolve from the global meter once per event type on
+/// first emit, so emitting before the provider install would bind that event
+/// type to the no-op meter for the process lifetime. The gate also keeps an
+/// endpointless configuration recording nothing, as before.
+fn metrics_initialized() -> bool {
+    CONFIG
+        .read()
+        .expect("config lock poisoned")
+        .metrics
+        .is_some()
+}
+
 pub fn increment_total_requests() {
-    if let Some(metrics) = CONFIG.read().expect("config lock poisoned").metrics.clone() {
-        metrics.total_requests_counter.add(1, &[]);
+    if metrics_initialized() {
+        emit(DhcpRequestReceived);
     }
 }
 
-pub fn increment_dropped_requests(reason: String) {
-    if let Some(metrics) = CONFIG.read().expect("config lock poisoned").metrics.clone() {
-        metrics
-            .dropped_requests_counter
-            .add(1, &[KeyValue::new("reason", reason)]);
+pub fn increment_dropped_requests(reason: DropReason) {
+    if metrics_initialized() {
+        emit(DhcpRequestDropped { reason });
+    }
+}
+
+pub fn increment_reply_sent(message_type: ReplyMessageType) {
+    if metrics_initialized() {
+        emit(DhcpReplySent { message_type });
     }
 }
 
@@ -222,19 +433,24 @@ pub fn set_service_healthy(healthy: bool) {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CStr;
+
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use prometheus::{Encoder, TextEncoder};
 
     use super::*;
+    use crate::discovery::{DiscoveryBuilderResult, discovery_builder_result_as_str};
 
+    /// The certificate-expiry gauge stays on the per-process meter; its
+    /// exposition is pinned verbatim.
     #[test]
-    fn test_metrics() {
+    fn certificate_gauge_exposition_is_stable() {
         let mconf = new_metrics_setup("carbide-dhcp", "forge-system", false).unwrap();
         let metrics = initialize_metrics(&mconf);
         metrics
             .certificate_expiration_value
             .store(1740173562, Ordering::SeqCst);
-        metrics.total_requests_counter.add(1, &[]);
-        metrics.dropped_requests_counter.add(1, &[]);
 
         let mut buffer = vec![];
         let encoder = TextEncoder::new();
@@ -243,5 +459,295 @@ mod tests {
 
         let prom_metrics = String::from_utf8(buffer).unwrap();
         assert_eq!(prom_metrics, include_str!("../tests/fixtures/metrics.txt"));
+    }
+
+    #[test]
+    fn reply_message_type_maps_the_rfc2131_reply_codes_and_buckets_the_rest() {
+        check_values(
+            [
+                Check {
+                    scenario: "DHCPOFFER (2)",
+                    input: 2u8,
+                    expect: ReplyMessageType::Offer,
+                },
+                Check {
+                    scenario: "DHCPACK (5)",
+                    input: 5,
+                    expect: ReplyMessageType::Ack,
+                },
+                Check {
+                    scenario: "DHCPNAK (6)",
+                    input: 6,
+                    expect: ReplyMessageType::Nak,
+                },
+                Check {
+                    scenario: "DHCPDISCOVER (1) is not a reply type",
+                    input: 1,
+                    expect: ReplyMessageType::Other,
+                },
+                Check {
+                    scenario: "DHCPREQUEST (3) is not a reply type",
+                    input: 3,
+                    expect: ReplyMessageType::Other,
+                },
+                Check {
+                    scenario: "unknown code buckets as other",
+                    input: 250,
+                    expect: ReplyMessageType::Other,
+                },
+            ],
+            ReplyMessageType::from,
+        );
+    }
+
+    /// Pins every `reason` label rendering. The strings are the metric's
+    /// contract: the long-counted reasons must keep their exact legacy bytes,
+    /// and the newer ones must hold still for the same reason.
+    #[test]
+    fn drop_reason_renders_the_contract_strings_byte_identically() {
+        check_values(
+            [
+                Check {
+                    scenario: "non-relayed packet (legacy)",
+                    input: DropReason::NonRelayedPacket,
+                    expect: "NonRelayedPacket",
+                },
+                Check {
+                    scenario: "no usable IPv4 address (legacy)",
+                    input: DropReason::NoUsableIPv4Address,
+                    expect: "NoUsableIPv4Address",
+                },
+                Check {
+                    scenario: "discovery success without machine (legacy)",
+                    input: DropReason::Success,
+                    expect: "Success",
+                },
+                Check {
+                    scenario: "invalid discovery builder pointer (legacy)",
+                    input: DropReason::InvalidDiscoveryBuilderPointer,
+                    expect: "InvalidDiscoveryBuilderPointer",
+                },
+                Check {
+                    scenario: "invalid mac address (legacy)",
+                    input: DropReason::InvalidMacAddress,
+                    expect: "InvalidMacAddress",
+                },
+                Check {
+                    scenario: "invalid vendor class (legacy)",
+                    input: DropReason::InvalidVendorClass,
+                    expect: "InvalidVendorClass",
+                },
+                Check {
+                    scenario: "invalid machine pointer (legacy)",
+                    input: DropReason::InvalidMachinePointer,
+                    expect: "InvalidMachinePointer",
+                },
+                Check {
+                    scenario: "builder error (legacy)",
+                    input: DropReason::BuilderError,
+                    expect: "BuilderError",
+                },
+                Check {
+                    scenario: "fetch machine error (legacy)",
+                    input: DropReason::FetchMachineError,
+                    expect: "FetchMachineError",
+                },
+                Check {
+                    scenario: "invalid circuit id (legacy)",
+                    input: DropReason::InvalidCircuitId,
+                    expect: "InvalidCircuitId",
+                },
+                Check {
+                    scenario: "too many failures (legacy)",
+                    input: DropReason::TooManyFailuresError,
+                    expect: "TooManyFailuresError",
+                },
+                Check {
+                    scenario: "invalid desired address (legacy)",
+                    input: DropReason::InvalidDesiredAddress,
+                    expect: "InvalidDesiredAddress",
+                },
+                Check {
+                    scenario: "option encoding failed (new)",
+                    input: DropReason::OptionEncodingFailed,
+                    expect: "OptionEncodingFailed",
+                },
+                Check {
+                    scenario: "missing machine context (new)",
+                    input: DropReason::MissingMachineContext,
+                    expect: "MissingMachineContext",
+                },
+                Check {
+                    scenario: "allocation refused (new)",
+                    input: DropReason::AllocationRefused,
+                    expect: "AllocationRefused",
+                },
+                Check {
+                    scenario: "renewal refused (new)",
+                    input: DropReason::RenewalRefused,
+                    expect: "RenewalRefused",
+                },
+                Check {
+                    scenario: "unknown bucket",
+                    input: DropReason::Unknown,
+                    expect: "Unknown",
+                },
+            ],
+            DropReason::as_label,
+        );
+    }
+
+    /// The metric label is `as_label` verbatim, for every variant -- the
+    /// string table above therefore pins what lands on the exposition.
+    #[test]
+    fn label_value_renders_as_label_for_every_variant() {
+        for reason in DropReason::ALL {
+            assert_eq!(
+                reason.label_value().as_str(),
+                reason.as_label(),
+                "{reason:?}"
+            );
+        }
+    }
+
+    /// The pkt4_receive discovery-failure site passes
+    /// `discovery_builder_result_as_str(...)` straight through the FFI, so
+    /// every result name must map onto the taxonomy and render back to the
+    /// same bytes -- a new `DiscoveryBuilderResult` variant that fell into
+    /// the `Unknown` bucket would fail here.
+    #[test]
+    fn drop_reason_round_trips_every_discovery_builder_result_string() {
+        for result in [
+            DiscoveryBuilderResult::Success,
+            DiscoveryBuilderResult::InvalidDiscoveryBuilderPointer,
+            DiscoveryBuilderResult::InvalidMacAddress,
+            DiscoveryBuilderResult::InvalidVendorClass,
+            DiscoveryBuilderResult::InvalidMachinePointer,
+            DiscoveryBuilderResult::BuilderError,
+            DiscoveryBuilderResult::FetchMachineError,
+            DiscoveryBuilderResult::InvalidCircuitId,
+            DiscoveryBuilderResult::TooManyFailuresError,
+            DiscoveryBuilderResult::InvalidDesiredAddress,
+        ] {
+            let reason_str = unsafe { CStr::from_ptr(discovery_builder_result_as_str(result)) }
+                .to_str()
+                .unwrap();
+            let reason = DropReason::from(reason_str);
+            assert_ne!(reason, DropReason::Unknown, "{result:?} is unmapped");
+            assert_eq!(reason.label_value().as_str(), reason_str, "{result:?}");
+        }
+    }
+
+    #[test]
+    fn unmapped_reason_strings_bucket_to_unknown() {
+        assert_eq!(DropReason::from("SomeFutureReason"), DropReason::Unknown);
+    }
+
+    /// All three packet counters are metric-only: one emit moves exactly its
+    /// counter -- under the exposed name dashboards use -- and builds no log
+    /// line at all (the Kea process has no tracing subscriber; the C++ log
+    /// lines remain the log side).
+    #[test]
+    fn packet_events_count_under_the_exposed_names_and_never_log() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit(DhcpRequestReceived);
+            emit(DhcpRequestDropped {
+                reason: DropReason::TooManyFailuresError,
+            });
+            emit(DhcpReplySent {
+                message_type: ReplyMessageType::Offer,
+            });
+        });
+
+        assert!(logs.is_empty(), "log = off events must not log: {logs:?}");
+        assert_eq!(
+            metrics.counter_delta("carbide_dhcp_requests_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_dropped_requests_total",
+                &[("reason", "TooManyFailuresError")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_replies_sent_total",
+                &[("message_type", "offer")]
+            ),
+            1.0
+        );
+    }
+
+    /// The C++ callouts reach the counters through the FFI layer: reason
+    /// strings map onto the bounded taxonomy (unknown ones bucket), the raw
+    /// Kea message-type code maps onto the reply label, and nothing records
+    /// until `metrics_server` has initialized metrics -- the gate that also
+    /// guarantees the global meter provider is installed before the first
+    /// emit.
+    #[test]
+    fn ffi_increments_gate_on_initialization_and_map_their_arguments() {
+        let metrics = MetricsCapture::start();
+
+        // Before initialization the gate keeps every counter still. (Nothing
+        // else in this test binary sets `CONFIG.metrics`, so this phase is
+        // deterministic.)
+        unsafe {
+            crate::carbide_increment_total_requests();
+            crate::carbide_increment_dropped_requests(c"NonRelayedPacket".as_ptr());
+        }
+        crate::carbide_increment_reply_sent(5);
+        assert_eq!(
+            metrics.counter_delta("carbide_dhcp_requests_total", &[]),
+            0.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_replies_sent_total",
+                &[("message_type", "ack")]
+            ),
+            0.0
+        );
+
+        // Initialize the way `metrics_server` does (a local registry carries
+        // the gauge; the counters resolve from the global test meter).
+        let mconf = new_metrics_setup("carbide-dhcp", "forge-system", false).unwrap();
+        let initialized = initialize_metrics(&mconf);
+        CONFIG.write().expect("config lock poisoned").metrics = Some(initialized);
+
+        unsafe {
+            crate::carbide_increment_total_requests();
+            crate::carbide_increment_dropped_requests(c"NonRelayedPacket".as_ptr());
+            crate::carbide_increment_dropped_requests(c"NotAReasonWeKnow".as_ptr());
+        }
+        crate::carbide_increment_reply_sent(5); // DHCPACK
+
+        assert_eq!(
+            metrics.counter_delta("carbide_dhcp_requests_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_dropped_requests_total",
+                &[("reason", "NonRelayedPacket")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_dropped_requests_total",
+                &[("reason", "Unknown")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_replies_sent_total",
+                &[("message_type", "ack")]
+            ),
+            1.0
+        );
     }
 }

--- a/crates/dhcp/tests/fixtures/metrics.txt
+++ b/crates/dhcp/tests/fixtures/metrics.txt
@@ -1,9 +1,3 @@
 # HELP carbide_dhcp_certificate_expiration_time The certificate expiration time (epoch seconds)
 # TYPE carbide_dhcp_certificate_expiration_time gauge
 carbide_dhcp_certificate_expiration_time 1740173562
-# HELP carbide_dhcp_dropped_requests_total The number of dropped DHCP requests
-# TYPE carbide_dhcp_dropped_requests_total counter
-carbide_dhcp_dropped_requests_total 1
-# HELP carbide_dhcp_requests_total The total number of DHCP requests
-# TYPE carbide_dhcp_requests_total counter
-carbide_dhcp_requests_total 1


### PR DESCRIPTION
The Kea hook's drop counter under-counts: two hard-drop paths and six allocation/renewal refusals log without incrementing, and there is no reply counter at all -- so grant rate and the full drop taxonomy are both blind spots on the primary DHCP serving path. This closes both.

- `carbide_dhcp_replies_sent_total{message_type}` -- new, counts every reply Kea actually sends (`offer`/`ack`/`nak`/`other`), incremented at the end of `pkt4_send` and suppressed when the exchange was marked dropped. Lease grants are the `offer`/`ack` series, matching the DPU dhcp-server's counter of the same name.
- `carbide_dhcp_dropped_requests_total{reason}` -- the exposed name, the `reason` label key, and every pre-existing reason string stay byte-identical for existing dashboards, while eight previously-uncounted paths now increment it: option-encoding failures, missing machine context, and the six allocation/renewal refusals. A refused REQUEST counts both its refusal and the `nak` reply that follows -- both really happened.

Notable details:

- The raw-string reason plumbing hardens into a bounded `DropReason` enum with a manual `LabelValue` impl pinning the legacy strings verbatim; unrecognized FFI strings bucket to `Unknown` instead of minting new label values.
- All events are metric-only (`log = off`): the Kea process has no tracing subscriber, and every existing C++ LOG line stays untouched -- the C++ diff is pure one-line increments beside the drops they count.
- An option-encoding failure that throws on several options of one reply counts that packet's drop once (status-guarded).
- The in-tree real-Kea integration tests -- the hook loaded into an actual multi-threaded Kea -- pass with the new counters live.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3177
