### PR TITLE
feat(hw-health): out-of-band GPU count vs SKU (#301)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "base64",
+ "bmc-mock",
  "bytes",
  "carbide-health-report",
  "carbide-instrument",

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -608,7 +608,10 @@ impl InternalRBACRules {
         x.perm("VerifySkuForMachine", vec![ForgeAdminCLI]);
         x.perm("RemoveSkuAssociation", vec![ForgeAdminCLI]);
         x.perm("GetAllSkuIds", vec![ForgeAdminCLI, SiteAgent, Flow]);
-        x.perm("FindSkusByIds", vec![ForgeAdminCLI, SiteAgent, Flow]);
+        x.perm(
+            "FindSkusByIds",
+            vec![ForgeAdminCLI, Health, SiteAgent, Flow],
+        );
         x.perm("DeleteSku", vec![ForgeAdminCLI]);
         x.perm("UpdateSkuMetadata", vec![ForgeAdminCLI]);
         x.perm("UpdateMachineHardwareInfo", vec![ForgeAdminCLI]);

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -108,6 +108,7 @@ tonic-prost-build = { workspace = true }
 bench-hooks = []
 
 [dev-dependencies]
+bmc-mock = { path = "../bmc-mock" }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 criterion = { workspace = true }

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -183,6 +183,14 @@ firmware_refresh_interval = "30m"
 poll_interval = "1m"
 state_refresh_interval = "30m"
 
+# GPU inventory: out-of-band GPU count vs the machine's assigned SKU (issue #301).
+# Disabled by default. Requires [endpoint_sources.carbide_api] (to resolve the
+# expected count from the SKU) and [sinks.health_report] (to deliver alerts) to be
+# enabled, or config validation fails. GPU population is near-static, so keep the
+# interval infrequent (default 1h). Uncomment to enable:
+# [collectors.gpu_inventory]
+# interval = "1h"
+
 [collectors.logs]
 #  "auto": (default)
 #       - spawn SSE per endpoint

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -150,6 +150,42 @@ impl ApiClientWrapper {
 
         Ok(())
     }
+    /// Fetch SKU manifests by id — the expected-hardware source of truth used
+    /// to validate out-of-band GPU count against the assigned SKU.
+    pub async fn find_skus_by_ids(
+        &self,
+        ids: Vec<String>,
+    ) -> Result<Vec<rpc::forge::Sku>, HealthError> {
+        let request = rpc::forge::SkusByIdsRequest { ids };
+
+        let response = self
+            .client
+            .find_skus_by_ids(request)
+            .await
+            .map_err(HealthError::ApiInvocationError)?;
+
+        Ok(response.skus)
+    }
+
+    /// Fetch a machine's currently-assigned SKU id, re-read live each call so SKU
+    /// assignments/changes after a collector starts are picked up (no caching).
+    pub async fn machine_hw_sku(
+        &self,
+        machine_id: carbide_uuid::machine::MachineId,
+    ) -> Result<Option<String>, HealthError> {
+        let request = rpc::forge::MachinesByIdsRequest {
+            machine_ids: vec![machine_id],
+            ..Default::default()
+        };
+
+        let response = self
+            .client
+            .find_machines_by_ids(request)
+            .await
+            .map_err(HealthError::ApiInvocationError)?;
+
+        Ok(response.machines.into_iter().next().and_then(|m| m.hw_sku))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/health/src/collectors/gpu_inventory.rs
+++ b/crates/health/src/collectors/gpu_inventory.rs
@@ -1,0 +1,492 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use carbide_uuid::machine::MachineId;
+use nv_redfish::core::{Bmc, ToSnakeCase};
+use nv_redfish::resource::State;
+
+use crate::HealthError;
+use crate::api_client::ApiClientWrapper;
+use crate::collectors::inventory::{DiscoveredEntity, SharedInventory};
+use crate::collectors::runtime::{IterationResult, PeriodicCollector};
+use crate::endpoint::{BmcEndpoint, EndpointMetadata};
+use crate::sink::{
+    Classification, CollectorEvent, DataSink, EventContext, HealthReport, HealthReportAlert,
+    HealthReportSuccess, HealthReportTarget, Probe, ReportSource,
+};
+
+/// Resolved expected-GPU state for the endpoint's assigned SKU.
+#[derive(Clone, Debug)]
+enum Expected {
+    /// No SKU assigned yet — nothing to validate.
+    NoSku,
+    /// The assigned SKU id, but its manifest could not be found.
+    SkuMissing(String),
+    /// Expected GPU count from the SKU manifest.
+    Count(u32),
+}
+
+pub struct GpuInventoryCollectorConfig<B: Bmc> {
+    pub data_sink: Option<Arc<dyn DataSink>>,
+    pub api_client: Arc<ApiClientWrapper>,
+    /// Shared entity inventory published by the entity-discovery collector for
+    /// this endpoint. GPU counts are read from here rather than re-queried, so
+    /// the two collectors share a single Redfish enumeration.
+    pub(crate) shared: SharedInventory<B>,
+}
+
+pub struct GpuInventoryCollector<B: Bmc> {
+    endpoint: Arc<BmcEndpoint>,
+    event_context: EventContext,
+    /// Entity inventory published by the entity-discovery collector.
+    shared: SharedInventory<B>,
+    data_sink: Option<Arc<dyn DataSink>>,
+    api_client: Arc<ApiClientWrapper>,
+    /// Machine id for this endpoint. The assigned SKU is re-read live each iteration
+    /// (not cached) so SKU assignments/changes after start are honored.
+    machine_id: Option<MachineId>,
+}
+
+impl<B: Bmc + 'static> GpuInventoryCollector<B> {
+    /// Resolve the expected GPU count from the machine's currently-assigned SKU.
+    /// Re-reads the SKU live every call (no caching) so assignments/changes after
+    /// the collector starts are picked up.
+    async fn resolve_expected(&self) -> Result<Expected, HealthError> {
+        let Some(machine_id) = self.machine_id else {
+            return Ok(Expected::NoSku);
+        };
+        let Some(sku_id) = self.api_client.machine_hw_sku(machine_id).await? else {
+            return Ok(Expected::NoSku);
+        };
+        let skus = self
+            .api_client
+            .find_skus_by_ids(vec![sku_id.clone()])
+            .await?;
+        Ok(match skus.into_iter().next() {
+            None => Expected::SkuMissing(sku_id),
+            Some(sku) => Expected::Count(
+                sku.components
+                    .map(|c| c.gpus.iter().map(|g| g.count).sum())
+                    .unwrap_or(0),
+            ),
+        })
+    }
+
+    /// Count the machine's GPUs from the shared entity inventory that the
+    /// entity-discovery collector publishes for this endpoint — reusing the
+    /// existing Redfish enumeration instead of re-querying the BMC.
+    ///
+    /// Returns `None` when no inventory snapshot exists yet (discovery hasn't run
+    /// for this endpoint), so the caller skips the iteration rather than treating
+    /// an unknown count as zero and false-alerting.
+    ///
+    /// GPUs surface in the inventory two ways depending on how they attach; we
+    /// count both and take the max — no vendor table, works across Dell / Lenovo /
+    /// Supermicro / NVIDIA regardless of GPU form:
+    /// - **SXM / HGX baseboards** (H100 SXM, GB200, GB300, GH200) → one
+    ///   `HGX_GPU_*` chassis per GPU (`is_hgx_gpu_chassis`).
+    /// - **PCIe cards** (L40 / L40S, H100 PCIe, A100) → Redfish `Processors` with
+    ///   `ProcessorType == GPU` (`is_gpu_processor`).
+    ///
+    /// Some platforms (e.g. GB200) expose the *same* GPUs as both chassis and
+    /// processors, so we take the max rather than the sum to avoid double-counting.
+    /// `max` is deliberate: `min` would false-alert on platforms that populate only
+    /// one view, and `sum` would double-count dual-view platforms.
+    ///
+    /// Resources reported with `Status.State == Absent` (a defined but empty slot)
+    /// are excluded so a placeholder entry can't mask a genuinely missing GPU — see
+    /// [`is_present`] for the treatment of the other, degraded-but-present states.
+    ///
+    /// Limitation: this trusts the discovered inventory — if a failed GPU still
+    /// appears (stale inventory, still `Enabled`), the count won't drop. GPUs
+    /// exposed ONLY under `PCIeDevices` (neither an HGX chassis nor a GPU
+    /// `Processor`) are not counted; add a PCIe path once a platform that needs it
+    /// is confirmed via Redfish.
+    fn count_gpus(&self) -> Option<u32> {
+        let inventory = self.shared.load_full()?;
+        Some(Self::count_gpus_in(&inventory.entities))
+    }
+
+    /// GPU count for a set of discovered entities: `max(HGX_GPU_* chassis,
+    /// ProcessorType==GPU processors)`.
+    fn count_gpus_in(entities: &[DiscoveredEntity<B>]) -> u32 {
+        let chassis_gpus = entities
+            .iter()
+            .filter(|e| Self::is_hgx_gpu_chassis(e))
+            .count() as u32;
+        let processor_gpus = entities
+            .iter()
+            .filter(|e| Self::is_gpu_processor(e))
+            .count() as u32;
+        chassis_gpus.max(processor_gpus)
+    }
+
+    /// HGX path: each GPU module is one `HGX_GPU_*` chassis (`HGX_GPU_SXM_*` on
+    /// Viking/H100, `HGX_GPU_*` on GH200/GB200/GB300). NVSwitch trays excluded.
+    fn is_hgx_gpu_chassis(entity: &DiscoveredEntity<B>) -> bool {
+        let DiscoveredEntity::Chassis { entity, .. } = entity else {
+            return false;
+        };
+        let raw = entity.raw();
+        let id = &raw.base.id;
+        let state = raw
+            .status
+            .as_ref()
+            .and_then(|s| s.state.as_ref())
+            .and_then(|s| s.as_ref());
+        id.starts_with("HGX_GPU_") && !id.contains("NVSwitch") && is_present(state)
+    }
+
+    /// Standard-server path: GPUs exposed as Redfish Processors
+    /// (`ProcessorType == GPU`). Vendor-neutral across Dell / Lenovo / HPE /
+    /// Supermicro and model-agnostic — counts every GPU (H100 PCIe, L40 / L40S,
+    /// A100, …), confirmed on hardware (Lenovo ThinkSystem SR670 V2 with 8x L40
+    /// reports 8 `ProcessorType=GPU` processors via XCC).
+    fn is_gpu_processor(entity: &DiscoveredEntity<B>) -> bool {
+        let DiscoveredEntity::Processor { entity, .. } = entity else {
+            return false;
+        };
+        let raw = entity.raw();
+        let state = raw
+            .status
+            .as_ref()
+            .and_then(|s| s.state.as_ref())
+            .and_then(|s| s.as_ref());
+        raw.processor_type
+            .flatten()
+            .is_some_and(|pt| pt.to_snake_case() == "gpu")
+            && is_present(state)
+    }
+
+    fn emit_alert(&self, message: String) {
+        tracing::warn!(bmc = %self.endpoint.addr.mac, %message, "GPU inventory alert");
+        let report = HealthReport {
+            source: ReportSource::GpuInventory,
+            target: Some(HealthReportTarget::Machine),
+            observed_at: Some(chrono::Utc::now()),
+            successes: Vec::new(),
+            alerts: vec![HealthReportAlert {
+                probe_id: Probe::GpuInventory,
+                target: None,
+                message,
+                classifications: vec![Classification::PreventAllocations],
+            }],
+        };
+        self.emit(report);
+    }
+
+    fn emit(&self, report: HealthReport) {
+        if let Some(sink) = &self.data_sink {
+            sink.handle_event(
+                &self.event_context,
+                &CollectorEvent::HealthReport(Arc::new(report)),
+            );
+        }
+    }
+}
+
+/// Whether a discovered resource is physically present and should be counted.
+///
+/// Redfish may list a resource with `Status.State == Absent` — a defined but
+/// empty slot with no device installed (per the DMTF Redfish resource-status
+/// model). Counting such a "GPU" would mask a genuinely missing one and defeat
+/// the #301 shortage check, so it is excluded.
+///
+/// Every other state — including a missing `Status`, and non-operational-but-
+/// installed states like `Disabled`, `UnavailableOffline` or `StandbyOffline` —
+/// is treated as present. Those represent physical hardware that is degraded, not
+/// absent; a GPU *count* shortage means missing hardware, and degraded health is
+/// surfaced by other signals rather than by dropping the count (which would
+/// otherwise raise a spurious "fewer GPUs than the SKU expects" alert).
+fn is_present(state: Option<&State>) -> bool {
+    !matches!(state, Some(State::Absent))
+}
+
+/// Build the health report for a GPU-count comparison — the core of issue #301:
+/// alert when the BMC sees fewer GPUs than the SKU expects, success otherwise.
+fn gpu_count_report(expected: u32, actual: u32) -> HealthReport {
+    if actual < expected {
+        HealthReport {
+            source: ReportSource::GpuInventory,
+            target: Some(HealthReportTarget::Machine),
+            observed_at: Some(chrono::Utc::now()),
+            successes: Vec::new(),
+            alerts: vec![HealthReportAlert {
+                probe_id: Probe::GpuInventory,
+                target: None,
+                message: format!(
+                    "Expected gpu count ({expected}) does not match actual ({actual}) \
+                     as seen out-of-band via BMC"
+                ),
+                classifications: vec![Classification::PreventAllocations],
+            }],
+        }
+    } else {
+        HealthReport {
+            source: ReportSource::GpuInventory,
+            target: Some(HealthReportTarget::Machine),
+            observed_at: Some(chrono::Utc::now()),
+            successes: vec![HealthReportSuccess {
+                probe_id: Probe::GpuInventory,
+                target: None,
+            }],
+            alerts: Vec::new(),
+        }
+    }
+}
+
+impl<B: Bmc + 'static> PeriodicCollector<B> for GpuInventoryCollector<B> {
+    type Config = GpuInventoryCollectorConfig<B>;
+
+    fn new_runner(
+        _bmc: Arc<B>,
+        endpoint: Arc<BmcEndpoint>,
+        config: Self::Config,
+    ) -> Result<Self, HealthError> {
+        let event_context =
+            EventContext::from_endpoint(endpoint.as_ref(), "gpu_inventory_collector");
+        let machine_id = match &endpoint.metadata {
+            Some(EndpointMetadata::Machine(m)) => Some(m.machine_id),
+            _ => None,
+        };
+        Ok(Self {
+            endpoint,
+            event_context,
+            shared: config.shared,
+            data_sink: config.data_sink,
+            api_client: config.api_client,
+            machine_id,
+        })
+    }
+
+    async fn run_iteration(&mut self) -> Result<IterationResult, HealthError> {
+        let expected_count = match self.resolve_expected().await? {
+            // No SKU assigned, or the SKU declares zero GPUs (e.g. a CPU-only node):
+            // nothing to validate. Emit a success so any prior shortage alert on
+            // this machine clears (recovery), rather than lingering forever.
+            Expected::NoSku | Expected::Count(0) => {
+                self.emit(gpu_count_report(0, 0));
+                return Ok(IterationResult {
+                    refresh_triggered: false,
+                    entity_count: None,
+                    fetch_failures: 0,
+                });
+            }
+            Expected::SkuMissing(sku_id) => {
+                self.emit_alert(format!("The assigned sku {sku_id} does not exist"));
+                return Ok(IterationResult {
+                    refresh_triggered: false,
+                    // Actual GPU count was never queried (bad SKU reference), so it
+                    // is unknown here — report None rather than a misleading 0.
+                    entity_count: None,
+                    fetch_failures: 0,
+                });
+            }
+            Expected::Count(n) => n,
+        };
+
+        // Read the GPU count from the shared entity inventory (populated by the
+        // entity-discovery collector). If discovery hasn't produced a snapshot yet,
+        // skip this iteration rather than false-alerting on a not-yet-known count.
+        let Some(actual) = self.count_gpus() else {
+            tracing::debug!(
+                bmc = %self.endpoint.addr.mac,
+                "Entity inventory not ready yet; skipping GPU inventory iteration"
+            );
+            return Ok(IterationResult {
+                refresh_triggered: false,
+                entity_count: None,
+                fetch_failures: 0,
+            });
+        };
+
+        let report = gpu_count_report(expected_count, actual);
+        if !report.alerts.is_empty() {
+            tracing::warn!(
+                bmc = %self.endpoint.addr.mac,
+                expected = expected_count,
+                actual,
+                "GPU count below SKU expectation"
+            );
+        }
+        self.emit(report);
+
+        Ok(IterationResult {
+            refresh_triggered: false,
+            entity_count: Some(actual as usize),
+            fetch_failures: 0,
+        })
+    }
+
+    fn collector_type(&self) -> &'static str {
+        "gpu_inventory_collector"
+    }
+}
+
+/// Integration tests for GPU counting. They build `DiscoveredEntity` values from
+/// realistic Redfish trees served in-process by `bmc-mock` — the same entity
+/// shapes the entity-discovery collector publishes — then count GPUs from them,
+/// exercising the real inventory-backed path:
+/// - `is_hgx_gpu_chassis` (`HGX_GPU_*`) is the same code for H100 SXM, GH200,
+///   GB200 and GB300 — GB300 pins it to an exact count.
+/// - `is_gpu_processor` (`ProcessorType == GPU`) is validated against GB200, the
+///   only in-process fixture that models GPUs as Redfish Processors — the same
+///   signal PCIe GPUs (L40/L40S, H100 PCIe) produce on Dell/Lenovo/HPE.
+#[cfg(test)]
+mod bmc_mock_integration_tests {
+    use std::sync::Arc;
+
+    use bmc_mock::test_support::{
+        TestBmc, TestBmcHandle, dell_poweredge_r750_bmc, dgx_gb300_bmc, wiwynn_gb200_bmc,
+    };
+
+    use super::{GpuInventoryCollector, gpu_count_report};
+    use crate::collectors::inventory::DiscoveredEntity;
+    use crate::sink::{Classification, Probe};
+
+    /// Build the discovered-entity list (processors + chassis) from a mock BMC,
+    /// mirroring how the entity-discovery collector populates the shared inventory.
+    async fn entities_from(h: &TestBmcHandle) -> Vec<DiscoveredEntity<TestBmc>> {
+        let root = h.service_root.as_ref();
+        let mut entities = Vec::new();
+
+        if let Some(systems) = root.systems().await.expect("systems") {
+            for system in systems.members().await.expect("system members") {
+                let system = Arc::new(system);
+                let processors = system
+                    .processors()
+                    .await
+                    .expect("processors")
+                    .unwrap_or_default();
+                for processor in processors {
+                    entities.push(DiscoveredEntity::Processor {
+                        entity: Arc::new(processor),
+                        system: system.clone(),
+                        sensors: Vec::new(),
+                    });
+                }
+            }
+        }
+
+        if let Some(chassis_list) = root.chassis().await.expect("chassis") {
+            for chassis in chassis_list.members().await.expect("chassis members") {
+                entities.push(DiscoveredEntity::Chassis {
+                    entity: Arc::new(chassis),
+                    sensors: Vec::new(),
+                });
+            }
+        }
+
+        entities
+    }
+
+    fn count(entities: &[DiscoveredEntity<TestBmc>]) -> u32 {
+        GpuInventoryCollector::<TestBmc>::count_gpus_in(entities)
+    }
+
+    #[test]
+    fn alerts_when_fewer_gpus_than_sku_expects() {
+        // Issue #301 core: BMC sees 6 GPUs, the SKU expects 8 -> shortage alert.
+        let report = gpu_count_report(8, 6);
+        assert!(report.successes.is_empty());
+        assert_eq!(report.alerts.len(), 1);
+        let alert = &report.alerts[0];
+        assert_eq!(alert.probe_id, Probe::GpuInventory);
+        assert_eq!(
+            alert.classifications,
+            vec![Classification::PreventAllocations]
+        );
+        assert!(
+            alert.message.contains('6') && alert.message.contains('8'),
+            "message should name actual and expected: {}",
+            alert.message
+        );
+    }
+
+    #[test]
+    fn success_when_gpu_count_matches_or_exceeds_sku() {
+        // Exact match -> success, no alert.
+        let matched = gpu_count_report(8, 8);
+        assert!(matched.alerts.is_empty());
+        assert_eq!(matched.successes.len(), 1);
+        // More GPUs than the SKU expects is not a shortage -> still success.
+        assert!(gpu_count_report(4, 5).alerts.is_empty());
+        // Clear/no-op case (no SKU or SKU declares 0 GPUs) -> success, no alert,
+        // which clears any prior shortage alert on the machine.
+        let cleared = gpu_count_report(0, 0);
+        assert!(cleared.alerts.is_empty());
+        assert_eq!(cleared.successes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn dgx_gb300_counts_four_gpus_from_inventory() {
+        // DGX GB300 exposes 4 HGX_GPU_ chassis; counting from the discovered
+        // inventory must find exactly 4 — the number the #301 decision compares.
+        let h = dgx_gb300_bmc().await;
+        let entities = entities_from(&h).await;
+        assert_eq!(count(&entities), 4, "DGX GB300: 4 HGX_GPU_ chassis");
+        // Feed the count into the #301 decision: SKU expecting 8 -> shortage.
+        assert_eq!(gpu_count_report(8, count(&entities)).alerts.len(), 1);
+        assert!(gpu_count_report(4, count(&entities)).alerts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn gb200_counts_gpus_via_both_views_without_double_counting() {
+        // GB200 lists the same GPUs both as HGX_GPU_* chassis and as GPU
+        // processors. Both views must find them, and count_gpus_in takes the max
+        // (not the sum), so they are not double-counted.
+        let h = wiwynn_gb200_bmc().await;
+        let entities = entities_from(&h).await;
+
+        let chassis = entities
+            .iter()
+            .filter(|e| GpuInventoryCollector::<TestBmc>::is_hgx_gpu_chassis(e))
+            .count();
+        let processors = entities
+            .iter()
+            .filter(|e| GpuInventoryCollector::<TestBmc>::is_gpu_processor(e))
+            .count();
+
+        assert!(chassis > 0, "expected HGX_GPU_* chassis, got {chassis}");
+        assert!(processors > 0, "expected GPU processors, got {processors}");
+        assert_eq!(count(&entities) as usize, chassis.max(processors));
+    }
+
+    #[tokio::test]
+    async fn dell_r750_gpuless_counts_zero() {
+        // The R750 fixture is a GPU-less server: neither view finds a GPU.
+        let h = dell_poweredge_r750_bmc().await;
+        let entities = entities_from(&h).await;
+        assert_eq!(count(&entities), 0);
+    }
+
+    #[test]
+    fn absent_state_is_not_counted_but_degraded_is() {
+        use nv_redfish::resource::State;
+
+        // Absent = defined-but-empty slot -> not present, must be excluded so a
+        // missing GPU isn't masked by a placeholder entry.
+        assert!(!super::is_present(Some(&State::Absent)));
+        // Present, degraded-but-installed, and missing-state -> counted (physical
+        // hardware is there; degraded health is a separate signal).
+        assert!(super::is_present(Some(&State::Enabled)));
+        assert!(super::is_present(Some(&State::UnavailableOffline)));
+        assert!(super::is_present(None));
+    }
+}

--- a/crates/health/src/collectors/mod.rs
+++ b/crates/health/src/collectors/mod.rs
@@ -18,6 +18,7 @@
 mod discovery;
 mod entity_metrics;
 mod firmware;
+mod gpu_inventory;
 pub(crate) mod inventory;
 mod leak_detector;
 mod logs;
@@ -30,6 +31,7 @@ mod sensors;
 pub use discovery::{EntityDiscoveryCollector, EntityDiscoveryCollectorConfig};
 pub use entity_metrics::{MetricsCollector, MetricsCollectorConfig};
 pub use firmware::{FirmwareCollector, FirmwareCollectorConfig};
+pub use gpu_inventory::{GpuInventoryCollector, GpuInventoryCollectorConfig};
 pub(crate) use inventory::SharedInventory;
 pub use leak_detector::{LeakDetectorCollector, LeakDetectorCollectorConfig};
 pub(crate) use logs::auto::{AutoFailureBudget, BudgetDecision, FailureKind};

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -596,6 +596,9 @@ pub struct CollectorsConfig {
 
     /// NVUE collector configuration for direct NVUE HTTP(s) polling of NVLink switches
     pub nvue: Configurable<NvueCollectorConfig>,
+
+    /// GPU inventory collector: compares OOB GPU count vs the assigned SKU.
+    pub gpu_inventory: Configurable<GpuInventoryConfig>,
 }
 
 impl Default for CollectorsConfig {
@@ -610,6 +613,7 @@ impl Default for CollectorsConfig {
             nmxt: Configurable::Disabled,
             nmxc: Configurable::Disabled,
             nvue: Configurable::Disabled,
+            gpu_inventory: Configurable::Disabled,
         }
     }
 }
@@ -724,6 +728,25 @@ impl Default for MetricsCollectorConfig {
         Self {
             fetch_interval: Duration::from_secs(120),
             fetch_concurrency: 4,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GpuInventoryConfig {
+    /// How often to re-check the GPU count against the assigned SKU. GPU
+    /// population is near-static and each iteration re-reads the SKU from the
+    /// NICo API, so this defaults to a low frequency (1h, matching the entity
+    /// discovery refresh cadence) rather than hammering the API.
+    #[serde(with = "humantime_serde")]
+    pub interval: Duration,
+}
+
+impl Default for GpuInventoryConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(3600),
         }
     }
 }
@@ -1482,6 +1505,27 @@ impl Config {
             nmxc.validate()?;
         }
 
+        if let Configurable::Enabled(gpu_inventory) = &self.collectors.gpu_inventory {
+            if !self.endpoint_sources.carbide_api.is_enabled() {
+                return Err(
+                    "collectors.gpu_inventory requires endpoint_sources.carbide_api to be enabled \
+                     (expected GPU counts are resolved from the machine SKU via the Carbide API)"
+                        .to_string(),
+                );
+            }
+            if !self.sinks.health_report.is_enabled() {
+                return Err(
+                    "collectors.gpu_inventory requires sinks.health_report to be enabled \
+                     (GPU shortage alerts are delivered through the health-report sink)"
+                        .to_string(),
+                );
+            }
+            if gpu_inventory.interval.is_zero() {
+                // A zero interval would busy-loop the collector and flood the BMC / API.
+                return Err("collectors.gpu_inventory.interval must be greater than 0".to_string());
+            }
+        }
+
         if let Configurable::Enabled(ref otlp) = self.sinks.otlp {
             if otlp.targets.is_empty() {
                 return Err("sinks.otlp.targets must not be empty".to_string());
@@ -1788,6 +1832,47 @@ username = "root"
             .extract::<Config>();
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_gpu_inventory_requires_carbide_api_and_health_report() {
+        let mut config = Config::default();
+        config.collectors.gpu_inventory = Configurable::Enabled(GpuInventoryConfig::default());
+
+        // Enabled without the Carbide API source -> invalid (can't resolve SKU).
+        config.endpoint_sources.carbide_api = Configurable::Disabled;
+        config.sinks.health_report = Configurable::Enabled(HealthReportSinkConfig::default());
+        assert!(config.validate().is_err());
+
+        // Enabled without the health-report sink -> invalid (alerts go nowhere).
+        config.endpoint_sources.carbide_api =
+            Configurable::Enabled(CarbideApiConnectionConfig::default());
+        config.sinks.health_report = Configurable::Disabled;
+        assert!(config.validate().is_err());
+
+        // Both dependencies present -> valid.
+        config.sinks.health_report = Configurable::Enabled(HealthReportSinkConfig::default());
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_gpu_inventory_rejects_zero_interval() {
+        let mut config = Config::default();
+        config.endpoint_sources.carbide_api =
+            Configurable::Enabled(CarbideApiConnectionConfig::default());
+        config.sinks.health_report = Configurable::Enabled(HealthReportSinkConfig::default());
+
+        // A zero interval would busy-loop the collector -> rejected.
+        config.collectors.gpu_inventory = Configurable::Enabled(GpuInventoryConfig {
+            interval: Duration::from_secs(0),
+        });
+        assert!(config.validate().is_err());
+
+        // A positive interval with both dependencies present -> valid.
+        config.collectors.gpu_inventory = Configurable::Enabled(GpuInventoryConfig {
+            interval: Duration::from_secs(300),
+        });
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -24,11 +24,12 @@ use arc_swap::ArcSwapOption;
 use prometheus::{Histogram, HistogramOpts};
 
 use crate::HealthError;
+use crate::api_client::ApiClientWrapper;
 use crate::bmc::BmcClient;
 use crate::collectors::{Collector, LogDowngradeRegistry, SharedInventory};
 use crate::config::{
     Config, Configurable, DiscoveryConfig, FirmwareCollectorConfig as FirmwareCollectorOptions,
-    LeakDetectorCollectorConfig as LeakDetectorCollectorOptions,
+    GpuInventoryConfig, LeakDetectorCollectorConfig as LeakDetectorCollectorOptions,
     LogsCollectorConfig as LogsCollectorOptions, MetricsCollectorConfig as MetricsCollectorOptions,
     MtlsProfileConfig, NmxcCollectorConfig as NmxcCollectorOptions,
     NmxtCollectorConfig as NmxtCollectorOptions, NvueCollectorConfig as NvueCollectorOptions,
@@ -50,10 +51,11 @@ pub(super) enum CollectorKind {
     Nmxc,
     NvueRest,
     NvueGnmi,
+    GpuInventory,
 }
 
 impl CollectorKind {
-    pub(super) const ALL: [CollectorKind; 10] = [
+    pub(super) const ALL: [CollectorKind; 11] = [
         CollectorKind::Discovery,
         CollectorKind::Sensor,
         CollectorKind::Metrics,
@@ -64,6 +66,7 @@ impl CollectorKind {
         CollectorKind::Nmxc,
         CollectorKind::NvueRest,
         CollectorKind::NvueGnmi,
+        CollectorKind::GpuInventory,
     ];
 
     pub(super) fn stop_message(self) -> &'static str {
@@ -71,6 +74,7 @@ impl CollectorKind {
             CollectorKind::Discovery => {
                 "Stopping entity discovery collector for removed BMC endpoint"
             }
+            CollectorKind::GpuInventory => "Stopping GPU inventory collector",
             CollectorKind::Sensor => "Stopping sensor collector for removed BMC endpoint",
             CollectorKind::Metrics => "Stopping entity metrics collector for removed BMC endpoint",
             CollectorKind::Logs => "Stopping logs collector for removed BMC endpoint",
@@ -99,6 +103,7 @@ pub(super) struct CollectorState {
     nmxc: HashMap<Cow<'static, str>, Collector>,
     nvue_rest: HashMap<Cow<'static, str>, Collector>,
     nvue_gnmi: HashMap<Cow<'static, str>, Collector>,
+    gpu_inventory: HashMap<Cow<'static, str>, Collector>,
     inventories: HashMap<Cow<'static, str>, SharedInventory<BmcClient>>,
 }
 
@@ -115,6 +120,7 @@ impl CollectorState {
             nmxc: HashMap::new(),
             nvue_rest: HashMap::new(),
             nvue_gnmi: HashMap::new(),
+            gpu_inventory: HashMap::new(),
             inventories: HashMap::new(),
         }
     }
@@ -131,6 +137,7 @@ impl CollectorState {
             CollectorKind::Nmxc => &self.nmxc,
             CollectorKind::NvueRest => &self.nvue_rest,
             CollectorKind::NvueGnmi => &self.nvue_gnmi,
+            CollectorKind::GpuInventory => &self.gpu_inventory,
         }
     }
 
@@ -149,6 +156,7 @@ impl CollectorState {
             CollectorKind::Nmxc => &mut self.nmxc,
             CollectorKind::NvueRest => &mut self.nvue_rest,
             CollectorKind::NvueGnmi => &mut self.nvue_gnmi,
+            CollectorKind::GpuInventory => &mut self.gpu_inventory,
         }
     }
 
@@ -199,6 +207,7 @@ impl CollectorState {
             .chain(self.nmxc.keys())
             .chain(self.nvue_rest.keys())
             .chain(self.nvue_gnmi.keys())
+            .chain(self.gpu_inventory.keys())
             .filter(|key| !active_keys.contains(*key))
             .cloned()
             .collect()
@@ -239,6 +248,8 @@ pub struct DiscoveryLoopContext {
 
     /// Whether any enabled sink consumes `CollectorEvent::Log` payloads.
     pub(crate) log_event_sink_enabled: bool,
+    pub(crate) gpu_inventory_config: Configurable<GpuInventoryConfig>,
+    pub(crate) api_client: Option<Arc<ApiClientWrapper>>,
     pub(crate) log_downgrade_registry: Arc<LogDowngradeRegistry>,
 
     /// Whether log collectors should attach diagnostic payload carriers.
@@ -311,6 +322,16 @@ impl DiscoveryLoopContext {
             tls_config,
             tls_http_client_provider,
             log_event_sink_enabled: config.sinks.includes_log_events(),
+            gpu_inventory_config: config.collectors.gpu_inventory.clone(),
+            api_client: match &config.endpoint_sources.carbide_api {
+                Configurable::Enabled(source_cfg) => Some(Arc::new(ApiClientWrapper::new(
+                    source_cfg.root_ca.clone(),
+                    source_cfg.client_cert.clone(),
+                    source_cfg.client_key.clone(),
+                    &source_cfg.api_url,
+                ))),
+                _ => None,
+            },
             log_downgrade_registry: Arc::new(LogDowngradeRegistry::new()),
             logs_include_diagnostics: config.sinks.includes_log_diagnostics(),
         })

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -25,11 +25,12 @@ use crate::bmc::BmcClient;
 use crate::collectors::{
     AutoFailureBudget, BackoffConfig, BudgetDecision, Collector, CollectorStartContext,
     EntityDiscoveryCollector, EntityDiscoveryCollectorConfig, FailureKind, FirmwareCollector,
-    FirmwareCollectorConfig, LeakDetectorCollector, LeakDetectorCollectorConfig, LogsCollector,
-    LogsCollectorConfig, MetricsCollector, MetricsCollectorConfig, NmxcCollector,
-    NmxcCollectorConfig, NmxtCollector, NmxtCollectorConfig, NvueRestCollector,
-    NvueRestCollectorConfig, SensorCollector, SensorCollectorConfig, SseLogCollector,
-    SseLogCollectorConfig, StreamingCollectorStartContext, spawn_gnmi_collector,
+    FirmwareCollectorConfig, GpuInventoryCollector, GpuInventoryCollectorConfig,
+    LeakDetectorCollector, LeakDetectorCollectorConfig, LogsCollector, LogsCollectorConfig,
+    MetricsCollector, MetricsCollectorConfig, NmxcCollector, NmxcCollectorConfig, NmxtCollector,
+    NmxtCollectorConfig, NvueRestCollector, NvueRestCollectorConfig, SensorCollector,
+    SensorCollectorConfig, SseLogCollector, SseLogCollectorConfig, StreamingCollectorStartContext,
+    spawn_gnmi_collector,
 };
 use crate::config::{Configurable, LogCollectionMode, PeriodicLogConfig};
 use crate::endpoint::{BmcEndpoint, EndpointMetadata, SwitchEndpointRole};
@@ -80,8 +81,16 @@ fn spawn_generic_redfish_collectors(
 
     let sensors_enabled = matches!(ctx.sensors_config, Configurable::Enabled(_));
     let metrics_enabled = matches!(ctx.metrics_config, Configurable::Enabled(_));
+    // The GPU inventory collector reads GPU counts from the shared entity
+    // inventory, so entity discovery must also run wherever it does — even if
+    // sensors/metrics are disabled. Mirror the GPU collector's own spawn gate
+    // (enabled + API client present + machine endpoint) so discovery starts for
+    // exactly those endpoints and not for switches / power shelves.
+    let gpu_inventory_enabled = matches!(ctx.gpu_inventory_config, Configurable::Enabled(_))
+        && ctx.api_client.is_some()
+        && matches!(endpoint.metadata, Some(EndpointMetadata::Machine(_)));
 
-    if (sensors_enabled || metrics_enabled)
+    if (sensors_enabled || metrics_enabled || gpu_inventory_enabled)
         && !ctx.collectors.contains(CollectorKind::Discovery, &key)
     {
         let shared = ctx.collectors.inventory_for(&key);
@@ -383,6 +392,50 @@ fn spawn_generic_redfish_collectors(
         }
     }
 
+    if let Configurable::Enabled(gpu_cfg) = &ctx.gpu_inventory_config
+        && let Some(api_client) = &ctx.api_client
+        // GPU inventory validation only applies to machine endpoints (it needs a
+        // machine id + assigned SKU). Skip switch / power-shelf endpoints so we
+        // don't emit machine-target reports that get dropped for lack of context.
+        && matches!(endpoint.metadata, Some(EndpointMetadata::Machine(_)))
+        && !ctx.collectors.contains(CollectorKind::GpuInventory, &key)
+    {
+        let collector_registry = Arc::new(
+            ctx.metrics_manager
+                .create_collector_registry(format!("gpu_inventory_{key}"), metrics_prefix)?,
+        );
+        // Reuse the entity-discovery collector's inventory for this endpoint so GPU
+        // counting shares its Redfish enumeration instead of re-querying the BMC.
+        let shared = ctx.collectors.inventory_for(&key);
+        match Collector::start::<GpuInventoryCollector<BmcClient>>(
+            endpoint_arc.clone(),
+            bmc.clone(),
+            GpuInventoryCollectorConfig {
+                data_sink: data_sink.clone(),
+                api_client: api_client.clone(),
+                shared,
+            },
+            CollectorStartContext {
+                limiter: ctx.limiter.clone(),
+                iteration_interval: gpu_cfg.interval,
+                collector_registry,
+                metrics_manager: ctx.metrics_manager.clone(),
+            },
+        ) {
+            Ok(monitor) => {
+                ctx.collectors
+                    .insert(CollectorKind::GpuInventory, key.clone().into(), monitor);
+            }
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "Could not start GPU inventory collector for: {:?}",
+                    endpoint.addr
+                );
+            }
+        }
+    }
+
     if let Configurable::Enabled(leak_detector_cfg) = &ctx.leak_detector_config
         && !ctx.collectors.contains(CollectorKind::LeakDetector, &key)
     {
@@ -635,8 +688,8 @@ mod tests {
     use super::*;
     use crate::collectors::DowngradeReason;
     use crate::config::{
-        AutoModeConfig, Config, Configurable, LogsCollectorConfig, NvueCollectorConfig,
-        NvueGnmiConfig, PeriodicLogConfig, TracingSinkConfig,
+        AutoModeConfig, CarbideApiConnectionConfig, Config, Configurable, LogsCollectorConfig,
+        NvueCollectorConfig, NvueGnmiConfig, PeriodicLogConfig, TracingSinkConfig,
     };
     use crate::endpoint::test_support::endpoint_with_creds;
     use crate::endpoint::{
@@ -1296,6 +1349,46 @@ mod tests {
         assert_eq!(ctx.collectors.len(CollectorKind::Discovery), 1);
         assert_eq!(ctx.collectors.len(CollectorKind::Sensor), 0);
         assert_eq!(ctx.collectors.len(CollectorKind::Metrics), 1);
+    }
+
+    #[tokio::test]
+    async fn gpu_inventory_only_starts_discovery() {
+        // GpuInventoryCollector reads GPU counts from the shared entity inventory,
+        // so enabling it must start entity discovery even with sensors/metrics off,
+        // otherwise the collector would read an empty snapshot forever.
+        let mut config = Config::default();
+        config.collectors.sensors = Configurable::Disabled;
+        config.collectors.metrics = Configurable::Disabled;
+        config.collectors.logs = Configurable::Disabled;
+        config.collectors.firmware = Configurable::Disabled;
+        config.collectors.leak_detector = Configurable::Disabled;
+        config.collectors.nmxt = Configurable::Disabled;
+        config.collectors.nvue = Configurable::Disabled;
+        // GPU inventory needs the API client (SKU lookup), which the context builds
+        // from the carbide_api source.
+        config.endpoint_sources.carbide_api =
+            Configurable::Enabled(CarbideApiConnectionConfig::default());
+        config.collectors.gpu_inventory = Configurable::Enabled(Default::default());
+
+        let mut ctx = context_with_config(config, "test_discovery_with_gpu_inventory");
+        let endpoint = test_endpoint(
+            Ipv4Addr::new(10, 0, 0, 23),
+            "aa:bb:cc:00:00:23",
+            Some(machine_metadata()),
+        );
+
+        spawn_collectors_for_endpoint(
+            &mut ctx,
+            &endpoint,
+            Some(Arc::new(NoopSink)),
+            "test_discovery_with_gpu_inventory",
+        )
+        .expect("spawn should succeed");
+
+        assert_eq!(ctx.collectors.len(CollectorKind::Discovery), 1);
+        assert_eq!(ctx.collectors.len(CollectorKind::GpuInventory), 1);
+        assert_eq!(ctx.collectors.len(CollectorKind::Sensor), 0);
+        assert_eq!(ctx.collectors.len(CollectorKind::Metrics), 0);
     }
 
     #[tokio::test]

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -375,6 +375,7 @@ pub enum ReportSource {
     TrayLeakDetection,
     RackLeakDetection,
     NvueLeakage,
+    GpuInventory,
 }
 
 impl ReportSource {
@@ -386,6 +387,7 @@ impl ReportSource {
             Self::TrayLeakDetection => "tray-leak-detection",
             Self::RackLeakDetection => "rack-leak-detection",
             Self::NvueLeakage => "nvue-leakage",
+            Self::GpuInventory => "gpu-inventory",
         }
     }
 }
@@ -396,6 +398,7 @@ pub enum Probe {
     IntrusionSensorTriggered,
     LeakDetection,
     NvueLeakage,
+    GpuInventory,
 }
 
 impl Probe {
@@ -405,6 +408,9 @@ impl Probe {
             Self::IntrusionSensorTriggered => "IntrusionSensorTriggered",
             Self::LeakDetection => "BmcLeakDetection",
             Self::NvueLeakage => "NvueLeakage",
+            // Reuse the existing shared "SkuValidation" probe id so OOB GPU-count
+            // alerts dedup with the machine-controller's in-band SKU alerts.
+            Self::GpuInventory => "SkuValidation",
         }
     }
 }


### PR DESCRIPTION
## Summary

Out-of-band detection of missing GPUs, addressing #301.

Today SKU validation only runs in-band and at limited points in the host
lifecycle, so a GPU that drops off the BMC can go unnoticed. This adds a
periodic out-of-band GPU-count check to the hw-health service.

## What's included

**GpuInventoryCollector — GPU count vs. assigned SKU**

Periodically compares a host's out-of-band GPU count against its assigned SKU
total and raises a health alert when the count is short.

- **Reuses the entity-discovery collector's inventory** — it reads the shared
  `EntityInventory` that discovery already publishes for the endpoint instead of
  doing its own Redfish enumeration (per review).
- **Vendor-agnostic counting** — GPUs attach two ways, so we count both and take
  the max (not the sum, to avoid double-counting dual-view platforms like GB200):
  - SXM / HGX baseboards (H100 SXM, GB200, GB300, GH200) → one `HGX_GPU_*` chassis
  - PCIe cards (L40 / L40S, H100 PCIe, A100) → Redfish `Processors` with `ProcessorType=GPU`
- **Excludes `Status.State == Absent`** — a defined-but-empty slot is not counted,
  so a placeholder entry can't mask a genuinely missing GPU. Degraded-but-present
  states (`Disabled`, `UnavailableOffline`, …) are still counted (documented).

## Safety / rollout

- **Disabled by default** — opt-in via `[collectors.gpu_inventory]` (documented in
  `config.example.toml`).
- **Config validation** — enabling it without the Carbide API source or the
  health-report sink, or with a zero `interval`, is rejected at startup.
- **Machine endpoints only** — skips switch / power-shelf endpoints.
- **RBAC** — grants the Health role `FindSkusByIds` (to resolve the expected count).

## Testing

- `cargo test -p carbide-health` — 409 pass; `cargo fmt --check` + clippy clean.
- Integration (bmc-mock, real Redfish trees): DGX GB300 = 4, GB200 (both views,
  max not double-counted), Dell R750 = 0.
- Unit: shortage → alert decision, `Absent`-state exclusion, config validation
  (dependencies + zero interval).
- The api-core RBAC change can't compile on macOS (Linux-only TPM dep) → relies on CI.

## Changed from earlier revisions (per review)

- **Removed the SEL GPU-fault processor** — XID/SEL analysis is owned by the HaaS
  team; deferred to a focused follow-up once clear/reconciliation semantics are
  designed from real SEL samples.
- GPU counting now **reuses discovery's inventory** rather than a second Redfish sweep.
