### PR TITLE
docs(cli): add the boot-interface command reference pages

### DIFF
--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-candidates.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-candidates.md
@@ -1,0 +1,62 @@
+# `nico-admin-cli boot-interface candidates`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **candidates**_
+
+## NAME
+
+nico-admin-cli-boot-interface-candidates - List boot-interface
+candidates for a machine and the picks among them
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface candidates** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*MACHINE*\>
+
+## DESCRIPTION
+
+List every NIC that could be the boot interface for a machine (the
+managed \`machine_interfaces\` rows and the pre-first-lease predictions),
+and mark the picks among them: \`current\` (what resolution targets
+now: the primary interface if one is set, else the lowest-MAC
+non-underlay interface), \`default\` (what the automatic selection would
+choose if no primary interface were set), and \`explored\` (the default
+site-explorer recorded for the BMC endpoint of the machine). Underlay
+rows are listed but marked ineligible. Every pick is computed
+server-side by the same selection code the machine-controller acts on.
+Read-only.
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> - primary-id: Sort by the primary id
+>
+> - state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*MACHINE*\>  
+The machine ID whose boot-interface candidates to list
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface candidates 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format json boot-interface candidates 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-set.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-set.md
@@ -1,0 +1,67 @@
+# `nico-admin-cli boot-interface set`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **set**_
+
+## NAME
+
+nico-admin-cli-boot-interface-set - Set the boot interface for a machine
+(promotes it to the primary interface)
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface set** \[**--reboot**\]
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\<*MACHINE*\> \<*INTERFACE*\>
+
+## DESCRIPTION
+
+Make an interface the boot interface for a machine by promoting it to
+the primary interface, the designation every boot flow acts on. This
+is the same operation as \`managed-host set-primary-interface\`: the BMC
+boot order is updated first, then the primary flag moves in the
+database. The interface can be named by machine-interface UUID or by MAC
+address; a MAC must match exactly one managed interface row on the
+machine.
+
+## OPTIONS
+
+**--reboot**  
+Reboot the host after the update
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> - primary-id: Sort by the primary id
+>
+> - state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*MACHINE*\>  
+The machine whose boot interface to set
+
+\<*INTERFACE*\>  
+The interface to boot from: a machine-interface UUID or a MAC address
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 00:11:22:33:44:55
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789
+nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 00:11:22:33:44:55 --reboot
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-show.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface-show.md
@@ -1,0 +1,60 @@
+# `nico-admin-cli boot-interface show`
+
+_[Hardware commands](../../hardware.md) › [boot-interface](./boot-interface.md) › **show**_
+
+## NAME
+
+nico-admin-cli-boot-interface-show - Show boot interfaces for a machine
+from every store (troubleshooting)
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface show** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*MACHINE*\>
+
+## DESCRIPTION
+
+Gather the boot-interface view for one machine from all four stores and
+print them together: the managed \`machine_interfaces\` rows
+(authoritative for a managed machine), \`predicted_machine_interfaces\`
+(pre-first-lease candidates), the \`explored_endpoints\` default (for
+endpoints without a machine), and the retained post-deletion pairs
+(including stale records). Also reports the effective boot interface the
+system would select and flags when the stores disagree. Read-only.
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> - primary-id: Sort by the primary id
+>
+> - state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*MACHINE*\>  
+The machine ID whose boot interfaces to gather
+
+## Examples
+
+```sh
+nico-admin-cli boot-interface show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format json boot-interface show 12345678-1234-5678-90ab-cdef01234567
+nico-admin-cli --format yaml boot-interface show 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface.md
+++ b/docs/manuals/nico-admin-cli/commands/boot-interface/boot-interface.md
@@ -1,0 +1,50 @@
+# `nico-admin-cli boot-interface`
+
+_[Hardware commands](../../hardware.md) › **boot-interface**_
+
+## NAME
+
+nico-admin-cli-boot-interface - Machine boot-interface management
+
+## SYNOPSIS
+
+**nico-admin-cli boot-interface** \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Machine boot-interface management
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> - primary-id: Sort by the primary id
+>
+> - state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`show`](./boot-interface-show.md) | Show boot interfaces for a machine from every store (troubleshooting) |
+| [`candidates`](./boot-interface-candidates.md) | List boot-interface candidates for a machine and the picks among them |
+| [`set`](./boot-interface-set.md) | Set the boot interface for a machine (promotes it to the primary interface) |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/hardware.md
+++ b/docs/manuals/nico-admin-cli/hardware.md
@@ -8,6 +8,7 @@ For global flags and setup, see [the overview](./README.md) and [`setup.md`](./s
 |---|---|
 | [`attestation`](./commands/attestation/attestation.md) | MeasuredBoot or SPDM attestations. |
 | [`bmc-machine`](./commands/bmc-machine/bmc-machine.md) | BMC Machine related handling. |
+| [`boot-interface`](./commands/boot-interface/boot-interface.md) | Machine boot-interface management. |
 | [`boot-override`](./commands/boot-override/boot-override.md) | Machine boot override. |
 | [`browse`](./commands/browse/browse.md) | Browse subsystem resource trees via the API server. |
 | [`component-manager`](./commands/component-manager/component-manager.md) | Component manager actions. |


### PR DESCRIPTION
The generated CLI reference pages for the new `boot-interface` command family (`show`, `candidates`, `set`) from #3341, plus the hardware-index row -- split out so the code lands independently of the docs review. Straight `generate-cli-docs` output, no hand-authored content.

This supports https://github.com/NVIDIA/infra-controller/issues/3335
