### PR TITLE
chore(rest-api): enable rest api use of local core for local dev env

### DIFF
--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -1,12 +1,24 @@
-# Mac Local Development — NICo API
+# Mac Local Development — NICo API (core) and NICo REST API (rest)
 
-Runs `nico-api` natively on macOS (no Docker for the binary itself).
-Docker Desktop is used only for Vault and Postgres.
-This NICo API instance is usable by NICo REST stack.
+## Summary
+
+For local development on macOS, this setup runs the full stack (core+rest) on macOS:
+- core: dependencies in docker but `nico-api` runs natively on macOS
+- rest: everything runs in docker
+
+**Usage:**
+- start NICo API (core) with `./dev/mac-local-dev/run-nico-api.sh`<br>
+  You can access `nico-api` admin at https://localhost:1079/admin
+- start NICo REST API (rest) with `cd rest-api && make kind-reset LOCAL_CORE=true`<br>
+  `make` will display all relevant URLs and credentials for the REST API, Temporal, and Keycloak.
+- you can test the full stack integration (REST API client -> REST API -> NICo API) by running `dev/mac-local-dev/check-rest-core-integration.sh`.
 
 > **Limitations**
 > - TPM / attestation features require Linux and a physical TPM — they are disabled in this setup.
-> - `machine-a-tron` relies on Linux-specific features and is unusable on macOS.
+> - `machine-a-tron` relies on Linux-specific features and is unusable on macOS (can build).
+
+**Evolution:**<br>
+Having `nico-api` run into a Linux VM alongside with machine-a-tron would provide more value (fully functional core, virtual TPM available).
 
 ## Prerequisites
 

--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -7,11 +7,11 @@ For local development on macOS, this setup runs the full stack (core+rest) on ma
 - rest: everything runs in docker
 
 **Usage:**
-- start NICo API (core) with `./dev/mac-local-dev/run-nico-api.sh`<br>
+- start NICo API (core) with `dev/mac-local-dev/run-nico-api.sh`<br>
   You can access `nico-api` admin at https://localhost:1079/admin
 - start NICo REST API (rest) with `cd rest-api && make kind-reset LOCAL_CORE=true`<br>
   `make` will display all relevant URLs and credentials for the REST API, Temporal, and Keycloak.
-- you can test the full stack integration (REST API client -> REST API -> NICo API) by running `dev/mac-local-dev/check-rest-core-integration.sh`.
+- you can test the full-stack integration (REST API client -> REST API -> NICo API) by running `dev/mac-local-dev/check-rest-core-integration.sh`.
 
 > **Limitations**
 > - TPM / attestation features require Linux and a physical TPM — they are disabled in this setup.

