### PR TITLE
patch(v2.0): Ensure REST API generated SDK is up to date

### DIFF
--- a/rest-api/sdk/standard/client.go
+++ b/rest-api/sdk/standard/client.go
@@ -555,6 +555,15 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		*s = string(b)
 		return nil
 	}
+	if r, ok := v.(*io.Reader); ok {
+		*r = bytes.NewReader(b)
+		return nil
+	}
+	// Must stay before the JSON branch: json.Unmarshal would base64-decode into *[]byte.
+	if p, ok := v.(*[]byte); ok {
+		*p = b
+		return nil
+	}
 	if f, ok := v.(*os.File); ok {
 		f, err = os.CreateTemp("", "HttpClientFile")
 		if err != nil {

--- a/rest-api/sdk/standard/model_operating_system.go
+++ b/rest-api/sdk/standard/model_operating_system.go
@@ -53,7 +53,7 @@ type OperatingSystem struct {
 	IpxeScript NullableString `json:"ipxeScript,omitempty"`
 	// User data for the Operating System
 	UserData NullableString `json:"userData,omitempty"`
-	// Whether the Operating System is cloud-init based; true if there is non-empty `userData`, false otherwise.
+	// Specified when the Operating System is cloud-init based
 	IsCloudInit *bool `json:"isCloudInit,omitempty"`
 	// Indicates whether the Phone Home service should be enabled or disabled for Operating System
 	PhoneHomeEnabled *bool `json:"phoneHomeEnabled,omitempty"`

--- a/rest-api/sdk/standard/model_operating_system_create_request.go
+++ b/rest-api/sdk/standard/model_operating_system_create_request.go
@@ -56,8 +56,7 @@ type OperatingSystemCreateRequest struct {
 	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
 	// User data for the Operating System
 	UserData NullableString `json:"userData,omitempty"`
-	// Deprecated and ignored: whether the Operating System is cloud-init based. Value now derived from `userData`.
-	// Deprecated
+	// Specified when the Operating System is cloud-init based
 	IsCloudInit *bool `json:"isCloudInit,omitempty"`
 	// Indicates if the user data can be overridden at Instance creation time
 	AllowOverride *bool `json:"allowOverride,omitempty"`
@@ -705,7 +704,6 @@ func (o *OperatingSystemCreateRequest) UnsetUserData() {
 }
 
 // GetIsCloudInit returns the IsCloudInit field value if set, zero value otherwise.
-// Deprecated
 func (o *OperatingSystemCreateRequest) GetIsCloudInit() bool {
 	if o == nil || IsNil(o.IsCloudInit) {
 		var ret bool
@@ -716,7 +714,6 @@ func (o *OperatingSystemCreateRequest) GetIsCloudInit() bool {
 
 // GetIsCloudInitOk returns a tuple with the IsCloudInit field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-// Deprecated
 func (o *OperatingSystemCreateRequest) GetIsCloudInitOk() (*bool, bool) {
 	if o == nil || IsNil(o.IsCloudInit) {
 		return nil, false
@@ -734,7 +731,6 @@ func (o *OperatingSystemCreateRequest) HasIsCloudInit() bool {
 }
 
 // SetIsCloudInit gets a reference to the given bool and assigns it to the IsCloudInit field.
-// Deprecated
 func (o *OperatingSystemCreateRequest) SetIsCloudInit(v bool) {
 	o.IsCloudInit = &v
 }

--- a/rest-api/sdk/standard/model_operating_system_update_request.go
+++ b/rest-api/sdk/standard/model_operating_system_update_request.go
@@ -46,8 +46,7 @@ type OperatingSystemUpdateRequest struct {
 	PhoneHomeEnabled NullableBool `json:"phoneHomeEnabled,omitempty"`
 	// User data for the Operating System
 	UserData NullableString `json:"userData,omitempty"`
-	// Deprecated and ignored: whether the Operating System is cloud-init based. Value now derived from `userData`.
-	// Deprecated
+	// Specified when the Operating System is cloud-init based
 	IsCloudInit NullableBool `json:"isCloudInit,omitempty"`
 	// Indicates if the user data can be overridden at Instance creation time
 	AllowOverride NullableBool `json:"allowOverride,omitempty"`
@@ -591,7 +590,6 @@ func (o *OperatingSystemUpdateRequest) UnsetUserData() {
 }
 
 // GetIsCloudInit returns the IsCloudInit field value if set, zero value otherwise (both if not set or set to explicit null).
-// Deprecated
 func (o *OperatingSystemUpdateRequest) GetIsCloudInit() bool {
 	if o == nil || IsNil(o.IsCloudInit.Get()) {
 		var ret bool
@@ -603,7 +601,6 @@ func (o *OperatingSystemUpdateRequest) GetIsCloudInit() bool {
 // GetIsCloudInitOk returns a tuple with the IsCloudInit field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-// Deprecated
 func (o *OperatingSystemUpdateRequest) GetIsCloudInitOk() (*bool, bool) {
 	if o == nil {
 		return nil, false
@@ -621,7 +618,6 @@ func (o *OperatingSystemUpdateRequest) HasIsCloudInit() bool {
 }
 
 // SetIsCloudInit gets a reference to the given NullableBool and assigns it to the IsCloudInit field.
-// Deprecated
 func (o *OperatingSystemUpdateRequest) SetIsCloudInit(v bool) {
 	o.IsCloudInit.Set(&v)
 }


### PR DESCRIPTION
The REST API SDK code in `release/v2.0` is out of sync, this PR brings it up to speed.

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)