### PR TITLE
perf(logging): render log lines with less work per field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6818,6 +6818,7 @@ name = "logfmt"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "criterion",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/api-core/src/logging/setup.rs
+++ b/crates/api-core/src/logging/setup.rs
@@ -46,7 +46,9 @@ pub struct Logging {
     pub filter: Arc<ActiveLevel>,
     pub tracing_enabled: Arc<AtomicBool>,
     pub spancount_reader: Option<spancounter::SpanCountReader>,
-    /// Log stream used to feed the admin web UI.
+    /// Log stream used to feed the admin web UI. Only fed when the admin UI is
+    /// enabled (`enable_admin_ui`); otherwise no [`LogStreamLayer`] is
+    /// installed and the stream stays empty.
     pub log_stream: LogStream,
 }
 
@@ -75,11 +77,25 @@ pub fn dep_log_filter(env_filter: EnvFilter) -> EnvFilter {
         .unwrap_or_else(|err| panic!("could not reparse combined filter '{combined}': {err}"))
 }
 
+/// The admin-UI log-stream layer, or `None` when the admin UI is disabled.
+/// The layer's only consumer is the web UI's log viewer: with the UI off there
+/// is no subscriber, so installing it would spend per-event work (a second
+/// field visit, timestamp/target strings, ring-buffer churn under a mutex) on
+/// lines nothing reads. Composed into the registry as an `Option`, which
+/// `tracing-subscriber` treats as a no-op layer when `None`.
+fn admin_ui_log_stream_layer(
+    enable_admin_ui: bool,
+    log_stream: &LogStream,
+) -> Option<LogStreamLayer> {
+    enable_admin_ui.then(|| LogStreamLayer::new(log_stream.clone()))
+}
+
 pub fn setup_logging(
     debug: u8,
     extra_logfmt_event_fields: Vec<String>,
     override_logging_subscriber: Option<impl SubscriberInitExt>,
     log_history_max_bytes: usize,
+    enable_admin_ui: bool,
     tracing_config: &TracingConfig,
 ) -> eyre::Result<Logging> {
     // Install the global W3C trace-context propagator so NICo can extract inbound and inject
@@ -170,12 +186,17 @@ pub fn setup_logging(
                 }
             };
 
+        // Installed only when the admin UI can consume it; `None` keeps this
+        // second per-event consumer out of the subscriber stack entirely.
+        let log_stream_layer = admin_ui_log_stream_layer(enable_admin_ui, &log_stream)
+            .map(|layer| layer.with_filter(initial_log_filter.clone()));
+
         tracing_subscriber::registry()
             .with(log_events.layer().with_filter(initial_log_filter.clone()))
             .with(spancount_layer.with_filter(log_level))
             .with(maybe_otel_tracing_layer)
             .with(logfmt_stdout_formatter.with_filter(logfmt_stdout_filter))
-            .with(LogStreamLayer::new(log_stream.clone()).with_filter(initial_log_filter.clone()))
+            .with(log_stream_layer)
             .with(sqlx_query_tracing::create_sqlx_query_tracing_layer())
             .try_init()
             .wrap_err("new tracing subscriber try_init()")?;
@@ -672,6 +693,49 @@ mod tests {
                 assert!(!encoded.contains(r#"mygauge{error="ErrC",state="mystate"} 1"#));
             }
         }
+    }
+
+    #[test]
+    fn log_stream_layer_absent_when_admin_ui_disabled() {
+        use tracing_subscriber::prelude::*;
+
+        let stream = LogStream::new(8, 64 * 1024);
+        let layer = admin_ui_log_stream_layer(false, &stream);
+        assert!(layer.is_none(), "disabled admin UI must not build a layer");
+
+        // Composed the way `setup_logging` composes it, the `None` layer is a
+        // no-op: events reach neither live subscribers nor the replay ring.
+        let mut rx = stream.subscribe();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("not streamed");
+        });
+        assert!(
+            rx.try_recv().is_err(),
+            "no line may be broadcast with the admin UI disabled"
+        );
+        assert!(
+            stream.latest(10).is_empty(),
+            "no history may be retained with the admin UI disabled"
+        );
+    }
+
+    #[test]
+    fn log_stream_layer_present_when_admin_ui_enabled() {
+        use tracing_subscriber::prelude::*;
+
+        let stream = LogStream::new(8, 64 * 1024);
+        let mut rx = stream.subscribe();
+        let layer = admin_ui_log_stream_layer(true, &stream);
+        assert!(layer.is_some(), "enabled admin UI must build the layer");
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("streamed");
+        });
+        let line = rx.try_recv().expect("a line should have been broadcast");
+        assert_eq!(line.message, "streamed");
+        assert_eq!(stream.latest(10).len(), 1);
     }
 
     /// Install `dep_log_filter(user_directives)` as the thread-local subscriber

