### PR TITLE
feat(health)!: add multi-target support for OTLP sinks

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -98,16 +98,25 @@ max_backups = 5
 
 [sinks.otlp]
 enabled = false
-endpoint = "http://localhost:4317"
 
-# Include Redfish diagnostic payload fields in OTLP logs.
+# Each target owns its endpoint, queues, batching policy, and diagnostics policy.
+# Add more target tables for fan-out.
+[[sinks.otlp.targets]]
+endpoint = "http://localhost:4317"
+batch_size = 512
+flush_interval = "2s"
+
+# Include Redfish diagnostic payload fields in OTLP logs for this target.
 # If every diagnostic-capable sink leaves diagnostics off, collectors do not
 # attach them. OTLP exports parent logs normally and keeps diagnostics as
 # latest-wins per endpoint while the drain is backed up.
 include_diagnostics = false
-
-batch_size = 512
-flush_interval = "2s"
+#
+# [[sinks.otlp.targets]]
+# endpoint = "http://telemetry.example.com:4317"
+# batch_size = 1024
+# flush_interval = "5s"
+# include_diagnostics = true
 
 [sinks.health_report]
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -292,7 +293,7 @@ impl SinksConfig {
             || self
                 .otlp
                 .as_option()
-                .is_some_and(|config| config.include_diagnostics)
+                .is_some_and(OtlpSinkConfig::includes_diagnostics)
     }
 }
 
@@ -344,38 +345,80 @@ impl Default for LogFileSinkConfig {
     }
 }
 
-/// OTLP gRPC sink configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Configures OTLP/gRPC fan-out to independent targets.
+///
+/// Each supported log and metric is sent to every target. Targets own separate
+/// queues and drain tasks, so a slow or unavailable destination does not block
+/// delivery to another destination.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct OtlpSinkConfig {
-    /// OTLP gRPC target.
+    /// Destinations that receive OTLP logs and metrics.
+    ///
+    /// At least one target is required when the sink is enabled.
+    pub targets: Vec<OtlpTargetConfig>,
+}
+
+impl OtlpSinkConfig {
+    fn includes_diagnostics(&self) -> bool {
+        self.targets.iter().any(|target| target.include_diagnostics)
+    }
+}
+
+/// Delivery and batching policy for one OTLP/gRPC destination.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OtlpTargetConfig {
+    /// Endpoint URI that receives both logs and metrics over OTLP/gRPC.
     pub endpoint: String,
 
-    /// Maximum number of events or samples exported per request.
+    /// Maximum number of events or samples exported per request. Defaults to
+    /// 512.
+    #[serde(default = "OtlpTargetConfig::default_batch_size")]
     pub batch_size: usize,
 
-    /// Maximum time to wait before flushing a non-empty batch.
-    #[serde(with = "humantime_serde")]
+    /// Maximum time to wait before flushing a non-empty batch for either
+    /// signal. Defaults to two seconds.
+    #[serde(
+        default = "OtlpTargetConfig::default_flush_interval",
+        with = "humantime_serde"
+    )]
     pub flush_interval: std::time::Duration,
 
-    /// Export Redfish diagnostic payload fields.
+    /// Export Redfish diagnostic payload fields to this target.
     ///
     /// Disabled by default because payload bodies are opaque and may be large or
     /// sensitive. If no diagnostic-capable sink enables diagnostics, collectors
     /// do not attach diagnostic fields. OTLP exports parent logs normally and
     /// keeps diagnostics as latest-wins per endpoint while the drain is backed
     /// up.
+    #[serde(default)]
     pub include_diagnostics: bool,
 }
 
