### PR TITLE
feat: count validation and measured boot outcomes

### DIFF
--- a/crates/api-core/src/attestation/measured_boot.rs
+++ b/crates/api-core/src/attestation/measured_boot.rs
@@ -45,6 +45,41 @@ pub enum VerifyQuoteState {
     CompleteFailure,
 }
 
+/// Which check (or both) of a measured-boot quote failed verification.
+/// `VerificationError` covers a quote whose checks could not even run --
+/// malformed AK, signature, or attestation bytes, or an unsupported
+/// signature type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+pub(crate) enum MeasuredBootVerificationFailureCause {
+    SignatureInvalid,
+    HashMismatch,
+    SignatureAndHashMismatch,
+    VerificationError,
+}
+
+/// A measured-boot quote failed verification: the PCR signature, the PCR
+/// hash, or both did not check out -- or the checks themselves errored --
+/// and the attestation was rejected. The full TPM event log rides the log
+/// line as context, as these warn lines always included it; `error` holds
+/// the underlying reason when the checks errored.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_measured_boot_verification_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "measured boot quote verification failed",
+    describe = "Number of measured boot verification failures, across quote verification and attestation handling, by cause"
+)]
+pub(crate) struct MeasuredBootVerificationFailed {
+    #[label]
+    pub(crate) cause: MeasuredBootVerificationFailureCause,
+    #[context]
+    pub(crate) event_log: String,
+    #[context]
+    pub(crate) error: String,
+}
+
 impl VerifyQuoteState {
     pub fn from_results(signature_valid: bool, pcr_hash_matches: bool) -> Self {
         match (signature_valid, pcr_hash_matches) {
@@ -69,28 +104,31 @@ pub fn verify_quote_state(
     match quote_state {
         VerifyQuoteState::Success => Ok(()),
         VerifyQuoteState::SignatureInvalid => {
-            tracing::warn!(
-                "PCR signature invalid (event log: {}",
-                event_log_to_string(event_log)
-            );
+            carbide_instrument::emit(MeasuredBootVerificationFailed {
+                cause: MeasuredBootVerificationFailureCause::SignatureInvalid,
+                event_log: event_log_to_string(event_log),
+                error: String::new(),
+            });
             Err(CarbideError::AttestQuoteError(
                 "PCR signature invalid (see logs for full event log)".to_string(),
             ))
         }
         VerifyQuoteState::VerifyHashNoMatch => {
-            tracing::warn!(
-                "PCR hash mismatch (event log: {}",
-                event_log_to_string(event_log)
-            );
+            carbide_instrument::emit(MeasuredBootVerificationFailed {
+                cause: MeasuredBootVerificationFailureCause::HashMismatch,
+                event_log: event_log_to_string(event_log),
+                error: String::new(),
+            });
             Err(CarbideError::AttestQuoteError(
                 "PCR hash does not match (see logs for full event log)".to_string(),
             ))
         }
         VerifyQuoteState::CompleteFailure => {
-            tracing::warn!(
-                "PCR signature invalid and PCR hash mismatch (event log: {}",
-                event_log_to_string(event_log)
-            );
+            carbide_instrument::emit(MeasuredBootVerificationFailed {
+                cause: MeasuredBootVerificationFailureCause::SignatureAndHashMismatch,
+                event_log: event_log_to_string(event_log),
+                error: String::new(),
+            });
             Err(CarbideError::AttestQuoteError(
                 "PCR signature invalid and PCR hash mismatch (see logs for full event log)"
                     .to_string(),
@@ -480,6 +518,8 @@ pub mod linux_build {
 }
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
     use super::*;
 
     #[test]
@@ -493,6 +533,65 @@ mod tests {
                 e.to_string(),
                 "Attest Bind Key Error: Creds file is too short: 3 bytes"
             ),
+        }
+    }
+
+    /// Every failing verification writes one WARN line (the event log as a
+    /// field) AND moves the failure counter under its cause label; a passing
+    /// verification emits nothing. The `verification_error` cause -- the
+    /// checks themselves erroring in `attest_quote` -- rides the same event
+    /// with the underlying reason as the `error` field.
+    #[test]
+    fn verification_failure_logs_and_counts_by_cause() {
+        let event_log = Some(b"tpm event log".to_vec());
+
+        // The quote-failure DB tests each drive one cause once, from
+        // seconds-long flows that do not hold the capture lock -- the odds of
+        // one landing inside this capture window are negligible.
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            assert!(verify_quote_state(true, true, &event_log).is_ok());
+            assert!(verify_quote_state(false, true, &event_log).is_err());
+            assert!(verify_quote_state(true, false, &event_log).is_err());
+            assert!(verify_quote_state(false, false, &event_log).is_err());
+            carbide_instrument::emit(MeasuredBootVerificationFailed {
+                cause: MeasuredBootVerificationFailureCause::VerificationError,
+                event_log: event_log_to_string(&event_log),
+                error: "PCR signature verification failed: bad AK".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 4, "the success case must not log");
+        let field = |log: &carbide_instrument::testing::CapturedLog, name: &str| {
+            log.fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        };
+        for (log, cause_label, error) in [
+            (&logs[0], "signature_invalid", ""),
+            (&logs[1], "hash_mismatch", ""),
+            (&logs[2], "signature_and_hash_mismatch", ""),
+            (
+                &logs[3],
+                "verification_error",
+                "PCR signature verification failed: bad AK",
+            ),
+        ] {
+            assert_eq!(log.level, tracing::Level::WARN, "cause {cause_label}");
+            assert_eq!(log.message, "measured boot quote verification failed");
+            assert_eq!(field(log, "cause"), Some(cause_label.to_string()));
+            assert_eq!(field(log, "event_log"), Some("tpm event log".to_string()));
+            assert_eq!(field(log, "error"), Some(error.to_string()));
+
+            assert_eq!(
+                metrics.counter_delta(
+                    "carbide_measured_boot_verification_failures_total",
+                    &[("cause", cause_label)],
+                ),
+                1.0,
+                "counter for cause={cause_label}"
+            );
         }
     }
 }

--- a/crates/api-core/src/handlers/attestation.rs
+++ b/crates/api-core/src/handlers/attestation.rs
@@ -277,22 +277,25 @@ pub(crate) async fn attest_quote(
         &request.attestation,
         &request.signature,
     )
-    .inspect_err(|_| {
-        tracing::warn!(
-            "PCR signature verification failed (event log: {})",
-            crate::attestation::event_log_to_string(&request.event_log)
-        );
+    .inspect_err(|e| {
+        carbide_instrument::emit(crate::attestation::MeasuredBootVerificationFailed {
+            cause: crate::attestation::MeasuredBootVerificationFailureCause::VerificationError,
+            event_log: crate::attestation::event_log_to_string(&request.event_log),
+            error: format!("PCR signature verification failed: {e}"),
+        });
     })?;
 
     // Make sure we can verify the the PCR hash one way
     // or another. If it can't be, return an error.
     let pcr_hash_matches =
         crate::attestation::verify_pcr_hash(&request.attestation, &request.pcr_values)
-            .inspect_err(|_| {
-                tracing::warn!(
-                    "PCR hash verification failed (event log: {})",
-                    crate::attestation::event_log_to_string(&request.event_log)
-                );
+            .inspect_err(|e| {
+                carbide_instrument::emit(crate::attestation::MeasuredBootVerificationFailed {
+                    cause:
+                        crate::attestation::MeasuredBootVerificationFailureCause::VerificationError,
+                    event_log: crate::attestation::event_log_to_string(&request.event_log),
+                    error: format!("PCR hash verification failed: {e}"),
+                });
             })?;
 
     // And now pass on through the computed signature

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -38,6 +38,9 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::handlers::utils::convert_and_log_machine_id;
+use crate::machine_validation::{
+    MachineValidationCompleted, MachineValidationFailureCause, MachineValidationOutcome,
+};
 
 /// Temporary: when `true`, MV mutation handlers return `FailedPrecondition` and do not write to the DB.
 ///
@@ -95,29 +98,15 @@ pub(crate) async fn mark_machine_validation_complete(
     let mut state = MachineValidationState::Success;
 
     let machine_validation_error = req.machine_validation_error;
-    let machine_validation_results = match machine_validation_error.as_ref() {
-        Some(machine_validation_error) => {
-            state = MachineValidationState::Failed;
-            machine_validation_error.clone()
-        }
-        None => "Success".to_owned(),
-    };
+    if machine_validation_error.is_some() {
+        state = MachineValidationState::Failed;
+    }
 
-    let validation_result_error;
-    let result =
-        match db::machine_validation_result::validate_current_context(&mut txn, validation_id)
-            .await?
-        {
-            Some(error_message) => {
-                state = MachineValidationState::Failed;
-                validation_result_error = Some(error_message.clone());
-                error_message
-            }
-            None => {
-                validation_result_error = None;
-                "Success".to_owned()
-            }
-        };
+    let validation_result_error =
+        db::machine_validation_result::validate_current_context(&mut txn, validation_id).await?;
+    if validation_result_error.is_some() {
+        state = MachineValidationState::Failed;
+    }
 
     let completed = db::machine_validation::mark_machine_validation_complete(
         &mut txn,
@@ -138,6 +127,15 @@ pub(crate) async fn mark_machine_validation_complete(
         txn.commit().await?;
         return Ok(Response::new(rpc::MachineValidationCompletedResponse {}));
     }
+
+    // This call owns the run's active-to-terminal transition (checked above),
+    // so it emits the run's one completion event -- after the commit below.
+    let completion = completion_event(
+        machine_id,
+        *validation_id,
+        machine_validation_error.as_deref(),
+        validation_result_error.as_deref(),
+    );
 
     if let Some(machine_validation_error) = machine_validation_error {
         db::machine::update_failure_details_by_machine_id(
@@ -160,7 +158,13 @@ pub(crate) async fn mark_machine_validation_complete(
         updated_validation_health_report
             .alerts
             .push(health_report::HealthProbeAlert {
-                id: "FailedValidationTestCompletion".parse().unwrap(),
+                // The shared cause vocabulary names this alert, so the label
+                // and the alert id cannot drift apart.
+                id: MachineValidationFailureCause::FailedValidationTestCompletion
+                    .health_alert_id()
+                    .expect("a failure cause always names its alert")
+                    .parse()
+                    .unwrap(),
                 target: None,
                 in_alert_since: Some(chrono::Utc::now()),
                 message: format!(
@@ -195,15 +199,47 @@ pub(crate) async fn mark_machine_validation_complete(
 
     txn.commit().await?;
 
-    tracing::info!(
-        %machine_id,
-        result, "machine_validation_completed:machine_validation_results",
-    );
-    tracing::info!(
-        %machine_id,
-        machine_validation_results, "machine_validation_completed",
-    );
+    carbide_instrument::emit(completion);
     Ok(Response::new(rpc::MachineValidationCompletedResponse {}))
+}
+
+/// The completion event for a run, from the two failure channels the handler
+/// sees: a scout-reported run error means the run never completed its tests,
+/// which takes precedence over a failed test found in the recorded results; a
+/// run with neither passed. Both errors ride the log line when both are
+/// present.
+fn completion_event(
+    machine_id: carbide_uuid::machine::MachineId,
+    validation_id: carbide_uuid::machine_validation::MachineValidationId,
+    machine_validation_error: Option<&str>,
+    validation_result_error: Option<&str>,
+) -> MachineValidationCompleted {
+    let (outcome, cause) = match (machine_validation_error, validation_result_error) {
+        (None, None) => (
+            MachineValidationOutcome::Passed,
+            MachineValidationFailureCause::None,
+        ),
+        (Some(_), _) => (
+            MachineValidationOutcome::Failed,
+            MachineValidationFailureCause::FailedValidationTestCompletion,
+        ),
+        (None, Some(_)) => (
+            MachineValidationOutcome::Failed,
+            MachineValidationFailureCause::FailedValidationTest,
+        ),
+    };
+    let error = match (machine_validation_error, validation_result_error) {
+        (Some(run_error), Some(test_error)) => format!("{run_error}; {test_error}"),
+        (Some(error), None) | (None, Some(error)) => error.to_string(),
+        (None, None) => String::new(),
+    };
+    MachineValidationCompleted {
+        outcome,
+        cause,
+        machine_id,
+        validation_id,
+        error,
+    }
 }
 
 pub(crate) async fn persist_validation_result(
@@ -1083,4 +1119,82 @@ pub async fn apply_config_on_startup(
     txn.commit().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use super::*;
+
+    /// The handler's two failure channels map onto the bounded cause
+    /// vocabulary: the scout-reported run error outranks a failed test found
+    /// in the recorded results, and the error context keeps both texts when
+    /// both are present.
+    #[test]
+    fn completion_event_maps_error_channels_to_outcome_and_cause() {
+        struct Case {
+            scenario: &'static str,
+            machine_validation_error: Option<&'static str>,
+            validation_result_error: Option<&'static str>,
+            expect_outcome: MachineValidationOutcome,
+            expect_cause: MachineValidationFailureCause,
+            expect_error: &'static str,
+        }
+
+        let cases = [
+            Case {
+                scenario: "no errors passes",
+                machine_validation_error: None,
+                validation_result_error: None,
+                expect_outcome: MachineValidationOutcome::Passed,
+                expect_cause: MachineValidationFailureCause::None,
+                expect_error: "",
+            },
+            Case {
+                scenario: "scout-reported run error",
+                machine_validation_error: Some("scout died"),
+                validation_result_error: None,
+                expect_outcome: MachineValidationOutcome::Failed,
+                expect_cause: MachineValidationFailureCause::FailedValidationTestCompletion,
+                expect_error: "scout died",
+            },
+            Case {
+                scenario: "failed test in the recorded results",
+                machine_validation_error: None,
+                validation_result_error: Some("test exited 1"),
+                expect_outcome: MachineValidationOutcome::Failed,
+                expect_cause: MachineValidationFailureCause::FailedValidationTest,
+                expect_error: "test exited 1",
+            },
+            Case {
+                scenario: "run error outranks a failed test; both errors kept",
+                machine_validation_error: Some("scout died"),
+                validation_result_error: Some("test exited 1"),
+                expect_outcome: MachineValidationOutcome::Failed,
+                expect_cause: MachineValidationFailureCause::FailedValidationTestCompletion,
+                expect_error: "scout died; test exited 1",
+            },
+        ];
+
+        let machine_id = carbide_uuid::machine::MachineId::from_str(
+            "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
+        )
+        .expect("a valid machine id");
+        let validation_id = carbide_uuid::machine_validation::MachineValidationId::new();
+
+        for case in cases {
+            let event = completion_event(
+                machine_id,
+                validation_id,
+                case.machine_validation_error,
+                case.validation_result_error,
+            );
+            assert_eq!(event.outcome, case.expect_outcome, "{}", case.scenario);
+            assert_eq!(event.cause, case.expect_cause, "{}", case.scenario);
+            assert_eq!(event.machine_id, machine_id, "{}", case.scenario);
+            assert_eq!(event.validation_id, validation_id, "{}", case.scenario);
+            assert_eq!(event.error, case.expect_error, "{}", case.scenario);
+        }
+    }
 }

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -36,6 +36,89 @@ use tokio_util::sync::CancellationToken;
 use self::metrics::MachineValidationMetrics;
 use crate::CarbideResult;
 
+/// The terminal outcome of a machine validation run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+pub(crate) enum MachineValidationOutcome {
+    Passed,
+    Failed,
+}
+
+/// Why a machine validation run failed, in the vocabulary of the
+/// health-report alert ids the completion paths record. `None` is the label
+/// value for a passed run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+pub(crate) enum MachineValidationFailureCause {
+    None,
+    FailedValidationRunItems,
+    FailedValidationTest,
+    FailedValidationTestCompletion,
+    StaleMachineValidationAttempt,
+    StaleMachineValidationRun,
+}
+
+impl MachineValidationFailureCause {
+    /// The health-report alert id recorded for this failure cause; `None` is
+    /// the passed-run label value and records no alert.
+    pub(crate) fn health_alert_id(self) -> Option<&'static str> {
+        match self {
+            Self::None => None,
+            Self::FailedValidationRunItems => Some("FailedValidationRunItems"),
+            Self::FailedValidationTest => Some("FailedValidationTest"),
+            Self::FailedValidationTestCompletion => Some("FailedValidationTestCompletion"),
+            Self::StaleMachineValidationAttempt => Some("StaleMachineValidationAttempt"),
+            Self::StaleMachineValidationRun => Some("StaleMachineValidationRun"),
+        }
+    }
+}
+
+/// A machine validation run completed as passed or failed -- reported by
+/// scout through the completion handler, or reconciled by the manager when
+/// every run item is terminal or the run goes stale. Every emitting path
+/// sits behind the run's single active-to-terminal transition in the
+/// database, so a run counts at most once and the per-cause rate is the
+/// validation pass/fail funnel.
+///
+/// Runs that a disabled validation config skips are deliberately not
+/// counted: the machine controller flips them to `Skipped` through the same
+/// database gate without emitting. If skips ever become worth counting, an
+/// `outcome = Skipped` variant slots in beside `Passed`/`Failed`.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_machine_validation_outcomes_total",
+    component = "nico-api",
+    log = dynamic,
+    metric = counter,
+    message = "machine validation completed",
+    describe = "Number of machine validation runs that completed as passed or failed, by outcome and failure cause; runs skipped by a disabled validation config are not counted"
+)]
+pub(crate) struct MachineValidationCompleted {
+    #[label]
+    pub(crate) outcome: MachineValidationOutcome,
+    #[label]
+    pub(crate) cause: MachineValidationFailureCause,
+    #[context]
+    pub(crate) machine_id: carbide_uuid::machine::MachineId,
+    #[context]
+    pub(crate) validation_id: carbide_uuid::machine_validation::MachineValidationId,
+    #[context]
+    pub(crate) error: String,
+}
+
+/// A passed run logs as routine progress; a failed run logs at the warning
+/// level the stale-run reconciler already used.
+impl carbide_instrument::DynamicLog for MachineValidationCompleted {
+    fn log_at(&self) -> carbide_instrument::LogAt {
+        match self.outcome {
+            MachineValidationOutcome::Passed => {
+                carbide_instrument::LogAt::Level(tracing::Level::INFO)
+            }
+            MachineValidationOutcome::Failed => {
+                carbide_instrument::LogAt::Level(tracing::Level::WARN)
+            }
+        }
+    }
+}
+
 pub struct MachineValidationManager {
     database_connection: sqlx::PgPool,
     config: MachineValidationConfig,
@@ -106,13 +189,22 @@ impl MachineValidationManager {
     /// Returns true if we stopped early due to a timeout.
     pub async fn run_single_iteration(&self) -> CarbideResult<()> {
         let mut metrics = MachineValidationMetrics::new();
+        // Completion events for the runs this iteration transitions, emitted
+        // only after the transaction commits: an iteration that fails and
+        // rolls back leaves the runs active, so an early emit would count
+        // them again when the next iteration re-flips the gate.
+        let mut completions: Vec<MachineValidationCompleted> = Vec::new();
 
         let mut txn = db::Transaction::begin(&self.database_connection).await?;
         let now = chrono::Utc::now();
         let heartbeat_stale_timeout = heartbeat_stale_timeout(self.config.stale_run_timeout);
 
         for validation in db::machine_validation::find_active(&mut txn).await? {
-            reconcile_terminal_run_items(txn.as_pgconn(), validation).await?;
+            if let Some(completion) =
+                reconcile_terminal_run_items(txn.as_pgconn(), validation).await?
+            {
+                completions.push(completion);
+            }
         }
 
         let stale_attempts = db::machine_validation_execution::find_stale_active_attempts(
@@ -126,8 +218,11 @@ impl MachineValidationManager {
             .into_iter()
             .filter(|attempt| attempt.last_heartbeat_at.is_some())
         {
-            if reconcile_stale_attempt(txn.as_pgconn(), stale_attempt, now).await? {
+            if let Some(completion) =
+                reconcile_stale_attempt(txn.as_pgconn(), stale_attempt, now).await?
+            {
                 metrics.stale_validation += 1;
+                completions.push(completion);
             }
         }
 
@@ -139,7 +234,7 @@ impl MachineValidationManager {
         );
 
         for validation in stale_validations {
-            if reconcile_stale_validation(
+            if let Some(completion) = reconcile_stale_validation(
                 txn.as_pgconn(),
                 validation,
                 self.config.stale_run_timeout,
@@ -148,6 +243,7 @@ impl MachineValidationManager {
             .await?
             {
                 metrics.stale_validation += 1;
+                completions.push(completion);
             }
         }
 
@@ -193,6 +289,12 @@ impl MachineValidationManager {
         self.metric_holder.update_metrics(metrics);
 
         txn.commit().await?;
+
+        // The transitions are durable now, so count (and log) each completion
+        // exactly once.
+        for completion in completions {
+            carbide_instrument::emit(completion);
+        }
 
         Ok(())
     }
@@ -242,16 +344,20 @@ fn stale_validations(
         .collect()
 }
 
+// Each reconcile function returns the completion event for the run it
+// transitioned (`None` when another path already completed it) instead of
+// emitting: the caller's transaction is still open, and the event must not
+// count a transition that later rolls back.
 async fn reconcile_terminal_run_items(
     txn: &mut sqlx::PgConnection,
     validation: MachineValidation,
-) -> CarbideResult<bool> {
+) -> CarbideResult<Option<MachineValidationCompleted>> {
     let run_items =
         db::machine_validation_execution::find_run_items_by_run_id(&mut *txn, &validation.id)
             .await?;
 
     if run_items.is_empty() || !run_items.iter().all(run_item_is_terminal) {
-        return Ok(false);
+        return Ok(None);
     }
 
     if run_items
@@ -272,7 +378,7 @@ async fn reconcile_terminal_run_items(
             txn,
             &validation.id,
             error_message,
-            "FailedValidationRunItems",
+            MachineValidationFailureCause::FailedValidationRunItems,
         )
         .await;
     }
@@ -288,7 +394,13 @@ async fn reconcile_terminal_run_items(
         status,
     )
     .await?;
-    Ok(completed)
+    Ok(completed.then(|| MachineValidationCompleted {
+        outcome: MachineValidationOutcome::Passed,
+        cause: MachineValidationFailureCause::None,
+        machine_id: validation.machine_id,
+        validation_id: validation.id,
+        error: String::new(),
+    }))
 }
 
 fn run_item_is_terminal(run_item: &MachineValidationRunItem) -> bool {
@@ -304,7 +416,7 @@ async fn reconcile_stale_attempt(
     txn: &mut sqlx::PgConnection,
     stale_attempt: db::machine_validation_execution::StaleMachineValidationAttempt,
     now: chrono::DateTime<chrono::Utc>,
-) -> CarbideResult<bool> {
+) -> CarbideResult<Option<MachineValidationCompleted>> {
     let error_message = format!(
         "Machine validation attempt {} for test {} in run {} stopped heartbeating or exceeded its timeout",
         stale_attempt.attempt_id, stale_attempt.test_id, stale_attempt.validation_id
@@ -322,14 +434,14 @@ async fn reconcile_stale_attempt(
             attempt_id = %stale_attempt.attempt_id,
             "skipping stale machine validation attempt because it is no longer active"
         );
-        return Ok(false);
+        return Ok(None);
     };
 
     complete_active_validation_as_failed(
         txn,
         &validation_id,
         error_message,
-        "StaleMachineValidationAttempt",
+        MachineValidationFailureCause::StaleMachineValidationAttempt,
     )
     .await
 }
@@ -338,8 +450,8 @@ async fn complete_active_validation_as_failed(
     txn: &mut sqlx::PgConnection,
     validation_id: &carbide_uuid::machine_validation::MachineValidationId,
     error_message: String,
-    alert_id: &str,
-) -> CarbideResult<bool> {
+    cause: MachineValidationFailureCause,
+) -> CarbideResult<Option<MachineValidationCompleted>> {
     let validation = db::machine_validation::find_by_id(&mut *txn, validation_id).await?;
     let status = MachineValidationStatus {
         state: MachineValidationState::Failed,
@@ -354,11 +466,13 @@ async fn complete_active_validation_as_failed(
     )
     .await?;
 
-    if completed {
-        record_failed_validation_side_effects(txn, &validation, error_message, alert_id).await?;
+    if !completed {
+        return Ok(None);
     }
 
-    Ok(completed)
+    let completion =
+        record_failed_validation_side_effects(txn, &validation, error_message, cause).await?;
+    Ok(Some(completion))
 }
 
 async fn reconcile_stale_validation(
@@ -366,9 +480,10 @@ async fn reconcile_stale_validation(
     validation: MachineValidation,
     stale_run_timeout: std::time::Duration,
     now: chrono::DateTime<chrono::Utc>,
-) -> CarbideResult<bool> {
-    // Returns true only when this call actually transitions an active stale run.
-    // False means another path already completed or reconciled the run.
+) -> CarbideResult<Option<MachineValidationCompleted>> {
+    // Returns the completion only when this call actually transitions an
+    // active stale run. `None` means another path already completed or
+    // reconciled the run.
     let error_message = format!(
         "Machine validation run {} exceeded its expected duration plus stale timeout",
         validation.id
@@ -392,40 +507,52 @@ async fn reconcile_stale_validation(
             validation_id = %validation.id,
             "skipping stale machine validation because it is no longer active or stale"
         );
-        return Ok(false);
+        return Ok(None);
     };
 
-    record_failed_validation_side_effects(
+    let completion = record_failed_validation_side_effects(
         txn,
         &validation,
-        error_message.clone(),
-        "StaleMachineValidationRun",
+        error_message,
+        MachineValidationFailureCause::StaleMachineValidationRun,
     )
     .await?;
 
-    tracing::warn!(
-        validation_id = %validation.id,
-        machine_id = %validation.machine_id,
-        error = %error_message,
-        "reconciled stale machine validation run"
-    );
-
-    Ok(true)
+    Ok(Some(completion))
 }
 
 async fn record_failed_validation_side_effects(
     txn: &mut sqlx::PgConnection,
     validation: &MachineValidation,
     error_message: String,
-    alert_id: &str,
-) -> CarbideResult<()> {
+    cause: MachineValidationFailureCause,
+) -> CarbideResult<MachineValidationCompleted> {
+    // The caller just transitioned this run from active to terminal, so this
+    // builds the run's one completion event; the manager emits it after the
+    // iteration's transaction commits. The run counts even when the owning
+    // machine lookup below comes up empty.
+    let completion = MachineValidationCompleted {
+        outcome: MachineValidationOutcome::Failed,
+        cause,
+        machine_id: validation.machine_id,
+        validation_id: validation.id,
+        error: error_message.clone(),
+    };
+
+    let Some(alert_id) = cause.health_alert_id() else {
+        // Unreachable from the completion paths: every caller passes a
+        // failure cause. Without an alert id there are no side effects to
+        // record.
+        return Ok(completion);
+    };
+
     let Some(machine) = db::machine::find_by_validation_id(txn, &validation.id).await? else {
         tracing::warn!(
             validation_id = %validation.id,
             machine_id = %validation.machine_id,
             "failed machine validation has no owning machine"
         );
-        return Ok(());
+        return Ok(completion);
     };
 
     db::machine::update_failure_details_by_machine_id(
@@ -456,7 +583,7 @@ async fn record_failed_validation_side_effects(
     db::machine::set_machine_validation_request(txn, &machine.id, false).await?;
     db::machine::update_machine_validation_time(&machine.id, txn).await?;
 
-    Ok(())
+    Ok(completion)
 }
 
 #[cfg(test)]
@@ -519,5 +646,121 @@ mod tests {
         );
 
         assert!(stale.is_empty());
+    }
+
+    /// One completion emit writes the log line at the outcome's level -- INFO
+    /// for a passed run, WARN for every failure cause -- with the ids and
+    /// error as fields, AND moves the outcome counter under the snake_case
+    /// labels.
+    #[test]
+    fn completion_logs_and_counts_by_outcome_and_cause() {
+        use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
+                .expect("a valid machine id");
+        let validation_id = MachineValidationId::new();
+
+        let combos = [
+            (
+                MachineValidationOutcome::Passed,
+                MachineValidationFailureCause::None,
+                "",
+            ),
+            (
+                MachineValidationOutcome::Failed,
+                MachineValidationFailureCause::FailedValidationRunItems,
+                "run item failed",
+            ),
+            (
+                MachineValidationOutcome::Failed,
+                MachineValidationFailureCause::FailedValidationTest,
+                "test failed",
+            ),
+            (
+                MachineValidationOutcome::Failed,
+                MachineValidationFailureCause::FailedValidationTestCompletion,
+                "run did not complete",
+            ),
+            (
+                MachineValidationOutcome::Failed,
+                MachineValidationFailureCause::StaleMachineValidationAttempt,
+                "attempt stopped heartbeating",
+            ),
+            (
+                MachineValidationOutcome::Failed,
+                MachineValidationFailureCause::StaleMachineValidationRun,
+                "run exceeded its timeout",
+            ),
+        ];
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            for (outcome, cause, error) in combos {
+                carbide_instrument::emit(MachineValidationCompleted {
+                    outcome,
+                    cause,
+                    machine_id,
+                    validation_id,
+                    error: error.to_string(),
+                });
+            }
+        });
+
+        assert_eq!(logs.len(), 6);
+        let field = |log: &carbide_instrument::testing::CapturedLog, name: &str| {
+            log.fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.clone())
+        };
+        for log in &logs {
+            assert_eq!(log.message, "machine validation completed");
+            assert_eq!(field(log, "machine_id"), Some(machine_id.to_string()));
+            assert_eq!(field(log, "validation_id"), Some(validation_id.to_string()));
+        }
+        assert_eq!(logs[0].level, tracing::Level::INFO);
+        assert_eq!(field(&logs[0], "outcome"), Some("passed".to_string()));
+        assert_eq!(field(&logs[0], "cause"), Some("none".to_string()));
+        assert_eq!(field(&logs[0], "error"), Some(String::new()));
+        for (log, cause_label, error) in [
+            (&logs[1], "failed_validation_run_items", "run item failed"),
+            (&logs[2], "failed_validation_test", "test failed"),
+            (
+                &logs[3],
+                "failed_validation_test_completion",
+                "run did not complete",
+            ),
+            (
+                &logs[4],
+                "stale_machine_validation_attempt",
+                "attempt stopped heartbeating",
+            ),
+            (
+                &logs[5],
+                "stale_machine_validation_run",
+                "run exceeded its timeout",
+            ),
+        ] {
+            assert_eq!(log.level, tracing::Level::WARN, "cause {cause_label}");
+            assert_eq!(field(log, "outcome"), Some("failed".to_string()));
+            assert_eq!(field(log, "cause"), Some(cause_label.to_string()));
+            assert_eq!(field(log, "error"), Some(error.to_string()));
+        }
+
+        // The exact-delta assertion sticks to the one (outcome, cause) pair
+        // no DB-gated completion-flow test in this binary drives (the others
+        // emit from the product funnels without holding the capture lock), so
+        // a parallel run cannot inflate it.
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_machine_validation_outcomes_total",
+                &[
+                    ("outcome", "failed"),
+                    ("cause", "failed_validation_run_items"),
+                ],
+            ),
+            1.0,
+        );
     }
 }

--- a/crates/api-core/src/measured_boot/metrics_collector/mod.rs
+++ b/crates/api-core/src/measured_boot/metrics_collector/mod.rs
@@ -30,6 +30,26 @@ pub(crate) mod metrics;
 use carbide_uuid::measured_boot::MeasurementBundleId;
 use metrics::MeasuredBootMetricsCollectorMetrics;
 
+/// One full pass of the measured-boot metrics collector over profiles,
+/// bundles, and machines. Never logged -- the collector has always been
+/// silent about routine iterations -- but the histogram's per-outcome
+/// `_count` is the iteration and error rate, and the distribution is what a
+/// pass costs as the site's measured-boot data grows.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_measured_boot_collector_iteration_latency_milliseconds",
+    component = "nico-api",
+    log = off,
+    metric = histogram,
+    describe = "Number of milliseconds a full measured boot metrics collector iteration took, by outcome"
+)]
+struct MeasuredBootCollectorIteration {
+    #[label]
+    outcome: carbide_instrument::Outcome,
+    #[observation]
+    took: std::time::Duration,
+}
+
 /// `MeasuredBootMetricsCollector` monitors the state of all measured boot data.
 pub struct MeasuredBootMetricsCollector {
     database_connection: sqlx::PgPool,
@@ -94,6 +114,16 @@ impl MeasuredBootMetricsCollector {
     }
 
     pub async fn run_single_iteration(&self) -> CarbideResult<()> {
+        let started = std::time::Instant::now();
+        let result = self.collect_metrics().await;
+        carbide_instrument::emit(MeasuredBootCollectorIteration {
+            outcome: carbide_instrument::Outcome::from(&result),
+            took: started.elapsed(),
+        });
+        result
+    }
+
+    async fn collect_metrics(&self) -> CarbideResult<()> {
         let mut metrics = MeasuredBootMetricsCollectorMetrics::new();
 
         let mut txn = db::Transaction::begin(&self.database_connection).await?;
@@ -183,5 +213,54 @@ fn get_bundle_state(
         }
     } else {
         MeasurementBundleState::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::*;
+
+    /// The iteration event is metric-only: each outcome records its duration
+    /// in milliseconds under the shared outcome label, and no log line is
+    /// constructed at all. (Nothing else in this test binary drives the
+    /// collector, so the exact per-label deltas are race-free.)
+    #[test]
+    fn collector_iteration_records_latency_without_logging() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            carbide_instrument::emit(MeasuredBootCollectorIteration {
+                outcome: carbide_instrument::Outcome::Ok,
+                took: std::time::Duration::from_millis(1500),
+            });
+            carbide_instrument::emit(MeasuredBootCollectorIteration {
+                outcome: carbide_instrument::Outcome::Error,
+                took: std::time::Duration::from_millis(250),
+            });
+        });
+
+        assert!(
+            logs.is_empty(),
+            "log = off must build no log line: {logs:?}"
+        );
+        for (outcome, milliseconds) in [("ok", 1500.0), ("error", 250.0)] {
+            assert_eq!(
+                metrics.histogram_count_delta(
+                    "carbide_measured_boot_collector_iteration_latency_milliseconds",
+                    &[("outcome", outcome)],
+                ),
+                1,
+                "observation count for outcome={outcome}"
+            );
+            assert_eq!(
+                metrics.histogram_sum_delta(
+                    "carbide_measured_boot_collector_iteration_latency_milliseconds",
+                    &[("outcome", outcome)],
+                ),
+                milliseconds,
+                "recorded milliseconds for outcome={outcome}"
+            );
+        }
     }
 }

--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -2120,6 +2120,12 @@ async fn test_machine_validation_manager_reconciles_stale_run(
 
     let mut config = env.config.machine_validation_config.clone();
     config.stale_run_timeout = std::time::Duration::from_secs(1);
+    // Reconciling the stale run is the run's one completion, so the outcome
+    // counter must move exactly once under the stale-run cause. Only this
+    // test drives that cause through the product funnel, and the emit-level
+    // test serializes behind the same capture lock, so the exact delta is
+    // race-free.
+    let metrics = carbide_instrument::testing::MetricsCapture::start();
     crate::machine_validation::MachineValidationManager::new(
         env.pool.clone(),
         config,
@@ -2127,6 +2133,17 @@ async fn test_machine_validation_manager_reconciles_stale_run(
     )
     .run_single_iteration()
     .await?;
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_machine_validation_outcomes_total",
+            &[
+                ("outcome", "failed"),
+                ("cause", "stale_machine_validation_run"),
+            ],
+        ),
+        1.0
+    );
+    drop(metrics);
 
     let late_result_name = "late-stale-result".to_string();
     env.api

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -68,6 +68,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_machine_validation_failed</td><td>gauge</td><td>Count of machine validation that have failed</td></tr>
 <tr><td>carbide_machine_validation_in_progress</td><td>gauge</td><td>Count of machine validation that are in progress</td></tr>
 <tr><td>carbide_machine_validation_oldest_active_age_seconds</td><td>gauge</td><td>Age in seconds of the oldest active machine validation run</td></tr>
+<tr><td>carbide_machine_validation_outcomes_total</td><td>counter</td><td>Number of machine validation runs that completed as passed or failed, by outcome and failure cause; runs skipped by a disabled validation config are not counted</td></tr>
 <tr><td>carbide_machine_validation_stale_runs_count</td><td>gauge</td><td>Count of active machine validation runs considered stale</td></tr>
 <tr><td>carbide_machine_validation_tests</td><td>gauge</td><td>The details of machine validation tests</td></tr>
 <tr><td>carbide_machines_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_machines in the system</td></tr>
@@ -87,10 +88,12 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_machines_total</td><td>gauge</td><td>The total number of carbide_machines in the system</td></tr>
 <tr><td>carbide_machines_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_machines in the system with a given state that failed state handling</td></tr>
 <tr><td>carbide_measured_boot_bundles_total</td><td>gauge</td><td>The total number of measured boot bundles.</td></tr>
+<tr><td>carbide_measured_boot_collector_iteration_latency_milliseconds</td><td>histogram</td><td>Number of milliseconds a full measured boot metrics collector iteration took, by outcome</td></tr>
 <tr><td>carbide_measured_boot_machines_per_bundle_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot bundle state.</td></tr>
 <tr><td>carbide_measured_boot_machines_per_machine_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot machine state.</td></tr>
 <tr><td>carbide_measured_boot_machines_total</td><td>gauge</td><td>The total number of machines reporting measurements.</td></tr>
 <tr><td>carbide_measured_boot_profiles_total</td><td>gauge</td><td>The total number of measured boot profiles.</td></tr>
+<tr><td>carbide_measured_boot_verification_failures_total</td><td>counter</td><td>Number of measured boot verification failures, across quote verification and attestation handling, by cause</td></tr>
 <tr><td>carbide_network_segments_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_network_segments in the system</td></tr>
 <tr><td>carbide_network_segments_handler_latency_in_state_milliseconds</td><td>histogram</td><td>The amount of time it took to invoke the state handler for objects of type carbide_network_segments in a certain state</td></tr>
 <tr><td>carbide_network_segments_iteration_latency_milliseconds</td><td>histogram</td><td>The elapsed time in the last state processor iteration to handle objects of type carbide_network_segments</td></tr>


### PR DESCRIPTION
Machine validation completions and measured-boot verification failures are logged and persisted but never counted -- "what fraction of validations fail, and why" and "are attestation quotes failing" have no dashboard answer, and stale-timeout storms are indistinguishable from genuine test failures. This makes all of it countable.

- `carbide_machine_validation_outcomes_total{outcome, cause}` -- every validation run that completes as passed or failed, with the cause vocabulary drawn from the code's own health-alert ids so the label and the alert can never drift. Emitted exactly once per committed completion across all three completion paths (the scout-driven handler, the manager's failure funnel, and the manager's reconciled successes -- a path the plan had missed); manager-side events accumulate during the iteration and emit only after its transaction commits, so a rolled-back flip never counts. Runs skipped by a disabled validation config are deliberately not counted, and the description says so.
- `carbide_measured_boot_verification_failures_total{cause}` -- quote verifications that failed, split `signature_invalid` / `hash_mismatch` / `signature_and_hash_mismatch` / `verification_error` (the checks could not even run -- malformed bytes, unsupported signature type); the events own the historical warn lines, keeping the TPM event log as a structured field and adding the underlying error the old lines never included.
- `carbide_measured_boot_collector_iteration_latency_milliseconds{outcome}` -- the metrics collector's iteration, timed for the first time; metric-only, since it never logged.

Notable details:

- Alert-cause coupling is structural: the funnel takes the typed cause and derives the alert-id string from it, and the handler's one literal now routes through the same vocabulary.
- Eight log lines were consolidated into the events at their historical levels; the removed message strings are listed in this description's review thread for anyone with dashboards pinned to them: the two handler completion INFOs, the stale-run WARN, and the five PCR-verification WARNs (whose old texts survive as the error field's prefix).
- The frozen validation and measured-boot gauges are untouched, and the collector's golden fixture is unaffected (framework events ride the global meter, not its local test provider).

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3175
