### PR TITLE
perf(dpu): batch the per-host extension-service + domain reads

### DIFF
--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -347,6 +347,19 @@ pub(crate) async fn get_managed_host_network_config_inner(
             let segment_details = segment_details.iter().map(|x|(x.id, x)).collect::<HashMap<_,_>>();
             let mut tenant_loopback_ips: HashMap<VpcId, String> = HashMap::new();
 
+            // Resolve every segment domain in a single query up front, then look each one up by id
+            // inside the interface loop. The domains map keeps its rows keyed by id so a missing
+            // entry still surfaces the same NotFoundError the per-interface lookup used to raise.
+            let subdomain_ids = segment_details
+                .values()
+                .filter_map(|segment| segment.config.subdomain_id)
+                .unique()
+                .collect_vec();
+            let domains_by_id =
+                db::dns::domain::find_by_uuids(txn.as_pgconn(), &subdomain_ids)
+                    .await
+                    .map_err(CarbideError::from)?;
+
             // if there is no device then this is a legacy config and only the primary dpu is allowed.
             // all other DPUs don't get interfaces
             for iface in interfaces.iter().filter(|i|
@@ -397,16 +410,14 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
                 // Build the FQDN from this interface's segment domain.
                 let domain = match segment.config.subdomain_id {
-                    Some(domain_id) => {
-                        db::dns::domain::find_by_uuid(txn.as_pgconn(), domain_id)
-                            .await
-                            .map_err(CarbideError::from)?
-                            .ok_or_else(|| CarbideError::NotFoundError {
-                                kind: "domain",
-                                id: domain_id.to_string(),
-                            })?
-                            .name
-                    }
+                    Some(domain_id) => domains_by_id
+                        .get(&domain_id)
+                        .ok_or_else(|| CarbideError::NotFoundError {
+                            kind: "domain",
+                            id: domain_id.to_string(),
+                        })?
+                        .name
+                        .clone(),
                     None => "unknowndomain".to_string(),
                 };
                 let fqdn = if let Some(hostname) = &instance.config.tenant.hostname {
@@ -524,23 +535,37 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
     // First fetch from the database, while we have a transaction:
     let extension_service_info = if let Some(instance) = snapshot.instance.as_ref() {
-        let mut extension_service_info: Vec<ExtensionServiceInfo> =
-            Vec::with_capacity(instance.config.extension_services.service_configs.len());
-        for config in &instance.config.extension_services.service_configs {
-            // @TODO(Felicity): optimize database query to fetch all extension service versions at once.
-            //  This might be ok for now since the number of extension services is expected to be small.
-            let service_res =
-                db::extension_service::find_by_ids(&mut txn, &[config.service_id], false).await?;
-            let service =
-                service_res
-                    .into_iter()
-                    .next()
-                    .ok_or_else(|| CarbideError::NotFoundError {
-                        kind: "ExtensionService",
-                        id: config.service_id.to_string(),
-                    })?;
+        let service_configs = &instance.config.extension_services.service_configs;
 
-            let version = db::extension_service::find_version_info(
+        // Fetch every configured extension service in one query, then index by id so each config
+        // resolves its service from memory instead of issuing a query per config.
+        let service_ids = service_configs
+            .iter()
+            .map(|config| config.service_id)
+            .unique()
+            .collect_vec();
+        let services_by_id = db::extension_service::find_by_ids(&mut txn, &service_ids, false)
+            .await?
+            .into_iter()
+            .map(|service| (service.id, service))
+            .collect::<HashMap<_, _>>();
+
+        let mut extension_service_info: Vec<ExtensionServiceInfo> =
+            Vec::with_capacity(service_configs.len());
+        for config in service_configs {
+            let service = services_by_id
+                .get(&config.service_id)
+                .cloned()
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "ExtensionService",
+                    id: config.service_id.to_string(),
+                })?;
+
+            // The pinned version is looked up individually so the exact
+            // `version == config.version` selection (and its full data/credential/observability
+            // payload) is preserved per config. The batched `services_by_id` lookup above already
+            // established the service exists, so this skips the per-service existence probe.
+            let version = db::extension_service::find_version_info_of_known_service(
                 &mut txn,
                 config.service_id,
                 Some(config.version),

--- a/crates/api-db/src/dns/domain.rs
+++ b/crates/api-db/src/dns/domain.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use carbide_uuid::domain::DomainId;
@@ -192,6 +193,23 @@ pub async fn find_by_uuid(
         .map(|f| f.first().cloned())
 }
 
+/// Batched counterpart to [`find_by_uuid`]: fetch every domain in `ids` with a single
+/// `WHERE id = ANY($1)` query (deleted entries included, matching `find_by_uuid`), keyed by id.
+///
+/// Ids that have no matching row are simply absent from the returned map, so callers can
+/// reproduce `find_by_uuid`'s "not found" handling with a `.get(&id)` lookup.
+pub async fn find_by_uuids(
+    txn: impl DbReader<'_>,
+    ids: &[DomainId],
+) -> Result<HashMap<DomainId, Domain>, DatabaseError> {
+    if ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    find_all_by(txn, ObjectColumnFilter::List(IdColumn, ids), true)
+        .await
+        .map(|domains| domains.into_iter().map(|d| (d.id, d)).collect())
+}
+
 pub async fn delete(value: Domain, txn: &mut PgConnection) -> Result<Domain, DatabaseError> {
     let query = "UPDATE domains SET updated=NOW(), deleted=NOW() WHERE id=$1 RETURNING *";
     sqlx::query_as::<_, DbDomain>(query)
@@ -227,4 +245,123 @@ fn test_generate_domain_serial_format() {
     let serial = dns_record::SoaRecord::generate_new_serial();
 
     assert_eq!(serial, expected_serial);
+}
+
+#[cfg(test)]
+mod test_find_by_uuids {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use model::dns::NewDomain;
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::prelude::*;
+
+    use crate as db;
+
+    /// Counts `sqlx::query*` tracing events so a batched query can be shown to collapse an N+1
+    /// loop down to a single database round trip.
+    #[derive(Clone, Default)]
+    struct QueryCounter(Arc<AtomicUsize>);
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
+        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
+            if e.metadata().target().starts_with("sqlx::query") {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+    impl QueryCounter {
+        fn count(&self) -> usize {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn find_by_uuids_collapses_n_plus_one(pool: sqlx::PgPool) {
+        const N: usize = 8;
+
+        // Seed N distinct domains.
+        let mut txn = pool.begin().await.expect("begin");
+        let mut ids = Vec::with_capacity(N);
+        for i in 0..N {
+            let domain =
+                db::dns::domain::persist(NewDomain::new(format!("n{i}.metal.net")), &mut txn)
+                    .await
+                    .expect("persist domain");
+            ids.push(domain.id);
+        }
+        txn.commit().await.expect("commit");
+
+        // BEFORE: one find_by_uuid per id. The reads run straight off the pool
+        // -- no transaction -- so the count reflects only the find_by_uuid
+        // calls, not begin/commit statements.
+        let before = QueryCounter::default();
+        let looped = {
+            let counter = before.clone();
+            let pool = &pool;
+            let ids = &ids;
+            async move {
+                let mut names = std::collections::HashMap::new();
+                for id in ids {
+                    let domain = db::dns::domain::find_by_uuid(pool, *id)
+                        .await
+                        .expect("find_by_uuid")
+                        .expect("domain present");
+                    names.insert(domain.id, domain.name);
+                }
+                names
+            }
+            .with_subscriber(tracing::Dispatch::new(
+                tracing_subscriber::registry().with(counter),
+            ))
+            .await
+        };
+        let before_count = before.count();
+
+        // AFTER: a single batched find_by_uuids.
+        let after = QueryCounter::default();
+        let batched = {
+            let counter = after.clone();
+            let pool = &pool;
+            let ids = &ids;
+            async move {
+                db::dns::domain::find_by_uuids(pool, ids)
+                    .await
+                    .expect("find_by_uuids")
+            }
+            .with_subscriber(tracing::Dispatch::new(
+                tracing_subscriber::registry().with(counter),
+            ))
+            .await
+        };
+        let after_count = after.count();
+
+        // Data equality: same set of (id -> name) pairs.
+        assert_eq!(batched.len(), N, "batched returned all N domains");
+        let batched_names = batched
+            .into_iter()
+            .map(|(id, domain)| (id, domain.name))
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(
+            looped, batched_names,
+            "batched call returns the same id->name mapping as the loop"
+        );
+
+        // Bite-check: the loop MUST be more than one query, or the measurement is vacuous.
+        assert!(
+            before_count > 1,
+            "bite-check failed: looped find_by_uuid issued {before_count} queries (expected > 1)"
+        );
+        assert_eq!(
+            before_count, N,
+            "looped find_by_uuid issues one query per id"
+        );
+        assert_eq!(
+            after_count, 1,
+            "batched find_by_uuids issues a single query"
+        );
+
+        println!(
+            "dns::domain N+1: before(loop find_by_uuid)={before_count} after(find_by_uuids)={after_count} (N={N})"
+        );
+    }
 }

--- a/crates/api-db/src/extension_service.rs
+++ b/crates/api-db/src/extension_service.rs
@@ -417,6 +417,26 @@ pub async fn find_version_info(
         }
     }
 
+    find_version_info_of_known_service(txn, service_id, version).await
+}
+
+/// Finds a specific version of an extension service, or the latest version if not specified,
+/// for callers that have already established the service exists and is not deleted (e.g. via a
+/// batched [`find_by_ids`] in the same transaction).
+///
+/// Unlike [`find_version_info`], this skips the service-existence probe and issues a single
+/// query, so an unknown service id surfaces as the version-not-found error rather than the
+/// service-not-found error.
+///
+/// # Parameters
+/// * `txn`        - A reference to an active DB transaction
+/// * `service_id` - The ID of the extension service
+/// * `version`    - Optional specific version number to retrieve. If None, returns the latest version
+pub async fn find_version_info_of_known_service(
+    txn: &mut PgConnection,
+    service_id: ExtensionServiceId,
+    version: Option<ConfigVersion>,
+) -> DatabaseResult<ExtensionServiceVersionInfo> {
     // Build the version lookup query.
     let mut builder = sqlx::QueryBuilder::new(
         "SELECT service_id, version, data, observability, has_credential, created, deleted \
@@ -727,4 +747,252 @@ pub async fn set_updated_timestamp(
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod test_batched_lookups {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use config_version::ConfigVersion;
+    use model::extension_service::ExtensionServiceType;
+    use model::metadata::Metadata;
+    use model::tenant::TenantOrganizationId;
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    const TENANT_ORG: &str = "test-org";
+
+    /// Counts `sqlx::query*` tracing events so a batched query can be shown to collapse an N+1
+    /// loop down to a single database round trip.
+    #[derive(Clone, Default)]
+    struct QueryCounter(Arc<AtomicUsize>);
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
+        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
+            if e.metadata().target().starts_with("sqlx::query") {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+    impl QueryCounter {
+        fn count(&self) -> usize {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
+
+    /// Seed N extension services (each with an initial version), returning their ids and the
+    /// exact `ConfigVersion` stored for each so tests can look versions up by exact match.
+    async fn seed_services(
+        pool: &sqlx::PgPool,
+        n: usize,
+    ) -> Vec<(ExtensionServiceId, ConfigVersion)> {
+        let tenant: TenantOrganizationId = TENANT_ORG.parse().expect("valid tenant org id");
+        let mut txn = pool.begin().await.expect("begin");
+
+        // Extension services carry an FK to tenants(organization_id); seed the tenant first.
+        crate::tenant::create_and_persist(
+            TENANT_ORG.to_string(),
+            Metadata {
+                name: "Test Org".to_string(),
+                description: String::new(),
+                labels: std::collections::HashMap::new(),
+            },
+            None,
+            &mut txn,
+        )
+        .await
+        .expect("create tenant");
+
+        let mut seeded = Vec::with_capacity(n);
+        for i in 0..n {
+            let service_id = ExtensionServiceId::new();
+            let version = ConfigVersion::initial();
+            create(
+                &mut txn,
+                version,
+                &service_id,
+                &ExtensionServiceType::KubernetesPod,
+                &format!("svc-{i}"),
+                &tenant,
+                Some("test service"),
+                "some-data",
+                None,
+                false,
+            )
+            .await
+            .expect("create extension service");
+            seeded.push((service_id, version));
+        }
+        txn.commit().await.expect("commit");
+        seeded
+    }
+
+    #[crate::sqlx_test]
+    async fn find_by_ids_collapses_n_plus_one(pool: sqlx::PgPool) {
+        const N: usize = 8;
+        let seeded = seed_services(&pool, N).await;
+        let ids = seeded.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+
+        // The reads run on plain pool connections -- no transaction -- so no
+        // begin/commit statements land in the counts. Each counted region
+        // acquires its connection inside the instrumented future.
+
+        // BEFORE: find_by_ids called with a 1-element slice per service (the pattern in dpu.rs).
+        let before = QueryCounter::default();
+        let looped = {
+            let counter = before.clone();
+            let pool = &pool;
+            let ids = &ids;
+            async move {
+                let mut conn = pool.acquire().await.expect("acquire");
+                let mut names = std::collections::HashMap::new();
+                for id in ids {
+                    let service = find_by_ids(&mut conn, &[*id], false)
+                        .await
+                        .expect("find_by_ids")
+                        .into_iter()
+                        .next()
+                        .expect("service present");
+                    names.insert(service.id, service.name);
+                }
+                names
+            }
+            .with_subscriber(tracing::Dispatch::new(
+                tracing_subscriber::registry().with(counter),
+            ))
+            .await
+        };
+        let before_count = before.count();
+
+        // AFTER: a single find_by_ids over the whole set.
+        let after = QueryCounter::default();
+        let batched = {
+            let counter = after.clone();
+            let pool = &pool;
+            let ids = &ids;
+            async move {
+                let mut conn = pool.acquire().await.expect("acquire");
+                find_by_ids(&mut conn, ids, false)
+                    .await
+                    .expect("find_by_ids")
+            }
+            .with_subscriber(tracing::Dispatch::new(
+                tracing_subscriber::registry().with(counter),
+            ))
+            .await
+        };
+        let after_count = after.count();
+
+        // Data equality: same set of (id -> name) pairs.
+        assert_eq!(batched.len(), N, "batched returned all N services");
+        let batched_names = batched
+            .into_iter()
+            .map(|service| (service.id, service.name))
+            .collect::<std::collections::HashMap<_, _>>();
+        assert_eq!(
+            looped, batched_names,
+            "batched find_by_ids returns the same id->name mapping as the loop"
+        );
+
+        // Bite-check: the loop MUST be more than one query.
+        assert!(
+            before_count > 1,
+            "bite-check failed: looped find_by_ids issued {before_count} queries (expected > 1)"
+        );
+        assert_eq!(
+            before_count, N,
+            "looped find_by_ids issues one query per id"
+        );
+        assert_eq!(
+            after_count, 1,
+            "batched find_by_ids issues a single query for the whole set"
+        );
+
+        println!(
+            "extension_service by-id N+1: before(loop find_by_ids)={before_count} after(find_by_ids batch)={after_count} (N={N})"
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn find_version_info_of_known_service_skips_existence_probe(pool: sqlx::PgPool) {
+        let seeded = seed_services(&pool, 1).await;
+        let (service_id, version) = seeded[0];
+
+        // The reads run on plain pool connections -- no transaction -- so no
+        // begin/commit statements land in the counts. Each counted region
+        // acquires its connection inside the instrumented future.
+
+        // find_version_info: existence probe + version lookup.
+        let probed = QueryCounter::default();
+        let probed_info = {
+            let counter = probed.clone();
+            let pool = &pool;
+            async move {
+                let mut conn = pool.acquire().await.expect("acquire");
+                find_version_info(&mut conn, service_id, Some(version))
+                    .await
+                    .expect("find_version_info")
+            }
+            .with_subscriber(tracing::Dispatch::new(
+                tracing_subscriber::registry().with(counter),
+            ))
+            .await
+        };
+        let probed_count = probed.count();
+
+        // find_version_info_of_known_service: the version lookup alone.
+        let unprobed = QueryCounter::default();
+        let unprobed_info = {
+            let counter = unprobed.clone();
+            let pool = &pool;
+            async move {
+                let mut conn = pool.acquire().await.expect("acquire");
+                find_version_info_of_known_service(&mut conn, service_id, Some(version))
+                    .await
+                    .expect("find_version_info_of_known_service")
+            }
+            .with_subscriber(tracing::Dispatch::new(
+                tracing_subscriber::registry().with(counter),
+            ))
+            .await
+        };
+        let unprobed_count = unprobed.count();
+
+        // Data equality: both lookups return the same version row.
+        assert_eq!(
+            (
+                probed_info.service_id,
+                probed_info.version,
+                probed_info.data,
+                probed_info.observability,
+                probed_info.has_credential,
+                probed_info.created,
+            ),
+            (
+                unprobed_info.service_id,
+                unprobed_info.version,
+                unprobed_info.data,
+                unprobed_info.observability,
+                unprobed_info.has_credential,
+                unprobed_info.created,
+            ),
+            "both lookups return the same version info"
+        );
+
+        assert_eq!(
+            probed_count, 2,
+            "find_version_info issues two queries (existence probe + version lookup)"
+        );
+        assert_eq!(
+            unprobed_count, 1,
+            "find_version_info_of_known_service issues the version lookup alone"
+        );
+
+        println!(
+            "extension_service version lookup: find_version_info={probed_count} \
+             find_version_info_of_known_service={unprobed_count}"
+        );
+    }
 }


### PR DESCRIPTION
The per-host network-config poll resolved each interface's DNS domain with its own query and each of the instance's extension services with its own lookup -- plus an existence probe before every version read -- for every managed host, on every poll interval.

The poll now gathers the distinct ids up front and reads each set once, resolving from in-memory maps:

- `dns::domain::find_by_uuids` -- the batched counterpart to `find_by_uuid`; the domain lookup drops from one-per-interface (~8-9 per host) to one.
- The instance's extension-service records load in one query, and `find_version_info_of_known_service` skips the existence probe when the caller has already verified the service, halving that lookup.
- The per-interface "domain not found" behavior is unchanged.

Query-count tests pin the batched readers: one query for N ids, not N, and one query per version lookup when the service is pre-verified.

This supports https://github.com/NVIDIA/infra-controller/issues/3214


Closes #3214
