### PR TITLE
feat: count client certificate renewals and expose the expiry gauge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,10 +1597,12 @@ name = "carbide-certs"
 version = "0.0.0"
 dependencies = [
  "carbide-host-support",
+ "carbide-instrument",
  "carbide-rpc",
  "carbide-tls",
  "eyre",
  "rand 0.10.1",
+ "tokio",
  "tonic",
  "tracing",
 ]

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -68,6 +68,27 @@ impl AgentMetricsState {
             })
             .build();
     }
+
+    // Export the expiry of the TLS client certificate the agent presents to
+    // the Forge API, as a Unix timestamp. `expiry` runs on every metrics
+    // collection, so the exported value follows certificate renewals; a
+    // collection that finds no readable certificate observes nothing. This
+    // only needs to be called once per lifetime of the Meter (which is
+    // probably the same as the process lifetime).
+    pub fn record_client_cert_expiry_time(
+        &self,
+        expiry: impl Fn() -> Option<i64> + Send + Sync + 'static,
+    ) {
+        self.meter
+            .i64_observable_gauge("client_cert_expiry_time_seconds")
+            .with_description("Timestamp when the agent's TLS client certificate expires")
+            .with_callback(move |cert_expiry_time| {
+                if let Some(timestamp) = expiry() {
+                    cert_expiry_time.observe(timestamp, &[]);
+                }
+            })
+            .build();
+    }
 }
 
 pub fn create_metrics(meter: Meter) -> Arc<AgentMetricsState> {

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -197,6 +197,14 @@ pub async fn setup_and_run(
         }
     }
 
+    // The certificate-expiry gauge re-reads the certificate on every metrics
+    // collection, so it follows the renewals ClientCertRenewer performs over
+    // the agent's lifetime.
+    {
+        let forge_client_config = Arc::clone(&forge_client_config);
+        metrics.record_client_cert_expiry_time(move || forge_client_config.client_cert_expiry());
+    }
+
     if options.agent_platform_type.is_dpu_os()
         && !agent_config.machine.is_fake_dpu
         && let Err(e) = crate::agent_platform::ensure_doca_containers().await

--- a/crates/agent/src/tests/fixtures/metrics.txt
+++ b/crates/agent/src/tests/fixtures/metrics.txt
@@ -1,6 +1,9 @@
 # HELP agent_start_time_seconds Timestamp of the agent process's last start
 # TYPE agent_start_time_seconds gauge
 agent_start_time_seconds 1740171801
+# HELP client_cert_expiry_time_seconds Timestamp when the agent's TLS client certificate expires
+# TYPE client_cert_expiry_time_seconds gauge
+client_cert_expiry_time_seconds 1742763762
 # HELP forge_dpu_agent_network_communication_error_total Network monitor errors related to ping dpu
 # TYPE forge_dpu_agent_network_communication_error_total counter
 forge_dpu_agent_network_communication_error_total{dest_dpu_id="fm100dsm61jm8b3ltfj0vh1vnhqff6jak7dhmp429qen6jtr0njjt5iqeq0",error_type="PingError",source_dpu_id="fm100ds10jimoops3mvpb4udrtnp9031m8sif0846eqbu4i5o49n74ijnf0"} 1

