### PR TITLE
feat: let health sink failures actually count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "hyper-util",
  "logfmt",
  "mac_address",
+ "metrics-endpoint",
  "nv-redfish",
  "prometheus",
  "prost",

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -42,6 +42,7 @@ hyper = { workspace = true }
 hyper-rustls = { workspace = true, features = ["http2"] }
 hyper-util = { workspace = true }
 mac_address = { workspace = true }
+metrics-endpoint = { path = "../metrics-endpoint" }
 prometheus = { workspace = true }
 reqwest = { workspace = true, features = ["query", "json"] }
 rustls = { workspace = true }
@@ -98,6 +99,7 @@ tonic-prost-build = { workspace = true }
 bench-hooks = []
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 criterion = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/health/benches/collector_pipeline.rs
+++ b/crates/health/benches/collector_pipeline.rs
@@ -39,9 +39,14 @@ impl DataSink for CountingSink {
         "counting_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), carbide_health::HealthError> {
         black_box(context);
         black_box(event);
+        Ok(())
     }
 }
 

--- a/crates/health/benches/processor_pipeline.rs
+++ b/crates/health/benches/processor_pipeline.rs
@@ -43,9 +43,14 @@ impl DataSink for CountingSink {
         "counting_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), carbide_health::HealthError> {
         std::hint::black_box(context);
         std::hint::black_box(event);
+        Ok(())
     }
 }
 

--- a/crates/health/benches/sink_pipeline.rs
+++ b/crates/health/benches/sink_pipeline.rs
@@ -45,9 +45,14 @@ impl DataSink for CountingSink {
         "counting_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), carbide_health::HealthError> {
         std::hint::black_box(context);
         std::hint::black_box(event);
+        Ok(())
     }
 }
 

--- a/crates/health/src/collectors/nmxt.rs
+++ b/crates/health/src/collectors/nmxt.rs
@@ -943,10 +943,15 @@ Link_Down{Port_Number="1"} 5
                 "capturing_sink"
             }
 
-            fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+            fn try_handle_event(
+                &self,
+                _context: &EventContext,
+                event: &CollectorEvent,
+            ) -> Result<(), crate::HealthError> {
                 if let CollectorEvent::Metric(sample) = event {
                     self.samples.lock().unwrap().push((**sample).clone());
                 }
+                Ok(())
             }
         }
 
@@ -1052,10 +1057,15 @@ Link_Down{Port_Number="1"} 5
                 "capturing_sink"
             }
 
-            fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+            fn try_handle_event(
+                &self,
+                _context: &EventContext,
+                event: &CollectorEvent,
+            ) -> Result<(), crate::HealthError> {
                 if let CollectorEvent::Metric(sample) = event {
                     self.samples.lock().unwrap().push((**sample).clone());
                 }
+                Ok(())
             }
         }
 

--- a/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
@@ -345,11 +345,16 @@ mod tests {
             "capturing_sink"
         }
 
-        fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+        fn try_handle_event(
+            &self,
+            context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
             self.events
                 .lock()
                 .expect("lock poisoned")
                 .push((context.clone(), event.clone()));
+            Ok(())
         }
     }
 

--- a/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
@@ -990,11 +990,16 @@ mod tests {
             "capturing_sink"
         }
 
-        fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+        fn try_handle_event(
+            &self,
+            context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
             self.events
                 .lock()
                 .expect("lock poisoned")
                 .push((context.clone(), event.clone()));
+            Ok(())
         }
     }
 

--- a/crates/health/src/collectors/nvue/rest/collector.rs
+++ b/crates/health/src/collectors/nvue/rest/collector.rs
@@ -791,7 +791,11 @@ mod tests {
             "capturing_sink"
         }
 
-        fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
             match event {
                 CollectorEvent::Metric(sample) => {
                     self.samples.lock().unwrap().push((**sample).clone());
@@ -805,6 +809,7 @@ mod tests {
                 | CollectorEvent::Log(_)
                 | CollectorEvent::Firmware(_) => {}
             }
+            Ok(())
         }
     }
 
@@ -924,10 +929,15 @@ mod tests {
                 "capturing_sink"
             }
 
-            fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+            fn try_handle_event(
+                &self,
+                _context: &EventContext,
+                event: &CollectorEvent,
+            ) -> Result<(), crate::HealthError> {
                 if let CollectorEvent::Metric(sample) = event {
                     self.samples.lock().unwrap().push((**sample).clone());
                 }
+                Ok(())
             }
         }
 
@@ -1054,10 +1064,15 @@ mod tests {
                 "capturing_sink"
             }
 
-            fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+            fn try_handle_event(
+                &self,
+                _context: &EventContext,
+                event: &CollectorEvent,
+            ) -> Result<(), crate::HealthError> {
                 if let CollectorEvent::Metric(sample) = event {
                     self.samples.lock().unwrap().push((**sample).clone());
                 }
+                Ok(())
             }
         }
 
@@ -1214,10 +1229,15 @@ mod tests {
                 "capturing_sink"
             }
 
-            fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+            fn try_handle_event(
+                &self,
+                _context: &EventContext,
+                event: &CollectorEvent,
+            ) -> Result<(), crate::HealthError> {
                 if let CollectorEvent::Metric(sample) = event {
                     self.samples.lock().unwrap().push((**sample).clone());
                 }
+                Ok(())
             }
         }
 

