### PR TITLE
feat: export the MQTT client's statistics and connection state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7175,10 +7175,15 @@ name = "mqttea"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "carbide-instrument",
  "carbide-test-support",
  "chrono",
  "clap",
  "oauth2",
+ "opentelemetry 0.32.0",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
+ "prometheus",
  "prost",
  "prost-build",
  "prost-types",

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1166,6 +1166,7 @@ async fn initialize_and_start_controllers<'a>(
             client.connect().await.map_err(|e| {
                 eyre::eyre!("Failed to connect DSX Exchange Event Bus MQTT client: {e}")
             })?;
+            client.register_metrics(&meter, "dsx_event_bus");
 
             tracing::info!(
                 "DSX Exchange Event Bus enabled, publishing to {}:{}",
@@ -1530,8 +1531,10 @@ async fn initialize_and_start_controllers<'a>(
     .start(join_set, cancel_token.clone())?;
 
     if carbide_config.is_dpa_enabled() {
-        let mqtt_client =
-            Some(start_dpa_handler(join_set, api_service.clone(), cancel_token.clone()).await?);
+        let dpa_mqtt_client =
+            start_dpa_handler(join_set, api_service.clone(), cancel_token.clone()).await?;
+        dpa_mqtt_client.register_metrics(&meter, "dpa");
+        let mqtt_client = Some(dpa_mqtt_client);
 
         let subnet_ip = carbide_config.get_dpa_subnet_ip()?;
 

--- a/crates/dsx-exchange-consumer/src/lib.rs
+++ b/crates/dsx-exchange-consumer/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
 
     // Set up OpenTelemetry + Prometheus metrics
     let metrics_setup =
-        metrics_endpoint::new_metrics_setup("carbide-dsx-exchange-consumer", "carbide", false)
+        metrics_endpoint::new_metrics_setup("carbide-dsx-exchange-consumer", "carbide", true)
             .map_err(|e| DsxConsumerError::Metrics(e.to_string()))?;
 
     let registry = metrics_setup.registry;
@@ -90,6 +90,7 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
     let rx = mqtt_consumer::connect(
         &config.mqtt,
         consumer_metrics.clone(),
+        &meter,
         credential_manager.clone(),
     )
     .await?;

--- a/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
+++ b/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
@@ -44,11 +44,14 @@ pub enum MqttMessage {
 
 /// Connect to MQTT and return a receiver for incoming messages.
 ///
-/// Sets up the MQTT client, registers message handlers, subscribes to topics,
-/// and connects. Returns a receiver that yields messages with drop-on-overflow.
+/// Sets up the MQTT client, registers message handlers and the client's
+/// queue/publish/connection metrics on the meter, subscribes to topics,
+/// and connects. Returns a receiver that yields messages with
+/// drop-on-overflow.
 pub async fn connect(
     config: &MqttConfig,
     metrics: ConsumerMetrics,
+    meter: &opentelemetry::metrics::Meter,
     credential_reader: Arc<dyn CredentialReader>,
 ) -> Result<mpsc::Receiver<MqttMessage>, DsxConsumerError> {
     let (tx, rx) = mpsc::channel(config.queue_capacity);
@@ -73,6 +76,7 @@ pub async fn connect(
     let client = MqtteaClient::new(&config.endpoint, config.port, &client_id, Some(options))
         .await
         .map_err(|e| DsxConsumerError::Mqtt(e.to_string()))?;
+    client.register_metrics(meter, "dsx_exchange_consumer");
 
     // Register message types with distinct suffix patterns.
     // mqttea converts simple strings to suffix regex: "Metadata" -> "/Metadata$"

--- a/crates/mqttea/Cargo.toml
+++ b/crates/mqttea/Cargo.toml
@@ -26,7 +26,9 @@ name = "mqttea"
 path = "src/lib.rs"
 
 [dependencies]
+carbide-instrument = { path = "../instrument" }
 trace-propagation = { path = "../trace-propagation" }
+opentelemetry = { workspace = true }
 tokio = { features = ["full"], workspace = true }
 rumqttc = { workspace = true }
 prost = { workspace = true }
@@ -48,7 +50,11 @@ oauth2 = { workspace = true }
 reqwest = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-prometheus = { workspace = true }
+prometheus = { workspace = true }
 prost-build = { workspace = true }
 tokio-test = { workspace = true }
 

--- a/crates/mqttea/src/client/core.rs
+++ b/crates/mqttea/src/client/core.rs
@@ -25,6 +25,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use carbide_instrument::emit;
 use rumqttc::{AsyncClient, Event, EventLoop, MqttOptions, Packet, QoS};
 use tokio::sync::{Mutex, RwLock, Semaphore, mpsc};
 use tracing::{debug, error, info, warn};
@@ -34,7 +35,9 @@ use crate::client::{ClientOptions, ClosureAdapter, ErasedHandler, ReceivedMessag
 use crate::errors::MqtteaClientError;
 use crate::registry::MqttRegistry;
 use crate::registry::types::PublishOptions;
-use crate::stats::{PublishStats, PublishStatsTracker, QueueStats, QueueStatsTracker};
+use crate::stats::{
+    ConnectionStateTracker, PublishStats, PublishStatsTracker, QueueStats, QueueStatsTracker,
+};
 use crate::traits::MessageHandler;
 
 const DEFAULT_KEEP_ALIVE: std::time::Duration = std::time::Duration::from_secs(300);
@@ -76,6 +79,9 @@ pub struct MqtteaClient {
     queue_stats: Arc<QueueStatsTracker>,
     // publish_stats tracks message publishing statistics and success rates.
     publish_stats: Arc<PublishStatsTracker>,
+    // connection_state tracks whether the client currently holds an
+    // acknowledged broker connection.
+    connection_state: Arc<ConnectionStateTracker>,
     // registry encapsulates all message type registration and routing logic.
     // Made pub(crate) so trait implementations in registry.rs can access it.
     pub(crate) registry: Arc<RwLock<MqttRegistry>>,
@@ -117,6 +123,7 @@ impl MqtteaClient {
 
         let queue_stats = Arc::new(QueueStatsTracker::new());
         let publish_stats = Arc::new(PublishStatsTracker::new());
+        let connection_state = Arc::new(ConnectionStateTracker::new());
 
         // Create client-scoped registry instead of using global static.
         let registry = Arc::new(RwLock::new(MqttRegistry::new()));
@@ -145,6 +152,7 @@ impl MqtteaClient {
             handlers,
             queue_stats,
             publish_stats,
+            connection_state,
             registry,
         }))
     }
@@ -225,6 +233,7 @@ impl MqtteaClient {
         // freeing up the underlying message channel to continue receiving
         // messages.
         let queue_stats_producer = self.queue_stats.clone();
+        let connection_state = self.connection_state.clone();
         let registry_clone = self.registry.clone();
         let credentials_provider = self.credentials_provider.clone();
         let client_for_reconnect = self.clone();
@@ -237,7 +246,11 @@ impl MqtteaClient {
                         if let Event::Incoming(Packet::ConnAck(connack)) = &event {
                             let should_replay =
                                 should_replay_subscriptions(has_connected, connack.session_present);
+                            if has_connected {
+                                emit(MqttReconnected {});
+                            }
                             has_connected = true;
+                            connection_state.set_connected(true);
                             backoff_strategy.reset();
 
                             if should_replay {
@@ -286,6 +299,7 @@ impl MqtteaClient {
                     }
                     Err(e) => {
                         error!("MQTT event loop connection error: {:?}", e);
+                        connection_state.set_connected(false);
                         queue_stats_producer.increment_event_loop_errors();
 
                         // Refresh credentials before reconnection attempt if a provider is configured.
@@ -383,12 +397,10 @@ impl MqtteaClient {
                     let _permit = match semaphore_internal.acquire().await {
                         Ok(permit) => permit,
                         Err(e) => {
-                            // TODO(chet): Totally need to export a metric here,
-                            // since we're dropping messages at this point.
-                            error!(
-                                "failed to acquire semaphore permit for message_type={}: {e}",
-                                std::any::type_name::<T>().to_string()
-                            );
+                            emit(HandlerDispatchDropped {
+                                message_type: std::any::type_name::<T>(),
+                                error: e.to_string(),
+                            });
                             return;
                         }
                     };
@@ -544,6 +556,7 @@ impl MqtteaClient {
             .await
             .map_err(MqtteaClientError::ConnectionError)?;
 
+        self.connection_state.set_connected(false);
         info!("MQTT client disconnected");
         Ok(())
     }
@@ -561,6 +574,32 @@ impl MqtteaClient {
     // Tracks success/failure rates and throughput of outgoing messages.
     pub fn publish_stats(&self) -> PublishStats {
         self.publish_stats.to_stats()
+    }
+
+    // is_connected reports whether the client currently holds an
+    // acknowledged broker connection: true after a ConnAck, false after a
+    // connection error or disconnect() (and before connect()).
+    pub fn is_connected(&self) -> bool {
+        self.connection_state.is_connected()
+    }
+
+    // register_metrics registers observable instruments over the client's
+    // stats trackers on the given meter: gauges for point-in-time state
+    // (queue depth in messages and bytes, connection state) and observable
+    // counters for the monotonic totals (processed/failed/dropped and
+    // published/failed message and byte counts, event loop errors,
+    // unmatched topics). The callbacks read the existing atomics at
+    // collection time; nothing on the message path changes.
+    //
+    // Every series is labeled client=<client> so multiple clients in one
+    // process stay distinct. The value must be a compile-time literal
+    // naming the client's role (e.g. "dsx_event_bus") -- it is the
+    // cardinality bound, so never pass a configured or generated client id.
+    // Call once per client, any time after construction.
+    pub fn register_metrics(&self, meter: &opentelemetry::metrics::Meter, client: &'static str) {
+        self.queue_stats.register_metrics(meter, client);
+        self.publish_stats.register_metrics(meter, client);
+        self.connection_state.register_metrics(meter, client);
     }
 
     // is_queue_empty checks if the internal message queue is empty.
@@ -613,6 +652,40 @@ fn should_replay_subscriptions(has_connected_before: bool, session_present: bool
     has_connected_before && !session_present
 }
 
+// The event loop received a ConnAck after having been connected before:
+// the broker connection was re-established. The rate is the signal (a
+// healthy client reconnects rarely); the surrounding reconnect machinery
+// already logs its own details, so this event is metric-only.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_mqtt_reconnects_total",
+    component = "mqttea",
+    log = off,
+    metric = counter,
+    describe = "Number of times an MQTT client re-established its broker connection after the initial connect"
+)]
+struct MqttReconnected {}
+
+// A received message was dropped at handler dispatch because the
+// concurrency semaphore could not be acquired (it only fails once the
+// semaphore is closed, so this also means the message's handler will
+// never run).
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_mqtt_dispatch_dropped_total",
+    component = "mqttea",
+    log = error,
+    metric = counter,
+    message = "failed to acquire semaphore permit, dropping message",
+    describe = "Number of received MQTT messages dropped because the handler concurrency semaphore could not be acquired"
+)]
+struct HandlerDispatchDropped {
+    #[context]
+    message_type: &'static str,
+    #[context]
+    error: String,
+}
+
 // SuperBasicBackoff is a basic backoff I'm implementing
 // to back off if there are errors during event loop
 // processing. Right now it's just hard-coded to start
@@ -649,7 +722,53 @@ impl SuperBasicBackoff {
 
 #[cfg(test)]
 mod tests {
-    use super::should_replay_subscriptions;
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::{HandlerDispatchDropped, MqttReconnected, should_replay_subscriptions};
+
+    #[test]
+    fn dispatch_dropped_event_logs_error_and_ticks_counter() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit(HandlerDispatchDropped {
+                message_type: "mqttea::tests::Demo",
+                error: "semaphore closed".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::ERROR);
+        assert_eq!(
+            logs[0].message,
+            "failed to acquire semaphore permit, dropping message"
+        );
+        assert!(logs[0].fields.contains(&(
+            "message_type".to_string(),
+            "mqttea::tests::Demo".to_string()
+        )));
+        assert!(
+            logs[0]
+                .fields
+                .contains(&("error".to_string(), "semaphore closed".to_string()))
+        );
+        assert_eq!(
+            metrics.counter_delta("carbide_mqtt_dispatch_dropped_total", &[]),
+            1.0
+        );
+    }
+
+    #[test]
+    fn reconnect_event_is_metric_only() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| emit(MqttReconnected {}));
+
+        assert!(logs.is_empty());
+        assert_eq!(
+            metrics.counter_delta("carbide_mqtt_reconnects_total", &[]),
+            1.0
+        );
+    }
 
     #[test]
     fn does_not_replay_on_initial_connect() {

--- a/crates/mqttea/src/stats/connection.rs
+++ b/crates/mqttea/src/stats/connection.rs
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// src/mqttea/stats/connection.rs
+// Broker connection state tracking.
+//
+// Holds the client's point-in-time connection flag: the event loop sets
+// it on every ConnAck, clears it on every connection error, and
+// disconnect() clears it on a clean shutdown. Lock-free, like the other
+// stats trackers.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Meter;
+
+// ConnectionStateTracker enables thread-safe updates to the client's
+// broker connection state using atomic operations.
+#[derive(Debug)]
+pub struct ConnectionStateTracker {
+    // connected is true while the client holds an acknowledged broker
+    // connection (a ConnAck arrived and no connection error has been
+    // seen since).
+    connected: Arc<AtomicBool>,
+}
+
+impl Default for ConnectionStateTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConnectionStateTracker {
+    // new creates a ConnectionStateTracker in the disconnected state
+    // (e.g. used during MqtteaClient initialization, before connect()).
+    pub fn new() -> Self {
+        Self {
+            connected: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    // set_connected records a connection state transition. The event loop
+    // calls this with true on every ConnAck and with false on every
+    // connection error; disconnect() calls it with false.
+    pub fn set_connected(&self, connected: bool) {
+        self.connected.store(connected, Ordering::Relaxed);
+    }
+
+    // is_connected reports whether the client currently holds an
+    // acknowledged broker connection.
+    pub fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Relaxed)
+    }
+
+    // register_metrics registers an observable gauge over the connection
+    // flag on the given meter. The series is labeled client=<client> so
+    // multiple clients in one process stay distinct; the value must be a
+    // compile-time literal (it is the cardinality bound). Call once per
+    // tracker -- a second registration would mint duplicate series.
+    pub fn register_metrics(&self, meter: &Meter, client: &'static str) {
+        let connected = self.connected.clone();
+        meter
+            .u64_observable_gauge("carbide_mqtt_connected")
+            .with_description(
+                "Number of active broker connections held by the MQTT client (1 while connected, 0 otherwise)",
+            )
+            .with_callback(move |observer| {
+                observer.observe(
+                    connected.load(Ordering::Relaxed) as u64,
+                    &[KeyValue::new("client", client)],
+                );
+            })
+            .build();
+    }
+}

--- a/crates/mqttea/src/stats/mod.rs
+++ b/crates/mqttea/src/stats/mod.rs
@@ -18,8 +18,10 @@
 // src/mqttea/stats/mod.rs
 // Re-exports for stats module.
 
+pub mod connection;
 pub mod publish;
 pub mod queue;
 
+pub use connection::ConnectionStateTracker;
 pub use publish::{PublishStats, PublishStatsTracker};
 pub use queue::{QueueStats, QueueStatsTracker};

--- a/crates/mqttea/src/stats/publish.rs
+++ b/crates/mqttea/src/stats/publish.rs
@@ -24,6 +24,9 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Meter;
+
 // PublishStats stores a snapshot of sent message statistics.
 #[derive(Debug, Clone)]
 pub struct PublishStats {
@@ -97,6 +100,50 @@ impl PublishStatsTracker {
         self.published_count.store(0, Ordering::Relaxed);
         self.failed_count.store(0, Ordering::Relaxed);
         self.published_bytes.store(0, Ordering::Relaxed);
+    }
+
+    // register_metrics registers observable counters over the tracker's
+    // atomics on the given meter (all three totals are monotonic; the
+    // Prometheus exporter appends the `_total` suffix). Every series is
+    // labeled client=<client> so multiple clients in one process stay
+    // distinct; the value must be a compile-time literal (it is the
+    // cardinality bound). Call once per tracker -- a second registration
+    // would mint duplicate series.
+    //
+    // The callbacks read the atomics at collection time; nothing on the
+    // publish path changes. Note that reset_counters() shows up as an
+    // ordinary Prometheus counter reset.
+    pub fn register_metrics(&self, meter: &Meter, client: &'static str) {
+        let counters = [
+            (
+                "carbide_mqtt_messages_published",
+                "Number of MQTT messages successfully queued for publishing to the broker",
+                &self.published_count,
+            ),
+            (
+                "carbide_mqtt_publish_failures",
+                "Number of MQTT message publish attempts that failed",
+                &self.failed_count,
+            ),
+            (
+                "carbide_mqtt_published_bytes",
+                "Number of bytes of MQTT messages successfully queued for publishing to the broker",
+                &self.published_bytes,
+            ),
+        ];
+        for (name, description, total) in counters {
+            let total = total.clone();
+            meter
+                .u64_observable_counter(name)
+                .with_description(description)
+                .with_callback(move |observer| {
+                    observer.observe(
+                        total.load(Ordering::Relaxed) as u64,
+                        &[KeyValue::new("client", client)],
+                    );
+                })
+                .build();
+        }
     }
 
     // to_stats will create an immutable snapshot of current publish

--- a/crates/mqttea/src/stats/queue.rs
+++ b/crates/mqttea/src/stats/queue.rs
@@ -26,6 +26,9 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Meter;
+
 // QueueStats stores a snapshot of received message processing
 // statistics.
 #[derive(Debug, Clone)]
@@ -190,6 +193,99 @@ impl QueueStatsTracker {
         self.failed_count.store(0, Ordering::Relaxed);
         self.event_loop_errors.store(0, Ordering::Relaxed);
         self.unmatched_topics.store(0, Ordering::Relaxed);
+    }
+
+    // register_metrics registers observable instruments over the tracker's
+    // atomics on the given meter: gauges for the point-in-time pending
+    // counters, and observable counters for the monotonic totals. Every
+    // series is labeled client=<client> so multiple clients in one process
+    // stay distinct; the value must be a compile-time literal (it is the
+    // cardinality bound). Call once per tracker -- a second registration
+    // would mint duplicate series.
+    //
+    // The callbacks read the atomics at collection time; nothing on the
+    // message path changes. Note that reset_counters() shows up on the
+    // observable counters as an ordinary Prometheus counter reset.
+    pub fn register_metrics(&self, meter: &Meter, client: &'static str) {
+        let gauges = [
+            (
+                "carbide_mqtt_queue_pending_messages",
+                "Number of received MQTT messages currently waiting in the client's processing queue",
+                &self.pending_count,
+            ),
+            (
+                "carbide_mqtt_queue_pending_bytes",
+                "Number of bytes of received MQTT messages currently waiting in the client's processing queue",
+                &self.pending_bytes,
+            ),
+        ];
+        for (name, description, value) in gauges {
+            let value = value.clone();
+            meter
+                .u64_observable_gauge(name)
+                .with_description(description)
+                .with_callback(move |observer| {
+                    observer.observe(
+                        value.load(Ordering::Relaxed) as u64,
+                        &[KeyValue::new("client", client)],
+                    );
+                })
+                .build();
+        }
+
+        // Monotonic totals; the Prometheus exporter appends the `_total`
+        // suffix, so these expose as `carbide_mqtt_messages_processed_total`
+        // and so on.
+        let counters = [
+            (
+                "carbide_mqtt_messages_processed",
+                "Number of received MQTT messages successfully processed by a registered handler",
+                &self.processed_count,
+            ),
+            (
+                "carbide_mqtt_processed_bytes",
+                "Number of bytes of received MQTT messages successfully processed by a registered handler",
+                &self.processed_bytes,
+            ),
+            (
+                "carbide_mqtt_messages_failed",
+                "Number of received MQTT messages whose handler failed or that had no handler registered",
+                &self.failed_count,
+            ),
+            (
+                "carbide_mqtt_messages_dropped",
+                "Number of received MQTT messages dropped because the client's processing queue was full",
+                &self.dropped_count,
+            ),
+            (
+                "carbide_mqtt_dropped_bytes",
+                "Number of bytes of received MQTT messages dropped because the client's processing queue was full",
+                &self.dropped_bytes,
+            ),
+            (
+                "carbide_mqtt_event_loop_errors",
+                "Number of connection errors encountered by the MQTT client's event loop",
+                &self.event_loop_errors,
+            ),
+            (
+                "carbide_mqtt_unmatched_topics",
+                "Number of received MQTT messages whose topic matched no registered handler pattern",
+                &self.unmatched_topics,
+            ),
+        ];
+        for (name, description, total) in counters {
+            let total = total.clone();
+            meter
+                .u64_observable_counter(name)
+                .with_description(description)
+                .with_callback(move |observer| {
+                    observer.observe(
+                        total.load(Ordering::Relaxed) as u64,
+                        &[KeyValue::new("client", client)],
+                    );
+                })
+                .build();
+        }
     }
 
     // to_stats will create an immutable snapshot of current statistics.

--- a/crates/mqttea/tests/stats.rs
+++ b/crates/mqttea/tests/stats.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use mqttea::stats::{PublishStatsTracker, QueueStatsTracker};
+use mqttea::stats::{ConnectionStateTracker, PublishStatsTracker, QueueStatsTracker};
 
 // Tests for QueueStatsTracker creation and initial state
 #[test]
@@ -512,4 +512,223 @@ fn test_stats_clone() {
     assert_eq!(stats1.pending_messages, stats2.pending_messages);
     assert_eq!(stats1.total_processed, stats2.total_processed);
     assert_eq!(stats1.total_bytes_processed, stats2.total_bytes_processed);
+}
+
+// Tests for register_metrics: the observable instruments expose the
+// trackers' atomics through a local meter provider backed by a plain
+// prometheus registry (gathering the registry runs the callbacks).
+
+// test_meter builds a meter whose instruments export into the returned
+// prometheus registry. The provider must stay alive for the registry to
+// keep collecting.
+fn test_meter() -> (
+    opentelemetry_sdk::metrics::SdkMeterProvider,
+    prometheus::Registry,
+    opentelemetry::metrics::Meter,
+) {
+    let registry = prometheus::Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .without_scope_info()
+        .without_target_info()
+        .build()
+        .expect("build prometheus exporter");
+    let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_reader(exporter)
+        .build();
+    let meter = opentelemetry::metrics::MeterProvider::meter(&provider, "mqttea-test");
+    (provider, registry, meter)
+}
+
+// metric_value reads a counter or gauge value (with exactly the given
+// label pairs) out of a gathered prometheus registry.
+fn metric_value(registry: &prometheus::Registry, name: &str, labels: &[(&str, &str)]) -> f64 {
+    for family in registry.gather() {
+        if family.name() != name {
+            continue;
+        }
+        for metric in family.get_metric() {
+            let metric_labels: Vec<(String, String)> = metric
+                .get_label()
+                .iter()
+                .map(|pair| (pair.name().to_string(), pair.value().to_string()))
+                .collect();
+            let expected: Vec<(String, String)> = labels
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            if metric_labels == expected {
+                return match family.get_field_type() {
+                    prometheus::proto::MetricType::COUNTER => metric.get_counter().value(),
+                    prometheus::proto::MetricType::GAUGE => metric.get_gauge().value(),
+                    other => panic!("unexpected metric type {other:?} for {name}"),
+                };
+            }
+        }
+        panic!("metric {name} has no series with labels {labels:?}");
+    }
+    panic!("metric {name} not found in registry");
+}
+
+#[test]
+fn test_queue_stats_register_metrics_exposes_atomics() {
+    let (_provider, registry, meter) = test_meter();
+    let tracker = QueueStatsTracker::new();
+    tracker.register_metrics(&meter, "test_client");
+
+    // Three messages in, one processed, one failed, plus a queue-full
+    // drop, an event loop error, and an unmatched topic.
+    tracker.increment_pending(100);
+    tracker.increment_pending(250);
+    tracker.increment_pending(75);
+    tracker.decrement_pending_increment_processed(100);
+    tracker.decrement_pending_increment_failed(250);
+    tracker.increment_dropped(500);
+    tracker.increment_event_loop_errors();
+    tracker.increment_unmatched_topics();
+
+    let labels = [("client", "test_client")];
+    struct Expect {
+        metric: &'static str,
+        value: f64,
+    }
+    let expectations = [
+        Expect {
+            metric: "carbide_mqtt_queue_pending_messages",
+            value: 1.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_queue_pending_bytes",
+            value: 75.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_messages_processed_total",
+            value: 1.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_processed_bytes_total",
+            value: 100.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_messages_failed_total",
+            value: 1.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_messages_dropped_total",
+            value: 1.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_dropped_bytes_total",
+            value: 500.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_event_loop_errors_total",
+            value: 1.0,
+        },
+        Expect {
+            metric: "carbide_mqtt_unmatched_topics_total",
+            value: 1.0,
+        },
+    ];
+    for expect in expectations {
+        assert_eq!(
+            metric_value(&registry, expect.metric, &labels),
+            expect.value,
+            "unexpected value for {}",
+            expect.metric
+        );
+    }
+}
+
+#[test]
+fn test_publish_stats_register_metrics_exposes_atomics() {
+    let (_provider, registry, meter) = test_meter();
+    let tracker = PublishStatsTracker::new();
+    tracker.register_metrics(&meter, "test_client");
+
+    tracker.increment_published(512);
+    tracker.increment_published(256);
+    tracker.increment_failed();
+
+    let labels = [("client", "test_client")];
+    assert_eq!(
+        metric_value(&registry, "carbide_mqtt_messages_published_total", &labels),
+        2.0
+    );
+    assert_eq!(
+        metric_value(&registry, "carbide_mqtt_publish_failures_total", &labels),
+        1.0
+    );
+    assert_eq!(
+        metric_value(&registry, "carbide_mqtt_published_bytes_total", &labels),
+        768.0
+    );
+}
+
+#[test]
+fn test_connection_state_register_metrics_tracks_transitions() {
+    let (_provider, registry, meter) = test_meter();
+    let tracker = ConnectionStateTracker::new();
+    tracker.register_metrics(&meter, "test_client");
+
+    let labels = [("client", "test_client")];
+
+    // Created disconnected.
+    assert!(!tracker.is_connected());
+    assert_eq!(
+        metric_value(&registry, "carbide_mqtt_connected", &labels),
+        0.0
+    );
+
+    // ConnAck arrives.
+    tracker.set_connected(true);
+    assert!(tracker.is_connected());
+    assert_eq!(
+        metric_value(&registry, "carbide_mqtt_connected", &labels),
+        1.0
+    );
+
+    // Connection error drops the flag again.
+    tracker.set_connected(false);
+    assert_eq!(
+        metric_value(&registry, "carbide_mqtt_connected", &labels),
+        0.0
+    );
+}
+
+// A client-level registration covers all three trackers: every instrument
+// appears in the exposition, and a client that never connected reports
+// zeros with the connected gauge down.
+#[tokio::test]
+async fn test_client_register_metrics_registers_all_instruments() {
+    let (_provider, registry, meter) = test_meter();
+    let client = mqttea::MqtteaClient::new("localhost", 1883, "test-metrics-client", None)
+        .await
+        .expect("create client");
+    client.register_metrics(&meter, "test_client");
+
+    let labels = [("client", "test_client")];
+    let all_instruments = [
+        "carbide_mqtt_queue_pending_messages",
+        "carbide_mqtt_queue_pending_bytes",
+        "carbide_mqtt_connected",
+        "carbide_mqtt_messages_processed_total",
+        "carbide_mqtt_processed_bytes_total",
+        "carbide_mqtt_messages_failed_total",
+        "carbide_mqtt_messages_dropped_total",
+        "carbide_mqtt_dropped_bytes_total",
+        "carbide_mqtt_event_loop_errors_total",
+        "carbide_mqtt_unmatched_topics_total",
+        "carbide_mqtt_messages_published_total",
+        "carbide_mqtt_publish_failures_total",
+        "carbide_mqtt_published_bytes_total",
+    ];
+    for name in all_instruments {
+        assert_eq!(
+            metric_value(&registry, name, &labels),
+            0.0,
+            "expected {name} to be registered at zero"
+        );
+    }
+    assert!(!client.is_connected());
 }


### PR DESCRIPTION
The mqttea client library has always counted its work -- queued and published messages, failures, drops, event-loop errors -- into per-client atomics that no meter ever read, and its dispatch path drops messages with only a TODO comment where a metric should be. This exports all of it.

- `MqtteaClient::register_metrics(&meter, client)` registers observable instruments over the existing trackers, every series labeled by a compile-time client name (`dsx_event_bus`, `dpa`, `dsx_exchange_consumer`) -- client ids are uniquified per pod, so the static label is the cardinality bound. Gauges: `carbide_mqtt_queue_pending_messages`, `carbide_mqtt_queue_pending_bytes`, `carbide_mqtt_connected`. Counters: processed/failed/dropped messages and bytes, publishes and publish failures, event-loop errors, unmatched topics.
- `carbide_mqtt_reconnects_total` -- a new connection-state tracker counts every reconnect (the first connect never counts); the state gauge flips on ConnAck and on poll errors.
- `carbide_mqtt_dispatch_dropped_total` -- the TODO is now a counter whose event owns the existing "failed to acquire semaphore permit" ERROR line, with the message type and error as structured fields.

Notable details:

- Wired in both consumers with meters: the API binary (its dsx-event-bus and DPA clients) and the DSX exchange consumer -- which also flips its metrics setup to install the global meter provider, since the framework's events resolve through it and would otherwise silently no-op in exactly the edge process where reconnect visibility matters most.
- The reconnects counter is process-wide rather than client-labeled: it fires in the event-loop task, which holds only the per-pod client id; per-client reconnect pressure is derivable from the labeled event-loop error series.
- No log line was removed; the queue-full and event-loop warns stay as they were.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3178