--- a/crates/api-core/src/logging/stream.rs
+++ b/crates/api-core/src/logging/stream.rs
@@ -251,13 +251,17 @@ where
     fn on_close(&self, id: Id, ctx: Context<'_, S>) {
         let Some(span) = ctx.span(&id) else { return };
 
-        let (mut fields, elapsed_ms) = {
-            let extensions = span.extensions();
-            let Some(data) = extensions.get::<SpanData>() else {
-                return;
-            };
-            (data.fields.clone(), data.opened_at.elapsed().as_millis())
+        // The span is closing and this layer is the only reader of its
+        // `SpanData`, so take the data out of the extensions rather than
+        // cloning the whole field map.
+        let Some(data) = span.extensions_mut().remove::<SpanData>() else {
+            return;
         };
+        let SpanData {
+            mut fields,
+            opened_at,
+        } = data;
+        let elapsed_ms = opened_at.elapsed().as_millis();
 
         // Put `span_id` to its own slot (for span click-to-filter)
         // and record how long the span was open.

--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -70,7 +70,9 @@ fn vault_config_for_site(vault: &VaultConfig, carbide_config: &CarbideConfig) ->
 /// Note: even when `Some` is passed, the admin UI is only mounted if the
 /// `enable_admin_ui` config flag is true (the default). When it's false,
 /// `start_api` drops the builder and serves gRPC only — so `Some` here means
-/// "offer the UI", not "force it on".
+/// "offer the UI", not "force it on". The flag also gates the log-stream
+/// layer feeding the UI's live log viewer: with the UI off, no per-event
+/// work is spent collecting lines nothing can read.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     debug: u8,
@@ -121,6 +123,7 @@ pub async fn run(
             carbide_machine_controller::extra_logfmt_logging_fields(),
             None::<NoSubscriber>,
             log_history_max_bytes,
+            carbide_config.enable_admin_ui,
             &carbide_config.tracing,
         )
         .wrap_err("setup_telemetry")?

--- a/crates/logfmt/Cargo.toml
+++ b/crates/logfmt/Cargo.toml
@@ -29,10 +29,21 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 tracing-subscriber = { features = [
   "env-filter",
   "local-time",
 ], workspace = true }
+
+[features]
+# Exposes selected internals to `benches/` so the benchmarks drive the real
+# code paths. Not part of the crate's API.
+bench-hooks = []
+
+[[bench]]
+name = "logfmt_layer"
+harness = false
+required-features = ["bench-hooks"]
 
 [lints]
 workspace = true

--- a/crates/logfmt/benches/logfmt_layer.rs
+++ b/crates/logfmt/benches/logfmt_layer.rs
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Benchmarks the logfmt layer's per-line cost on the event hot path, plus the
+//! value-quoting scan in isolation.
+//!
+//! Run with:
+//!   cargo bench -p logfmt --features bench-hooks
+//!
+//! Before the criterion benches run, `main` reports allocations per formatted
+//! line, counted by a wrapping `#[global_allocator]` (bench binaries have their
+//! own allocator, so this never affects the library or its users).
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, criterion_group};
+use tracing_subscriber::prelude::*;
+
+/// Counts every allocation entry point (`alloc`, `realloc`, `alloc_zeroed`) so
+/// the bench can report allocations per log line.
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+/// A dispatch with just the logfmt layer, writing to `std::io::sink()` (a ZST,
+/// so boxing the writer per line does not allocate): the measurement is the
+/// layer's formatting work, not stdout.
+fn logfmt_subscriber() -> impl tracing::Subscriber {
+    tracing_subscriber::registry()
+        .with(logfmt::layer().with_writer(Arc::new(|| Box::new(std::io::sink()))))
+}
+
+/// A realistic INFO line: a message plus 10 mixed fields (strings - one needing
+/// quotes, debug values, integers, a float, a bool), all inside the same event.
+fn emit_line() {
+    tracing::info!(
+        machine_id = "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0",
+        state = "waiting_for_dpu_up",
+        previous_state = "dpu_reprovision",
+        attempt = 3_i64,
+        port = 8443_u64,
+        progress = 0.75_f64,
+        forced = false,
+        elapsed = ?std::time::Duration::from_millis(15_734),
+        interface = "enp1s0f0np0",
+        note = "boot order re-asserted after NIC de-enumeration",
+        "machine state transition applied",
+    );
+}
+
+fn bench_event_line(c: &mut Criterion) {
+    let _guard = tracing::subscriber::set_default(logfmt_subscriber());
+    c.bench_function("logfmt_event_line_10_fields", |b| b.iter(emit_line));
+}
+
+fn bench_quoting_scan(c: &mut Criterion) {
+    // Typical clean ASCII values (no quoting needed - the common case, where
+    // the whole value must be scanned to prove it).
+    let long = black_box("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
+    c.bench_function("value_needs_quoting_clean_ascii_59b", |b| {
+        b.iter(|| logfmt::bench_hooks::value_needs_quoting(black_box(long)))
+    });
+    let short = black_box("waiting_for_dpu_up");
+    c.bench_function("value_needs_quoting_clean_ascii_18b", |b| {
+        b.iter(|| logfmt::bench_hooks::value_needs_quoting(black_box(short)))
+    });
+    // A value that needs quoting: the scan short-circuits at the first
+    // quote-triggering byte (the space), the contrasting case to the
+    // full-length clean scans above.
+    let quoted = black_box("machine came back from reboot");
+    c.bench_function("value_needs_quoting_spaced_ascii_29b", |b| {
+        b.iter(|| logfmt::bench_hooks::value_needs_quoting(black_box(quoted)))
+    });
+}
+
+/// Reports allocations per line, measured outside criterion so the harness's
+/// own allocations don't pollute the count.
+fn report_allocs_per_line() {
+    let _guard = tracing::subscriber::set_default(logfmt_subscriber());
+    // Warm up the thread-local format buffer to its steady-state capacity.
+    for _ in 0..256 {
+        emit_line();
+    }
+    const LINES: u64 = 10_000;
+    let before = ALLOCATIONS.load(Ordering::Relaxed);
+    for _ in 0..LINES {
+        emit_line();
+    }
+    let delta = ALLOCATIONS.load(Ordering::Relaxed) - before;
+    eprintln!(
+        "allocs/line: {:.2} ({delta} allocations over {LINES} lines)",
+        delta as f64 / LINES as f64
+    );
+}
+
+criterion_group!(benches, bench_event_line, bench_quoting_scan);
+
+fn main() {
+    report_allocs_per_line();
+    benches();
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/crates/logfmt/src/lib.rs
+++ b/crates/logfmt/src/lib.rs
@@ -382,9 +382,22 @@ where
             if let Some(message) = &visitor.message {
                 write!(out, "{} ", kvp("msg", message))?;
             }
-            visitor.fields.sort();
-            for s in visitor.fields {
-                write!(out, "{s} ")?;
+            visitor.fields.sort_by(RenderedField::emit_order);
+            for field in &visitor.fields {
+                // Deliberately raw byte copies rather than the obvious
+                // `write!(out, "{key}={value} ")`: this loop is the hottest
+                // path in the layer, and routing each field through
+                // `core::fmt`'s dispatch costs the line a measurable slice of
+                // its win (about -14% per line instead of -25%, per the
+                // `logfmt_event_line_10_fields` bench -- re-verify there when
+                // touching this). It is safe precisely because both parts are
+                // fully rendered at record time: nothing here quotes, escapes,
+                // or interprets -- a field emits as three straight copies into
+                // the reused buffer.
+                out.extend_from_slice(field.key.as_str().as_bytes());
+                out.push(b'=');
+                out.extend_from_slice(field.value.as_bytes());
+                out.push(b' ');
             }
             writeln!(
                 out,
@@ -529,12 +542,18 @@ enum EscapedKeyName<'a> {
     Escaped(String),
 }
 
+impl EscapedKeyName<'_> {
+    fn as_str(&self) -> &str {
+        match self {
+            EscapedKeyName::Original(s) => s,
+            EscapedKeyName::Escaped(s) => s,
+        }
+    }
+}
+
 impl std::fmt::Display for EscapedKeyName<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EscapedKeyName::Original(s) => s.fmt(f),
-            EscapedKeyName::Escaped(s) => s.fmt(f),
-        }
+        self.as_str().fmt(f)
     }
 }
 