--- a/crates/health/src/collectors/runtime.rs
+++ b/crates/health/src/collectors/runtime.rs
@@ -622,10 +622,15 @@ mod tests {
             "counting_sink"
         }
 
-        fn handle_event(&self, _context: &EventContext, event: &CollectorEvent) {
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
             if matches!(event, CollectorEvent::Log(_)) {
                 self.0.fetch_add(1, Ordering::SeqCst);
             }
+            Ok(())
         }
     }
 

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -649,7 +649,13 @@ mod tests {
             "noop"
         }
 
-        fn handle_event(&self, _context: &EventContext, _event: &CollectorEvent) {}
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            _event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
+            Ok(())
+        }
     }
 
     fn context_with_config(config: Config, metrics_name: &str) -> DiscoveryLoopContext {

--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -118,6 +118,10 @@ pub struct MetricsManager {
     global_registry: Registry,
     telemetry_registry: Registry,
     component_metrics: Arc<ComponentMetrics>,
+    /// The instrumentation framework's registry, exposed through the same
+    /// /metrics response so its events are scrapeable without migrating this
+    /// server off its raw prometheus pipeline. Set once at startup.
+    framework_registry: std::sync::OnceLock<Registry>,
 }
 
 impl MetricsManager {
@@ -130,6 +134,7 @@ impl MetricsManager {
             global_registry,
             telemetry_registry,
             component_metrics,
+            framework_registry: std::sync::OnceLock::new(),
         })
     }
 
@@ -157,8 +162,18 @@ impl MetricsManager {
         CollectorRegistry::new(id, self.telemetry_registry.clone(), prefix)
     }
 
+    /// Makes the instrumentation framework's registry part of every
+    /// subsequent /metrics response. A second call is ignored.
+    pub fn expose_framework_registry(&self, registry: Registry) {
+        let _ = self.framework_registry.set(registry);
+    }
+
     pub fn export_metrics(&self) -> Result<String, HealthError> {
-        export_registry(&self.global_registry)
+        let mut exposition = export_registry(&self.global_registry)?;
+        if let Some(framework) = self.framework_registry.get() {
+            exposition.push_str(&export_registry(framework)?);
+        }
+        Ok(exposition)
     }
 
     pub fn export_telemetry(&self) -> Result<String, HealthError> {

--- a/crates/health/src/otlp/drain.rs
+++ b/crates/health/src/otlp/drain.rs
@@ -18,10 +18,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use carbide_instrument::emit;
 use tonic::transport::Channel;
 
 use super::collector_logs::logs_service_client::LogsServiceClient;
 use super::convert::build_export_request;
+use super::{OtlpExportFailed, OtlpSignal};
 use crate::collectors::{BackoffConfig, ExponentialBackoff};
 use crate::sink::otlp::OtlpQueue;
 use crate::sink::{CollectorEvent, EventContext};
@@ -172,13 +174,13 @@ impl OtlpDrainTask {
                     tokio::time::sleep(delay).await;
                 }
                 Err(status) => {
-                    tracing::error!(
-                        code = ?status.code(),
-                        message = status.message(),
+                    emit(OtlpExportFailed {
+                        signal: OtlpSignal::Logs,
+                        code: status.code().into(),
+                        error: status.message().to_string(),
                         record_count,
                         attempt,
-                        "otlp export failed, dropping batch"
-                    );
+                    });
                     break;
                 }
             }

--- a/crates/health/src/otlp/metrics_drain.rs
+++ b/crates/health/src/otlp/metrics_drain.rs
@@ -18,10 +18,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use carbide_instrument::emit;
 use tonic::transport::Channel;
 
 use super::collector_metrics::metrics_service_client::MetricsServiceClient;
 use super::convert::build_metrics_export_request;
+use super::{OtlpExportFailed, OtlpSignal};
 use crate::collectors::{BackoffConfig, ExponentialBackoff};
 use crate::sink::otlp::OtlpMetricsQueue;
 use crate::sink::{EventContext, MetricSample};
@@ -175,13 +177,13 @@ impl OtlpMetricsDrainTask {
                     tokio::time::sleep(delay).await;
                 }
                 Err(status) => {
-                    tracing::error!(
-                        code = ?status.code(),
-                        message = status.message(),
-                        point_count,
+                    emit(OtlpExportFailed {
+                        signal: OtlpSignal::Metrics,
+                        code: status.code().into(),
+                        error: status.message().to_string(),
+                        record_count: point_count,
                         attempt,
-                        "otlp metrics export failed, dropping batch"
-                    );
+                    });
                     break;
                 }
             }

--- a/crates/health/src/otlp/mod.rs
+++ b/crates/health/src/otlp/mod.rs
@@ -19,6 +19,90 @@ pub mod convert;
 pub mod drain;
 pub mod metrics_drain;
 
