### PR TITLE
fix(nico-pxe): set internal API URL in configmap

### DIFF
--- a/helm/charts/nico-pxe/templates/configmap.yaml
+++ b/helm/charts/nico-pxe/templates/configmap.yaml
@@ -6,8 +6,15 @@ metadata:
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
 data:
-  NICO_API_HOST: {{ printf "%s.%s.svc.cluster.local" .Values.apiServiceName (include "nico-pxe.namespace" .) | quote }}
-  NICO_API_PORT: {{ .Values.config.nicoApiPort | default "1079" | quote }}
+  {{- $namespace := include "nico-pxe.namespace" . }}
+  {{- $apiHost := printf "%s.%s.svc.cluster.local" .Values.apiServiceName $namespace }}
+  {{- $apiPort := .Values.config.nicoApiPort | default "1079" | toString }}
+  NICO_API_HOST: {{ $apiHost | quote }}
+  NICO_API_PORT: {{ $apiPort | quote }}
+  {{- /* Default to the configured API service mTLS hostname unless explicitly overridden by exact-case extraEnvData. */}}
+  {{- if not (hasKey .Values.config.extraEnvData "CARBIDE_API_INTERNAL_URL") }}
+  CARBIDE_API_INTERNAL_URL: {{ printf "https://%s:%s" $apiHost $apiPort | quote }}
+  {{- end }}
   {{- range $key, $value := .Values.config.extraEnvData }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/helm/charts/nico-pxe/tests/apiservice_test.yaml
+++ b/helm/charts/nico-pxe/tests/apiservice_test.yaml
@@ -9,6 +9,9 @@ tests:
       - equal:
           path: data.NICO_API_HOST
           value: nico-api.nico-system.svc.cluster.local
+      - equal:
+          path: data.CARBIDE_API_INTERNAL_URL
+          value: https://nico-api.nico-system.svc.cluster.local:1079
   - it: apiServiceName overrides the API host to carbide-api
     set:
       apiServiceName: carbide-api
@@ -16,3 +19,23 @@ tests:
       - equal:
           path: data.NICO_API_HOST
           value: carbide-api.nico-system.svc.cluster.local
+      - equal:
+          path: data.CARBIDE_API_INTERNAL_URL
+          value: https://carbide-api.nico-system.svc.cluster.local:1079
+  - it: nicoApiPort overrides the internal API URL port
+    set:
+      config.nicoApiPort: "11443"
+    asserts:
+      - equal:
+          path: data.NICO_API_PORT
+          value: "11443"
+      - equal:
+          path: data.CARBIDE_API_INTERNAL_URL
+          value: https://nico-api.nico-system.svc.cluster.local:11443
+  - it: extraEnvData overrides CARBIDE_API_INTERNAL_URL
+    set:
+      config.extraEnvData.CARBIDE_API_INTERNAL_URL: https://override.example:1079
+    asserts:
+      - equal:
+          path: data.CARBIDE_API_INTERNAL_URL
+          value: https://override.example:1079


### PR DESCRIPTION
Render CARBIDE_API_INTERNAL_URL from the configured nico-api service host and port so nico-pxe does not fall back to the built-in carbide-api hostname. This keeps the PXE service aligned with the mTLS certificate name used by the deployed API service.

The exact-case extraEnvData override behavior is preserved for deployments that need to provide a custom internal API URL.

## Related issues

None

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual validation:
- helm lint helm/charts/nico-pxe
- helm template nico-pxe helm/charts/nico-pxe --namespace forge-system
- helm template nico-pxe helm/charts/nico-pxe --namespace forge-system --set config.extraEnvData.CARBIDE_API_INTERNAL_URL=https://override.example:1079

## Additional Notes

helm-unittest was not installed in this environment, so the chart unit test file was updated but not executed locally.

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