--- a/crates/agent/src/tests/metrics.rs
+++ b/crates/agent/src/tests/metrics.rs
@@ -40,6 +40,7 @@ fn test_metrics() {
     let metrics = crate::instrumentation::create_metrics(meter.clone());
     metrics.record_machine_boot_time(1740171762);
     metrics.record_agent_start_time(1740171801);
+    metrics.record_client_cert_expiry_time(|| Some(1742763762));
 
     let network_monitor_metrics = NetworkMonitorMetricsState::initialize(
         meter,
@@ -94,4 +95,36 @@ fn test_metrics() {
 
     let prom_metrics = String::from_utf8(buffer).unwrap();
     assert_eq!(prom_metrics, include_str!("fixtures/metrics.txt"));
+}
+
+/// A metrics collection that finds no readable client certificate exports no
+/// expiry series at all, rather than a misleading placeholder value.
+#[test]
+fn client_cert_expiry_gauge_exports_nothing_without_a_certificate() {
+    let prometheus_registry = prometheus::Registry::new();
+    let metrics_exporter = opentelemetry_prometheus::exporter()
+        .with_registry(prometheus_registry.clone())
+        .without_scope_info()
+        .without_target_info()
+        .build()
+        .unwrap();
+    let meter_provider = opentelemetry_sdk::metrics::MeterProviderBuilder::default()
+        .with_reader(metrics_exporter)
+        .build();
+    let meter = meter_provider.meter("agent");
+
+    let metrics = crate::instrumentation::create_metrics(meter);
+    metrics.record_client_cert_expiry_time(|| None);
+
+    let exported: Vec<String> = prometheus_registry
+        .gather()
+        .iter()
+        .map(|family| family.name().to_string())
+        .collect();
+    assert!(
+        !exported
+            .iter()
+            .any(|name| name.contains("client_cert_expiry_time_seconds")),
+        "an unreadable certificate must export no expiry series: {exported:?}"
+    );
 }

--- a/crates/certs/Cargo.toml
+++ b/crates/certs/Cargo.toml
@@ -32,8 +32,15 @@ tracing = { workspace = true }
 
 # [local-dependencies]
 carbide-host-support = { path = "../host-support", default-features = false }
+carbide-instrument = { path = "../instrument" }
 carbide-tls = { path = "../tls" }
 carbide-rpc = { path = "../rpc" }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+# [local-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 
 [lints]
 workspace = true

--- a/crates/certs/src/cert_renewal.rs
+++ b/crates/certs/src/cert_renewal.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 use ::rpc::forge as rpc;
 use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
 use carbide_host_support::registration;
+use carbide_instrument::{DynamicLog, Event, LogAt, Outcome, emit};
 use eyre::Context;
 use forge_tls::client_config::ClientCert;
 use rand::RngExt;
@@ -32,6 +33,42 @@ const MAX_CERT_RENEWAL_TIME_SECS: u64 = 7 * 24 * 60 * 60; // 7 days
 
 const MIN_CERT_RENEWAL_FAILURE_TIME_SECS: u64 = 60; // 1 min
 const MAX_CERT_RENEWAL_FAILURE_TIME_SECS: u64 = 5 * 60; // 5min
+
+/// A client-certificate renewal ran to completion, successfully or not. A
+/// call that finds the renewal window still closed neither counts nor logs.
+///
+/// The event owns the completion log line: a success logs at INFO, a failure
+/// logs at ERROR with the error chain as context, and both report when the
+/// next attempt is due (the next regular renewal window on success, the
+/// short retry window on failure).
+#[derive(Event)]
+#[event(
+    name = "carbide_certs_renewals_total",
+    component = "carbide-certs",
+    log = dynamic,
+    metric = counter,
+    message = "Client certificate renewal completed",
+    describe = "Number of client certificate renewal attempts, by outcome"
+)]
+struct CertRenewalCompleted {
+    #[label]
+    outcome: Outcome,
+    /// The failure's error chain; empty on success.
+    #[context]
+    error: String,
+    /// Seconds until the next renewal attempt.
+    #[context]
+    next_attempt_in_secs: u64,
+}
+
+impl DynamicLog for CertRenewalCompleted {
+    fn log_at(&self) -> LogAt {
+        match self.outcome {
+            Outcome::Ok => LogAt::Level(tracing::Level::INFO),
+            Outcome::Error => LogAt::Level(tracing::Level::ERROR),
+        }
+    }
+}
 
 pub struct ClientCertRenewer {
     cert_renewal_time: std::time::Instant,
@@ -59,22 +96,23 @@ impl ClientCertRenewer {
     ) {
         let now = std::time::Instant::now();
         if now > self.cert_renewal_time {
-            let cert_renewal_period = match self.renew_certificates(override_client_cert).await {
+            let result = self.renew_certificates(override_client_cert).await;
+            let cert_renewal_period = match &result {
                 Ok(()) => {
                     rand::rng().random_range(MIN_CERT_RENEWAL_TIME_SECS..MAX_CERT_RENEWAL_TIME_SECS)
                 }
-                Err(err) => {
-                    let cert_renewal_period = rand::rng().random_range(
-                        MIN_CERT_RENEWAL_FAILURE_TIME_SECS..MAX_CERT_RENEWAL_FAILURE_TIME_SECS,
-                    );
-                    tracing::error!(
-                        error = format!("{err:#}"),
-                        "Failed to renew client certificates. Will retry in {cert_renewal_period}s"
-                    );
-
-                    cert_renewal_period
-                }
+                Err(_) => rand::rng().random_range(
+                    MIN_CERT_RENEWAL_FAILURE_TIME_SECS..MAX_CERT_RENEWAL_FAILURE_TIME_SECS,
+                ),
             };
+            emit(CertRenewalCompleted {
+                outcome: Outcome::from(&result),
+                error: result
+                    .err()
+                    .map(|err| format!("{err:#}"))
+                    .unwrap_or_default(),
+                next_attempt_in_secs: cert_renewal_period,
+            });
             self.cert_renewal_time = now.add(Duration::from_secs(cert_renewal_period));
         }
     }
@@ -112,5 +150,108 @@ impl ClientCertRenewer {
         .wrap_err("renew_certificates: Failed to write certs to disk")?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+
+    use super::*;
+
+    fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
+        log.fields
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+    }
+
+    /// A completed renewal logs the completion at INFO -- with the next
+    /// renewal window as context -- and moves only the `outcome="ok"` series.
+    #[test]
+    fn successful_renewal_logs_info_and_counts_ok() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit(CertRenewalCompleted {
+                outcome: Outcome::Ok,
+                error: String::new(),
+                next_attempt_in_secs: 432_000,
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::INFO);
+        assert_eq!(logs[0].message, "Client certificate renewal completed");
+        assert_eq!(field(&logs[0], "outcome"), Some("ok"));
+        assert_eq!(field(&logs[0], "next_attempt_in_secs"), Some("432000"));
+        assert_eq!(
+            metrics.counter_delta("carbide_certs_renewals_total", &[("outcome", "ok")]),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta("carbide_certs_renewals_total", &[("outcome", "error")]),
+            0.0
+        );
+    }
+
+    /// A failed renewal logs the completion at ERROR -- with the error chain
+    /// and the retry window as context -- and moves only the
+    /// `outcome="error"` series.
+    #[test]
+    fn failed_renewal_logs_error_and_counts_error() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit(CertRenewalCompleted {
+                outcome: Outcome::Error,
+                error: "renew_certificates: deadline exceeded".to_string(),
+                next_attempt_in_secs: 90,
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::ERROR);
+        assert_eq!(logs[0].message, "Client certificate renewal completed");
+        assert_eq!(field(&logs[0], "outcome"), Some("error"));
+        assert_eq!(
+            field(&logs[0], "error"),
+            Some("renew_certificates: deadline exceeded")
+        );
+        assert_eq!(field(&logs[0], "next_attempt_in_secs"), Some("90"));
+        assert_eq!(
+            metrics.counter_delta("carbide_certs_renewals_total", &[("outcome", "error")]),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta("carbide_certs_renewals_total", &[("outcome", "ok")]),
+            0.0
+        );
+    }
+
+    /// A call inside the renewal window skips: no renewal is attempted, so
+    /// nothing counts and nothing logs.
+    #[test]
+    fn skipped_renewal_neither_counts_nor_logs() {
+        let metrics = MetricsCapture::start();
+        // A fresh renewer's first renewal is days away, so this call skips.
+        let mut renewer = ClientCertRenewer::new(
+            "https://localhost:1".to_string(),
+            Arc::new(ForgeClientConfig::new(String::new(), None)),
+        );
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let logs = capture_logs(|| {
+            runtime.block_on(renewer.renew_certificates_if_necessary(None));
+        });
+
+        assert!(logs.is_empty(), "a skipped renewal must not log: {logs:?}");
+        assert_eq!(
+            metrics.counter_delta("carbide_certs_renewals_total", &[("outcome", "ok")]),
+            0.0
+        );
+        assert_eq!(
+            metrics.counter_delta("carbide_certs_renewals_total", &[("outcome", "error")]),
+            0.0
+        );
     }
 }


### PR DESCRIPTION
A silent client-certificate renewal failure is an eventual mass mTLS outage with no leading indicator: renewals log at scattered levels and export nothing, and nothing reports how close any agent's certificate is to expiring. This adds both signals.

- `carbide_certs_renewals_total{outcome}` -- counts every renewal attempt from the shared `ClientCertRenewer` (the DPU agent and the OTel agent both run it). The event is the framework's first production use of `log = dynamic`: one declaration owns the log line for both branches, INFO on a completed renewal (a line that never existed -- completions were silent) and ERROR on a failure (the old line's error chain and retry timing ride along as fields). A renewal skipped inside its window neither counts nor logs.
- `client_cert_expiry_time_seconds` -- an observable gauge on the DPU agent's meter beside its `machine_boot_time_seconds` siblings, reading the certificate's `not_after` from disk at each scrape so it tracks renewals; a missing or unparseable certificate exports no series rather than a placeholder. "Time until expiry drops below N days" becomes the alert that fires before the outage.

Notable details:

- The two existing progress lines ("Trying to renew...", "Received new machine certificate...") stay: they mark attempt-start and pre-disk-write, distinct moments from the completion the event marks, and they keep an RPC failure distinguishable from a disk-write failure in logs.
- The OTel agent has no meter by design; its emits no-op against the global meter while the log line still renders through its logfmt subscriber.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3177