+use carbide_instrument::LabelValue;
+
+/// Which OTLP signal a drain exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum OtlpSignal {
+    Logs,
+    Metrics,
+}
+
+/// A gRPC status code as a bounded metric label: one variant per
+/// [`tonic::Code`], a set closed by the gRPC protocol itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum GrpcCode {
+    Ok,
+    Cancelled,
+    Unknown,
+    InvalidArgument,
+    DeadlineExceeded,
+    NotFound,
+    AlreadyExists,
+    PermissionDenied,
+    ResourceExhausted,
+    FailedPrecondition,
+    Aborted,
+    OutOfRange,
+    Unimplemented,
+    Internal,
+    Unavailable,
+    DataLoss,
+    Unauthenticated,
+}
+
+impl From<tonic::Code> for GrpcCode {
+    fn from(code: tonic::Code) -> Self {
+        match code {
+            tonic::Code::Ok => Self::Ok,
+            tonic::Code::Cancelled => Self::Cancelled,
+            tonic::Code::Unknown => Self::Unknown,
+            tonic::Code::InvalidArgument => Self::InvalidArgument,
+            tonic::Code::DeadlineExceeded => Self::DeadlineExceeded,
+            tonic::Code::NotFound => Self::NotFound,
+            tonic::Code::AlreadyExists => Self::AlreadyExists,
+            tonic::Code::PermissionDenied => Self::PermissionDenied,
+            tonic::Code::ResourceExhausted => Self::ResourceExhausted,
+            tonic::Code::FailedPrecondition => Self::FailedPrecondition,
+            tonic::Code::Aborted => Self::Aborted,
+            tonic::Code::OutOfRange => Self::OutOfRange,
+            tonic::Code::Unimplemented => Self::Unimplemented,
+            tonic::Code::Internal => Self::Internal,
+            tonic::Code::Unavailable => Self::Unavailable,
+            tonic::Code::DataLoss => Self::DataLoss,
+            tonic::Code::Unauthenticated => Self::Unauthenticated,
+        }
+    }
+}
+
+/// A drain dropped a whole export batch: the collector rejected it with a
+/// non-retryable status, or the retry budget ran out.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_health_otlp_export_failures_total",
+    component = "nico-hardware-health",
+    log = error,
+    metric = counter,
+    message = "otlp export failed, dropping batch",
+    describe = "Number of OTLP export batches dropped after a send failure, by signal and gRPC status code."
+)]
+pub(crate) struct OtlpExportFailed {
+    #[label]
+    pub signal: OtlpSignal,
+    #[label]
+    pub code: GrpcCode,
+    /// The status message the collector returned.
+    #[context]
+    pub error: String,
+    /// How many log records or metric points the dropped batch held.
+    #[context]
+    pub record_count: usize,
+    /// The attempt index the drop happened on (the retry cap for retryable
+    /// statuses, earlier for non-retryable ones).
+    #[context]
+    pub attempt: usize,
+}
+
 #[allow(clippy::all)]
 pub mod opentelemetry {
     pub mod proto {
@@ -63,3 +147,60 @@ pub use opentelemetry::proto::common::v1 as common;
 pub use opentelemetry::proto::logs::v1 as logs;
 pub use opentelemetry::proto::metrics::v1 as metrics;
 pub use opentelemetry::proto::resource::v1 as resource;
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::{OtlpExportFailed, OtlpSignal};
+
+    /// A dropped logs batch writes one ERROR line and ticks the counter's
+    /// logs-signal series, labelled with the gRPC status code.
+    #[test]
+    fn otlp_export_failure_logs_error_and_ticks_counter() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit(OtlpExportFailed {
+                signal: OtlpSignal::Logs,
+                code: tonic::Code::Unavailable.into(),
+                error: "connection refused".to_string(),
+                record_count: 17,
+                attempt: 5,
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::ERROR);
+        assert_eq!(logs[0].message, "otlp export failed, dropping batch");
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_health_otlp_export_failures_total",
+                &[("signal", "logs"), ("code", "unavailable")],
+            ),
+            1.0
+        );
+    }
+
+    /// The metrics drain counts on its own signal series, and multi-word
+    /// gRPC codes render as snake_case label values.
+    #[test]
+    fn otlp_metrics_export_failure_counts_on_the_metrics_signal_series() {
+        let metrics = MetricsCapture::start();
+        emit(OtlpExportFailed {
+            signal: OtlpSignal::Metrics,
+            code: tonic::Code::DeadlineExceeded.into(),
+            error: "deadline exceeded".to_string(),
+            record_count: 3,
+            attempt: 0,
+        });
+
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_health_otlp_export_failures_total",
+                &[("signal", "metrics"), ("code", "deadline_exceeded")],
+            ),
+            1.0
+        );
+    }
+}

--- a/crates/health/src/processor/mod.rs
+++ b/crates/health/src/processor/mod.rs
@@ -29,6 +29,7 @@ pub use intrusion_events::BmcIntrusionEventProcessor;
 pub use leak_events::LeakEventProcessor;
 pub use rack_leak::RackLeakProcessor;
 
+use crate::HealthError;
 use crate::metrics::{ComponentMetrics, MetricsManager};
 use crate::sink::{CollectorEvent, DataSink, EventContext};
 
@@ -106,14 +107,18 @@ impl DataSink for EventProcessingPipeline {
         "event_processing_pipeline"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         let mut queue = VecDeque::from(vec![PendingEvent {
             event: Cow::Borrowed(event),
             blocked_processors: vec![false; self.processors.len()],
         }]);
 
         while let Some(current) = queue.pop_front() {
-            self.sink.handle_event(context, &current.event);
+            self.sink.try_handle_event(context, &current.event)?;
             self.next_events(
                 context,
                 &current.event,
@@ -121,6 +126,8 @@ impl DataSink for EventProcessingPipeline {
                 &mut queue,
             );
         }
+
+        Ok(())
     }
 }
 
