### PR TITLE
perf(db): count rows in the database instead of fetching them to count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "carbide-version",
  "chrono",
  "config-version",
+ "const_format",
  "ctor",
  "dns-record",
  "domain",

--- a/crates/api-core/src/handlers/compute_allocation.rs
+++ b/crates/api-core/src/handlers/compute_allocation.rs
@@ -451,17 +451,9 @@ pub(crate) async fn update(
             instance_type_id: Some(instance_type_id.to_string()),
         };
 
-        let instance_count = instance::find_ids(&mut txn, filter).await?.len();
+        let instance_count = instance::count_ids(&mut txn, filter).await?;
 
-        if instance_count
-            > new_tenant_allocation_total
-                .try_into()
-                .map_err(|e: TryFromIntError| CarbideError::Internal {
-                    message: format!(
-                        "unable to compare current instance and allocation counts - {e}"
-                    ),
-                })?
-        {
+        if instance_count > i64::from(new_tenant_allocation_total) {
             return Err(CarbideError::FailedPrecondition(format!(
                 "requested update would decrease allocation count ({new_tenant_allocation_total}) below existing instances count ({instance_count})"
             ))
@@ -594,17 +586,9 @@ pub(crate) async fn delete(
             instance_type_id: Some(allocation.instance_type_id.to_string()),
         };
 
-        let instance_count = instance::find_ids(&mut txn, filter).await?.len();
+        let instance_count = instance::count_ids(&mut txn, filter).await?;
 
-        if instance_count
-            > new_tenant_allocation_total
-                .try_into()
-                .map_err(|e: TryFromIntError| CarbideError::Internal {
-                    message: format!(
-                        "unable to compare current instance and allocation counts - {e}"
-                    ),
-                })?
-        {
+        if instance_count > i64::from(new_tenant_allocation_total) {
             return Err(CarbideError::FailedPrecondition(format!(
                 "requested delete would decrease allocation count ({new_tenant_allocation_total}) below existing instances count ({instance_count})"
             ))

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -638,10 +638,13 @@ pub async fn batch_allocate_instances(
             instance_type_id: Some(instance_type_id.to_string()),
         };
 
-        let new_total_instance_count =
-            req_count + db::instance::find_ids(&mut txn, filter).await?.len();
+        // Saturate rather than wrap: an absurd request count then trips the
+        // limit check (fail closed) instead of going negative past it.
+        let new_total_instance_count = i64::try_from(req_count)
+            .unwrap_or(i64::MAX)
+            .saturating_add(db::instance::count_ids(&mut txn, filter).await?);
 
-        if new_total_instance_count > compute_allocation_total as usize {
+        if new_total_instance_count > i64::from(compute_allocation_total) {
             // # enforce_if_present:  Instance type not required in creation request. If sent and allocations are found for instance type ID, enforce it; otherwise, it's like no limits.
             // # always:              Instance type not required in creation request. If sent, enforce allocations.  If none are found, its a constraint value of 0 (i.e., you get nothing / default-deny).
             // # warn_only (default): Instance type not required in creation request. If sent in and allocations are found, don't enforce, but log what would have happened if they were enforced.

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -44,6 +44,7 @@ carbide-ipxe-renderer = { path = "../ipxe-renderer" }
 #these are alphabetized
 async-trait = { workspace = true }
 chrono = { workspace = true }
+const_format = { workspace = true }
 domain = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -18,6 +18,7 @@ use std::net::IpAddr;
 
 use chrono::{DateTime, Utc};
 use config_version::ConfigVersion;
+use const_format::concatcp;
 use mac_address::MacAddress;
 use model::firmware::FirmwareComponentType;
 use model::machine_boot_interface::MachineBootInterface;
@@ -189,33 +190,107 @@ pub async fn find_all(txn: impl DbReader<'_>) -> Result<Vec<ExploredEndpoint>, D
         .map_err(|e| DatabaseError::new("explored_endpoints find_all", e))
 }
 
+/// The WHERE clause matching endpoints still in preingestion that are neither
+/// waiting for a site-explorer refresh nor in an error state. If
+/// LastExplorationError is completely nonexistent it is NULL; if it is there
+/// and indicates a null value it is 'null'.
+///
+/// [`find_preingest_not_waiting_not_error`] and
+/// [`count_preingest_not_waiting_not_error`] both build their queries from
+/// this, so the row-returning and counting variants cannot drift apart.
+const PREINGEST_NOT_WAITING_NOT_ERROR_WHERE: &str = "(preingestion_state IS NULL OR preingestion_state->'state' != '\"complete\"')
+                            AND waiting_for_explorer_refresh = false
+                            AND (exploration_report->'LastExplorationError' IS NULL OR exploration_report->'LastExplorationError' = 'null')";
+
 /// find_preingest_not_waiting gets everything that is still in preingestion that isn't waiting for site explorer to refresh it again and isn't in an error state.
 pub async fn find_preingest_not_waiting_not_error(
     txn: impl DbReader<'_>,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
-    let query = "SELECT * FROM explored_endpoints
-                        WHERE (preingestion_state IS NULL OR preingestion_state->'state' != '\"complete\"')
-                            AND waiting_for_explorer_refresh = false
-                            AND (exploration_report->'LastExplorationError' IS NULL OR exploration_report->'LastExplorationError' = 'null')"; // If LastExplorationError is completely notexistant it is NULL, if it is there and indicates a null value it is 'null'.
+    const QUERY: &str = concatcp!(
+        "SELECT * FROM explored_endpoints
+                        WHERE ",
+        PREINGEST_NOT_WAITING_NOT_ERROR_WHERE
+    );
 
-    sqlx::query_as::<_, DbExploredEndpoint>(query)
+    sqlx::query_as::<_, DbExploredEndpoint>(QUERY)
         .fetch_all(txn)
         .await
         .map(|endpoints| endpoints.into_iter().map(Into::into).collect())
         .map_err(|e| DatabaseError::new("explored_endpoints find_preingest_not_waiting", e))
 }
 
-/// find_preingest_installing returns the endpoints where wew are waiting for firmware installs
+/// Counts the endpoints still in preingestion that are neither waiting for a
+/// site-explorer refresh nor in an error state.
+///
+/// Callers that only need the number of such endpoints (e.g. a metric gauge)
+/// use this instead of `find_preingest_not_waiting_not_error(..).len()`: it runs
+/// the same predicate but selects a scalar `count(*)`, so the database neither
+/// returns nor decodes the per-row `exploration_report` jsonb blob. Unlike that
+/// row-returning twin, the count also includes rows whose `exploration_report`
+/// or `preingestion_state` would fail to deserialize (COUNT never decodes them)
+/// — intentional for a metrics counter.
+pub async fn count_preingest_not_waiting_not_error(
+    txn: impl DbReader<'_>,
+) -> Result<i64, DatabaseError> {
+    const QUERY: &str = concatcp!(
+        "SELECT count(*) FROM explored_endpoints
+                        WHERE ",
+        PREINGEST_NOT_WAITING_NOT_ERROR_WHERE
+    );
+
+    sqlx::query_scalar(QUERY).fetch_one(txn).await.map_err(|e| {
+        DatabaseError::new(
+            "explored_endpoints count_preingest_not_waiting_not_error",
+            e,
+        )
+    })
+}
+
+/// The WHERE clause matching endpoints waiting on a firmware install.
+///
+/// [`find_preingest_installing`] and [`count_preingest_installing`] both build
+/// their queries from this, so the row-returning and counting variants cannot
+/// drift apart.
+const PREINGEST_INSTALLING_WHERE: &str = "preingestion_state->'state' = '\"upgradefirmwarewait\"'";
+
+/// find_preingest_installing returns the endpoints where we are waiting for firmware installs.
+///
+/// The metrics caller now uses [`count_preingest_installing`]; this
+/// row-returning form remains for callers that need the endpoints themselves
+/// and anchors the count's parity test.
 pub async fn find_preingest_installing(
     txn: impl DbReader<'_>,
 ) -> Result<Vec<ExploredEndpoint>, DatabaseError> {
-    let query = "SELECT * FROM explored_endpoints WHERE preingestion_state->'state' = '\"upgradefirmwarewait\"'";
+    const QUERY: &str = concatcp!(
+        "SELECT * FROM explored_endpoints WHERE ",
+        PREINGEST_INSTALLING_WHERE
+    );
 
-    sqlx::query_as::<_, DbExploredEndpoint>(query)
+    sqlx::query_as::<_, DbExploredEndpoint>(QUERY)
         .fetch_all(txn)
         .await
         .map(|endpoints| endpoints.into_iter().map(Into::into).collect())
-        .map_err(|e| DatabaseError::new("explored_endpoints find_preingest_not_waiting", e))
+        .map_err(|e| DatabaseError::new("explored_endpoints find_preingest_installing", e))
+}
+
+/// Counts the endpoints waiting for a firmware install to finish.
+///
+/// The counting counterpart to [`find_preingest_installing`]: callers that only
+/// need the number (e.g. a metric gauge) use this so the database returns a
+/// single scalar rather than every matching row's `exploration_report` jsonb.
+/// Unlike that row-returning twin, the count also includes rows whose
+/// `exploration_report` or `preingestion_state` would fail to deserialize
+/// (COUNT never decodes them) — intentional for a metrics counter.
+pub async fn count_preingest_installing(txn: impl DbReader<'_>) -> Result<i64, DatabaseError> {
+    const QUERY: &str = concatcp!(
+        "SELECT count(*) FROM explored_endpoints WHERE ",
+        PREINGEST_INSTALLING_WHERE
+    );
+
+    sqlx::query_scalar(QUERY)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new("explored_endpoints count_preingest_installing", e))
 }
 
 /// find_all_no_upgrades returns all explored endpoints that site explorer has been able to probe, but ignores anything currently undergoing an upgrade
@@ -826,4 +901,91 @@ pub async fn set_pause_ingestion_and_poweron(
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod count_preingest_tests {
+    use super::*;
+
+    /// An `UpgradeFirmwareWait` state — the one the "installing" predicate keys
+    /// on. Built from the real enum so the row-returning path can deserialize it.
+    fn installing_state() -> PreingestionState {
+        PreingestionState::UpgradeFirmwareWait {
+            task_id: "task-1".to_string(),
+            final_version: "1.2.3".to_string(),
+            upgrade_type: FirmwareComponentType::default(),
+            power_drains_needed: None,
+            firmware_number: None,
+        }
+    }
+
+    /// Inserts an explored endpoint with a fat, *decodable* `exploration_report`
+    /// blob and the given preingestion `state`. Both are built from the real
+    /// model types so the row-returning path can deserialize them — which is
+    /// exactly the per-row cost the count path avoids.
+    async fn seed_endpoint(txn: &mut PgConnection, addr: &str, state: PreingestionState) {
+        // A real report with a deliberately large field, so the row-returning
+        // path has genuine multi-KB jsonb to decode; the count path never
+        // touches it.
+        let report = EndpointExplorationReport {
+            model: Some("x".repeat(4096)),
+            ..Default::default()
+        };
+        sqlx::query(
+            "INSERT INTO explored_endpoints (address, exploration_report, version, preingestion_state, waiting_for_explorer_refresh) \
+             VALUES ($1::inet, $2, 'V1-T1733777281821769', $3, false)",
+        )
+        .bind(addr)
+        .bind(sqlx::types::Json(report))
+        .bind(sqlx::types::Json(state))
+        .execute(&mut *txn)
+        .await
+        .expect("seed explored_endpoint");
+    }
+
+    /// `count_preingest_not_waiting_not_error` returns the same tally as
+    /// `find_preingest_not_waiting_not_error(..).len()`. The win: the count
+    /// query returns one scalar, whereas the find query returns every matching
+    /// row and decodes each row's multi-KB `exploration_report` jsonb — so the
+    /// win is rows + per-row jsonb decode, N -> 0.
+    #[crate::sqlx_test]
+    async fn count_matches_find_not_waiting_not_error(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        // Three endpoints still in preingestion (not complete), not waiting, no error.
+        seed_endpoint(&mut txn, "10.0.0.1", PreingestionState::Initial).await;
+        seed_endpoint(&mut txn, "10.0.0.2", PreingestionState::RecheckVersions).await;
+        seed_endpoint(&mut txn, "10.0.0.3", installing_state()).await;
+        // One that is complete -> excluded by the predicate.
+        seed_endpoint(&mut txn, "10.0.0.4", PreingestionState::Complete).await;
+
+        let rows = find_preingest_not_waiting_not_error(&mut *txn)
+            .await
+            .unwrap();
+        let count = count_preingest_not_waiting_not_error(&mut *txn)
+            .await
+            .unwrap();
+
+        assert_eq!(rows.len(), 3, "three endpoints match the predicate");
+        assert_eq!(count, 3, "count agrees with the row count");
+        assert_eq!(count, rows.len() as i64);
+    }
+
+    /// `count_preingest_installing` returns the same tally as
+    /// `find_preingest_installing(..).len()` without returning/decoding the
+    /// per-row jsonb reports.
+    #[crate::sqlx_test]
+    async fn count_matches_find_installing(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        seed_endpoint(&mut txn, "10.0.1.1", installing_state()).await;
+        seed_endpoint(&mut txn, "10.0.1.2", installing_state()).await;
+        // Not installing -> excluded.
+        seed_endpoint(&mut txn, "10.0.1.3", PreingestionState::Initial).await;
+
+        let rows = find_preingest_installing(&mut *txn).await.unwrap();
+        let count = count_preingest_installing(&mut *txn).await.unwrap();
+
+        assert_eq!(rows.len(), 2, "two endpoints are installing firmware");
+        assert_eq!(count, 2, "count agrees with the row count");
+        assert_eq!(count, rows.len() as i64);
+    }
 }

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -65,7 +65,43 @@ pub async fn find_ids(
     filter: model::instance::InstanceSearchFilter,
 ) -> Result<Vec<InstanceId>, DatabaseError> {
     let mut builder = sqlx::QueryBuilder::new("SELECT id FROM instances WHERE TRUE "); // The TRUE will be optimized away.
+    push_search_filter(&mut builder, filter)?;
 
+    let query = builder.build_query_as();
+    query
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::new("instance::find_ids", e))
+}
+
+/// Counts the instances matching `filter` without materializing their ids.
+///
+/// Callers that only need the number of matches use this instead of
+/// `find_ids(..).len()`: it runs the same predicate but selects a scalar
+/// `count(*)`, so the database returns a single row rather than one id per
+/// matching instance. Shares its WHERE clause with [`find_ids`] via
+/// [`push_search_filter`], so the two always agree on which rows match.
+pub async fn count_ids(
+    txn: impl DbReader<'_>,
+    filter: model::instance::InstanceSearchFilter,
+) -> Result<i64, DatabaseError> {
+    let mut builder = sqlx::QueryBuilder::new("SELECT count(*) FROM instances WHERE TRUE "); // The TRUE will be optimized away.
+    push_search_filter(&mut builder, filter)?;
+
+    builder
+        .build_query_scalar()
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new("instance::count_ids", e))
+}
+
+/// Appends the `InstanceSearchFilter` predicate onto a query builder whose SQL
+/// already ends in `... WHERE TRUE `. Shared by [`find_ids`] and [`count_ids`]
+/// so the row-returning and counting queries filter identically.
+fn push_search_filter(
+    builder: &mut sqlx::QueryBuilder<sqlx::Postgres>,
+    filter: model::instance::InstanceSearchFilter,
+) -> Result<(), DatabaseError> {
     if let Some(label) = filter.label {
         match (label.key.is_empty(), label.value) {
             // Label key is empty, label value is set.
@@ -127,11 +163,7 @@ WHERE instance_addresses.vpc_id = ",
         builder.push(")");
     }
 
-    let query = builder.build_query_as();
-    query
-        .fetch_all(txn)
-        .await
-        .map_err(|e| DatabaseError::new("instance::find_ids", e))
+    Ok(())
 }
 
 pub async fn find(
@@ -1294,5 +1326,94 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(snapshots.len(), 2);
+    }
+}
+
+#[cfg(test)]
+mod count_ids_tests {
+    use super::*;
+
+    /// Seeds `n` instances for one tenant + instance type and returns the
+    /// filter that selects exactly those instances.
+    async fn seed_instances(
+        txn: &mut PgConnection,
+        tenant_org: &str,
+        instance_type_id: &str,
+        n: usize,
+    ) -> model::instance::InstanceSearchFilter {
+        sqlx::query("INSERT INTO instance_types (id, name) VALUES ($1, $1) ON CONFLICT DO NOTHING")
+            .bind(instance_type_id)
+            .execute(&mut *txn)
+            .await
+            .expect("seed instance_type");
+
+        for _ in 0..n {
+            let machine_id = uuid::Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO machines (id, dpf) \
+                 VALUES ($1, '{\"enabled\": false, \"used_for_ingestion\": false}'::jsonb)",
+            )
+            .bind(machine_id)
+            .execute(&mut *txn)
+            .await
+            .expect("seed machine");
+            sqlx::query(
+                "INSERT INTO instances (id, machine_id, tenant_org, instance_type_id) \
+                 VALUES (gen_random_uuid(), $1, $2, $3)",
+            )
+            .bind(machine_id)
+            .bind(tenant_org)
+            .bind(instance_type_id)
+            .execute(&mut *txn)
+            .await
+            .expect("seed instance");
+        }
+
+        model::instance::InstanceSearchFilter {
+            label: None,
+            tenant_org_id: Some(tenant_org.to_string()),
+            vpc_id: None,
+            instance_type_id: Some(instance_type_id.to_string()),
+        }
+    }
+
+    /// `count_ids` returns the same tally as `find_ids(..).len()`, but the win
+    /// is in what crosses the wire: `find_ids` materializes and decodes one
+    /// `InstanceId` per matching row (N rows), whereas `count_ids` returns a
+    /// single scalar (1 row). Same one query either way — this is a
+    /// rows-transferred/decoded win (N -> 1), not a round-trip win.
+    #[crate::sqlx_test]
+    async fn count_ids_matches_find_ids_len_without_materializing(pool: sqlx::PgPool) {
+        const N: usize = 5;
+        let mut txn = pool.begin().await.unwrap();
+        let filter = seed_instances(&mut txn, "count-ids-tenant", "count-ids-type", N).await;
+
+        let ids = find_ids(&mut *txn, filter.clone()).await.unwrap();
+        let count = count_ids(&mut *txn, filter).await.unwrap();
+
+        // find_ids materialized N ids; count_ids returned the scalar tally.
+        assert_eq!(ids.len(), N, "find_ids should materialize {N} ids");
+        assert_eq!(count, N as i64, "count_ids should tally {N}");
+        assert_eq!(
+            count,
+            ids.len() as i64,
+            "count_ids must agree with find_ids(..).len()"
+        );
+    }
+
+    /// The shared WHERE builder keeps `count_ids` scoped to the same filter as
+    /// `find_ids`: instances for a different tenant are not counted.
+    #[crate::sqlx_test]
+    async fn count_ids_respects_the_filter(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let filter = seed_instances(&mut txn, "tenant-a", "type-a", 3).await;
+        // Rows sharing only ONE filter dimension: same tenant with another
+        // type, and another tenant with the same type. The filter must exclude
+        // both, so a regression that drops either predicate fails the count.
+        let _ = seed_instances(&mut txn, "tenant-a", "type-b", 2).await;
+        let _ = seed_instances(&mut txn, "tenant-b", "type-a", 2).await;
+
+        let count = count_ids(&mut *txn, filter).await.unwrap();
+        assert_eq!(count, 3, "only tenant-a/type-a instances are counted");
     }
 }

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -35,7 +35,7 @@ use model::network_prefix::NetworkPrefix;
 use model::network_segment::{
     NetworkSegment, NetworkSegmentControllerState, NetworkSegmentSearchConfig, NetworkSegmentType,
 };
-use sqlx::{FromRow, PgConnection, PgTransaction, query_as};
+use sqlx::{FromRow, PgConnection, PgTransaction, query_as, query_scalar};
 
 use super::{ObjectColumnFilter, network_segment, vpc};
 use crate::db_read::DbReader;
@@ -198,6 +198,9 @@ fn validate(
 }
 
 /// Counts the amount of addresses that have been allocated for a given segment.
+///
+/// Keep this predicate in sync with [`segment_has_allocations`] (used by the
+/// segment-drain reconcile).
 pub async fn count_by_segment_id(
     txn: &mut PgConnection,
     segment_id: &NetworkSegmentId,
@@ -215,6 +218,31 @@ pub async fn count_by_segment_id(
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
     Ok(address_count.max(0) as usize)
+}
+
+/// Returns whether a segment still holds any IP allocation — a machine
+/// interface or an instance address bound to it.
+///
+/// The drain check only needs to know whether *any* allocation remains, so this
+/// answers it in a single round-trip: one query with two `EXISTS` subqueries,
+/// which Postgres can answer without necessarily probing both tables.
+/// Callers previously ran [`count_by_segment_id`] and
+/// [`crate::machine_interface::count_by_segment_id`] and summed the totals —
+/// two round-trips to compute a boolean. Both per-table count functions remain
+/// in production use for the can't-delete-yet error messages
+/// (`network_segment::mark_as_deleted`); keep this predicate in sync with them.
+pub async fn segment_has_allocations(
+    txn: &mut PgConnection,
+    segment_id: &NetworkSegmentId,
+) -> Result<bool, DatabaseError> {
+    let query = "SELECT \
+                 EXISTS(SELECT 1 FROM machine_interfaces WHERE segment_id = $1) \
+                 OR EXISTS(SELECT 1 FROM instance_addresses WHERE segment_id = $1::uuid)";
+    query_scalar(query)
+        .bind(segment_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 /// Tries to allocate IP addresses for a tenant network configuration
@@ -809,5 +837,158 @@ mod tests {
         let config = create_valid_network_config();
         data[9].status.controller_state.value = NetworkSegmentControllerState::Provisioning;
         assert!(super::validate(&data, &config, &[], false).is_err());
+    }
+}
+
+#[cfg(test)]
+mod segment_has_allocations_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use model::network_prefix::NewNetworkPrefix;
+    use model::network_segment::{
+        AllocationStrategy, NetworkSegmentControllerState, NetworkSegmentType, NewNetworkSegment,
+    };
+    use tracing::instrument::WithSubscriber;
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    /// Counts `sqlx::query*` tracing events so a measured block's round-trips can
+    /// be asserted. sqlx consults the *current* dispatcher when logging a
+    /// statement, so the scoped `Dispatch` installed by `with_subscriber` sees
+    /// these events regardless of the harness's global `sqlx=warn` filter.
+    #[derive(Clone, Default)]
+    struct QueryCounter(Arc<AtomicUsize>);
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
+        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
+            if e.metadata().target().starts_with("sqlx::query") {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Seeds a Ready segment plus one machine interface bound to it, so both the
+    /// old count path and the new EXISTS path see an allocation.
+    async fn seed_segment_with_interface(pool: &sqlx::PgPool) -> NetworkSegmentId {
+        let mut txn = pool.begin().await.unwrap();
+        let segment_id: NetworkSegmentId = uuid::Uuid::new_v4().into();
+        network_segment::persist(
+            NewNetworkSegment {
+                id: segment_id,
+                name: format!("seg-{segment_id}"),
+                subdomain_id: None,
+                vpc_id: None,
+                mtu: 1500,
+                prefixes: vec![NewNetworkPrefix {
+                    prefix: "10.9.0.0/24".parse().unwrap(),
+                    gateway: None,
+                    dhcpv6_link_address: None,
+                    num_reserved: 1,
+                }],
+                vlan_id: None,
+                vni: None,
+                segment_type: NetworkSegmentType::Underlay,
+                can_stretch: Some(false),
+                allocation_strategy: AllocationStrategy::Reserved,
+            },
+            txn.deref_mut(),
+            NetworkSegmentControllerState::Ready,
+        )
+        .await
+        .expect("seed segment");
+
+        // A machine interface bound to the segment is one form of allocation.
+        sqlx::query(
+            "INSERT INTO machine_interfaces (segment_id, mac_address, primary_interface, hostname) \
+             VALUES ($1, '02:00:00:00:00:01'::macaddr, true, 'drain-test-host')",
+        )
+        .bind(segment_id)
+        .execute(txn.deref_mut())
+        .await
+        .expect("seed machine interface");
+
+        txn.commit().await.unwrap();
+        segment_id
+    }
+
+    /// Bite-check the round-trip win: the old drain check issued two `count(*)`
+    /// queries (one per table) to compute a boolean, whereas
+    /// `segment_has_allocations` answers it in a single query. Measures 2 vs 1.
+    #[crate::sqlx_test]
+    async fn segment_has_allocations_is_one_round_trip(pool: sqlx::PgPool) {
+        let segment_id = seed_segment_with_interface(&pool).await;
+
+        // Old path: machine_interface::count_by_segment_id + instance_address::count_by_segment_id.
+        let old_counter = QueryCounter::default();
+        let seg = segment_id;
+        let pool_ref = &pool;
+        async {
+            let mut txn = pool_ref.begin().await.unwrap();
+            let mi = crate::machine_interface::count_by_segment_id(&mut txn, &seg)
+                .await
+                .unwrap();
+            let ia = count_by_segment_id(&mut txn, &seg).await.unwrap();
+            // The allocation we seeded is visible to the old summed check.
+            assert!(mi + ia > 0, "seeded interface should register");
+        }
+        .with_subscriber(tracing::Dispatch::new(
+            tracing_subscriber::registry().with(old_counter.clone()),
+        ))
+        .await;
+        let old_queries = old_counter.0.load(Ordering::Relaxed);
+
+        // New path: a single EXISTS-OR-EXISTS query.
+        let new_counter = QueryCounter::default();
+        let has = async {
+            let mut txn = pool_ref.begin().await.unwrap();
+            segment_has_allocations(&mut txn, &seg).await.unwrap()
+        }
+        .with_subscriber(tracing::Dispatch::new(
+            tracing_subscriber::registry().with(new_counter.clone()),
+        ))
+        .await;
+        let new_queries = new_counter.0.load(Ordering::Relaxed);
+
+        assert!(has, "segment_has_allocations must see the seeded interface");
+        assert_eq!(old_queries, 2, "old drain check issued two count queries");
+        assert_eq!(new_queries, 1, "segment_has_allocations issues one query");
+    }
+
+    /// A segment with no interfaces and no instance addresses reports no
+    /// allocations.
+    #[crate::sqlx_test]
+    async fn segment_has_allocations_false_when_empty(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let segment_id: NetworkSegmentId = uuid::Uuid::new_v4().into();
+        network_segment::persist(
+            NewNetworkSegment {
+                id: segment_id,
+                name: format!("empty-{segment_id}"),
+                subdomain_id: None,
+                vpc_id: None,
+                mtu: 1500,
+                prefixes: vec![NewNetworkPrefix {
+                    prefix: "10.9.1.0/24".parse().unwrap(),
+                    gateway: None,
+                    dhcpv6_link_address: None,
+                    num_reserved: 1,
+                }],
+                vlan_id: None,
+                vni: None,
+                segment_type: NetworkSegmentType::Underlay,
+                can_stretch: Some(false),
+                allocation_strategy: AllocationStrategy::Reserved,
+            },
+            txn.deref_mut(),
+            NetworkSegmentControllerState::Ready,
+        )
+        .await
+        .expect("seed empty segment");
+
+        let has = segment_has_allocations(&mut txn, &segment_id)
+            .await
+            .unwrap();
+        assert!(!has, "empty segment has no allocations");
     }
 }

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -484,6 +484,11 @@ pub async fn find_by_machine_ids(
     )
 }
 
+/// Counts the machine interfaces bound to a given segment.
+///
+/// Keep this predicate in sync with
+/// [`crate::instance_address::segment_has_allocations`] (used by the
+/// segment-drain reconcile).
 pub async fn count_by_segment_id(
     txn: &mut PgConnection,
     segment_id: &NetworkSegmentId,

--- a/crates/network-segment-controller/src/handler.rs
+++ b/crates/network-segment-controller/src/handler.rs
@@ -129,21 +129,16 @@ impl StateHandler for NetworkSegmentStateHandler {
                         // If ones are still allocated, we can not delete and have to
                         // update the `delete_at` timestamp.
                         let mut txn = ctx.services.db_pool.begin().await?;
-                        let num_machine_interfaces =
-                            db::machine_interface::count_by_segment_id(&mut txn, &state.id).await?;
-                        let num_instance_addresses =
-                            db::instance_address::count_by_segment_id(&mut txn, &state.id).await?;
-                        if num_machine_interfaces + num_instance_addresses > 0 {
+                        if db::instance_address::segment_has_allocations(&mut txn, &state.id)
+                            .await?
+                        {
                             let delete_at = chrono::Utc::now()
                                 .checked_add_signed(self.drain_period)
                                 .unwrap_or_else(chrono::Utc::now);
-                            let total_allocated_ips =
-                                num_machine_interfaces + num_instance_addresses;
                             tracing::info!(
                                 ?delete_at,
-                                total_allocated_ips,
                                 segment = %state.id,
-                                "{total_allocated_ips} allocated IPs for segment. Waiting for deletion until {delete_at:?}",
+                                "Segment still has allocated IPs; waiting until the drain deadline to delete",
                             );
                             let new_state = NetworkSegmentControllerState::Deleting {
                                 deletion_state: NetworkSegmentDeletionState::DrainAllocatedIps {

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -267,12 +267,12 @@ impl PreingestionManager {
         }
 
         metrics.machines_in_preingestion =
-            db::explored_endpoints::find_preingest_not_waiting_not_error(&db)
+            db::explored_endpoints::count_preingest_not_waiting_not_error(&db)
                 .await?
-                .len();
-        metrics.waiting_for_installation = db::explored_endpoints::find_preingest_installing(&db)
+                .max(0) as usize;
+        metrics.waiting_for_installation = db::explored_endpoints::count_preingest_installing(&db)
             .await?
-            .len();
+            .max(0) as usize;
 
         tracing::debug!(
             "Preingestion metrics: in_preingestion {} waiting {} delayed {}",


### PR DESCRIPTION
Several hot reads pulled full result sets only to count them: compute-allocation and instance-create loaded every matching instance id to take `.len()`, the preingestion metrics decoded every explored endpoint's multi-KB Redfish report jsonb just to count rows, and the network-segment drain ran two `COUNT(*)` round-trips to learn whether any allocation was left.

Each now asks the database directly:

- `instance::count_ids` -- `SELECT count(*)` built from the same WHERE builder as `find_ids`, so the two can't drift; callers compare an `i64` and drop a fallible conversion.
- `count_preingest_*` -- count matching endpoints without transferring or decoding the exploration-report jsonb (the WHERE lives in a shared `const` with the row-returning twin).
- `instance_address::segment_has_allocations` -- one `EXISTS ... OR EXISTS` query in place of the drain's two-count round-trip pair.

The row-returning readers stay for callers that need the data. Tests pin the wins: a query-count guard on the drain (2 -> 1), count/find parity guards on every conversion, and a filter-conjunction guard on `count_ids`.

This supports https://github.com/NVIDIA/infra-controller/issues/3217


Closes #3217
