### PR TITLE
feat(machine-a-tron): add machine status API and minimal UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,6 +2347,7 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1187,6 +1187,7 @@ where
         carbide_api_url: format!("https://{}:{}", api_addr.ip(), api_addr.port()),
         log_file: None,
         bmc_mock_port: 0, // unused, we're using dynamic ports on localhost
+        bmc_mock_certs_dir: None,
         interface: String::from("UNUSED"), // unused, we're using dynamic ports on localhost
         tui_enabled: false,
         use_single_bmc_mock: false, // unused, we're constructing machines ourselves

--- a/crates/bmc-mock/src/combined_server.rs
+++ b/crates/bmc-mock/src/combined_server.rs
@@ -19,14 +19,13 @@ use std::collections::HashMap;
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 
-use axum::{Router, ServiceExt};
+use axum::Router;
 use axum_server::tls_rustls::RustlsConfig;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use tower::Layer;
 use tower_http::normalize_path::NormalizePathLayer;
 
-use crate::combined_service::CombinedService;
+use crate::combined_service::combined_router;
 
 pub enum ListenerOrAddress {
     Listener(TcpListener),
@@ -75,6 +74,20 @@ impl CombinedServer {
         listener_or_address: Option<ListenerOrAddress>,
         server_config: rustls::ServerConfig,
     ) -> Self {
+        Self::run_router(
+            name,
+            combined_router(routers_by_ip_address),
+            listener_or_address,
+            server_config,
+        )
+    }
+
+    pub fn run_router(
+        name: &str,
+        router: Router,
+        listener_or_address: Option<ListenerOrAddress>,
+        server_config: rustls::ServerConfig,
+    ) -> Self {
         let config = RustlsConfig::from_config(Arc::new(server_config));
 
         let axum_handle = axum_server::Handle::new();
@@ -103,15 +116,13 @@ impl CombinedServer {
         };
         tracing::info!("Listening on {}", addr);
 
-        let service = CombinedService::new(routers_by_ip_address);
-
         // Inject middleware to normalize request URIs by dropping the trailing slash
-        let service = NormalizePathLayer::trim_trailing_slash().layer(service);
+        let router = router.layer(NormalizePathLayer::trim_trailing_slash());
         let join_handle = tokio::task::Builder::new()
             .name(name)
             .spawn(async move {
                 server
-                    .serve(service.into_make_service())
+                    .serve(router.into_make_service())
                     .await
                     .inspect_err(|e| {
                         tracing::error!("BMC mock could not listen on address {}: {}", addr, e)

--- a/crates/bmc-mock/src/combined_service.rs
+++ b/crates/bmc-mock/src/combined_service.rs
@@ -16,85 +16,164 @@
  */
 
 use std::collections::HashMap;
-use std::convert::Infallible;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use axum::Router;
 use axum::body::Body;
+use axum::extract::State;
 use axum::http::header::{FORWARDED, HOST};
 use axum::http::{Request, StatusCode};
 use axum::response::Response;
-use hyper::body::Incoming;
+use axum::routing::any;
 use tokio::sync::RwLock;
-use tower::Service;
 
-/// Tower srvice for multiplexed axum::Routers on a single IP/port.
+use crate::http::call_router_with_new_request;
+
+/// Multiplexed axum::Routers on a single IP/port.
 ///
 /// HTTP header `forwarded` is used to route the request to the
 /// appropriate entry.
 ///
 /// Note: that this code is not BMC-mock specific and potentially can
 /// be separate crate if needed.
+pub fn combined_router(routers: Arc<RwLock<HashMap<String, Router>>>) -> Router {
+    Router::new()
+        .route("/{*all}", any(process))
+        .with_state(CombinedRouter { routers })
+}
+
 #[derive(Clone)]
-pub struct CombinedService {
+struct CombinedRouter {
     routers: Arc<RwLock<HashMap<String, Router>>>,
 }
 
-impl CombinedService {
-    pub fn new(routers: Arc<RwLock<HashMap<String, Router>>>) -> Self {
-        Self { routers }
+async fn process(
+    State(state): State<CombinedRouter>,
+    request: axum::http::Request<Body>,
+) -> Response {
+    let forwarded_host = forwarded_host(&request);
+    let host = request
+        .headers()
+        .get(HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(ToOwned::to_owned);
+    let authority = request.uri().authority().map(|v| v.as_str().to_owned());
+    let router = find_router(
+        &state.routers,
+        forwarded_host.as_deref(),
+        host.as_deref(),
+        authority.as_deref(),
+    )
+    .await;
+
+    if let Some(mut router) = router {
+        call_router_with_new_request(&mut router, request).await
+    } else {
+        no_router_response(
+            forwarded_host.as_deref(),
+            host.as_deref(),
+            authority.as_deref(),
+        )
     }
 }
 
-impl Service<axum::http::Request<Incoming>> for CombinedService {
-    type Response = Response<Body>;
-    type Error = Infallible;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+fn forwarded_host<B>(request: &Request<B>) -> Option<String> {
+    request
+        .headers()
+        .get(FORWARDED)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|fh| {
+            fh.split(';')
+                .find(|substr| substr.starts_with("host="))
+                .map(|substr| substr.replace("host=", ""))
+        })
+}
 
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        std::task::Poll::Ready(Ok(()))
+async fn find_router(
+    routers: &Arc<RwLock<HashMap<String, Router>>>,
+    forwarded_host: Option<&str>,
+    host: Option<&str>,
+    authority: Option<&str>,
+) -> Option<Router> {
+    let routers = routers.read().await;
+    forwarded_host
+        .and_then(|forwarded_host| routers.get(forwarded_host).cloned())
+        .or_else(|| host.and_then(|host| routers.get(host).cloned()))
+        .or_else(|| authority.and_then(|authority| routers.get(authority).cloned()))
+        .or_else(|| routers.get("").cloned())
+}
+
+fn no_router_response(
+    forwarded_host: Option<&str>,
+    host: Option<&str>,
+    authority: Option<&str>,
+) -> Response {
+    let err = format!(
+        "no router configured for forwarded_host/host/authority: {forwarded_host:?}/{host:?}/{authority:?}"
+    );
+    tracing::info!("{err}");
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(err.into())
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tokio::sync::RwLock;
+    use tower::ServiceExt;
+
+    use super::combined_router;
+
+    #[tokio::test]
+    async fn routes_by_forwarded_host() {
+        let router = combined_router(Arc::new(RwLock::new(HashMap::from([(
+            "172.20.0.20".to_string(),
+            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+        )]))));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1")
+                    .header("forwarded", "host=172.20.0.20")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"bmc");
     }
 
-    fn call(&mut self, request: Request<Incoming>) -> Self::Future {
-        let routers = self.routers.clone();
-        Box::pin(async move {
-            // https://datatracker.ietf.org/doc/html/rfc7239#section-5.3
-            let forwarded_host = request
-                .headers()
-                .get(FORWARDED)
-                .and_then(|v| v.to_str().ok())
-                .and_then(|fh| {
-                    fh.split(';')
-                        .find(|substr| substr.starts_with("host="))
-                        .map(|substr| substr.replace("host=", ""))
-                });
-            let host = request.headers().get(HOST).and_then(|v| v.to_str().ok());
-            let authority = request.uri().authority().map(|v| v.as_str());
-            let routers = routers.read().await;
-            let router = forwarded_host
-                .as_ref()
-                .and_then(|forwarded_host| routers.get(forwarded_host).cloned())
-                .or_else(|| host.and_then(|host| routers.get(host).cloned()))
-                .or_else(|| authority.and_then(|authority| routers.get(authority).cloned()))
-                .or_else(|| routers.get("").cloned());
-            drop(routers);
+    #[tokio::test]
+    async fn preserves_empty_key_fallback() {
+        let router = combined_router(Arc::new(RwLock::new(HashMap::from([(
+            "".to_string(),
+            Router::new().route("/redfish/v1", get(|| async { "default" })),
+        )]))));
 
-            if let Some(mut router) = router {
-                router.call(request).await
-            } else {
-                let err = format!(
-                    "no router configured for forwarded_host/host/authority: {forwarded_host:?}/{host:?}/{authority:?}"
-                );
-                tracing::info!("{err}");
-                Ok(Response::builder()
-                    .status(StatusCode::NOT_FOUND)
-                    .body(err.into())
-                    .unwrap())
-            }
-        })
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"default");
     }
 }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -40,6 +40,7 @@ pub mod tls;
 
 pub use bmc_state::{BmcEvent, BmcState};
 pub use combined_server::{CombinedServer, ListenerOrAddress};
+pub use combined_service::combined_router;
 pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,
 };

--- a/crates/machine-a-tron/Cargo.toml
+++ b/crates/machine-a-tron/Cargo.toml
@@ -44,6 +44,7 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 axum = { workspace = true }
+tower = { workspace = true }
 crossterm = { features = ["event-stream"], workspace = true }
 ratatui = { workspace = true }
 mac_address = { workspace = true }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -192,6 +192,9 @@ pub struct MachineATronConfig {
     #[serde(default = "default_bmc_mock_port")]
     pub bmc_mock_port: u16,
 
+    #[serde(default)]
+    pub bmc_mock_certs_dir: Option<PathBuf>,
+
     /// Set this to true if you want each mock machine to run a mock BMC ssh server. This is useful
     /// for testing things like ssh-console.
     #[serde(default = "default_false")]

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::response::{Html, Response};
+use axum::routing::{any, get};
+use axum::{Json, Router};
+use tower::Service;
+
+use crate::host_machine::HostMachineHandle;
+use crate::status::{MachineStatusConfig, MachinesStatusResponse};
+
+pub fn append(router: Router, control_state: ControlState) -> Router {
+    Router::new()
+        .route("/", get(get_machines_ui))
+        .route("/machines/status", get(get_machines_status))
+        .route("/{*all}", any(process))
+        .with_state(ControlRouter {
+            inner: router,
+            control_state,
+        })
+}
+
+#[derive(Clone)]
+pub struct ControlState {
+    machine_handles: Arc<Vec<HostMachineHandle>>,
+    status_config: MachineStatusConfig,
+}
+
+impl ControlState {
+    pub fn new(
+        machine_handles: Vec<HostMachineHandle>,
+        status_config: MachineStatusConfig,
+    ) -> Self {
+        Self {
+            machine_handles: Arc::new(machine_handles),
+            status_config,
+        }
+    }
+
+    fn machines_status(&self) -> MachinesStatusResponse {
+        MachinesStatusResponse {
+            machines: self
+                .machine_handles
+                .iter()
+                .map(|machine| machine.status(&self.status_config))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ControlRouter {
+    inner: Router,
+    control_state: ControlState,
+}
+
+async fn get_machines_status(State(state): State<ControlRouter>) -> Json<MachinesStatusResponse> {
+    Json(state.control_state.machines_status())
+}
+
+async fn get_machines_ui() -> Html<&'static str> {
+    Html(include_str!("../web/index.html"))
+}
+
+async fn process(State(mut state): State<ControlRouter>, request: Request<Body>) -> Response {
+    call_inner_router(&mut state.inner, request).await
+}
+
+async fn call_inner_router(router: &mut Router, request: Request<Body>) -> Response {
+    let (head, body) = request.into_parts();
+
+    let mut rb = Request::builder().uri(&head.uri).method(&head.method);
+    for (key, value) in &head.headers {
+        rb = rb.header(key, value);
+    }
+    let inner_request = rb.body(body).unwrap();
+
+    router.call(inner_request).await.expect("Infallible error")
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    use super::{ControlState, append};
+    use crate::status::MachineStatusConfig;
+
+    #[tokio::test]
+    async fn machines_status_returns_json() {
+        let router = append(
+            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
+        );
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/machines/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], br#"{"machines":[]}"#);
+    }
+
+    #[tokio::test]
+    async fn machines_ui_returns_html() {
+        let router = append(
+            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
+        );
+
+        let response = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("machine-a-tron machines"));
+    }
+
+    #[tokio::test]
+    async fn unmatched_paths_forward_to_inner_router() {
+        let router = append(
+            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
+        );
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert_eq!(&body[..], b"bmc");
+    }
+}

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -34,6 +34,7 @@ use crate::config::{MachineATronContext, PersistedDpuMachine};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay, DpuDhcpRelayServer};
 use crate::host_machine::HandleMessageResult;
 use crate::machine_state_machine::{LiveState, MachineStateMachine, OsImage, PersistedMachine};
+use crate::status::{BmcStatus, EndpointStatus, MachineStatus, MachineStatusConfig};
 use crate::tui::HostDetails;
 use crate::{MachineConfig, saturating_add_duration_to_instant};
 
@@ -284,7 +285,8 @@ impl DpuMachine {
                 HandleMessageResult::ProcessStateNow
             }
             DpuMachineMessage::SetApiState(api_state) => {
-                self.api_state = api_state;
+                self.api_state = api_state.clone();
+                self.live_state.write().unwrap().api_state = api_state;
                 HandleMessageResult::ContinuePolling
             }
             DpuMachineMessage::WaitUntilMachineUpWithApiState(state, reply) => {
@@ -404,6 +406,27 @@ impl DpuMachineHandle {
             booted_os: guard.booted_os.to_string(),
             next_boot_kind: guard.ui_next_boot_kind().into(),
             power_state: guard.power_state,
+        }
+    }
+
+    pub fn status(&self, config: &MachineStatusConfig) -> MachineStatus {
+        let live_state = self.0.live_state.read().unwrap();
+        MachineStatus {
+            mat_id: self.0.mat_id.to_string(),
+            machine_id: live_state
+                .observed_machine_id
+                .as_ref()
+                .map(ToString::to_string),
+            hardware_type: None,
+            mat_state: live_state.state_string.map(ToOwned::to_owned),
+            api_state: live_state.api_state.clone(),
+            power_state: live_state.power_state.to_string(),
+            machine_ip: live_state.machine_ip.map(|ip| ip.to_string()),
+            bmc: BmcStatus {
+                ip: live_state.bmc_ip.map(|ip| ip.to_string()),
+                redfish: EndpointStatus::redfish(config),
+            },
+            dpus: Vec::new(),
         }
     }
 

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -38,6 +38,7 @@ use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
 use crate::machine_state_machine::{LiveState, MachineStateMachine, PersistedMachine};
 use crate::saturating_add_duration_to_instant;
+use crate::status::{BmcStatus, EndpointStatus, MachineStatus, MachineStatusConfig};
 use crate::tui::{HostDetails, UiUpdate};
 
 pub struct HostMachine {
@@ -392,7 +393,8 @@ impl HostMachine {
                 HandleMessageResult::ContinuePolling
             }
             HostMachineMessage::SetApiState(api_state) => {
-                self.api_state = api_state;
+                self.api_state = api_state.clone();
+                self.live_state.write().unwrap().api_state = api_state;
                 HandleMessageResult::ContinuePolling
             }
         }
@@ -600,6 +602,27 @@ impl HostMachineHandle {
 
     pub fn machine_config_section(&self) -> &str {
         &self.0.machine_config_section
+    }
+
+    pub fn status(&self, config: &MachineStatusConfig) -> MachineStatus {
+        let live_state = self.0.live_state.read().unwrap();
+        MachineStatus {
+            mat_id: self.0.mat_id.to_string(),
+            machine_id: live_state
+                .observed_machine_id
+                .as_ref()
+                .map(ToString::to_string),
+            hardware_type: Some(self.0.host_info.hw_type),
+            mat_state: live_state.state_string.map(ToOwned::to_owned),
+            api_state: live_state.api_state.clone(),
+            power_state: live_state.power_state.to_string(),
+            machine_ip: live_state.machine_ip.map(|ip| ip.to_string()),
+            bmc: BmcStatus {
+                ip: live_state.bmc_ip.map(|ip| ip.to_string()),
+                redfish: EndpointStatus::redfish(config),
+            },
+            dpus: self.0.dpus.iter().map(|dpu| dpu.status(config)).collect(),
+        }
     }
 
     pub fn persisted(&self) -> PersistedHostMachine {

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -18,6 +18,7 @@ pub mod api_client;
 pub mod api_throttler;
 mod bmc_mock_wrapper;
 mod config;
+mod control_router;
 mod dhcp_wrapper;
 mod dpu_machine;
 mod host_machine;
@@ -26,6 +27,7 @@ mod machine_fsm;
 mod machine_state_machine;
 mod machine_utils;
 mod mock_ssh_server;
+mod status;
 mod subnet;
 mod tabs;
 mod tui;
@@ -39,6 +41,7 @@ pub use config::{
     MachineATronArgs, MachineATronConfig, MachineATronContext, MachineConfig, PersistedDpuMachine,
     PersistedHostMachine,
 };
+pub use control_router::{ControlState, append as append_control_routes};
 pub use dpu_machine::DpuMachineHandle;
 pub use host_machine::HostMachineHandle;
 pub use machine_a_tron::{AppEvent, MachineATron};
@@ -47,6 +50,7 @@ pub use mock_ssh_server::{
     Credentials as MockSshCredentials, MockSshServerHandle, PromptBehavior,
     spawn as spawn_mock_ssh_server,
 };
+pub use status::{MachineStatus, MachineStatusConfig, MachinesStatusResponse};
 pub use tui::{Tui, UiUpdate};
 pub use tui_host_logs::TuiHostLogs;
 

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -33,9 +33,9 @@ use forge_tls::client_config::{
 };
 use mac_address::MacAddress;
 use machine_a_tron::{
-    AppEvent, BmcMockRegistry, BmcRegistrationMode, MachineATron, MachineATronArgs,
-    MachineATronConfig, MachineATronContext, MockSshServerHandle, PromptBehavior, Tui, TuiHostLogs,
-    api_throttler, spawn_mock_ssh_server,
+    AppEvent, BmcMockRegistry, BmcRegistrationMode, ControlState, MachineATron, MachineATronArgs,
+    MachineATronConfig, MachineATronContext, MachineStatusConfig, MockSshServerHandle,
+    PromptBehavior, Tui, TuiHostLogs, api_throttler, append_control_routes, spawn_mock_ssh_server,
 };
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -169,10 +169,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ),
     });
 
+    let bmc_mock_certs_dir = app_config.bmc_mock_certs_dir.clone();
+
     let app_context = Arc::new(MachineATronContext {
         app_config,
         forge_client_config,
-        bmc_mock_certs_dir: None,
+        bmc_mock_certs_dir,
         bmc_registration_mode,
         api_throttler,
         desired_firmware_versions,
@@ -185,18 +187,45 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut mat = MachineATron::new(app_context.clone());
 
-    // If we're using a combined BMC mock that routes to each mock machine using headers, launch it now
+    // Machines are created paused here. While paused, their actors do not advance the FSM, so
+    // BMC DHCP and shared-router registration cannot run before the combined BMC mock listener is
+    // started below.
+    let machine_handles = mat.make_machines(true).await?;
+
+    // Persist them once in case of unclean shutdown
+    app_context.app_config.write_persisted_machines(
+        machine_handles
+            .iter()
+            .map(|m| m.persisted())
+            .collect::<Vec<_>>()
+            .as_slice(),
+    )?;
+
+    // If we're using a combined BMC mock that routes to each mock machine using headers, launch it
+    // after the machines are created so the control UI can report their handles.
     let maybe_bmc_mock_handles: Option<(CombinedServer, Option<MockSshServerHandle>)> =
         match &app_context.bmc_registration_mode {
             BmcRegistrationMode::BackingInstance(bmc_mock_registry) => {
-                let certs_dir = PathBuf::from(forge_root_ca_path.clone())
-                    .parent()
-                    .map(Path::to_path_buf);
+                let certs_dir = app_context
+                    .bmc_mock_certs_dir
+                    .as_ref()
+                    .cloned()
+                    .or_else(|| {
+                        PathBuf::from(forge_root_ca_path.clone())
+                            .parent()
+                            .map(Path::to_path_buf)
+                    });
 
                 let server_config = bmc_mock::tls::server_config(certs_dir)?;
-                let bmc_https_mock = bmc_mock::CombinedServer::run(
+                let control_state = ControlState::new(
+                    machine_handles.clone(),
+                    MachineStatusConfig::new(bmc_mock_port),
+                );
+                let bmc_router = bmc_mock::combined_router(bmc_mock_registry.clone());
+                let router = append_control_routes(bmc_router, control_state);
+                let bmc_https_mock = bmc_mock::CombinedServer::run_router(
                     "bmc-mock",
-                    bmc_mock_registry.clone(),
+                    router,
                     Some(ListenerOrAddress::Address(
                         format!("0.0.0.0:{bmc_mock_port}").parse().unwrap(),
                     )),
@@ -232,17 +261,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 None
             }
         };
-
-    let machine_handles = mat.make_machines(true).await?;
-
-    // Persist them once in case of unclean shutdown
-    app_context.app_config.write_persisted_machines(
-        machine_handles
-            .iter()
-            .map(|m| m.persisted())
-            .collect::<Vec<_>>()
-            .as_slice(),
-    )?;
 
     // Run TUI
     let (app_tx, app_rx) = mpsc::channel(5000);

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use bmc_mock::HostHardwareType;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy)]
+pub struct MachineStatusConfig {
+    pub redfish_reachable_port: u16,
+    pub redfish_listen_port: u16,
+}
+
+impl MachineStatusConfig {
+    pub fn new(redfish_listen_port: u16) -> Self {
+        Self {
+            redfish_reachable_port: 443,
+            redfish_listen_port,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MachinesStatusResponse {
+    pub machines: Vec<MachineStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MachineStatus {
+    pub mat_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machine_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hardware_type: Option<HostHardwareType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mat_state: Option<String>,
+    pub api_state: String,
+    pub power_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub machine_ip: Option<String>,
+    pub bmc: BmcStatus,
+    pub dpus: Vec<MachineStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BmcStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    pub redfish: EndpointStatus,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct EndpointStatus {
+    pub reachable_port: u16,
+    pub listen_port: u16,
+}
+
+impl EndpointStatus {
+    pub fn redfish(config: &MachineStatusConfig) -> Self {
+        Self {
+            reachable_port: config.redfish_reachable_port,
+            listen_port: config.redfish_listen_port,
+        }
+    }
+}

--- a/crates/machine-a-tron/web/index.html
+++ b/crates/machine-a-tron/web/index.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>machine-a-tron machines</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f4f5f2;
+      --fg: #111111;
+      --muted: #5f666d;
+      --line: #d7d9d2;
+      --panel: #ffffff;
+      --panel-alt: #f8f9f6;
+      --accent: #76b900;
+      --accent-fg: #172400;
+      --warn: #b15c00;
+      --error: #c21f32;
+      --header-bg: #111111;
+      --header-fg: #ffffff;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b0c0d;
+        --fg: #f5f7f2;
+        --muted: #aeb5aa;
+        --line: #30352d;
+        --panel: #151713;
+        --panel-alt: #1b1f18;
+        --accent: #76b900;
+        --accent-fg: #f5ffe4;
+        --warn: #ffb84d;
+        --error: #ff6b7a;
+        --header-bg: #050505;
+        --header-fg: #ffffff;
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--fg);
+      font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    main {
+      width: auto;
+      margin: 16px;
+    }
+
+    header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 650;
+      color: var(--fg);
+    }
+
+    .meta {
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    .error {
+      display: none;
+      margin-bottom: 12px;
+      padding: 8px 10px;
+      border: 1px solid color-mix(in srgb, var(--error), transparent 55%);
+      color: var(--error);
+      background: color-mix(in srgb, var(--error), transparent 92%);
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-top: 3px solid var(--accent);
+      background: var(--panel);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+      min-width: 1040px;
+    }
+
+    .col-machine {
+      width: 27%;
+    }
+
+    .col-hardware {
+      width: 14%;
+    }
+
+    .col-state {
+      width: 12%;
+    }
+
+    .col-power {
+      width: 8%;
+    }
+
+    .col-ip {
+      width: 10%;
+    }
+
+    .col-bmc {
+      width: 9%;
+    }
+
+    .col-redfish {
+      width: 8%;
+    }
+
+    th,
+    td {
+      padding: 9px 10px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+      overflow-wrap: anywhere;
+    }
+
+    th {
+      color: var(--header-fg);
+      background: var(--header-bg);
+      font-size: 12px;
+      font-weight: 650;
+      text-transform: uppercase;
+    }
+
+    tbody tr:nth-child(even) {
+      background: var(--panel-alt);
+    }
+
+    tbody tr:hover {
+      background: color-mix(in srgb, var(--accent), var(--panel) 88%);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: 0;
+    }
+
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      overflow-wrap: anywhere;
+    }
+
+    .machine {
+      font-weight: 650;
+      color: var(--accent);
+    }
+
+    .dpu .machine {
+      padding-left: 18px;
+      color: color-mix(in srgb, var(--accent), var(--muted) 35%);
+    }
+
+    .state {
+      display: inline-block;
+      max-width: 100%;
+      padding: 2px 7px;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      background: color-mix(in srgb, var(--panel), var(--line) 24%);
+      line-height: 1.25;
+      overflow-wrap: anywhere;
+      white-space: normal;
+    }
+
+    .state.on,
+    .state.available,
+    .state.running {
+      border-color: color-mix(in srgb, var(--accent), transparent 35%);
+      color: var(--accent-fg);
+      background: color-mix(in srgb, var(--accent), var(--panel) 78%);
+    }
+
+    .state.warning,
+    .state.powercycling {
+      border-color: color-mix(in srgb, var(--warn), transparent 50%);
+      color: var(--warn);
+    }
+
+    .empty {
+      padding: 24px;
+      color: var(--muted);
+      text-align: center;
+      border: 1px solid var(--line);
+      background: var(--panel);
+    }
+
+    @media (max-width: 700px) {
+      main {
+        margin: 10px;
+      }
+
+      header {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      .meta {
+        white-space: normal;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>machine-a-tron machines</h1>
+      <div class="meta"><span id="count">0</span> machines | <span id="updated">not loaded</span></div>
+    </header>
+    <div id="error" class="error"></div>
+    <div id="content" class="empty">Loading machines</div>
+  </main>
+
+  <script>
+    const content = document.getElementById("content");
+    const count = document.getElementById("count");
+    const updated = document.getElementById("updated");
+    const error = document.getElementById("error");
+
+    function text(value) {
+      return value === undefined || value === null || value === "" ? "-" : String(value);
+    }
+
+    function html(value) {
+      return text(value).replace(/[&<>"']/g, (ch) => ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[ch]);
+    }
+
+    function stateClass(value) {
+      return text(value).toLowerCase().replace(/[^a-z0-9]+/g, "");
+    }
+
+    function endpoint(endpoint) {
+      if (!endpoint) {
+        return "-";
+      }
+      return `${text(endpoint.reachable_port)} -> ${text(endpoint.listen_port)}`;
+    }
+
+    function flatten(machine, depth = 0) {
+      const rows = [{ machine, depth }];
+      for (const dpu of machine.dpus || []) {
+        rows.push(...flatten(dpu, depth + 1));
+      }
+      return rows;
+    }
+
+    function render(data) {
+      const machines = data.machines || [];
+      const rows = machines.flatMap((machine) => flatten(machine));
+      count.textContent = machines.length;
+      updated.textContent = new Date().toLocaleTimeString();
+
+      if (rows.length === 0) {
+        content.className = "empty";
+        content.textContent = "No machines";
+        return;
+      }
+
+      content.className = "table-wrap";
+      content.innerHTML = `
+        <table>
+          <colgroup>
+            <col class="col-machine">
+            <col class="col-hardware">
+            <col class="col-state">
+            <col class="col-state">
+            <col class="col-power">
+            <col class="col-ip">
+            <col class="col-bmc">
+            <col class="col-redfish">
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Machine</th>
+              <th>Hardware</th>
+              <th>MAT</th>
+              <th>API</th>
+              <th>Power</th>
+              <th>Machine IP</th>
+              <th>BMC IP</th>
+              <th>Redfish</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rows.map(({ machine, depth }) => `
+              <tr class="${depth > 0 ? "dpu" : ""}">
+                <td class="machine"><code>${html(machine.machine_id || machine.mat_id)}</code></td>
+                <td>${depth > 0 ? "DPU" : html(machine.hardware_type)}</td>
+                <td><span class="state ${stateClass(machine.mat_state)}">${html(machine.mat_state)}</span></td>
+                <td><span class="state ${stateClass(machine.api_state)}">${html(machine.api_state)}</span></td>
+                <td><span class="state ${stateClass(machine.power_state)}">${html(machine.power_state)}</span></td>
+                <td><code>${html(machine.machine_ip)}</code></td>
+                <td><code>${html(machine.bmc && machine.bmc.ip)}</code></td>
+                <td><code>${html(endpoint(machine.bmc && machine.bmc.redfish))}</code></td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+      `;
+    }
+
+    async function refresh() {
+      try {
+        const response = await fetch("/machines/status", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        render(await response.json());
+        error.style.display = "none";
+      } catch (e) {
+        error.textContent = `Failed to load machine status: ${e.message}`;
+        error.style.display = "block";
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 5000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Serve a machine status endpoint and lightweight HTML UI from the combined BMC mock listener. Expose current host/DPU state, API state, power state, IPs, and Redfish port mapping while preserving existing combined router behavior.

## Related issues

Closes: #3379 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

