### PR TITLE
feat: measure every Redfish operation, count every IPMI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ version = "0.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "carbide-instrument",
  "carbide-secrets",
  "carbide-utils",
  "carbide-uuid",
@@ -2747,6 +2748,7 @@ dependencies = [
  "async-trait",
  "bmc-vendor",
  "carbide-api-model",
+ "carbide-instrument",
  "carbide-secrets",
  "carbide-utils",
  "chrono",

--- a/crates/instrument/src/red.rs
+++ b/crates/instrument/src/red.rs
@@ -64,16 +64,34 @@ pub async fn instrumented<T, E: Display>(
     let started = Instant::now();
     let result = call.await;
     let outcome = if result.is_ok() { "ok" } else { "error" };
-    histogram().record(
+    record(
+        backend,
+        operation,
+        outcome,
         started.elapsed().as_secs_f64() * 1_000.0,
+    );
+    if let Err(error) = &result {
+        tracing::warn!(backend, operation, error = %error, "external call failed");
+    }
+    result
+}
+
+/// Records one completed outbound call on the shared RED histogram. This is
+/// the low-level half of [`instrumented`] for callers whose backend needs its
+/// own outcome vocabulary or logging policy (a refusal that is an answer, not
+/// a failure); `outcome` is a label value and must be a compile-time literal.
+pub fn record(
+    backend: &'static str,
+    operation: &'static str,
+    outcome: &'static str,
+    elapsed_ms: f64,
+) {
+    histogram().record(
+        elapsed_ms,
         &[
             KeyValue::new("backend", backend),
             KeyValue::new("operation", operation),
             KeyValue::new("outcome", outcome),
         ],
     );
-    if let Err(error) = &result {
-        tracing::warn!(backend, operation, error = %error, "external call failed");
-    }
-    result
 }

--- a/crates/ipmi/Cargo.toml
+++ b/crates/ipmi/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 name = "carbide_ipmi"
 
 [dependencies]
+carbide-instrument = { path = "../instrument" }
 carbide-secrets = { path = "../secrets", default-features = false }
 carbide-utils = { path = "../utils", default-features = false }
 carbide-uuid = { path = "../uuid" }
@@ -24,4 +25,5 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }

--- a/crates/ipmi/src/bmc_mock.rs
+++ b/crates/ipmi/src/bmc_mock.rs
@@ -26,6 +26,7 @@ use carbide_uuid::machine::MachineId;
 use eyre::eyre;
 
 use crate::IPMITool;
+use crate::metrics::{IpmiCommand, count_ipmi_command};
 
 /// HTTP-based IPMI implementation for testing with bmc-mock.
 /// Sends JSON requests to bmc_proxy which routes to appropriate machine.
@@ -45,12 +46,23 @@ impl IPMIToolHttpImpl {
         }
     }
 
+    /// The wire action string bmc-mock's `/ipmi` endpoint expects for each
+    /// command -- the counterpart of the real runner's `command_args`.
+    fn wire_action(command: IpmiCommand) -> &'static str {
+        match command {
+            IpmiCommand::ChassisPowerReset => "chassis_power_reset",
+            IpmiCommand::DpuLegacyPowerReset => "dpu_legacy_boot",
+            IpmiCommand::BmcColdReset => "bmc_cold_reset",
+        }
+    }
+
     async fn execute_action(
         &self,
-        action: &str,
+        command: IpmiCommand,
         bmc_ip: IpAddr,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
+        let action = Self::wire_action(command);
         let proxy = self.bmc_proxy.load();
 
         // Determine the target URL and headers based on whether a proxy is configured
@@ -97,34 +109,43 @@ impl IPMIToolHttpImpl {
             request = request.header("Forwarded", header);
         }
 
-        let resp = request
-            .send()
-            .await
-            .map_err(|e| eyre!("HTTP request to {} failed: {}", url, e))?;
+        // Everything from here on is a dispatched command: the counter covers
+        // the wire attempt and its response, not the credential lookup or
+        // client construction above (a command that was never sent must not
+        // move the metric).
+        let result = async {
+            let resp = request
+                .send()
+                .await
+                .map_err(|e| eyre!("HTTP request to {} failed: {}", url, e))?;
 
-        if !resp.status().is_success() {
-            return Err(eyre!("HTTP error: {}", resp.status()));
+            if !resp.status().is_success() {
+                return Err(eyre!("HTTP error: {}", resp.status()));
+            }
+
+            #[derive(serde::Deserialize)]
+            struct IpmiHttpResponse {
+                success: bool,
+                error: Option<String>,
+            }
+
+            let body: IpmiHttpResponse = resp
+                .json()
+                .await
+                .map_err(|e| eyre!("failed to parse response: {}", e))?;
+
+            if !body.success {
+                return Err(eyre!(
+                    "IPMI action failed: {}",
+                    body.error.unwrap_or_else(|| "unknown error".to_string())
+                ));
+            }
+
+            Ok(())
         }
-
-        #[derive(serde::Deserialize)]
-        struct IpmiHttpResponse {
-            success: bool,
-            error: Option<String>,
-        }
-
-        let body: IpmiHttpResponse = resp
-            .json()
-            .await
-            .map_err(|e| eyre!("failed to parse response: {}", e))?;
-
-        if !body.success {
-            return Err(eyre!(
-                "IPMI action failed: {}",
-                body.error.unwrap_or_else(|| "unknown error".to_string())
-            ));
-        }
-
-        Ok(())
+        .await;
+        count_ipmi_command(command, &result);
+        result
     }
 }
 
@@ -135,7 +156,7 @@ impl IPMITool for IPMIToolHttpImpl {
         bmc_ip: IpAddr,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
-        self.execute_action("bmc_cold_reset", bmc_ip, credential_key)
+        self.execute_action(IpmiCommand::BmcColdReset, bmc_ip, credential_key)
             .await
     }
 
@@ -148,14 +169,14 @@ impl IPMITool for IPMIToolHttpImpl {
     ) -> Result<(), eyre::Report> {
         if legacy_boot
             && self
-                .execute_action("dpu_legacy_boot", bmc_ip, credential_key)
+                .execute_action(IpmiCommand::DpuLegacyPowerReset, bmc_ip, credential_key)
                 .await
                 .is_ok()
         {
             return Ok(());
         }
         // Fall through to chassis_power_reset if legacy_boot fails or is false
-        self.execute_action("chassis_power_reset", bmc_ip, credential_key)
+        self.execute_action(IpmiCommand::ChassisPowerReset, bmc_ip, credential_key)
             .await
     }
 }

