### PR TITLE
fix: hw-health lower fatal mistype

### DIFF
--- a/crates/health/src/processor/health_report.rs
+++ b/crates/health/src/processor/health_report.rs
@@ -102,7 +102,7 @@ impl HealthReportProcessor {
             return SensorHealth::Fatal;
         }
 
-        if let Some(lower_fatal) = health.range_min
+        if let Some(lower_fatal) = health.lower_fatal
             && reading <= lower_fatal
         {
             return SensorHealth::Fatal;


### PR DESCRIPTION
HealthClassification acted on `range_min` instead of `lower_fatal` for Fatal state. 

## Related issues
#3402 3402

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

