### PR TITLE
feat: count managed loop iterations, retry failed health discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,6 +3212,7 @@ name = "carbide-utils"
 version = "0.0.0"
 dependencies = [
  "byte-unit",
+ "carbide-instrument",
  "carbide-network",
  "carbide-test-support",
  "chrono",
@@ -3227,6 +3228,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/api-core/src/dpa/handler.rs
+++ b/crates/api-core/src/dpa/handler.rs
@@ -329,11 +329,11 @@ pub async fn start_dpa_handler(
             if queue_stats.total_processed != last_processed
                 || publish_stats.total_published != last_sent
             {
-                println!(
-                    "Stats: {} received, {} sent, {} pending",
-                    queue_stats.total_processed,
-                    publish_stats.total_published,
-                    queue_stats.pending_messages
+                tracing::debug!(
+                    received = queue_stats.total_processed,
+                    sent = publish_stats.total_published,
+                    pending = queue_stats.pending_messages,
+                    "DPA MQTT client stats"
                 );
                 last_processed = queue_stats.total_processed;
                 last_sent = publish_stats.total_published;

--- a/crates/api-core/src/machine_update_manager/mod.rs
+++ b/crates/api-core/src/machine_update_manager/mod.rs
@@ -27,9 +27,10 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use carbide_machine_controller::dpf::DpfOperations;
+use carbide_utils::managed_loop::{self, LoopManager};
 use carbide_utils::periodic_timer::PeriodicTimer;
 use carbide_uuid::machine::MachineId;
-use db::work_lock_manager::WorkLockManagerHandle;
+use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use db::{DatabaseError, ObjectFilter, Transaction};
 use host_firmware::HostFirmwareUpdate;
 use machine_update_module::MachineUpdateModule;
@@ -43,8 +44,8 @@ use tokio_util::sync::CancellationToken;
 
 use self::dpu_nic_firmware::DpuNicFirmwareUpdate;
 use self::metrics::MachineUpdateManagerMetrics;
-use crate::CarbideResult;
 use crate::cfg::file::{CarbideConfig, MaxConcurrentUpdates};
+use crate::{CarbideError, CarbideResult};
 
 /// The MachineUpdateManager periodically runs [modules](machine_update_module::MachineUpdateModule) to initiate upgrades of machine components.
 /// On each iteration the MachineUpdateManager will:
@@ -145,9 +146,8 @@ impl MachineUpdateManager {
         let timer = PeriodicTimer::new(self.run_interval);
         loop {
             let tick = timer.tick();
-            if let Err(e) = self.run_single_iteration().await {
-                tracing::warn!("MachineUpdateManager error: {}", e);
-            }
+            let result = self.run_single_iteration().await;
+            managed_loop::record_iteration(LoopManager::MachineUpdateManager, &result);
 
             tokio::select! {
                 _ = tick.sleep() => {},
@@ -193,11 +193,17 @@ impl MachineUpdateManager {
             .await
         {
             Ok(lock) => lock,
-            Err(e) => {
+            Err(e @ AcquireLockError::WorkAlreadyLocked(_)) => {
                 tracing::warn!(
-                    "MachineUpdateManager failed to acquire work lock: Another instance of carbide running? {e}"
+                    error = %e,
+                    "MachineUpdateManager failed to acquire work lock: Another instance of carbide running?"
                 );
                 return Ok(());
+            }
+            Err(e) => {
+                return Err(CarbideError::internal(format!(
+                    "failed to acquire machine update work lock: {e}"
+                )));
             }
         };
 

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -22,6 +22,7 @@ use std::io;
 use std::sync::Arc;
 
 use carbide_machine_controller::config::machine_validation::MachineValidationConfig;
+use carbide_utils::managed_loop::{self, LoopManager};
 use carbide_utils::periodic_timer::PeriodicTimer;
 use db::ObjectColumnFilter;
 use db::machine_validation::StateColumn;
@@ -171,9 +172,8 @@ impl MachineValidationManager {
         let timer = PeriodicTimer::new(self.config.run_interval);
         loop {
             let tick = timer.tick();
-            if let Err(e) = self.run_single_iteration().await {
-                tracing::warn!("MachineValidationManager error: {}", e);
-            }
+            let result = self.run_single_iteration().await;
+            managed_loop::record_iteration(LoopManager::MachineValidationManager, &result);
 
             tokio::select! {
                 _ = tick.sleep() => {},

--- a/crates/api-core/src/mqtt_state_change_hook/republisher.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/republisher.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use carbide_mqtt_common::hook::{MqttPublisher, publish_with_deadline};
 use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
+use carbide_utils::managed_loop::{self, LoopManager};
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Utc};
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
@@ -133,9 +134,8 @@ impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
                 self.config.healthy_republish_every,
                 sweep,
             );
-            if let Err(e) = self.run_sweep(publish_healthy, &cancel_token).await {
-                tracing::warn!(error = %e, "Managed host state republish sweep failed");
-            }
+            let result = self.run_sweep(publish_healthy, &cancel_token).await;
+            managed_loop::record_iteration(LoopManager::ManagedHostStateRepublisher, &result);
             sweep = sweep.wrapping_add(1);
         }
     }
@@ -167,11 +167,9 @@ impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
                 return Ok(());
             }
             Err(e) => {
-                tracing::warn!(
-                    lock = REPUBLISH_WORK_KEY,
-                    "Unable to acquire managed host state republish lock: {e}"
-                );
-                return Ok(());
+                return Err(eyre::Report::new(e).wrap_err(format!(
+                    "unable to acquire managed host state republish lock `{REPUBLISH_WORK_KEY}`"
+                )));
             }
         };
 

--- a/crates/api-core/src/tests/machine_update_manager.rs
+++ b/crates/api-core/src/tests/machine_update_manager.rs
@@ -34,12 +34,12 @@ use sqlx::PgConnection;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
-use crate::CarbideResult;
 use crate::cfg::file::CarbideConfig;
 use crate::machine_update_manager::MachineUpdateManager;
 use crate::machine_update_manager::machine_update_module::MachineUpdateModule;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::create_managed_host;
+use crate::{CarbideError, CarbideResult};
 
 const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/cfg/test_data");
 
@@ -261,6 +261,48 @@ fn test_start(pool: sqlx::PgPool) {
     let end_count = test_module.get_start_updates_called();
 
     assert_eq!(start_count, end_count);
+}
+
+/// A lock acquisition that fails for infrastructure reasons (here: the work
+/// lock manager is gone, so the command channel is closed) must propagate out
+/// of `run_single_iteration` as an error rather than being swallowed as a
+/// benign yield -- it is what flips the loop's heartbeat to `outcome=error`.
+#[crate::sqlx_test()]
+fn test_run_single_iteration_propagates_lock_infrastructure_failure(pool: sqlx::PgPool) {
+    let test_module = Box::new(TestUpdateModule::new(vec![], HashSet::default()));
+    let mut join_set = JoinSet::new();
+    let work_lock_manager_handle =
+        db::work_lock_manager::start(&mut join_set, pool.clone(), Default::default())
+            .await
+            .unwrap();
+    join_set.shutdown().await;
+
+    let config: Arc<CarbideConfig> = Arc::new(
+        Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/full_config.toml")))
+            .extract()
+            .unwrap(),
+    );
+    let update_manager = MachineUpdateManager::new_with_modules(
+        pool,
+        config,
+        vec![test_module],
+        work_lock_manager_handle,
+    );
+
+    let err = update_manager
+        .run_single_iteration()
+        .await
+        .expect_err("a dead work lock manager is an infrastructure failure, not a yield");
+    assert!(
+        matches!(err, CarbideError::Internal { .. }),
+        "expected CarbideError::Internal, got {err:?}"
+    );
+    assert!(
+        err.to_string()
+            .contains("failed to acquire machine update work lock"),
+        "unexpected message: {err}"
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/health/src/discovery/mod.rs
+++ b/crates/health/src/discovery/mod.rs
@@ -20,12 +20,152 @@ mod context;
 mod iteration;
 mod spawn;
 
+use std::time::Duration;
+
+use async_trait::async_trait;
+use carbide_utils::managed_loop::{self, LoopManager};
 pub use context::DiscoveryLoopContext;
 pub use iteration::run_discovery_iteration;
+
+use crate::HealthError;
+use crate::collectors::{BackoffConfig, ExponentialBackoff};
 
 #[derive(Debug, Clone)]
 pub struct DiscoveryIterationStats {
     pub discovered_endpoints: usize,
     pub sharded_endpoints: usize,
     pub active_monitors: usize,
+}
+
+/// One pass of the endpoint discovery loop: the unit of work
+/// [`run_discovery_loop`] repeats, counts, and retries.
+#[async_trait]
+pub(crate) trait DiscoveryIteration: Send {
+    async fn run_once(&mut self) -> Result<(), HealthError>;
+}
+
+/// Drives `iteration` forever on the discovery cadence. Every pass is
+/// counted by the shared managed-loop event; a failed pass writes that
+/// event's WARN line and schedules a capped exponential backoff instead of
+/// ending the loop, and the next success resets the backoff and returns the
+/// cadence to `interval`.
+pub(crate) async fn run_discovery_loop(
+    interval: Duration,
+    backoff_config: BackoffConfig,
+    mut iteration: impl DiscoveryIteration,
+) {
+    let mut backoff = ExponentialBackoff::new(&backoff_config);
+    loop {
+        let result = iteration.run_once().await;
+        managed_loop::record_iteration(LoopManager::HealthDiscovery, &result);
+        let delay = match result {
+            Ok(()) => {
+                backoff.reset();
+                interval
+            }
+            Err(_) => backoff.next_delay(),
+        };
+        tokio::time::sleep(delay).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::MetricsCapture;
+
+    use super::*;
+
+    /// A scripted pass: succeeds or fails per the script and reports when
+    /// each pass started.
+    struct ScriptedIteration {
+        script: Vec<bool>,
+        calls: usize,
+        times: tokio::sync::mpsc::UnboundedSender<tokio::time::Instant>,
+    }
+
+    #[async_trait]
+    impl DiscoveryIteration for ScriptedIteration {
+        async fn run_once(&mut self) -> Result<(), HealthError> {
+            let ok = self.script[self.calls.min(self.script.len() - 1)];
+            self.calls += 1;
+            self.times
+                .send(tokio::time::Instant::now())
+                .expect("test holds the receiver");
+            if ok {
+                Ok(())
+            } else {
+                Err(HealthError::GenericError("iteration failed".to_string()))
+            }
+        }
+    }
+
+    /// A failing iteration keeps the loop alive on a doubling retry cadence
+    /// (instead of the historical first-error exit), and the next success
+    /// resets the backoff so a later failure retries from the initial delay
+    /// again. Iteration start times come out exact under the paused clock;
+    /// only the backoff's random jitter (less than one doubling) widens the
+    /// asserted windows.
+    #[tokio::test(start_paused = true)]
+    async fn discovery_loop_retries_failures_and_resets_backoff() {
+        let metrics = MetricsCapture::start();
+        let (times_tx, mut times_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let loop_task = tokio::spawn(run_discovery_loop(
+            Duration::from_secs(300),
+            BackoffConfig {
+                initial: Duration::from_secs(1),
+                max: Duration::from_secs(8),
+            },
+            ScriptedIteration {
+                // Two failures (retry, then doubled retry), a success
+                // (normal cadence), then a failure that must retry from the
+                // initial delay again.
+                script: vec![false, false, true, false, true],
+                calls: 0,
+                times: times_tx,
+            },
+        ));
+
+        let mut times = Vec::new();
+        for _ in 0..5 {
+            times.push(times_rx.recv().await.expect("loop keeps iterating"));
+        }
+        loop_task.abort();
+
+        let gaps: Vec<Duration> = times.windows(2).map(|pair| pair[1] - pair[0]).collect();
+        let within = |gap: Duration, low: u64, high: u64| {
+            gap >= Duration::from_secs(low) && gap < Duration::from_secs(high)
+        };
+
+        // The first failure retries within [initial, 2 * initial): the loop
+        // survived the error.
+        assert!(within(gaps[0], 1, 2), "first retry: {gaps:?}");
+        // A second consecutive failure doubles the delay.
+        assert!(within(gaps[1], 2, 4), "doubled retry: {gaps:?}");
+        // A success sleeps the full discovery interval, exactly.
+        assert_eq!(
+            gaps[2],
+            Duration::from_secs(300),
+            "normal cadence: {gaps:?}"
+        );
+        // The success also reset the backoff: the next failure retries from
+        // the initial delay again, not from the doubled one.
+        assert!(within(gaps[3], 1, 2), "retry after reset: {gaps:?}");
+
+        // Every pass counted under its outcome: three failures, two successes.
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_managed_loop_iterations_total",
+                &[("manager", "health_discovery"), ("outcome", "error")],
+            ),
+            3.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_managed_loop_iterations_total",
+                &[("manager", "health_discovery"), ("outcome", "ok")],
+            ),
+            2.0
+        );
+    }
 }

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use nv_redfish::bmc_http::reqwest::{
     BmcError, Client as ReqwestClient, ClientParams as ReqwestClientParams,
 };
@@ -41,6 +42,7 @@ pub use config::Config;
 pub use discovery::{DiscoveryIterationStats, DiscoveryLoopContext};
 
 use crate::api_client::{ApiClientWrapper, ApiEndpointSource};
+use crate::collectors::BackoffConfig;
 use crate::config::Configurable;
 use crate::endpoint::{CompositeEndpointSource, EndpointSource, StaticEndpointSource};
 use crate::limiter::{BucketLimiter, NoopLimiter, RateLimiter};
@@ -273,6 +275,43 @@ fn build_data_sink(
     ))))
 }
 
+/// The per-pass work of the endpoint discovery loop: one discovery iteration
+/// plus the gauge updates its stats feed.
+struct ServiceDiscoveryIteration {
+    endpoint_source: Arc<dyn EndpointSource>,
+    shard_manager: ShardManager,
+    ctx: DiscoveryLoopContext,
+    data_sink: Option<Arc<dyn DataSink>>,
+    config: Arc<Config>,
+    discovery_endpoints_gauge: GaugeVec,
+    active_endpoints_gauge: Gauge,
+}
+
+#[async_trait]
+impl discovery::DiscoveryIteration for ServiceDiscoveryIteration {
+    async fn run_once(&mut self) -> Result<(), HealthError> {
+        let stats = discovery::run_discovery_iteration(
+            self.endpoint_source.clone(),
+            &self.shard_manager,
+            &mut self.ctx,
+            self.data_sink.clone(),
+            &self.config.metrics.prefix,
+        )
+        .await?;
+
+        self.discovery_endpoints_gauge
+            .get_metric_with_label_values(&["discovered"])?
+            .set(stats.discovered_endpoints as f64);
+        self.discovery_endpoints_gauge
+            .get_metric_with_label_values(&["sharded"])?
+            .set(stats.sharded_endpoints as f64);
+        self.active_endpoints_gauge
+            .set(stats.active_monitors as f64);
+
+        Ok(())
+    }
+}
+
 pub async fn run_service(config: Config) -> Result<(), HealthError> {
     if let Some(tls_config) = &config.tls.switch {
         tls::preflight(tls_config).await?;
@@ -282,6 +321,19 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
 
     let metrics_endpoint = config.metrics_addr()?;
     let metrics_manager = Arc::new(MetricsManager::new(&config.metrics.prefix)?);
+
+    // Back the global OpenTelemetry meter with a prometheus registry and
+    // merge that registry into this binary's /metrics exposition, so events
+    // emitted through the instrumentation framework -- and the log-event
+    // counts accumulating since startup -- are scrapeable alongside the raw
+    // prometheus pipeline. The setup must outlive the servers: dropping it
+    // would drop the meter provider and stop the exported values.
+    let framework_metrics =
+        metrics_endpoint::new_metrics_setup("carbide-hw-health", "carbide", true).map_err(|e| {
+            HealthError::GenericError(format!("framework metrics setup failed: {e}"))
+        })?;
+    carbide_instrument::log_events::register(&framework_metrics.meter);
+    metrics_manager.expose_framework_registry(framework_metrics.registry.clone());
 
     let join_listener = tokio::spawn(run_metrics_server(
         metrics_endpoint,
@@ -318,7 +370,7 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
 
     let config_arc = Arc::new(config);
 
-    let join_discovery: tokio::task::JoinHandle<Result<(), HealthError>> = tokio::spawn({
+    let join_discovery: tokio::task::JoinHandle<()> = tokio::spawn({
         let config = config_arc.clone();
         let shard_manager = ShardManager {
             shard: config.shard,
@@ -334,41 +386,26 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
             } else {
                 Arc::new(NoopLimiter)
             };
-        let metrics_manager = metrics_manager.clone();
-        let active_endpoints_gauge = active_endpoints_gauge.clone();
-        let discovery_endpoints_gauge = discovery_endpoints_gauge.clone();
-        let endpoint_source = endpoint_source.clone();
-        let data_sink = data_sink.clone();
 
-        let mut ctx = DiscoveryLoopContext::new_with_tls_config(
+        let ctx = DiscoveryLoopContext::new_with_tls_config(
             limiter,
-            metrics_manager,
+            metrics_manager.clone(),
             config.clone(),
             tls_config,
         )?;
 
-        async move {
-            loop {
-                let stats = discovery::run_discovery_iteration(
-                    endpoint_source.clone(),
-                    &shard_manager,
-                    &mut ctx,
-                    data_sink.clone(),
-                    &config.metrics.prefix,
-                )
-                .await?;
+        let interval = config.endpoint_discovery_interval;
+        let iteration = ServiceDiscoveryIteration {
+            endpoint_source: endpoint_source.clone(),
+            shard_manager,
+            ctx,
+            data_sink: data_sink.clone(),
+            config,
+            discovery_endpoints_gauge: discovery_endpoints_gauge.clone(),
+            active_endpoints_gauge: active_endpoints_gauge.clone(),
+        };
 
-                discovery_endpoints_gauge
-                    .get_metric_with_label_values(&["discovered"])?
-                    .set(stats.discovered_endpoints as f64);
-                discovery_endpoints_gauge
-                    .get_metric_with_label_values(&["sharded"])?
-                    .set(stats.sharded_endpoints as f64);
-                active_endpoints_gauge.set(stats.active_monitors as f64);
-
-                tokio::time::sleep(config.endpoint_discovery_interval).await;
-            }
-        }
+        discovery::run_discovery_loop(interval, BackoffConfig::default(), iteration)
     });
 
     tokio::select! {
@@ -387,11 +424,8 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
         }
         res = join_discovery => {
             match res {
-                Ok(Ok(_)) => {
-                    tracing::error!("Discovery loop shutdown");
-                }
-                Ok(Err(e)) => {
-                    tracing::error!(error=?e, "Discovery loop ended unexpectedly");
+                Ok(()) => {
+                    tracing::error!("Discovery loop ended unexpectedly");
                 }
                 Err(e) => {
                     tracing::error!(error=?e, "Discovery loop join error");

--- a/crates/health/src/main.rs
+++ b/crates/health/src/main.rs
@@ -30,8 +30,8 @@ async fn main() -> Result<(), HealthError> {
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
 
-    // Counts events from startup; the metric registers once this binary's
-    // /metrics speaks OpenTelemetry (it serves a raw prometheus Registry today).
+    // Counts events from startup; `run_service` registers the metric with the
+    // framework registry its /metrics response exposes.
     let log_events = carbide_instrument::LogEventsMetric::new("nico-hardware-health");
     tracing_subscriber::registry()
         .with(log_events.layer())

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -34,6 +34,7 @@ test-support = [
 ]
 
 [dependencies]
+carbide-instrument = { path = "../instrument" }
 carbide-network = { path = "../network" }
 
 byte-unit = { workspace = true }
@@ -50,8 +51,10 @@ serde = { workspace = true, features = ["derive"] }
 sqlx = { workspace = true, features = ["postgres"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 
 [lints]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -23,6 +23,7 @@ pub mod arch;
 pub mod cmd;
 pub mod config;
 mod host_port_pair;
+pub mod managed_loop;
 pub mod metrics;
 pub mod periodic_timer;
 pub mod redfish;

--- a/crates/utils/src/managed_loop.rs
+++ b/crates/utils/src/managed_loop.rs
@@ -1,0 +1,216 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! The shared heartbeat for managed maintenance loops: every iteration
+//! counts once in `carbide_managed_loop_iterations_total`, by manager and
+//! outcome, so a single query shows which loops are running, how often, and
+//! which of them are failing -- across binaries.
+
+use carbide_instrument::Outcome;
+
+/// The managed loop an iteration belongs to: the `manager` label on
+/// [`ManagedLoopIteration`].
+///
+/// The measured boot metrics collector is deliberately absent: its
+/// iterations are already counted, split by the same outcome label, by the
+/// `_count` series of
+/// `carbide_measured_boot_collector_iteration_latency_milliseconds`, and a
+/// second per-iteration counter would duplicate that series.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+pub enum LoopManager {
+    /// The machine update manager's update-initiation pass (`nico-api`).
+    MachineUpdateManager,
+    /// The machine validation manager's reconciliation pass (`nico-api`).
+    MachineValidationManager,
+    /// The managed-host-state republisher's MQTT sweep (`nico-api`).
+    ManagedHostStateRepublisher,
+    /// The BMC endpoint discovery pass (`nico-hardware-health`).
+    HealthDiscovery,
+}
+
+/// One pass of a managed maintenance loop completed. Each manager's rate
+/// is its heartbeat -- a series that stops moving means the loop is stuck or
+/// gone -- and the `outcome = error` split is its failure rate. A pass that
+/// yields because another instance holds its work lock still counts as `ok`:
+/// the loop itself is alive. A pass that cannot even ask for the lock
+/// (database down or overloaded) counts as `error`: nothing is doing the
+/// work.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_managed_loop_iterations_total",
+    component = "managed-loop",
+    log = dynamic,
+    metric = counter,
+    message = "managed loop iteration failed",
+    describe = "Number of managed loop iterations, by manager and outcome; the measured boot metrics collector's iterations are counted by its latency histogram instead"
+)]
+pub struct ManagedLoopIteration {
+    #[label]
+    pub manager: LoopManager,
+    #[label]
+    pub outcome: Outcome,
+    /// The iteration error's text; empty on success (the line only renders
+    /// on failure).
+    #[context]
+    pub error: String,
+}
+
+/// Every iteration is counted; only the failures write the WARN line these
+/// loops have always logged.
+impl carbide_instrument::DynamicLog for ManagedLoopIteration {
+    fn log_at(&self) -> carbide_instrument::LogAt {
+        match self.outcome {
+            Outcome::Ok => carbide_instrument::LogAt::Off,
+            Outcome::Error => carbide_instrument::LogAt::Level(tracing::Level::WARN),
+        }
+    }
+}
+
+/// Counts one loop iteration from its result: an ok iteration counts
+/// silently, a failed one also writes the event's WARN line with the error
+/// text.
+pub fn record_iteration<T, E: std::fmt::Display>(manager: LoopManager, result: &Result<T, E>) {
+    carbide_instrument::emit(ManagedLoopIteration {
+        manager,
+        outcome: Outcome::from(result),
+        error: match result {
+            Ok(_) => String::new(),
+            Err(error) => error.to_string(),
+        },
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+
+    use super::*;
+
+    fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
+        log.fields
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+    }
+
+    /// One `record_iteration` call moves the counter under the site's
+    /// manager and the result's outcome; an ok iteration builds no log line
+    /// at all, a failed one writes exactly the WARN line with the error text.
+    #[test]
+    fn record_iteration_counts_every_outcome_and_logs_only_failures() {
+        struct Case {
+            scenario: &'static str,
+            manager: LoopManager,
+            result: Result<(), &'static str>,
+            expect_manager: &'static str,
+            expect_outcome: &'static str,
+            expect_warn_error: Option<&'static str>,
+        }
+
+        let cases = [
+            Case {
+                scenario: "ok iteration counts silently",
+                manager: LoopManager::MachineUpdateManager,
+                result: Ok(()),
+                expect_manager: "machine_update_manager",
+                expect_outcome: "ok",
+                expect_warn_error: None,
+            },
+            Case {
+                scenario: "failed iteration counts and warns",
+                manager: LoopManager::HealthDiscovery,
+                result: Err("connection refused"),
+                expect_manager: "health_discovery",
+                expect_outcome: "error",
+                expect_warn_error: Some("connection refused"),
+            },
+        ];
+
+        for case in cases {
+            let metrics = MetricsCapture::start();
+            let logs = capture_logs(|| record_iteration(case.manager, &case.result));
+
+            match case.expect_warn_error {
+                None => {
+                    assert!(
+                        logs.is_empty(),
+                        "{}: expected no log line: {logs:?}",
+                        case.scenario
+                    );
+                }
+                Some(error) => {
+                    assert_eq!(logs.len(), 1, "{}", case.scenario);
+                    assert_eq!(logs[0].level, tracing::Level::WARN, "{}", case.scenario);
+                    assert_eq!(
+                        logs[0].message, "managed loop iteration failed",
+                        "{}",
+                        case.scenario
+                    );
+                    assert_eq!(
+                        field(&logs[0], "manager"),
+                        Some(case.expect_manager),
+                        "{}",
+                        case.scenario
+                    );
+                    assert_eq!(field(&logs[0], "error"), Some(error), "{}", case.scenario);
+                }
+            }
+
+            assert_eq!(
+                metrics.counter_delta(
+                    "carbide_managed_loop_iterations_total",
+                    &[
+                        ("manager", case.expect_manager),
+                        ("outcome", case.expect_outcome),
+                    ],
+                ),
+                1.0,
+                "{}",
+                case.scenario
+            );
+        }
+    }
+
+    /// The manager label separates the loops into independent series: two
+    /// managers reporting the same outcome each move their own counter once.
+    #[test]
+    fn record_iteration_counts_each_manager_separately() {
+        let metrics = MetricsCapture::start();
+        capture_logs(|| {
+            for manager in [
+                LoopManager::MachineValidationManager,
+                LoopManager::ManagedHostStateRepublisher,
+            ] {
+                record_iteration::<(), &str>(manager, &Ok(()));
+            }
+        });
+
+        for manager in [
+            "machine_validation_manager",
+            "managed_host_state_republisher",
+        ] {
+            assert_eq!(
+                metrics.counter_delta(
+                    "carbide_managed_loop_iterations_total",
+                    &[("manager", manager), ("outcome", "ok")],
+                ),
+                1.0,
+                "manager {manager}"
+            );
+        }
+    }
+}

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -89,6 +89,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_machines_time_in_state_seconds</td><td>histogram</td><td>The amount of time objects of type carbide_machines have spent in a certain state</td></tr>
 <tr><td>carbide_machines_total</td><td>gauge</td><td>The total number of carbide_machines in the system</td></tr>
 <tr><td>carbide_machines_with_state_handling_errors_per_state</td><td>gauge</td><td>The number of carbide_machines in the system with a given state that failed state handling</td></tr>
+<tr><td>carbide_managed_loop_iterations_total</td><td>counter</td><td>Number of managed loop iterations, by manager and outcome; the measured boot metrics collector&#39;s iterations are counted by its latency histogram instead</td></tr>
 <tr><td>carbide_measured_boot_bundles_total</td><td>gauge</td><td>The total number of measured boot bundles.</td></tr>
 <tr><td>carbide_measured_boot_collector_iteration_latency_milliseconds</td><td>histogram</td><td>Number of milliseconds a full measured boot metrics collector iteration took, by outcome</td></tr>
 <tr><td>carbide_measured_boot_machines_per_bundle_state_total</td><td>gauge</td><td>The total number of machines per a given measured boot bundle state.</td></tr>


### PR DESCRIPTION
Every long-lived manager loop now reports the same heartbeat -- `carbide_managed_loop_iterations_total{manager, outcome}` -- and health discovery survives failures instead of dying on the first one.

- One count per pass across the machine update manager, machine validation, the managed-host-state republisher, and health discovery; ok passes stay silent, failures own their historical warn lines. Lock contention counts as `ok` (another instance holds the work); a lock layer that is down counts as the `error` it is.
- The measured boot metrics collector is deliberately absent -- its latency histogram's per-outcome `_count` already counts its iterations, and the metric description says where to look.
- Health discovery: the first error used to kill the task, leaving the pod restart as the de-facto retry; it now warns, backs off (1s doubling to 30s with jitter, reset on success), and retries in-process. Expect restart counts to drop and the failure signal to live in this counter instead.
- The health binary's framework-emitted metrics actually export now: `run_service` installs the meter provider and merges the framework registry into `/metrics` (`expose_framework_registry` finally has a caller), which also lights up the health egress counters and log-event counts.
- Drive-by: the DPA MQTT stats `println!` is now a structured `tracing::debug!`.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3175