-impl Default for OtlpSinkConfig {
-    fn default() -> Self {
-        Self {
-            endpoint: "http://localhost:4317".to_string(),
-            include_diagnostics: false,
-            batch_size: 512,
-            flush_interval: std::time::Duration::from_secs(2),
+impl OtlpTargetConfig {
+    fn default_batch_size() -> usize {
+        512
+    }
+
+    fn default_flush_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(2)
+    }
+
+    fn validate(&self, index: usize) -> Result<(), String> {
+        let path = format!("sinks.otlp.targets[{index}]");
+
+        if self.batch_size == 0 {
+            return Err(format!("{path}.batch_size must be greater than 0"));
         }
+
+        if self.flush_interval.is_zero() {
+            return Err(format!("{path}.flush_interval must be greater than 0"));
+        }
+
+        tonic::transport::Channel::from_shared(self.endpoint.clone())
+            .map_err(|_| format!("invalid {path}.endpoint: {}", self.endpoint))?;
+
+        Ok(())
     }
 }
 
@@ -1440,8 +1483,22 @@ impl Config {
         }
 
         if let Configurable::Enabled(ref otlp) = self.sinks.otlp {
-            tonic::transport::Channel::from_shared(otlp.endpoint.clone())
-                .map_err(|_| format!("invalid sinks.otlp.endpoint: {}", otlp.endpoint))?;
+            if otlp.targets.is_empty() {
+                return Err("sinks.otlp.targets must not be empty".to_string());
+            }
+
+            let mut endpoints = HashSet::new();
+
+            for (index, target) in otlp.targets.iter().enumerate() {
+                target.validate(index)?;
+
+                if !endpoints.insert(target.endpoint.as_str()) {
+                    return Err(format!(
+                        "sinks.otlp.targets[{index}].endpoint must be unique: {}",
+                        target.endpoint
+                    ));
+                }
+            }
         }
 
         self.metrics_addr()?;
@@ -1881,12 +1938,29 @@ username = "root"
         assert!(config.validate().is_ok());
 
         config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
-            endpoint: "not a valid uri\n".to_string(),
-            ..OtlpSinkConfig::default()
+            targets: vec![OtlpTargetConfig {
+                endpoint: "not a valid uri\n".to_string(),
+                batch_size: 512,
+                flush_interval: Duration::from_secs(2),
+                include_diagnostics: false,
+            }],
         });
+
         assert!(config.validate().is_err());
 
         config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig::default());
+
+        assert!(config.validate().is_err());
+
+        config.sinks.otlp = Configurable::Enabled(OtlpSinkConfig {
+            targets: vec![OtlpTargetConfig {
+                endpoint: "http://localhost:4317".to_string(),
+                batch_size: 512,
+                flush_interval: Duration::from_secs(2),
+                include_diagnostics: false,
+            }],
+        });
+
         assert!(config.validate().is_ok());
     }
 
@@ -1902,16 +1976,109 @@ username = "root"
             .extract()
             .expect("log file config should parse");
         let otlp: OtlpSinkConfig = Figment::new()
-            .merge(Toml::string("include_diagnostics = true"))
+            .merge(Toml::string(
+                r#"
+[[targets]]
+endpoint = "http://localhost:4317"
+include_diagnostics = true
+"#,
+            ))
             .extract()
             .expect("otlp config should parse");
 
         assert!(tracing.include_diagnostics);
         assert!(log_file.include_diagnostics);
-        assert!(otlp.include_diagnostics);
+        assert!(otlp.includes_diagnostics());
         assert!(!TracingSinkConfig::default().include_diagnostics);
         assert!(!LogFileSinkConfig::default().include_diagnostics);
