### PR TITLE
test(api-db): share one query-counting helper instead of a copy per module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,11 @@ dependencies = [
 [[package]]
 name = "carbide-test-support"
 version = "0.0.0"
+dependencies = [
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "carbide-tls"

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -53,7 +53,7 @@ Other common places where we've seen `#[allow(dead_code)]` that are not necessar
 
 Prefer **table-driven tests** for any function that maps inputs to outputs, errors, or other observable results —
 parsers, validators, conversions, serde round-trips, formatters, and the like. The `carbide-test-support` crate
-provides tiny, zero-dependency helpers for exactly this. Add it as a dev-dependency:
+provides tiny helpers for exactly this. Add it as a dev-dependency:
 
 ```toml
 [dev-dependencies]

--- a/crates/api-db/src/dns/domain.rs
+++ b/crates/api-db/src/dns/domain.rs
@@ -249,31 +249,10 @@ fn test_generate_domain_serial_format() {
 
 #[cfg(test)]
 mod test_find_by_uuids {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
+    use carbide_test_support::query_counter::count_queries;
     use model::dns::NewDomain;
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::prelude::*;
 
     use crate as db;
-
-    /// Counts `sqlx::query*` tracing events so a batched query can be shown to collapse an N+1
-    /// loop down to a single database round trip.
-    #[derive(Clone, Default)]
-    struct QueryCounter(Arc<AtomicUsize>);
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
-        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
-            if e.metadata().target().starts_with("sqlx::query") {
-                self.0.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-    impl QueryCounter {
-        fn count(&self) -> usize {
-            self.0.load(Ordering::Relaxed)
-        }
-    }
 
     #[crate::sqlx_test]
     async fn find_by_uuids_collapses_n_plus_one(pool: sqlx::PgPool) {
@@ -294,12 +273,10 @@ mod test_find_by_uuids {
         // BEFORE: one find_by_uuid per id. The reads run straight off the pool
         // -- no transaction -- so the count reflects only the find_by_uuid
         // calls, not begin/commit statements.
-        let before = QueryCounter::default();
-        let looped = {
-            let counter = before.clone();
+        let (looped, before_count) = {
             let pool = &pool;
             let ids = &ids;
-            async move {
+            count_queries(async move {
                 let mut names = std::collections::HashMap::new();
                 for id in ids {
                     let domain = db::dns::domain::find_by_uuid(pool, *id)
@@ -309,31 +286,21 @@ mod test_find_by_uuids {
                     names.insert(domain.id, domain.name);
                 }
                 names
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter),
-            ))
+            })
             .await
         };
-        let before_count = before.count();
 
         // AFTER: a single batched find_by_uuids.
-        let after = QueryCounter::default();
-        let batched = {
-            let counter = after.clone();
+        let (batched, after_count) = {
             let pool = &pool;
             let ids = &ids;
-            async move {
+            count_queries(async move {
                 db::dns::domain::find_by_uuids(pool, ids)
                     .await
                     .expect("find_by_uuids")
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter),
-            ))
+            })
             .await
         };
-        let after_count = after.count();
 
         // Data equality: same set of (id -> name) pairs.
         assert_eq!(batched.len(), N, "batched returned all N domains");

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -568,6 +568,7 @@ mod test {
     use std::str::FromStr;
 
     use carbide_libmlx_model::device::info::MlxDeviceInfo;
+    use carbide_test_support::query_counter::count_queries;
     use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
     use mac_address::MacAddress;
     use model::dpa_interface::{
@@ -590,29 +591,6 @@ mod test {
     async fn find_by_machine_ids_issues_one_query(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        use std::sync::Arc;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        use tracing::instrument::WithSubscriber;
-        use tracing_subscriber::prelude::*;
-
-        /// A tracing layer that counts sqlx query-execution events. sqlx emits
-        /// one event on target `sqlx::query` per executed statement, so the
-        /// count of these events is the number of round trips to Postgres.
-        #[derive(Clone, Default)]
-        struct QueryCounter(Arc<AtomicUsize>);
-        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
-            fn on_event(
-                &self,
-                e: &tracing::Event<'_>,
-                _c: tracing_subscriber::layer::Context<'_, S>,
-            ) {
-                if e.metadata().target().starts_with("sqlx::query") {
-                    self.0.fetch_add(1, Ordering::Relaxed);
-                }
-            }
-        }
-
         // Seed helper: create `n` distinct machines, each with exactly one
         // dpa_interface, and return their ids. Each MachineId is minted from a
         // per-index hardware hash (the same shape as the `test_machine_id`
@@ -662,14 +640,11 @@ mod test {
         const N: usize = 5;
         let ids = seed(&pool, 0, N).await?;
 
-        let counter = QueryCounter::default();
-        let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(counter.clone()));
-
         // BEFORE: the per-machine loop (the N+1 pattern).
-        let per_machine: std::collections::HashMap<MachineId, Vec<_>> = {
+        let (per_machine, before): (std::collections::HashMap<MachineId, Vec<_>>, usize) = {
             let pool = &pool;
             let ids = &ids;
-            async move {
+            count_queries(async move {
                 let mut out = std::collections::HashMap::new();
                 for id in ids {
                     let v = crate::dpa_interface::find_by_machine_id(
@@ -682,11 +657,9 @@ mod test {
                     out.insert(*id, v);
                 }
                 out
-            }
-            .with_subscriber(dispatch.clone())
+            })
             .await
         };
-        let before = counter.0.load(Ordering::Relaxed);
         println!("BEFORE (per-machine loop, N={N}): {before} queries");
 
         // BITE-CHECK: the per-machine loop MUST issue one query per machine.
@@ -698,20 +671,17 @@ mod test {
              a count of 0 means the query counter isn't seeing sqlx::query events"
         );
 
-        // AFTER: the batched loader. Reset the counter first.
-        counter.0.store(0, Ordering::Relaxed);
-        let batched = {
+        // AFTER: the batched loader.
+        let (batched, after) = {
             let pool = &pool;
             let ids = &ids;
-            async move {
+            count_queries(async move {
                 crate::dpa_interface::find_by_machine_ids(pool, ids, DpaSearchConfig::default())
                     .await
                     .unwrap()
-            }
-            .with_subscriber(dispatch.clone())
+            })
             .await
         };
-        let after = counter.0.load(Ordering::Relaxed);
         println!("AFTER (batched find_by_machine_ids, N={N}): {after} queries");
         assert_eq!(after, 1, "batched loader must issue exactly one query");
 
@@ -737,42 +707,34 @@ mod test {
 
         // Re-confirm the per-machine loop scales linearly at N2 as well, so the
         // "constant vs linear" contrast is anchored on both sides.
-        let counter2 = QueryCounter::default();
-        let dispatch2 =
-            tracing::Dispatch::new(tracing_subscriber::registry().with(counter2.clone()));
-        {
+        let ((), before2) = {
             let pool = &pool;
             let ids2 = &ids2;
-            async move {
+            count_queries(async move {
                 for id in ids2 {
                     crate::dpa_interface::find_by_machine_id(pool, *id, DpaSearchConfig::default())
                         .await
                         .unwrap();
                 }
-            }
-            .with_subscriber(dispatch2.clone())
+            })
             .await
         };
-        let before2 = counter2.0.load(Ordering::Relaxed);
         println!("BEFORE (per-machine loop, N={N2}): {before2} queries");
         assert_eq!(
             before2, N2,
             "per-machine loop should issue exactly N={N2} queries"
         );
 
-        counter2.0.store(0, Ordering::Relaxed);
-        let batched2 = {
+        let (batched2, after2) = {
             let pool = &pool;
             let ids2 = &ids2;
-            async move {
+            count_queries(async move {
                 crate::dpa_interface::find_by_machine_ids(pool, ids2, DpaSearchConfig::default())
                     .await
                     .unwrap()
-            }
-            .with_subscriber(dispatch2.clone())
+            })
             .await
         };
-        let after2 = counter2.0.load(Ordering::Relaxed);
         println!("AFTER (batched find_by_machine_ids, N={N2}): {after2} queries");
         assert_eq!(
             after2, 1,
@@ -787,18 +749,15 @@ mod test {
         // ---- Scenario 3: N = 0, no query at all ----
         // An empty id slice short-circuits before building the query, matching
         // the sibling batch helpers.
-        counter2.0.store(0, Ordering::Relaxed);
-        let batched_empty = {
+        let (batched_empty, empty_count) = {
             let pool = &pool;
-            async move {
+            count_queries(async move {
                 crate::dpa_interface::find_by_machine_ids(pool, &[], DpaSearchConfig::default())
                     .await
                     .unwrap()
-            }
-            .with_subscriber(dispatch2.clone())
+            })
             .await
         };
-        let empty_count = counter2.0.load(Ordering::Relaxed);
         println!("EMPTY (batched find_by_machine_ids, N=0): {empty_count} queries");
         assert_eq!(
             empty_count, 0,

--- a/crates/api-db/src/extension_service.rs
+++ b/crates/api-db/src/extension_service.rs
@@ -751,36 +751,15 @@ pub async fn set_updated_timestamp(
 
 #[cfg(test)]
 mod test_batched_lookups {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
+    use carbide_test_support::query_counter::count_queries;
     use config_version::ConfigVersion;
     use model::extension_service::ExtensionServiceType;
     use model::metadata::Metadata;
     use model::tenant::TenantOrganizationId;
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::prelude::*;
 
     use super::*;
 
     const TENANT_ORG: &str = "test-org";
-
-    /// Counts `sqlx::query*` tracing events so a batched query can be shown to collapse an N+1
-    /// loop down to a single database round trip.
-    #[derive(Clone, Default)]
-    struct QueryCounter(Arc<AtomicUsize>);
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
-        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
-            if e.metadata().target().starts_with("sqlx::query") {
-                self.0.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-    impl QueryCounter {
-        fn count(&self) -> usize {
-            self.0.load(Ordering::Relaxed)
-        }
-    }
 
     /// Seed N extension services (each with an initial version), returning their ids and the
     /// exact `ConfigVersion` stored for each so tests can look versions up by exact match.
@@ -840,12 +819,10 @@ mod test_batched_lookups {
         // acquires its connection inside the instrumented future.
 
         // BEFORE: find_by_ids called with a 1-element slice per service (the pattern in dpu.rs).
-        let before = QueryCounter::default();
-        let looped = {
-            let counter = before.clone();
+        let (looped, before_count) = {
             let pool = &pool;
             let ids = &ids;
-            async move {
+            count_queries(async move {
                 let mut conn = pool.acquire().await.expect("acquire");
                 let mut names = std::collections::HashMap::new();
                 for id in ids {
@@ -858,32 +835,22 @@ mod test_batched_lookups {
                     names.insert(service.id, service.name);
                 }
                 names
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter),
-            ))
+            })
             .await
         };
-        let before_count = before.count();
 
         // AFTER: a single find_by_ids over the whole set.
-        let after = QueryCounter::default();
-        let batched = {
-            let counter = after.clone();
+        let (batched, after_count) = {
             let pool = &pool;
             let ids = &ids;
-            async move {
+            count_queries(async move {
                 let mut conn = pool.acquire().await.expect("acquire");
                 find_by_ids(&mut conn, ids, false)
                     .await
                     .expect("find_by_ids")
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter),
-            ))
+            })
             .await
         };
-        let after_count = after.count();
 
         // Data equality: same set of (id -> name) pairs.
         assert_eq!(batched.len(), N, "batched returned all N services");
@@ -925,40 +892,28 @@ mod test_batched_lookups {
         // acquires its connection inside the instrumented future.
 
         // find_version_info: existence probe + version lookup.
-        let probed = QueryCounter::default();
-        let probed_info = {
-            let counter = probed.clone();
+        let (probed_info, probed_count) = {
             let pool = &pool;
-            async move {
+            count_queries(async move {
                 let mut conn = pool.acquire().await.expect("acquire");
                 find_version_info(&mut conn, service_id, Some(version))
                     .await
                     .expect("find_version_info")
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter),
-            ))
+            })
             .await
         };
-        let probed_count = probed.count();
 
         // find_version_info_of_known_service: the version lookup alone.
-        let unprobed = QueryCounter::default();
-        let unprobed_info = {
-            let counter = unprobed.clone();
+        let (unprobed_info, unprobed_count) = {
             let pool = &pool;
-            async move {
+            count_queries(async move {
                 let mut conn = pool.acquire().await.expect("acquire");
                 find_version_info_of_known_service(&mut conn, service_id, Some(version))
                     .await
                     .expect("find_version_info_of_known_service")
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter),
-            ))
+            })
             .await
         };
-        let unprobed_count = unprobed.count();
 
         // Data equality: both lookups return the same version row.
         assert_eq!(

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -743,6 +743,7 @@ mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
 
+    use carbide_test_support::query_counter::count_queries;
     use carbide_uuid::vpc::VpcId;
     use chrono::Utc;
     use config_version::{ConfigVersion, Versioned};
@@ -897,36 +898,6 @@ mod tests {
     // measures the lock-window reduction directly: one INSERT regardless of
     // how many addresses an instance's interfaces carry.
 
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::prelude::*;
-
-    /// A `tracing` layer that counts every `sqlx::query*` event. sqlx emits one
-    /// such event per statement it executes, so the count is the statement
-    /// count for whatever ran under this subscriber.
-    ///
-    /// The test harness installs a global `sqlx=warn` `EnvFilter`. A per-target
-    /// filter registers `Interest::sometimes()`, so this scoped subscriber
-    /// still receives the events even though the global filter would drop them.
-    #[derive(Clone, Default)]
-    struct QueryCounter(Arc<AtomicUsize>);
-
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
-        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
-            if e.metadata().target().starts_with("sqlx::query") {
-                self.0.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-
-    impl QueryCounter {
-        fn count(&self) -> usize {
-            self.0.load(Ordering::Relaxed)
-        }
-    }
-
     /// Inserts the minimal FK ancestry `instance_addresses` requires (one vpc,
     /// one machine, one instance, one segment) and returns their ids.
     ///
@@ -1038,15 +1009,11 @@ mod tests {
 
         // --- BEFORE: unbatched loop ---
         let (before_count, before_persisted) = {
-            let counter = QueryCounter::default();
-            let mut txn = async {
+            let (mut txn, before_count) = count_queries(async {
                 let mut txn = pool.begin().await.unwrap();
                 insert_one_at_a_time(txn.as_mut(), &rows).await.unwrap();
                 txn
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter.clone()),
-            ))
+            })
             .await;
 
             let persisted: i64 = sqlx::query_scalar(
@@ -1058,22 +1025,18 @@ mod tests {
             .unwrap();
             // Roll the addresses back so AFTER starts clean.
             txn.rollback().await.unwrap();
-            (counter.count(), persisted)
+            (before_count, persisted)
         };
 
         // --- AFTER: batched helper ---
         let (after_count, after_persisted) = {
-            let counter = QueryCounter::default();
-            let mut txn = async {
+            let (mut txn, after_count) = count_queries(async {
                 let mut txn = pool.begin().await.unwrap();
                 insert_instance_addresses(txn.as_mut(), &rows)
                     .await
                     .unwrap();
                 txn
-            }
-            .with_subscriber(tracing::Dispatch::new(
-                tracing_subscriber::registry().with(counter.clone()),
-            ))
+            })
             .await;
 
             let persisted: i64 = sqlx::query_scalar(
@@ -1084,7 +1047,7 @@ mod tests {
             .await
             .unwrap();
             txn.rollback().await.unwrap();
-            (counter.count(), persisted)
+            (after_count, persisted)
         };
 
         println!(
@@ -1165,50 +1128,24 @@ mod tests {
     /// drop-rollback executes a statement, so the count stays at zero.
     #[crate::sqlx_test]
     async fn insert_instance_addresses_empty_is_noop(pool: sqlx::PgPool) {
-        let counter = QueryCounter::default();
-        async {
+        let ((), count) = count_queries(async {
             let mut txn = pool.begin().await.unwrap();
             insert_instance_addresses(txn.as_mut(), &[]).await.unwrap();
-        }
-        .with_subscriber(tracing::Dispatch::new(
-            tracing_subscriber::registry().with(counter.clone()),
-        ))
+        })
         .await;
-        assert_eq!(
-            counter.count(),
-            0,
-            "empty insert should issue no statements"
-        );
+        assert_eq!(count, 0, "empty insert should issue no statements");
     }
 }
 
 #[cfg(test)]
 mod segment_has_allocations_tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
+    use carbide_test_support::query_counter::count_queries;
     use model::network_prefix::NewNetworkPrefix;
     use model::network_segment::{
         AllocationStrategy, NetworkSegmentControllerState, NetworkSegmentType, NewNetworkSegment,
     };
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::prelude::*;
 
     use super::*;
-
-    /// Counts `sqlx::query*` tracing events so a measured block's round-trips can
-    /// be asserted. sqlx consults the *current* dispatcher when logging a
-    /// statement, so the scoped `Dispatch` installed by `with_subscriber` sees
-    /// these events regardless of the harness's global `sqlx=warn` filter.
-    #[derive(Clone, Default)]
-    struct QueryCounter(Arc<AtomicUsize>);
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
-        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
-            if e.metadata().target().starts_with("sqlx::query") {
-                self.0.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
 
     /// Seeds a Ready segment plus one machine interface bound to it, so both the
     /// old count path and the new EXISTS path see an allocation.
@@ -1262,10 +1199,9 @@ mod segment_has_allocations_tests {
         let segment_id = seed_segment_with_interface(&pool).await;
 
         // Old path: machine_interface::count_by_segment_id + instance_address::count_by_segment_id.
-        let old_counter = QueryCounter::default();
         let seg = segment_id;
         let pool_ref = &pool;
-        async {
+        let ((), old_queries) = count_queries(async {
             let mut txn = pool_ref.begin().await.unwrap();
             let mi = crate::machine_interface::count_by_segment_id(&mut txn, &seg)
                 .await
@@ -1273,24 +1209,15 @@ mod segment_has_allocations_tests {
             let ia = count_by_segment_id(&mut txn, &seg).await.unwrap();
             // The allocation we seeded is visible to the old summed check.
             assert!(mi + ia > 0, "seeded interface should register");
-        }
-        .with_subscriber(tracing::Dispatch::new(
-            tracing_subscriber::registry().with(old_counter.clone()),
-        ))
+        })
         .await;
-        let old_queries = old_counter.0.load(Ordering::Relaxed);
 
         // New path: a single EXISTS-OR-EXISTS query.
-        let new_counter = QueryCounter::default();
-        let has = async {
+        let (has, new_queries) = count_queries(async {
             let mut txn = pool_ref.begin().await.unwrap();
             segment_has_allocations(&mut txn, &seg).await.unwrap()
-        }
-        .with_subscriber(tracing::Dispatch::new(
-            tracing_subscriber::registry().with(new_counter.clone()),
-        ))
+        })
         .await;
-        let new_queries = new_counter.0.load(Ordering::Relaxed);
 
         assert!(has, "segment_has_allocations must see the seeded interface");
         assert_eq!(old_queries, 2, "old drain check issued two count queries");

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -1057,47 +1057,11 @@ pub async fn create_common_pools(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     use carbide_test_support::Outcome::*;
+    use carbide_test_support::query_counter::count_queries;
     use carbide_test_support::{Case, check_cases};
-    use tracing::instrument::WithSubscriber;
-    use tracing_subscriber::prelude::*;
 
     use super::*;
-
-    /// A tracing `Layer` that tallies every `sqlx::query` event. sqlx emits one
-    /// such event per statement it executes, so the tally is a direct count of
-    /// database round-trips inside the scope it is attached to.
-    ///
-    /// sqlx consults the *current* dispatcher when logging a statement, so the
-    /// scoped `Dispatch` installed by `with_subscriber` sees these events
-    /// regardless of the harness's global `sqlx=warn` filter (see
-    /// `setup_test_logging`).
-    #[derive(Clone, Default)]
-    struct QueryCounter(Arc<AtomicUsize>);
-
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
-        fn on_event(&self, e: &tracing::Event<'_>, _c: tracing_subscriber::layer::Context<'_, S>) {
-            if e.metadata().target().starts_with("sqlx::query") {
-                self.0.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-
-    /// Count the `sqlx::query` events emitted while `fut` runs, by driving it
-    /// under a scoped subscriber holding a fresh [`QueryCounter`].
-    async fn count_queries<F, T>(fut: F) -> (T, usize)
-    where
-        F: std::future::Future<Output = T>,
-    {
-        let counter = QueryCounter::default();
-        let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(counter.clone()));
-        let out = fut.with_subscriber(dispatch).await;
-        let count = counter.0.load(Ordering::Relaxed);
-        (out, count)
-    }
 
     /// A single successful auto-assign `allocate` must cost exactly one database
     /// round-trip. It previously cost two: a full-pool `stats()` pre-scan ran

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -18,12 +18,19 @@
 name = "carbide-test-support"
 version = "0.0.0"
 edition.workspace = true
-description = "A tiny, zero-dependency crate for making table-driven tests."
+description = "A tiny crate of shared test helpers: table-driven tests and query counting."
 license.workspace = true
 authors.workspace = true
 
 [lib]
 name = "carbide_test_support"
+
+[dependencies]
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-//! Tiny, zero-dependency helpers for making table-driven tests.
+//! Tiny shared test helpers: table-driven tests, and a query counter for
+//! pinning database round-trip counts (see [`query_counter`]).
 //!
 //! Write a test as a list of labeled cases — each a `scenario`, an `input`, and an
 //! `expect`ed result — then run them all through one operation, written once.
@@ -205,6 +206,8 @@
 //! [`Case`] and [`Check`]. [`assert_outcome`] is the primitive they are built on;
 //! reach for it directly only when a case needs a fully hand-written body that
 //! neither a macro nor [`Case::check`] can express.
+
+pub mod query_counter;
 
 use std::fmt::Debug;
 use std::future::Future;

--- a/crates/test-support/src/query_counter.rs
+++ b/crates/test-support/src/query_counter.rs
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Counts the `sqlx::query` events a measured block emits, so a test can
+//! assert how many database round-trips a code path costs. Used by the
+//! query-count regression tests that pin "this used to be N statements and
+//! is now 1" claims.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
+
+/// A tracing `Layer` that tallies every `sqlx::query` event. sqlx emits one
+/// such event per statement it executes, so the tally is a direct count of
+/// database round-trips inside the scope it is attached to.
+///
+/// sqlx consults the *current* dispatcher when logging a statement, so the
+/// scoped `Dispatch` installed by `with_subscriber` sees these events
+/// regardless of any global test subscriber's `sqlx=warn` filter.
+///
+/// `BEGIN` and a dropped transaction's rollback are queued without an
+/// executed statement and tally nothing; an explicit `COMMIT` or `ROLLBACK`
+/// tallies one event each. Counted futures therefore open their transaction
+/// inside the measured block and either drop it there or return it out for
+/// verification, keeping the tally exactly the statements under test.
+#[derive(Clone, Default)]
+pub struct QueryCounter(Arc<AtomicUsize>);
+
+impl QueryCounter {
+    /// Number of `sqlx::query` events tallied so far.
+    pub fn count(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for QueryCounter {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().target().starts_with("sqlx::query") {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Drives `fut` under a scoped subscriber holding a fresh [`QueryCounter`]
+/// and returns the future's output together with the number of `sqlx::query`
+/// events it emitted.
+pub async fn count_queries<F, T>(fut: F) -> (T, usize)
+where
+    F: std::future::Future<Output = T>,
+{
+    let counter = QueryCounter::default();
+    let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(counter.clone()));
+    let out = fut.with_subscriber(dispatch).await;
+    let count = counter.count();
+    (out, count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the counting rule without a database: exactly the events whose
+    /// target starts with `sqlx::query` tally, everything else is ignored.
+    #[tokio::test]
+    async fn counts_only_sqlx_query_targets() {
+        let ((), count) = count_queries(async {
+            tracing::event!(target: "sqlx::query", tracing::Level::DEBUG, "counted");
+            tracing::event!(target: "sqlx::query::slow", tracing::Level::WARN, "counted");
+            tracing::event!(target: "sqlx::pool", tracing::Level::DEBUG, "ignored");
+            tracing::event!(target: "app", tracing::Level::INFO, "ignored");
+        })
+        .await;
+        assert_eq!(count, 2, "exactly the sqlx::query-prefixed events tally");
+    }
+}


### PR DESCRIPTION
The perf train's query-count regression tests each carried their own copy of the same little helper: a tracing layer tallying `sqlx::query` events, so a test can assert "this path used to be N round-trips and is now 1." Deliberate while the train was in flight (kept the parallel branches conflict-free); with the train landed, api-db held six copies plus a duplicated wrapper.

- `carbide-test-support` now provides the one canonical `QueryCounter` + `count_queries`, with a doc that records what the copies each learned separately: `BEGIN` and drop-rollbacks tally nothing, explicit `COMMIT`/`ROLLBACK` tally one each — so counted futures open their transaction inside the measured block.
- All six modules convert to `count_queries(async { ... })`; every asserted count and printed measurement is unchanged, and all forty-nine counting tests pass against real Postgres.
- Test-only: no production crate gains the new `tracing`/`tracing-subscriber` dependencies (test-support is dev-dependency-everywhere), and the crate's "zero-dependency" tagline retires alongside.

This supports https://github.com/NVIDIA/infra-controller/issues/3412


Closes #3412
