### PR TITLE
feat: time firmware downloads and split their failures by cause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "bmc-vendor",
  "carbide-api-db",
  "carbide-api-model",
+ "carbide-instrument",
  "carbide-macros",
  "carbide-sqlx-testing",
  "carbide-test-support",

--- a/crates/firmware/Cargo.toml
+++ b/crates/firmware/Cargo.toml
@@ -16,6 +16,7 @@ test-support = ["dep:temp-dir", "dep:regex"]
 [dependencies]
 bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-model = { path = "../api-model", default-features = false }
+carbide-instrument = { path = "../instrument" }
 
 # these are alphabetized
 eyre = { workspace = true }
@@ -35,6 +36,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 carbide-test-support = { path = "../test-support" }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-macros = { path = "../macros" }
 carbide-api-db = { path = "../api-db", default-features = false }
 sqlx = { workspace = true }

--- a/crates/firmware/src/downloader.rs
+++ b/crates/firmware/src/downloader.rs
@@ -20,13 +20,94 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt, emit};
 use eyre::{Report, WrapErr, eyre};
 use futures_util::StreamExt;
 use reqwest_middleware::ClientWithMiddleware as Client;
 use sha2::{Digest, Sha256};
 use tokio::fs::File;
+
+/// How a background firmware download attempt ended, as a bounded metric
+/// label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum DownloadOutcome {
+    /// Downloaded, verified, and renamed into place.
+    Ok,
+    /// The request never produced a response: connection, DNS, or TLS
+    /// trouble (or, for `file://` sources, a source that cannot be opened).
+    Fetch,
+    /// The server answered, but with a non-success HTTP status.
+    Status,
+    /// The response body broke off mid-transfer.
+    Transfer,
+    /// The downloaded artifact failed SHA-256 verification.
+    Checksum,
+    /// Local filesystem trouble: creating the cache directory or staging
+    /// file, writing downloaded bytes, or renaming the artifact into place.
+    Io,
+}
+
+/// A background firmware download attempt ran to completion. The event owns
+/// the completion log line (INFO on success, ERROR on any failure) and
+/// records the attempt's duration.
+#[derive(Event)]
+#[event(
+    name = "carbide_firmware_download_duration_seconds",
+    component = "carbide-firmware",
+    log = dynamic,
+    metric = histogram,
+    message = "Firmware download finished",
+    describe = "Duration of background firmware artifact downloads, by outcome; an ok attempt \
+                spans fetch, checksum verification, and publish, and the _count series, split \
+                by outcome, is the download and failure rate."
+)]
+pub(crate) struct DownloadFinished {
+    #[label]
+    pub outcome: DownloadOutcome,
+    #[observation]
+    pub took: Duration,
+    #[context]
+    pub url: String,
+    #[context]
+    pub filename: String,
+    /// The failure's error chain; empty on success.
+    #[context]
+    pub error: String,
+}
+
+/// The URL as it may be logged: everything after `?` is dropped, so a
+/// presigned or tokenized artifact URL never lands its credentials in the
+/// log line while the location stays identifiable.
+pub(crate) fn loggable_url(url: &str) -> String {
+    url.split('?').next().unwrap_or(url).to_string()
+}
+
+impl DynamicLog for DownloadFinished {
+    fn log_at(&self) -> LogAt {
+        match self.outcome {
+            DownloadOutcome::Ok => LogAt::Level(tracing::Level::INFO),
+            DownloadOutcome::Fetch
+            | DownloadOutcome::Status
+            | DownloadOutcome::Transfer
+            | DownloadOutcome::Checksum
+            | DownloadOutcome::Io => LogAt::Level(tracing::Level::ERROR),
+        }
+    }
+}
+
+/// A failed download attempt: the bounded cause for the metric label, plus
+/// the detailed report for the log line.
+struct DownloadError {
+    outcome: DownloadOutcome,
+    report: Report,
+}
+
+/// Tags a failure report with its bounded cause, for `map_err`.
+fn fail(outcome: DownloadOutcome) -> impl FnOnce(Report) -> DownloadError {
+    move |report| DownloadError { outcome, report }
+}
 
 #[derive(Clone, Debug)]
 pub struct FirmwareDownloader {
@@ -114,46 +195,59 @@ impl FirmwareDownloader {
         let client = state.client.clone().unwrap();
         let actual = self.actual.clone();
         tokio::spawn(async move {
+            let started = Instant::now();
             let dst_filename = format!("{filename_string}.download");
-            match download(&filename, &url, &dst_filename, client, fake_sleep).await {
-                Err(e) => {
-                    tracing::error!("FirmwareDownloader failed: {e}");
-                    let _ = std::fs::remove_file(dst_filename);
-                    actual
-                        .lock()
-                        .unwrap()
-                        .clear_download_state(&filename_string);
-                }
-                Ok(_) => {
-                    tracing::info!("Completed download of {url} to {filename_string}");
-                    if let Err(e) = verify_sha256(&dst_filename, &sha256) {
-                        tracing::error!("FirmwareDownloader checksum for {url} failed: {e}");
-                        let _ = std::fs::remove_file(dst_filename);
-                        actual
-                            .lock()
-                            .unwrap()
-                            .clear_download_state(&filename_string);
-                        return;
-                    }
-                    if let Err(e) = std::fs::rename(&dst_filename, &filename) {
-                        tracing::error!("FirmwareDownloader rename failed: {e}");
-                        let _ = std::fs::remove_file(dst_filename);
-                        actual
-                            .lock()
-                            .unwrap()
-                            .clear_download_state(&filename_string);
-                        return;
-                    }
-
-                    actual
-                        .lock()
-                        .unwrap()
-                        .clear_download_state(&filename_string);
-                }
+            let result =
+                download_and_publish(&filename, &url, &dst_filename, client, fake_sleep, &sha256)
+                    .await;
+            if result.is_err() {
+                std::fs::remove_file(&dst_filename).ok();
+            }
+            let (outcome, error) = match result {
+                Ok(()) => (DownloadOutcome::Ok, String::new()),
+                Err(failure) => (failure.outcome, format!("{:#}", failure.report)),
             };
+            emit(DownloadFinished {
+                outcome,
+                took: started.elapsed(),
+                url: loggable_url(&url),
+                filename: filename_string.clone(),
+                error,
+            });
+            actual
+                .lock()
+                .unwrap()
+                .clear_download_state(&filename_string);
         });
         false
     }
+}
+
+/// Downloads to the staging file, verifies the artifact against the expected
+/// checksum, and renames it into place. Failures come back tagged with the
+/// bounded cause the metric label uses.
+async fn download_and_publish(
+    filename: &Path,
+    url: &String,
+    dst_filename: &String,
+    client: Client,
+    fake_sleep: Option<Duration>,
+    sha256: &str,
+) -> Result<(), DownloadError> {
+    download(filename, url, dst_filename, client, fake_sleep).await?;
+    verify_sha256(dst_filename, sha256)
+        .wrap_err(format!(
+            "Downloaded artifact from {} failed verification",
+            loggable_url(url)
+        ))
+        .map_err(fail(DownloadOutcome::Checksum))?;
+    std::fs::rename(dst_filename, filename)
+        .wrap_err(format!(
+            "Unable to rename {dst_filename} to {}",
+            filename.display()
+        ))
+        .map_err(fail(DownloadOutcome::Io))?;
+    Ok(())
 }
 
 impl FirmwareDownloaderActual {
@@ -202,23 +296,25 @@ async fn download(
     dst_filename: &String,
     client: Client,
     fake_sleep: Option<Duration>,
-) -> Result<(), Report> {
+) -> Result<(), DownloadError> {
     // Actual downloader.  We aren't able to return errors to callers here, we just print to the log, and will retry on the next request.
     let dirname = match Path::parent(filename) {
         Some(x) => x,
         None => {
-            return Err(eyre!(
+            return Err(fail(DownloadOutcome::Io)(eyre!(
                 "Could not find dirname of {}",
                 filename.to_string_lossy()
-            ));
+            )));
         }
     };
 
     std::fs::create_dir_all(dirname)
-        .wrap_err(format!("Unable to create directory {}", dirname.display()))?;
-    let mut dst_file = File::create(&dst_filename)
+        .wrap_err(format!("Unable to create directory {}", dirname.display()))
+        .map_err(fail(DownloadOutcome::Io))?;
+    let mut dst_file = File::create(dst_filename)
         .await
-        .wrap_err(format!("Unable to create file {dst_filename}"))?;
+        .wrap_err(format!("Unable to create file {dst_filename}"))
+        .map_err(fail(DownloadOutcome::Io))?;
 
     if let Some(duration) = fake_sleep {
         // For testing only, wait a given amount of time then write an empty file
@@ -231,36 +327,55 @@ async fn download(
         let src_filename = url.strip_prefix("file:/").unwrap(); // Leave the second / for the root
         let mut src_file = File::open(src_filename)
             .await
-            .wrap_err(format!("FirmwareDownloader could not open source {url}"))?;
+            .wrap_err(format!(
+                "FirmwareDownloader could not open source {}",
+                loggable_url(url)
+            ))
+            .map_err(fail(DownloadOutcome::Fetch))?;
         return tokio::io::copy(&mut src_file, &mut dst_file)
             .await
             .map(|_| ())
-            .map_err(|e| eyre!("FirmwareDownloader had problems saving file from {url}: {e}"));
+            .map_err(|e| {
+                fail(DownloadOutcome::Transfer)(eyre!(
+                    "FirmwareDownloader had problems saving file from {}: {e}",
+                    loggable_url(url)
+                ))
+            });
     }
 
-    let res = client.get(url).send().await.wrap_err(format!(
-        "FirmwareDownloader got error trying to download {url}"
-    ))?;
+    let res = client
+        .get(url)
+        .send()
+        .await
+        .wrap_err(format!(
+            "FirmwareDownloader got error trying to download {}",
+            loggable_url(url)
+        ))
+        .map_err(fail(DownloadOutcome::Fetch))?;
     if !res.status().is_success() {
-        return Err(eyre!(
-            "FirmwareDownloader got non-success status trying to download {url}: {}",
+        return Err(fail(DownloadOutcome::Status)(eyre!(
+            "FirmwareDownloader got non-success status trying to download {}: {}",
+            loggable_url(url),
             res.status()
-        ));
+        )));
     }
     let mut body = res.bytes_stream();
     while let Some(segment) = body.next().await {
         match segment {
             Err(e) => {
-                return Err(eyre!(
-                    "FirmwareDownloader had problems downloading {url}: {e}"
-                ));
+                return Err(fail(DownloadOutcome::Transfer)(eyre!(
+                    "FirmwareDownloader had problems downloading {}: {e}",
+                    loggable_url(url)
+                )));
             }
             Ok(segment) => {
                 tokio::io::copy(&mut segment.as_ref(), &mut dst_file)
                     .await
                     .wrap_err(format!(
-                        "FirmwareDownloader had problems saving file from {url}"
-                    ))?;
+                        "FirmwareDownloader had problems saving file from {}",
+                        loggable_url(url)
+                    ))
+                    .map_err(fail(DownloadOutcome::Io))?;
             }
         }
     }

--- a/crates/firmware/src/tests/downloader.rs
+++ b/crates/firmware/src/tests/downloader.rs
@@ -18,11 +18,43 @@
 use std::path::Path;
 use std::time::Duration;
 
+use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+use carbide_instrument::{LabelValue, emit};
+use carbide_test_support::{Check, check_values};
 use sha2::Digest;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 use crate::downloader::*;
+
+const DOWNLOAD_DURATION_METRIC: &str = "carbide_firmware_download_duration_seconds";
+
+#[test]
+fn loggable_url_drops_query_parameters() {
+    assert_eq!(
+        loggable_url("https://firmware.example/bmc.fwpkg?X-Amz-Signature=secret"),
+        "https://firmware.example/bmc.fwpkg",
+    );
+    assert_eq!(
+        loggable_url("file:///tmp/bmc.fwpkg"),
+        "file:///tmp/bmc.fwpkg"
+    );
+}
+
+/// Polls until the download-duration histogram has recorded `expect`
+/// observations under `outcome` -- the completion event is the signal that a
+/// background download attempt finished.
+async fn wait_for_downloads(metrics: &MetricsCapture, outcome: &str, expect: u64) {
+    let mut count = 0;
+    while metrics.histogram_count_delta(DOWNLOAD_DURATION_METRIC, &[("outcome", outcome)]) < expect
+    {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        count += 1;
+        if count >= 1000 {
+            panic!("No download finished with outcome={outcome}");
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_firmware_downloader_repeated() {
@@ -60,6 +92,7 @@ async fn test_download_without_checksum() -> Result<(), std::io::Error> {
 
     let _ = std::fs::remove_file(filename);
     let downloader = FirmwareDownloader::new();
+    let metrics = MetricsCapture::start();
 
     let mut count = 0;
     loop {
@@ -70,6 +103,9 @@ async fn test_download_without_checksum() -> Result<(), std::io::Error> {
                 panic!("Should not have taken this long");
             }
         } else {
+            // >=1 rather than an exact delta: concurrent tests can add ok
+            // samples, but if the ok emit vanished nothing could satisfy this.
+            wait_for_downloads(&metrics, "ok", 1).await;
             let _ = std::fs::remove_file(filename);
             let _ = std::fs::remove_file(src_filename);
             return Ok(());
@@ -163,10 +199,162 @@ async fn test_available_checksum_failure_does_not_publish_file() -> Result<(), s
     let _ = std::fs::remove_file(filename);
     let downloader = FirmwareDownloader::new();
 
+    let metrics = MetricsCapture::start();
     assert!(!downloader.available(filename, &url, &"0".repeat(64)));
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    wait_for_downloads(&metrics, "checksum", 1).await;
 
     assert!(!filename.exists());
     let _ = std::fs::remove_file(src_filename);
     Ok(())
+}
+
+/// A source that cannot be opened is the fetch failure: the attempt counts
+/// under `outcome="fetch"` and publishes nothing.
+#[tokio::test]
+async fn test_available_fetch_failure_counts() -> Result<(), std::io::Error> {
+    let filename = Path::new("/tmp/test_firmware_fetch_failure");
+    let src_filename = "/tmp/test_firmware_fetch_failure_missing_src";
+    let url = format!("file://{src_filename}");
+
+    let _ = std::fs::remove_file(filename);
+    let _ = std::fs::remove_file(src_filename);
+    let downloader = FirmwareDownloader::new();
+
+    let metrics = MetricsCapture::start();
+    assert!(!downloader.available(filename, &url, ""));
+    wait_for_downloads(&metrics, "fetch", 1).await;
+
+    assert!(!filename.exists());
+    Ok(())
+}
+
+/// The label vocabulary is the dashboard contract: every download outcome
+/// renders as its snake_case name.
+#[test]
+fn download_outcome_labels_render_snake_case() {
+    check_values(
+        [
+            Check {
+                scenario: "success",
+                input: DownloadOutcome::Ok,
+                expect: "ok".to_string(),
+            },
+            Check {
+                scenario: "request failure",
+                input: DownloadOutcome::Fetch,
+                expect: "fetch".to_string(),
+            },
+            Check {
+                scenario: "non-success HTTP status",
+                input: DownloadOutcome::Status,
+                expect: "status".to_string(),
+            },
+            Check {
+                scenario: "broken body stream",
+                input: DownloadOutcome::Transfer,
+                expect: "transfer".to_string(),
+            },
+            Check {
+                scenario: "checksum verification failure",
+                input: DownloadOutcome::Checksum,
+                expect: "checksum".to_string(),
+            },
+            Check {
+                scenario: "local filesystem failure",
+                input: DownloadOutcome::Io,
+                expect: "io".to_string(),
+            },
+        ],
+        |outcome| outcome.label_value().to_string(),
+    );
+}
+
+/// One emit per download attempt: the histogram records the duration under
+/// the attempt's outcome, and the event owns the completion line -- INFO for
+/// a success, ERROR for any failure, with the URL and error detail as
+/// context.
+#[test]
+fn download_finished_records_duration_and_owns_the_completion_line() {
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(DownloadFinished {
+            outcome: DownloadOutcome::Ok,
+            took: Duration::from_secs(30),
+            url: "https://firmware.example/bmc.fwpkg".to_string(),
+            filename: "/firmware/bmc.fwpkg".to_string(),
+            error: String::new(),
+        });
+        // Failure labels deliberately disjoint from the labels the
+        // end-to-end download tests in this binary reach (`ok`, `checksum`,
+        // `fetch`): the capture mutex serializes only capture-holding tests,
+        // so a label a capture-less test can move would race these deltas.
+        emit(DownloadFinished {
+            outcome: DownloadOutcome::Status,
+            took: Duration::from_secs(2),
+            url: "https://firmware.example/bmc.fwpkg".to_string(),
+            filename: "/firmware/bmc.fwpkg".to_string(),
+            error: "FirmwareDownloader got non-success status trying to download \
+                    https://firmware.example/bmc.fwpkg: 404 Not Found"
+                .to_string(),
+        });
+        emit(DownloadFinished {
+            outcome: DownloadOutcome::Transfer,
+            took: Duration::from_secs(3),
+            url: "https://firmware.example/uefi.fwpkg".to_string(),
+            filename: "/firmware/uefi.fwpkg".to_string(),
+            error: "connection reset by peer".to_string(),
+        });
+        emit(DownloadFinished {
+            outcome: DownloadOutcome::Io,
+            took: Duration::from_secs(4),
+            url: "https://firmware.example/cec.fwpkg".to_string(),
+            filename: "/firmware/cec.fwpkg".to_string(),
+            error: "No space left on device".to_string(),
+        });
+    });
+
+    assert_eq!(logs.len(), 4, "every completion writes its line: {logs:?}");
+    assert!(
+        logs.iter()
+            .all(|entry| entry.message == "Firmware download finished")
+    );
+    assert_eq!(logs[0].level, tracing::Level::INFO);
+    assert!(
+        logs[1..]
+            .iter()
+            .all(|entry| entry.level == tracing::Level::ERROR)
+    );
+
+    let field = |entry: &CapturedLog, name: &str| {
+        entry
+            .fields
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.clone())
+    };
+    assert_eq!(field(&logs[1], "outcome").as_deref(), Some("status"));
+    assert!(
+        field(&logs[1], "url").is_some_and(|url| url.contains("bmc.fwpkg")),
+        "the completion line names the URL"
+    );
+    assert!(
+        field(&logs[1], "error").is_some_and(|error| error.contains("404")),
+        "the completion line holds the error detail"
+    );
+
+    // No delta assertion for `ok`: the end-to-end download tests in this
+    // binary complete successful downloads outside any capture window, so
+    // that series moves concurrently.
+    for (outcome, seconds) in [("status", 2.0), ("transfer", 3.0), ("io", 4.0)] {
+        assert_eq!(
+            metrics.histogram_count_delta(DOWNLOAD_DURATION_METRIC, &[("outcome", outcome)]),
+            1,
+            "one observation under outcome={outcome}",
+        );
+        let sum = metrics.histogram_sum_delta(DOWNLOAD_DURATION_METRIC, &[("outcome", outcome)]);
+        assert!(
+            (sum - seconds).abs() < 1e-9,
+            "outcome={outcome} records {seconds}s, got {sum}"
+        );
+    }
 }


### PR DESCRIPTION
Firmware artifact downloads are the api process's longest-running background HTTP work, and until now their only trace was log lines. `carbide_firmware_download_duration_seconds{outcome}` times every attempt; its `_count` series split by outcome is the fetch/status/checksum failure-counter set in one metric.

- `outcome` names what actually broke: `fetch` (no response), `status` (non-2xx), `transfer` (mid-stream break), `checksum` (SHA-256 mismatch), `io` (staging/rename) -- the download path now tags its errors with the cause instead of flattening everything into one report.
- The event owns the four historical log lines at their levels, with the full error chain as a structured field. One line per attempt now: a failed-verify attempt used to log completion INFO then checksum ERROR; it logs only the ERROR.
- An `ok` attempt's duration spans fetch, verification, and publish (the description says so), so each outcome series reads consistently.
- The no-URL config path stays log-only (it re-fires every poll without a download running).
- No catalogue row: the integration environment never exercises a download, and the scrape-derived catalogue lists only what the regen mints -- same treatment as the machine-update Failed-state histogram.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3174