@@ -146,8 +153,13 @@ mod tests {
             "counting_sink"
         }
 
-        fn handle_event(&self, _context: &EventContext, _event: &CollectorEvent) {
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            _event: &CollectorEvent,
+        ) -> Result<(), HealthError> {
             self.counter.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 

--- a/crates/health/src/sink/composite.rs
+++ b/crates/health/src/sink/composite.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use super::{CollectorEvent, DataSink, EventContext};
+use crate::HealthError;
 use crate::metrics::{ComponentKind, ComponentMetrics, MetricsManager};
 
 pub struct CompositeDataSink {
@@ -34,12 +35,17 @@ impl CompositeDataSink {
         }
     }
 
-    fn record_sink_operation(&self, sink: &dyn DataSink, duration: std::time::Duration) {
+    fn record_sink_operation(
+        &self,
+        sink: &dyn DataSink,
+        duration: std::time::Duration,
+        success: bool,
+    ) {
         self.component_metrics.record_operation(
             ComponentKind::Sink,
             sink.sink_type(),
             duration,
-            true,
+            success,
         );
     }
 }
@@ -49,11 +55,20 @@ impl DataSink for CompositeDataSink {
         "composite_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    /// Fans the event out to every sink, recording each sink's duration and
+    /// outcome. A failing sink never blocks the others: its error is fully
+    /// reported here (the sink logs its own detail, the composite meters the
+    /// failure), so the fanout itself always succeeds.
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         for sink in &self.sinks {
             let start = Instant::now();
-            sink.handle_event(context, event);
-            self.record_sink_operation(sink.as_ref(), start.elapsed());
+            let result = sink.try_handle_event(context, event);
+            self.record_sink_operation(sink.as_ref(), start.elapsed(), result.is_ok());
         }
+        Ok(())
     }
 }

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -33,7 +33,7 @@ use serde::Serialize;
 use crate::endpoint::{BmcAddr, BmcEndpoint, EndpointMetadata, MachineData, SwitchEndpointRole};
 use crate::metrics::MetricLabel;
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, carbide_instrument::LabelValue)]
 pub enum HealthReportTarget {
     Machine,
     PowerShelf,

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -21,11 +21,13 @@ use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use carbide_instrument::{Outcome, emit};
 use carbide_uuid::machine::MachineId;
 
 use super::dedup_queue::DedupQueue;
 use super::{
-    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportTarget, ReportSource,
+    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportSubmitted,
+    HealthReportTarget, ReportSource,
 };
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
@@ -111,11 +113,15 @@ impl HealthReportSink {
 
                     match report.as_ref().try_into() {
                         Ok(converted) => {
-                            if let Err(error) =
-                                worker_client.submit_health_report(&key.id, converted).await
-                            {
-                                tracing::warn!(?error, worker_id, "Failed to submit health report");
-                            }
+                            let result =
+                                worker_client.submit_health_report(&key.id, converted).await;
+                            emit(HealthReportSubmitted {
+                                target: HealthReportTarget::Machine,
+                                outcome: Outcome::from(&result),
+                                id: key.id.to_string(),
+                                worker_id,
+                                error: result.err().map(|e| e.to_string()).unwrap_or_default(),
+                            });
                         }
                         Err(error) => {
                             tracing::warn!(
@@ -164,12 +170,16 @@ impl DataSink for HealthReportSink {
         "health_report_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         let CollectorEvent::HealthReport(report) = event else {
-            return;
+            return Ok(());
         };
         if report.target != Some(HealthReportTarget::Machine) {
-            return;
+            return Ok(());
         }
 
         if self.skip_empty_reports && report.is_empty() {
@@ -177,7 +187,7 @@ impl DataSink for HealthReportSink {
                 source = ?report.source,
                 "Skipping empty machine health report"
             );
-            return;
+            return Ok(());
         }
 
         if let Some(machine_id) = context.machine_id() {
@@ -201,7 +211,7 @@ impl DataSink for HealthReportSink {
                             machine_id = %key.id,
                             "Suppressing unchanged success-only health report"
                         );
-                        return;
+                        return Ok(());
                     }
                     cache.entries.insert(
                         key.clone(),
@@ -218,11 +228,15 @@ impl DataSink for HealthReportSink {
             }
 
             self.queue.save_latest(key, Arc::clone(report));
+            Ok(())
         } else {
             tracing::warn!(
                 report = ?report,
                 "Received machine-target HealthReport event without machine_id context"
             );
+            Err(HealthError::GenericError(
+                "machine-target health report event without machine_id context".to_string(),
+            ))
         }
     }
 }

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -23,6 +23,7 @@ use std::sync::Mutex;
 use serde::Serialize;
 
 use super::{CollectorEvent, DataSink, EventContext, LogRecord};
+use crate::HealthError;
 use crate::config::LogFileSinkConfig;
 
 /// Durable JSONL log sink. Writes CollectorEvent::Log records to rotating
@@ -51,9 +52,13 @@ impl DataSink for LogFileSink {
         "log_file_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         let CollectorEvent::Log(record) = event else {
-            return;
+            return Ok(());
         };
 
         // Diagnostics are opt-in for log files. When enabled, fold the
@@ -66,18 +71,23 @@ impl DataSink for LogFileSink {
             Ok(json) => json,
             Err(e) => {
                 tracing::error!(error = ?e, "failed to serialize log record");
-                return;
+                return Err(e.into());
             }
         };
 
         let Ok(mut writer) = self.writer.lock() else {
             tracing::error!("log file writer lock poisoned");
-            return;
+            return Err(HealthError::GenericError(
+                "log file writer lock poisoned".to_string(),
+            ));
         };
 
         if let Err(e) = writer.write_line(&line) {
             tracing::error!(error = ?e, "failed to write log record to file");
+            return Err(HealthError::GenericError(e));
         }
+
+        Ok(())
     }
 }
 

--- a/crates/health/src/sink/mod.rs
+++ b/crates/health/src/sink/mod.rs
@@ -49,10 +49,73 @@ pub use tracing::TracingSink;
 pub(crate) use self::otlp::OtlpSink;
 #[cfg(feature = "bench-hooks")]
 pub use self::otlp::OtlpSink;
+use crate::HealthError;
 
 pub trait DataSink: Send + Sync {
     fn sink_type(&self) -> &'static str;
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent);
+
+    /// Handles one event, surfacing failure to the caller.
+    ///
+    /// Implementations log their own failure detail at the failure site; the
+    /// returned error exists so dispatchers can meter per-sink outcomes (the
+    /// composite records it as `component_failures_total{component_kind="sink"}`).
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError>;
+
+    /// Fire-and-forget entry point for callers that do not track outcomes.
+    ///
+    /// The result is deliberately dropped here: failures are already logged
+    /// by the failing sink, and metered when dispatched through the composite.
+    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+        if let Err(error) = self.try_handle_event(context, event) {
+            // Fire-and-forget by contract: the sink logged its own detail and
+            // the composite meters failures; this line is the safety net for a
+            // future sink that forgets to do either.
+            ::tracing::debug!(%error, "sink dropped an event");
+        }
+    }
+}
+
+/// One attempt to submit a health report upstream to the NICo API, emitted by
+/// the report sinks' submission workers for every completed attempt.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_health_report_submissions_total",
+    component = "nico-hardware-health",
+    log = dynamic,
+    metric = counter,
+    message = "Failed to submit health report",
+    describe = "Number of health report submissions to the NICo API, by report target and outcome."
+)]
+pub(crate) struct HealthReportSubmitted {
+    #[label]
+    pub target: HealthReportTarget,
+    #[label]
+    pub outcome: carbide_instrument::Outcome,
+    /// The machine, rack, switch, or power shelf the report describes.
+    #[context]
+    pub id: String,
+    #[context]
+    pub worker_id: usize,
+    /// The submission error's text; empty on success (the line only renders
+    /// on failure).
+    #[context]
+    pub error: String,
+}
+
+/// Every submission is counted; only the failures write the WARN line.
+impl carbide_instrument::DynamicLog for HealthReportSubmitted {
+    fn log_at(&self) -> carbide_instrument::LogAt {
+        match self.outcome {
+            carbide_instrument::Outcome::Error => {
+                carbide_instrument::LogAt::Level(::tracing::Level::WARN)
+            }
+            carbide_instrument::Outcome::Ok => carbide_instrument::LogAt::Off,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -80,8 +143,13 @@ mod tests {
             "counting_sink"
         }
 
-        fn handle_event(&self, _context: &EventContext, _event: &CollectorEvent) {
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            _event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
             self.counter.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -92,7 +160,31 @@ mod tests {
             "noop_sink"
         }
 
-        fn handle_event(&self, _context: &EventContext, _event: &CollectorEvent) {}
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            _event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
+            Ok(())
+        }
+    }
+
+    struct FailingSink;
+
+    impl DataSink for FailingSink {
+        fn sink_type(&self) -> &'static str {
+            "failing_sink"
+        }
+
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            _event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
+            Err(crate::HealthError::GenericError(
+                "sink rejected the event".to_string(),
+            ))
+        }
     }
 
     #[tokio::test]