@@ -560,14 +579,57 @@ fn kvp<K, V>(key: K, value: V) -> Kvp<K, V> {
     Kvp { key, value }
 }
 
-/// Returns `true` if [`str::escape_debug`] would rewrite `c` into something
+/// Returns `true` if [`char::escape_debug`] would rewrite `c` into something
 /// other than the character itself (e.g. `\`, `"`, `'`, or a control
 /// character). Such characters are only safe inside a quoted value: an escaped
 /// character emitted in an unquoted token would be read back literally,
 /// corrupting the value.
+///
+/// Constructing the `escape_debug` iterator per character is comparatively
+/// expensive, so [`value_needs_quoting`] only consults this for non-ASCII
+/// characters; ASCII is classified by [`ascii_needs_quoting`].
 fn char_is_escaped(c: char) -> bool {
     let mut escaped = c.escape_debug();
     escaped.next() != Some(c) || escaped.next().is_some()
+}
+
+/// Whether an ASCII byte forces the value it appears in to be quoted: space
+/// and everything below it (the C0 controls), DEL, `=`, `"`, `'`, and `\` -
+/// exactly the ASCII characters matched by the quoting rule: `c <= ' '` and
+/// `c == '='` directly, plus those [`char::escape_debug`] rewrites (the
+/// escaped quotes/backslash and the non-printable controls).
+/// `quoting_classifier_matches_escape_debug_probe_for_every_char` pins this
+/// to the `escape_debug`-probe classification for every character.
+fn ascii_needs_quoting(byte: u8) -> bool {
+    matches!(byte, 0..=b' ' | 0x7F | b'=' | b'"' | b'\'' | b'\\')
+}
+
+/// Whether `c` forces the value it appears in to be quoted.
+fn char_needs_quoting(c: char) -> bool {
+    if c.is_ascii() {
+        ascii_needs_quoting(c as u8)
+    } else {
+        // Non-ASCII is never `<= ' '` or `=`, so only the escape probe applies.
+        char_is_escaped(c)
+    }
+}
+
+/// Returns `true` if the value must be rendered quoted: it contains whitespace
+/// or `=` (which would break an unquoted token), or any character that
+/// `escape_debug` rewrites. Escaping is only meaningful inside quotes, so a
+/// value that needs escaping must also be quoted; a value escaped yet left
+/// unquoted (e.g. one containing a backslash but no whitespace) would be
+/// corrupted when read back.
+///
+/// Values are overwhelmingly clean ASCII, so the scan proves the whole value
+/// ASCII once (a vectorized check) and then classifies plain bytes; only
+/// values with non-ASCII characters take the per-`char` path.
+fn value_needs_quoting(value: &str) -> bool {
+    if value.is_ascii() {
+        value.bytes().any(ascii_needs_quoting)
+    } else {
+        value.chars().any(char_needs_quoting)
+    }
 }
 
 impl<K: AsRef<str>, V: AsRef<str>> std::fmt::Display for Kvp<K, V> {
@@ -575,22 +637,26 @@ impl<K: AsRef<str>, V: AsRef<str>> std::fmt::Display for Kvp<K, V> {
         let escaped_key = escape_key_name(self.key.as_ref());
         let value = self.value.as_ref();
 
-        // Quote the value if it contains whitespace or `=` (which would break
-        // an unquoted token), or any character that `escape_debug` rewrites.
-        // Escaping is only meaningful inside quotes, so a value that needs
-        // escaping must also be quoted; previously such values (e.g. those
-        // containing a backslash but no whitespace) were escaped yet left
-        // unquoted, which corrupts them when read back.
-        if value
-            .chars()
-            .any(|c| c <= ' ' || c == '=' || char_is_escaped(c))
-        {
+        if value_needs_quoting(value) {
             write!(f, r#"{}="{}""#, escaped_key, value.escape_debug())?;
         } else {
             write!(f, "{}={}", escaped_key, value)?;
         }
 
         Ok(())
+    }
+}
+
+/// Hooks for `benches/` only (behind the `bench-hooks` feature): re-exports
+/// internals so the benchmarks measure the real code paths. Not part of the
+/// crate's API.
+#[cfg(feature = "bench-hooks")]
+pub mod bench_hooks {
+    /// Thin `#[inline]` wrapper over the crate-private quoting scan, so the
+    /// benchmark measures the real implementation.
+    #[inline]
+    pub fn value_needs_quoting(value: &str) -> bool {
+        super::value_needs_quoting(value)
     }
 }
 
@@ -630,49 +696,138 @@ impl field::Visit for SpanAttributeVisitor<'_> {
     }
 }
 