-        assert!(!OtlpSinkConfig::default().include_diagnostics);
+        assert!(!OtlpSinkConfig::default().includes_diagnostics());
+    }
+
+    #[test]
+    fn otlp_target_list_parses_independent_settings() {
+        let otlp: OtlpSinkConfig = Figment::new()
+            .merge(Toml::string(
+                r#"
+[[targets]]
+endpoint = "http://site.example:4317"
+
+[[targets]]
+endpoint = "https://central.example:4317"
+batch_size = 1024
+flush_interval = "5s"
+include_diagnostics = true
+"#,
+            ))
+            .extract()
+            .expect("multi-target OTLP config should parse");
+
+        let targets = &otlp.targets;
+
+        assert_eq!(targets.len(), 2);
+        assert_eq!(targets[0].batch_size, 512);
+        assert_eq!(targets[0].flush_interval, Duration::from_secs(2));
+        assert_eq!(targets[1].batch_size, 1024);
+        assert_eq!(targets[1].flush_interval, Duration::from_secs(5));
+        assert!(targets[1].include_diagnostics);
+
+        let mut config = Config::default();
+
+        config.sinks.otlp = Configurable::Enabled(otlp);
+
+        config
+            .validate()
+            .expect("multi-target OTLP config should validate");
+    }
+
+    #[test]
+    fn otlp_target_list_rejects_invalid_target_contracts() {
+        struct TestCase {
+            name: &'static str,
+            toml: &'static str,
+            expected: &'static str,
+        }
+
+        let cases = [
+            TestCase {
+                name: "empty list",
+                toml: "targets = []",
+                expected: "sinks.otlp.targets must not be empty",
+            },
+            TestCase {
+                name: "zero batch size",
+                toml: r#"
+[[targets]]
+endpoint = "http://site.example:4317"
+batch_size = 0
+"#,
+                expected: "sinks.otlp.targets[0].batch_size must be greater than 0",
+            },
+            TestCase {
+                name: "duplicate endpoint",
+                toml: r#"
+[[targets]]
+endpoint = "http://site.example:4317"
+
+[[targets]]
+endpoint = "http://site.example:4317"
+"#,
+                expected: "sinks.otlp.targets[1].endpoint must be unique: http://site.example:4317",
+            },
+        ];
+
+        for case in cases {
+            let otlp: OtlpSinkConfig = Figment::new()
+                .merge(Toml::string(case.toml))
+                .extract()
+                .expect(case.name);
+
+            let mut config = Config::default();
+            config.sinks.otlp = Configurable::Enabled(otlp);
+
+            let error = config.validate().expect_err(case.name);
+
+            assert_eq!(error, case.expected, "{}", case.name);
+        }
     }
 
     /// Verifies collectors attach diagnostics only when a capable sink opts in.
@@ -1924,7 +2091,14 @@ username = "root"
                 SinksConfig {
                     tracing: Configurable::Enabled(TracingSinkConfig::default()),
                     log_file: Configurable::Enabled(LogFileSinkConfig::default()),
-                    otlp: Configurable::Enabled(OtlpSinkConfig::default()),
+                    otlp: Configurable::Enabled(OtlpSinkConfig {
+                        targets: vec![OtlpTargetConfig {
+                            endpoint: "http://localhost:4317".to_string(),
+                            batch_size: 512,
+                            flush_interval: Duration::from_secs(2),
+                            include_diagnostics: false,
+                        }],
+                    }),
                     ..SinksConfig::default()
                 },
                 false,