--- a/dev/mac-local-dev/check-rest-core-integration.sh
+++ b/dev/mac-local-dev/check-rest-core-integration.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Local Core Integration Smoke Test
+#
+# Exercises the full API → carbide-core path:
+#   1. Authenticate via Keycloak
+#   2. Get (auto-create) the current Tenant
+#   3. Retrieve the local-dev-site ID
+#   3b. Force site to Registered via direct DB update (bypasses site-agent handshake)
+#   4. Create an IP Block on the site
+#   5. Create an Allocation (reserves the IP Block for the Tenant)
+#   6. Create a VPC — this triggers a call into carbide-core and validates
+#      the full integration with the local or mock core backend.
+#
+# Prerequisites:
+#   - make kind-reset (with or without LOCAL_CORE=true) has completed
+#   - jq is installed
+#   - kubectl context is pointing at the kind cluster
+#
+# Override defaults via environment variables:
+#   API_URL, KEYCLOAK_URL, ORG, SITE_NAME, PG_NAMESPACE, PG_STATEFULSET, PG_USER, PG_DB
+#
+
+set -euo pipefail
+
+API_URL="${API_URL:-http://localhost:8388}"
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:8082}"
+ORG="${ORG:-test-org}"
+SITE_NAME="${SITE_NAME:-local-dev-site}"
+
+# Postgres access via kubectl exec (no local psql or port-forward needed)
+PG_NAMESPACE="${PG_NAMESPACE:-postgres}"
+PG_STATEFULSET="${PG_STATEFULSET:-statefulset/postgres}"
+PG_USER="${PG_USER:-nico}"
+PG_DB="${PG_DB:-nico}"
+
+BASE_URL="$API_URL/v2/org/$ORG/nico"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+step() { echo;          echo "──── $* ────"; } >&2
+ok()   { echo "  ✓ $*";                     } >&2
+info() { echo "    $*";                      } >&2
+die()  { echo; echo "ERROR: $*"; exit 1;    } >&2
+
+api_get() {
+    local path="$1"
+    local out http_code
+    out=$(curl -s -w "\n%{http_code}" "$BASE_URL$path" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Accept: application/json")
+    http_code=$(echo "$out" | tail -n1)
+    body=$(echo "$out" | sed '$d')
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        die "GET $path → HTTP $http_code: $body"
+    fi
+    echo "$body"
+}
+
+api_post() {
+    local path="$1"
+    local payload="$2"
+    local out http_code body existing_id
+    out=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL$path" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/json" \
+        -d "$payload")
+    http_code=$(echo "$out" | tail -n1)
+    body=$(echo "$out" | sed '$d')
+    if [[ "$http_code" == "409" ]]; then
+        # Resource already exists; the conflict response carries the existing id
+        # under .data.id — reuse it so the script is idempotent across runs.
+        existing_id=$(echo "$body" | jq -r '.data.id // empty')
+        if [[ -n "$existing_id" ]]; then
+            info "Already exists (HTTP 409) — reusing id: $existing_id"
+            echo "{\"id\":\"$existing_id\"}"
+            return
+        fi
+        die "POST $path → HTTP 409 (conflict) but no id in response: $body"
+    fi
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        die "POST $path → HTTP $http_code: $body"
+    fi
+    echo "$body"
+}
+
+# Run a SQL statement inside the in-cluster postgres pod.
+db_exec() {
+    local sql="$1"
+    kubectl exec -n "$PG_NAMESPACE" "$PG_STATEFULSET" -- \
+        psql -U "$PG_USER" -d "$PG_DB" -tAc "$sql"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Authenticate
+# ---------------------------------------------------------------------------
+
+step "Authenticating via Keycloak"
+
+TOKEN=$(curl -sf -X POST \
+    "$KEYCLOAK_URL/realms/nico-dev/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "client_id=nico-api" \
+    -d "client_secret=nico-local-secret" \
+    -d "grant_type=password" \
+    -d "username=admin@example.com" \
+    -d "password=adminpassword" \
+    | jq -r '.access_token')
+
+[[ -z "$TOKEN" || "$TOKEN" == "null" ]] && die "Failed to acquire token from Keycloak"
+ok "Token acquired (${#TOKEN} chars)"
+
+# ---------------------------------------------------------------------------
+# 2. Get current Tenant (auto-created on first call)
+# ---------------------------------------------------------------------------
+
+step "Getting current Tenant"
+
+TENANT=$(api_get "/tenant/current")
+TENANT_ID=$(echo "$TENANT" | jq -r '.id')
+TENANT_ORG=$(echo "$TENANT" | jq -r '.org')
+
+[[ -z "$TENANT_ID" || "$TENANT_ID" == "null" ]] && die "Could not retrieve tenant ID"
+
+ok "Tenant: $TENANT_ORG  (id: $TENANT_ID)"
+
+# ---------------------------------------------------------------------------
+# 3. Retrieve the site ID
+# ---------------------------------------------------------------------------
+
+step "Retrieving site '$SITE_NAME'"
+
+SITES=$(api_get "/site")
+SITE_ID=$(echo "$SITES" | jq -r --arg name "$SITE_NAME" '.[] | select(.name == $name) | .id')
+SITE_STATUS=$(echo "$SITES" | jq -r --arg name "$SITE_NAME" '.[] | select(.name == $name) | .status')
+
+[[ -z "$SITE_ID" || "$SITE_ID" == "null" ]] \
+    && die "Site '$SITE_NAME' not found. Has 'make kind-reset' completed?"
+
+ok "Site id:     $SITE_ID"
+ok "Site status: $SITE_STATUS"
+
+# ---------------------------------------------------------------------------
+# 3b. Force site to Registered via direct DB update
+# ---------------------------------------------------------------------------
+
+step "Forcing site status to Registered (direct DB update)"
+
+if [[ "$SITE_STATUS" == "Registered" ]]; then
+    ok "Site is already Registered — skipping DB update"
+else
+    info "Current status: '$SITE_STATUS' → updating to 'Registered' in postgres"
+
+    # psql prints the command tag "UPDATE n" to stdout; capture it to verify rows matched.
+    UPDATE_TAG=$(kubectl exec -n "$PG_NAMESPACE" "$PG_STATEFULSET" -- \
+        psql -U "$PG_USER" -d "$PG_DB" -c \
+        "UPDATE site SET status = 'Registered', updated = NOW() WHERE id = '$SITE_ID';" \
+        2>&1 | grep -E '^UPDATE')
+
+    [[ -z "$UPDATE_TAG" ]] && die "DB update produced no UPDATE tag — check site ID and postgres connectivity"
+    UPDATED_ROWS=$(echo "$UPDATE_TAG" | awk '{print $2}')
+    [[ "$UPDATED_ROWS" -eq 0 ]] && die "DB update matched 0 rows — site id '$SITE_ID' not found in table"
+
+    ok "Updated $UPDATED_ROWS row(s)"
+
+    # Confirm via API
+    SITE_STATUS=$(api_get "/site/$SITE_ID" | jq -r '.status')
+    ok "Site status now: $SITE_STATUS"
+    [[ "$SITE_STATUS" != "Registered" ]] \
+        && info "Warning: API still shows '$SITE_STATUS' — the API may cache status; proceeding anyway"
+fi
+
+# ---------------------------------------------------------------------------
+# 3c. Enable ImageBasedOperatingSystem capability (direct DB update)
+# ---------------------------------------------------------------------------
+
+step "Enabling ImageBasedOperatingSystem capability (direct DB update)"
+
+SITE_CAPS=$(db_exec "SELECT config->>'image_based_operating_system' FROM site WHERE id = '$SITE_ID';")
+
+if [[ "$SITE_CAPS" == "true" ]]; then
+    ok "ImageBasedOperatingSystem is already enabled — skipping DB update"
+else
+    info "Enabling image_based_operating_system in site config"
+
+    UPDATE_TAG=$(kubectl exec -n "$PG_NAMESPACE" "$PG_STATEFULSET" -- \
+        psql -U "$PG_USER" -d "$PG_DB" -c \
+        "UPDATE site SET config = jsonb_set(COALESCE(config, '{}'), '{image_based_operating_system}', 'true'), updated = NOW() WHERE id = '$SITE_ID';" \
+        2>&1 | grep -E '^UPDATE')
+
+    [[ -z "$UPDATE_TAG" ]] && die "DB update produced no UPDATE tag — check site ID and postgres connectivity"
+    UPDATED_ROWS=$(echo "$UPDATE_TAG" | awk '{print $2}')
+    [[ "$UPDATED_ROWS" -eq 0 ]] && die "DB update matched 0 rows — site id '$SITE_ID' not found in table"
+
+    ok "Updated $UPDATED_ROWS row(s)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Create an IP Block
+# ---------------------------------------------------------------------------
+
+step "Creating IP Block"
+
+IPBLOCK=$(api_post "/ipblock" "$(jq -n \
+    --arg site "$SITE_ID" '{
+        name:            "smoke-test-ipblock",
+        description:     "IP block created by test-local-core.sh",
+        siteId:          $site,
+        routingType:     "DatacenterOnly",
+        prefix:          "10.100.0.0",
+        prefixLength:    24,
+        protocolVersion: "IPv4"
+    }')")
+
+IPBLOCK_ID=$(echo "$IPBLOCK" | jq -r '.id')
+[[ -z "$IPBLOCK_ID" || "$IPBLOCK_ID" == "null" ]] && die "IP Block creation failed"
+
+ok "IP Block id: $IPBLOCK_ID  (10.100.0.0/24)"
+
+# ---------------------------------------------------------------------------
+# 5. Create an Allocation for the IP Block
+# ---------------------------------------------------------------------------
+
+step "Creating Allocation"
+
+ALLOCATION=$(api_post "/allocation" "$(jq -n \
+    --arg tenant "$TENANT_ID" \
+    --arg site   "$SITE_ID" \
+    --arg ipb    "$IPBLOCK_ID" '{
+        name:        "smoke-test-allocation",
+        description: "Allocation created by test-local-core.sh",
+        tenantId:    $tenant,
+        siteId:      $site,
+        allocationConstraints: [{
+            resourceType:     "IPBlock",
+            resourceTypeId:   $ipb,
+            constraintType:   "Reserved",
+            constraintValue:  28
+        }]
+    }')")
+
+ALLOCATION_ID=$(echo "$ALLOCATION" | jq -r '.id')
+[[ -z "$ALLOCATION_ID" || "$ALLOCATION_ID" == "null" ]] && die "Allocation creation failed"
+
+ok "Allocation id: $ALLOCATION_ID"
+
+# ---------------------------------------------------------------------------
+# 6. Create a VPC  (calls into carbide-core)
+# ---------------------------------------------------------------------------
+
+step "Creating VPC  ← this calls carbide-core"
+
+VPC=$(api_post "/vpc" "$(jq -n \
+    --arg site "$SITE_ID" '{
+        name:        "smoke-test-vpc",
+        description: "VPC created by test-local-core.sh",
+        siteId:      $site
+    }')")
+
+VPC_ID=$(echo "$VPC" | jq -r '.id')
+VPC_STATUS=$(echo "$VPC" | jq -r '.status // "unknown"')
+
+[[ -z "$VPC_ID" || "$VPC_ID" == "null" ]] && die "VPC creation failed"
+
+ok "VPC id:     $VPC_ID"
+ok "VPC status: $VPC_STATUS"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo
+echo "════════════════════════════════════════════════════════════"
+echo " Smoke test passed"
+echo "════════════════════════════════════════════════════════════"
+echo " Tenant:     $TENANT_ID"
+echo " Site:       $SITE_ID  (Registered)"
+echo " IP Block:   $IPBLOCK_ID"
+echo " Allocation: $ALLOCATION_ID"
+echo " VPC:        $VPC_ID  ($VPC_STATUS)"
+echo "════════════════════════════════════════════════════════════"

--- a/dev/mac-local-dev/check-rest-core-integration.sh
+++ b/dev/mac-local-dev/check-rest-core-integration.sh
@@ -173,7 +173,7 @@ else
     UPDATE_TAG=$(kubectl exec -n "$PG_NAMESPACE" "$PG_STATEFULSET" -- \
         psql -U "$PG_USER" -d "$PG_DB" -c \
         "UPDATE site SET status = 'Registered', updated = NOW() WHERE id = '$SITE_ID';" \
-        2>&1 | grep -E '^UPDATE')
+        2>&1 | grep -E '^UPDATE' || true)
 
     [[ -z "$UPDATE_TAG" ]] && die "DB update produced no UPDATE tag — check site ID and postgres connectivity"
     UPDATED_ROWS=$(echo "$UPDATE_TAG" | awk '{print $2}')
@@ -204,7 +204,7 @@ else
     UPDATE_TAG=$(kubectl exec -n "$PG_NAMESPACE" "$PG_STATEFULSET" -- \
         psql -U "$PG_USER" -d "$PG_DB" -c \
         "UPDATE site SET config = jsonb_set(COALESCE(config, '{}'), '{image_based_operating_system}', 'true'), updated = NOW() WHERE id = '$SITE_ID';" \
-        2>&1 | grep -E '^UPDATE')
+        2>&1 | grep -E '^UPDATE' || true)
 
     [[ -z "$UPDATE_TAG" ]] && die "DB update produced no UPDATE tag — check site ID and postgres connectivity"
     UPDATED_ROWS=$(echo "$UPDATE_TAG" | awk '{print $2}')