@@ -139,6 +231,119 @@ mod tests {
         composite.handle_event(&context, &event);
 
         assert_eq!(success_counter.load(Ordering::SeqCst), 2);
+    }
+
+    /// A failing sink must move `component_failures_total{component_kind="sink"}`
+    /// for its own series, keep the fanout going, and leave the healthy
+    /// sinks' failure series untouched.
+    #[tokio::test]
+    async fn test_composite_sink_meters_per_sink_failures() {
+        let handled_counter = Arc::new(AtomicUsize::new(0));
+        let metrics_manager =
+            Arc::new(MetricsManager::new("test").expect("should create metrics manager"));
+
+        let composite = CompositeDataSink::new(
+            vec![
+                Arc::new(FailingSink),
+                Arc::new(CountingSink {
+                    counter: handled_counter.clone(),
+                }),
+            ],
+            metrics_manager.clone(),
+        );
+
+        let context = EventContext {
+            endpoint_key: "42:9e:b1:bd:9d:dd".to_string(),
+            addr: BmcAddr {
+                ip: "10.0.0.1".parse().expect("valid ip"),
+                port: Some(443),
+                mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
+            },
+            collector_type: "test",
+            metadata: None,
+            rack_id: None,
+        };
+        let event = CollectorEvent::MetricCollectionStart;
+
+        composite.handle_event(&context, &event);
+        composite.handle_event(&context, &event);
+
+        assert_eq!(
+            handled_counter.load(Ordering::SeqCst),
+            2,
+            "a failing sink must not block the sinks after it"
+        );
+
+        let export = metrics_manager
+            .export_metrics()
+            .expect("service metrics export should work");
+        let failure_lines: Vec<&str> = export
+            .lines()
+            .filter(|line| line.starts_with("test_component_failures_total{"))
+            .collect();
+
+        assert_eq!(
+            failure_lines,
+            vec![
+                r#"test_component_failures_total{component_kind="sink",component_name="failing_sink"} 2"#
+            ],
+            "only the failing sink's series may move"
+        );
+    }
+
+    /// A failed submission writes one WARN line and ticks the counter's
+    /// error series.
+    #[test]
+    fn health_report_submission_failure_logs_warn_and_ticks_counter() {
+        use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            carbide_instrument::emit(super::HealthReportSubmitted {
+                target: super::HealthReportTarget::Rack,
+                outcome: carbide_instrument::Outcome::Error,
+                id: "RACK_1".to_string(),
+                worker_id: 3,
+                error: "connection refused".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::WARN);
+        assert_eq!(logs[0].message, "Failed to submit health report");
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_health_report_submissions_total",
+                &[("target", "rack"), ("outcome", "error")],
+            ),
+            1.0
+        );
+    }
+
+    /// A successful submission is counted but never logged.
+    #[test]
+    fn health_report_submission_success_counts_without_logging() {
+        use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            carbide_instrument::emit(super::HealthReportSubmitted {
+                target: super::HealthReportTarget::Machine,
+                outcome: carbide_instrument::Outcome::Ok,
+                id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string(),
+                worker_id: 0,
+                error: String::new(),
+            });
+        });
+
+        assert!(logs.is_empty(), "successful submissions must not log");
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_health_report_submissions_total",
+                &[("target", "machine"), ("outcome", "ok")],
+            ),
+            1.0
+        );
     }
 
     #[tokio::test]

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -199,7 +199,11 @@ impl DataSink for OtlpSink {
         "otlp_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         if let CollectorEvent::Metric(sample) = event {
             let key = metric_queue_key(context, sample);
 
@@ -210,17 +214,17 @@ impl DataSink for OtlpSink {
                 self.metrics_replaced_total.inc();
             }
 
-            return;
+            return Ok(());
         }
 
         if !is_otlp_log_relevant(event) {
-            return;
+            return Ok(());
         }
 
         let (key, event) = match event {
             CollectorEvent::Log(record) => {
                 self.enqueue_log_event(context, record);
-                return;
+                return Ok(());
             }
             CollectorEvent::HealthReport(report) => {
                 let key = format!(
@@ -235,12 +239,14 @@ impl DataSink for OtlpSink {
                 let key = format!("{}|firmware|{}", context.endpoint_key, info.component);
                 (key, event.clone())
             }
-            _ => return,
+            _ => return Ok(()),
         };
 
         if self.queue.save_latest(key, (context.clone(), event)) {
             self.replaced_total.inc();
         }
+
+        Ok(())
     }
 }
 