+/// One event field, rendered and ready to emit: the key as it will be written
+/// (dots already rewritten to underscores) and the value bytes exactly as they
+/// will appear after the `=` (quoted and escaped when required). Rendering at
+/// record time keeps the per-field work to a single owned `String` (the value)
+/// and lets the sort and the final write run over ready bytes.
+struct RenderedField {
+    key: EscapedKeyName<'static>,
+    value: String,
+}
+
+impl RenderedField {
+    fn new(field: &Field, value: String) -> Self {
+        Self {
+            key: escape_key_name(field.name()),
+            value,
+        }
+    }
+
+    /// Byte order of the emitted `key=value` tokens - the order event fields
+    /// have always been written in (previously achieved by sorting the fully
+    /// formatted token strings). Comparing the parts directly is a pair of
+    /// cheap `str` compares in almost every case; only when one key is a
+    /// strict prefix of the other does the `=` terminator compete with the
+    /// longer key's next byte (e.g. `a1=2` sorts before `a=1` because
+    /// '1' < '='). Identifier field names cannot contain `=`, but tracing
+    /// also accepts string-literal names that can: that ties the byte
+    /// comparison, and the remaining token bytes then decide -- keeping the
+    /// order total (a non-total comparator can panic `sort_by`) and equal to
+    /// the rendered-token order in every case.
+    fn emit_order(&self, other: &Self) -> std::cmp::Ordering {
+        let a = self.key.as_str().as_bytes();
+        let b = other.key.as_str().as_bytes();
+        match a.cmp(b) {
+            std::cmp::Ordering::Equal => self.value.cmp(&other.value),
+            _ if a.len() < b.len() && b.starts_with(a) => b'='.cmp(&b[a.len()]).then_with(|| {
+                self.value.as_bytes().iter().cmp(
+                    b[a.len() + 1..]
+                        .iter()
+                        .chain(std::iter::once(&b'='))
+                        .chain(other.value.as_bytes()),
+                )
+            }),
+            _ if b.len() < a.len() && a.starts_with(b) => a[b.len()].cmp(&b'=').then_with(|| {
+                a[b.len() + 1..]
+                    .iter()
+                    .chain(std::iter::once(&b'='))
+                    .chain(self.value.as_bytes())
+                    .cmp(other.value.as_bytes().iter())
+            }),
+            ord => ord,
+        }
+    }
+}
+
+/// The quoted-and-`escape_debug`-escaped rendering of a value that needs it:
+/// the single source of truth for the quoted form, shared by every render
+/// path so they cannot drift apart.
+#[inline]
+fn render_quoted(value: &str) -> String {
+    format!("\"{}\"", value.escape_debug())
+}
+
+/// Renders a value the exact way [`Kvp`] emits it after the `=`: quoted and
+/// `escape_debug`-escaped when required, verbatim otherwise. Takes the value
+/// by `String` so the (typical) clean case reuses the allocation.
+fn render_value(value: String) -> String {
+    if value_needs_quoting(&value) {
+        render_quoted(&value)
+    } else {
+        value
+    }
+}
+
 /// A visitor for recording fields in span events
