### PR TITLE
feat(flow): Add idempotent operation-run task submission

### DIFF
--- a/rest-api/flow/internal/converter/dao/converter.go
+++ b/rest-api/flow/internal/converter/dao/converter.go
@@ -187,6 +187,7 @@ func TaskFrom(dao *model.Task) *taskdef.Task {
 		StartedAt:      dao.StartedAt,
 		FinishedAt:     dao.FinishedAt,
 		QueueExpiresAt: dao.QueueExpiresAt,
+		IdempotencyKey: dao.IdempotencyKey,
 	}
 }
 
@@ -319,6 +320,7 @@ func TaskTo(task *taskdef.Task) *model.Task {
 		Report:         task.Report,
 		AppliedRuleID:  task.AppliedRuleID,
 		QueueExpiresAt: task.QueueExpiresAt,
+		IdempotencyKey: task.IdempotencyKey,
 	}
 }
 

--- a/rest-api/flow/internal/db/migrations/20260709120000_add_task_idempotency_key.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260709120000_add_task_idempotency_key.down.sql
@@ -1,0 +1,5 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+DROP INDEX IF EXISTS task_idempotency_key_unique;
+ALTER TABLE task DROP COLUMN IF EXISTS idempotency_key;

--- a/rest-api/flow/internal/db/migrations/20260709120000_add_task_idempotency_key.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260709120000_add_task_idempotency_key.up.sql
@@ -1,0 +1,8 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+ALTER TABLE task ADD COLUMN IF NOT EXISTS idempotency_key text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS task_idempotency_key_unique
+    ON task (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/rest-api/flow/internal/db/model/task.go
+++ b/rest-api/flow/internal/db/model/task.go
@@ -46,12 +46,60 @@ type Task struct {
 	// QueueExpiresAt is set only for waiting tasks. After this time, the
 	// Promoter will discard the task instead of promoting it.
 	QueueExpiresAt *time.Time `bun:"queue_expires_at"`
+
+	IdempotencyKey string `bun:"idempotency_key,nullzero"`
+}
+
+func (t *Task) HasIdempotencyKey() bool {
+	return t != nil && t.IdempotencyKey != ""
 }
 
 // Create inserts the task record into the backing store.
 func (t *Task) Create(ctx context.Context, idb bun.IDB) error {
 	_, err := idb.NewInsert().Model(t).Exec(ctx)
 	return err
+}
+
+// CreateOrGetByIdempotencyKey inserts the task or returns the existing task
+// carrying the same idempotency key.
+func (t *Task) CreateOrGetByIdempotencyKey(
+	ctx context.Context,
+	idb bun.IDB,
+) (*Task, bool, error) {
+	if !t.HasIdempotencyKey() {
+		return nil, false, fmt.Errorf("idempotency key is required")
+	}
+
+	// First try to insert the candidate task. The partial unique index on
+	// idempotency_key lets Postgres arbitrate concurrent submissions for the
+	// same logical request.
+	result, err := idb.NewInsert().
+		Model(t).
+		On("CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING").
+		Exec(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return nil, false, err
+	}
+
+	// A non-zero row count means this call created the task and the caller can
+	// continue with the candidate row it supplied.
+	if rowsAffected > 0 {
+		return t, true, nil
+	}
+
+	// No row was inserted, so another attempt already created the task. Return
+	// the persisted row so callers can recover the task ID and scheduling state.
+	existing, err := GetTaskByIdempotencyKey(ctx, idb, t.IdempotencyKey)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return existing, false, nil
 }
 
 // UpdateScheduledTask updates the scheduled task information.
@@ -240,6 +288,26 @@ func GetTask(ctx context.Context, idb bun.IDB, id uuid.UUID) (*Task, error) {
 	if err := idb.NewSelect().
 		Model(&task).
 		Where("id = ?", id).
+		Scan(ctx); err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+// GetTaskByIdempotencyKey retrieves one task by its stable submission key.
+func GetTaskByIdempotencyKey(
+	ctx context.Context,
+	idb bun.IDB,
+	key string,
+) (*Task, error) {
+	if key == "" {
+		return nil, fmt.Errorf("idempotency key is required")
+	}
+
+	var task Task
+	if err := idb.NewSelect().
+		Model(&task).
+		Where("idempotency_key = ?", key).
 		Scan(ctx); err != nil {
 		return nil, err
 	}

--- a/rest-api/flow/internal/operation/request.go
+++ b/rest-api/flow/internal/operation/request.go
@@ -62,6 +62,14 @@ type Request struct {
 	// this would need to become []uuid.UUID (or a separate AllowedRackIDs
 	// field). Do not add that generalization until there is a concrete caller.
 	RequiredRackID uuid.UUID
+
+	// IdempotencyKey, when set, makes submission create or return one task for
+	// this request. It is only valid for requests constrained to one rack.
+	IdempotencyKey string
+}
+
+func (r *Request) HasIdempotencyKey() bool {
+	return r != nil && r.IdempotencyKey != ""
 }
 
 func (r *Request) Validate() error {
@@ -75,6 +83,10 @@ func (r *Request) Validate() error {
 
 	if err := r.TargetSpec.Validate(); err != nil {
 		return fmt.Errorf("invalid target spec: %w", err)
+	}
+
+	if r.HasIdempotencyKey() && r.RequiredRackID == uuid.Nil {
+		return fmt.Errorf("idempotency key requires RequiredRackID")
 	}
 
 	return nil

--- a/rest-api/flow/internal/operationrun/manager/dispatcher/dispatcher_test.go
+++ b/rest-api/flow/internal/operationrun/manager/dispatcher/dispatcher_test.go
@@ -132,6 +132,11 @@ func TestDispatchRunSubmitsPendingTargetsUpToConcurrency(t *testing.T) {
 
 	require.Len(t, taskManager.requests, 1)
 	require.Equal(t, firstRackID, taskManager.requests[0].RequiredRackID)
+	require.Equal(
+		t,
+		targetIdempotencyKey(store.targets[0].ID),
+		taskManager.requests[0].IdempotencyKey,
+	)
 	require.Equal(t, operation.ConflictStrategyReject, taskManager.requests[0].ConflictStrategy)
 	require.Equal(
 		t,
@@ -145,6 +150,43 @@ func TestDispatchRunSubmitsPendingTargetsUpToConcurrency(t *testing.T) {
 	require.Equal(t, operationrun.OperationRunTargetStatusSubmitted, store.targets[0].Status)
 	require.Equal(t, &taskID, store.targets[0].TaskID)
 	require.Equal(t, operationrun.OperationRunTargetStatusPending, store.targets[1].Status)
+}
+
+func TestDispatchRunRetriesClaimedTargetWithStableIdempotencyKey(t *testing.T) {
+	runID := uuid.New()
+	rackID := uuid.New()
+	taskID := uuid.New()
+	now := time.Date(2026, 6, 26, 10, 2, 0, 0, time.UTC)
+	target := testTarget(runID, rackID, uuid.New(), 0, 0)
+	target.Status = operationrun.OperationRunTargetStatusClaimed
+	expired := now.Add(-time.Second)
+	target.RetryAfter = &expired
+
+	store := newFakeStore(
+		testRun(t, runID, 1, operationrun.PhasePolicy{}),
+		[]*operationrun.OperationRunTarget{target},
+	)
+	store.run.Status = operationrun.OperationRunStatusRunning
+	taskManager := &fakeTaskManager{
+		results: map[uuid.UUID]submitResult{
+			rackID: {ids: []uuid.UUID{taskID}},
+		},
+	}
+	dispatcher := newTestDispatcherAt(t, Dependencies{
+		Store:       store,
+		TaskManager: taskManager,
+		TaskStore:   &fakeTaskStore{},
+	}, Config{
+		FetchBatch: 10,
+	}, now)
+
+	err := dispatcher.dispatchRun(context.Background(), runID)
+	require.NoError(t, err)
+
+	require.Len(t, taskManager.requests, 1)
+	require.Equal(t, targetIdempotencyKey(target.ID), taskManager.requests[0].IdempotencyKey)
+	require.Equal(t, operationrun.OperationRunTargetStatusSubmitted, store.targets[0].Status)
+	require.Equal(t, &taskID, store.targets[0].TaskID)
 }
 
 func TestDispatchRunReconcilesCompletedTaskAndCompletesRun(t *testing.T) {

--- a/rest-api/flow/internal/operationrun/manager/dispatcher/execution.go
+++ b/rest-api/flow/internal/operationrun/manager/dispatcher/execution.go
@@ -15,6 +15,8 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 )
 
+const idempotencyKeyPrefix = "operation-run-target:"
+
 func (d *Dispatcher) execute(
 	prep *preparedDispatch,
 	decision dispatchDecision,
@@ -220,12 +222,6 @@ func (d *Dispatcher) submit(
 
 	taskID := taskIDs[0]
 	target.Submit(taskID, "submitted")
-
-	// TODO: Make operation-run submissions fully idempotent by passing a
-	// stable task ID or idempotency key through TaskManager.SubmitTask. The
-	// claim lease prevents permanent quota starvation, but a crash after
-	// task creation and before this state update can still leave an orphan
-	// task that the dispatcher cannot associate back to this target.
 	return true, d.updateTargetAfterSubmit(ctx, target)
 }
 
@@ -279,7 +275,12 @@ func operationRequestForTarget(
 		ConflictStrategy: operation.ConflictStrategyReject,
 		RuleID:           operations.ExtractRuleID(info),
 		RequiredRackID:   target.RackID,
+		IdempotencyKey:   targetIdempotencyKey(target.ID),
 	}, nil
+}
+
+func targetIdempotencyKey(targetID uuid.UUID) string {
+	return idempotencyKeyPrefix + targetID.String()
 }
 
 // targetReadyForSubmission identifies targets that can be claimed now,

--- a/rest-api/flow/internal/scheduler/taskschedule/dispatcher_test.go
+++ b/rest-api/flow/internal/scheduler/taskschedule/dispatcher_test.go
@@ -159,6 +159,18 @@ func (m *mockTaskStore) CreateTask(_ context.Context, _ *taskdef.Task) error {
 	panic("mockTaskStore.CreateTask: not implemented")
 }
 
+func (m *mockTaskStore) LockRack(_ context.Context, _ uuid.UUID) error {
+	panic("mockTaskStore.LockRack: not implemented")
+}
+
+func (m *mockTaskStore) LockIdempotencyKey(_ context.Context, _ string) error {
+	panic("mockTaskStore.LockIdempotencyKey: not implemented")
+}
+
+func (m *mockTaskStore) GetTaskByIdempotencyKey(_ context.Context, _ string) (*taskdef.Task, error) {
+	panic("mockTaskStore.GetTaskByIdempotencyKey: not implemented")
+}
+
 func (m *mockTaskStore) GetTasks(_ context.Context, _ []uuid.UUID) ([]*taskdef.Task, error) {
 	panic("mockTaskStore.GetTasks: not implemented")
 }

--- a/rest-api/flow/internal/task/conflict/store_mock_test.go
+++ b/rest-api/flow/internal/task/conflict/store_mock_test.go
@@ -83,6 +83,18 @@ func (m *mockStore) CreateTask(_ context.Context, _ *taskdef.Task) error {
 	panic("mockStore.CreateTask: not implemented")
 }
 
+func (m *mockStore) LockRack(_ context.Context, _ uuid.UUID) error {
+	panic("mockStore.LockRack: not implemented")
+}
+
+func (m *mockStore) LockIdempotencyKey(_ context.Context, _ string) error {
+	panic("mockStore.LockIdempotencyKey: not implemented")
+}
+
+func (m *mockStore) GetTaskByIdempotencyKey(_ context.Context, _ string) (*taskdef.Task, error) {
+	panic("mockStore.GetTaskByIdempotencyKey: not implemented")
+}
+
 func (m *mockStore) GetTask(_ context.Context, _ uuid.UUID) (*taskdef.Task, error) {
 	panic("mockStore.GetTask: not implemented")
 }

--- a/rest-api/flow/internal/task/manager/manager.go
+++ b/rest-api/flow/internal/task/manager/manager.go
@@ -282,72 +282,26 @@ func (m *ManagerImpl) createAndExecuteTask(
 	req *operation.Request,
 	targetRack *rack.Rack,
 ) (uuid.UUID, error) {
-	// Build component map by type for fine-grained conflict detection.
-	compsByType := make(
-		map[devicetypes.ComponentType][]uuid.UUID,
-		len(targetRack.Components),
-	)
-	for _, c := range targetRack.Components {
-		compsByType[c.Type] = append(compsByType[c.Type], c.Info.ID)
+	if req.HasIdempotencyKey() {
+		return m.createAndExecuteIdempotentTask(ctx, req, targetRack)
 	}
 
-	// Build the task record (status and rule are determined below).
-	task := taskdef.Task{
-		ID:        uuid.New(),
-		Operation: req.Operation,
-		RackID:    targetRack.Info.ID,
-		Attributes: taskcommon.TaskAttributes{
-			ComponentsByType: compsByType,
-		},
-		Description:  req.Description,
-		ExecutorType: taskcommon.ExecutorTypeUnknown,
-		ExecutionID:  "",
-	}
+	task := newTaskForRack(req, targetRack)
 
 	// Check for conflicts inside a transaction to avoid a race between the
 	// check and the creation.
 	txErr := m.taskStore.RunInTransaction(
 		ctx,
 		func(txCtx context.Context) error {
-			hasConflict, err := m.conflictResolver.HasConflict(
-				txCtx, &task,
-			)
+			err := m.lockRackAndResolveConflict(txCtx, req, targetRack, &task)
 			if err != nil {
 				return err
-			}
-
-			if hasConflict {
-				if req.ConflictStrategy != operation.ConflictStrategyQueue {
-					return fmt.Errorf(
-						"rack %s already has a conflicting task: %w",
-						targetRack.Info.ID, ErrRackConflict,
-					)
-				}
-
-				count, err := m.taskStore.CountWaitingTasksForRack(
-					txCtx, targetRack.Info.ID,
-				)
-				if err != nil {
-					return err
-				}
-				if count >= m.maxWaitingPerRack {
-					return fmt.Errorf(
-						"rack %s waiting queue is full (%d/%d tasks)",
-						targetRack.Info.ID, count, m.maxWaitingPerRack,
-					)
-				}
-
-				task.Status = taskcommon.TaskStatusWaiting
-				task.Message = message.ForStatus(taskcommon.TaskStatusWaiting)
-				task.QueueExpiresAt = m.getReqExpiresAt(req)
-			} else {
-				task.Status = taskcommon.TaskStatusPending
-				task.Message = message.ForStatus(taskcommon.TaskStatusPending)
 			}
 
 			return m.taskStore.CreateTask(txCtx, &task)
 		},
 	)
+
 	if txErr != nil {
 		return uuid.Nil, txErr
 	}
@@ -366,6 +320,153 @@ func (m *ManagerImpl) createAndExecuteTask(
 	}
 
 	return task.ID, nil
+}
+
+func (m *ManagerImpl) createAndExecuteIdempotentTask(
+	ctx context.Context,
+	req *operation.Request,
+	targetRack *rack.Rack,
+) (uuid.UUID, error) {
+	var task taskdef.Task
+	txErr := m.taskStore.RunInTransaction(
+		ctx,
+		func(txCtx context.Context) error {
+			if err := m.taskStore.LockIdempotencyKey(txCtx, req.IdempotencyKey); err != nil {
+				return err
+			}
+
+			persistedTask, err := m.taskStore.GetTaskByIdempotencyKey(
+				txCtx,
+				req.IdempotencyKey,
+			)
+			if err != nil {
+				return err
+			}
+
+			if persistedTask != nil {
+				// There are existing tasks with this idempotency key, reuse it.
+				task = *persistedTask
+
+				if task.IsScheduled() {
+					// The task is already scheduled, so we can return it.
+					log.Info().
+						Str("task_id", task.ID.String()).
+						Str("idempotency_key", task.IdempotencyKey).
+						Msg("idempotent duplicate: returning existing scheduled task")
+					return nil
+				}
+			} else {
+				// No existing tasks with this idempotency key, create a new one.
+				task = newTaskForRack(req, targetRack)
+				if err := m.lockRackAndResolveConflict(txCtx, req, targetRack, &task); err != nil {
+					return err
+				}
+
+				if err := m.taskStore.CreateTask(txCtx, &task); err != nil {
+					return err
+				}
+			}
+
+			if task.Status == taskcommon.TaskStatusWaiting {
+				// The task has conflict and is waiting, so we can return it.
+				log.Info().
+					Str("task_id", task.ID.String()).
+					Str("rack_id", targetRack.Info.ID.String()).
+					Msg("task queued: waiting for rack to become available")
+				return nil
+			}
+
+			// Resolve and execute the task.
+			return m.resolveAndExecuteTask(txCtx, &task, targetRack)
+		},
+	)
+
+	if txErr != nil {
+		return uuid.Nil, txErr
+	}
+
+	return task.ID, nil
+}
+
+func newTaskForRack(req *operation.Request, targetRack *rack.Rack) taskdef.Task {
+	compsByType := make(
+		map[devicetypes.ComponentType][]uuid.UUID,
+		len(targetRack.Components),
+	)
+	for _, c := range targetRack.Components {
+		compsByType[c.Type] = append(compsByType[c.Type], c.Info.ID)
+	}
+
+	return taskdef.Task{
+		ID:        uuid.New(),
+		Operation: req.Operation,
+		RackID:    targetRack.Info.ID,
+		Attributes: taskcommon.TaskAttributes{
+			ComponentsByType: compsByType,
+		},
+		Description:    req.Description,
+		ExecutorType:   taskcommon.ExecutorTypeUnknown,
+		ExecutionID:    "",
+		IdempotencyKey: req.IdempotencyKey,
+	}
+}
+
+// lockRackAndResolveConflict must be called inside RunInTransaction.
+func (m *ManagerImpl) lockRackAndResolveConflict(
+	ctx context.Context,
+	req *operation.Request,
+	targetRack *rack.Rack,
+	task *taskdef.Task,
+) error {
+	// Serialize rack-level admission so concurrent submissions cannot both
+	// observe an empty active set and create conflicting pending tasks.
+	if err := m.taskStore.LockRack(ctx, targetRack.Info.ID); err != nil {
+		return err
+	}
+
+	hasConflict, err := m.conflictResolver.HasConflict(ctx, task)
+	if err != nil {
+		return err
+	}
+
+	if !hasConflict {
+		// No active task blocks this operation, so it can be scheduled
+		// immediately after the transaction commits.
+		task.Status = taskcommon.TaskStatusPending
+		task.Message = message.ForStatus(taskcommon.TaskStatusPending)
+		return nil
+	}
+
+	if req.ConflictStrategy != operation.ConflictStrategyQueue {
+		// The caller chose rejection over queueing, so surface the conflict
+		// without creating a task row.
+		return fmt.Errorf(
+			"rack %s already has a conflicting task: %w",
+			targetRack.Info.ID, ErrRackConflict,
+		)
+	}
+
+	count, err := m.taskStore.CountWaitingTasksForRack(ctx, targetRack.Info.ID)
+	if err != nil {
+		return err
+	}
+
+	if count >= m.maxWaitingPerRack {
+		// Preserve a bounded per-rack queue; otherwise a stuck rack could
+		// accumulate unbounded waiting work.
+		return fmt.Errorf(
+			"rack %s waiting queue is full (%d/%d tasks)",
+			targetRack.Info.ID, count, m.maxWaitingPerRack,
+		)
+	}
+
+	// Queue the task behind the currently active rack work. The promoter will
+	// move it to pending once the rack no longer has a conflicting active task.
+	task.Status = taskcommon.TaskStatusWaiting
+	task.Message = message.ForStatus(taskcommon.TaskStatusWaiting)
+	task.QueueExpiresAt = m.getReqExpiresAt(req)
+
+	return nil
 }
 
 // promoteTask is invoked by the Promoter to execute a previously waiting task
@@ -468,7 +569,7 @@ func (m *ManagerImpl) CancelTask(ctx context.Context, taskID uuid.UUID) error {
 
 	// Terminate the Temporal workflow if one was scheduled (pending/running).
 	// Waiting tasks have no workflow (ExecutionID is empty) so this is skipped.
-	if task.ExecutionID != "" {
+	if task.IsScheduled() {
 		if err := m.executor.TerminateTask(
 			ctx, task.ExecutionID, "Cancelled by user",
 		); err != nil {

--- a/rest-api/flow/internal/task/manager/manager_test.go
+++ b/rest-api/flow/internal/task/manager/manager_test.go
@@ -1,0 +1,398 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
+	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/conflict"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operationrules"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
+	taskdef "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/task"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+func TestCreateAndExecuteTaskReturnsExistingIdempotentTaskBeforeRackConflict(t *testing.T) {
+	ctx := context.Background()
+	rackID := uuid.New()
+	componentID := uuid.New()
+	taskID := uuid.New()
+	idempotencyKey := "operation-run-target:" + uuid.NewString()
+	op := testPowerControlOperation(t)
+	targetRack := newTestRack(rackID, "rack-1")
+	targetRack.AddComponent(newTestComponent(
+		componentID,
+		rackID,
+		devicetypes.ComponentTypeCompute,
+		"compute-1",
+	))
+	existingTask := &taskdef.Task{
+		ID:             taskID,
+		Operation:      op,
+		RackID:         rackID,
+		Status:         taskcommon.TaskStatusPending,
+		ExecutionID:    `{"workflow_id":"workflow","run_id":"run"}`,
+		IdempotencyKey: idempotencyKey,
+		Attributes: taskcommon.TaskAttributes{
+			ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+				devicetypes.ComponentTypeCompute: {componentID},
+			},
+		},
+	}
+	store := &managerTaskStore{
+		activeTasksByRack: map[uuid.UUID][]*taskdef.Task{
+			rackID: {
+				{
+					ID:        uuid.New(),
+					Operation: op,
+					RackID:    rackID,
+					Status:    taskcommon.TaskStatusRunning,
+					Attributes: taskcommon.TaskAttributes{
+						ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+							devicetypes.ComponentTypeCompute: {componentID},
+						},
+					},
+				},
+			},
+		},
+		taskByIdempotencyKey: map[string]*taskdef.Task{
+			idempotencyKey: existingTask,
+		},
+	}
+	manager := &ManagerImpl{
+		taskStore:           store,
+		conflictResolver:    conflict.NewResolver(store),
+		maxWaitingPerRack:   defaultMaxWaitingPerRack,
+		defaultQueueTimeout: defaultQueueTimeout,
+	}
+
+	gotTaskID, err := manager.createAndExecuteTask(ctx, &operation.Request{
+		Operation:        op,
+		Description:      "retry operation-run target",
+		ConflictStrategy: operation.ConflictStrategyReject,
+		RequiredRackID:   rackID,
+		IdempotencyKey:   idempotencyKey,
+	}, targetRack)
+
+	require.NoError(t, err)
+	require.Equal(t, taskID, gotTaskID)
+	require.Zero(t, store.listActiveCalls)
+	require.Zero(t, store.createTaskCalls)
+}
+
+func TestCreateAndExecuteTaskSchedulesExistingIdempotentTaskWithoutExecutionID(t *testing.T) {
+	ctx := context.Background()
+	rackID := uuid.New()
+	componentID := uuid.New()
+	taskID := uuid.New()
+	idempotencyKey := "operation-run-target:" + uuid.NewString()
+	op := testPowerControlOperation(t)
+	targetRack := newTestRack(rackID, "rack-1")
+	targetRack.AddComponent(newTestComponent(
+		componentID,
+		rackID,
+		devicetypes.ComponentTypeCompute,
+		"compute-1",
+	))
+	existingTask := &taskdef.Task{
+		ID:             taskID,
+		Operation:      op,
+		RackID:         rackID,
+		Status:         taskcommon.TaskStatusPending,
+		IdempotencyKey: idempotencyKey,
+		Attributes: taskcommon.TaskAttributes{
+			ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+				devicetypes.ComponentTypeCompute: {componentID},
+			},
+		},
+	}
+	store := &managerTaskStore{
+		taskByIdempotencyKey: map[string]*taskdef.Task{
+			idempotencyKey: existingTask,
+		},
+	}
+	executor := &managerExecutor{executionID: `{"workflow_id":"workflow","run_id":"run"}`}
+	manager := &ManagerImpl{
+		taskStore:           store,
+		executor:            executor,
+		maxWaitingPerRack:   defaultMaxWaitingPerRack,
+		defaultQueueTimeout: defaultQueueTimeout,
+	}
+
+	gotTaskID, err := manager.createAndExecuteTask(ctx, &operation.Request{
+		Operation:        op,
+		Description:      "retry operation-run target",
+		ConflictStrategy: operation.ConflictStrategyReject,
+		RequiredRackID:   rackID,
+		IdempotencyKey:   idempotencyKey,
+	}, targetRack)
+
+	require.NoError(t, err)
+	require.Equal(t, taskID, gotTaskID)
+	require.Equal(t, 1, executor.executeCalls)
+	require.Equal(t, taskID, executor.lastRequest.Info.TaskID)
+	require.Equal(t, 1, store.updateScheduledCalls)
+	require.Equal(t, executor.executionID, store.updatedScheduledTask.ExecutionID)
+	require.Zero(t, store.listActiveCalls)
+	require.Zero(t, store.createTaskCalls)
+}
+
+func testPowerControlOperation(t *testing.T) operation.Wrapper {
+	t.Helper()
+
+	info, err := (&operations.PowerControlTaskInfo{
+		Operation: operations.PowerOperationPowerOn,
+	}).Marshal()
+	require.NoError(t, err)
+
+	return operation.Wrapper{
+		Type: taskcommon.TaskTypePowerControl,
+		Code: taskcommon.OpCodePowerControlPowerOn,
+		Info: info,
+	}
+}
+
+type managerTaskStore struct {
+	activeTasksByRack    map[uuid.UUID][]*taskdef.Task
+	taskByIdempotencyKey map[string]*taskdef.Task
+	listActiveCalls      int
+	createTaskCalls      int
+	lockKeyCalls         int
+	lockRackCalls        int
+	updateScheduledCalls int
+	updatedScheduledTask *taskdef.Task
+}
+
+func (s *managerTaskStore) RunInTransaction(
+	ctx context.Context,
+	fn func(context.Context) error,
+) error {
+	return fn(ctx)
+}
+
+func (s *managerTaskStore) CreateTask(_ context.Context, _ *taskdef.Task) error {
+	s.createTaskCalls++
+	return fmt.Errorf("CreateTask should not be called")
+}
+
+func (s *managerTaskStore) LockRack(_ context.Context, _ uuid.UUID) error {
+	s.lockRackCalls++
+	return nil
+}
+
+func (s *managerTaskStore) LockIdempotencyKey(_ context.Context, _ string) error {
+	s.lockKeyCalls++
+	return nil
+}
+
+func (s *managerTaskStore) GetTaskByIdempotencyKey(
+	_ context.Context,
+	key string,
+) (*taskdef.Task, error) {
+	return s.taskByIdempotencyKey[key], nil
+}
+
+func (s *managerTaskStore) GetTask(_ context.Context, _ uuid.UUID) (*taskdef.Task, error) {
+	panic("managerTaskStore.GetTask: not implemented")
+}
+
+func (s *managerTaskStore) GetTasks(_ context.Context, _ []uuid.UUID) ([]*taskdef.Task, error) {
+	panic("managerTaskStore.GetTasks: not implemented")
+}
+
+func (s *managerTaskStore) ListTasks(
+	_ context.Context,
+	_ *taskcommon.TaskListOptions,
+	_ *dbquery.Pagination,
+) ([]*taskdef.Task, int32, error) {
+	panic("managerTaskStore.ListTasks: not implemented")
+}
+
+func (s *managerTaskStore) UpdateScheduledTask(_ context.Context, task *taskdef.Task) error {
+	s.updateScheduledCalls++
+	s.updatedScheduledTask = task
+	return nil
+}
+
+func (s *managerTaskStore) UpdateTaskStatus(
+	_ context.Context,
+	_ *taskdef.TaskStatusUpdate,
+) error {
+	panic("managerTaskStore.UpdateTaskStatus: not implemented")
+}
+
+func (s *managerTaskStore) UpdateTaskReport(
+	_ context.Context,
+	_ *taskdef.TaskReportUpdate,
+) error {
+	panic("managerTaskStore.UpdateTaskReport: not implemented")
+}
+
+func (s *managerTaskStore) ListActiveTasksForRack(
+	_ context.Context,
+	rackID uuid.UUID,
+) ([]*taskdef.Task, error) {
+	s.listActiveCalls++
+	return s.activeTasksByRack[rackID], nil
+}
+
+func (s *managerTaskStore) ListWaitingTasksForRack(
+	_ context.Context,
+	_ uuid.UUID,
+) ([]*taskdef.Task, error) {
+	panic("managerTaskStore.ListWaitingTasksForRack: not implemented")
+}
+
+func (s *managerTaskStore) CountWaitingTasksForRack(_ context.Context, _ uuid.UUID) (int, error) {
+	panic("managerTaskStore.CountWaitingTasksForRack: not implemented")
+}
+
+func (s *managerTaskStore) ListRacksWithWaitingTasks(_ context.Context) ([]uuid.UUID, error) {
+	panic("managerTaskStore.ListRacksWithWaitingTasks: not implemented")
+}
+
+func (s *managerTaskStore) CreateRule(
+	_ context.Context,
+	_ *operationrules.OperationRule,
+) error {
+	panic("managerTaskStore.CreateRule: not implemented")
+}
+
+func (s *managerTaskStore) UpdateRule(
+	_ context.Context,
+	_ uuid.UUID,
+	_ map[string]interface{},
+) error {
+	panic("managerTaskStore.UpdateRule: not implemented")
+}
+
+func (s *managerTaskStore) DeleteRule(_ context.Context, _ uuid.UUID) error {
+	panic("managerTaskStore.DeleteRule: not implemented")
+}
+
+func (s *managerTaskStore) SetRuleAsDefault(_ context.Context, _ uuid.UUID) error {
+	panic("managerTaskStore.SetRuleAsDefault: not implemented")
+}
+
+func (s *managerTaskStore) GetRule(
+	_ context.Context,
+	_ uuid.UUID,
+) (*operationrules.OperationRule, error) {
+	panic("managerTaskStore.GetRule: not implemented")
+}
+
+func (s *managerTaskStore) GetRuleByName(
+	_ context.Context,
+	_ string,
+) (*operationrules.OperationRule, error) {
+	panic("managerTaskStore.GetRuleByName: not implemented")
+}
+
+func (s *managerTaskStore) GetDefaultRule(
+	_ context.Context,
+	_ taskcommon.TaskType,
+	_ string,
+) (*operationrules.OperationRule, error) {
+	panic("managerTaskStore.GetDefaultRule: not implemented")
+}
+
+func (s *managerTaskStore) GetRuleByOperationAndRack(
+	_ context.Context,
+	_ taskcommon.TaskType,
+	_ string,
+	_ *uuid.UUID,
+) (*operationrules.OperationRule, error) {
+	panic("managerTaskStore.GetRuleByOperationAndRack: not implemented")
+}
+
+func (s *managerTaskStore) ListRules(
+	_ context.Context,
+	_ *taskcommon.OperationRuleListOptions,
+	_ *dbquery.Pagination,
+) ([]*operationrules.OperationRule, int32, error) {
+	panic("managerTaskStore.ListRules: not implemented")
+}
+
+func (s *managerTaskStore) AssociateRuleWithRack(
+	_ context.Context,
+	_ uuid.UUID,
+	_ uuid.UUID,
+) error {
+	panic("managerTaskStore.AssociateRuleWithRack: not implemented")
+}
+
+func (s *managerTaskStore) DisassociateRuleFromRack(
+	_ context.Context,
+	_ uuid.UUID,
+	_ taskcommon.TaskType,
+	_ string,
+) error {
+	panic("managerTaskStore.DisassociateRuleFromRack: not implemented")
+}
+
+func (s *managerTaskStore) GetRackRuleAssociation(
+	_ context.Context,
+	_ uuid.UUID,
+	_ taskcommon.TaskType,
+	_ string,
+) (*uuid.UUID, error) {
+	panic("managerTaskStore.GetRackRuleAssociation: not implemented")
+}
+
+func (s *managerTaskStore) ListRackRuleAssociations(
+	_ context.Context,
+	_ uuid.UUID,
+) ([]*operationrules.RackRuleAssociation, error) {
+	panic("managerTaskStore.ListRackRuleAssociations: not implemented")
+}
+
+var _ interface {
+	RunInTransaction(context.Context, func(context.Context) error) error
+} = (*managerTaskStore)(nil)
+
+type managerExecutor struct {
+	executionID  string
+	executeCalls int
+	lastRequest  *taskdef.ExecutionRequest
+}
+
+func (e *managerExecutor) Start(context.Context) error {
+	return nil
+}
+
+func (e *managerExecutor) Stop(context.Context) error {
+	return nil
+}
+
+func (e *managerExecutor) Type() taskcommon.ExecutorType {
+	return taskcommon.ExecutorTypeTemporal
+}
+
+func (e *managerExecutor) Execute(
+	_ context.Context,
+	req *taskdef.ExecutionRequest,
+) (*taskdef.ExecutionResponse, error) {
+	e.executeCalls++
+	e.lastRequest = req
+	return &taskdef.ExecutionResponse{ExecutionID: e.executionID}, nil
+}
+
+func (e *managerExecutor) CheckStatus(
+	context.Context,
+	string,
+) (taskcommon.TaskStatus, error) {
+	panic("managerExecutor.CheckStatus: not implemented")
+}
+
+func (e *managerExecutor) TerminateTask(context.Context, string, string) error {
+	panic("managerExecutor.TerminateTask: not implemented")
+}

--- a/rest-api/flow/internal/task/store/postgres.go
+++ b/rest-api/flow/internal/task/store/postgres.go
@@ -71,6 +71,57 @@ func (s *PostgresStore) CreateTask(
 	return nil
 }
 
+// LockRack takes a transaction-scoped advisory lock for rack-level task
+// admission. The lock is released automatically when the transaction ends.
+func (s *PostgresStore) LockRack(ctx context.Context, rackID uuid.UUID) error {
+	if rackID == uuid.Nil {
+		return errors.GRPCErrorInvalidArgument("rack ID is required")
+	}
+	return s.lockAdvisoryKey(ctx, rackID.String())
+}
+
+// LockIdempotencyKey takes a transaction-scoped advisory lock for stable
+// submission lookup and resume. The lock is released automatically when the
+// transaction ends.
+func (s *PostgresStore) LockIdempotencyKey(ctx context.Context, key string) error {
+	if key == "" {
+		return errors.GRPCErrorInvalidArgument("idempotency key is required")
+	}
+	return s.lockAdvisoryKey(ctx, key)
+}
+
+func (s *PostgresStore) lockAdvisoryKey(ctx context.Context, key string) error {
+	tx, ok := ctx.Value(txKey).(bun.Tx)
+	if !ok {
+		return errors.GRPCErrorInternal("advisory lock requires an active transaction")
+	}
+
+	if _, err := tx.
+		NewSelect().
+		ColumnExpr("pg_advisory_xact_lock(hashtextextended(?, 0))", key).
+		Exec(ctx); err != nil {
+		return errors.GRPCErrorInternal(err.Error())
+	}
+	return nil
+}
+
+// GetTaskByIdempotencyKey retrieves the existing task for a stable submission
+// key. A missing key returns nil so callers can continue normal creation.
+func (s *PostgresStore) GetTaskByIdempotencyKey(
+	ctx context.Context,
+	key string,
+) (*taskdef.Task, error) {
+	taskDao, err := model.GetTaskByIdempotencyKey(ctx, s.idb(ctx), key)
+	if err != nil {
+		if s.pg.GetErrorChecker().IsErrNoRows(err) {
+			return nil, nil
+		}
+		return nil, errors.GRPCErrorInternal(err.Error())
+	}
+
+	return dao.TaskFrom(taskDao), nil
+}
+
 // GetTask retrieves a single task by its ID.
 func (s *PostgresStore) GetTask(
 	ctx context.Context,
@@ -131,7 +182,7 @@ func (s *PostgresStore) UpdateScheduledTask(
 	task *taskdef.Task,
 ) error {
 	taskDao := dao.TaskTo(task)
-	if err := taskDao.UpdateScheduledTask(ctx, s.pg.DB); err != nil {
+	if err := taskDao.UpdateScheduledTask(ctx, s.idb(ctx)); err != nil {
 		return errors.GRPCErrorInternal(err.Error())
 	}
 

--- a/rest-api/flow/internal/task/store/store.go
+++ b/rest-api/flow/internal/task/store/store.go
@@ -29,6 +29,21 @@ type Store interface {
 	// CreateTask creates a new task record.
 	CreateTask(ctx context.Context, task *taskdef.Task) error
 
+	// LockRack takes a transaction-scoped lock for rack-level task admission.
+	// Callers must invoke it inside RunInTransaction before conflict checks.
+	LockRack(ctx context.Context, rackID uuid.UUID) error
+
+	// LockIdempotencyKey takes a transaction-scoped lock for stable submission
+	// lookup and resume. Callers must invoke it inside RunInTransaction.
+	LockIdempotencyKey(ctx context.Context, key string) error
+
+	// GetTaskByIdempotencyKey retrieves the existing task for a stable
+	// submission key. It returns nil when no task exists for the key.
+	GetTaskByIdempotencyKey(
+		ctx context.Context,
+		key string,
+	) (*taskdef.Task, error)
+
 	// GetTask retrieves a single task by its ID.
 	// Returns an error if the task is not found.
 	GetTask(ctx context.Context, id uuid.UUID) (*taskdef.Task, error)

--- a/rest-api/flow/internal/task/task/task.go
+++ b/rest-api/flow/internal/task/task/task.go
@@ -50,6 +50,15 @@ type Task struct {
 	// After this time the Promoter terminates the task automatically.
 	// Nil for non-waiting tasks.
 	QueueExpiresAt *time.Time
+
+	// IdempotencyKey is an optional stable submission key. When set, retries
+	// return the existing task instead of creating another row.
+	IdempotencyKey string
+}
+
+// IsScheduled reports whether the task has been submitted to an executor.
+func (t *Task) IsScheduled() bool {
+	return t != nil && t.ExecutionID != ""
 }
 
 // WorkflowComponent holds the minimal component data needed to execute


### PR DESCRIPTION
<!-- Describe what this PR does -->
- Operation-run dispatch can retry target submission after the service
   restarts or after a transient failure. Without a stable task idempotency
   key, those retries may create duplicate tasks for the same operation-run
   target or hit rack-conflict rejection instead of returning the task that
   was already persisted.
- Persist an optional task idempotency key, have operation-run targets submit
  with a stable key, and return or resume the existing task when a retry uses
   the same key.
- Serialize idempotent lookup/resume with an idempotency-key advisory lock,
   and serialize rack-level conflict admission with a rack advisory lock so
   concurrent submissions cannot both pass conflict checks.

- ## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

