### PR TITLE
fix(scrabbing): ignore when there's no defined raid array on lenovo raid kits

### DIFF
--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -276,10 +276,6 @@ async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
             // assume it is two raid 0s created by the RAID kit if we see a single raid0 output
             cmdrun::run_prog(lenovo_mnv_cli_prog, ["vd", "-a", "delete", "-i", "0"]).await?;
             cmdrun::run_prog(lenovo_mnv_cli_prog, ["vd", "-a", "delete", "-i", "1"]).await?;
-        } else {
-            return Err(CarbideClientError::GenericError(
-                "Could not find a RAID0 or RAID1 on the raid kit".to_string(),
-            ));
         }
 
         // Clean the disks


### PR DESCRIPTION
Lenovo RAID kits may get into the scrabbing state where the RAID arrays have been deleted already by the user.  So instead of returning an error if there's no existing RAID array we just proceed as normal by erasing the disks.  If the disk erase fails, we will get an error there.

## Type of Change
- [X] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