-pub struct FieldVisitor {
-    pub message: Option<String>,
-    pub fields: Vec<String>,
+struct FieldVisitor {
+    message: Option<String>,
+    fields: Vec<RenderedField>,
+}
+
+impl FieldVisitor {
+    /// Numeric and bool renderings never contain characters that need
+    /// quoting, so they are emitted verbatim (as the numeric visitor paths
+    /// always have been).
+    fn push_unquoted(&mut self, field: &Field, value: impl ToString) {
+        self.fields
+            .push(RenderedField::new(field, value.to_string()));
+    }
 }
 
 impl Visit for FieldVisitor {
+    // Same decision as `render_value`, taken from `&str` so a value that
+    // needs quoting renders straight into its quoted form without first
+    // paying an intermediate `String`.
     fn record_str(&mut self, field: &Field, value: &str) {
-        self.fields.push(format!("{}", kvp(field.name(), value)));
+        let rendered = if value_needs_quoting(value) {
+            render_quoted(value)
+        } else {
+            value.to_string()
+        };
+        self.fields.push(RenderedField::new(field, rendered));
     }
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
         if field.name() == "message" {
             self.message = Some(format!("{value:?}"));
             return;
         }
-        self.record_str(field, &format!("{value:?}"));
+        // Render the debug value once and requote only when needed, rather
+        // than formatting the rendered value a second time.
+        let rendered = render_value(format!("{value:?}"));
+        self.fields.push(RenderedField::new(field, rendered));
     }
     fn record_f64(&mut self, field: &Field, value: f64) {
-        self.fields
-            .push(format!("{}={value}", escape_key_name(field.name())));
+        self.push_unquoted(field, value);
     }
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.fields
-            .push(format!("{}={value}", escape_key_name(field.name())));
+        self.push_unquoted(field, value);
     }
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.fields
-            .push(format!("{}={value}", escape_key_name(field.name())));
+        self.push_unquoted(field, value);
     }
     fn record_i128(&mut self, field: &Field, value: i128) {
-        self.fields
-            .push(format!("{}={value}", escape_key_name(field.name())));
+        self.push_unquoted(field, value);
     }
     fn record_u128(&mut self, field: &Field, value: u128) {
-        self.fields
-            .push(format!("{}={value}", escape_key_name(field.name())));
+        self.push_unquoted(field, value);
     }
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.fields
-            .push(format!("{}={value}", escape_key_name(field.name())));
+        self.push_unquoted(field, value);
     }
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.record_str(field, &value.to_string());
+        let rendered = render_value(value.to_string());
+        self.fields.push(RenderedField::new(field, rendered));
     }
 }
 
