### PR TITLE
ci: remove redundant post-checkout fetches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,8 +170,6 @@ jobs:
 
           set -euo pipefail
 
-          # Fetch tags for accurate git describe
-          git fetch --tags --force
           SHORT_SHA=$(git rev-parse --short=7 HEAD)
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "Using Git describe to extract version as VERSION and HELM_VERSION"
@@ -1243,7 +1241,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           MERGE_BASE="$(git merge-base HEAD origin/main)"
           BASE_PROTO_DIR="$(mktemp -d)"
           trap 'rm -rf "${BASE_PROTO_DIR}"' EXIT

--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -68,7 +68,6 @@ jobs:
             branch="${GITHUB_REF_NAME}"
             echo "${branch#pull-request/}" > preview-metadata/pr_number
             echo "${branch}" > preview-metadata/head_ref
-            git fetch origin "${DEFAULT_BRANCH}" --depth=64 2>/dev/null || true
             git diff --name-only "origin/${DEFAULT_BRANCH}...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
           fi
 

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -119,7 +119,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           MERGE_BASE="$(git merge-base HEAD origin/main)"
 
           echo "merge_base=${MERGE_BASE}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -78,7 +78,6 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
-          git fetch --tags --force
           RAW_VERSION=$(git describe --tags --first-parent --always --long)
           SEMANTIC_VERSION="${RAW_VERSION}"
 


### PR DESCRIPTION
## Summary

- remove redundant post-checkout fetches from Core and REST CI
- remove the silently ignored Fern default-branch fetch
- preserve `persist-credentials: false` on every affected checkout

## Root cause

Full-history `actions/checkout` steps already fetch all branches and tags, including `origin/main`. The later shell-level `git fetch` commands therefore add no data. After #3006 set `persist-credentials: false`, those commands also lost authentication after checkout and began failing in private mirrors even though the initial checkout succeeded.

## Impact

This keeps the credential-hardening behavior while allowing the workflows to run in private mirrors. Public-repository behavior and the calculated versions/comparison bases remain unchanged.


## Validation

- parsed all modified workflows with `yq`
- ran `actionlint` with existing custom-runner-label, pre-existing ShellCheck, and existing untrusted-expression diagnostics excluded
- ran `git diff --check`
- verified both commits are signed and DCO-signoff compliant
- CI requested with `/ok to test`
