### PR TITLE
bug: 2822: Use interface associated with boot interface id if host is booted with non-DPU interface.

### DIFF
--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -159,8 +159,31 @@ pub(crate) async fn discover_machine(
         .await?;
     }
 
-    let interface =
+    let mut interface =
         db::machine_interface::find_by_ip_or_id(&mut txn, remote_ip, interface_id).await?;
+
+    // Host-only: a host can get its lease/IP on an interface that isn't yet
+    // associated with a machine, while its DPU-paired predicted-host record
+    // lives on the DPU-connected boot interface named by the kernel-cmdline
+    // `machine_interface_id`. When the connecting (IP-resolved) interface has no
+    // machine, prefer that cmdline interface for host identity so both the
+    // TPM/serial guard below and the host-id sync operate on the correct record
+    // instead of failing with `machine_id not found`. Gated on `!is_dpu()` — the
+    // DPU discovery path resolves its interface differently and is unaffected.
+    if !hardware_info.is_dpu()
+        && interface.machine_id.is_none()
+        && let Some(cmdline_id) = interface_id.filter(|id| *id != interface.id)
+        && let Ok(cmdline_interface) = db::machine_interface::find_one(&mut txn, cmdline_id).await
+        && cmdline_interface.machine_id.is_some()
+    {
+        tracing::info!(
+            ip_interface_id = %interface.id,
+            %cmdline_id,
+            "Connecting interface has no associated machine; using kernel-cmdline machine_interface_id for host identity",
+        );
+        interface = cmdline_interface;
+    }
+
     if !hardware_info.is_dpu()
         && hardware_info.tpm_ek_certificate.is_none()
         && stable_machine_id.source() == MachineIdSource::ProductBoardChassisSerial

--- a/crates/api-core/src/tests/common/api_fixtures/host.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/host.rs
@@ -152,6 +152,38 @@ pub async fn host_discover_machine_with_reporter(
     response.machine_id.expect("machine_id must be set")
 }
 
+/// Like [`host_discover_machine`], but the request arrives from `remote_ip` (via
+/// `X-Forwarded-For`) while still passing `machine_interface_id` as the
+/// kernel-cmdline interface. Exercises the case where the IP-resolved interface
+/// differs from the cmdline interface. Returns the gRPC result so callers can
+/// assert success or failure.
+pub async fn host_discover_machine_from_remote_ip(
+    env: &TestEnv,
+    host_config: &ManagedHostConfig,
+    machine_interface_id: MachineInterfaceId,
+    remote_ip: std::net::IpAddr,
+) -> Result<MachineId, tonic::Status> {
+    let mut discovery_info = DiscoveryInfo::try_from(HardwareInfo::from(host_config)).unwrap();
+    discovery_info.attest_key_info = Some(AttestKeyInfo {
+        ek_pub: EK_PUB_SERIALIZED.to_vec(),
+        ak_pub: AK_PUB_SERIALIZED.to_vec(),
+        ak_name: AK_NAME_SERIALIZED.to_vec(),
+    });
+
+    let mut request = Request::new(MachineDiscoveryInfo {
+        machine_interface_id: Some(machine_interface_id),
+        discovery_data: Some(DiscoveryData::Info(discovery_info)),
+        create_machine: true,
+        ..Default::default()
+    });
+    request
+        .metadata_mut()
+        .insert("x-forwarded-for", remote_ip.to_string().parse().unwrap());
+
+    let response = env.api.discover_machine(request).await?.into_inner();
+    Ok(response.machine_id.expect("machine_id must be set"))
+}
+
 pub async fn host_uefi_setup(env: &TestEnv, host_machine_id: &MachineId) {
     let machine = TestMachine::new(*host_machine_id, env.api.clone());
 

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -18,7 +18,9 @@ use std::net::IpAddr;
 use std::str::FromStr;
 
 use common::api_fixtures::dpu::create_dpu_machine;
-use common::api_fixtures::host::{host_discover_dhcp, host_discover_machine_with_reporter};
+use common::api_fixtures::host::{
+    host_discover_dhcp, host_discover_machine_from_remote_ip, host_discover_machine_with_reporter,
+};
 use common::api_fixtures::{FIXTURE_DHCP_RELAY_ADDRESS, create_managed_host, create_test_env};
 use itertools::Itertools;
 use mac_address::MacAddress;
@@ -261,6 +263,54 @@ async fn test_discover_dpu_not_create_machine(
     let response = env.api.discover_machine(req).await;
 
     assert!(response.is_err());
+
+    Ok(())
+}
+
+/// Regression for #2822: when a host's connecting (IP-resolved) interface is not
+/// yet associated with a machine, discovery must fall back to the kernel-cmdline
+/// `machine_interface_id` (the DPU-connected interface carrying the
+/// predicted-host record) instead of failing with `machine_id not found`.
+#[crate::sqlx_test]
+async fn test_host_discovery_falls_back_to_cmdline_interface_when_ip_unassociated(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let host_config = env.managed_host_config();
+    let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
+    // The DPU-connected interface that carries the predicted-host record.
+    let cmdline_interface_id = host_discover_dhcp(&env, &host_config, &dpu_machine_id).await;
+
+    // A separate interface the host actually connects on: it has an IP but is not
+    // yet associated with any machine.
+    let mut txn = env.pool.begin().await?;
+    let stray = db::machine_interface::validate_existing_mac_and_create(
+        &mut txn,
+        MacAddress::from_str("aa:bb:cc:dd:ee:01").unwrap(),
+        std::slice::from_ref(&FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()),
+        None,
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+    assert!(
+        stray.machine_id.is_none(),
+        "stray connecting interface must be unassociated"
+    );
+    assert_ne!(stray.id, cmdline_interface_id);
+    let stray_ip = *stray
+        .addresses
+        .first()
+        .expect("stray interface must have an IP");
+
+    // Connect via the stray IP but pass the DPU-connected interface as the
+    // kernel-cmdline machine_interface_id. Without the fallback this fails with
+    // `machine_id not found`.
+    let machine_id =
+        host_discover_machine_from_remote_ip(&env, &host_config, cmdline_interface_id, stray_ip)
+            .await
+            .expect("host registration should succeed via cmdline-interface fallback");
+    assert!(machine_id.machine_type().is_host());
 
     Ok(())
 }


### PR DESCRIPTION
Use interface associated with boot interface id if host is booted with non-DPU interface

## Related issues
[Issue 2822](https://github.com/NVIDIA/infra-controller/issues/2822)

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