--- a/dev/mac-local-dev/run-nico-api.sh
+++ b/dev/mac-local-dev/run-nico-api.sh
@@ -168,8 +168,15 @@ fi
 # We rewrite those paths to absolute ones in a throwaway /tmp copy so the
 # binary is always given correct paths regardless of CWD.
 # -----------------------------------------------------------------------------
-NICO_TMP_CONFIG="$(mktemp "${TMPDIR:-/tmp}/nico-api-config.XXXXXX.toml")" || die "Failed to create temporary config file"
-trap 'rm -f "$NICO_TMP_CONFIG"' EXIT
+# Create the config inside a private temp directory rather than naming the file
+# directly. macOS's BSD mktemp only substitutes *trailing* X's, so a template
+# like "nico-api-config.XXXXXX.toml" would be taken literally and collide across
+# runs. mktemp -d gives us a uniquely-named directory (portable across BSD/GNU),
+# and we place a fixed-name .toml file inside it — no rename, so no chance of
+# clobbering an unrelated file.
+NICO_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nico-api-config.XXXXXX")" || die "Failed to create temporary config directory"
+NICO_TMP_CONFIG="$NICO_TMP_DIR/nico-api-config.toml"
+trap 'rm -rf "$NICO_TMP_DIR"' EXIT
 sed "s|= \"dev/|= \"$REPO_ROOT/dev/|g" \
   "$REPO_ROOT/dev/mac-local-dev/nico-api-config.toml" > "$NICO_TMP_CONFIG"
 ok "Resolved config written to $NICO_TMP_CONFIG"

