### PR TITLE
feat: ensure the boot config through one shared mechanism

### DIFF
--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -444,6 +444,7 @@ impl TestEnv {
             ManagedHostState::StartAssignmentCycle => state.clone(),
             ManagedHostState::HostReprovision { .. } => state.clone(),
             ManagedHostState::BomValidating { .. } => state.clone(),
+            ManagedHostState::EnsureBootConfig { .. } => state.clone(),
             ManagedHostState::Validation { validation_state } => match validation_state {
                 ValidationState::MachineValidation { machine_validation } => {
                     match machine_validation {

--- a/crates/api-core/src/tests/dpu_reprovisioning.rs
+++ b/crates/api-core/src/tests/dpu_reprovisioning.rs
@@ -27,9 +27,10 @@ use common::api_fixtures::{
 use libredfish::{EnabledDisabled, SystemPowerControl};
 use model::instance::status::tenant::TenantState;
 use model::machine::{
-    DpuInitState, FailureCause, FailureDetails, FailureSource, InstallDpuOsState, InstanceState,
-    Machine, MachineLastRebootRequestedMode, MachineState, ManagedHostState, ReprovisionState,
-    SetBootOrderInfo, SetBootOrderState, StateMachineArea, UnlockHostState,
+    DpuInitState, EnsureBootConfigStep, FailureCause, FailureDetails, FailureSource,
+    InstallDpuOsState, InstanceState, Machine, MachineLastRebootRequestedMode, MachineState,
+    ManagedHostState, ReprovisionState, SetBootOrderInfo, SetBootOrderState, StateMachineArea,
+    UnlockHostState,
 };
 use model::test_support::HardwareInfoTemplate;
 use rpc::forge::MachineArchitecture;
@@ -56,15 +57,22 @@ const DGX_H100_INFO_JSON: &[u8] = br#"{
     }
 }"#;
 
-fn reprovision_set_host_boot_order_state(
-    set_boot_order_state: SetBootOrderState,
-) -> ReprovisionState {
-    ReprovisionState::SetHostBootOrder {
+fn ensure_apply_step(set_boot_order_state: SetBootOrderState) -> EnsureBootConfigStep {
+    EnsureBootConfigStep::Apply {
         set_boot_order_info: SetBootOrderInfo {
             set_boot_order_jid: None,
             set_boot_order_state,
             retry_count: 0,
         },
+    }
+}
+
+/// The shared EnsureBootConfig state as DPU-reprovision host boot repair uses
+/// it: resuming at the BMC reboot once the boot config is ensured.
+fn ensure_boot_config_for(mh: &TestManagedHost, step: EnsureBootConfigStep) -> ManagedHostState {
+    ManagedHostState::EnsureBootConfig {
+        resume_to: Box::new(mh.new_dpu_reprovision_state(ReprovisionState::RebootHostBmc)),
+        step,
     }
 }
 
@@ -80,26 +88,8 @@ fn reprovision_host_boot_repair_states(
     mh: &TestManagedHost,
     shape: ReprovisionHostBootRepairShape,
 ) -> Vec<ManagedHostState> {
-    let states = [
-        ReprovisionState::PrepareHostBootRepair,
-        ReprovisionState::UnlockHostForBootRepair {
-            unlock_host_state: UnlockHostState::DisableLockdown,
-        },
-        ReprovisionState::CheckHostBootConfig,
-        ReprovisionState::ConfigureHostBoot { retry_count: 0 },
-        ReprovisionState::PollingHostBiosSetup { retry_count: 0 },
-        reprovision_set_host_boot_order_state(SetBootOrderState::SetBootOrder),
-        reprovision_set_host_boot_order_state(SetBootOrderState::WaitForSetBootOrderJobScheduled),
-        reprovision_set_host_boot_order_state(SetBootOrderState::RebootHost),
-        reprovision_set_host_boot_order_state(SetBootOrderState::WaitForSetBootOrderJobCompletion),
-        reprovision_set_host_boot_order_state(SetBootOrderState::CheckBootOrder),
-        ReprovisionState::LockHostAfterBootRepair,
-        ReprovisionState::RebootHostBmc,
-    ];
-
-    states
-        .into_iter()
-        .map(|state| match shape {
+    let wrap = |state: ReprovisionState| -> ManagedHostState {
+        match shape {
             ReprovisionHostBootRepairShape::SingleDpu => mh.new_dpu_reprovision_state(state),
             ReprovisionHostBootRepairShape::AssignedSingleDpu => {
                 mh.new_dpu_assigned_reprovision_state(state)
@@ -113,8 +103,35 @@ fn reprovision_host_boot_repair_states(
             ReprovisionHostBootRepairShape::AllDpus => {
                 mh.new_dpus_reprovision_state(&vec![&state; mh.dpu_ids.len()])
             }
-        })
-        .collect()
+        }
+    };
+    let ensure = |step: EnsureBootConfigStep| -> ManagedHostState {
+        ManagedHostState::EnsureBootConfig {
+            resume_to: Box::new(wrap(ReprovisionState::RebootHostBmc)),
+            step,
+        }
+    };
+
+    vec![
+        wrap(ReprovisionState::PrepareHostBootRepair),
+        wrap(ReprovisionState::UnlockHostForBootRepair {
+            unlock_host_state: UnlockHostState::DisableLockdown,
+        }),
+        wrap(ReprovisionState::CheckHostBootConfig),
+        wrap(ReprovisionState::ConfigureHostBoot { retry_count: 0 }),
+        wrap(ReprovisionState::PollingHostBiosSetup { retry_count: 0 }),
+        ensure(ensure_apply_step(SetBootOrderState::SetBootOrder)),
+        ensure(ensure_apply_step(
+            SetBootOrderState::WaitForSetBootOrderJobScheduled,
+        )),
+        ensure(ensure_apply_step(SetBootOrderState::RebootHost)),
+        ensure(ensure_apply_step(
+            SetBootOrderState::WaitForSetBootOrderJobCompletion,
+        )),
+        ensure(ensure_apply_step(SetBootOrderState::CheckBootOrder)),
+        ensure(EnsureBootConfigStep::Relock),
+        wrap(ReprovisionState::RebootHostBmc),
+    ]
 }
 
 /// Return true when any DPU in a reprovisioning managed-host state matches.
@@ -505,7 +522,7 @@ async fn test_dpu_reprovision_viking_repairs_bios_before_boot_order_skip(pool: s
     let dpu = dpu_machine.next_iteration_machine(&env).await;
     assert_eq!(
         dpu.current_state(),
-        &mh.new_dpu_reprovision_state(ReprovisionState::LockHostAfterBootRepair)
+        &ensure_boot_config_for(&mh, EnsureBootConfigStep::Relock)
     );
 
     let actions = env

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -58,10 +58,11 @@ use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     BiosConfigInfo, BiosConfigState, CleanupContext, CleanupState, DpuDiscoveringState,
-    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
-    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
-    MachineValidatingState, ManagedHostState, MeasuringState, PowerState, SetBootOrderInfo,
-    SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
+    DpuInitState, DpuReprovisionStates, EnsureBootConfigStep, FailureCause, FailureDetails,
+    FailureSource, HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode,
+    MachineState, MachineValidatingState, ManagedHostState, MeasuringState, PowerState,
+    SetBootOrderInfo, SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
+    UnlockHostState, ValidationState,
 };
 use model::network_segment::NetworkSegmentType;
 use model::site_explorer::{EndpointExplorationReport, ExploredDpu, ExploredManagedHost};
@@ -3158,7 +3159,7 @@ async fn test_set_boot_order_reassert_window_expiry_bounds_reapplies(pool: sqlx:
 /// reorder, verify), re-locks, and resumes validation from its reboot step --
 /// instead of pacing reboots that can never succeed.
 #[crate::sqlx_test]
-async fn test_machine_validation_repairs_reverted_boot_config(pool: sqlx::PgPool) {
+async fn test_machine_validation_ensures_drifted_boot_config(pool: sqlx::PgPool) {
     let env = create_zero_dpu_test_env(pool).await;
 
     let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
@@ -3260,6 +3261,183 @@ async fn test_machine_validation_repairs_reverted_boot_config(pool: sqlx::PgPool
     // Across the repair, the re-assert targeting the boot NIC preceded the reorder.
     let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
     assert_machine_setup_precedes_reorder_for(&actions, boot_nic_mac);
+}
+
+/// Boot-order-only drift (the HTTP-boot device is in place, the order
+/// changed on its own) is also detected while waiting for a validation
+/// reboot: the flow corrects the order -- without re-asserting the device --
+/// re-locks, and resumes validation.
+#[crate::sqlx_test]
+async fn test_machine_validation_ensures_drifted_boot_order(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let host_id = mh.host().id;
+    let boot_nic_mac = host_inband_nic_mac(&env, host_id).await;
+
+    // Device intact, order drifted.
+    env.redfish_sim.set_is_boot_order_setup(false);
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Enabled);
+
+    set_host_controller_state_stuck_in(
+        &env,
+        host_id,
+        &ManagedHostState::Validation {
+            validation_state: ValidationState::MachineValidation {
+                machine_validation: MachineValidatingState::MachineValidating {
+                    context: "Discovery".to_string(),
+                    id: MachineValidationId::new(),
+                    completed: 1,
+                    total: 1,
+                    is_enabled: true,
+                },
+            },
+        },
+        0,
+    )
+    .await;
+
+    let checkpoint = env.redfish_sim.timepoint();
+
+    let mut resumed = false;
+    for _ in 0..20 {
+        env.run_machine_state_controller_iteration().await;
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        if matches!(
+            host.current_state(),
+            ManagedHostState::Validation {
+                validation_state: ValidationState::MachineValidation {
+                    machine_validation: MachineValidatingState::RebootHost { .. },
+                },
+            }
+        ) {
+            resumed = true;
+            break;
+        }
+    }
+    assert!(
+        resumed,
+        "order-only drift should be corrected and validation resumed"
+    );
+
+    let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
+    assert!(
+        actions.iter().any(|a| matches!(
+            a,
+            RedfishSimAction::SetBootOrderDpuFirst { boot_interface_mac }
+                if *boot_interface_mac == boot_nic_mac.to_string()
+        )),
+        "the drifted boot order should be set for the boot NIC, got: {actions:?}"
+    );
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a, RedfishSimAction::MachineSetup { .. })),
+        "the device is in place; correcting the order must not re-assert it, got: {actions:?}"
+    );
+    assert!(
+        env.redfish_sim
+            .lockdown_states()
+            .iter()
+            .all(|l| *l == libredfish::EnabledDisabled::Enabled),
+        "the BMC should be re-locked once the boot order is corrected"
+    );
+}
+
+/// Records still parked in the pre-consolidation validation ensure states
+/// transition into `EnsureBootConfig` at the equivalent step, resuming
+/// validation from its reboot step with the same validation id.
+#[crate::sqlx_test]
+async fn test_pre_consolidation_validation_states_continue_via_ensure_boot_config(
+    pool: sqlx::PgPool,
+) {
+    let env = create_zero_dpu_test_env(pool).await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let host_id = mh.host().id;
+    env.redfish_sim.set_is_bios_setup(false);
+    env.redfish_sim.set_is_boot_order_setup(false);
+
+    let validation_id = MachineValidationId::new();
+    let boot_order_info = SetBootOrderInfo {
+        set_boot_order_jid: None,
+        set_boot_order_state: SetBootOrderState::SetBootOrder,
+        retry_count: 0,
+    };
+
+    struct ParkedLegacyStateCase {
+        name: &'static str,
+        parked: MachineValidatingState,
+        expected_step: EnsureBootConfigStep,
+    }
+
+    let cases = [
+        ParkedLegacyStateCase {
+            name: "prepare",
+            parked: MachineValidatingState::PrepareBootRepair { validation_id },
+            expected_step: EnsureBootConfigStep::CheckLockdown,
+        },
+        ParkedLegacyStateCase {
+            name: "unlock",
+            parked: MachineValidatingState::UnlockForBootRepair {
+                validation_id,
+                unlock_host_state: UnlockHostState::DisableLockdown,
+            },
+            expected_step: EnsureBootConfigStep::Unlock {
+                unlock_host_state: UnlockHostState::DisableLockdown,
+            },
+        },
+        ParkedLegacyStateCase {
+            name: "apply",
+            parked: MachineValidatingState::RepairBootConfig {
+                validation_id,
+                set_boot_order_info: boot_order_info.clone(),
+            },
+            expected_step: EnsureBootConfigStep::Apply {
+                set_boot_order_info: boot_order_info.clone(),
+            },
+        },
+        ParkedLegacyStateCase {
+            name: "relock",
+            parked: MachineValidatingState::LockAfterBootRepair { validation_id },
+            expected_step: EnsureBootConfigStep::Relock,
+        },
+    ];
+
+    for case in cases {
+        set_host_controller_state_stuck_in(
+            &env,
+            host_id,
+            &ManagedHostState::Validation {
+                validation_state: ValidationState::MachineValidation {
+                    machine_validation: case.parked,
+                },
+            },
+            0,
+        )
+        .await;
+
+        env.run_machine_state_controller_iteration().await;
+
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        let expected = ManagedHostState::EnsureBootConfig {
+            resume_to: Box::new(ManagedHostState::Validation {
+                validation_state: ValidationState::MachineValidation {
+                    machine_validation: MachineValidatingState::RebootHost { validation_id },
+                },
+            }),
+            step: case.expected_step,
+        };
+        assert_eq!(
+            host.current_state(),
+            &expected,
+            "case {}: a record parked in the old validation ensure state should continue via EnsureBootConfig",
+            case.name
+        );
+    }
 }
 
 /// When HostInit/PollingBiosSetup retry budget is exhausted, enter Failed and recover via is_bios_setup.

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1192,6 +1192,16 @@ pub enum ManagedHostState {
     Validation {
         validation_state: ValidationState,
     },
+    /// Ensures the host's boot config is what it should be, then resumes the
+    /// interrupted state. Entered whenever a reboot-wait notices the config
+    /// drifted (changed externally, a BIOS quirk, or the boot NIC dropping
+    /// off the BMC's inventory during a reboot's POST): unlock the BMC if it
+    /// is locked, drive the boot-order flow to put the config back, re-lock
+    /// per the expected-machine policy, and resume where the host left off.
+    EnsureBootConfig {
+        resume_to: Box<ManagedHostState>,
+        step: EnsureBootConfigStep,
+    },
     /// Host is Ready for instance creation.
     Ready,
     /// Host is assigned to an Instance.
@@ -2129,6 +2139,37 @@ pub enum UnlockHostState {
     WaitForUefiBoot,
 }
 
+/// Progression of [`ManagedHostState::EnsureBootConfig`]: check whether the
+/// BMC is locked, unlock it if so, drive the boot-order flow to put the boot
+/// config back, then re-lock and resume.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "step", rename_all = "lowercase")]
+pub enum EnsureBootConfigStep {
+    CheckLockdown,
+    Unlock {
+        unlock_host_state: UnlockHostState,
+    },
+    Apply {
+        set_boot_order_info: SetBootOrderInfo,
+    },
+    Relock,
+}
+
+impl Display for EnsureBootConfigStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EnsureBootConfigStep::CheckLockdown => write!(f, "CheckLockdown"),
+            EnsureBootConfigStep::Unlock { unlock_host_state } => {
+                write!(f, "Unlock/{unlock_host_state:?}")
+            }
+            EnsureBootConfigStep::Apply {
+                set_boot_order_info,
+            } => write!(f, "Apply/{:?}", set_boot_order_info.set_boot_order_state),
+            EnsureBootConfigStep::Relock => write!(f, "Relock"),
+        }
+    }
+}
+
 /// Struct to store information if Reprovision is requested.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReprovisionRequest {
@@ -2290,6 +2331,9 @@ impl Display for ManagedHostState {
                 write!(f, "HostInitializing/{machine_state}")
             }
             ManagedHostState::Ready => write!(f, "Ready"),
+            ManagedHostState::EnsureBootConfig { step, .. } => {
+                write!(f, "EnsureBootConfig/{step}")
+            }
             ManagedHostState::Assigned { instance_state, .. } => match instance_state {
                 InstanceState::DPUReprovision { dpu_states } => {
                     let dpu_lowest_state = dpu_states
@@ -2363,6 +2407,17 @@ impl Display for ManagedHostState {
 }
 
 impl ManagedHostState {
+    /// The state this host is operating for. `EnsureBootConfig` is a
+    /// transparent maintenance step ensuring the boot config on behalf of its
+    /// `resume_to` state -- callers reasoning about the host's lifecycle
+    /// (restart requests, tenant status, assignment) should look through it.
+    pub fn effective_state(&self) -> &ManagedHostState {
+        match self {
+            ManagedHostState::EnsureBootConfig { resume_to, .. } => resume_to.effective_state(),
+            other => other,
+        }
+    }
+
     pub fn dpu_state_string(&self, dpu_id: &MachineId) -> String {
         match self {
             ManagedHostState::DpuDiscoveringState { dpu_states } => dpu_states
@@ -2399,6 +2454,9 @@ impl ManagedHostState {
                 format!("WaitingForCleanup/{cleanup_state}")
             }
             ManagedHostState::ForceDeletion => "ForceDeletion".to_string(),
+            ManagedHostState::EnsureBootConfig { step, .. } => {
+                format!("EnsureBootConfig/{step}")
+            }
             ManagedHostState::Failed { details, .. } => {
                 format!("Failed/{}", details.cause)
             }
@@ -2673,6 +2731,9 @@ pub fn state_sla(
             BomValidating::WaitingForSkuAssignment(_bom_validating_context) => StateSla::no_sla(),
             _ => StateSla::with_sla(slas::BOM_VALIDATION, time_in_state),
         },
+        ManagedHostState::EnsureBootConfig { .. } => {
+            StateSla::with_sla(slas::VALIDATION, time_in_state)
+        }
         ManagedHostState::Validation { validation_state } => match validation_state {
             ValidationState::MachineValidation { machine_validation } => match machine_validation {
                 MachineValidatingState::MachineValidating { .. } => {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -73,16 +73,17 @@ use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
     AttestationMode, BomValidating, BomValidatingContext, CleanupContext, CleanupState,
     CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver,
-    DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
-    HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
-    InstanceState, LockdownInfo, LockdownState, MAX_FIRMWARE_UPGRADE_RETRIES, Machine,
-    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineNextStateResolver,
-    MachineState, MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot,
-    MeasuringState, NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation,
-    PowerDrainState, PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext,
-    SecureEraseBossState, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
-    SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState, UnlockHostState,
-    ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
+    DpuInitState, EnsureBootConfigStep, FailureCause, FailureDetails, FailureSource,
+    HostPlatformConfigurationState, HostReprovisionState, InitialResetPhase, InstallDpuOsState,
+    InstanceNextStateResolver, InstanceState, LockdownInfo, LockdownState,
+    MAX_FIRMWARE_UPGRADE_RETRIES, Machine, MachineLastRebootRequested,
+    MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState,
+    MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
+    NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
+    PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext, SecureEraseBossState,
+    SetBootOrderInfo, SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
+    UefiSetupInfo, UefiSetupState, UnlockHostState, ValidationState,
+    dpf_based_dpu_provisioning_possible, get_display_ids,
 };
 use model::power_manager::PowerHandlingOutcome;
 use model::predicted_machine_interface::PredictedMachineInterface;
@@ -1700,6 +1701,16 @@ impl MachineStateHandler {
                     .await
                 }
             },
+            ManagedHostState::EnsureBootConfig { resume_to, step } => {
+                ensure_boot_config(
+                    ctx,
+                    &self.host_handler.host_handler_params,
+                    mh_snapshot,
+                    resume_to,
+                    step,
+                )
+                .await
+            }
         }
     }
 
@@ -1818,7 +1829,9 @@ impl MachineStateHandler {
             .filter(|x| x.reprovision_requested.is_some())
             .collect_vec();
 
-        match managed_state {
+        // A host mid-EnsureBootConfig is still operating for its resumed
+        // state -- honor restart requests against that state, not the wrapper.
+        match managed_state.effective_state() {
             ManagedHostState::Assigned {
                 instance_state: InstanceState::DPUReprovision { .. } | InstanceState::Failed { .. },
             } => {
@@ -3301,20 +3314,15 @@ async fn handle_dpu_reprovision(
             .await?
             {
                 PollingBiosSetupOutcome::Verified => {
-                    let next_state = if should_skip_boot_order_remediation(state) {
-                        ReprovisionState::LockHostAfterBootRepair
+                    // The boot-order set and the re-lock run through the
+                    // shared EnsureBootConfig flow, resuming at the BMC reboot.
+                    let step = if should_skip_boot_order_remediation(state) {
+                        EnsureBootConfigStep::Relock
                     } else {
-                        ReprovisionState::SetHostBootOrder {
-                            set_boot_order_info: SetBootOrderInfo {
-                                set_boot_order_jid: None,
-                                set_boot_order_state: SetBootOrderState::SetBootOrder,
-                                retry_count: 0,
-                            },
-                        }
+                        ensure_boot_config_apply_start()
                     };
-
                     Ok(StateHandlerOutcome::transition(
-                        update_reprovision_targets_to_reprovision_state(state, next_state)?,
+                        ensure_for_reprovision_tail(state, step)?,
                     ))
                 }
                 PollingBiosSetupOutcome::EnterRecovery(bios_config_info) => {
@@ -3338,74 +3346,27 @@ async fn handle_dpu_reprovision(
         ReprovisionState::SetHostBootOrder {
             set_boot_order_info,
         } => {
-            // Promote the selected DPU boot option after machine_setup has enabled it.
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(&state.host_snapshot)
-                .await?;
-
-            match set_host_boot_order(
-                ctx,
-                reachability_params,
-                redfish_client.as_ref(),
-                state,
-                set_boot_order_info.clone(),
-            )
-            .await?
-            {
-                SetBootOrderOutcome::Continue(boot_order_info) => {
-                    Ok(StateHandlerOutcome::transition(
-                        update_reprovision_targets_to_reprovision_state(
-                            state,
-                            ReprovisionState::SetHostBootOrder {
-                                set_boot_order_info: boot_order_info,
-                            },
-                        )?,
-                    ))
+            // Compat-only: records parked here pre-consolidation continue
+            // through the shared EnsureBootConfig flow. Boot order is not
+            // NICo-managed on DGX H100/Viking hardware, so a record parked
+            // mid-chain there restarts the flow from the top: the BIOS side
+            // still gets ensured, and the flow itself skips the boot order.
+            let step = if should_skip_boot_order_remediation(state) {
+                ensure_boot_config_apply_start()
+            } else {
+                EnsureBootConfigStep::Apply {
+                    set_boot_order_info: set_boot_order_info.clone(),
                 }
-                SetBootOrderOutcome::Done => Ok(StateHandlerOutcome::transition(
-                    update_reprovision_targets_to_reprovision_state(
-                        state,
-                        ReprovisionState::LockHostAfterBootRepair,
-                    )?,
-                )),
-                SetBootOrderOutcome::WaitingForReboot(reason) => {
-                    Ok(StateHandlerOutcome::wait(reason))
-                }
-                SetBootOrderOutcome::Wait(reason) => Ok(StateHandlerOutcome::wait(reason)),
-            }
+            };
+            Ok(StateHandlerOutcome::transition(
+                ensure_for_reprovision_tail(state, step)?,
+            ))
         }
         ReprovisionState::LockHostAfterBootRepair => {
-            // Preserve expected-machine lockdown policy after temporarily
-            // opening the BMC for host boot repair.
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(&state.host_snapshot)
-                .await?;
-
-            if state.host_snapshot.host_profile.disable_lockdown {
-                tracing::info!(
-                    machine_id = %state.host_snapshot.id,
-                    "Skipping lockdown re-enable in DPU reprovision per expected-machine config"
-                );
-            } else {
-                match redfish_client.lockdown_bmc(EnabledDisabled::Enabled).await {
-                    Ok(()) => {}
-                    Err(RedfishError::NotSupported(_)) => {
-                        tracing::info!(
-                            machine_id = %state.host_snapshot.id,
-                            "BMC vendor does not support re-enabling lockdown after DPU reprovision host boot repair"
-                        );
-                    }
-                    Err(e) => return Err(redfish_error("lockdown_bmc", e)),
-                }
-            }
-
+            // Compat-only: records parked here pre-consolidation re-lock
+            // through the shared EnsureBootConfig flow.
             Ok(StateHandlerOutcome::transition(
-                update_reprovision_targets_to_reprovision_state(
-                    state,
-                    ReprovisionState::RebootHostBmc,
-                )?,
+                ensure_for_reprovision_tail(state, EnsureBootConfigStep::Relock)?,
             ))
         }
         ReprovisionState::RebootHostBmc => {
@@ -11405,6 +11366,317 @@ async fn handle_instance_host_platform_config(
     Ok(StateHandlerOutcome::transition(next_state))
 }
 
+/// Rebuild the [`ManagedHostState::EnsureBootConfig`] wrapper at a new step.
+fn ensure_boot_config_at(
+    resume_to: &ManagedHostState,
+    step: EnsureBootConfigStep,
+) -> ManagedHostState {
+    ManagedHostState::EnsureBootConfig {
+        resume_to: Box::new(resume_to.clone()),
+        step,
+    }
+}
+
+/// `EnsureBootConfig` resuming DPU-reprovision host boot repair at its
+/// BMC-reboot tail.
+fn ensure_for_reprovision_tail(
+    state: &ManagedHostStateSnapshot,
+    step: EnsureBootConfigStep,
+) -> Result<ManagedHostState, StateHandlerError> {
+    Ok(ManagedHostState::EnsureBootConfig {
+        resume_to: Box::new(update_reprovision_targets_to_reprovision_state(
+            state,
+            ReprovisionState::RebootHostBmc,
+        )?),
+        step,
+    })
+}
+
+/// The starting point for the boot-order flow when EnsureBootConfig drives
+/// it: the flow itself checks what is already in place and only re-applies
+/// what drifted.
+fn ensure_boot_config_apply_start() -> EnsureBootConfigStep {
+    EnsureBootConfigStep::Apply {
+        set_boot_order_info: SetBootOrderInfo {
+            set_boot_order_jid: None,
+            set_boot_order_state: SetBootOrderState::SetBootOrder,
+            retry_count: 0,
+        },
+    }
+}
+
+/// Pace reboots for a host that has not come back, while ensuring its boot
+/// config is still what it should be. A host whose config drifted (changed
+/// externally, a BIOS quirk, or the boot NIC dropping off the BMC's inventory
+/// during the reboot's POST) can never boot back on its own -- further
+/// reboots don't restore a setting that is gone -- so this transitions to
+/// [`ManagedHostState::EnsureBootConfig`] (resuming `resume_to`) instead of
+/// rebooting again. Reboot-wait sites call this in place of
+/// [`trigger_reboot_if_needed`] to get drift handling without bespoke code.
+async fn pace_reboot_or_ensure_boot_config(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    reachability_params: &ReachabilityParams,
+    resume_to: ManagedHostState,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    if let RequiredBootInterface::Ready(boot_interface) = require_boot_interface(
+        mh_snapshot,
+        &predictions,
+        "verifying the boot config while waiting for a reboot",
+        |message| message,
+    )? {
+        let redfish_client = ctx
+            .services
+            .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+            .await?;
+        match boot_interface
+            .run(|bi| redfish_client.is_bios_setup(Some(bi)))
+            .await
+        {
+            Ok(false) => {
+                tracing::warn!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Boot config reads drifted while waiting for a reboot; ensuring it",
+                );
+                return Ok(StateHandlerOutcome::transition(
+                    ManagedHostState::EnsureBootConfig {
+                        resume_to: Box::new(resume_to),
+                        step: EnsureBootConfigStep::CheckLockdown,
+                    },
+                ));
+            }
+            Ok(true) => {
+                // The HTTP-boot device is in place -- the boot order can
+                // still have drifted on its own (except on hardware where
+                // it is not NICo-managed), leaving the host booting the
+                // wrong device. Ensure that too rather than pacing forever.
+                if !should_skip_boot_order_remediation(mh_snapshot) {
+                    match boot_interface
+                        .run(|bi| redfish_client.is_boot_order_setup(bi))
+                        .await
+                    {
+                        Ok(false) => {
+                            tracing::warn!(
+                                machine_id = %mh_snapshot.host_snapshot.id,
+                                "Boot order reads drifted while waiting for a reboot; ensuring it",
+                            );
+                            return Ok(StateHandlerOutcome::transition(
+                                ManagedHostState::EnsureBootConfig {
+                                    resume_to: Box::new(resume_to),
+                                    step: EnsureBootConfigStep::CheckLockdown,
+                                },
+                            ));
+                        }
+                        Ok(true) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                machine_id = %mh_snapshot.host_snapshot.id,
+                                error = %e,
+                                "Could not verify the boot order while waiting for a reboot; will retry",
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    error = %e,
+                    "Could not verify the boot config while waiting for a reboot; will retry",
+                );
+            }
+        }
+    }
+    let status = trigger_reboot_if_needed(
+        &mh_snapshot.host_snapshot,
+        mh_snapshot,
+        None,
+        reachability_params,
+        ctx,
+    )
+    .await?;
+    Ok(StateHandlerOutcome::wait(status.status))
+}
+
+/// Drives [`ManagedHostState::EnsureBootConfig`]: make the host's boot config
+/// what it should be, then resume the interrupted state. Checks whether the
+/// BMC is locked and unlocks it if so (BIOS writes bounce off a locked BMC),
+/// drives the boot-order flow to put the config back (it verifies first and
+/// only re-applies what drifted), re-locks per the expected-machine policy,
+/// and transitions back to `resume_to`.
+async fn ensure_boot_config(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    host_handler_params: &HostHandlerParams,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    resume_to: &ManagedHostState,
+    step: &EnsureBootConfigStep,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+
+    match step {
+        EnsureBootConfigStep::CheckLockdown => {
+            let next = match redfish_client.lockdown_status().await {
+                Err(RedfishError::NotSupported(_)) => {
+                    tracing::info!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "BMC vendor does not support checking lockdown status; ensuring the boot config directly",
+                    );
+                    ensure_boot_config_apply_start()
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        error = %e,
+                        "Failed to fetch lockdown status while ensuring the boot config",
+                    );
+                    return Ok(StateHandlerOutcome::wait(format!(
+                        "Failed to fetch lockdown status: {e}"
+                    )));
+                }
+                Ok(lockdown_status) if !lockdown_status.is_fully_disabled() => {
+                    tracing::info!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "Lockdown is enabled; unlocking before ensuring the boot config",
+                    );
+                    EnsureBootConfigStep::Unlock {
+                        unlock_host_state: UnlockHostState::DisableLockdown,
+                    }
+                }
+                Ok(_) => ensure_boot_config_apply_start(),
+            };
+            Ok(StateHandlerOutcome::transition(ensure_boot_config_at(
+                resume_to, next,
+            )))
+        }
+        EnsureBootConfigStep::Unlock { unlock_host_state } => {
+            let next = match unlock_host_state {
+                UnlockHostState::DisableLockdown => {
+                    // Tolerate a vendor that reports lockdown status but does
+                    // not support setting it, symmetric with the re-lock step.
+                    match redfish_client.lockdown_bmc(EnabledDisabled::Disabled).await {
+                        Ok(()) => {}
+                        Err(RedfishError::NotSupported(_)) => {
+                            tracing::info!(
+                                machine_id = %mh_snapshot.host_snapshot.id,
+                                "BMC vendor does not support disabling lockdown while ensuring the boot config",
+                            );
+                        }
+                        Err(e) => return Err(redfish_error("lockdown_bmc", e)),
+                    }
+
+                    let vendor = mh_snapshot.host_snapshot.bmc_vendor();
+                    if vendor.is_supermicro() {
+                        tracing::info!(
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            %vendor,
+                            "BMC lockdown disabled; rebooting host so Redfish reflects actual boot state",
+                        );
+                        EnsureBootConfigStep::Unlock {
+                            unlock_host_state: UnlockHostState::RebootHost,
+                        }
+                    } else {
+                        ensure_boot_config_apply_start()
+                    }
+                }
+                UnlockHostState::RebootHost => {
+                    host_power_control(
+                        redfish_client.as_ref(),
+                        &mh_snapshot.host_snapshot,
+                        SystemPowerControl::ForceRestart,
+                        ctx,
+                    )
+                    .await
+                    .map_err(|e| {
+                        StateHandlerError::GenericError(eyre::eyre!(
+                            "failed to ForceRestart host after disabling BMC lockdown: {}",
+                            e
+                        ))
+                    })?;
+
+                    EnsureBootConfigStep::Unlock {
+                        unlock_host_state: UnlockHostState::WaitForUefiBoot,
+                    }
+                }
+                UnlockHostState::WaitForUefiBoot => {
+                    let entered_at = mh_snapshot.host_snapshot.state.version.timestamp();
+                    if wait(
+                        &entered_at,
+                        host_handler_params.reachability_params.uefi_boot_wait,
+                    ) {
+                        return Ok(StateHandlerOutcome::wait(format!(
+                            "Waiting for UEFI boot to complete on {} after post-unlock reboot",
+                            mh_snapshot.host_snapshot.id
+                        )));
+                    }
+                    ensure_boot_config_apply_start()
+                }
+            };
+            Ok(StateHandlerOutcome::transition(ensure_boot_config_at(
+                resume_to, next,
+            )))
+        }
+        EnsureBootConfigStep::Apply {
+            set_boot_order_info,
+        } => {
+            match set_host_boot_order(
+                ctx,
+                &host_handler_params.reachability_params,
+                redfish_client.as_ref(),
+                mh_snapshot,
+                set_boot_order_info.clone(),
+            )
+            .await?
+            {
+                SetBootOrderOutcome::Continue(info) => {
+                    Ok(StateHandlerOutcome::transition(ensure_boot_config_at(
+                        resume_to,
+                        EnsureBootConfigStep::Apply {
+                            set_boot_order_info: info,
+                        },
+                    )))
+                }
+                SetBootOrderOutcome::Done => Ok(StateHandlerOutcome::transition(
+                    ensure_boot_config_at(resume_to, EnsureBootConfigStep::Relock),
+                )),
+                SetBootOrderOutcome::WaitingForReboot(reason)
+                | SetBootOrderOutcome::Wait(reason) => Ok(StateHandlerOutcome::wait(reason)),
+            }
+        }
+        EnsureBootConfigStep::Relock => {
+            // Restore the lockdown this flow temporarily opened, then resume
+            // the interrupted state.
+            if mh_snapshot.host_snapshot.host_profile.disable_lockdown {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Skipping lockdown re-enable after ensuring the boot config per expected-machine config",
+                );
+            } else {
+                match redfish_client.lockdown_bmc(EnabledDisabled::Enabled).await {
+                    Ok(()) => {}
+                    Err(RedfishError::NotSupported(_)) => {
+                        tracing::info!(
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            "BMC vendor does not support re-enabling lockdown after ensuring the boot config",
+                        );
+                    }
+                    Err(e) => return Err(redfish_error("lockdown_bmc", e)),
+                }
+            }
+
+            tracing::info!(
+                machine_id = %mh_snapshot.host_snapshot.id,
+                resume_to = %resume_to,
+                "Boot config ensured; resuming",
+            );
+            Ok(StateHandlerOutcome::transition(resume_to.clone()))
+        }
+    }
+}
+
 async fn set_host_boot_order(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     reachability_params: &ReachabilityParams,
@@ -11487,6 +11759,18 @@ async fn set_host_boot_order(
                     set_boot_order_state: SetBootOrderState::WaitForHttpBootDeviceApplied,
                     retry_count: set_boot_order_info.retry_count,
                 }));
+            }
+
+            // Boot order is not NICo-managed on DGX H100/Viking hardware --
+            // ensuring the boot config there means ensuring the BIOS side only.
+            // With the HTTP-boot device verified above, there is nothing more
+            // to apply.
+            if should_skip_boot_order_remediation(mh_snapshot) {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Boot config verified; boot order is not managed on this hardware",
+                );
+                return Ok(SetBootOrderOutcome::Done);
             }
 
             // HTTP-boot device is already set, so `machine_setup` was not re-run

--- a/crates/machine-controller/src/handler/machine_validation.rs
+++ b/crates/machine-controller/src/handler/machine_validation.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 use carbide_uuid::machine_validation::MachineValidationId;
-use libredfish::{EnabledDisabled, RedfishError, SystemPowerControl};
+use libredfish::SystemPowerControl;
 use model::machine::{
-    FailureCause, MachineState, MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot,
-    SetBootOrderInfo, SetBootOrderState, UnlockHostState, ValidationState,
+    EnsureBootConfigStep, FailureCause, MachineState, MachineValidatingState, ManagedHostState,
+    ManagedHostStateSnapshot, ValidationState,
 };
 use model::machine_validation::{MachineValidationState, MachineValidationStatus};
 use state_controller::state_handler::{
@@ -28,9 +28,8 @@ use state_controller::state_handler::{
 use super::{HostHandlerParams, is_machine_validation_requested, machine_validation_completed};
 use crate::context::{MachineStateHandlerContextObjects, MachineStateHandlerServices};
 use crate::handler::{
-    RequiredBootInterface, SetBootOrderOutcome, handler_host_power_control, host_power_control,
-    load_boot_predictions, rebooted, redfish_error, require_boot_interface, set_host_boot_order,
-    trigger_reboot_if_needed, wait,
+    ensure_boot_config_apply_start, handler_host_power_control, pace_reboot_or_ensure_boot_config,
+    rebooted, should_skip_boot_order_remediation,
 };
 
 /// The validation flavor of the managed-host state, so the repair arms can
@@ -41,14 +40,16 @@ fn validating(machine_validation: MachineValidatingState) -> ManagedHostState {
     }
 }
 
-/// The starting point for the boot-order flow when validation boot repair
-/// re-drives it: the flow itself checks what is already in place and only
-/// re-applies what the reboot reverted.
-fn boot_repair_start() -> SetBootOrderInfo {
-    SetBootOrderInfo {
-        set_boot_order_jid: None,
-        set_boot_order_state: SetBootOrderState::SetBootOrder,
-        retry_count: 0,
+/// `EnsureBootConfig` resuming validation from its reboot step.
+fn ensure_for_validation(
+    validation_id: MachineValidationId,
+    step: EnsureBootConfigStep,
+) -> ManagedHostState {
+    ManagedHostState::EnsureBootConfig {
+        resume_to: Box::new(validating(MachineValidatingState::RebootHost {
+            validation_id,
+        })),
+        step,
     }
 }
 
@@ -145,55 +146,15 @@ pub(crate) async fn handle_machine_validation_state(
                 is_enabled,
             );
             if !rebooted(&mh_snapshot.host_snapshot) {
-                // Ensure the boot config is still what it should be while
-                // waiting. If it reads reverted -- changed externally, a BIOS
-                // quirk, or the boot NIC dropping off the BMC's inventory
-                // during the reboot's POST -- the host can't boot into the
-                // validation environment, and further reboots can't restore a
-                // setting that is gone. Correct it instead of pacing forever.
-                let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
-                if let RequiredBootInterface::Ready(boot_interface) = require_boot_interface(
-                    mh_snapshot,
-                    &predictions,
-                    "verifying the boot config during validation",
-                    |message| message,
-                )? {
-                    let redfish_client = ctx
-                        .services
-                        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
-                        .await?;
-                    match boot_interface
-                        .run(|bi| redfish_client.is_bios_setup(Some(bi)))
-                        .await
-                    {
-                        Ok(false) => {
-                            tracing::warn!(
-                                machine_id = %mh_snapshot.host_snapshot.id,
-                                "Boot config reads reverted while waiting for the validation reboot; correcting it via boot repair",
-                            );
-                            return Ok(StateHandlerOutcome::transition(validating(
-                                MachineValidatingState::PrepareBootRepair { validation_id: *id },
-                            )));
-                        }
-                        Ok(true) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                machine_id = %mh_snapshot.host_snapshot.id,
-                                error = %e,
-                                "Could not verify the boot config while waiting for the validation reboot; will retry",
-                            );
-                        }
-                    }
-                }
-                let status = trigger_reboot_if_needed(
-                    &mh_snapshot.host_snapshot,
-                    mh_snapshot,
-                    None,
-                    &host_handler_params.reachability_params,
+                // Pace the reboot, ensuring the boot config is still what it
+                // should be -- a drifted config can never boot back on its own.
+                return pace_reboot_or_ensure_boot_config(
                     ctx,
+                    mh_snapshot,
+                    &host_handler_params.reachability_params,
+                    validating(MachineValidatingState::RebootHost { validation_id: *id }),
                 )
-                .await?;
-                return Ok(StateHandlerOutcome::wait(status.status));
+                .await;
             }
             if !host_handler_params.machine_validation_config.enabled {
                 return skip_machine_validation(ctx, id, mh_snapshot).await;
@@ -237,204 +198,48 @@ pub(crate) async fn handle_machine_validation_state(
             }
             Ok(StateHandlerOutcome::do_nothing())
         }
+        // Compat-only: records still parked in the pre-consolidation ensure
+        // states transition into `EnsureBootConfig` (same step, resuming
+        // validation from its reboot step) on their next pass.
         MachineValidatingState::PrepareBootRepair { validation_id } => {
-            // Boot repair writes BIOS settings, and lockdown was enabled
-            // earlier in HostInit -- writes bounce off a locked BMC. Check and
-            // unlock first, mirroring host boot repair.
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
-                .await?;
-
-            let next = match redfish_client.lockdown_status().await {
-                Err(RedfishError::NotSupported(_)) => {
-                    tracing::info!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        "BMC vendor does not support checking lockdown status during validation boot repair",
-                    );
-                    MachineValidatingState::RepairBootConfig {
-                        validation_id: *validation_id,
-                        set_boot_order_info: boot_repair_start(),
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        error = %e,
-                        "Failed to fetch lockdown status during validation boot repair",
-                    );
-                    return Ok(StateHandlerOutcome::wait(format!(
-                        "Failed to fetch lockdown status: {e}"
-                    )));
-                }
-                Ok(lockdown_status) if !lockdown_status.is_fully_disabled() => {
-                    tracing::info!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        "Lockdown is enabled during validation boot repair; disabling before boot config writes",
-                    );
-                    MachineValidatingState::UnlockForBootRepair {
-                        validation_id: *validation_id,
-                        unlock_host_state: UnlockHostState::DisableLockdown,
-                    }
-                }
-                Ok(_) => MachineValidatingState::RepairBootConfig {
-                    validation_id: *validation_id,
-                    set_boot_order_info: boot_repair_start(),
-                },
-            };
-
-            Ok(StateHandlerOutcome::transition(validating(next)))
+            Ok(StateHandlerOutcome::transition(ensure_for_validation(
+                *validation_id,
+                EnsureBootConfigStep::CheckLockdown,
+            )))
         }
         MachineValidatingState::UnlockForBootRepair {
             validation_id,
             unlock_host_state,
-        } => {
-            // Mirror host boot repair's unlock choreography.
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
-                .await?;
-
-            let next = match unlock_host_state {
-                UnlockHostState::DisableLockdown => {
-                    // Tolerate a vendor that reports lockdown status but does
-                    // not support setting it, symmetric with the re-lock step.
-                    match redfish_client.lockdown_bmc(EnabledDisabled::Disabled).await {
-                        Ok(()) => {}
-                        Err(RedfishError::NotSupported(_)) => {
-                            tracing::info!(
-                                machine_id = %mh_snapshot.host_snapshot.id,
-                                "BMC vendor does not support disabling lockdown during validation boot repair",
-                            );
-                        }
-                        Err(e) => return Err(redfish_error("lockdown_bmc", e)),
-                    }
-
-                    let vendor = mh_snapshot.host_snapshot.bmc_vendor();
-                    if vendor.is_supermicro() {
-                        tracing::info!(
-                            machine_id = %mh_snapshot.host_snapshot.id,
-                            %vendor,
-                            "BMC lockdown disabled; rebooting host so Redfish reflects actual boot state",
-                        );
-                        MachineValidatingState::UnlockForBootRepair {
-                            validation_id: *validation_id,
-                            unlock_host_state: UnlockHostState::RebootHost,
-                        }
-                    } else {
-                        MachineValidatingState::RepairBootConfig {
-                            validation_id: *validation_id,
-                            set_boot_order_info: boot_repair_start(),
-                        }
-                    }
-                }
-                UnlockHostState::RebootHost => {
-                    host_power_control(
-                        redfish_client.as_ref(),
-                        &mh_snapshot.host_snapshot,
-                        SystemPowerControl::ForceRestart,
-                        ctx,
-                    )
-                    .await
-                    .map_err(|e| {
-                        StateHandlerError::GenericError(eyre::eyre!(
-                            "failed to ForceRestart host after disabling BMC lockdown: {}",
-                            e
-                        ))
-                    })?;
-
-                    MachineValidatingState::UnlockForBootRepair {
-                        validation_id: *validation_id,
-                        unlock_host_state: UnlockHostState::WaitForUefiBoot,
-                    }
-                }
-                UnlockHostState::WaitForUefiBoot => {
-                    let entered_at = mh_snapshot.host_snapshot.state.version.timestamp();
-                    if wait(
-                        &entered_at,
-                        host_handler_params.reachability_params.uefi_boot_wait,
-                    ) {
-                        return Ok(StateHandlerOutcome::wait(format!(
-                            "Waiting for UEFI boot to complete on {} after post-unlock reboot",
-                            mh_snapshot.host_snapshot.id
-                        )));
-                    }
-                    MachineValidatingState::RepairBootConfig {
-                        validation_id: *validation_id,
-                        set_boot_order_info: boot_repair_start(),
-                    }
-                }
-            };
-
-            Ok(StateHandlerOutcome::transition(validating(next)))
-        }
+        } => Ok(StateHandlerOutcome::transition(ensure_for_validation(
+            *validation_id,
+            EnsureBootConfigStep::Unlock {
+                unlock_host_state: unlock_host_state.clone(),
+            },
+        ))),
         MachineValidatingState::RepairBootConfig {
             validation_id,
             set_boot_order_info,
         } => {
-            // Re-drive the boot-order flow: it checks what is already in
-            // place, re-asserts the reverted HTTP-boot device (rebooting to
-            // apply it), sets the boot order, and verifies -- the same engine
-            // the boot-configuration stages use.
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
-                .await?;
-
-            match set_host_boot_order(
-                ctx,
-                &host_handler_params.reachability_params,
-                redfish_client.as_ref(),
-                mh_snapshot,
-                set_boot_order_info.clone(),
-            )
-            .await?
-            {
-                SetBootOrderOutcome::Continue(info) => Ok(StateHandlerOutcome::transition(
-                    validating(MachineValidatingState::RepairBootConfig {
-                        validation_id: *validation_id,
-                        set_boot_order_info: info,
-                    }),
-                )),
-                SetBootOrderOutcome::Done => Ok(StateHandlerOutcome::transition(validating(
-                    MachineValidatingState::LockAfterBootRepair {
-                        validation_id: *validation_id,
-                    },
-                ))),
-                SetBootOrderOutcome::WaitingForReboot(reason)
-                | SetBootOrderOutcome::Wait(reason) => Ok(StateHandlerOutcome::wait(reason)),
-            }
+            // Boot order is not NICo-managed on DGX H100/Viking hardware, so
+            // a record parked mid-chain there restarts the flow from the top:
+            // the BIOS side still gets ensured, and the flow itself skips the
+            // boot order.
+            let step = if should_skip_boot_order_remediation(mh_snapshot) {
+                ensure_boot_config_apply_start()
+            } else {
+                EnsureBootConfigStep::Apply {
+                    set_boot_order_info: set_boot_order_info.clone(),
+                }
+            };
+            Ok(StateHandlerOutcome::transition(ensure_for_validation(
+                *validation_id,
+                step,
+            )))
         }
         MachineValidatingState::LockAfterBootRepair { validation_id } => {
-            // Restore the lockdown that boot repair temporarily opened, then
-            // resume validation from its reboot step.
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
-                .await?;
-
-            if mh_snapshot.host_snapshot.host_profile.disable_lockdown {
-                tracing::info!(
-                    machine_id = %mh_snapshot.host_snapshot.id,
-                    "Skipping lockdown re-enable after validation boot repair per expected-machine config",
-                );
-            } else {
-                match redfish_client.lockdown_bmc(EnabledDisabled::Enabled).await {
-                    Ok(()) => {}
-                    Err(RedfishError::NotSupported(_)) => {
-                        tracing::info!(
-                            machine_id = %mh_snapshot.host_snapshot.id,
-                            "BMC vendor does not support re-enabling lockdown after validation boot repair",
-                        );
-                    }
-                    Err(e) => return Err(redfish_error("lockdown_bmc", e)),
-                }
-            }
-
-            Ok(StateHandlerOutcome::transition(validating(
-                MachineValidatingState::RebootHost {
-                    validation_id: *validation_id,
-                },
+            Ok(StateHandlerOutcome::transition(ensure_for_validation(
+                *validation_id,
+                EnsureBootConfigStep::Relock,
             )))
         }
     }

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -26,9 +26,9 @@ use model::dpa_interface::DpaSearchConfig;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::slas::MachineSlaConfig;
 use model::machine::{
-    self, AttestationMode, DpuDiscoveringState, DpuInitState, HostHealthConfig,
-    MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
-    SpdmMeasuringState, ValidationState,
+    self, AttestationMode, DpuDiscoveringState, DpuInitState, EnsureBootConfigStep,
+    HostHealthConfig, MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot,
+    MeasuringState, SpdmMeasuringState, ValidationState,
 };
 use sqlx::PgConnection;
 use state_controller::io::StateControllerIO;
@@ -270,7 +270,18 @@ impl StateControllerIO for MachineStateControllerIO {
                 MachineValidatingState::LockAfterBootRepair { .. } => "lockafterbootrepair",
             }
         }
+        fn ensure_boot_config_step_name(step: &EnsureBootConfigStep) -> &'static str {
+            match step {
+                EnsureBootConfigStep::CheckLockdown => "checklockdown",
+                EnsureBootConfigStep::Unlock { .. } => "unlock",
+                EnsureBootConfigStep::Apply { .. } => "apply",
+                EnsureBootConfigStep::Relock => "relock",
+            }
+        }
         match state {
+            ManagedHostState::EnsureBootConfig { step, .. } => {
+                ("ensurebootconfig", ensure_boot_config_step_name(step))
+            }
             ManagedHostState::DpuDiscoveringState { dpu_states } => {
                 // Min state indicates the least processed DPU. The state machine is blocked
                 // becasue of this.

--- a/crates/rpc/src/model/instance/status/tenant.rs
+++ b/crates/rpc/src/model/instance/status/tenant.rs
@@ -53,6 +53,9 @@ pub fn instance_status_tenant_state(
         }
     };
 
+    // A host mid-EnsureBootConfig is still operating for its resumed state
+    // (an assigned host ensuring its boot config is Updating, not Invalid).
+    let machine_state = machine_state.effective_state().clone();
     let tenant_state = match machine_state {
         ManagedHostState::Ready => {
             if operator_managed_networking {
@@ -322,6 +325,51 @@ mod tests {
                             model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
                     },
                 } => Yields(TenantState::Ready),
+            }
+        );
+    }
+
+    /// A host mid-EnsureBootConfig is still operating for its resumed state:
+    /// an assigned host ensuring its boot config during a DPU reprovision
+    /// reports Updating, not Invalid.
+    #[test]
+    fn ensure_boot_config_projects_the_resumed_state() {
+        let machine_id =
+            MachineId::from_str("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
+                .unwrap();
+        let assigned_reprovision = ManagedHostState::Assigned {
+            instance_state: InstanceState::DPUReprovision {
+                dpu_states: model::machine::DpuReprovisionStates {
+                    states: std::collections::HashMap::from([(
+                        machine_id,
+                        model::machine::ReprovisionState::RebootHostBmc,
+                    )]),
+                },
+            },
+        };
+
+        scenarios!(
+            run = |machine_state| {
+                instance_status_tenant_state(
+                    machine_state,
+                    SyncState::Synced,
+                    true,
+                    None,
+                    true,
+                    false,
+                    false,
+                )
+                .map_err(drop)
+            };
+            "assigned reprovision itself" {
+                assigned_reprovision.clone() => Yields(TenantState::Updating),
+            }
+
+            "ensuring the boot config for it" {
+                ManagedHostState::EnsureBootConfig {
+                    resume_to: Box::new(assigned_reprovision),
+                    step: model::machine::EnsureBootConfigStep::Relock,
+                } => Yields(TenantState::Updating),
             }
         );
     }


### PR DESCRIPTION
The state machine establishes a host's boot config once, early -- but the
stages that reboot hosts each grew their own way of noticing the config
drifted across a reboot and putting it back: machine validation carried four
ensure states, DPU reprovision carried a five-state host boot repair, and
every future reboot site was on its own. The mechanics were already shared;
the noticing, the routing, and the resume were not.

One mechanism now owns all of it. EnsureBootConfig is a top-level state with
a resume continuation: it checks whether the BMC is locked and unlocks it if
so, drives the boot-order flow to put the config back (verifying first and
re-applying only what drifted), re-locks per the expected-machine policy, and
resumes the interrupted state.

- Machine validation and DPU reprovision's host boot repair now run through
  EnsureBootConfig; their old states remain only as thin compatibility shims
  that transition records parked in them into the shared flow.
- Detection lives in one shared pacing call, pace_reboot_or_ensure_boot_config:
  pace reboots for a host that has not come back, and when its boot config
  reads drifted -- changed externally, a BIOS quirk, or the boot NIC dropping
  off the BMC's inventory during POST -- ensure it instead of rebooting forever.
- The unlock step now tolerates vendors that report lockdown but cannot set it,
  matching the re-lock side.
- State history and metrics show the activity under one name (ensurebootconfig)
  wherever it happens.

Tests updated!

This supports https://github.com/NVIDIA/infra-controller/issues/3391

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