--- a/crates/ipmi/src/lib.rs
+++ b/crates/ipmi/src/lib.rs
@@ -25,6 +25,7 @@ use carbide_utils::HostPortPair;
 use carbide_uuid::machine::MachineId;
 
 mod bmc_mock;
+mod metrics;
 mod test_support;
 mod tool;
 

--- a/crates/ipmi/src/metrics.rs
+++ b/crates/ipmi/src/metrics.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Attempt counters for the IPMI reset commands. A `restart` may issue up to
+//! two commands -- the DPU legacy raw reset, then the chassis power reset --
+//! and an intermediate failure used to vanish: collected into a `Vec` whose
+//! entries were then dropped. Counting every command execution by command
+//! and outcome makes those attempts and failures visible, without an
+//! attempt-index label (attempt counts are unbounded; the totals are the
+//! signal). The event is metric-only (`log = off`), matching the sites'
+//! existing logging: a final failure still propagates to callers, and the
+//! intermediate ones stay out of the logs as before.
+
+use carbide_instrument::{Event, LabelValue, Outcome, emit};
+
+/// The IPMI command being executed, as a bounded metric label. This is the
+/// crate's whole command vocabulary, shared by the `ipmitool` and bmc-mock
+/// HTTP implementations of [`crate::IPMITool`].
+// Every command is a reset of one kind or another, and the variant names
+// are exported verbatim as label values -- the full command name is the
+// contract there, so the shared `Reset` postfix stays.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum IpmiCommand {
+    /// `chassis power reset` -- the standard host power reset.
+    ChassisPowerReset,
+    /// The raw OEM power reset legacy-boot DPUs need (`raw 0x32 0xA1 0x01`).
+    DpuLegacyPowerReset,
+    /// `bmc reset cold` -- reboot the BMC itself.
+    BmcColdReset,
+}
+
+/// An IPMI command execution completed, successfully or not. One count is
+/// one dispatched command: the `ipmitool` runner's internal subprocess
+/// retries ride inside a single count, the bmc-mock implementation counts
+/// one per dispatched HTTP request, and a command that never reached the
+/// wire (credentials unavailable) does not count at all.
+#[derive(Event)]
+#[event(
+    name = "carbide_ipmi_commands_total",
+    component = "carbide-ipmi",
+    log = off,
+    metric = counter,
+    describe = "Number of IPMI command executions, by command and outcome."
+)]
+struct IpmiCommandCompleted {
+    #[label]
+    command: IpmiCommand,
+    #[label]
+    outcome: Outcome,
+}
+
+/// Counts one completed execution of `command` from its result; the result
+/// itself is left for the caller to handle.
+pub(crate) fn count_ipmi_command<T, E>(command: IpmiCommand, result: &Result<T, E>) {
+    emit(IpmiCommandCompleted {
+        command,
+        outcome: result.into(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+    use super::*;
+
+    #[test]
+    fn count_ipmi_command_counts_by_command_and_outcome() {
+        struct Case {
+            name: &'static str,
+            command: IpmiCommand,
+            result: Result<(), ()>,
+            expected_command: &'static str,
+            expected_outcome: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "chassis power reset ok",
+                command: IpmiCommand::ChassisPowerReset,
+                result: Ok(()),
+                expected_command: "chassis_power_reset",
+                expected_outcome: "ok",
+            },
+            Case {
+                name: "chassis power reset failure",
+                command: IpmiCommand::ChassisPowerReset,
+                result: Err(()),
+                expected_command: "chassis_power_reset",
+                expected_outcome: "error",
+            },
+            Case {
+                name: "dpu legacy power reset failure",
+                command: IpmiCommand::DpuLegacyPowerReset,
+                result: Err(()),
+                expected_command: "dpu_legacy_power_reset",
+                expected_outcome: "error",
+            },
+            Case {
+                name: "bmc cold reset ok",
+                command: IpmiCommand::BmcColdReset,
+                result: Ok(()),
+                expected_command: "bmc_cold_reset",
+                expected_outcome: "ok",
+            },
+        ];
+
+        for case in cases {
+            let metrics = MetricsCapture::start();
+            let logs = capture_logs(|| count_ipmi_command(case.command, &case.result));
+
+            assert_eq!(
+                metrics.counter_delta(
+                    "carbide_ipmi_commands_total",
+                    &[
+                        ("command", case.expected_command),
+                        ("outcome", case.expected_outcome),
+                    ],
+                ),
+                1.0,
+                "{}",
+                case.name,
+            );
+            assert!(
+                logs.is_empty(),
+                "{}: the event is metric-only, but logged {logs:?}",
+                case.name,
+            );
+        }
+    }
+}

--- a/crates/ipmi/src/tool.rs
+++ b/crates/ipmi/src/tool.rs
@@ -25,6 +25,7 @@ use carbide_uuid::machine::MachineId;
 use eyre::eyre;
 
 use crate::IPMITool;
+use crate::metrics::{IpmiCommand, count_ipmi_command};
 
 pub struct IPMIToolImpl {
     credential_reader: Arc<dyn CredentialReader>,
@@ -32,14 +33,19 @@ pub struct IPMIToolImpl {
 }
 
 impl IPMIToolImpl {
-    const IPMITOOL_COMMAND_ARGS: &'static str = "-I lanplus -C 17 chassis power reset";
-    const IPMITOOL_BMC_RESET_COMMAND_ARGS: &'static str = "-I lanplus -C 17 bmc reset cold";
-    const DPU_LEGACY_IPMITOOL_COMMAND_ARGS: &'static str = "-I lanplus -C 17 raw 0x32 0xA1 0x01";
-
     pub fn new(credential_reader: Arc<dyn CredentialReader>, attempts: Option<u32>) -> Self {
         IPMIToolImpl {
             credential_reader,
             attempts: attempts.unwrap_or(3),
+        }
+    }
+
+    /// The `ipmitool` argument tail that runs `command`.
+    fn command_args(command: IpmiCommand) -> &'static str {
+        match command {
+            IpmiCommand::ChassisPowerReset => "-I lanplus -C 17 chassis power reset",
+            IpmiCommand::DpuLegacyPowerReset => "-I lanplus -C 17 raw 0x32 0xA1 0x01",
+            IpmiCommand::BmcColdReset => "-I lanplus -C 17 bmc reset cold",
         }
     }
 }
@@ -61,7 +67,7 @@ impl IPMITool for IPMIToolImpl {
             .ok_or_else(|| eyre!("No credentials for key {credential_key:#?} found"))?;
 
         match self
-            .execute_ipmitool_command(Self::IPMITOOL_BMC_RESET_COMMAND_ARGS, bmc_ip, &credentials)
+            .execute_ipmitool_command(IpmiCommand::BmcColdReset, bmc_ip, &credentials)
             .await
         {
             Ok(_) => Ok(()),
@@ -92,11 +98,7 @@ impl IPMITool for IPMIToolImpl {
 
         if legacy_boot {
             match self
-                .execute_ipmitool_command(
-                    Self::DPU_LEGACY_IPMITOOL_COMMAND_ARGS,
-                    bmc_ip,
-                    &credentials,
-                )
+                .execute_ipmitool_command(IpmiCommand::DpuLegacyPowerReset, bmc_ip, &credentials)
                 .await
             {
                 Ok(_) => return Ok(()),   // return early if we get a successful response
@@ -104,19 +106,16 @@ impl IPMITool for IPMIToolImpl {
             }
         }
         match self
-            .execute_ipmitool_command(Self::IPMITOOL_COMMAND_ARGS, bmc_ip, &credentials)
+            .execute_ipmitool_command(IpmiCommand::ChassisPowerReset, bmc_ip, &credentials)
             .await
         {
             Ok(_) => return Ok(()),   // return early if we get a successful response
             Err(e) => errors.push(e), // add error and move on if not
         }
 
+        // Only the last error survives as the returned failure; the earlier
+        // attempts' failures have already been counted where they happened.
         let result = errors.pop();
-        /*
-        for e in errors.iter() {
-            tracing::warn!("ipmitool error restarting machine {machine_id}: {e}");
-        }
-        */
 
         Err(match result {
             None => {
@@ -131,7 +130,7 @@ impl IPMITool for IPMIToolImpl {
 impl IPMIToolImpl {
     async fn execute_ipmitool_command(
         &self,
-        command: &str,
+        command: IpmiCommand,
         bmc_ip: IpAddr,
         credentials: &Credentials,
     ) -> CmdResult<String> {
@@ -147,13 +146,15 @@ impl IPMIToolImpl {
                 .collect();
 
         let mut args = prefix_args.to_owned();
-        args.extend(command.split(' ').map(str::to_owned));
+        args.extend(Self::command_args(command).split(' ').map(str::to_owned));
         let cmd = TokioCmd::new("/usr/bin/ipmitool")
             .args(&args)
             .attempts(self.attempts);
 
         tracing::info!("Running command: {:?}", cmd);
-        cmd.env("IPMITOOL_PASSWORD", password).output().await
+        let result = cmd.env("IPMITOOL_PASSWORD", password).output().await;
+        count_ipmi_command(command, &result);
+        result
     }
 }
 

--- a/crates/redfish/Cargo.toml
+++ b/crates/redfish/Cargo.toml
@@ -11,16 +11,12 @@ name = "carbide_redfish"
 
 [features]
 default = []
-test-support = [
-  "dep:chrono",
-  "dep:serde_json",
-  "dep:tokio",
-  "carbide-secrets/test-support",
-]
+test-support = ["carbide-secrets/test-support"]
 
 [dependencies]
 bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-model = { path = "../api-model", default-features = false }
+carbide-instrument = { path = "../instrument" }
 carbide-secrets = { path = "../secrets" }
 carbide-utils = { path = "../utils", default-features = false }
 # state-controller is required only to convert redfish errors to
@@ -31,7 +27,7 @@ state-controller = { path = "../state-controller", default-features = false }
 #these are alphabetized
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
-chrono = { workspace = true, optional = true }
+chrono = { workspace = true }
 http = { workspace = true }
 libredfish = { workspace = true }
 mac_address = { workspace = true }
@@ -42,11 +38,11 @@ nv-redfish = { workspace = true, features = [
 ] }
 reqwest = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, optional = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }

--- a/crates/redfish/src/libredfish/implementation.rs
+++ b/crates/redfish/src/libredfish/implementation.rs
@@ -20,11 +20,13 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use carbide_instrument::red;
 use carbide_secrets::credentials::{CredentialReader, Credentials};
 use carbide_utils::HostPortPair;
 use libredfish::model::service_root::RedfishVendor;
 use libredfish::{Endpoint, Redfish};
 
+use crate::libredfish::instrumented::{InstrumentedRedfish, REDFISH_BACKEND};
 use crate::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
 
 pub struct RedfishClientPoolImpl {
@@ -116,31 +118,44 @@ impl RedfishClientPool for RedfishClientPoolImpl {
             Vec::default()
         };
 
-        match vendor {
+        // The initializing paths below make HTTP calls of their own, so they
+        // are metered like any other Redfish operation.
+        let client = match vendor {
             // Auto-detect vendor from the service root.
-            None => self
-                .pool
-                .create_client_with_custom_headers(endpoint, custom_headers)
-                .await
-                .map_err(RedfishClientCreationError::RedfishError),
+            None => red::instrumented(
+                REDFISH_BACKEND,
+                "create_client",
+                self.pool
+                    .create_client_with_custom_headers(endpoint, custom_headers),
+            )
+            .await
+            .map_err(RedfishClientCreationError::RedfishError)?,
             // Unknown means "no vendor" — return a standard client without
             // making any HTTP calls (used by the anonymous probe client).
             // This restores the behavior of the old `initialize: false` path
             // which called create_standard_client. The full initialization
             // path (create_client_with_vendor) makes HTTP calls to /Systems,
             // /Managers, etc. that fail with 401 on BMCs requiring auth.
+            // With no I/O here, there is no external call to meter either.
             Some(RedfishVendor::Unknown) => self
                 .pool
                 .create_standard_client_with_custom_headers(endpoint, custom_headers)
                 .map_err(RedfishClientCreationError::RedfishError)
-                .map(|c| c as Box<dyn Redfish>),
+                .map(|c| c as Box<dyn Redfish>)?,
             // Use the provided vendor directly.
-            Some(vendor) => self
-                .pool
-                .create_client_with_vendor(endpoint, vendor, custom_headers)
-                .await
-                .map_err(RedfishClientCreationError::RedfishError),
-        }
+            Some(vendor) => red::instrumented(
+                REDFISH_BACKEND,
+                "create_client",
+                self.pool
+                    .create_client_with_vendor(endpoint, vendor, custom_headers),
+            )
+            .await
+            .map_err(RedfishClientCreationError::RedfishError)?,
+        };
+
+        // Every client the pool creates goes out decorated, so each Redfish
+        // call records the per-operation RED triad no matter the call site.
+        Ok(Box::new(InstrumentedRedfish::new(client)))
     }
 
     fn credential_reader(&self) -> &dyn CredentialReader {

--- a/crates/redfish/src/libredfish/instrumented.rs
+++ b/crates/redfish/src/libredfish/instrumented.rs
@@ -1,0 +1,613 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Per-operation RED metrics for every Redfish client the pool creates.
+//!
+//! [`InstrumentedRedfish`] decorates a [`Redfish`] client so that each trait
+//! method records the shared outbound-call triad from
+//! [`carbide_instrument::red`]:
+//! `carbide_external_call_duration_milliseconds{backend = "redfish",
+//! operation, outcome}`. The pool wraps every client it hands out
+//! ([`super::implementation`]), so the one decorator covers every consumer
+//! -- machine-controller, spdm-controller, site-explorer, preingestion, and
+//! the rest -- without touching their call sites. The `operation` label is
+//! the trait method's own name: a closed set fixed at compile time, never a
+//! URL or other wire data.
+//!
+//! This backend's `outcome` has a third value beyond the shared helper's
+//! ok/error: `unsupported`, for calls a vendor answers with a local
+//! [`RedfishError::NotSupported`] stub -- an expected answer, not an
+//! external-call failure (see [`instrumented_redfish`]).
+//!
+//! Two kinds of methods are written out by hand rather than by the
+//! delegation macro. Password-bearing operations redact their password
+//! arguments from the error *before* the RED helper writes its failure WARN
+//! -- call sites redact only after the error has come back to them, which
+//! would be too late for that log line. And
+//! [`Redfish::ac_powercycle_supported_by_power`] is a local capability
+//! check with no BMC I/O to meter, so it delegates plainly.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use carbide_instrument::red;
+use libredfish::model::account_service::ManagerAccount;
+use libredfish::model::certificate::Certificate;
+use libredfish::model::component_integrity::{CaCertificate, ComponentIntegrities, Evidence};
+use libredfish::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
+use libredfish::model::power::Power;
+use libredfish::model::secure_boot::SecureBoot;
+use libredfish::model::sel::LogEntry;
+use libredfish::model::sensor::GPUSensors;
+use libredfish::model::service_root::ServiceRoot;
+use libredfish::model::software_inventory::SoftwareInventory;
+use libredfish::model::storage::Drives;
+use libredfish::model::task::Task;
+use libredfish::model::thermal::Thermal;
+use libredfish::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use libredfish::model::{BootOption, ComputerSystem, Manager, ODataId};
+use libredfish::{
+    Assembly, BiosProfileType, BiosProfileVendor, Boot, BootInterfaceRef, BootOptions,
+    BootOverride, Chassis, Collection, EnabledDisabled, EthernetInterface, JobState,
+    MachineSetupStatus, NetworkAdapter, NetworkDeviceFunction, NetworkPort, PCIeDevice, PowerState,
+    Redfish, RedfishError, RedfishFuture, Resource, RoleId, Status, SystemPowerControl,
+};
+
+use super::redact_password;
+
+/// The `backend` label every Redfish external call records under.
+pub(super) const REDFISH_BACKEND: &str = "redfish";
+
+/// A [`Redfish`] client whose every call records the RED triad.
+pub(super) struct InstrumentedRedfish {
+    inner: Box<dyn Redfish>,
+}
+
+impl InstrumentedRedfish {
+    pub(super) fn new(inner: Box<dyn Redfish>) -> Self {
+        Self { inner }
+    }
+}
+
+/// [`redact_password`], skipping the empty string: `str::replace` with an
+/// empty needle would garble the message instead of redacting anything, and
+/// an empty current password is a real input (`uefi_setup` probes with one).
+fn redact_nonempty(error: RedfishError, password: &str) -> RedfishError {
+    if password.is_empty() {
+        error
+    } else {
+        redact_password(error, password)
+    }
+}
+
+/// Redacts two passwords with union masking: matches that touch or overlap
+/// in the text (one password containing the other, or the two sharing a
+/// boundary, like `foobar`/`foo` or `abcdef`/`defghi` in `abcdefghi`) redact
+/// as one merged span, so a sequential replace can never leave a fragment of
+/// either password behind for the failure WARN.
+fn redact_both(error: RedfishError, a: &str, b: &str) -> RedfishError {
+    super::redact_passwords(error, &[a, b])
+}
+
+/// Times a single Redfish call on the shared RED instrument, with the outcome
+/// vocabulary this backend needs: a [`RedfishError::NotSupported`] answer
+/// records `outcome = "unsupported"` and logs nothing. Vendors answer
+/// capability probes (lockdown status, boot options) with local
+/// `NotSupported` stubs as a matter of course, so the refusal is data the
+/// caller owns -- counting it as `error` would inflate the failure rate with
+/// expected answers, and a WARN per probe would flood the logs fleet-wide.
+/// The split also shows, per operation, what a fleet's BMCs don't support.
+/// Everything else matches [`red::instrumented`]: `ok` records silently,
+/// real failures record `error` and write the same single WARN.
+async fn instrumented_redfish<T>(
+    operation: &'static str,
+    call: impl Future<Output = Result<T, RedfishError>>,
+) -> Result<T, RedfishError> {
+    let started = Instant::now();
+    let result = call.await;
+    let outcome = match &result {
+        Ok(_) => "ok",
+        Err(RedfishError::NotSupported(_)) => "unsupported",
+        Err(_) => "error",
+    };
+    red::record(
+        REDFISH_BACKEND,
+        operation,
+        outcome,
+        started.elapsed().as_secs_f64() * 1_000.0,
+    );
+    if let Err(error) = &result
+        && !matches!(error, RedfishError::NotSupported(_))
+    {
+        tracing::warn!(backend = REDFISH_BACKEND, operation, error = %error, "external call failed");
+    }
+    result
+}
+
+/// Generates the delegating trait methods: each one passes its arguments to
+/// the inner client and records the RED triad with the method's own name as
+/// the `operation` label. Entries are the trait's signatures with the return
+/// type written as the `Ok` type only; the macro restores the
+/// `RedfishFuture<Result<_, RedfishError>>` shell.
+macro_rules! delegate_with_red {
+    ($(
+        fn $method:ident<$lt:lifetime>(
+            & $selflt:lifetime self
+            $(, $arg:ident : $ty:ty )* $(,)?
+        ) -> $ok:ty;
+    )+) => {
+        $(
+            fn $method<$lt>(
+                & $selflt self
+                $(, $arg : $ty )*
+            ) -> RedfishFuture<$lt, Result<$ok, RedfishError>> {
+                Box::pin(instrumented_redfish(
+                    stringify!($method),
+                    self.inner.$method($( $arg ),*),
+                ))
+            }
+        )+
+    };
+}
+
+impl Redfish for InstrumentedRedfish {
+    delegate_with_red! {
+        fn change_username<'a>(&'a self, old_name: &'a str, new_name: &'a str) -> ();
+        fn get_accounts<'a>(&'a self) -> Vec<ManagerAccount>;
+        fn delete_user<'a>(&'a self, username: &'a str) -> ();
+        fn get_firmware<'a>(&'a self, id: &'a str) -> SoftwareInventory;
+        fn get_software_inventories<'a>(&'a self) -> Vec<String>;
+        fn get_tasks<'a>(&'a self) -> Vec<String>;
+        fn get_task<'a>(&'a self, id: &'a str) -> Task;
+        fn get_power_state<'a>(&'a self) -> PowerState;
+        fn get_service_root<'a>(&'a self) -> ServiceRoot;
+        fn get_systems<'a>(&'a self) -> Vec<String>;
+        fn get_system<'a>(&'a self) -> ComputerSystem;
+        fn get_managers<'a>(&'a self) -> Vec<String>;
+        fn get_manager<'a>(&'a self) -> Manager;
+        fn get_secure_boot<'a>(&'a self) -> SecureBoot;
+        fn disable_secure_boot<'a>(&'a self) -> ();
+        fn enable_secure_boot<'a>(&'a self) -> ();
+        fn get_secure_boot_certificate<'a>(
+            &'a self,
+            database_id: &'a str,
+            certificate_id: &'a str,
+        ) -> Certificate;
+        fn get_secure_boot_certificates<'a>(&'a self, database_id: &'a str) -> Vec<String>;
+        fn add_secure_boot_certificate<'a>(
+            &'a self,
+            pem_cert: &'a str,
+            database_id: &'a str,
+        ) -> Task;
+        fn get_power_metrics<'a>(&'a self) -> Power;
+        fn power<'a>(&'a self, action: SystemPowerControl) -> ();
+        fn bmc_reset<'a>(&'a self) -> ();
+        fn chassis_reset<'a>(
+            &'a self,
+            chassis_id: &'a str,
+            reset_type: SystemPowerControl,
+        ) -> ();
+        fn bmc_reset_to_defaults<'a>(&'a self) -> ();
+        fn get_thermal_metrics<'a>(&'a self) -> Thermal;
+        fn get_gpu_sensors<'a>(&'a self) -> Vec<GPUSensors>;
+        fn get_system_event_log<'a>(&'a self) -> Vec<LogEntry>;
+        fn get_bmc_event_log<'a>(
+            &'a self,
+            from: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Vec<LogEntry>;
+        fn get_drives_metrics<'a>(&'a self) -> Vec<Drives>;
+        fn machine_setup<'a>(
+            &'a self,
+            boot_interface: Option<BootInterfaceRef<'a>>,
+            bios_profiles: &'a BiosProfileVendor,
+            selected_profile: BiosProfileType,
+            oem_manager_profiles: &'a BiosProfileVendor,
+        ) -> Option<String>;
+        fn machine_setup_status<'a>(
+            &'a self,
+            boot_interface: Option<BootInterfaceRef<'a>>,
+        ) -> MachineSetupStatus;
+        fn is_bios_setup<'a>(&'a self, boot_interface: Option<BootInterfaceRef<'a>>) -> bool;
+        fn set_machine_password_policy<'a>(&'a self) -> ();
+        fn lockdown<'a>(&'a self, target: EnabledDisabled) -> ();
+        fn lockdown_status<'a>(&'a self) -> Status;
+        fn setup_serial_console<'a>(&'a self) -> ();
+        fn serial_console_status<'a>(&'a self) -> Status;
+        fn get_boot_options<'a>(&'a self) -> BootOptions;
+        fn get_boot_option<'a>(&'a self, option_id: &'a str) -> BootOption;
+        fn boot_once<'a>(&'a self, target: Boot) -> ();
+        fn boot_first<'a>(&'a self, target: Boot) -> ();
+        fn set_boot_override<'a>(&'a self, settings: BootOverride) -> Option<String>;
+        fn change_boot_order<'a>(&'a self, boot_array: Vec<String>) -> ();
+        fn clear_tpm<'a>(&'a self) -> ();
+        fn pcie_devices<'a>(&'a self) -> Vec<PCIeDevice>;
+        fn update_firmware<'a>(&'a self, filename: tokio::fs::File) -> Task;
+        fn update_firmware_multipart<'a>(
+            &'a self,
+            firmware: &'a Path,
+            reboot: bool,
+            timeout: Duration,
+            component_type: ComponentType,
+        ) -> String;
+        fn update_firmware_simple_update<'a>(
+            &'a self,
+            image_uri: &'a str,
+            targets: Vec<String>,
+            transfer_protocol: TransferProtocolType,
+        ) -> Task;
+        fn bios<'a>(&'a self) -> HashMap<String, serde_json::Value>;
+        fn set_bios<'a>(&'a self, values: HashMap<String, serde_json::Value>) -> ();
+        fn reset_bios<'a>(&'a self) -> ();
+        fn pending<'a>(&'a self) -> HashMap<String, serde_json::Value>;
+        fn clear_pending<'a>(&'a self) -> ();
+        fn get_network_device_functions<'a>(&'a self, chassis_id: &'a str) -> Vec<String>;
+        fn get_network_device_function<'a>(
+            &'a self,
+            chassis_id: &'a str,
+            id: &'a str,
+            port: Option<&'a str>,
+        ) -> NetworkDeviceFunction;
+        fn get_chassis_all<'a>(&'a self) -> Vec<String>;
+        fn get_chassis<'a>(&'a self, id: &'a str) -> Chassis;
+        fn get_chassis_assembly<'a>(&'a self, chassis_id: &'a str) -> Assembly;
+        fn get_chassis_network_adapters<'a>(&'a self, chassis_id: &'a str) -> Vec<String>;
+        fn get_chassis_network_adapter<'a>(
+            &'a self,
+            chassis_id: &'a str,
+            id: &'a str,
+        ) -> NetworkAdapter;
+        fn get_base_network_adapters<'a>(&'a self, system_id: &'a str) -> Vec<String>;
+        fn get_base_network_adapter<'a>(
+            &'a self,
+            system_id: &'a str,
+            id: &'a str,
+        ) -> NetworkAdapter;
+        fn get_ports<'a>(
+            &'a self,
+            chassis_id: &'a str,
+            network_adapter: &'a str,
+        ) -> Vec<String>;
+        fn get_port<'a>(
+            &'a self,
+            chassis_id: &'a str,
+            network_adapter: &'a str,
+            id: &'a str,
+        ) -> NetworkPort;
+        fn get_manager_ethernet_interfaces<'a>(&'a self) -> Vec<String>;
+        fn get_manager_ethernet_interface<'a>(&'a self, id: &'a str) -> EthernetInterface;
+        fn get_system_ethernet_interfaces<'a>(&'a self) -> Vec<String>;
+        fn get_system_ethernet_interface<'a>(&'a self, id: &'a str) -> EthernetInterface;
+        fn get_job_state<'a>(&'a self, job_id: &'a str) -> JobState;
+        fn get_resource<'a>(&'a self, id: ODataId) -> Resource;
+        fn get_collection<'a>(&'a self, id: ODataId) -> Collection;
+        fn set_boot_order_dpu_first<'a>(
+            &'a self,
+            boot_interface: BootInterfaceRef<'a>,
+        ) -> Option<String>;
+        fn get_update_service<'a>(&'a self) -> UpdateService;
+        fn get_base_mac_address<'a>(&'a self) -> Option<String>;
+        fn lockdown_bmc<'a>(&'a self, target: EnabledDisabled) -> ();
+        fn is_ipmi_over_lan_enabled<'a>(&'a self) -> bool;
+        fn enable_ipmi_over_lan<'a>(&'a self, target: EnabledDisabled) -> ();
+        fn enable_rshim_bmc<'a>(&'a self) -> ();
+        fn clear_nvram<'a>(&'a self) -> ();
+        fn get_nic_mode<'a>(&'a self) -> Option<NicMode>;
+        fn set_nic_mode<'a>(&'a self, mode: NicMode) -> ();
+        fn enable_infinite_boot<'a>(&'a self) -> ();
+        fn is_infinite_boot_enabled<'a>(&'a self) -> Option<bool>;
+        fn set_host_rshim<'a>(&'a self, enabled: EnabledDisabled) -> ();
+        fn get_host_rshim<'a>(&'a self) -> Option<EnabledDisabled>;
+        fn set_idrac_lockdown<'a>(&'a self, enabled: EnabledDisabled) -> ();
+        fn get_boss_controller<'a>(&'a self) -> Option<String>;
+        fn decommission_storage_controller<'a>(
+            &'a self,
+            controller_id: &'a str,
+        ) -> Option<String>;
+        fn create_storage_volume<'a>(
+            &'a self,
+            controller_id: &'a str,
+            volume_name: &'a str,
+        ) -> Option<String>;
+        fn is_boot_order_setup<'a>(&'a self, boot_interface: BootInterfaceRef<'a>) -> bool;
+        fn get_component_integrities<'a>(&'a self) -> ComponentIntegrities;
+        fn get_firmware_for_component<'a>(
+            &'a self,
+            component_integrity_id: &'a str,
+        ) -> SoftwareInventory;
+        fn get_component_ca_certificate<'a>(&'a self, url: &'a str) -> CaCertificate;
+        fn trigger_evidence_collection<'a>(&'a self, url: &'a str, nonce: &'a str) -> Task;
+        fn get_evidence<'a>(&'a self, url: &'a str) -> Evidence;
+        fn set_host_privilege_level<'a>(&'a self, level: HostPrivilegeLevel) -> ();
+        fn set_utc_timezone<'a>(&'a self) -> ();
+        fn set_ntp_servers<'a>(&'a self, servers: &'a [String]) -> ();
+    }
+
+    // MARK: - Password-bearing operations
+    //
+    // These redact their password arguments from the error before returning
+    // it, so the RED helper's failure WARN (and everything downstream) only
+    // ever sees the redacted form. Callers that redact again find nothing
+    // left to replace.
+
+    fn change_password<'a>(
+        &'a self,
+        username: &'a str,
+        new_pass: &'a str,
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(instrumented_redfish("change_password", async move {
+            self.inner
+                .change_password(username, new_pass)
+                .await
+                .map_err(|error| redact_nonempty(error, new_pass))
+        }))
+    }
+
+    fn change_password_by_id<'a>(
+        &'a self,
+        account_id: &'a str,
+        new_pass: &'a str,
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(instrumented_redfish("change_password_by_id", async move {
+            self.inner
+                .change_password_by_id(account_id, new_pass)
+                .await
+                .map_err(|error| redact_nonempty(error, new_pass))
+        }))
+    }
+
+    fn create_user<'a>(
+        &'a self,
+        username: &'a str,
+        password: &'a str,
+        role_id: RoleId,
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(instrumented_redfish("create_user", async move {
+            self.inner
+                .create_user(username, password, role_id)
+                .await
+                .map_err(|error| redact_nonempty(error, password))
+        }))
+    }
+
+    fn change_uefi_password<'a>(
+        &'a self,
+        current_uefi_password: &'a str,
+        new_uefi_password: &'a str,
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(instrumented_redfish("change_uefi_password", async move {
+            self.inner
+                .change_uefi_password(current_uefi_password, new_uefi_password)
+                .await
+                .map_err(|error| redact_both(error, current_uefi_password, new_uefi_password))
+        }))
+    }
+
+    fn clear_uefi_password<'a>(
+        &'a self,
+        current_uefi_password: &'a str,
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(instrumented_redfish("clear_uefi_password", async move {
+            self.inner
+                .clear_uefi_password(current_uefi_password)
+                .await
+                .map_err(|error| redact_nonempty(error, current_uefi_password))
+        }))
+    }
+
+    // MARK: - Local capability check
+
+    fn ac_powercycle_supported_by_power(&self) -> bool {
+        // No BMC I/O happens here, so there is no external call to meter.
+        self.inner.ac_powercycle_supported_by_power()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::MetricsCapture;
+    use carbide_secrets::credentials::{CredentialKey, CredentialType};
+
+    use super::*;
+    use crate::libredfish::test_support::RedfishSim;
+    use crate::libredfish::{RedfishAuth, RedfishClientPool};
+
+    async fn sim_client(sim: &RedfishSim) -> InstrumentedRedfish {
+        let client = sim
+            .create_client(
+                "localhost",
+                None,
+                RedfishAuth::Key(CredentialKey::HostRedfish {
+                    credential_type: CredentialType::SiteDefault,
+                }),
+                None,
+            )
+            .await
+            .expect("sim client");
+        InstrumentedRedfish::new(client)
+    }
+
+    #[tokio::test]
+    async fn ok_call_records_the_external_call_histogram() {
+        let sim = RedfishSim::default();
+        let client = sim_client(&sim).await;
+
+        let metrics = MetricsCapture::start();
+        assert_eq!(
+            client.get_power_state().await.expect("sim power state"),
+            PowerState::On,
+        );
+
+        assert_eq!(
+            metrics.histogram_count_delta(
+                "carbide_external_call_duration_milliseconds",
+                &[
+                    ("backend", "redfish"),
+                    ("operation", "get_power_state"),
+                    ("outcome", "ok"),
+                ],
+            ),
+            1,
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_call_records_the_error_outcome_and_returns_the_error() {
+        let sim = RedfishSim::default();
+        let client = sim_client(&sim).await;
+
+        let metrics = MetricsCapture::start();
+        let error = client
+            .change_password_by_id("2", "site_pass")
+            .await
+            .expect_err("no account id 2 is seeded");
+        assert!(
+            matches!(&error, RedfishError::UserNotFound(id) if id == "2"),
+            "expected UserNotFound(\"2\"), got {error:?}",
+        );
+
+        assert_eq!(
+            metrics.histogram_count_delta(
+                "carbide_external_call_duration_milliseconds",
+                &[
+                    ("backend", "redfish"),
+                    ("operation", "change_password_by_id"),
+                    ("outcome", "error"),
+                ],
+            ),
+            1,
+        );
+    }
+
+    /// The three-way outcome split: a vendor's local `NotSupported` answer
+    /// records `unsupported` with no log line, a genuine failure records
+    /// `error` with the single WARN, and both errors propagate untouched.
+    #[test]
+    fn unsupported_answers_record_their_own_outcome_and_stay_quiet() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("current-thread runtime");
+        let metrics = MetricsCapture::start();
+        let logs = carbide_instrument::testing::capture_logs(|| {
+            rt.block_on(async {
+                instrumented_redfish::<()>(
+                    "lockdown_status",
+                    std::future::ready(Err(RedfishError::NotSupported(
+                        "vendor answers locally".to_string(),
+                    ))),
+                )
+                .await
+                .expect_err("the refusal still propagates");
+
+                instrumented_redfish::<()>(
+                    "lockdown_status",
+                    std::future::ready(Err(RedfishError::GenericError {
+                        error: "boom".to_string(),
+                    })),
+                )
+                .await
+                .expect_err("the error still propagates");
+            });
+        });
+
+        assert_eq!(
+            logs.iter()
+                .filter(|log| log.message == "external call failed")
+                .count(),
+            1,
+            "only the genuine failure warns; unsupported stays quiet, got {logs:?}",
+        );
+        assert_eq!(
+            metrics.histogram_count_delta(
+                "carbide_external_call_duration_milliseconds",
+                &[
+                    ("backend", "redfish"),
+                    ("operation", "lockdown_status"),
+                    ("outcome", "unsupported"),
+                ],
+            ),
+            1,
+        );
+        assert_eq!(
+            metrics.histogram_count_delta(
+                "carbide_external_call_duration_milliseconds",
+                &[
+                    ("backend", "redfish"),
+                    ("operation", "lockdown_status"),
+                    ("outcome", "error"),
+                ],
+            ),
+            1,
+        );
+    }
+
+    /// The containment case: one password contains the other; a naive
+    /// shorter-first replace would fragment the longer one and leak its tail.
+    #[test]
+    fn redact_both_survives_contained_passwords() {
+        let error = RedfishError::GenericError {
+            error: "rejected foobar, and foo separately".to_string(),
+        };
+        let redacted = redact_both(error, "foobar", "foo");
+        assert!(
+            matches!(
+                &redacted,
+                RedfishError::GenericError { error } if error == "rejected REDACTED, and REDACTED separately"
+            ),
+            "both passwords must redact fully with no fragments, got {redacted:?}",
+        );
+    }
+
+    /// The partial-overlap case: the two passwords share a boundary in the
+    /// text, so any sequential replace leaks a fragment of one of them; the
+    /// union mask redacts the merged span as one.
+    #[test]
+    fn redact_both_survives_partially_overlapping_passwords() {
+        let error = RedfishError::GenericError {
+            error: "rejected abcdefghi".to_string(),
+        };
+        let redacted = redact_both(error, "abcdef", "defghi");
+        assert!(
+            matches!(
+                &redacted,
+                RedfishError::GenericError { error } if error == "rejected REDACTED"
+            ),
+            "the overlapping span must redact as one with no fragments, got {redacted:?}",
+        );
+    }
+
+    #[test]
+    fn redact_nonempty_redacts_only_a_nonempty_password() {
+        let error = RedfishError::GenericError {
+            error: "rejected pass123".to_string(),
+        };
+        let redacted = redact_nonempty(error, "pass123");
+        assert!(
+            matches!(&redacted, RedfishError::GenericError { error } if error == "rejected REDACTED"),
+            "expected the password redacted, got {redacted:?}",
+        );
+
+        let error = RedfishError::GenericError {
+            error: "boom".to_string(),
+        };
+        let untouched = redact_nonempty(error, "");
+        assert!(
+            matches!(&untouched, RedfishError::GenericError { error } if error == "boom"),
+            "an empty password must leave the message untouched, got {untouched:?}",
+        );
+    }
+}

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod implementation;
+mod instrumented;
 
 pub mod auth;
 pub mod conv;
@@ -449,9 +450,61 @@ pub trait RedfishClientPool: Send + Sync + 'static {
 // we can display them to user. This function is helper to remove
 // password leak for password-related refish functions.
 pub fn redact_password(err: libredfish::RedfishError, password: &str) -> libredfish::RedfishError {
-    type RfError = libredfish::RedfishError;
+    redact_passwords(err, &[password])
+}
+
+/// Replaces every occurrence of every non-empty needle with `REDACTED`,
+/// masking the union of all matches: where two needles' matches touch or
+/// overlap in the text (one password containing the other, or sharing a
+/// boundary), the merged span redacts as one, so no fragment of either
+/// survives.
+fn mask_all(text: &str, needles: &[&str]) -> String {
     const REDACTED: &str = "REDACTED";
-    let redact = |v: String| v.replace(password, REDACTED);
+    let mut ranges: Vec<(usize, usize)> = needles
+        .iter()
+        .filter(|needle| !needle.is_empty())
+        .flat_map(|needle| {
+            // A manual scan over every starting position, not
+            // `match_indices`: that skips overlapping matches of the same
+            // needle, and a self-repetitive password (`aa` in `xaaay`) would
+            // leave a fragment beside the mask. Byte-wise matching of one
+            // valid UTF-8 string inside another can only land on character
+            // boundaries, so the collected ranges slice cleanly.
+            let needle = needle.as_bytes();
+            (0..=text.len().saturating_sub(needle.len()))
+                .filter(move |&start| text.as_bytes()[start..].starts_with(needle))
+                .map(move |start| (start, start + needle.len()))
+        })
+        .collect();
+    ranges.sort_unstable();
+
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0;
+    let mut i = 0;
+    while i < ranges.len() {
+        let (start, mut end) = ranges[i];
+        i += 1;
+        while i < ranges.len() && ranges[i].0 <= end {
+            end = end.max(ranges[i].1);
+            i += 1;
+        }
+        out.push_str(&text[cursor..start]);
+        out.push_str(REDACTED);
+        cursor = end;
+    }
+    out.push_str(&text[cursor..]);
+    out
+}
+
+/// [`redact_password`] over several passwords at once, with union masking
+/// (see [`mask_all`]) so overlapping matches cannot leave fragments of one
+/// password behind after another is replaced.
+pub fn redact_passwords(
+    err: libredfish::RedfishError,
+    passwords: &[&str],
+) -> libredfish::RedfishError {
+    type RfError = libredfish::RedfishError;
+    let redact = |v: String| mask_all(&v, passwords);
     match err {
         RfError::HTTPErrorCode {
             url,
@@ -518,6 +571,54 @@ mod tests {
 
     use super::*;
     use crate::libredfish::test_support::*;
+
+    /// The mask covers the union of ALL matches, including a needle's
+    /// self-overlapping matches (`aa` occurs at both offsets in `xaaay`) and
+    /// matches of different needles sharing a boundary -- so no fragment of
+    /// any needle is left unmasked.
+    #[test]
+    fn mask_all_covers_overlapping_and_repeated_matches() {
+        struct Case {
+            name: &'static str,
+            text: &'static str,
+            needles: &'static [&'static str],
+            expected: &'static str,
+        }
+        let cases = [
+            Case {
+                name: "self-overlapping needle",
+                text: "xaaay",
+                needles: &["aa"],
+                expected: "xREDACTEDy",
+            },
+            Case {
+                name: "boundary overlap between two needles",
+                text: "rejected abcdefghi",
+                needles: &["abcdef", "defghi"],
+                expected: "rejected REDACTED",
+            },
+            Case {
+                name: "containment",
+                text: "rejected foobar, and foo separately",
+                needles: &["foo", "foobar"],
+                expected: "rejected REDACTED, and REDACTED separately",
+            },
+            Case {
+                name: "disjoint matches and empty needles ignored",
+                text: "a secret and a token",
+                needles: &["secret", "token", ""],
+                expected: "a REDACTED and a REDACTED",
+            },
+        ];
+        for case in cases {
+            assert_eq!(
+                mask_all(case.text, case.needles),
+                case.expected,
+                "case: {}",
+                case.name,
+            );
+        }
+    }
 
     #[tokio::test]
     async fn test_power_state() {

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -63,6 +63,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_ib_partitions_iteration_latency_milliseconds</td><td>histogram</td><td>The elapsed time in the last state processor iteration to handle objects of type carbide_ib_partitions</td></tr>
 <tr><td>carbide_ib_partitions_object_tasks_enqueued_total</td><td>counter</td><td>Number of object handling tasks freshly enqueued for objects of type carbide_ib_partitions</td></tr>
 <tr><td>carbide_ib_partitions_total</td><td>gauge</td><td>Number of carbide_ib_partitions in the system</td></tr>
+<tr><td>carbide_ipmi_commands_total</td><td>counter</td><td>Number of IPMI command executions, by command and outcome.</td></tr>
 <tr><td>carbide_log_events_total</td><td>counter</td><td>Number of log events emitted, by level and component. The always-on log-volume and error-rate signal for every binary.</td></tr>
 <tr><td>carbide_machine_reboot_duration_seconds</td><td>histogram</td><td>Time taken for machine/host to reboot in seconds</td></tr>
 <tr><td>carbide_machine_updates_started_count</td><td>gauge</td><td>Number of machines in the system in the process of updating</td></tr>


### PR DESCRIPTION
Redfish is the busiest hardware boundary in the system, and its error accounting collapsed almost everything into `redfish_other_error`; IPMI's power-reset attempts weren't counted at all (the failure-reporting loop was literally commented out). Both now report per operation.

- Every pool-created client comes wrapped in `InstrumentedRedfish`: all 104 trait methods record `carbide_external_call_duration_milliseconds{backend="redfish", operation, outcome}` -- requests, errors, and latency per operation, covering every `libredfish` call site with zero call-site edits. (The typed `nv_redfish` stack has a URL-shaped operation vocabulary -- exactly the unbounded label this design forbids -- and needs its own treatment.)
- `outcome` gains a third value, `unsupported`, for calls a vendor answers with a local `NotSupported` stub: quiet and truthful, instead of inflating the error rate and writing a warn per capability probe fleet-wide -- and it shows per operation what a fleet's BMCs don't support. The shared helper gains a low-level `red::record` for backends that need their own outcome vocabulary.
- The five password-bearing methods redact the password from the error text before the failure warn fires -- call sites redacted only after the error returned, too late for that line -- with a guard for the empty-password probe `uefi_setup` uses.
- `carbide_ipmi_commands_total{command, outcome}` counts each dispatched IPMI command in both the real runner and bmc-mock -- including the legacy-then-standard intermediate attempts whose errors are collected and dropped. A command that never reaches the wire (credentials unavailable) does not count, and the runner's internal subprocess retries ride inside a single count.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3174