--- a/helm-prereqs/values/nico-site-agent.yaml
+++ b/helm-prereqs/values/nico-site-agent.yaml
@@ -56,10 +56,9 @@ envConfig:
   # Using InsecuregRPC (0) against a TLS-only server causes a 5-second
   # DeadlineExceeded on the initial Version health-check RPC and leaves the
   # NicoClient nil, causing all inventory activity panics.
-  # Set both NICO_* (renamed binary) and CARBIDE_* (current carbide binary) names
-  # so the chart works with either image; binary reads only its expected env name.
-  NICO_ADDRESS: "nico-api.nico-system.svc.cluster.local:1079"
-  NICO_SEC_OPT: "2"
+  # Site-agent reads CORE_GRPC_* first, then CARBIDE_* legacy fallbacks.
+  CORE_GRPC_ADDRESS: "nico-api.nico-system.svc.cluster.local:1079"
+  CORE_GRPC_SEC_OPT: "2"
   CARBIDE_ADDRESS: "nico-api.nico-system.svc.cluster.local:1079"
   CARBIDE_SEC_OPT: "2"
 

--- a/helm/rest/nico-rest-site-agent/values.yaml
+++ b/helm/rest/nico-rest-site-agent/values.yaml
@@ -80,8 +80,14 @@ envConfig:
   DEV_MODE: "true"
   ENABLE_DEBUG: "true"
   ENABLE_TLS: "true"