@@ -1954,8 +2128,35 @@ username = "root"
                 "otlp-diagnostics",
                 SinksConfig {
                     otlp: Configurable::Enabled(OtlpSinkConfig {
-                        include_diagnostics: true,
-                        ..OtlpSinkConfig::default()
+                        targets: vec![OtlpTargetConfig {
+                            endpoint: "http://localhost:4317".to_string(),
+                            batch_size: 512,
+                            flush_interval: Duration::from_secs(2),
+                            include_diagnostics: true,
+                        }],
+                    }),
+                    ..SinksConfig::default()
+                },
+                true,
+            ),
+            (
+                "one-of-multiple-otlp-targets-enables-diagnostics",
+                SinksConfig {
+                    otlp: Configurable::Enabled(OtlpSinkConfig {
+                        targets: vec![
+                            OtlpTargetConfig {
+                                endpoint: "http://site.example:4317".to_string(),
+                                batch_size: 512,
+                                flush_interval: Duration::from_secs(2),
+                                include_diagnostics: false,
+                            },
+                            OtlpTargetConfig {
+                                endpoint: "http://central.example:4317".to_string(),
+                                batch_size: 512,
+                                flush_interval: Duration::from_secs(2),
+                                include_diagnostics: true,
+                            },
+                        ],
                     }),
                     ..SinksConfig::default()
                 },
@@ -1992,7 +2193,14 @@ username = "root"
             (
                 "otlp",
                 SinksConfig {
-                    otlp: Configurable::Enabled(OtlpSinkConfig::default()),
+                    otlp: Configurable::Enabled(OtlpSinkConfig {
+                        targets: vec![OtlpTargetConfig {
+                            endpoint: "http://localhost:4317".to_string(),
+                            batch_size: 512,
+                            flush_interval: Duration::from_secs(2),
+                            include_diagnostics: false,
+                        }],
+                    }),
                     ..SinksConfig::default()
                 },
                 true,

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -242,12 +242,17 @@ fn build_data_sink(
 
     if let Configurable::Enabled(ref otlp_cfg) = config.sinks.otlp {
         let mapper: Arc<dyn RedfishEventMapper> = Arc::new(OpenBmcEventMapper);
-        sinks.push(Arc::new(OtlpSink::new(
-            otlp_cfg,
+
+        let otlp_sinks = OtlpSink::new_many(
+            &otlp_cfg.targets,
             mapper,
             &metrics_manager,
             &config.metrics.prefix,
-        )?));
+        )?;
+
+        for sink in otlp_sinks {
+            sinks.push(Arc::new(sink));
+        }
     }
 
     if sinks.is_empty() {

--- a/crates/health/src/otlp/drain.rs
+++ b/crates/health/src/otlp/drain.rs
@@ -25,33 +25,23 @@ use super::collector_logs::logs_service_client::LogsServiceClient;
 use super::convert::build_export_request;
 use super::{OtlpExportFailed, OtlpSignal};
 use crate::collectors::{BackoffConfig, ExponentialBackoff};
+use crate::config::OtlpTargetConfig;
 use crate::sink::otlp::OtlpQueue;
 use crate::sink::{CollectorEvent, EventContext};
 
 pub(crate) struct OtlpDrainTask {
     queue: Arc<OtlpQueue>,
-    endpoint: String,
-    batch_size: usize,
-    flush_interval: Duration,
+    target: OtlpTargetConfig,
 }
 
 impl OtlpDrainTask {
-    pub fn new(
-        queue: Arc<OtlpQueue>,
-        endpoint: String,
-        batch_size: usize,
-        flush_interval: Duration,
-    ) -> Self {
-        Self {
-            queue,
-            endpoint,
-            batch_size,
-            flush_interval,
-        }
+    pub fn new(queue: Arc<OtlpQueue>, target: OtlpTargetConfig) -> Self {
+        Self { queue, target }
     }
 
     fn drain_batch(&self, batch: &mut Vec<(EventContext, CollectorEvent)>) {
-        let remaining = self.batch_size.saturating_sub(batch.len());
+        let remaining = self.target.batch_size.saturating_sub(batch.len());
+
         for _ in 0..remaining {
             match self.queue.pop() {
                 Some((_key, value)) => batch.push(value),
@@ -66,14 +56,15 @@ impl OtlpDrainTask {
             None => return,
         };
 
-        let mut batch = Vec::with_capacity(self.batch_size);
-        let mut interval = tokio::time::interval(self.flush_interval);
+        let mut batch = Vec::with_capacity(self.target.batch_size);
+        let mut interval = tokio::time::interval(self.target.flush_interval);
 
         loop {
             tokio::select! {
                 _ = self.queue.notified() => {
                     self.drain_batch(&mut batch);
-                    if batch.len() >= self.batch_size {
+
+                    if batch.len() >= self.target.batch_size {
                         self.flush(&mut client, &mut batch).await;
                         interval.reset();
                     }
@@ -89,14 +80,15 @@ impl OtlpDrainTask {
     }
 
     async fn connect(&self) -> Option<LogsServiceClient<Channel>> {
-        let endpoint = match Channel::from_shared(self.endpoint.clone()) {
-            Ok(e) => e,
+        let endpoint = match Channel::from_shared(self.target.endpoint.clone()) {
+            Ok(endpoint) => endpoint,
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    endpoint = %self.endpoint,
-                    "invalid otlp endpoint uri, stopping drain"
+                    endpoint = %self.target.endpoint,
+                    "invalid otlp target endpoint uri, stopping drain"
                 );
+
                 return None;
             }
         };
@@ -109,16 +101,21 @@ impl OtlpDrainTask {
         loop {
             match endpoint.connect().await {
                 Ok(channel) => {
-                    tracing::info!(endpoint = %self.endpoint, "connected to otlp collector");
+                    tracing::info!(
+                        endpoint = %self.target.endpoint,
+                        "connected to otlp target"
+                    );
+
                     return Some(LogsServiceClient::new(channel));
                 }
                 Err(error) => {
                     let delay = backoff.next_delay();
+
                     tracing::warn!(
                         ?error,
-                        endpoint = %self.endpoint,
+                        endpoint = %self.target.endpoint,
                         retry_in = ?delay,
-                        "failed to connect to otlp collector"
+                        "failed to connect to otlp target"
                     );
                     tokio::time::sleep(delay).await;
                 }
@@ -159,7 +156,12 @@ impl OtlpDrainTask {
         for attempt in 0..=MAX_RETRIES {
             match client.export(request.clone()).await {
                 Ok(_) => {
-                    tracing::debug!(record_count, "exported logs to otlp collector");
+                    tracing::debug!(
+                        endpoint = %self.target.endpoint,
+                        record_count,
+                        "exported logs to otlp target"
+                    );
+
                     break;
                 }
                 Err(status) if is_retryable(&status) && attempt < MAX_RETRIES => {
@@ -167,6 +169,7 @@ impl OtlpDrainTask {
                     tracing::warn!(
                         code = ?status.code(),
                         message = status.message(),
+                        endpoint = %self.target.endpoint,
                         attempt,
                         retry_in = ?delay,
                         "retryable otlp export error"
@@ -180,6 +183,7 @@ impl OtlpDrainTask {
                         error: status.message().to_string(),
                         record_count,
                         attempt,
+                        endpoint: self.target.endpoint.clone(),
                     });
                     break;
                 }

--- a/crates/health/src/otlp/metrics_drain.rs
+++ b/crates/health/src/otlp/metrics_drain.rs
@@ -25,36 +25,32 @@ use super::collector_metrics::metrics_service_client::MetricsServiceClient;
 use super::convert::build_metrics_export_request;
 use super::{OtlpExportFailed, OtlpSignal};
 use crate::collectors::{BackoffConfig, ExponentialBackoff};
+use crate::config::OtlpTargetConfig;
 use crate::sink::otlp::OtlpMetricsQueue;
 use crate::sink::{EventContext, MetricSample};
 
 pub(crate) struct OtlpMetricsDrainTask {
     queue: Arc<OtlpMetricsQueue>,
-    endpoint: String,
-    batch_size: usize,
-    flush_interval: Duration,
+    target: OtlpTargetConfig,
     metric_name_prefix: String,
 }
 
 impl OtlpMetricsDrainTask {
     pub fn new(
         queue: Arc<OtlpMetricsQueue>,
-        endpoint: String,
-        batch_size: usize,
-        flush_interval: Duration,
+        target: OtlpTargetConfig,
         metric_name_prefix: String,
     ) -> Self {
         Self {
             queue,
-            endpoint,
-            batch_size,
-            flush_interval,
+            target,
             metric_name_prefix,
         }
     }
 
     fn drain_batch(&self, batch: &mut Vec<(EventContext, MetricSample)>) {
-        let remaining = self.batch_size.saturating_sub(batch.len());
+        let remaining = self.target.batch_size.saturating_sub(batch.len());
+
         for _ in 0..remaining {
             match self.queue.pop() {
                 Some((_key, value)) => batch.push(value),
@@ -69,14 +65,15 @@ impl OtlpMetricsDrainTask {
             None => return,
         };
 
-        let mut batch = Vec::with_capacity(self.batch_size);
-        let mut interval = tokio::time::interval(self.flush_interval);
+        let mut batch = Vec::with_capacity(self.target.batch_size);
+        let mut interval = tokio::time::interval(self.target.flush_interval);
 
         loop {
             tokio::select! {
                 _ = self.queue.notified() => {
                     self.drain_batch(&mut batch);
-                    if batch.len() >= self.batch_size {
+
+                    if batch.len() >= self.target.batch_size {
                         self.flush(&mut client, &mut batch).await;
                         interval.reset();
                     }
@@ -92,14 +89,15 @@ impl OtlpMetricsDrainTask {
     }
 
     async fn connect(&self) -> Option<MetricsServiceClient<Channel>> {
-        let endpoint = match Channel::from_shared(self.endpoint.clone()) {
-            Ok(e) => e,
+        let endpoint = match Channel::from_shared(self.target.endpoint.clone()) {
+            Ok(endpoint) => endpoint,
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    endpoint = %self.endpoint,
+                    endpoint = %self.target.endpoint,
                     "invalid otlp metrics endpoint uri, stopping drain"
                 );
+
                 return None;
             }
         };
@@ -112,14 +110,19 @@ impl OtlpMetricsDrainTask {
         loop {
             match endpoint.connect().await {
                 Ok(channel) => {
-                    tracing::info!(endpoint = %self.endpoint, "connected to otlp metrics collector");
+                    tracing::info!(
+                        endpoint = %self.target.endpoint,
+                        "connected to otlp metrics collector"
+                    );
+
                     return Some(MetricsServiceClient::new(channel));
                 }
                 Err(error) => {
                     let delay = backoff.next_delay();
+
                     tracing::warn!(
                         ?error,
-                        endpoint = %self.endpoint,
+                        endpoint = %self.target.endpoint,
                         retry_in = ?delay,
                         "failed to connect to otlp metrics collector"
                     );
@@ -162,7 +165,12 @@ impl OtlpMetricsDrainTask {
         for attempt in 0..=MAX_RETRIES {
             match client.export(request.clone()).await {
                 Ok(_) => {
-                    tracing::debug!(point_count, "exported metrics to otlp collector");
+                    tracing::debug!(
+                        endpoint = %self.target.endpoint,
+                        point_count,
+                        "exported metrics to otlp target"
+                    );
+
                     break;
                 }
                 Err(status) if is_retryable(&status) && attempt < MAX_RETRIES => {
@@ -170,6 +178,7 @@ impl OtlpMetricsDrainTask {
                     tracing::warn!(
                         code = ?status.code(),
                         message = status.message(),
+                        endpoint = %self.target.endpoint,
                         attempt,
                         retry_in = ?delay,
                         "retryable otlp metrics export error"
@@ -183,6 +192,7 @@ impl OtlpMetricsDrainTask {
                         error: status.message().to_string(),
                         record_count: point_count,
                         attempt,
+                        endpoint: self.target.endpoint.clone(),
                     });
                     break;
                 }

--- a/crates/health/src/otlp/mod.rs
+++ b/crates/health/src/otlp/mod.rs
@@ -101,6 +101,10 @@ pub(crate) struct OtlpExportFailed {
     /// statuses, earlier for non-retryable ones).
     #[context]
     pub attempt: usize,
+
+    /// Configured endpoint that rejected or failed to accept the batch.
+    #[context]
+    pub endpoint: String,
 }
 
 #[allow(clippy::all)]
@@ -167,6 +171,7 @@ mod tests {
                 error: "connection refused".to_string(),
                 record_count: 17,
                 attempt: 5,
+                endpoint: "http://localhost:4317".to_string(),
             });
         });
 
@@ -193,6 +198,7 @@ mod tests {
             error: "deadline exceeded".to_string(),
             record_count: 3,
             attempt: 0,
+            endpoint: "http://localhost:4317".to_string(),
         });
 
         assert_eq!(

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -17,13 +17,13 @@
 
 use std::sync::Arc;
 
-use prometheus::Counter;
+use prometheus::{Counter, CounterVec, Opts};
 
 use super::dedup_queue::DedupQueue;
 use super::event_mapper::RedfishEventMapper;
 use super::{CollectorEvent, DataSink, EventContext, LogRecord, MetricSample};
 use crate::HealthError;
-use crate::config::OtlpSinkConfig;
+use crate::config::OtlpTargetConfig;
 use crate::metrics::MetricsManager;
 use crate::otlp::drain::OtlpDrainTask;
 use crate::otlp::metrics_drain::OtlpMetricsDrainTask;
@@ -84,65 +84,85 @@ fn metric_queue_key(context: &EventContext, sample: &MetricSample) -> OtlpMetric
 }
 
 impl OtlpSink {
-    pub fn new(
-        config: &OtlpSinkConfig,
+    /// Creates one independently queued sink for each configured OTLP target.
+    ///
+    /// The returned order matches `configs`. Each sink starts separate log and
+    /// metric drain tasks, and its queue replacement counters use its position
+    /// in `configs` as the bounded `target_index` label.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no Tokio runtime is active, or if Prometheus metrics
+    /// cannot be created, registered, or initialized for a target.
+    pub fn new_many(
+        configs: &[OtlpTargetConfig],
         mapper: Arc<dyn RedfishEventMapper>,
         metrics_manager: &MetricsManager,
         prefix: &str,
-    ) -> Result<Self, HealthError> {
+    ) -> Result<Vec<Self>, HealthError> {
         let handle = tokio::runtime::Handle::try_current().map_err(|e| {
             HealthError::GenericError(format!("otlp sink requires active tokio runtime: {e}"))
         })?;
 
-        let queue: Arc<OtlpQueue> = Arc::new(DedupQueue::new());
-        let metrics_queue: Arc<OtlpMetricsQueue> = Arc::new(DedupQueue::new());
-
-        let replaced_total = Counter::new(
-            format!("{prefix}_otlp_sink_replaced_total"),
-            "total log events replaced in the otlp queue before drain could process them",
+        let replaced_total = CounterVec::new(
+            Opts::new(
+                format!("{prefix}_otlp_sink_replaced_total"),
+                "total log events replaced in the otlp queue before drain could process them, labeled by configured target index",
+            ),
+            &["target_index"],
         )?;
 
         metrics_manager
             .global_registry()
             .register(Box::new(replaced_total.clone()))?;
 
-        let metrics_replaced_total = Counter::new(
-            format!("{prefix}_otlp_sink_metrics_replaced_total"),
-            "total metric samples replaced in the otlp queue before drain could process them",
+        let metrics_replaced_total = CounterVec::new(
+            Opts::new(
+                format!("{prefix}_otlp_sink_metrics_replaced_total"),
+                "total metric samples replaced in the otlp queue before drain could process them, labeled by configured target index",
+            ),
+            &["target_index"],
         )?;
 
         metrics_manager
             .global_registry()
             .register(Box::new(metrics_replaced_total.clone()))?;
 
-        let drain = OtlpDrainTask::new(
-            queue.clone(),
-            config.endpoint.clone(),
-            config.batch_size,
-            config.flush_interval,
-        );
-        handle.spawn(drain.run());
+        let mut sinks = Vec::with_capacity(configs.len());
 
-        // Metrics use a separate drain so either signal type can make progress
-        // when the other collector is slow or temporarily failing.
-        let metrics_drain = OtlpMetricsDrainTask::new(
-            metrics_queue.clone(),
-            config.endpoint.clone(),
-            config.batch_size,
-            config.flush_interval,
-            prefix.to_string(),
-        );
+        for (target_index, config) in configs.iter().enumerate() {
+            let queue: Arc<OtlpQueue> = Arc::new(DedupQueue::new());
+            let metrics_queue: Arc<OtlpMetricsQueue> = Arc::new(DedupQueue::new());
+            let target_index = target_index.to_string();
+            let replaced_total = replaced_total.get_metric_with_label_values(&[&target_index])?;
 
-        handle.spawn(metrics_drain.run());
+            let metrics_replaced_total =
+                metrics_replaced_total.get_metric_with_label_values(&[&target_index])?;
 
-        Ok(Self {
-            queue,
-            metrics_queue,
-            replaced_total,
-            metrics_replaced_total,
-            mapper,
-            include_diagnostics: config.include_diagnostics,
-        })
+            let drain = OtlpDrainTask::new(queue.clone(), config.clone());
+            handle.spawn(drain.run());
+
+            // Each target and signal owns a drain so a slow collector cannot
+            // block delivery to another target or signal.
+            let metrics_drain = OtlpMetricsDrainTask::new(
+                metrics_queue.clone(),
+                config.clone(),
+                prefix.to_string(),
+            );
+
+            handle.spawn(metrics_drain.run());
+
+            sinks.push(Self {
+                queue,
+                metrics_queue,
+                replaced_total,
+                metrics_replaced_total,
+                mapper: mapper.clone(),
+                include_diagnostics: config.include_diagnostics,
+            });
+        }
+
+        Ok(sinks)
     }
 
     /// Enqueues the emitted log record using the parent event identity.
@@ -259,7 +279,7 @@ mod tests {
 
     use super::*;
     use crate::sink::event_mapper::OpenBmcEventMapper;
-    use crate::sink::{DiagnosticLogRecord, LogRecord, MetricSample};
+    use crate::sink::{CompositeDataSink, DiagnosticLogRecord, LogRecord, MetricSample};
 
     fn test_context() -> EventContext {
         EventContext {
@@ -469,6 +489,81 @@ mod tests {
         let ctx = test_context();
         sink.handle_event(&ctx, &log_event("OpenBMC.0.1.Test", r#"["sensor1"]"#));
         assert!(sink.queue.pop().is_some());
+    }
+
+    #[test]
+    fn composite_fans_log_event_to_each_otlp_target_queue() {
+        let first = Arc::new(test_sink());
+        let second = Arc::new(test_sink());
+        let sinks: Vec<Arc<dyn DataSink>> = vec![first.clone(), second.clone()];
+
+        let metrics_manager = Arc::new(
+            MetricsManager::new("otlp_multi_target_test")
+                .expect("metrics manager should initialize"),
+        );
+
+        let composite = CompositeDataSink::new(sinks, metrics_manager);
+        let context = test_context();
+        let event = log_event("OpenBMC.0.1.Test", r#"["sensor1"]"#);
+
+        composite.handle_event(&context, &event);
+
+        assert!(first.queue.pop().is_some());
+        assert!(second.queue.pop().is_some());
+    }
+
+    #[tokio::test]
+    async fn new_many_labels_replacement_counters_by_target_index() {
+        let configs = vec![
+            OtlpTargetConfig {
+                endpoint: "http://first.example:4317".to_string(),
+                batch_size: 512,
+                flush_interval: std::time::Duration::from_secs(2),
+                include_diagnostics: false,
+            },
+            OtlpTargetConfig {
+                endpoint: "http://second.example:4317".to_string(),
+                batch_size: 512,
+                flush_interval: std::time::Duration::from_secs(2),
+                include_diagnostics: false,
+            },
+        ];
+
+        let metrics_manager = MetricsManager::new("otlp_replacement_manager")
+            .expect("metrics manager should initialize");
+
+        let sinks = OtlpSink::new_many(
+            &configs,
+            Arc::new(OpenBmcEventMapper),
+            &metrics_manager,
+            "otlp_replacement_test",
+        )
+        .expect("OTLP sinks should initialize");
+
+        sinks[0].replaced_total.inc();
+        sinks[1].metrics_replaced_total.inc();
+
+        let metrics = metrics_manager
+            .export_metrics()
+            .expect("metrics should export");
+
+        assert!(
+            metrics
+                .contains("otlp_replacement_test_otlp_sink_replaced_total{target_index=\"0\"} 1")
+        );
+
+        assert!(
+            metrics
+                .contains("otlp_replacement_test_otlp_sink_replaced_total{target_index=\"1\"} 0")
+        );
+
+        assert!(metrics.contains(
+            "otlp_replacement_test_otlp_sink_metrics_replaced_total{target_index=\"0\"} 0"
+        ));
+
+        assert!(metrics.contains(
+            "otlp_replacement_test_otlp_sink_metrics_replaced_total{target_index=\"1\"} 1"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Add multi-target support to the OTLP sink.

The OTLP sink now accepts a required `targets` list. Each target has its own name, endpoint, batching settings, and diagnostic inclusion setting. Logs and metrics emitted to the OTLP sink are forwarded to every configured target, with independent queues and drains so a slow or unavailable target does not block other targets.

## Related issues

Closes #3414

## Type of Change

- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [x] **This PR contains breaking changes**

This PR changes the configuration surface for the OTLP sink in `carbide-health`. Depending on existing deployment configurations, this PR may or may not require a config update.

The previous top-level OTLP fields are replaced by `sinks.otlp.targets`.

Before:

```toml
[sinks.otlp]
enabled = true
endpoint = "http://localhost:4317"
batch_size = 512
flush_interval = "2s"
include_diagnostics = false
```

After:

```toml
[sinks.otlp]
enabled = true

[[sinks.otlp.targets]]
endpoint = "http://localhost:4317"
batch_size = 512
flush_interval = "2s"
include_diagnostics = false
```

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Helm and deployment templates do not appear to require updates because they do not currently template `sinks.otlp` settings.