--- a/crates/health/src/sink/power_shelf_health_report.rs
+++ b/crates/health/src/sink/power_shelf_health_report.rs
@@ -17,11 +17,13 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::{Outcome, emit};
 use carbide_uuid::power_shelf::PowerShelfId;
 
 use super::dedup_queue::DedupQueue;
 use super::{
-    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportTarget, ReportSource,
+    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportSubmitted,
+    HealthReportTarget, ReportSource,
 };
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
@@ -65,17 +67,16 @@ impl PowerShelfHealthReportSink {
 
                     match report.as_ref().try_into() {
                         Ok(converted) => {
-                            if let Err(error) = worker_client
+                            let result = worker_client
                                 .submit_power_shelf_health_report(&key.id, converted)
-                                .await
-                            {
-                                tracing::warn!(
-                                    ?error,
-                                    worker_id,
-                                    power_shelf_id = %key.id,
-                                    "Failed to submit power shelf health report"
-                                );
-                            }
+                                .await;
+                            emit(HealthReportSubmitted {
+                                target: HealthReportTarget::PowerShelf,
+                                outcome: Outcome::from(&result),
+                                id: key.id.to_string(),
+                                worker_id,
+                                error: result.err().map(|e| e.to_string()).unwrap_or_default(),
+                            });
                         }
                         Err(error) => {
                             tracing::warn!(
@@ -102,13 +103,17 @@ impl DataSink for PowerShelfHealthReportSink {
         "power_shelf_health_report_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         let CollectorEvent::HealthReport(report) = event else {
-            return;
+            return Ok(());
         };
 
         if report.target != Some(HealthReportTarget::PowerShelf) {
-            return;
+            return Ok(());
         }
 
         if self.skip_empty_reports && report.is_empty() {
@@ -116,7 +121,7 @@ impl DataSink for PowerShelfHealthReportSink {
                 source = ?report.source,
                 "Skipping empty power shelf health report"
             );
-            return;
+            return Ok(());
         }
 
         let power_shelf_id = if let Some(power_shelf_id) = context.power_shelf_id() {
@@ -126,7 +131,9 @@ impl DataSink for PowerShelfHealthReportSink {
                 endpoint_key = context.endpoint_key(),
                 "Received power-shelf-target HealthReport event without power_shelf_id context"
             );
-            return;
+            return Err(HealthError::GenericError(
+                "power-shelf-target health report event without power_shelf_id context".to_string(),
+            ));
         };
 
         let key = PowerShelfHealthReportKey {
@@ -134,5 +141,7 @@ impl DataSink for PowerShelfHealthReportSink {
             source: report.source,
         };
         self.queue.save_latest(key, Arc::clone(report));
+
+        Ok(())
     }
 }

--- a/crates/health/src/sink/prometheus.rs
+++ b/crates/health/src/sink/prometheus.rs
@@ -154,12 +154,12 @@ impl PrometheusSink {
         }
     }
 
-    fn remove_collector_metrics(&self, context: &EventContext) {
+    fn remove_collector_metrics(&self, context: &EventContext) -> Result<(), HealthError> {
         let Some(endpoint_metrics) = self.stream_metrics.get::<str>(context.endpoint_key()) else {
-            return;
+            return Ok(());
         };
         let Some((_, metrics)) = endpoint_metrics.remove(context.collector_type) else {
-            return;
+            return Ok(());
         };
 
         metrics.clear();
@@ -170,7 +170,10 @@ impl PrometheusSink {
                 collector = context.collector_type,
                 "Failed to unregister Prometheus stream metrics"
             );
+            return Err(error.into());
         }
+
+        Ok(())
     }
 }
 
@@ -179,7 +182,11 @@ impl DataSink for PrometheusSink {
         "prometheus_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         match event {
             CollectorEvent::MetricCollectionStart => {
                 match self.get_or_create_stream_metrics(context) {
@@ -191,6 +198,7 @@ impl DataSink for PrometheusSink {
                             collector = context.collector_type,
                             "Failed to initialize Prometheus stream metrics"
                         );
+                        return Err(error);
                     }
                 }
             }
@@ -216,6 +224,7 @@ impl DataSink for PrometheusSink {
                         metric_type = sample.metric_type,
                         "Failed to record Prometheus metric sample"
                     );
+                    return Err(error);
                 }
             },
             CollectorEvent::MetricCollectionEnd => {
@@ -226,11 +235,13 @@ impl DataSink for PrometheusSink {
                     entry.value().sweep_stale();
                 }
             }