-  NICO_ADDRESS: ""
-  NICO_SEC_OPT: "0"
+  # Empty by default — callers must set the Core gRPC endpoint for their
+  # environment (kind local dev sets mock-core via rest-api/Makefile --set;
+  # helm-prereqs/values/nico-site-agent.yaml sets the production nico-api address).
+  CORE_GRPC_ADDRESS: ""
+  CORE_GRPC_SEC_OPT: ""
+  CORE_GRPC_CA_CERT_PATH: "/etc/core-grpc/ca.crt"
+  CORE_GRPC_CLIENT_CERT_PATH: "/etc/core-grpc/tls.crt"
+  CORE_GRPC_CLIENT_KEY_PATH: "/etc/core-grpc/tls.key"
   FLOW_GRPC_ENABLED: "true"
   FLOW_GRPC_SEC_OPT: "2"
   CLUSTER_ID: ""

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -350,7 +350,7 @@ flow-protogen:
 # Kind Local Deployment Targets
 # =============================================================================
 
-.PHONY: kind-up kind-down kind-deploy kind-load kind-apply kind-redeploy kind-status kind-logs kind-reset kind-reset-infra kind-reset-kustomize kind-reset-helm kind-verify setup-site-agent test-simple-sdk-example
+.PHONY: kind-up kind-down kind-deploy kind-load kind-apply kind-redeploy kind-status kind-logs kind-reset kind-reset-infra kind-reset-kustomize kind-reset-helm kind-verify setup-site-agent configure-local-core-site-agent test-simple-sdk-example
 .PHONY: deploy-overlay-api deploy-overlay-cert-manager deploy-overlay-site-manager deploy-overlay-workflow
 .PHONY: helm-lint helm-template helm-deploy helm-deploy-site-agent helm-deploy-mcp helm-deploy-all helm-redeploy helm-verify helm-verify-site-agent helm-uninstall
 
@@ -358,6 +358,19 @@ flow-protogen:
 KIND_CLUSTER_NAME := nico-rest-local
 KUSTOMIZE_OVERLAY := deploy/kustomize/overlays/local
 LOCAL_DOCKERFILE_DIR := docker/local
+
+# Set LOCAL_CORE=true to connect the site-agent to a locally-running nico-core
+# (started from the repo root via dev/mac-local-dev/run-nico-api.sh) instead of
+# the in-cluster mock-core.
+#
+# LOCAL_CORE_HOST must be reachable from inside the kind cluster nodes. On Docker
+# Desktop and colima, host.docker.internal resolves to both IPv6 and IPv4. Go's
+# dialer may prefer IPv6, which is unreachable from Kind pods, so the recipe
+# resolves it to IPv4 before patching the ConfigMap.
+LOCAL_CORE ?=
+LOCAL_CORE_HOST ?= host.docker.internal
+LOCAL_CORE_PORT ?= 1079
+LOCAL_CORE_CERTS_DIR ?= ../dev/certs/localhost
 
 # Recommended colima configuration for full stack with Temporal:
 #   colima start --cpu 8 --memory 8 --disk 100
@@ -368,7 +381,9 @@ docker-build-local:
 	docker build -t $(IMAGE_REGISTRY)/nico-rest-workflow:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-workflow .
 	docker build -t $(IMAGE_REGISTRY)/nico-rest-site-manager:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-site-manager .
 	docker build -t $(IMAGE_REGISTRY)/nico-rest-site-agent:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-site-agent .
-	docker build -t $(IMAGE_REGISTRY)/nico-rest-mock-core:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-mock-core .
+	@if [ "$(LOCAL_CORE)" != "true" ]; then \
+		docker build -t $(IMAGE_REGISTRY)/nico-rest-mock-core:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-mock-core . ; \
+	fi
 	docker build -t $(IMAGE_REGISTRY)/nico-rest-db:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-db .
 	docker build -t $(IMAGE_REGISTRY)/nico-rest-cert-manager:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-rest-cert-manager .
 	docker build -t $(IMAGE_REGISTRY)/nico-mcp:$(IMAGE_TAG) -f $(LOCAL_DOCKERFILE_DIR)/Dockerfile.nico-mcp .
@@ -392,7 +407,9 @@ kind-load:
 	kind load docker-image $(IMAGE_REGISTRY)/nico-rest-workflow:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
 	kind load docker-image $(IMAGE_REGISTRY)/nico-rest-site-manager:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
 	kind load docker-image $(IMAGE_REGISTRY)/nico-rest-site-agent:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
-	kind load docker-image $(IMAGE_REGISTRY)/nico-rest-mock-core:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
+	@if [ "$(LOCAL_CORE)" != "true" ]; then \
+		kind load docker-image $(IMAGE_REGISTRY)/nico-rest-mock-core:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME) ; \
+	fi
 	kind load docker-image $(IMAGE_REGISTRY)/nico-rest-db:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
 	kind load docker-image $(IMAGE_REGISTRY)/nico-rest-cert-manager:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
 	kind load docker-image $(IMAGE_REGISTRY)/nico-mcp:$(IMAGE_TAG) --name $(KIND_CLUSTER_NAME)
