### PR TITLE
docs(network): document MNNVL rack IP requirements in prerequisites

### DIFF
--- a/docs/getting-started/prerequisites/network.md
+++ b/docs/getting-started/prerequisites/network.md
@@ -36,6 +36,7 @@ Typically, a `/27` pool is used for services running on the control plane cluste
 | Item | Detail |
 |---|---|
 | IPs per host | 1 (host BMC) + 2 per DPU (DPU ARM OS + DPU BMC) |
+| IPs for MNNVL racks | 3 per switch (BMC + 2 NVOS) + 1 per power shelf PMC |
 | Managed by | NICo (can be split across multiple pools) |
 
 <Warning>Out-of-band (OOB) switches must have a DHCP relay pointing to the NICo DHCP service (refer to the [BMC and Out-of-Band Setup](bmc-oob-setup.md) page for more details).</Warning>


### PR DESCRIPTION
Add control-plane management IP counts for MNNVL racks (switch BMC, two NVOS addresses, and power shelf PMC) so site planners can size OOB pools correctly alongside standard host/DPU nodes.

<!-- Describe what this PR does -->

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Adds a row to the Control Plane Management Network table for MNNVL racks:
3 IPs per node (switch BMC + 2 NVOS) + 1 (power shelf PMC).

