### PR TITLE
chore(rms): update librms to v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6704,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "librms"
 version = "0.0.14"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-mts-rc04#ea1a14375cbc153ca096713daf184cb65a185538"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.1#d6d1c3545bdea108c27ec2d0be67fe22c5069a72"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11717,7 +11717,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-mts-rc04#ea1a14375cbc153ca096713daf184cb65a185538"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.1#d6d1c3545bdea108c27ec2d0be67fe22c5069a72"
 dependencies = [
  "async-trait",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.18" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.1" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -183,6 +183,14 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError>>>,
     update_switch_system_password_calls: Mutex<Vec<rms::UpdateSwitchSystemPasswordRequest>>,
 
+    batch_reset_switch_sdn_factory_default_responses:
+        Mutex<VecDeque<Result<rms::BatchResetSwitchSdnFactoryDefaultResponse, RackManagerError>>>,
+    batch_reset_switch_sdn_factory_default_calls:
+        Mutex<Vec<rms::BatchResetSwitchSdnFactoryDefaultRequest>>,
+
+    get_job_status_responses: Mutex<VecDeque<Result<rms::GetJobStatusResponse, RackManagerError>>>,
+    get_job_status_calls: Mutex<Vec<rms::GetJobStatusRequest>>,
+
     get_firmware_job_status_responses:
         Mutex<VecDeque<Result<rms::GetFirmwareJobStatusResponse, RackManagerError>>>,
     get_firmware_job_status_calls: Mutex<Vec<rms::GetFirmwareJobStatusRequest>>,
@@ -333,6 +341,10 @@ impl MockRmsApi {
             update_switch_system_image_calls: Default::default(),
             update_switch_system_password_responses: Default::default(),
             update_switch_system_password_calls: Default::default(),
+            batch_reset_switch_sdn_factory_default_responses: Default::default(),
+            batch_reset_switch_sdn_factory_default_calls: Default::default(),
+            get_job_status_responses: Default::default(),
+            get_job_status_calls: Default::default(),
             get_firmware_job_status_responses: Default::default(),
             get_firmware_job_status_calls: Default::default(),
             list_switch_firmware_responses: Default::default(),
@@ -636,6 +648,25 @@ impl MockRmsApi {
         rms::UpdateSwitchSystemPasswordRequest,
         rms::UpdateSwitchSystemPasswordResponse
     );
+
+    impl_enqueue_inspect!(
+        enqueue_batch_reset_switch_sdn_factory_default,
+        batch_reset_switch_sdn_factory_default_calls,
+        batch_reset_switch_sdn_factory_default_responses,
+        batch_reset_switch_sdn_factory_default_calls,
+        rms::BatchResetSwitchSdnFactoryDefaultRequest,
+        rms::BatchResetSwitchSdnFactoryDefaultResponse
+    );
+
+    impl_enqueue_inspect!(
+        enqueue_get_job_status,
+        get_job_status_calls,
+        get_job_status_responses,
+        get_job_status_calls,
+        rms::GetJobStatusRequest,
+        rms::GetJobStatusResponse
+    );
+
     impl_enqueue_inspect!(
         enqueue_get_firmware_job_status,
         get_firmware_job_status_calls,
@@ -1109,6 +1140,32 @@ impl RmsApi for MockRmsApi {
             .push(cmd);
         pop_or_err(&mut self.update_switch_system_password_responses.lock().await)
     }
+
+    async fn batch_reset_switch_sdn_factory_default(
+        &self,
+        cmd: rms::BatchResetSwitchSdnFactoryDefaultRequest,
+    ) -> Result<rms::BatchResetSwitchSdnFactoryDefaultResponse, RackManagerError> {
+        self.batch_reset_switch_sdn_factory_default_calls
+            .lock()
+            .await
+            .push(cmd);
+
+        pop_or_err(
+            &mut self
+                .batch_reset_switch_sdn_factory_default_responses
+                .lock()
+                .await,
+        )
+    }
+
+    async fn get_job_status(
+        &self,
+        cmd: rms::GetJobStatusRequest,
+    ) -> Result<rms::GetJobStatusResponse, RackManagerError> {
+        self.get_job_status_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_job_status_responses.lock().await)
+    }
+
     async fn get_power_state(
         &self,
         cmd: rms::GetPowerStateRequest,

--- a/crates/rack/src/rms_client.rs
+++ b/crates/rack/src/rms_client.rs
@@ -661,6 +661,21 @@ pub mod test_support {
         ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
             Ok(rms::UpdateSwitchSystemPasswordResponse::default())
         }
+
+        async fn batch_reset_switch_sdn_factory_default(
+            &self,
+            _cmd: rms::BatchResetSwitchSdnFactoryDefaultRequest,
+        ) -> Result<rms::BatchResetSwitchSdnFactoryDefaultResponse, RackManagerError> {
+            Ok(rms::BatchResetSwitchSdnFactoryDefaultResponse::default())
+        }
+
+        async fn get_job_status(
+            &self,
+            _cmd: rms::GetJobStatusRequest,
+        ) -> Result<rms::GetJobStatusResponse, RackManagerError> {
+            Ok(rms::GetJobStatusResponse::default())
+        }
+
         async fn set_power_state(
             &self,
             _cmd: rms::SetPowerStateRequest,


### PR DESCRIPTION
This is the first of multiple incremental steps to add eventually consistent NVOS password rotation support to NICo when integrated with RMS.

This PR is behavior-neutral. It updates `librms` to v0.9.1 and updates RMS mocks and test implementations to the expanded `RmsApi` trait. Existing runtime behavior remains unchanged.

## Related issues
Supports #2041 and #3522

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

This PR does not introduce breaking changes to NICo. `librms v0.9.1` includes breaking API changes for RPCs that NICo does not currently invoke.

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)