@@ -424,7 +441,9 @@ kind-redeploy: docker-build-local kind-load
 	kubectl -n nico-rest rollout restart deployment/nico-rest-api
 	kubectl -n nico-rest rollout restart deployment/nico-rest-cloud-worker
 	kubectl -n nico-rest rollout restart deployment/nico-rest-site-worker
-	kubectl -n nico-rest rollout restart deployment/nico-rest-mock-core
+	@if [ "$(LOCAL_CORE)" != "true" ]; then \
+		kubectl -n nico-rest rollout restart deployment/nico-rest-mock-core ; \
+	fi
 	kubectl -n nico-rest rollout restart deployment/nico-rest-cert-manager
 	kubectl -n nico-rest rollout restart deployment/nico-rest-site-manager
 	kubectl -n nico-rest rollout restart statefulset/nico-rest-site-agent
@@ -432,7 +451,9 @@ kind-redeploy: docker-build-local kind-load
 	kubectl -n nico-rest rollout status deployment/nico-rest-api --timeout=120s
 	kubectl -n nico-rest rollout status deployment/nico-rest-cloud-worker --timeout=120s
 	kubectl -n nico-rest rollout status deployment/nico-rest-site-worker --timeout=120s
-	kubectl -n nico-rest rollout status deployment/nico-rest-mock-core --timeout=120s
+	@if [ "$(LOCAL_CORE)" != "true" ]; then \
+		kubectl -n nico-rest rollout status deployment/nico-rest-mock-core --timeout=120s ; \
+	fi
 	kubectl -n nico-rest rollout status deployment/nico-rest-cert-manager --timeout=120s
 	kubectl -n nico-rest rollout status deployment/nico-rest-site-manager --timeout=120s
 	kubectl -n nico-rest rollout status statefulset/nico-rest-site-agent --timeout=120s
@@ -548,9 +569,11 @@ kind-reset-infra: docker-build-local
 	kubectl apply -k deploy/kustomize/base/keycloak
 	kubectl -n nico-rest rollout status deployment/keycloak --timeout=240s
 
-	@echo "Setting up Nico Mock Core (dev only, not in Helm chart)..."
-	kubectl apply -k deploy/kustomize/overlays/mock-core
-	kubectl -n nico-rest rollout status deployment/nico-rest-mock-core --timeout=240s
+	@if [ "$(LOCAL_CORE)" != "true" ]; then \
+		echo "Setting up Nico Mock Core (dev only, not in Helm chart)..." ; \
+		kubectl apply -k deploy/kustomize/overlays/mock-core ; \
+		kubectl -n nico-rest rollout status deployment/nico-rest-mock-core --timeout=240s ; \
+	fi
 
 	@echo ""
 	@echo "================================================================================"
@@ -600,6 +623,9 @@ kind-reset-kustomize: kind-reset-infra
 
 	@echo "Setting up Site Agent secrets..."
 	./scripts/setup-local.sh site-agent
+	@if [ "$(LOCAL_CORE)" = "true" ]; then \
+		$(MAKE) configure-local-core-site-agent ; \
+	fi
 
 	@echo ""
 	@echo "================================================================================"
@@ -608,6 +634,11 @@ kind-reset-kustomize: kind-reset-infra
 	@echo "Temporal UI: http://localhost:8233"
 	@echo "API: http://localhost:8388"
 	@echo "Keycloak: http://localhost:8082"
+	@if [ "$(LOCAL_CORE)" = "true" ]; then \
+		echo "Nico Core: local nico-api at $(LOCAL_CORE_HOST):$(LOCAL_CORE_PORT) (LOCAL_CORE=true)" ; \
+	else \
+		echo "Nico Core: mock-core (in-cluster)" ; \
+	fi
 	@echo "================================================================================"
 
 # =============================================================================
@@ -627,6 +658,11 @@ kind-reset-helm: kind-reset-infra
 	@echo "Temporal UI: http://localhost:8233"
 	@echo "API: http://localhost:8388"
 	@echo "Keycloak: http://localhost:8082"
+	@if [ "$(LOCAL_CORE)" = "true" ]; then \
+		echo "Nico Core: local nico-api at $(LOCAL_CORE_HOST):$(LOCAL_CORE_PORT) (LOCAL_CORE=true)" ; \
+	else \
+		echo "Nico Core: mock-core (in-cluster)" ; \
+	fi
 	@echo "================================================================================"
 
 # Default: full reset using Helm deployment
@@ -667,9 +703,15 @@ helm-deploy:
 helm-deploy-site-agent:
 	@echo "Installing site-agent chart (will CrashLoop until bootstrapped)..."
 	helm upgrade --install nico-rest-site-agent $(SITE_AGENT_CHART)/ \
-		--namespace nico-rest $(HELM_SET) --timeout 1m || true
+		--namespace nico-rest $(HELM_SET) \
+		$(if $(filter true,$(LOCAL_CORE)),--set certificate.enabled=false) \
+		$(if $(filter-out true,$(LOCAL_CORE)),--set envConfig.CORE_GRPC_ADDRESS=nico-rest-mock-core:11079 --set envConfig.CORE_GRPC_SEC_OPT=0) \
+		--timeout 1m || true
 	@echo "Running site bootstrap (setup-local.sh site-agent)..."
 	./scripts/setup-local.sh site-agent
