### PR TITLE
feat(api): add static address operation metrics

### DIFF
--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use ::rpc::forge as rpc;
+use carbide_instrument::emit;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::expected_machine::{
@@ -29,6 +30,9 @@ use uuid::Uuid;
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::handlers::machine_interface_address::update_preallocated_expected_machine_interface;
+use crate::handlers::static_address_metrics::{
+    PreallocationSuccess, StaticAddressPreallocationCompleted,
+};
 
 lazy_static! {
     // Verify what serial is alphanumeric string with, allows dashes '-' and underscores '_'
@@ -295,7 +299,7 @@ pub(crate) async fn update(
     normalize_host_bmc_configuration(&mut machine, existing.as_ref(), overrides)?;
     validate_expected_machine_for_insert(&machine)?;
 
-    update_preallocated_interfaces(
+    let preallocations = update_preallocated_interfaces(
         &mut txn,
         &machine,
         api.runtime_config.retained_boot_interface_window,
@@ -307,6 +311,10 @@ pub(crate) async fn update(
         .map_err(CarbideError::from)?;
 
     txn.commit().await?;
+
+    for outcome in preallocations {
+        emit(StaticAddressPreallocationCompleted::from(outcome));
+    }
 
     Ok(tonic::Response::new(()))
 }
@@ -734,11 +742,14 @@ async fn update_preallocated_interfaces(
     txn: &mut sqlx::PgConnection,
     machine: &ExpectedMachine,
     retained_window: Option<chrono::Duration>,
-) -> Result<(), CarbideError> {
+) -> Result<Vec<PreallocationSuccess>, CarbideError> {
+    let mut preallocations = Vec::new();
     let host_bmc = machine.effective_host_bmc();
     if host_bmc.fixed_ip.is_some() {
-        update_preallocated_expected_machine_interface(&mut *txn, &host_bmc, retained_window)
-            .await?;
+        preallocations.push(
+            update_preallocated_expected_machine_interface(&mut *txn, &host_bmc, retained_window)
+                .await?,
+        );
     }
 
     for interface in machine
@@ -748,12 +759,18 @@ async fn update_preallocated_interfaces(
         .filter(|interface| interface.mac_address != machine.bmc_mac_address)
     {
         if interface.fixed_ip.is_some() {
-            update_preallocated_expected_machine_interface(&mut *txn, interface, retained_window)
-                .await?;
+            preallocations.push(
+                update_preallocated_expected_machine_interface(
+                    &mut *txn,
+                    interface,
+                    retained_window,
+                )
+                .await?,
+            );
         }
     }
 
-    Ok(())
+    Ok(preallocations)
 }
 
 /// Preserve the request representation used by batch results and replace only
@@ -820,7 +837,7 @@ async fn create_expected_machine(
     machine: rpc::ExpectedMachine,
     id: Uuid,
     parsed_mac: MacAddress,
-) -> Result<rpc::ExpectedMachine, CarbideError> {
+) -> Result<(rpc::ExpectedMachine, Vec<PreallocationSuccess>), CarbideError> {
     let result_machine = batch_result_with_id(machine.clone(), id);
     let overrides = LegacyHostBmcOverrides::try_from(&machine)?;
     let db_data: ExpectedMachineData = machine.try_into()?;
@@ -835,7 +852,7 @@ async fn create_expected_machine(
     validate_expected_machine_for_insert(&expected_machine)?;
     db::expected_machine::create(txn, expected_machine).await?;
 
-    Ok(result_machine)
+    Ok((result_machine, Vec::new()))
 }
 
 /// Updates one expected machine inside an existing transaction (batch API).
@@ -848,7 +865,7 @@ async fn update_expected_machine(
     id: Uuid,
     parsed_mac: MacAddress,
     retained_window: Option<chrono::Duration>,
-) -> Result<rpc::ExpectedMachine, CarbideError> {
+) -> Result<(rpc::ExpectedMachine, Vec<PreallocationSuccess>), CarbideError> {
     let result_machine = batch_result_with_id(machine.clone(), id);
     let existing = db::expected_machine::find_for_update(
         &mut *txn,
@@ -870,11 +887,12 @@ async fn update_expected_machine(
     };
     normalize_host_bmc_configuration(&mut expected_machine, existing.as_ref(), overrides)?;
     validate_expected_machine_for_insert(&expected_machine)?;
-    update_preallocated_interfaces(txn, &expected_machine, retained_window).await?;
+    let preallocations =
+        update_preallocated_interfaces(txn, &expected_machine, retained_window).await?;
 
     db::expected_machine::update(txn, &expected_machine).await?;
 
-    Ok(result_machine)
+    Ok((result_machine, preallocations))
 }
 
 #[derive(Copy, Clone)]
@@ -924,7 +942,7 @@ async fn apply_operation(
     id: Uuid,
     parsed_mac: MacAddress,
     retained_window: Option<chrono::Duration>,
-) -> Result<rpc::ExpectedMachine, CarbideError> {
+) -> Result<(rpc::ExpectedMachine, Vec<PreallocationSuccess>), CarbideError> {
     match op {
         BatchOperation::Create => create_expected_machine(txn, machine, id, parsed_mac).await,
         BatchOperation::Update => {
@@ -982,8 +1000,13 @@ async fn process_batch_operations(
             )
             .await
             {
-                Ok(result_machine) => match txn.commit().await {
-                    Ok(_) => results.push(build_success_result(result_machine)),
+                Ok((result_machine, preallocations)) => match txn.commit().await {
+                    Ok(_) => {
+                        for outcome in preallocations {
+                            emit(StaticAddressPreallocationCompleted::from(outcome));
+                        }
+                        results.push(build_success_result(result_machine));
+                    }
                     Err(e) => {
                         results.push(build_failure_result(id, format!("Failed to commit: {}", e)))
                     }
@@ -1014,9 +1037,10 @@ async fn process_batch_operations(
 
     let mut txn = api.txn_begin().await?;
     let mut ordered_results = Vec::with_capacity(prepared.len());
+    let mut preallocations = Vec::new();
 
     for (request_index, machine, id, parsed_mac) in prepared {
-        let result_machine = match apply_operation(
+        let (result_machine, operation_preallocations) = match apply_operation(
             op,
             txn.as_pgconn(),
             machine,
@@ -1033,10 +1057,15 @@ async fn process_batch_operations(
                 return Err(error);
             }
         };
+        preallocations.extend(operation_preallocations);
         ordered_results.push((request_index, build_success_result(result_machine)));
     }
 
     txn.commit().await?;
+
+    for outcome in preallocations {
+        emit(StaticAddressPreallocationCompleted::from(outcome));
+    }
 
     ordered_results.sort_by_key(|(request_index, _)| *request_index);
     Ok(ordered_results

--- a/crates/api-core/src/handlers/expected_power_shelf.rs
+++ b/crates/api-core/src/handlers/expected_power_shelf.rs
@@ -16,6 +16,7 @@
  */
 
 use ::rpc::forge as rpc;
+use carbide_instrument::emit;
 use db::{DatabaseError, expected_power_shelf as db_expected_power_shelf};
 use mac_address::MacAddress;
 use model::expected_power_shelf::{ExpectedPowerShelf, ExpectedPowerShelfRequest};
@@ -24,6 +25,7 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::Api;
 use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
+use crate::handlers::static_address_metrics::StaticAddressPreallocationCompleted;
 
 pub async fn add_expected_power_shelf(
     api: &Api,
@@ -107,15 +109,19 @@ pub async fn update_expected_power_shelf(
             message: format!("Database error: {}", e),
         })?;
 
-    if let Some(bmc_ip) = power_shelf.bmc_ip_address {
-        update_preallocated_machine_interface(
-            &mut txn,
-            power_shelf.bmc_mac_address,
-            bmc_ip,
-            api.runtime_config.retained_boot_interface_window,
+    let preallocation = if let Some(bmc_ip) = power_shelf.bmc_ip_address {
+        Some(
+            update_preallocated_machine_interface(
+                &mut txn,
+                power_shelf.bmc_mac_address,
+                bmc_ip,
+                api.runtime_config.retained_boot_interface_window,
+            )
+            .await?,
         )
-        .await?;
-    }
+    } else {
+        None
+    };
 
     db_expected_power_shelf::update(&mut txn, &power_shelf)
         .await
@@ -124,6 +130,10 @@ pub async fn update_expected_power_shelf(
     txn.commit().await.map_err(|e| CarbideError::Internal {
         message: format!("Failed to commit transaction: {}", e),
     })?;
+
+    if let Some(outcome) = preallocation {
+        emit(StaticAddressPreallocationCompleted::from(outcome));
+    }
 
     Ok(Response::new(()))
 }

--- a/crates/api-core/src/handlers/expected_switch.rs
+++ b/crates/api-core/src/handlers/expected_switch.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 
 use ::rpc::forge as rpc;
 use ::rpc::forge_api_client::{EXPECTED_SWITCH_UPDATE_MASK_HEADER, ExpectedSwitchUpdateField};
+use carbide_instrument::emit;
 use db::{DatabaseError, expected_switch as db_expected_switch};
 use mac_address::MacAddress;
 use model::expected_switch::{ExpectedSwitch, ExpectedSwitchRequest};
@@ -27,6 +28,7 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::Api;
 use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
+use crate::handlers::static_address_metrics::StaticAddressPreallocationCompleted;
 
 fn parse_expected_switch_update_mask(
     request: &Request<rpc::ExpectedSwitch>,
@@ -271,25 +273,30 @@ pub async fn update_expected_switch(
 
     validate_expected_switch(&switch)?;
 
+    let mut preallocations = Vec::with_capacity(2);
     if let Some(bmc_ip) = switch.bmc_ip_address {
-        update_preallocated_machine_interface(
-            &mut txn,
-            switch.bmc_mac_address,
-            bmc_ip,
-            api.runtime_config.retained_boot_interface_window,
-        )
-        .await?;
+        preallocations.push(
+            update_preallocated_machine_interface(
+                &mut txn,
+                switch.bmc_mac_address,
+                bmc_ip,
+                api.runtime_config.retained_boot_interface_window,
+            )
+            .await?,
+        );
     }
     if let Some(nvos_ip) = switch.nvos_ip_address {
         // Pairing already validated above; nvos_mac_addresses has exactly one entry.
         let nvos_mac = switch.nvos_mac_addresses[0];
-        update_preallocated_machine_interface(
-            &mut txn,
-            nvos_mac,
-            nvos_ip,
-            api.runtime_config.retained_boot_interface_window,
-        )
-        .await?;
+        preallocations.push(
+            update_preallocated_machine_interface(
+                &mut txn,
+                nvos_mac,
+                nvos_ip,
+                api.runtime_config.retained_boot_interface_window,
+            )
+            .await?,
+        );
     }
 
     db_expected_switch::update(&mut txn, &switch)
@@ -299,6 +306,10 @@ pub async fn update_expected_switch(
     txn.commit().await.map_err(|e| CarbideError::Internal {
         message: format!("Failed to commit transaction: {}", e),
     })?;
+
+    for outcome in preallocations {
+        emit(StaticAddressPreallocationCompleted::from(outcome));
+    }
 
     Ok(Response::new(()))
 }

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_instrument::emit;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::allocation_type::AllocationType;
@@ -26,6 +27,10 @@ use tonic::{Request, Response, Status};
 
 use crate::api::Api;
 use crate::errors::CarbideError;
+use crate::handlers::static_address_metrics::{
+    PreallocationSuccess, StaticAddressAssignmentCompleted, StaticAddressPreallocationCompleted,
+    StaticAddressRemovalCompleted,
+};
 
 /// Update or create a machine_interface with a static address.
 ///
@@ -38,20 +43,22 @@ use crate::errors::CarbideError;
 /// machine_interface if it's safe to do so (no existing addresses).
 /// To change the IP on a live interface, operators should use
 /// 'machine-interfaces assign-address' or 'remove-address'.
-pub async fn update_preallocated_machine_interface(
+pub(super) async fn update_preallocated_machine_interface(
     txn: &mut sqlx::PgConnection,
     bmc_mac_address: MacAddress,
     bmc_ip: std::net::IpAddr,
     retained_window: Option<chrono::Duration>,
-) -> Result<(), CarbideError> {
-    update_preallocated_machine_interface_with_settings(
-        txn,
-        bmc_mac_address,
-        bmc_ip,
-        None,
-        retained_window,
+) -> Result<PreallocationSuccess, CarbideError> {
+    emit_preallocation_error(
+        update_preallocated_machine_interface_with_settings(
+            txn,
+            bmc_mac_address,
+            bmc_ip,
+            None,
+            retained_window,
+        )
+        .await,
     )
-    .await
 }
 
 /// Apply the existing safe update behavior to a fixed expected interface.
@@ -59,11 +66,26 @@ pub async fn update_preallocated_machine_interface(
 /// An addressed interface remains unchanged. A missing row is created with
 /// the declared interface settings. Any addressless row receives the fixed IP,
 /// but only an unassociated row also receives the role-derived settings.
-pub async fn update_preallocated_expected_machine_interface(
+pub(super) async fn update_preallocated_expected_machine_interface(
     txn: &mut sqlx::PgConnection,
     expected_interface: &ExpectedInterface,
     retained_window: Option<chrono::Duration>,
-) -> Result<(), CarbideError> {
+) -> Result<PreallocationSuccess, CarbideError> {
+    emit_preallocation_error(
+        update_preallocated_expected_machine_interface_inner(
+            txn,
+            expected_interface,
+            retained_window,
+        )
+        .await,
+    )
+}
+
+async fn update_preallocated_expected_machine_interface_inner(
+    txn: &mut sqlx::PgConnection,
+    expected_interface: &ExpectedInterface,
+    retained_window: Option<chrono::Duration>,
+) -> Result<PreallocationSuccess, CarbideError> {
     let fixed_ip = expected_interface
         .fixed_reservation_ip()
         .map_err(|message| {
@@ -119,7 +141,7 @@ async fn update_preallocated_machine_interface_with_settings(
     ip_address: std::net::IpAddr,
     settings: Option<ExpectedInterfaceSettings>,
     retained_window: Option<chrono::Duration>,
-) -> Result<(), CarbideError> {
+) -> Result<PreallocationSuccess, CarbideError> {
     let segment_type_guard = settings.and_then(|settings| settings.segment_type_guard);
     // Generalized ExpectedInterface declarations require a managed prefix
     // even when an addressed interface will otherwise remain unchanged.
@@ -178,6 +200,8 @@ async fn update_preallocated_machine_interface_with_settings(
                 machine_interface_id = %iface.id,
                 "Assigned static address to existing interface without addresses"
             );
+
+            Ok(PreallocationSuccess::Assigned)
         } else {
             // Interface already has address(es). We don't touch it --
             // expected data updates are decoupled from managed state.
@@ -188,6 +212,8 @@ async fn update_preallocated_machine_interface_with_settings(
                 existing_addresses = ?iface.addresses,
                 "Interface already has addresses, updated expected data only"
             );
+
+            Ok(PreallocationSuccess::Skipped)
         }
     } else {
         // No interface yet -- create a new one.
@@ -218,12 +244,54 @@ async fn update_preallocated_machine_interface_with_settings(
             network_segment_id = %segment.id,
             "Pre-allocated static machine interface"
         );
+
+        Ok(PreallocationSuccess::Created)
+    }
+}
+
+fn emit_preallocation_error(
+    result: Result<PreallocationSuccess, CarbideError>,
+) -> Result<PreallocationSuccess, CarbideError> {
+    if let Err(error) = &result {
+        emit(StaticAddressPreallocationCompleted::Error {
+            error: error.to_string(),
+        });
     }
 
-    Ok(())
+    result
 }
 
 pub async fn assign_static_address(
+    api: &Api,
+    request: Request<rpc::AssignStaticAddressRequest>,
+) -> Result<Response<rpc::AssignStaticAddressResponse>, CarbideError> {
+    let result = assign_static_address_inner(api, request).await;
+
+    let event = match &result {
+        Ok(response) => match rpc::AssignStaticAddressStatus::try_from(response.get_ref().status) {
+            Ok(rpc::AssignStaticAddressStatus::Assigned) => {
+                StaticAddressAssignmentCompleted::Assigned {}
+            }
+            Ok(rpc::AssignStaticAddressStatus::ReplacedStatic) => {
+                StaticAddressAssignmentCompleted::ReplacedStatic {}
+            }
+            Ok(rpc::AssignStaticAddressStatus::ReplacedDhcp) => {
+                StaticAddressAssignmentCompleted::ReplacedDhcp {}
+            }
+            Err(error) => StaticAddressAssignmentCompleted::Error {
+                error: error.to_string(),
+            },
+        },
+        Err(error) => StaticAddressAssignmentCompleted::Error {
+            error: error.to_string(),
+        },
+    };
+    emit(event);
+
+    result
+}
+
+async fn assign_static_address_inner(
     api: &Api,
     request: Request<rpc::AssignStaticAddressRequest>,
 ) -> Result<Response<rpc::AssignStaticAddressResponse>, CarbideError> {
@@ -285,6 +353,33 @@ pub async fn assign_static_address(
 }
 
 pub async fn remove_static_address(
+    api: &Api,
+    request: Request<rpc::RemoveStaticAddressRequest>,
+) -> Result<Response<rpc::RemoveStaticAddressResponse>, CarbideError> {
+    let result = remove_static_address_inner(api, request).await;
+
+    let event = match &result {
+        Ok(response) => match rpc::RemoveStaticAddressStatus::try_from(response.get_ref().status) {
+            Ok(rpc::RemoveStaticAddressStatus::Removed) => {
+                StaticAddressRemovalCompleted::Removed {}
+            }
+            Ok(rpc::RemoveStaticAddressStatus::NotFound) => {
+                StaticAddressRemovalCompleted::NotFound {}
+            }
+            Err(error) => StaticAddressRemovalCompleted::Error {
+                error: error.to_string(),
+            },
+        },
+        Err(error) => StaticAddressRemovalCompleted::Error {
+            error: error.to_string(),
+        },
+    };
+    emit(event);
+
+    result
+}
+
+async fn remove_static_address_inner(
     api: &Api,
     request: Request<rpc::RemoveStaticAddressRequest>,
 ) -> Result<Response<rpc::RemoveStaticAddressResponse>, CarbideError> {
@@ -362,4 +457,24 @@ pub async fn find_interface_addresses(
         interface_id: Some(interface_id),
         addresses: proto_addresses,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::capture_logs;
+
+    use super::*;
+
+    #[test]
+    fn preallocation_error_is_emitted_once() {
+        let logs = capture_logs(|| {
+            let result = emit_preallocation_error(Err(CarbideError::InvalidArgument(
+                "operation failed".to_string(),
+            )));
+            assert!(matches!(result, Err(CarbideError::InvalidArgument(_))));
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].level, tracing::Level::WARN);
+    }
 }

--- a/crates/api-core/src/handlers/mod.rs
+++ b/crates/api-core/src/handlers/mod.rs
@@ -82,6 +82,7 @@ pub mod site_explorer;
 pub mod site_prefix;
 pub mod sku;
 pub mod spx_partition;
+pub mod static_address_metrics;
 pub mod svpc;
 pub mod switch;
 pub mod tenant;

--- a/crates/api-core/src/handlers/static_address_metrics.rs
+++ b/crates/api-core/src/handlers/static_address_metrics.rs
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_instrument::{Event, LabelValue};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(super) enum AssignmentOutcome {
+    Assigned,
+    ReplacedStatic,
+    ReplacedDhcp,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(super) enum RemovalOutcome {
+    Removed,
+    NotFound,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(super) enum PreallocationOutcome {
+    Assigned,
+    Skipped,
+    Created,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PreallocationSuccess {
+    Assigned,
+    Skipped,
+    Created,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "static_address_assignment_completed",
+    metric_name = "carbide_static_address_assignments_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Number of static address assignment attempts, by outcome.",
+    labels(outcome: AssignmentOutcome),
+)]
+pub(super) enum StaticAddressAssignmentCompleted {
+    #[event(labels(outcome = Assigned))]
+    Assigned {},
+    #[event(labels(outcome = ReplacedStatic))]
+    ReplacedStatic {},
+    #[event(labels(outcome = ReplacedDhcp))]
+    ReplacedDhcp {},
+    #[event(
+        labels(outcome = Error),
+        log = warn,
+        message = "Static address assignment completed"
+    )]
+    Error {
+        #[context]
+        error: String,
+    },
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "static_address_removal_completed",
+    metric_name = "carbide_static_address_removals_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Number of static address removal attempts, by outcome.",
+    labels(outcome: RemovalOutcome),
+)]
+pub(super) enum StaticAddressRemovalCompleted {
+    #[event(labels(outcome = Removed))]
+    Removed {},
+    #[event(labels(outcome = NotFound))]
+    NotFound {},
+    #[event(
+        labels(outcome = Error),
+        log = warn,
+        message = "Static address removal completed"
+    )]
+    Error {
+        #[context]
+        error: String,
+    },
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "static_address_preallocation_completed",
+    metric_name = "carbide_static_address_preallocations_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Number of static address preallocation outcomes recorded, by outcome; successful outcomes are counted only after commit.",
+    labels(outcome: PreallocationOutcome),
+)]
+pub(super) enum StaticAddressPreallocationCompleted {
+    #[event(labels(outcome = Assigned))]
+    Assigned {},
+    #[event(labels(outcome = Skipped))]
+    Skipped {},
+    #[event(labels(outcome = Created))]
+    Created {},
+    #[event(
+        labels(outcome = Error),
+        log = warn,
+        message = "Static address preallocation completed"
+    )]
+    Error {
+        #[context]
+        error: String,
+    },
+}
+
+impl From<PreallocationSuccess> for StaticAddressPreallocationCompleted {
+    fn from(outcome: PreallocationSuccess) -> Self {
+        match outcome {
+            PreallocationSuccess::Assigned => Self::Assigned {},
+            PreallocationSuccess::Skipped => Self::Skipped {},
+            PreallocationSuccess::Created => Self::Created {},
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::*;
+
+    #[test]
+    fn preallocation_success_maps_to_expected_event() {
+        assert!(matches!(
+            StaticAddressPreallocationCompleted::from(PreallocationSuccess::Assigned),
+            StaticAddressPreallocationCompleted::Assigned {}
+        ));
+        assert!(matches!(
+            StaticAddressPreallocationCompleted::from(PreallocationSuccess::Skipped),
+            StaticAddressPreallocationCompleted::Skipped {}
+        ));
+        assert!(matches!(
+            StaticAddressPreallocationCompleted::from(PreallocationSuccess::Created),
+            StaticAddressPreallocationCompleted::Created {}
+        ));
+    }
+
+    #[test]
+    fn events_count_all_outcomes_and_log_only_errors() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit(StaticAddressAssignmentCompleted::Assigned {});
+            emit(StaticAddressAssignmentCompleted::ReplacedStatic {});
+            emit(StaticAddressAssignmentCompleted::ReplacedDhcp {});
+            emit(StaticAddressAssignmentCompleted::Error {
+                error: "operation failed".to_string(),
+            });
+
+            emit(StaticAddressRemovalCompleted::Removed {});
+            emit(StaticAddressRemovalCompleted::NotFound {});
+            emit(StaticAddressRemovalCompleted::Error {
+                error: "operation failed".to_string(),
+            });
+
+            emit(StaticAddressPreallocationCompleted::from(
+                PreallocationSuccess::Assigned,
+            ));
+            emit(StaticAddressPreallocationCompleted::from(
+                PreallocationSuccess::Skipped,
+            ));
+            emit(StaticAddressPreallocationCompleted::from(
+                PreallocationSuccess::Created,
+            ));
+            emit(StaticAddressPreallocationCompleted::Error {
+                error: "operation failed".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 3);
+        assert!(logs.iter().all(|log| log.level == tracing::Level::WARN));
+
+        assert_outcomes(
+            &metrics,
+            "carbide_static_address_assignments_total",
+            &["assigned", "replaced_static", "replaced_dhcp", "error"],
+        );
+        assert_outcomes(
+            &metrics,
+            "carbide_static_address_removals_total",
+            &["removed", "not_found", "error"],
+        );
+        // Product-path tests share the global metrics registry and can emit these
+        // outcomes concurrently, so only assert that this test emitted each one.
+        assert_outcomes_at_least(
+            &metrics,
+            "carbide_static_address_preallocations_total",
+            &["assigned", "skipped", "created", "error"],
+        );
+    }
+
+    fn assert_outcomes(metrics: &MetricsCapture, name: &str, outcomes: &[&str]) {
+        for outcome in outcomes {
+            assert_eq!(metrics.counter_delta(name, &[("outcome", outcome)]), 1.0);
+        }
+    }
+
+    fn assert_outcomes_at_least(metrics: &MetricsCapture, name: &str, outcomes: &[&str]) {
+        for outcome in outcomes {
+            assert!(metrics.counter_delta(name, &[("outcome", outcome)]) >= 1.0);
+        }
+    }
+}

--- a/crates/api-core/tests/integration/expected_switch_static_address.rs
+++ b/crates/api-core/tests/integration/expected_switch_static_address.rs
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_api_core::test_support::network_segment::create_static_assignments_segment;
+use carbide_instrument::testing::MetricsCapture;
+use carbide_test_harness::prelude::*;
+use mac_address::MacAddress;
+use rpc::forge::forge_server::Forge;
+
+#[sqlx_test]
+async fn test_update_with_bmc_and_nvos_ips_preallocates_both_interfaces(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let network_controller = env.network_controller();
+    let domain = env.test_domain().await;
+    network_controller.create_admin_segment(&domain).await;
+    network_controller.create_underlay_segment(&domain).await;
+    create_static_assignments_segment(env.api(), Some(domain.id)).await;
+
+    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:90".parse()?;
+    let nvos_mac: MacAddress = "7A:7B:7C:7D:7E:90".parse()?;
+    let bmc_ip = "192.0.2.190";
+    let nvos_ip = "192.0.2.191";
+
+    env.api()
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            bmc_mac_address: bmc_mac.to_string(),
+            nvos_mac_addresses: vec![nvos_mac.to_string()],
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-STATIC-UPDATE-001".into(),
+            metadata: Some(rpc::forge::Metadata::default()),
+            ..Default::default()
+        }))
+        .await?;
+
+    let metrics = MetricsCapture::start();
+
+    env.api()
+        .update_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            bmc_mac_address: bmc_mac.to_string(),
+            nvos_mac_addresses: vec![nvos_mac.to_string()],
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-STATIC-UPDATE-001".into(),
+            bmc_ip_address: bmc_ip.into(),
+            nvos_ip_address: Some(nvos_ip.into()),
+            metadata: Some(rpc::forge::Metadata::default()),
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut txn = env.api().database_connection.begin().await?;
+    for (mac, ip) in [(bmc_mac, bmc_ip), (nvos_mac, nvos_ip)] {
+        let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
+        assert_eq!(interfaces.len(), 1, "should create one interface for {mac}");
+        assert!(
+            interfaces[0].addresses.contains(&ip.parse()?),
+            "interface {mac} should contain static address {ip}"
+        );
+    }
+    txn.rollback().await?;
+
+    // This update creates two interfaces and therefore emits two `created`
+    // outcomes. Other tests share the global metrics registry and can only
+    // increase this delta, so use a lower bound rather than exact equality.
+    assert!(
+        metrics.counter_delta(
+            "carbide_static_address_preallocations_total",
+            &[("outcome", "created")],
+        ) >= 2.0
+    );
+
+    Ok(())
+}

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -24,6 +24,7 @@ mod expected_power_shelf;
 mod expected_power_shelf_crud;
 mod expected_power_shelf_static_address;
 mod expected_rack;
+mod expected_switch_static_address;
 mod explored_managed_host_find;
 mod explored_mlx_devices;
 mod find_by_ids_guards;

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -259,6 +259,9 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_update_explored_endpoints_count</td><td>gauge</td><td>Counts from the last update_explored_endpoints phase by kind</td></tr>
 <tr><td>carbide_spdm_evidence_collection_unexpected_task_states_total</td><td>counter</td><td>Number of unexpected SPDM evidence collection task states, by task state and next action.</td></tr>
 <tr><td>carbide_state_handler_wakeup_failures_total</td><td>counter</td><td>Number of times a machine&#39;s state handler could not be woken after an observed or desired state change</td></tr>
+<tr><td>carbide_static_address_assignments_total</td><td>counter</td><td>Number of static address assignment attempts, by outcome.</td></tr>
+<tr><td>carbide_static_address_preallocations_total</td><td>counter</td><td>Number of static address preallocation outcomes recorded, by outcome; successful outcomes are counted only after commit.</td></tr>
+<tr><td>carbide_static_address_removals_total</td><td>counter</td><td>Number of static address removal attempts, by outcome.</td></tr>
 <tr><td>carbide_static_credential_watcher_failures_total</td><td>counter</td><td>Number of static credential watcher failures, by operation.</td></tr>
 <tr><td>carbide_switch_slot_tray_enrichment_failures_total</td><td>counter</td><td>Number of switch slot and tray enrichment failures, by failure stage.</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>


### PR DESCRIPTION
Add outcome-based metrics for static address assignment, removal, and
preallocation operations.

The new events use the repository's `carbide_instrument::Event` framework
and expose these counters:

- `carbide_static_address_assignments_total`
- `carbide_static_address_removals_total`
- `carbide_static_address_preallocations_total`

Each counter includes a bounded `outcome` label. Error outcomes also emit
a warning containing the error context, while successful outcomes only
update the corresponding metric.

Assignment and removal count each completed attempt, including error
outcomes. Preallocation is transaction-aware: its own failures emit an
error outcome immediately, while successful `assigned`, `skipped`, and
`created` outcomes are recorded only after the enclosing transaction
commits. If preallocation succeeds but the enclosing transaction later
rolls back, no successful preallocation outcome is recorded.

The existing database and API behavior is unchanged. The handlers retain
the original operation results while buffering successful preallocation
outcomes until the transaction owner commits.

## Related issues

Closes #837

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated in Linux Docker environments:

- `cargo make --no-workspace clippy-flow`
  - Runs `cargo clippy --locked --all-targets --all-features`
  - Passed with no Clippy diagnostics
- `cargo xtask check-event-names`
  - Passed; 202 event names checked
- `cargo xtask check-metric-docs`
  - Passed; all 130 framework metrics are documented
- Focused unit and PostgreSQL-backed integration tests covering metric
  mappings, error logging, expected-machine batch behavior, power-shelf
  preallocation, and expected-switch preallocation all passed
- `expected_switch_static_address::test_update_with_bmc_and_nvos_ips_preallocates_both_interfaces`
  passed: 1 passed, 0 failed, 244 filtered out

A complete `carbide-api-core` library run reported 1566 passed, 10 failed,
and 4 ignored. Nine failures were environment-specific: three upgrade
tests could not read a build version because the minimal image lacked Git,
and six measured-boot tests lacked the `tpm2` executable. The remaining
global-metrics test collided with parallel shared-registry activity and
passed when rerun alone.

## Additional Notes

The preallocation counter has different commit semantics from assignment
and removal. Dashboard and alert consumers should treat successful
preallocation outcomes as committed outcomes rather than raw attempts.