-            CollectorEvent::CollectorRemoved => self.remove_collector_metrics(context),
+            CollectorEvent::CollectorRemoved => return self.remove_collector_metrics(context),
             CollectorEvent::Log(_)
             | CollectorEvent::Firmware(_)
             | CollectorEvent::HealthReport(_) => {}
         }
+
+        Ok(())
     }
 }
 

--- a/crates/health/src/sink/rack_health_report.rs
+++ b/crates/health/src/sink/rack_health_report.rs
@@ -17,11 +17,13 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::{Outcome, emit};
 use carbide_uuid::rack::RackId;
 
 use super::dedup_queue::DedupQueue;
 use super::{
-    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportTarget, ReportSource,
+    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportSubmitted,
+    HealthReportTarget, ReportSource,
 };
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
@@ -65,17 +67,16 @@ impl RackHealthReportSink {
 
                     match report.as_ref().try_into() {
                         Ok(converted) => {
-                            if let Err(error) = worker_client
+                            let result = worker_client
                                 .submit_rack_health_report(&key.id, converted)
-                                .await
-                            {
-                                tracing::warn!(
-                                    ?error,
-                                    worker_id,
-                                    rack_id = %key.id,
-                                    "Failed to submit rack health report"
-                                );
-                            }
+                                .await;
+                            emit(HealthReportSubmitted {
+                                target: HealthReportTarget::Rack,
+                                outcome: Outcome::from(&result),
+                                id: key.id.to_string(),
+                                worker_id,
+                                error: result.err().map(|e| e.to_string()).unwrap_or_default(),
+                            });
                         }
                         Err(error) => {
                             tracing::warn!(
@@ -102,13 +103,17 @@ impl DataSink for RackHealthReportSink {
         "rack_health_report_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         let CollectorEvent::HealthReport(report) = event else {
-            return;
+            return Ok(());
         };
 
         if report.target != Some(HealthReportTarget::Rack) {
-            return;
+            return Ok(());
         }
 
         if self.skip_empty_reports && report.is_empty() {
@@ -116,7 +121,7 @@ impl DataSink for RackHealthReportSink {
                 source = ?report.source,
                 "Skipping empty rack health report"
             );
-            return;
+            return Ok(());
         }
 
         let Some(rack_id) = context.rack_id() else {
@@ -124,7 +129,9 @@ impl DataSink for RackHealthReportSink {
                 endpoint_key = context.endpoint_key(),
                 "Received rack-target HealthReport event without rack_id context"
             );
-            return;
+            return Err(HealthError::GenericError(
+                "rack-target health report event without rack_id context".to_string(),
+            ));
         };
 
         let key = RackHealthReportKey {
@@ -132,5 +139,7 @@ impl DataSink for RackHealthReportSink {
             source: report.source,
         };
         self.queue.save_latest(key, Arc::clone(report));
+
+        Ok(())
     }
 }

--- a/crates/health/src/sink/switch_health_report.rs
+++ b/crates/health/src/sink/switch_health_report.rs
@@ -17,11 +17,13 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::{Outcome, emit};
 use carbide_uuid::switch::SwitchId;
 
 use super::dedup_queue::DedupQueue;
 use super::{
-    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportTarget, ReportSource,
+    CollectorEvent, DataSink, EventContext, HealthReport, HealthReportSubmitted,
+    HealthReportTarget, ReportSource,
 };
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
@@ -65,17 +67,16 @@ impl SwitchHealthReportSink {
 
                     match report.as_ref().try_into() {
                         Ok(converted) => {
-                            if let Err(error) = worker_client
+                            let result = worker_client
                                 .submit_switch_health_report(&key.id, converted)
-                                .await
-                            {
-                                tracing::warn!(
-                                    ?error,
-                                    worker_id,
-                                    switch_id = %key.id,
-                                    "Failed to submit switch health report"
-                                );
-                            }
+                                .await;
+                            emit(HealthReportSubmitted {
+                                target: HealthReportTarget::Switch,
+                                outcome: Outcome::from(&result),
+                                id: key.id.to_string(),
+                                worker_id,
+                                error: result.err().map(|e| e.to_string()).unwrap_or_default(),
+                            });
                         }
                         Err(error) => {
                             tracing::warn!(
@@ -102,13 +103,17 @@ impl DataSink for SwitchHealthReportSink {
         "switch_health_report_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         let CollectorEvent::HealthReport(report) = event else {
-            return;
+            return Ok(());
         };
 
         if report.target != Some(HealthReportTarget::Switch) {
-            return;
+            return Ok(());
         }
 
         if self.skip_empty_reports && report.is_empty() {
@@ -116,7 +121,7 @@ impl DataSink for SwitchHealthReportSink {
                 source = ?report.source,
                 "Skipping empty switch health report"
             );
-            return;
+            return Ok(());
         }
 
         let switch_id = if let Some(switch_id) = context.switch_id() {
@@ -126,7 +131,9 @@ impl DataSink for SwitchHealthReportSink {
                 endpoint_key = context.endpoint_key(),
                 "Received switch-target HealthReport event without switch_id context"
             );
-            return;
+            return Err(HealthError::GenericError(
+                "switch-target health report event without switch_id context".to_string(),
+            ));
         };
 
         let key = SwitchHealthReportKey {
@@ -134,5 +141,7 @@ impl DataSink for SwitchHealthReportSink {
             source: report.source,
         };
         self.queue.save_latest(key, Arc::clone(report));
+
+        Ok(())
     }
 }

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -16,6 +16,7 @@
  */
 
 use super::{CollectorEvent, DataSink, EventContext};
+use crate::HealthError;
 use crate::config::TracingSinkConfig;
 
 /// Sink that writes health events through the process tracing subscriber.
@@ -37,7 +38,11 @@ impl DataSink for TracingSink {
         "tracing_sink"
     }
 
-    fn handle_event(&self, context: &EventContext, event: &CollectorEvent) {
+    fn try_handle_event(
+        &self,
+        context: &EventContext,
+        event: &CollectorEvent,
+    ) -> Result<(), HealthError> {
         match event {
             CollectorEvent::MetricCollectionStart => {
                 tracing::info!(
@@ -130,5 +135,7 @@ impl DataSink for TracingSink {
                 );
             }
         }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
The health data plane's egress edges swallow their own failures: the sink seam hardcodes success, so `_component_failures_total{component_kind="sink"}` can never move; the OTLP drains drop whole batches with only an error log; and health-report submissions fail with nothing countable. This makes all three edges honest.

- The sink seam bug: `DataSink` now requires `try_handle_event() -> Result<(), HealthError>` (the old `handle_event` stays as a provided fire-and-forget wrapper, so the ~90 call sites are untouched), and the composite records each sink's real result -- the failure series that has been structurally dead starts moving on the existing `/metrics` pipeline. Fanout still never short-circuits: one failing sink logs, counts, and the rest keep receiving.
- `carbide_health_otlp_export_failures_total{signal, code}` -- a dropped batch was an error log and nothing else; the event owns that line now (same level and message), labeled by signal (`logs`/`metrics`) and the gRPC status code. Retryable-attempt warns are untouched -- this counts drops, not retries.
- `carbide_health_report_submissions_total{target, outcome}` -- one emit per submit attempt across all four report sinks, with `log = dynamic`: a failure warns with the grep-stable "Failed to submit health report" message, a success counts silently.
- The framework's meter provider now installs at service start and its registry rides the existing `/metrics` response (the dual-registry pattern), so the two new counters are scrapeable today rather than waiting on this binary's full OpenTelemetry migration.

Notable details:

- Two log consolidations worth a one-time alert-rule sweep: the metrics-drain drop line loses its "otlp metrics ..." wording (the `signal=metrics` label carries it), and the per-target submit failures share one message with the target in a label.
- The fire-and-forget wrapper debug-logs an error it would otherwise drop -- the safety net for a future sink that neither logs nor flows through the composite.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3178