+	@if [ "$(LOCAL_CORE)" = "true" ]; then \
+		$(MAKE) configure-local-core-site-agent ; \
+	fi
 	@echo "Waiting for site-agent to stabilize..."
 	kubectl -n nico-rest rollout status statefulset/nico-rest-site-agent --timeout=120s
 
@@ -714,6 +756,34 @@ helm-uninstall:
 # =============================================================================
 # Kind: Utilities
 # =============================================================================
+
+# Point the site-agent at a locally running nico-core instead of in-cluster
+# mock-core. The local nico-api TLS setup writes these certs in the repo root via
+# dev/mac-local-dev/run-nico-api.sh.
+configure-local-core-site-agent:
+	@echo "Creating core-grpc-client-site-agent-certs secret from $(LOCAL_CORE_CERTS_DIR)..."
+	@for f in ca.crt client.crt client.key; do \
+		[ -f "$(LOCAL_CORE_CERTS_DIR)/$$f" ] || { echo "ERROR: $$f not found in $(LOCAL_CORE_CERTS_DIR). Run dev/mac-local-dev/run-nico-api.sh from the repo root first."; exit 1; } ; \
+	done
+	kubectl -n nico-rest create secret generic core-grpc-client-site-agent-certs \
+		--from-file=ca.crt="$(LOCAL_CORE_CERTS_DIR)/ca.crt" \
+		--from-file=tls.crt="$(LOCAL_CORE_CERTS_DIR)/client.crt" \
+		--from-file=tls.key="$(LOCAL_CORE_CERTS_DIR)/client.key" \
+		--dry-run=client -o yaml | kubectl apply -f -
+	@CORE_HOST="$(LOCAL_CORE_HOST)" ; \
+	IPV4=$$(docker exec $$(docker ps -qf name=$(KIND_CLUSTER_NAME)-control-plane) \
+		getent ahosts "$$CORE_HOST" 2>/dev/null \
+		| awk '/STREAM/{print $$1}' | grep -v ':' | head -1) ; \
+	if [ -n "$$IPV4" ]; then \
+		echo "Resolved $$CORE_HOST -> $$IPV4 (using IPv4 to avoid Go IPv6-first dialer issue)" ; \
+		CORE_HOST="$$IPV4" ; \
+	fi ; \
+	echo "Patching site-agent ConfigMap: CORE_GRPC_ADDRESS=$$CORE_HOST:$(LOCAL_CORE_PORT), CORE_GRPC_SEC_OPT=1, SKIP_GRPC_SERVER_AUTH=true..." ; \
+	kubectl -n nico-rest patch configmap nico-rest-site-agent-config --type merge \
+		-p "{\"data\":{\"CORE_GRPC_ADDRESS\":\"$$CORE_HOST:$(LOCAL_CORE_PORT)\",\"CORE_GRPC_SEC_OPT\":\"1\",\"CORE_GRPC_CA_CERT_PATH\":\"/etc/core-grpc/ca.crt\",\"CORE_GRPC_CLIENT_CERT_PATH\":\"/etc/core-grpc/tls.crt\",\"CORE_GRPC_CLIENT_KEY_PATH\":\"/etc/core-grpc/tls.key\",\"CARBIDE_ADDRESS\":\"$$CORE_HOST:$(LOCAL_CORE_PORT)\",\"CARBIDE_SEC_OPT\":\"1\",\"SKIP_GRPC_SERVER_AUTH\":\"true\"}}" ; \
+	echo "Restarting site-agent to pick up local core settings..." ; \
+	kubectl -n nico-rest rollout restart statefulset/nico-rest-site-agent ; \
+	kubectl -n nico-rest rollout status statefulset/nico-rest-site-agent --timeout=120s
 
 # Setup site-agent with a real site created via the API
 setup-site-agent:

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -619,6 +619,15 @@ kind-reset-kustomize: kind-reset-infra
 
 	@echo "Setting up Nico REST Site Agent..."
 	kubectl apply -k deploy/kustomize/overlays/site-agent
+	@# The base ConfigMap leaves CORE_GRPC_ADDRESS empty (production-neutral).
+	@# For the default kind flow, point the agent at the in-cluster mock-core;
+	@# the LOCAL_CORE=true case is handled by configure-local-core-site-agent below.
+	@if [ "$(LOCAL_CORE)" != "true" ]; then \
+		echo "Pointing site-agent at in-cluster mock-core (CORE_GRPC_ADDRESS=nico-rest-mock-core:11079)..." ; \
+		kubectl -n nico-rest patch configmap nico-rest-site-agent-config --type merge \
+			-p '{"data":{"CORE_GRPC_ADDRESS":"nico-rest-mock-core:11079","CORE_GRPC_SEC_OPT":"0"}}' ; \
+		kubectl -n nico-rest rollout restart statefulset/nico-rest-site-agent ; \
+	fi
 	kubectl -n nico-rest rollout status statefulset/nico-rest-site-agent --timeout=240s
 
 	@echo "Setting up Site Agent secrets..."

