### PR TITLE
feat: measure every NSM, PSM, and RMS call with the RED helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3599,6 +3599,7 @@ dependencies = [
  "carbide-api-db",
  "carbide-api-model",
  "carbide-api-test-helper",
+ "carbide-instrument",
  "carbide-macros",
  "carbide-rack",
  "carbide-redfish",

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -25,6 +25,7 @@ authors.workspace = true
 async-trait = { workspace = true }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model" }
+carbide-instrument = { path = "../instrument" }
 carbide-rack = { path = "../rack", default-features = false }
 carbide-redfish = { path = "../redfish" }
 carbide-secrets = { path = "../secrets" }
@@ -46,6 +47,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 carbide-api-test-helper = { path = "../api-test-helper" }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing" }
 carbide-test-support = { path = "../test-support" }

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use carbide_instrument::red;
 use mac_address::MacAddress;
 use model::component_manager::{
     ConfigureSwitchCertificateState, FirmwareState, NvSwitchComponent, PowerAction,
@@ -113,12 +114,15 @@ async fn register_and_map(
 
     for ep in endpoints {
         let req = build_registration(ep);
-        let response = client
-            .register_nv_switches(nsm::RegisterNvSwitchesRequest {
+        let response = red::instrumented(
+            "nsm",
+            "register_nv_switches",
+            client.register_nv_switches(nsm::RegisterNvSwitchesRequest {
                 registration_requests: vec![req],
-            })
-            .await?
-            .into_inner();
+            }),
+        )
+        .await?
+        .into_inner();
 
         let Some(reg_resp) = response.responses.into_iter().next() else {
             tracing::warn!(bmc_mac = %ep.bmc_mac, "NSM returned empty response for switch");
@@ -191,12 +195,13 @@ impl NvSwitchManager for NsmSwitchBackend {
                 action: nsm_action as i32,
             };
 
-            let response = self
-                .client
-                .clone()
-                .power_control(request)
-                .await?
-                .into_inner();
+            let response = red::instrumented(
+                "nsm",
+                "power_control",
+                self.client.clone().power_control(request),
+            )
+            .await?
+            .into_inner();
 
             for r in response.responses {
                 let bmc_mac = uuid_to_mac
@@ -256,12 +261,13 @@ impl NvSwitchManager for NsmSwitchBackend {
                 components: nsm_components,
             };
 
-            let response = self
-                .client
-                .clone()
-                .queue_updates(request)
-                .await?
-                .into_inner();
+            let response = red::instrumented(
+                "nsm",
+                "queue_updates",
+                self.client.clone().queue_updates(request),
+            )
+            .await?
+            .into_inner();
 
             for r in response.results {
                 let bmc_mac = uuid_to_mac
@@ -308,12 +314,13 @@ impl NvSwitchManager for NsmSwitchBackend {
             let request = nsm::GetUpdatesForSwitchRequest {
                 switch_uuid: uuid.clone(),
             };
-            let response = self
-                .client
-                .clone()
-                .get_updates_for_switch(request)
-                .await?
-                .into_inner();
+            let response = red::instrumented(
+                "nsm",
+                "get_updates_for_switch",
+                self.client.clone().get_updates_for_switch(request),
+            )
+            .await?
+            .into_inner();
 
             for update in response.updates {
                 let bmc_mac = uuid_to_mac
@@ -337,7 +344,10 @@ impl NvSwitchManager for NsmSwitchBackend {
 
     #[instrument(skip(self), fields(backend = "nsm"))]
     async fn list_firmware_bundles(&self) -> Result<Vec<String>, ComponentManagerError> {
-        let response = self.client.clone().list_bundles(()).await?.into_inner();
+        let response =
+            red::instrumented("nsm", "list_bundles", self.client.clone().list_bundles(()))
+                .await?
+                .into_inner();
 
         Ok(response.bundles.into_iter().map(|b| b.version).collect())
     }
@@ -501,5 +511,45 @@ mod tests {
         let nvos_creds = nvos.credentials.as_ref().unwrap();
         assert_eq!(nvos_creds.username, "nvadmin");
         assert_eq!(nvos_creds.password, "nvos_pass");
+    }
+
+    #[tokio::test]
+    async fn nsm_call_failure_records_the_external_call_histogram() {
+        use carbide_instrument::testing::MetricsCapture;
+
+        // A lazy channel to an unroutable endpoint makes the wrapped call
+        // itself fail, exercising the RED wrap without a live NSM.
+        // A port that was just bound and released: connecting to it is refused
+        // deterministically, unlike a fixed low port something might occupy.
+        let refused_addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+            listener.local_addr().expect("local addr")
+        };
+        let channel = Channel::from_shared(format!("http://{refused_addr}"))
+            .expect("endpoint")
+            .connect_lazy();
+        let backend = NsmSwitchBackend {
+            client: nsm::nv_switch_manager_client::NvSwitchManagerClient::new(
+                TraceInjectService::new(channel),
+            ),
+        };
+
+        let metrics = MetricsCapture::start();
+        backend
+            .list_firmware_bundles()
+            .await
+            .expect_err("unroutable NSM endpoint must fail");
+
+        assert_eq!(
+            metrics.histogram_count_delta(
+                "carbide_external_call_duration_milliseconds",
+                &[
+                    ("backend", "nsm"),
+                    ("operation", "list_bundles"),
+                    ("outcome", "error"),
+                ],
+            ),
+            1,
+        );
     }
 }

--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use carbide_instrument::red;
 use carbide_secrets::credentials::Credentials;
 use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 use tonic::transport::Channel;
@@ -89,12 +90,15 @@ async fn register_with_psm(
         })
         .collect();
 
-    let response = client
-        .register_powershelves(psm::RegisterPowershelvesRequest {
+    let response = red::instrumented(
+        "psm",
+        "register_powershelves",
+        client.register_powershelves(psm::RegisterPowershelvesRequest {
             registration_requests: reqs,
-        })
-        .await?
-        .into_inner();
+        }),
+    )
+    .await?
+    .into_inner();
 
     let failures: Vec<_> = response
         .responses
@@ -141,21 +145,28 @@ impl PowerShelfManager for PsmPowerShelfBackend {
         };
 
         let response = match action {
-            PowerAction::On => self.client.clone().power_on(request).await?.into_inner(),
+            PowerAction::On => {
+                red::instrumented("psm", "power_on", self.client.clone().power_on(request))
+                    .await?
+                    .into_inner()
+            }
             PowerAction::ForceOff | PowerAction::GracefulShutdown => {
-                self.client.clone().power_off(request).await?.into_inner()
+                red::instrumented("psm", "power_off", self.client.clone().power_off(request))
+                    .await?
+                    .into_inner()
             }
             PowerAction::GracefulRestart
             | PowerAction::ForceRestart
             | PowerAction::AcPowercycle => {
-                let off = self
-                    .client
-                    .clone()
-                    .power_off(psm::PowershelfRequest {
+                let off = red::instrumented(
+                    "psm",
+                    "power_off",
+                    self.client.clone().power_off(psm::PowershelfRequest {
                         pmc_macs: pmc_macs.clone(),
-                    })
-                    .await?
-                    .into_inner();
+                    }),
+                )
+                .await?
+                .into_inner();
 
                 let mut results: Vec<PowerShelfComponentResult> = Vec::new();
                 let mut powered_off_macs: Vec<String> = Vec::new();
@@ -177,14 +188,15 @@ impl PowerShelfManager for PsmPowerShelfBackend {
                 }
 
                 if !powered_off_macs.is_empty() {
-                    let on = self
-                        .client
-                        .clone()
-                        .power_on(psm::PowershelfRequest {
+                    let on = red::instrumented(
+                        "psm",
+                        "power_on",
+                        self.client.clone().power_on(psm::PowershelfRequest {
                             pmc_macs: powered_off_macs,
-                        })
-                        .await?
-                        .into_inner();
+                        }),
+                    )
+                    .await?
+                    .into_inner();
 
                     for r in on.responses {
                         results.push(PowerShelfComponentResult {
@@ -256,12 +268,13 @@ impl PowerShelfManager for PsmPowerShelfBackend {
 
         let request = psm::UpdateFirmwareRequest { upgrades };
 
-        let response = self
-            .client
-            .clone()
-            .update_firmware(request)
-            .await?
-            .into_inner();
+        let response = red::instrumented(
+            "psm",
+            "update_firmware",
+            self.client.clone().update_firmware(request),
+        )
+        .await?
+        .into_inner();
 
         response
             .responses
@@ -320,12 +333,13 @@ impl PowerShelfManager for PsmPowerShelfBackend {
 
         let request = psm::GetFirmwareUpdateStatusRequest { queries };
 
-        let response = self
-            .client
-            .clone()
-            .get_firmware_update_status(request)
-            .await?
-            .into_inner();
+        let response = red::instrumented(
+            "psm",
+            "get_firmware_update_status",
+            self.client.clone().get_firmware_update_status(request),
+        )
+        .await?
+        .into_inner();
 
         response
             .statuses
@@ -356,12 +370,13 @@ impl PowerShelfManager for PsmPowerShelfBackend {
             pmc_macs: mac_strings(endpoints),
         };
 
-        let response = self
-            .client
-            .clone()
-            .list_available_firmware(request)
-            .await?
-            .into_inner();
+        let response = red::instrumented(
+            "psm",
+            "list_available_firmware",
+            self.client.clone().list_available_firmware(request),
+        )
+        .await?
+        .into_inner();
 
         response
             .upgrades
@@ -393,12 +408,13 @@ impl PowerShelfManager for PsmPowerShelfBackend {
             pmc_macs: mac_strings(endpoints),
         };
 
-        let response = self
-            .client
-            .clone()
-            .get_powershelves(request)
-            .await?
-            .into_inner();
+        let response = red::instrumented(
+            "psm",
+            "get_powershelves",
+            self.client.clone().get_powershelves(request),
+        )
+        .await?
+        .into_inner();
 
         let mut results = Vec::with_capacity(endpoints.len());
         for ep in endpoints {
@@ -488,5 +504,45 @@ mod tests {
         ];
         let macs = mac_strings(&eps);
         assert_eq!(macs, vec!["AA:BB:CC:DD:EE:01", "AA:BB:CC:DD:EE:02"]);
+    }
+
+    #[tokio::test]
+    async fn psm_call_failure_records_the_external_call_histogram() {
+        use carbide_instrument::testing::MetricsCapture;
+
+        // A lazy channel to an unroutable endpoint makes the wrapped call
+        // itself fail, exercising the RED wrap without a live PSM.
+        // A port that was just bound and released: connecting to it is refused
+        // deterministically, unlike a fixed low port something might occupy.
+        let refused_addr = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+            listener.local_addr().expect("local addr")
+        };
+        let channel = Channel::from_shared(format!("http://{refused_addr}"))
+            .expect("endpoint")
+            .connect_lazy();
+        let backend = PsmPowerShelfBackend {
+            client: psm::powershelf_manager_client::PowershelfManagerClient::new(
+                TraceInjectService::new(channel),
+            ),
+        };
+
+        let metrics = MetricsCapture::start();
+        backend
+            .list_firmware(&[])
+            .await
+            .expect_err("unroutable PSM endpoint must fail");
+
+        assert_eq!(
+            metrics.histogram_count_delta(
+                "carbide_external_call_duration_milliseconds",
+                &[
+                    ("backend", "psm"),
+                    ("operation", "register_powershelves"),
+                    ("outcome", "error"),
+                ],
+            ),
+            1,
+        );
     }
 }

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
+use carbide_instrument::red;
 use carbide_rack::firmware_object::rms_access_token_or_noauth;
 use carbide_rack::rms_node_type::{
     compute_node_type_for_profile, power_shelf_node_type_for_profile, switch_node_type_for_profile,
@@ -542,7 +543,13 @@ impl PowerShelfManager for RmsBackend {
                 operation,
             };
 
-            match self.client.batch_set_power_state(request).await {
+            match red::instrumented(
+                "rms",
+                "batch_set_power_state",
+                self.client.batch_set_power_state(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -621,7 +628,13 @@ impl PowerShelfManager for RmsBackend {
                 }
             };
 
-            match self.client.apply_firmware_object(request).await {
+            match red::instrumented(
+                "rms",
+                "apply_firmware_object",
+                self.client.apply_firmware_object(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let (success, error, job_id) = summarize_firmware_object_apply_response(
                         response,
@@ -705,7 +718,13 @@ impl PowerShelfManager for RmsBackend {
                 job_id: job_id.clone(),
             };
 
-            match self.client.get_firmware_job_status(request).await {
+            match red::instrumented(
+                "rms",
+                "get_firmware_job_status",
+                self.client.get_firmware_job_status(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let status_success = response.status == rms::ReturnCode::Success as i32;
                     let state = if status_success {
@@ -771,7 +790,13 @@ impl PowerShelfManager for RmsBackend {
                 rack_id: identity.rack_id.clone(),
             };
 
-            match self.client.get_node_firmware_inventory(request).await {
+            match red::instrumented(
+                "rms",
+                "get_node_firmware_inventory",
+                self.client.get_node_firmware_inventory(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     if response.status != rms::ReturnCode::Success as i32 {
                         results.push(PowerShelfFirmwareVersions {
@@ -862,17 +887,18 @@ impl PowerShelfManager for RmsBackend {
 async fn list_firmware_object_ids(
     client: &dyn RmsApi,
 ) -> Result<Vec<String>, ComponentManagerError> {
-    let response = client
-        .list_firmware_objects(rms::ListFirmwareObjectsRequest {
+    let response = red::instrumented(
+        "rms",
+        "list_firmware_objects",
+        client.list_firmware_objects(rms::ListFirmwareObjectsRequest {
             only_available: false,
             hardware_type: String::new(),
-        })
-        .await
-        .map_err(|e| {
-            ComponentManagerError::Internal(format!(
-                "failed to list firmware objects from RMS: {e}"
-            ))
-        })?;
+        }),
+    )
+    .await
+    .map_err(|e| {
+        ComponentManagerError::Internal(format!("failed to list firmware objects from RMS: {e}"))
+    })?;
 
     Ok(response.objects.into_iter().map(|fw| fw.id).collect())
 }
@@ -1019,7 +1045,13 @@ async fn query_rms_power_state(
         }),
     };
 
-    match client.batch_get_power_state(request).await {
+    match red::instrumented(
+        "rms",
+        "batch_get_power_state",
+        client.batch_get_power_state(request),
+    )
+    .await
+    {
         Ok(response) => {
             let batch = response.response.clone().unwrap_or_default();
             let stats = batch.stats.unwrap_or_default();
@@ -1299,7 +1331,13 @@ async fn query_tracked_firmware_job_status(
                 job_id: job_id.clone(),
             };
 
-            match client.get_firmware_job_status(request).await {
+            match red::instrumented(
+                "rms",
+                "get_firmware_job_status",
+                client.get_firmware_job_status(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let status_success = response.status == rms::ReturnCode::Success as i32;
                     let state = if status_success {
@@ -1330,7 +1368,13 @@ async fn query_tracked_firmware_job_status(
                 job_id: job_id.clone(),
             };
 
-            match client.get_switch_system_image_job_status(request).await {
+            match red::instrumented(
+                "rms",
+                "get_switch_system_image_job_status",
+                client.get_switch_system_image_job_status(request),
+            )
+            .await
+            {
                 Ok(response) if response.status == rms::ReturnCode::Success as i32 => {
                     let state = map_rms_switch_system_image_job_state(&response.state);
                     let error = if response.error_message.is_empty() {
@@ -1414,7 +1458,13 @@ impl NvSwitchManager for RmsBackend {
                 operation,
             };
 
-            match self.client.batch_set_power_state(request).await {
+            match red::instrumented(
+                "rms",
+                "batch_set_power_state",
+                self.client.batch_set_power_state(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -1496,7 +1546,13 @@ impl NvSwitchManager for RmsBackend {
                     resolved.node_type,
                     component_filters.clone(),
                 ) {
-                    Ok(request) => match self.client.apply_firmware_object(request).await {
+                    Ok(request) => match red::instrumented(
+                        "rms",
+                        "apply_firmware_object",
+                        self.client.apply_firmware_object(request),
+                    )
+                    .await
+                    {
                         Ok(response) => {
                             let (operation_success, error, job_id) =
                                 summarize_firmware_object_apply_response(
@@ -1552,7 +1608,13 @@ impl NvSwitchManager for RmsBackend {
                     bundle_version,
                     options,
                 ) {
-                    Ok(request) => match self.client.apply_switch_system_image(request).await {
+                    Ok(request) => match red::instrumented(
+                        "rms",
+                        "apply_switch_system_image",
+                        self.client.apply_switch_system_image(request),
+                    )
+                    .await
+                    {
                         Ok(response) => {
                             let (operation_success, error, job_id) =
                                 summarize_switch_system_image_apply_response(
@@ -1767,7 +1829,13 @@ impl NvSwitchManager for RmsBackend {
                 }),
             };
 
-            match self.client.batch_get_node_device_info(request).await {
+            match red::instrumented(
+                "rms",
+                "batch_get_node_device_info",
+                self.client.batch_get_node_device_info(request),
+            )
+            .await
+            {
                 Ok(info) => {
                     if info.status != rms::ReturnCode::Success as i32 {
                         let summary = if info.message.is_empty() {
@@ -1916,14 +1984,17 @@ async fn rms_configure_switch_certificate(
         domain: domain_name.map(str::to_owned),
     };
 
-    let response = client
-        .configure_switch_certificate(request)
-        .await
-        .map_err(|e| {
-            ComponentManagerError::Internal(format!(
-                "failed to start RMS switch certificate configuration: {e}"
-            ))
-        })?;
+    let response = red::instrumented(
+        "rms",
+        "configure_switch_certificate",
+        client.configure_switch_certificate(request),
+    )
+    .await
+    .map_err(|e| {
+        ComponentManagerError::Internal(format!(
+            "failed to start RMS switch certificate configuration: {e}"
+        ))
+    })?;
 
     let (success, error, job_id) =
         summarize_configure_switch_certificate_response(response, &node_id);
@@ -1949,14 +2020,17 @@ async fn rms_get_configure_switch_certificate_job_status(
         job_id: job_id.to_owned(),
     };
 
-    let response = client
-        .get_configure_switch_certificate_job_status(request)
-        .await
-        .map_err(|e| {
-            ComponentManagerError::Internal(format!(
-                "failed to get RMS switch certificate job status: {e}"
-            ))
-        })?;
+    let response = red::instrumented(
+        "rms",
+        "get_configure_switch_certificate_job_status",
+        client.get_configure_switch_certificate_job_status(request),
+    )
+    .await
+    .map_err(|e| {
+        ComponentManagerError::Internal(format!(
+            "failed to get RMS switch certificate job status: {e}"
+        ))
+    })?;
 
     if response.status != rms::ReturnCode::Success as i32 {
         let error = if response.error_message.is_empty() {
@@ -2045,7 +2119,13 @@ impl ComputeTrayManager for RmsBackend {
                 operation,
             };
 
-            match self.client.batch_set_power_state(request).await {
+            match red::instrumented(
+                "rms",
+                "batch_set_power_state",
+                self.client.batch_set_power_state(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -2133,7 +2213,13 @@ impl ComputeTrayManager for RmsBackend {
                 }
             };
 
-            match self.client.apply_firmware_object(request).await {
+            match red::instrumented(
+                "rms",
+                "apply_firmware_object",
+                self.client.apply_firmware_object(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let (success, error, job_id) = summarize_firmware_object_apply_response(
                         response,
@@ -2222,7 +2308,13 @@ impl ComputeTrayManager for RmsBackend {
                 job_id: job_id.clone(),
             };
 
-            match self.client.get_firmware_job_status(request).await {
+            match red::instrumented(
+                "rms",
+                "get_firmware_job_status",
+                self.client.get_firmware_job_status(request),
+            )
+            .await
+            {
                 Ok(response) => {
                     let status_success = response.status == rms::ReturnCode::Success as i32;
                     let state = if status_success {
@@ -2492,6 +2584,54 @@ mod tests {
         assert!(!success);
         assert_eq!(error.as_deref(), Some("RMS firmware update failed"));
         assert_eq!(job_id.as_deref(), Some("job-1"));
+    }
+
+    #[tokio::test]
+    async fn rms_calls_record_the_external_call_histogram_by_outcome() {
+        use carbide_instrument::testing::MetricsCapture;
+
+        let mock = MockRmsApi::new();
+        mock.enqueue_batch_get_power_state(Ok(rms::BatchGetPowerStateResponse::default()))
+            .await;
+        mock.enqueue_batch_get_power_state(Err(RackManagerError::ApiInvocationError(
+            tonic::Status::unavailable("down"),
+        )))
+        .await;
+
+        let device_mac: MacAddress = PS_MAC_1.parse().unwrap();
+        let metrics = MetricsCapture::start();
+        let mut observed = Vec::new();
+        for _ in 0..2 {
+            observed.push(
+                query_rms_power_state(
+                    &mock,
+                    rms::NodeInfo::default(),
+                    "node-1",
+                    device_mac,
+                    "power shelf",
+                )
+                .await,
+            );
+        }
+        assert!(
+            observed[1].error.is_some(),
+            "transport failure surfaces as an error"
+        );
+
+        for outcome in ["ok", "error"] {
+            assert_eq!(
+                metrics.histogram_count_delta(
+                    "carbide_external_call_duration_milliseconds",
+                    &[
+                        ("backend", "rms"),
+                        ("operation", "batch_get_power_state"),
+                        ("outcome", outcome),
+                    ],
+                ),
+                1,
+                "{outcome}"
+            );
+        }
     }
 
     // ---- Test helpers ----


### PR DESCRIPTION
The component manager talks to three external backends -- NSM, PSM, and RMS -- across 31 call sites, and none of them are measured: the `#[instrument]` spans carry a `backend` field, but nothing exports rate, errors, or latency. This wraps every one of those calls in the framework's `red::instrumented()` helper, so per-backend, per-operation request/error/latency series exist for the busiest uninstrumented boundary we have.

- `carbide_external_call_duration_milliseconds{backend, operation, outcome}` now covers `nsm` (5 operations), `psm` (9), and `rms` (17): backend labels mirror the existing span vocabulary, operations name the wire RPCs, and every label is a compile-time literal per the helper's cardinality contract.
- Per-site wraps rather than a choke point, deliberately: the NSM/PSM clients are generated by plain `tonic_prost_build` (outside the workspace codegen that auto-wraps its clients), and an RMS decorator would mean 43 delegating methods for the 11 RPCs this crate calls.

Notable details:

- One RMS adapter stays unwrapped on purpose -- its only caller is already wrapped, so wrapping both would double-record one outbound call.
- RMS durations include librms's client-side reconnect budget (up to 60 tries x 10s while holding the connection lock), so a reconnect storm reads as long `rms` observations with late errors -- that is the caller-experienced truth, worth knowing when reading the dashboard.
- Every existing span and device-scoped warn stays: an RMS transport failure now logs twice -- the helper's generic backend/operation line plus the device-identity line -- because MACs and job ids cannot live in bounded metric labels.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3174