@@ -1452,6 +1607,127 @@ mod tests {
             event_line.contains("service=deep-comp"),
             "deeply nested span did not inherit service: {event_line}"
         );
+    }
+
+    #[test]
+    fn quoting_classifier_matches_escape_debug_probe_for_every_char() {
+        // The previous classifier: probe `char::escape_debug` per character.
+        // Kept here verbatim as the reference the table-based classifier must
+        // match for every Unicode scalar value (which subsumes all ASCII, the
+        // controls, DEL, `\` `"` `'`, accented letters, and emoji).
+        fn old_needs_quoting(c: char) -> bool {
+            let mut escaped = c.escape_debug();
+            let is_escaped = escaped.next() != Some(c) || escaped.next().is_some();
+            c <= ' ' || c == '=' || is_escaped
+        }
+
+        for c in (0..=char::MAX as u32).filter_map(char::from_u32) {
+            assert_eq!(
+                char_needs_quoting(c),
+                old_needs_quoting(c),
+                "classifier mismatch for {c:?} (U+{:04X})",
+                c as u32
+            );
+        }
+
+        // And the value-level scan agrees for representative mixed values.
+        for value in [
+            "plain",
+            "café",
+            "ok😀",
+            r"a\b",
+            "O'Brien",
+            "a\"b",
+            "a b",
+            "a=b",
+            "tab\there",
+            "e\u{301}",
+            "\u{301}e",
+            "",
+        ] {
+            assert_eq!(
+                value_needs_quoting(value),
+                value.chars().any(old_needs_quoting),
+                "value scan mismatch for {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn event_fields_sort_in_rendered_token_order() {
+        // Pins the exact field ordering on an event line: byte order of the
+        // rendered `key=value` tokens, including the cases where that differs
+        // from ordering by (key, value):
+        //   * a key extending another key with a digit ('1' < '='), so `a1=2`
+        //     sorts before `a=1`;
+        //   * dotted keys sort by their emitted (underscore) form, so `aZ=4`
+        //     ('Z' < '_') sorts before `a_b=3` despite '.' < 'Z';
+        //   * duplicate keys order by rendered value bytes, where a quoted
+        //     rendering (`k="a b"`, '"' = 0x22) sorts before an unquoted
+        //     `k=#` (0x23).
+        let writer = TestWriter::new();
+        let cloned_writer = writer.clone();
+        let layer = layer().with_writer(Arc::new(move || Box::new(cloned_writer.clone())));
+
+        let _subscriber = tracing_subscriber::registry().with(layer).set_default();
+
+        tracing::warn!(
+            a = "1",
+            a1 = "2",
+            a.b = "3",
+            aZ = "4",
+            k = "#",
+            k = "a b",
+            "ordering"
+        );
+
+        let lines: Vec<String> = writer.text().lines().map(ToString::to_string).collect();
+        assert_eq!(lines.len(), 1, "got {}: {:?}", lines.len(), lines);
+        assert!(
+            lines[0].starts_with(
+                r#"level=WARN msg=ordering a1=2 a=1 aZ=4 a_b=3 k="a b" k=# location=""#
+            ),
+            "Line is: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn literal_key_containing_equals_keeps_the_order_total() {
+        // Field names are almost always identifiers, but tracing accepts
+        // string-literal names, so a key can contain `=`. The comparator's
+        // prefix arm then ties on the `=` byte and falls through to the
+        // remaining token bytes -- keeping the comparison total (a non-total
+        // comparator can panic `sort_by`) and the output in rendered-token
+        // byte order: `k==z` ('=' is 0x3D) sorts before `k=a` and `k=b`.
+        let writer = TestWriter::new();
+        let cloned_writer = writer.clone();
+        let layer = layer().with_writer(Arc::new(move || Box::new(cloned_writer.clone())));
+
+        let _subscriber = tracing_subscriber::registry().with(layer).set_default();
+
+        tracing::warn!(k = "b", "k=" = "z", k = "a", "total-order");
+
+        let lines: Vec<String> = writer.text().lines().map(ToString::to_string).collect();
+        assert_eq!(lines.len(), 1, "got {}: {:?}", lines.len(), lines);
+        assert!(
+            lines[0].starts_with(r#"level=WARN msg=total-order k==z k=a k=b location=""#),
+            "Line is: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn grapheme_extended_values_are_quoted_but_escaped_only_when_leading() {
+        // The quoting probe is per-char (`char::escape_debug`): a combining
+        // mark (grapheme-extended) anywhere in the value forces quoting. The
+        // rendering is `str::escape_debug`, which escapes a grapheme-extended
+        // char only in the first position - mid-string it stays literal inside
+        // the quotes.
+        assert_eq!(kvp("k", "e\u{301}").to_string(), "k=\"e\u{301}\"");
+        assert_eq!(kvp("k", "\u{301}e").to_string(), r#"k="\u{301}e""#);
+        // Printable non-ASCII (emoji) stays unquoted.
+        assert_eq!(kvp("k", "ok😀").to_string(), "k=ok😀");
     }
 
     #[test]


### PR DESCRIPTION
logfmt rendered every field of every log line into its own heap String, sorted the formatted strings, rewrote them into the output buffer, and double-formatted debug values -- and carbide-api installed the admin UI's live log-stream layer (BTreeMap, timestamp/target Strings, a mutex, a 128MiB ring buffer per line) even with the admin UI disabled.

Now each field renders once at record time:

- Each field renders once at record time and the write phase just copies the rendered parts, with the sort reproducing the exact rendered-token ordering -- pinned by tests for the key-prefix, escaped-key, duplicate-key, and literal-`=`-in-key edges (the last also keeps the comparator total).
- Quoting classifies ASCII with a byte-range match; a full Unicode-scalar sweep pins it to the old probe, which non-ASCII still uses.
- The admin log-stream layer installs only when `enable_admin_ui` is set, and closing spans move their field map out instead of cloning it.

Output bytes are a contract: all seventeen pre-existing golden tests pass unchanged. Benched at about -25% time and -43% allocations per line, with the clean-ASCII quoting scan several times faster. The emit loop stays deliberately raw byte copies -- the one measured spot where `write!`'s dispatch costs a visible slice of the win; its comment records the trade and the bench that re-verifies it.

This supports https://github.com/NVIDIA/infra-controller/issues/3219




Closes #3219