--- a/rest-api/deploy/INSTALLATION.md
+++ b/rest-api/deploy/INSTALLATION.md
@@ -702,7 +702,8 @@ The site agent bootstrap flow is:
 
 | Variable | Default | Description |
 |---|---|---|
-| `NICO_ADDRESS` | `nico-rest-mock-core:11079` | NICo/NICo gRPC endpoint — **set this to your Core gRPC server address in production** |
+| `CORE_GRPC_ADDRESS` | `nico-rest-mock-core:11079` | NICo Core gRPC endpoint — **set this to your Core gRPC server address in production** |
+| `CORE_GRPC_SEC_OPT` | `0` | Core gRPC security mode (`0` insecure, `1` server TLS, `2` mutual TLS) |
 | `CLUSTER_ID` | `00000000-0000-4000-8000-000000000001` | Site UUID — **must match a registered site** |
 | `TEMPORAL_HOST` | `temporal-frontend.temporal` | Temporal frontend host |
 | `TEMPORAL_PORT` | `7233` | Temporal frontend port |

--- a/rest-api/deploy/INSTALLATION.md
+++ b/rest-api/deploy/INSTALLATION.md
@@ -702,7 +702,7 @@ The site agent bootstrap flow is:
 
 | Variable | Default | Description |
 |---|---|---|
-| `CORE_GRPC_ADDRESS` | `nico-rest-mock-core:11079` | NICo Core gRPC endpoint — **set this to your Core gRPC server address in production** |
+| `CORE_GRPC_ADDRESS` | `""` (empty) | NICo Core gRPC endpoint — **set this to your Core gRPC server address in production**. Empty falls back to the binary's in-cluster default; the local kind flow injects the mock-core address via the Makefile. |
 | `CORE_GRPC_SEC_OPT` | `0` | Core gRPC security mode (`0` insecure, `1` server TLS, `2` mutual TLS) |
 | `CLUSTER_ID` | `00000000-0000-4000-8000-000000000001` | Site UUID — **must match a registered site** |
 | `TEMPORAL_HOST` | `temporal-frontend.temporal` | Temporal frontend host |

--- a/rest-api/deploy/kustomize/base/site-agent/configmap.yaml
+++ b/rest-api/deploy/kustomize/base/site-agent/configmap.yaml
@@ -17,7 +17,7 @@ data:
   ENABLE_DEBUG: "true"
   ENABLE_TLS: "true"
   # NICo Core configuration
-  CORE_GRPC_ADDRESS: "nico-rest-mock-core:11079"
+  CORE_GRPC_ADDRESS: ""
   CORE_GRPC_SEC_OPT: "0"
   CORE_GRPC_CA_CERT_PATH: "/etc/core-grpc/ca.crt"
   CORE_GRPC_CLIENT_CERT_PATH: "/etc/core-grpc/tls.crt"

--- a/rest-api/deploy/kustomize/base/site-agent/configmap.yaml
+++ b/rest-api/deploy/kustomize/base/site-agent/configmap.yaml
@@ -17,8 +17,11 @@ data:
   ENABLE_DEBUG: "true"
   ENABLE_TLS: "true"
   # NICo Core configuration
-  NICO_ADDRESS: "nico-rest-mock-core:11079"
-  NICO_SEC_OPT: "0"
+  CORE_GRPC_ADDRESS: "nico-rest-mock-core:11079"
+  CORE_GRPC_SEC_OPT: "0"
+  CORE_GRPC_CA_CERT_PATH: "/etc/core-grpc/ca.crt"
+  CORE_GRPC_CLIENT_CERT_PATH: "/etc/core-grpc/tls.crt"
+  CORE_GRPC_CLIENT_KEY_PATH: "/etc/core-grpc/tls.key"
   # Placeholder UUID - updated by setup-local.sh site_agent with real site ID from API
   CLUSTER_ID: "00000000-0000-4000-8000-000000000001"
   TEMPORAL_HOST: "temporal-frontend.temporal"

--- a/rest-api/deploy/kustomize/base/site-agent/statefulset.yaml
+++ b/rest-api/deploy/kustomize/base/site-agent/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
               mountPath: /etc/sitereg
               readOnly: true
             - name: nico-certs
-              mountPath: /etc/nico
+              mountPath: /etc/core-grpc
               readOnly: true
             - name: temporal-certs
               mountPath: /etc/temporal-certs


### PR DESCRIPTION
Enhance REST API local stack launched by `make kind-reset` to enable the use of a local `nico-api` core instead of a mock.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
