### PR TITLE
feat(dhcp): implemented DHCPv6 Kea callouts

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -827,7 +827,7 @@ script = ["cargo xtask check-isolated-package-builds"]
 workspace = false
 description = "Check cargo-deny against licenses we're using to validate that we're not introducing new licenses inadvertently"
 category = "Licensing"
-script = ["cargo deny check license"]
+script = ["cargo deny check licenses"]
 
 [tasks.check-bans]
 workspace = false

--- a/crates/dhcp/Cargo.toml
+++ b/crates/dhcp/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 chrono = { workspace = true }
 derive_builder = { workspace = true }
+dhcproto = { workspace = true }
 eyre = { workspace = true }
 hyper = { workspace = true, features = ["http2"] }
 hyper-util = { workspace = true, features = ["tokio"] }
@@ -37,7 +38,6 @@ metrics-endpoint = { path = "../metrics-endpoint" }
 
 [dev-dependencies]
 eyre = { workspace = true }
-dhcproto = { workspace = true }
 serde_json = { workspace = true }
 test-cdylib = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/dhcp/examples/kea-dhcp6-carbide.conf
+++ b/crates/dhcp/examples/kea-dhcp6-carbide.conf
@@ -1,0 +1,65 @@
+{
+	"Dhcp6": {
+		// Add names of your network interfaces to listen on.
+		"interfaces-config": {
+			"interfaces": [ "eth0" ]
+		},
+
+		"lease-database": {
+			"type": "memfile",
+			"name": "/var/lib/kea/kea-leases6.csv",
+			"lfc-interval": 3600
+		},
+
+		// IA_NA lifetimes are Kea-native, like kea-dhcp4.conf.
+		"preferred-lifetime": 3600,
+		"valid-lifetime": 7200,
+		"renew-timer": 1800,
+		"rebind-timer": 2880,
+		"decline-probation-period": 900,
+
+		"hooks-libraries": [
+			{
+				"library": "/usr/lib/kea/hooks/libdhcp.so",
+				"parameters": {
+					"carbide-api-url": "https://carbide-api:1079",
+					"carbide-metrics-endpoint": "[::]:1090",
+					"hook-dns-servers-ipv6": "2606:4700:4700::1111",
+					"hook-ntp-servers-ipv6": "",
+					"hook-provisioning-server-ipv6": "",
+					"hook-rapid-commit-v6": false
+				}
+			}
+		],
+
+		"subnet6": [
+			{
+				"subnet": "::/0",
+				"pools": [{
+					"pool": "2001:db8::1-2001:db8::ffff"
+				}]
+			}
+		],
+
+		"loggers": [
+			{
+				"name": "kea-dhcp6",
+				"output_options": [{"output": "stdout"}],
+				"severity": "DEBUG",
+				"debuglevel": 10
+			},
+			{
+				"name": "kea-dhcp6.carbide-rust",
+				"output_options": [{"output": "stdout"}],
+				"severity": "INFO",
+				"debuglevel": 10
+			},
+			{
+				"name": "kea-dhcp6.carbide-callouts",
+				"output_options": [{"output": "stdout"}],
+				"severity": "INFO",
+				"debuglevel": 10
+			}
+		]
+	}
+}

--- a/crates/dhcp/src/cache.rs
+++ b/crates/dhcp/src/cache.rs
@@ -23,7 +23,7 @@
 ///
 /// The cache is a static because we are called from Kea's hooks, potentially from multiple threads.
 use std::{
-    net::IpAddr,
+    net::{IpAddr, Ipv6Addr},
     sync::Mutex,
     time::{Duration, Instant},
 };
@@ -31,6 +31,7 @@ use std::{
 use lazy_static::lazy_static;
 use lru::LruCache;
 use mac_address::MacAddress;
+use rpc::forge as rpc;
 
 use crate::machine::Machine;
 
@@ -49,6 +50,9 @@ lazy_static! {
     static ref MACHINE_CACHE: Mutex<LruCache<String, CacheEntry>> = Mutex::new(LruCache::new(
         std::num::NonZeroUsize::new(MACHINE_CACHE_SIZE).unwrap()
     ));
+    static ref INVALIDATED_V6_LEASES: Mutex<LruCache<String, Instant>> = Mutex::new(LruCache::new(
+        std::num::NonZeroUsize::new(MACHINE_CACHE_SIZE).unwrap()
+    ));
 }
 
 #[derive(Debug, Clone)]
@@ -64,6 +68,19 @@ pub enum CacheEntryStatus {
     DiscoveryFailed,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CacheClass {
+    Lease,
+    OptionsOnly,
+}
+
+/// Cache namespace for entries that share identity fields but differ by protocol behavior.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct CacheScope {
+    pub address_family: rpc::AddressFamily,
+    pub cache_class: CacheClass,
+}
+
 /// Fetch an entry from the cache.
 ///
 /// Result is owned by the caller, it is a clone of cached item.
@@ -71,13 +88,43 @@ pub enum CacheEntryStatus {
 /// Returns None if we don't have that item in cache, or if we did but
 /// it's no longer valid (e.g. too old).
 pub fn get(
+    address_family: rpc::AddressFamily,
     mac_address: MacAddress,
     link_address: IpAddr,
     circuit_id: &Option<String>,
     remote_id: &Option<String>,
     vendor_id: &str,
 ) -> Option<CacheEntry> {
-    let key = &key(mac_address, link_address, circuit_id, remote_id, vendor_id);
+    get_classed(
+        address_family,
+        CacheClass::Lease,
+        mac_address,
+        link_address,
+        circuit_id,
+        remote_id,
+        vendor_id,
+    )
+}
+
+/// Fetch an entry from the cache with a protocol-specific cache class.
+pub fn get_classed(
+    address_family: rpc::AddressFamily,
+    cache_class: CacheClass,
+    mac_address: MacAddress,
+    link_address: IpAddr,
+    circuit_id: &Option<String>,
+    remote_id: &Option<String>,
+    vendor_id: &str,
+) -> Option<CacheEntry> {
+    let key = &key(
+        address_family,
+        cache_class,
+        mac_address,
+        link_address,
+        circuit_id,
+        remote_id,
+        vendor_id,
+    );
     if key.len() < MIN_KEY_LEN {
         log::debug!("Unexpected cache key, skipping: '{key}'");
         return None;
@@ -85,6 +132,18 @@ pub fn get(
     let mut cache = MACHINE_CACHE.lock().unwrap();
     if let Some(entry) = cache.get(key) {
         if !entry.has_expired() {
+            // Lease expiry tombstones are stronger than the normal cache TTL:
+            // stale API responses must not be reused after reclaim starts.
+            if address_family == rpc::AddressFamily::V6
+                && cache_class == CacheClass::Lease
+                && matches_invalidated_v6_lease(&entry.status, mac_address)
+            {
+                log::warn!(
+                    "removed cached DHCPv6 response for recently expired lease: mac={mac_address}"
+                );
+                let _removed = cache.pop_entry(key);
+                return None;
+            }
             return Some(entry.clone());
         } else {
             log::debug!("removed expired cached response for {mac_address:?}");
@@ -94,8 +153,55 @@ pub fn get(
     None
 }
 
+/// Fetch non-expired entries matching all key fields except vendor class.
+///
+/// This also performs opportunistic cache cleanup for expired or invalidated
+/// entries found while scanning matching vendor variants.
+pub fn get_classed_any_vendor(
+    address_family: rpc::AddressFamily,
+    cache_class: CacheClass,
+    mac_address: MacAddress,
+    link_address: IpAddr,
+    circuit_id: &Option<String>,
+    remote_id: &Option<String>,
+) -> Vec<CacheEntry> {
+    let prefix = key_prefix(
+        address_family,
+        cache_class,
+        mac_address,
+        link_address,
+        circuit_id,
+        remote_id,
+    );
+    let mut expired = Vec::new();
+    let mut matches = Vec::new();
+    let mut cache = MACHINE_CACHE.lock().unwrap();
+    for (key, entry) in cache.iter() {
+        if !key.starts_with(&prefix) {
+            continue;
+        }
+        // CONFIRM may search across vendor variants; keep the expiry tombstone
+        // semantics identical to the exact-key path.
+        let invalidated_v6_lease = address_family == rpc::AddressFamily::V6
+            && cache_class == CacheClass::Lease
+            && matches_invalidated_v6_lease(&entry.status, mac_address);
+        if entry.has_expired() || invalidated_v6_lease {
+            expired.push(key.clone());
+        } else {
+            matches.push(entry.clone());
+        }
+    }
+    // Remove stale matches after iteration so the LRU iterator is not mutated
+    // while it is still borrowed.
+    for key in expired {
+        let _removed = cache.pop_entry(&key);
+    }
+    matches
+}
+
 /// Insert or update an item in the cache
 pub fn put(
+    address_family: rpc::AddressFamily,
     mac_address: MacAddress,
     link_address: IpAddr,       // relay address
     circuit_id: Option<String>, // vlan id
@@ -103,7 +209,46 @@ pub fn put(
     vendor_id: &str,
     status: CacheEntryStatus,
 ) {
+    put_classed(
+        CacheScope {
+            address_family,
+            cache_class: CacheClass::Lease,
+        },
+        mac_address,
+        link_address,
+        circuit_id,
+        remote_id,
+        vendor_id,
+        status,
+    );
+}
+
+/// Insert or update an item in the cache with a protocol-specific cache class.
+pub fn put_classed(
+    scope: CacheScope,
+    mac_address: MacAddress,
+    link_address: IpAddr,
+    circuit_id: Option<String>,
+    remote_id: Option<String>,
+    vendor_id: &str,
+    status: CacheEntryStatus,
+) {
+    let CacheScope {
+        address_family,
+        cache_class,
+    } = scope;
+
+    if address_family == rpc::AddressFamily::V6
+        && cache_class == CacheClass::Lease
+        && matches_invalidated_v6_lease(&status, mac_address)
+    {
+        log::warn!("not caching DHCPv6 response for recently expired lease: mac={mac_address}");
+        return;
+    }
+
     let key = key(
+        address_family,
+        cache_class,
         mac_address,
         link_address,
         &circuit_id,
@@ -117,12 +262,95 @@ pub fn put(
     MACHINE_CACHE.lock().unwrap().put(key, new_entry);
 }
 
+/// Mark and remove cached DHCPv6 lease entries matching an expired API allocation.
+pub fn invalidate_v6_lease(address: Ipv6Addr, mac_address: MacAddress) -> usize {
+    INVALIDATED_V6_LEASES.lock().unwrap().put(
+        invalidated_v6_lease_key(address, mac_address),
+        Instant::now(),
+    );
+
+    let key_prefix = format!(
+        "{:?}_{:?}_{}_",
+        rpc::AddressFamily::V6,
+        CacheClass::Lease,
+        mac_address
+    );
+    let mut matched_keys = Vec::new();
+    let mut cache = MACHINE_CACHE.lock().unwrap();
+    for (key, entry) in cache.iter() {
+        if !key.starts_with(&key_prefix) {
+            continue;
+        }
+
+        // Expiry is scoped to the API-owned address and hook-selected MAC.
+        if let CacheEntryStatus::ValidEntry(machine) = &entry.status
+            && machine.discovery_info.mac_address == mac_address
+            && machine.inner.address.parse::<IpAddr>() == Ok(IpAddr::V6(address))
+        {
+            matched_keys.push(key.clone());
+        }
+    }
+
+    let removed = matched_keys.len();
+    for key in matched_keys {
+        let _removed = cache.pop_entry(&key);
+    }
+    removed
+}
+
+/// Clear the recent-expiry tombstone for a DHCPv6 lease.
+pub fn clear_v6_lease_invalidation(address: Ipv6Addr, mac_address: MacAddress) -> bool {
+    INVALIDATED_V6_LEASES
+        .lock()
+        .unwrap()
+        .pop_entry(&invalidated_v6_lease_key(address, mac_address))
+        .is_some()
+}
+
+/// Return whether a Machine points at a recently expired DHCPv6 lease.
+pub fn machine_matches_invalidated_v6_lease(machine: &Machine) -> bool {
+    match machine.inner.address.parse::<IpAddr>() {
+        Ok(IpAddr::V6(address)) => {
+            is_v6_lease_invalidated(address, machine.discovery_info.mac_address)
+        }
+        Ok(IpAddr::V4(_)) | Err(_) => false,
+    }
+}
+
 //
 // Internals
 //
 
+fn matches_invalidated_v6_lease(status: &CacheEntryStatus, mac_address: MacAddress) -> bool {
+    match status {
+        CacheEntryStatus::ValidEntry(machine) => match machine.inner.address.parse::<IpAddr>() {
+            Ok(IpAddr::V6(address)) => is_v6_lease_invalidated(address, mac_address),
+            Ok(IpAddr::V4(_)) | Err(_) => false,
+        },
+        CacheEntryStatus::DiscoveryFailing(_) | CacheEntryStatus::DiscoveryFailed => false,
+    }
+}
+
+fn is_v6_lease_invalidated(address: Ipv6Addr, mac_address: MacAddress) -> bool {
+    let key = invalidated_v6_lease_key(address, mac_address);
+    let mut invalidated = INVALIDATED_V6_LEASES.lock().unwrap();
+    if let Some(timestamp) = invalidated.get(&key)
+        && timestamp.elapsed() < MACHINE_CACHE_TIMEOUT
+    {
+        return true;
+    }
+    let _removed = invalidated.pop_entry(&key);
+    false
+}
+
+fn invalidated_v6_lease_key(address: Ipv6Addr, mac_address: MacAddress) -> String {
+    format!("{mac_address}_{address}")
+}
+
 // Unique identifier for this entry
 fn key(
+    address_family: rpc::AddressFamily,
+    cache_class: CacheClass,
     mac_address: MacAddress,
     link_address: IpAddr,
     circuit_id: &Option<String>,
@@ -130,7 +358,31 @@ fn key(
     vendor_id: &str,
 ) -> String {
     format!(
-        "{}_{}_{}_{}_{}",
+        "{}{}",
+        key_prefix(
+            address_family,
+            cache_class,
+            mac_address,
+            link_address,
+            circuit_id,
+            remote_id,
+        ),
+        vendor_id,
+    )
+}
+
+fn key_prefix(
+    address_family: rpc::AddressFamily,
+    cache_class: CacheClass,
+    mac_address: MacAddress,
+    link_address: IpAddr,
+    circuit_id: &Option<String>,
+    remote_id: &Option<String>,
+) -> String {
+    format!(
+        "{:?}_{:?}_{}_{}_{}_{}_",
+        address_family,
+        cache_class,
         mac_address,
         link_address,
         match circuit_id {
@@ -141,7 +393,6 @@ fn key(
             Some(rid) => rid.as_str(),
             None => "",
         },
-        vendor_id,
     )
 }
 
@@ -170,5 +421,123 @@ impl CacheEntryStatus {
             }
             CacheEntryStatus::DiscoveryFailed => CacheEntryStatus::DiscoveryFailed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use ::rpc::forge as rpc;
+
+    use super::*;
+    use crate::discovery::Discovery;
+
+    fn test_machine(mac_address: MacAddress, address: Ipv6Addr) -> Machine {
+        Machine {
+            inner: rpc::DhcpRecord {
+                mac_address: mac_address.to_string(),
+                address: address.to_string(),
+                ..Default::default()
+            },
+            discovery_info: Discovery {
+                relay_address: Ipv4Addr::UNSPECIFIED,
+                mac_address,
+                _client_system: None,
+                vendor_class: None,
+                link_select_address: None,
+                circuit_id: None,
+                remote_id: None,
+                desired_address: None,
+            },
+            vendor_class: None,
+        }
+    }
+
+    #[test]
+    fn invalidated_v6_lease_blocks_stale_positive_cache_reinsert() {
+        let mac_address = "02:00:00:00:00:aa".parse::<MacAddress>().unwrap();
+        let address = "2001:db8::aa".parse::<Ipv6Addr>().unwrap();
+        let link_address = IpAddr::V6("2001:db8::1".parse().unwrap());
+
+        // Seed and invalidate a cached lease entry, as lease6_expire does.
+        put_classed(
+            CacheScope {
+                address_family: rpc::AddressFamily::V6,
+                cache_class: CacheClass::Lease,
+            },
+            mac_address,
+            link_address,
+            None,
+            None,
+            "",
+            CacheEntryStatus::ValidEntry(Box::new(test_machine(mac_address, address))),
+        );
+        assert_eq!(invalidate_v6_lease(address, mac_address), 1);
+
+        // A concurrent path trying to reinsert the stale API address is ignored
+        // while the expiry tombstone is still live.
+        put_classed(
+            CacheScope {
+                address_family: rpc::AddressFamily::V6,
+                cache_class: CacheClass::Lease,
+            },
+            mac_address,
+            link_address,
+            None,
+            None,
+            "",
+            CacheEntryStatus::ValidEntry(Box::new(test_machine(mac_address, address))),
+        );
+        assert!(
+            get_classed(
+                rpc::AddressFamily::V6,
+                CacheClass::Lease,
+                mac_address,
+                link_address,
+                &None,
+                &None,
+                "",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn cleared_v6_lease_invalidation_allows_positive_cache_reinsert() {
+        let mac_address = "02:00:00:00:00:ab".parse::<MacAddress>().unwrap();
+        let address = "2001:db8::ab".parse::<Ipv6Addr>().unwrap();
+        let link_address = IpAddr::V6("2001:db8::1".parse().unwrap());
+
+        // A disabled expiry response means the API kept ownership, so the
+        // temporary tombstone must be removable.
+        assert_eq!(invalidate_v6_lease(address, mac_address), 0);
+        assert!(clear_v6_lease_invalidation(address, mac_address));
+
+        // Once cleared, the same API-owned lease is allowed back into cache.
+        put_classed(
+            CacheScope {
+                address_family: rpc::AddressFamily::V6,
+                cache_class: CacheClass::Lease,
+            },
+            mac_address,
+            link_address,
+            None,
+            None,
+            "",
+            CacheEntryStatus::ValidEntry(Box::new(test_machine(mac_address, address))),
+        );
+        assert!(
+            get_classed(
+                rpc::AddressFamily::V6,
+                CacheClass::Lease,
+                mac_address,
+                link_address,
+                &None,
+                &None,
+                "",
+            )
+            .is_some()
+        );
     }
 }

--- a/crates/dhcp/src/discovery.rs
+++ b/crates/dhcp/src/discovery.rs
@@ -19,6 +19,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use derive_builder::Builder;
 use mac_address::MacAddress;
+use rpc::forge as rpc;
 
 use crate::machine::Machine;
 use crate::metrics::set_service_healthy;
@@ -400,6 +401,7 @@ unsafe fn discovery_fetch_machine_at(
 
             let mut cache_entry_status = cache::CacheEntryStatus::DiscoveryFailing(0);
             if let Some(cache_entry) = cache::get(
+                rpc::AddressFamily::V4,
                 mac_address,
                 addr_for_dhcp,
                 &circuit_id,
@@ -473,6 +475,7 @@ unsafe fn discovery_fetch_machine_at(
                     }
 
                     cache::put(
+                        rpc::AddressFamily::V4,
                         mac_address,
                         addr_for_dhcp,
                         circuit_id,
@@ -488,6 +491,7 @@ unsafe fn discovery_fetch_machine_at(
                         "Error getting info back from the machine discovery: mac={mac_address} addr={addr_for_dhcp} err={e_str} api_url={url}"
                     );
                     cache::put(
+                        rpc::AddressFamily::V4,
                         mac_address,
                         addr_for_dhcp,
                         circuit_id,

--- a/crates/dhcp/src/discovery_v6.rs
+++ b/crates/dhcp/src/discovery_v6.rs
@@ -1,0 +1,924 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//! DHCPv6 decode and identity selection for the Kea hook.
+//!
+//! This module is intentionally not a general DHCPv6 implementation. Kea still
+//! owns the DHCP state machine and `dhcproto` decodes normal client messages;
+//! the local raw parsing is limited to the hook boundary where we must recover
+//! one-hop relay metadata, enforce relay trust rules, and select the client
+//! identity before calling the Carbide API. Kea may provide that relay metadata
+//! as a side-channel after unwrapping the packet, or leave it in the raw wire
+//! bytes, so this module handles both shapes with the same policy.
+
+use std::ffi::CString;
+use std::net::Ipv6Addr;
+
+use dhcproto::v6::{DhcpOption, Message, MessageType, OptionCode};
+use dhcproto::{Decodable, Decoder};
+use mac_address::MacAddress;
+use rpc::forge as rpc;
+
+const DHCPV6_RELAY_FORW: u8 = 12;
+const DHCPV6_RELAY_REPL: u8 = 13;
+const DUID_LLT: u16 = 1;
+const DUID_EN: u16 = 2;
+const DUID_LL: u16 = 3;
+const DUID_UUID: u16 = 4;
+const HTYPE_ETHERNET: u16 = 1;
+const ETHERNET_MAC_LEN: usize = 6;
+const DUID_EN_MIN_LEN: usize = 7;
+const DUID_MAX_LEN: usize = 128;
+const DUID_UUID_LEN: usize = 18;
+
+/// Supplemental relay metadata from Kea when it has already unwrapped the relay envelope.
+#[derive(Debug, Default, Clone)]
+pub struct RelayContext {
+    pub relay_count: usize,
+    pub hop_count: u8,
+    pub link_address: Option<Ipv6Addr>,
+    pub interface_id: Option<Vec<u8>>,
+    pub remote_id: Option<Vec<u8>>,
+    pub client_link_layer: Option<Vec<u8>>,
+}
+
+/// DHCPv6 discovery data selected by the hook before calling Carbide.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct V6Discovery {
+    pub selected_mac: MacAddress,
+    pub duid_mac: Option<MacAddress>,
+    pub duid: Vec<u8>,
+    pub message_type: MessageType,
+    pub relay_link: Option<Ipv6Addr>,
+    pub vendor_class: Option<String>,
+    pub interface_id: Option<Vec<u8>>,
+    pub remote_id: Option<Vec<u8>>,
+    pub desired_addr: Option<Ipv6Addr>,
+    pub ia_addrs: Vec<Ipv6Addr>,
+    pub has_ia_na: bool,
+    pub client_link_layer: Option<MacAddress>,
+}
+
+/// Reasons a DHCPv6 packet cannot be decoded or served by this hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum V6DecodeError {
+    MalformedPacket,
+    NestedRelay,
+    RelayHopCountExceeded(u8),
+    MissingDuid,
+    NoMacNoOption79,
+    UnsupportedDuid,
+    UnsupportedMessage(MessageType),
+}
+
+/// Result of parsing a DUID for a link-layer identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuidMac {
+    Mac(MacAddress),
+    NoLinkLayerMac,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DuidError {
+    Malformed,
+    UnsupportedType,
+}
+
+#[derive(Debug)]
+struct RawOption<'a> {
+    code: u16,
+    data: &'a [u8],
+}
+
+/// Decode a DHCPv6 packet without any Kea-provided relay fallback metadata.
+#[cfg(test)]
+pub fn decode(packet: &[u8]) -> Result<V6Discovery, V6DecodeError> {
+    decode_with_relay_context(packet, &RelayContext::default())
+}
+
+/// Decode a DHCPv6 packet and select the client identity for the Carbide API call.
+pub fn decode_with_relay_context(
+    packet: &[u8],
+    relay_context: &RelayContext,
+) -> Result<V6Discovery, V6DecodeError> {
+    if relay_context.relay_count > 1 {
+        return Err(V6DecodeError::NestedRelay);
+    }
+
+    let decoded = match packet.first().copied() {
+        Some(DHCPV6_RELAY_FORW) => decode_relay_forward(packet)?,
+        Some(DHCPV6_RELAY_REPL) => {
+            return Err(V6DecodeError::UnsupportedMessage(MessageType::RelayRepl));
+        }
+        Some(_) => decode_direct(packet, relay_context)?,
+        None => return Err(V6DecodeError::MalformedPacket),
+    };
+
+    select_identity(decoded)
+}
+
+/// Extract an Ethernet MAC from a DUID-LL or DUID-LLT byte string.
+pub fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
+    // Kea caps DUIDs at RFC 8415's 128-byte maximum.
+    if duid.len() < 2 || duid.len() > DUID_MAX_LEN {
+        return Err(DuidError::Malformed);
+    }
+
+    let duid_type = u16::from_be_bytes([duid[0], duid[1]]);
+    match duid_type {
+        DUID_LLT => parse_link_layer_duid(&duid[2..], 4),
+        DUID_LL => parse_link_layer_duid(&duid[2..], 0),
+        DUID_EN if duid.len() >= DUID_EN_MIN_LEN => Ok(DuidMac::NoLinkLayerMac),
+        DUID_UUID if duid.len() == DUID_UUID_LEN => Ok(DuidMac::NoLinkLayerMac),
+        DUID_EN | DUID_UUID => Err(DuidError::Malformed),
+        _ => Err(DuidError::UnsupportedType),
+    }
+}
+
+/// Parse RFC 6939 option 79 and return an Ethernet MAC when it carries one.
+pub fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
+    if payload.len() != 2 + ETHERNET_MAC_LEN {
+        return None;
+    }
+
+    let htype = u16::from_be_bytes([payload[0], payload[1]]);
+    (htype == HTYPE_ETHERNET).then(|| {
+        MacAddress::new([
+            payload[2], payload[3], payload[4], payload[5], payload[6], payload[7],
+        ])
+    })
+}
+
+/// Return a newly allocated MAC string extracted from a DHCPv6 DUID.
+///
+/// # Safety
+/// `duid_ptr` must be null only when `duid_len` is 0, or point to readable memory of that length.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_mac_from_duid(
+    duid_ptr: *const u8,
+    duid_len: usize,
+) -> *mut libc::c_char {
+    if duid_ptr.is_null() || duid_len == 0 {
+        return std::ptr::null_mut();
+    }
+
+    let duid = unsafe { std::slice::from_raw_parts(duid_ptr, duid_len) };
+    match extract_mac_from_duid(duid) {
+        Ok(DuidMac::Mac(mac)) => CString::new(mac.to_string())
+            .map(CString::into_raw)
+            .unwrap_or_else(|_| std::ptr::null_mut()),
+        Ok(DuidMac::NoLinkLayerMac) | Err(_) => std::ptr::null_mut(),
+    }
+}
+
+/// Free a MAC string returned by `carbide_mac_from_duid`.
+///
+/// # Safety
+/// `mac` must have been returned by this crate and not freed before.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_free_mac_string(mac: *mut libc::c_char) {
+    if mac.is_null() {
+        return;
+    }
+
+    unsafe {
+        drop(CString::from_raw(mac));
+    }
+}
+
+/// Parse the link-layer payload portion shared by DUID-LL and DUID-LLT.
+fn parse_link_layer_duid(bytes: &[u8], payload_offset: usize) -> Result<DuidMac, DuidError> {
+    if bytes.len() < 2 + payload_offset + ETHERNET_MAC_LEN {
+        return Err(DuidError::Malformed);
+    }
+
+    let htype = u16::from_be_bytes([bytes[0], bytes[1]]);
+    if htype != HTYPE_ETHERNET {
+        return Err(DuidError::UnsupportedType);
+    }
+
+    let mac = &bytes[2 + payload_offset..];
+    if mac.len() != ETHERNET_MAC_LEN {
+        return Err(DuidError::Malformed);
+    }
+
+    Ok(DuidMac::Mac(MacAddress::new([
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
+    ])))
+}
+
+#[derive(Debug)]
+struct DecodedV6 {
+    message: Message,
+    relay_link: Option<Ipv6Addr>,
+    interface_id: Option<Vec<u8>>,
+    remote_id: Option<Vec<u8>>,
+    client_link_layer: Option<Vec<u8>>,
+}
+
+/// Decode a client packet while preserving Kea-provided relay metadata.
+fn decode_direct(packet: &[u8], relay_context: &RelayContext) -> Result<DecodedV6, V6DecodeError> {
+    if relay_context.hop_count > 1 {
+        return Err(V6DecodeError::RelayHopCountExceeded(
+            relay_context.hop_count,
+        ));
+    }
+
+    // Kea may have stripped the relay envelope already; keep its relay fields
+    // only as fallback metadata and let the packet body drive message parsing.
+    let message =
+        Message::decode(&mut Decoder::new(packet)).map_err(|_| V6DecodeError::MalformedPacket)?;
+    Ok(DecodedV6 {
+        message,
+        relay_link: relay_context.link_address,
+        interface_id: relay_context.interface_id.clone(),
+        remote_id: relay_context.remote_id.clone(),
+        client_link_layer: relay_context.client_link_layer.clone(),
+    })
+}
+
+/// Decode one relay-forward envelope and its direct client message.
+///
+/// `dhcproto` handles the inner client message, but relay envelopes need a
+/// narrow raw-TLV pass here. In `dhcproto 0.15`, option 9 is modeled as another
+/// `RelayMessage`; for our authoritative path it normally carries a direct
+/// client message, and nested relay is intentionally rejected by policy.
+fn decode_relay_forward(packet: &[u8]) -> Result<DecodedV6, V6DecodeError> {
+    if packet.len() < 34 {
+        return Err(V6DecodeError::MalformedPacket);
+    }
+    let hop_count = packet[1];
+    if hop_count > 1 {
+        return Err(V6DecodeError::RelayHopCountExceeded(hop_count));
+    }
+
+    let link_address = Ipv6Addr::from(
+        <[u8; 16]>::try_from(&packet[2..18]).map_err(|_| V6DecodeError::MalformedPacket)?,
+    );
+    let options = parse_raw_options(&packet[34..])?;
+    let relay_messages = options
+        .iter()
+        .filter(|option| option.code == u16::from(OptionCode::RelayMsg))
+        .map(|option| option.data)
+        .collect::<Vec<_>>();
+    // Kea keeps only one decoded Relay Message for later processing. Reject
+    // duplicates so identity selection cannot observe a different client.
+    let relay_message = match relay_messages.as_slice() {
+        [relay_message] => *relay_message,
+        _ => return Err(V6DecodeError::MalformedPacket),
+    };
+
+    // Nested relay is deliberately unsupported because segment selection would
+    // otherwise need a clear policy for which relay link-address wins.
+    if matches!(
+        relay_message.first().copied(),
+        Some(DHCPV6_RELAY_FORW) | Some(DHCPV6_RELAY_REPL)
+    ) {
+        return Err(V6DecodeError::NestedRelay);
+    }
+
+    let message = Message::decode(&mut Decoder::new(relay_message))
+        .map_err(|_| V6DecodeError::MalformedPacket)?;
+    Ok(DecodedV6 {
+        message,
+        relay_link: Some(link_address),
+        interface_id: raw_option_bytes(&options, OptionCode::InterfaceId),
+        remote_id: raw_option_bytes(&options, OptionCode::RemoteId),
+        client_link_layer: raw_option_bytes(&options, OptionCode::ClientLinklayerAddr),
+    })
+}
+
+/// Select the MAC identity and transport fields sent to the Carbide API.
+fn select_identity(decoded: DecodedV6) -> Result<V6Discovery, V6DecodeError> {
+    let duid = match decoded.message.opts().get(OptionCode::ClientId) {
+        Some(DhcpOption::ClientId(duid)) if !duid.is_empty() => duid.clone(),
+        _ => return Err(V6DecodeError::MissingDuid),
+    };
+
+    let duid_mac = match extract_mac_from_duid(&duid) {
+        Ok(DuidMac::Mac(mac)) => Some(mac),
+        Ok(DuidMac::NoLinkLayerMac) => None,
+        Err(_) => return Err(V6DecodeError::UnsupportedDuid),
+    };
+    let client_link_layer = decoded
+        .client_link_layer
+        .as_deref()
+        .and_then(extract_mac_from_option79);
+
+    let selected_mac = match (client_link_layer, duid_mac) {
+        // RFC 6939 identifies the sending link, so it wins over a DUID MAC.
+        (Some(client_mac), Some(duid_mac)) => {
+            if client_mac != duid_mac {
+                log::warn!(
+                    "DHCPv6 option 79 MAC disagrees with DUID MAC client_mac={client_mac} duid_mac={duid_mac}"
+                );
+            }
+            client_mac
+        }
+        (Some(client_mac), None) => client_mac,
+        (None, Some(duid_mac)) => duid_mac,
+        (None, None) => return Err(V6DecodeError::NoMacNoOption79),
+    };
+
+    let options = decoded.message.opts();
+    let ia_na_count = ia_na_count(options);
+    let has_ia_na = ia_na_count > 0;
+    let has_unsupported_ia =
+        options.get(OptionCode::IATA).is_some() || options.get(OptionCode::IAPD).is_some();
+    let ia_addrs = ia_addrs(options);
+    let desired_addr = ia_addrs.first().copied();
+    let vendor_class = vendor_class(options);
+    let message_type = decoded.message.msg_type();
+    let lease_end_message = matches!(message_type, MessageType::Release | MessageType::Decline);
+    let api_bound_message = message_kind_for(message_type, has_ia_na).is_some();
+
+    // IA_TA, IA_PD, and multiple IA_NA/address containers cannot be mapped to
+    // the single-address Carbide API allocation contract.
+    if api_bound_message && (has_unsupported_ia || ia_na_count > 1 || ia_addrs.len() > 1) {
+        return Err(V6DecodeError::UnsupportedMessage(message_type));
+    }
+
+    // Lease-end and CONFIRM are handled locally; all API-bound request-like
+    // messages must map to a supported wire contract first.
+    if !api_bound_message && !matches!(message_type, MessageType::Confirm) && !lease_end_message {
+        return Err(V6DecodeError::UnsupportedMessage(message_type));
+    }
+
+    Ok(V6Discovery {
+        selected_mac,
+        duid_mac,
+        duid,
+        message_type,
+        relay_link: decoded.relay_link,
+        vendor_class,
+        interface_id: decoded.interface_id,
+        remote_id: decoded.remote_id,
+        desired_addr,
+        ia_addrs,
+        has_ia_na,
+        client_link_layer,
+    })
+}
+
+/// Map DHCPv6 transport message type to the existing Carbide API message kind.
+pub fn message_kind_for(message_type: MessageType, has_ia_na: bool) -> Option<rpc::MessageKind> {
+    match message_type {
+        // Stateless SOLICIT is an information-only observation; stateful
+        // SOLICIT starts address allocation.
+        MessageType::Solicit if has_ia_na => Some(rpc::MessageKind::V6Solicit),
+        MessageType::Solicit => Some(rpc::MessageKind::V6InfoRequest),
+        MessageType::InformationRequest => Some(rpc::MessageKind::V6InfoRequest),
+        // The API only needs one request-like value today: REQUEST, RENEW, and
+        // REBIND with IA_NA all ask Carbide for the same authoritative
+        // persisted lease, while Kea keeps the DHCP exchange-state differences.
+        MessageType::Request | MessageType::Renew | MessageType::Rebind if has_ia_na => {
+            Some(rpc::MessageKind::V6Request)
+        }
+        _ => None,
+    }
+}
+
+/// Count IA_NA containers supplied by the client.
+fn ia_na_count(options: &dhcproto::v6::DhcpOptions) -> usize {
+    options
+        .get_all(OptionCode::IANA)
+        .into_iter()
+        .flatten()
+        .filter(|option| matches!(option, DhcpOption::IANA(_)))
+        .count()
+}
+
+/// Return the requested IA_NA addresses supplied by the client.
+fn ia_addrs(options: &dhcproto::v6::DhcpOptions) -> Vec<Ipv6Addr> {
+    options
+        .get_all(OptionCode::IANA)
+        .into_iter()
+        .flatten()
+        .flat_map(|option| match option {
+            DhcpOption::IANA(ia_na) => ia_na
+                .opts
+                .iter()
+                .filter_map(|option| match option {
+                    DhcpOption::IAAddr(addr) => Some(addr.addr),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        })
+        .collect()
+}
+
+/// Extract the first vendor-class string that is valid UTF-8.
+fn vendor_class(options: &dhcproto::v6::DhcpOptions) -> Option<String> {
+    match options.get(OptionCode::VendorClass) {
+        Some(DhcpOption::VendorClass(vendor)) => vendor
+            .data
+            .iter()
+            .find_map(|value| String::from_utf8(value.clone()).ok()),
+        _ => None,
+    }
+}
+
+/// Parse raw DHCPv6 option TLVs from a relay envelope.
+fn parse_raw_options(mut bytes: &[u8]) -> Result<Vec<RawOption<'_>>, V6DecodeError> {
+    let mut options = Vec::new();
+    while !bytes.is_empty() {
+        if bytes.len() < 4 {
+            return Err(V6DecodeError::MalformedPacket);
+        }
+
+        let code = u16::from_be_bytes([bytes[0], bytes[1]]);
+        let len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+        bytes = &bytes[4..];
+        if bytes.len() < len {
+            return Err(V6DecodeError::MalformedPacket);
+        }
+
+        let (data, rest) = bytes.split_at(len);
+        options.push(RawOption { code, data });
+        bytes = rest;
+    }
+
+    Ok(options)
+}
+
+/// Return an owned copy of one raw relay option payload.
+fn raw_option_bytes(options: &[RawOption<'_>], code: OptionCode) -> Option<Vec<u8>> {
+    options
+        .iter()
+        .find(|option| option.code == u16::from(code))
+        .map(|option| option.data.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use dhcproto::v6::{DhcpOption, IAAddr, IANA, IAPD, IATA, UnknownOption};
+    use dhcproto::{Encodable, Encoder};
+
+    use super::*;
+
+    const DUID_LL: &[u8] = &[0, 3, 0, 1, 2, 0, 0, 0, 0, 1];
+    const DUID_LLT: &[u8] = &[0, 1, 0, 1, 1, 2, 3, 4, 2, 0, 0, 0, 0, 1];
+    const DUID_UUID: &[u8] = &[0, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    const OPTION79: &[u8] = &[0, 1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee];
+
+    /// Build a DUID-EN identity with the requested total byte length.
+    fn duid_en(len: usize) -> Vec<u8> {
+        // Type 2 plus enterprise-number form the minimum DUID-EN prefix.
+        let mut duid = vec![0, 2, 0, 0, 0, 1];
+        duid.resize(len, 0xaa);
+        duid
+    }
+
+    fn encode_message(message: Message) -> Vec<u8> {
+        let mut out = Vec::new();
+        message.encode(&mut Encoder::new(&mut out)).unwrap();
+        out
+    }
+
+    fn client_message(message_type: MessageType, has_ia_na: bool, duid: &[u8]) -> Message {
+        let mut message = Message::new_with_id(message_type, [0xaa, 0xbb, 0xcc]);
+        message
+            .opts_mut()
+            .insert(DhcpOption::ClientId(duid.to_vec()));
+        if has_ia_na {
+            let mut ia_na = IANA {
+                id: 1,
+                t1: 0,
+                t2: 0,
+                opts: Default::default(),
+            };
+            ia_na.opts.insert(DhcpOption::IAAddr(IAAddr {
+                addr: "2001:db8::42".parse().unwrap(),
+                preferred_life: 300,
+                valid_life: 600,
+                opts: Default::default(),
+            }));
+            message.opts_mut().insert(DhcpOption::IANA(ia_na));
+        }
+        message
+    }
+
+    fn option(code: OptionCode, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&u16::from(code).to_be_bytes());
+        out.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn relay_forward(inner: &[u8], hop_count: u8) -> Vec<u8> {
+        let mut out = vec![12, hop_count];
+        out.extend_from_slice(&Ipv6Addr::from(0x20010db8000000000000000000000001u128).octets());
+        out.extend_from_slice(&Ipv6Addr::from(0xfe800000000000000000000000000001u128).octets());
+        out.extend_from_slice(&option(OptionCode::InterfaceId, b"eth0"));
+        out.extend_from_slice(&option(OptionCode::RemoteId, b"rack-a"));
+        out.extend_from_slice(&option(OptionCode::ClientLinklayerAddr, OPTION79));
+        out.extend_from_slice(&option(OptionCode::RelayMsg, inner));
+        out
+    }
+
+    /// Build a Relay-Forward carrying two option-9 Relay Message payloads.
+    fn relay_forward_with_duplicate_relay_message(first: &[u8], second: &[u8]) -> Vec<u8> {
+        let mut out = vec![12, 0];
+        out.extend_from_slice(&Ipv6Addr::from(0x20010db8000000000000000000000001u128).octets());
+        out.extend_from_slice(&Ipv6Addr::from(0xfe800000000000000000000000000001u128).octets());
+        out.extend_from_slice(&option(OptionCode::InterfaceId, b"eth0"));
+        out.extend_from_slice(&option(OptionCode::RemoteId, b"rack-a"));
+        out.extend_from_slice(&option(OptionCode::RelayMsg, first));
+        out.extend_from_slice(&option(OptionCode::RelayMsg, second));
+        out
+    }
+
+    #[test]
+    fn extracts_mac_from_supported_duid_types() {
+        // DUID-LL and DUID-LLT carry the Ethernet MAC in different offsets.
+        assert_eq!(
+            extract_mac_from_duid(DUID_LL).unwrap(),
+            DuidMac::Mac("02:00:00:00:00:01".parse().unwrap())
+        );
+        assert_eq!(
+            extract_mac_from_duid(DUID_LLT).unwrap(),
+            DuidMac::Mac("02:00:00:00:00:01".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn classifies_duids_without_ethernet_mac() {
+        // Enterprise and UUID DUIDs are valid DHCPv6 identities, but do not
+        // contain the sending link MAC unless a relay supplies option 79.
+        assert_eq!(
+            extract_mac_from_duid(&[0, 2, 0, 0, 0, 1, 0xaa]).unwrap(),
+            DuidMac::NoLinkLayerMac
+        );
+        assert_eq!(
+            extract_mac_from_duid(&duid_en(DUID_MAX_LEN)).unwrap(),
+            DuidMac::NoLinkLayerMac
+        );
+        assert_eq!(
+            extract_mac_from_duid(DUID_UUID).unwrap(),
+            DuidMac::NoLinkLayerMac
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_duids() {
+        // Truncated and unknown DUID forms cannot safely identify the client.
+        assert_eq!(extract_mac_from_duid(&[0]), Err(DuidError::Malformed));
+        assert_eq!(
+            extract_mac_from_duid(&[0, 2, 0, 0, 0, 1]),
+            Err(DuidError::Malformed)
+        );
+        assert_eq!(
+            extract_mac_from_duid(&[0, 4, 0, 1, 2, 3]),
+            Err(DuidError::Malformed)
+        );
+        assert_eq!(
+            extract_mac_from_duid(&duid_en(DUID_MAX_LEN + 1)),
+            Err(DuidError::Malformed)
+        );
+        assert_eq!(
+            extract_mac_from_duid(&[0, 99, 0, 1, 2, 3]),
+            Err(DuidError::UnsupportedType)
+        );
+        assert_eq!(
+            extract_mac_from_duid(&[0, 3, 0, 32, 2, 0, 0, 0, 0, 1]),
+            Err(DuidError::UnsupportedType)
+        );
+    }
+
+    #[test]
+    fn parses_option79_ethernet_mac() {
+        // Option 79 is decoded as Unknown by dhcproto, so we hand-parse the
+        // link-layer type and address payload here.
+        assert_eq!(
+            extract_mac_from_option79(OPTION79),
+            Some("02:aa:bb:cc:dd:ee".parse().unwrap())
+        );
+        assert_eq!(extract_mac_from_option79(&[0, 2, 1, 2, 3, 4, 5, 6]), None);
+    }
+
+    #[test]
+    fn decodes_direct_stateful_solicit() {
+        // Stateful SOLICIT carries IA_NA and maps to the v6 allocation path.
+        let packet = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
+        let decoded = decode(&packet).unwrap();
+
+        assert_eq!(decoded.selected_mac, "02:00:00:00:00:01".parse().unwrap());
+        assert_eq!(decoded.desired_addr, Some("2001:db8::42".parse().unwrap()));
+        assert_eq!(
+            message_kind_for(decoded.message_type, decoded.has_ia_na),
+            Some(rpc::MessageKind::V6Solicit)
+        );
+    }
+
+    #[test]
+    fn decodes_relay_forward_with_option79_precedence() {
+        // A one-hop relay supplies segment metadata and option 79; option 79
+        // wins over the MAC embedded in DUID-LL/LLT.
+        let inner = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
+        let decoded = decode(&relay_forward(&inner, 1)).unwrap();
+
+        assert_eq!(decoded.selected_mac, "02:aa:bb:cc:dd:ee".parse().unwrap());
+        assert_eq!(
+            decoded.client_link_layer,
+            Some("02:aa:bb:cc:dd:ee".parse().unwrap())
+        );
+        assert_eq!(decoded.relay_link, Some("2001:db8::1".parse().unwrap()));
+        assert_eq!(decoded.interface_id, Some(b"eth0".to_vec()));
+        assert_eq!(decoded.remote_id, Some(b"rack-a".to_vec()));
+    }
+
+    #[test]
+    fn accepts_unwrapped_packet_with_kea_relay_context() {
+        // Kea may pass an already-unwrapped client message in data_; in that
+        // case relay metadata comes from the side-channel context.
+        let packet = encode_message(client_message(
+            MessageType::InformationRequest,
+            false,
+            DUID_LL,
+        ));
+        let decoded = decode_with_relay_context(
+            &packet,
+            &RelayContext {
+                relay_count: 1,
+                hop_count: 1,
+                link_address: Some("2001:db8::10".parse().unwrap()),
+                interface_id: Some(b"swp1".to_vec()),
+                remote_id: None,
+                client_link_layer: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(decoded.relay_link, Some("2001:db8::10".parse().unwrap()));
+        assert_eq!(decoded.interface_id, Some(b"swp1".to_vec()));
+        assert_eq!(
+            message_kind_for(decoded.message_type, decoded.has_ia_na),
+            Some(rpc::MessageKind::V6InfoRequest)
+        );
+    }
+
+    #[test]
+    fn drops_non_mac_duid_without_option79() {
+        // A DUID-UUID cannot be joined to the v4 MAC row unless option 79
+        // supplies the sending link-layer address.
+        let packet = encode_message(client_message(MessageType::Solicit, true, DUID_UUID));
+
+        assert_eq!(decode(&packet), Err(V6DecodeError::NoMacNoOption79));
+    }
+
+    #[test]
+    fn ignores_client_supplied_option79_for_non_mac_duid() {
+        // Option 79 is only trusted when it comes from relay metadata; a
+        // client-supplied inner option must not choose the Carbide MAC row.
+        let mut message = client_message(MessageType::Solicit, true, DUID_UUID);
+        message
+            .opts_mut()
+            .insert(DhcpOption::Unknown(UnknownOption::new(
+                OptionCode::ClientLinklayerAddr,
+                OPTION79.to_vec(),
+            )));
+
+        assert_eq!(
+            decode(&encode_message(message)),
+            Err(V6DecodeError::NoMacNoOption79)
+        );
+    }
+
+    #[test]
+    fn accepts_non_mac_duid_with_relay_option79() {
+        // Relay-supplied option 79 identifies the sending link for valid
+        // non-MAC DUIDs.
+        let inner = encode_message(client_message(MessageType::Solicit, true, DUID_UUID));
+
+        assert_eq!(
+            decode(&relay_forward(&inner, 1)).unwrap().selected_mac,
+            "02:aa:bb:cc:dd:ee".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn drops_malformed_duid_even_with_relay_option79() {
+        // Relay option 79 only helps valid non-MAC DUIDs; malformed or
+        // unhandled DUID forms are unsupported before MAC selection.
+        let truncated = encode_message(client_message(
+            MessageType::Solicit,
+            true,
+            &[0, 4, 0, 1, 2, 3],
+        ));
+        let non_ethernet = encode_message(client_message(
+            MessageType::Solicit,
+            true,
+            &[0, 3, 0, 32, 2, 0, 0, 0, 0, 1],
+        ));
+
+        assert_eq!(
+            decode(&relay_forward(&truncated, 1)),
+            Err(V6DecodeError::UnsupportedDuid)
+        );
+        assert_eq!(
+            decode(&relay_forward(&non_ethernet, 1)),
+            Err(V6DecodeError::UnsupportedDuid)
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_ia_shapes_before_api_classification() {
+        // IA_TA and IA_PD are non-goals and must not be downgraded to
+        // information-only or stateful API discovery.
+        let mut solicit_ia_ta = client_message(MessageType::Solicit, false, DUID_LL);
+        solicit_ia_ta.opts_mut().insert(DhcpOption::IATA(IATA {
+            id: 1,
+            opts: Default::default(),
+        }));
+        let mut solicit_ia_pd = client_message(MessageType::Solicit, false, DUID_LL);
+        solicit_ia_pd.opts_mut().insert(DhcpOption::IAPD(IAPD {
+            id: 1,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        }));
+
+        assert_eq!(
+            decode(&encode_message(solicit_ia_ta)),
+            Err(V6DecodeError::UnsupportedMessage(MessageType::Solicit))
+        );
+        assert_eq!(
+            decode(&encode_message(solicit_ia_pd)),
+            Err(V6DecodeError::UnsupportedMessage(MessageType::Solicit))
+        );
+    }
+
+    #[test]
+    fn rejects_supported_ia_na_when_unsupported_ia_is_also_present() {
+        // The API can return only one address for one supported IA_NA flow, so
+        // mixed unsupported IA containers are rejected before lease override.
+        let mut solicit_ia_ta = client_message(MessageType::Solicit, true, DUID_LL);
+        solicit_ia_ta.opts_mut().insert(DhcpOption::IATA(IATA {
+            id: 1,
+            opts: Default::default(),
+        }));
+        let mut request_ia_pd = client_message(MessageType::Request, true, DUID_LL);
+        request_ia_pd.opts_mut().insert(DhcpOption::IAPD(IAPD {
+            id: 1,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        }));
+
+        assert_eq!(
+            decode(&encode_message(solicit_ia_ta)),
+            Err(V6DecodeError::UnsupportedMessage(MessageType::Solicit))
+        );
+        assert_eq!(
+            decode(&encode_message(request_ia_pd)),
+            Err(V6DecodeError::UnsupportedMessage(MessageType::Request))
+        );
+    }
+
+    #[test]
+    fn rejects_ambiguous_ia_na_address_selection() {
+        // The current API contract has one desired address and one returned
+        // address, so multiple IA_NA containers or IAADDR hints are ambiguous.
+        let mut second_ia_na = IANA {
+            id: 2,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        };
+        second_ia_na.opts.insert(DhcpOption::IAAddr(IAAddr {
+            addr: "2001:db8::43".parse().unwrap(),
+            preferred_life: 300,
+            valid_life: 600,
+            opts: Default::default(),
+        }));
+        let mut multiple_ia_na = client_message(MessageType::Solicit, true, DUID_LL);
+        multiple_ia_na
+            .opts_mut()
+            .insert(DhcpOption::IANA(second_ia_na));
+
+        let mut multiple_iaaddr = client_message(MessageType::Solicit, true, DUID_LL);
+        if let Some(DhcpOption::IANA(ia_na)) = multiple_iaaddr.opts_mut().get_mut(OptionCode::IANA)
+        {
+            ia_na.opts.insert(DhcpOption::IAAddr(IAAddr {
+                addr: "2001:db8::43".parse().unwrap(),
+                preferred_life: 300,
+                valid_life: 600,
+                opts: Default::default(),
+            }));
+        }
+
+        assert_eq!(
+            decode(&encode_message(multiple_ia_na)),
+            Err(V6DecodeError::UnsupportedMessage(MessageType::Solicit))
+        );
+        assert_eq!(
+            decode(&encode_message(multiple_iaaddr)),
+            Err(V6DecodeError::UnsupportedMessage(MessageType::Solicit))
+        );
+    }
+
+    #[test]
+    fn accepts_lease_end_messages_with_unsupported_ia_for_kea_handling() {
+        // RELEASE and DECLINE are Kea protocol paths; Carbide validates
+        // identity and lets Kea handle them without API discovery.
+        let mut release = client_message(MessageType::Release, true, DUID_LL);
+        release.opts_mut().insert(DhcpOption::IATA(IATA {
+            id: 1,
+            opts: Default::default(),
+        }));
+        let mut decline = client_message(MessageType::Decline, true, DUID_LL);
+        decline.opts_mut().insert(DhcpOption::IAPD(IAPD {
+            id: 1,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        }));
+
+        assert_eq!(
+            decode(&encode_message(release)).unwrap().message_type,
+            MessageType::Release
+        );
+        assert_eq!(
+            decode(&encode_message(decline)).unwrap().message_type,
+            MessageType::Decline
+        );
+    }
+
+    #[test]
+    fn rejects_request_like_messages_without_ia_na() {
+        // REQUEST, RENEW, and REBIND are stateful paths; without IA_NA there
+        // is no supported lease request to send to the API.
+        for message_type in [
+            MessageType::Request,
+            MessageType::Renew,
+            MessageType::Rebind,
+        ] {
+            assert_eq!(
+                decode(&encode_message(client_message(
+                    message_type,
+                    false,
+                    DUID_LL
+                ))),
+                Err(V6DecodeError::UnsupportedMessage(message_type))
+            );
+        }
+    }
+
+    #[test]
+    fn drops_oversized_duid_en_even_with_relay_option79() {
+        // Relay option 79 may supply the MAC, but the DUID still has to fit
+        // Kea and RFC 8415 length limits.
+        let inner = encode_message(client_message(
+            MessageType::Solicit,
+            true,
+            &duid_en(DUID_MAX_LEN + 1),
+        ));
+
+        assert_eq!(
+            decode(&relay_forward(&inner, 1)),
+            Err(V6DecodeError::UnsupportedDuid)
+        );
+    }
+
+    #[test]
+    fn rejects_nested_or_multi_hop_relay() {
+        // Multi-hop relay handling needs an explicit segment precedence rule,
+        // so this milestone rejects it instead of serving silently.
+        let inner = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
+        let nested = relay_forward(&relay_forward(&inner, 1), 1);
+
+        assert_eq!(
+            decode(&relay_forward(&inner, 2)),
+            Err(V6DecodeError::RelayHopCountExceeded(2))
+        );
+        assert_eq!(decode(&nested), Err(V6DecodeError::NestedRelay));
+    }
+
+    #[test]
+    fn rejects_duplicate_relay_message_options() {
+        // Multiple option-9 payloads can make Rust and Kea inspect different
+        // inner clients, so reject before choosing an identity.
+        let first = encode_message(client_message(MessageType::Solicit, true, DUID_LL));
+        let second = encode_message(client_message(MessageType::Solicit, true, DUID_LLT));
+
+        assert_eq!(
+            decode(&relay_forward_with_duplicate_relay_message(&first, &second)),
+            Err(V6DecodeError::MalformedPacket)
+        );
+    }
+}

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -17,10 +17,135 @@
 
 #include "callouts.h"
 #include "carbide_rust.h"
+#include <dhcp/option6_ia.h>
+#include <dhcp/option6_iaaddr.h>
+#include <dhcp/option6_status_code.h>
 
 isc::log::Logger logger("carbide-callouts");
 
 const int IPV4_ADDR_SIZEB = 4;
+const int IPV6_ADDR_SIZEB = 16;
+
+const uint8_t *nullable_data(const OptionBuffer &buffer) {
+  return buffer.empty() ? nullptr : buffer.data();
+}
+
+// Own a Rust DHCP byte buffer for the duration of C++ option construction.
+class DhcpByteBufferGuard {
+public:
+  explicit DhcpByteBufferGuard(DhcpByteBuffer buffer) : buffer_(buffer) {}
+  ~DhcpByteBufferGuard() { machine_free_dhcp_byte_buffer(buffer_); }
+  DhcpByteBufferGuard(const DhcpByteBufferGuard &) = delete;
+  DhcpByteBufferGuard &operator=(const DhcpByteBufferGuard &) = delete;
+
+  bool empty() const { return buffer_.len == 0 || buffer_.ptr == nullptr; }
+
+  OptionBuffer optionBuffer() const {
+    return OptionBuffer(buffer_.ptr, buffer_.ptr + buffer_.len);
+  }
+
+private:
+  DhcpByteBuffer buffer_;
+};
+
+// Extract a DHCPv6 relay-option payload for the Rust decoder, returning an
+// empty buffer when Kea did not retain that relay metadata.
+OptionBuffer option_data(const Pkt6::RelayInfo &relay, uint16_t code) {
+  auto option = relay.options_.find(code);
+  if (option == relay.options_.end() || !option->second) {
+    return OptionBuffer();
+  }
+  return option->second->getData();
+}
+
+void add_or_replace_option6(Pkt6Ptr response6_ptr, uint16_t code,
+                            DhcpByteBuffer buffer) {
+  DhcpByteBufferGuard guard(buffer);
+
+  // Delete first so an intentionally empty trusted value removes any
+  // client-derived option already present on Kea's response.
+  response6_ptr->delOption(code);
+  if (guard.empty()) {
+    return;
+  }
+
+  OptionBuffer payload = guard.optionBuffer();
+  response6_ptr->addOption(OptionPtr(new Option(Option::V6, code, payload)));
+}
+
+void add_or_replace_option6(Pkt6Ptr response6_ptr, uint16_t code,
+                            const OptionBuffer &buffer) {
+  if (buffer.empty()) {
+    return;
+  }
+
+  response6_ptr->delOption(code);
+  response6_ptr->addOption(OptionPtr(new Option(Option::V6, code, buffer)));
+}
+
+void add_client_fqdn_option6(Pkt6Ptr query6_ptr, Pkt6Ptr response6_ptr,
+                             Machine *machine) {
+  response6_ptr->delOption(D6O_CLIENT_FQDN);
+
+  OptionPtr requested =
+      query6_ptr ? query6_ptr->getOption(D6O_CLIENT_FQDN) : OptionPtr();
+  if (!requested || requested->getData().empty()) {
+    return;
+  }
+
+  DhcpByteBuffer buffer = machine_get_client_fqdn_ipv6(machine);
+  DhcpByteBufferGuard guard(buffer);
+  if (guard.empty()) {
+    return;
+  }
+
+  OptionBuffer payload = guard.optionBuffer();
+  // Preserve client negotiation flags, but keep the API-owned hostname.
+  payload[0] = requested->getData()[0];
+  response6_ptr->addOption(
+      OptionPtr(new Option(Option::V6, D6O_CLIENT_FQDN, payload)));
+}
+
+void add_status6(Pkt6Ptr response6_ptr, uint16_t status,
+                 const std::string &message) {
+  response6_ptr->delOption(D6O_STATUS_CODE);
+  response6_ptr->addOption(
+      OptionPtr(new Option6StatusCode(status, message)));
+}
+
+void add_ia_na_status6(Pkt6Ptr query6_ptr, Pkt6Ptr response6_ptr,
+                       uint16_t status, const std::string &message) {
+  uint32_t iaid = 0;
+  if (query6_ptr) {
+    OptionPtr option = query6_ptr->getOption(D6O_IA_NA);
+    Option6IAPtr query_ia_na =
+        boost::dynamic_pointer_cast<Option6IA>(option);
+    if (query_ia_na) {
+      iaid = query_ia_na->getIAID();
+    }
+  }
+
+  // Replace Kea's old-address IA_NA success with an IA-scoped failure.
+  response6_ptr->delOption(D6O_STATUS_CODE);
+  response6_ptr->delOption(D6O_IA_NA);
+  Option6IAPtr ia_na(new Option6IA(D6O_IA_NA, iaid));
+  ia_na->addOption(OptionPtr(new Option6StatusCode(status, message)));
+  response6_ptr->addOption(ia_na);
+}
+
+void record_dropped_v6_request(const char *reason) {
+  // Preserve the shared v4/v6 counter while emitting the required v6 series.
+  carbide_increment_dropped_requests(reason);
+  carbide_increment_dropped_v6_requests(reason);
+}
+
+/// Records a DHCPv6 response that Kea is still allowed to send.
+void record_v6_reply_sent(CalloutHandle &handle, Pkt6Ptr response6_ptr) {
+  // Count only responses Kea will be allowed to put on the wire.
+  if (response6_ptr && handle.getStatus() != CalloutHandle::NEXT_STEP_DROP) {
+    carbide_increment_v6_reply_sent(response6_ptr->getType());
+  }
+}
 
 void CDHCPOptionsHandler<Option>::resetOption(boost::any param) {
   switch (option) {
@@ -325,6 +450,37 @@ void set_options(CalloutHandle &handle, Pkt4Ptr response4_ptr,
   machine_free_client_type(machine_client_type);
 }
 
+void set_options_v6(CalloutHandle &handle, Pkt6Ptr query6_ptr,
+                    Pkt6Ptr response6_ptr, Machine *machine) {
+  try {
+    // DNS servers: DHCPv6 option 23 is a flat IPv6 address list.
+    add_or_replace_option6(response6_ptr, D6O_NAME_SERVERS,
+                           machine_get_dns_servers_ipv6(machine));
+
+    // Domain search: Rust returns RFC 1035 wire-format domain names.
+    add_or_replace_option6(response6_ptr, D6O_DOMAIN_SEARCH,
+                           machine_get_domain_search_ipv6(machine));
+
+    // NTP servers: Rust returns RFC 5908 suboption TLVs for option 56.
+    add_or_replace_option6(response6_ptr, 56,
+                           machine_get_ntp_servers_ipv6(machine));
+
+    // Client FQDN is client-controlled; echo negotiation flags only and
+    // render the API-owned hostname. This cannot use add_or_replace_option6
+    // because the response payload depends on the client's requested flags.
+    add_client_fqdn_option6(query6_ptr, response6_ptr, machine);
+
+    if (machine_get_rapid_commit_v6(machine)) {
+      response6_ptr->delOption(D6O_RAPID_COMMIT);
+      response6_ptr->addOption(OptionPtr(new Option(Option::V6, D6O_RAPID_COMMIT)));
+    }
+  } catch (exception &e) {
+    LOG_ERROR(logger, "LOG_CARBIDE_PKT6_SEND: packet send Exception: %1")
+        .arg(e.what());
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+  }
+}
+
 void set_vendor_options(Pkt4Ptr response4_ptr) {
   OptionPtr option_vendor(
       new Option(Option::V4, DHO_VENDOR_ENCAPSULATED_OPTIONS));
@@ -340,6 +496,303 @@ void set_vendor_options(Pkt4Ptr response4_ptr) {
   option_vendor->addOption(vendor_option_6);
 
   response4_ptr->addOption(option_vendor);
+}
+
+// Resolve the authoritative Carbide IPv6 address cached on the DHCPv6 exchange.
+int get_carbide_lease6_address(CalloutHandle &handle, Lease6Ptr lease6,
+                               const std::string &hook_name,
+                               isc::asiolink::IOAddress &carbide_addr) {
+  if (!lease6) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Missing lease6 argument");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  boost::shared_ptr<Machine> machine;
+  try {
+    handle.getContext("machine", machine);
+  } catch (...) {
+    machine.reset();
+  }
+  if (!machine) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Missing machine object from handle context");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  uint8_t carbide_bytes[IPV6_ADDR_SIZEB] = {0};
+  if (!machine_get_interface_address_ipv6(machine.get(), carbide_bytes,
+                                          IPV6_ADDR_SIZEB)) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Carbide returned no usable IPv6 address");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  carbide_addr =
+      isc::asiolink::IOAddress::fromBytes(AF_INET6, carbide_bytes);
+  return 0;
+}
+
+// Ensure lease expiry uses the hook-selected MAC identity.
+int set_lease6_selected_hwaddr(CalloutHandle &handle, Lease6Ptr lease6,
+                               const std::string &hook_name) {
+  if (!lease6) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Missing lease6 argument");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  boost::shared_ptr<Machine> machine;
+  try {
+    handle.getContext("machine", machine);
+  } catch (...) {
+    machine.reset();
+  }
+  if (!machine) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Missing machine object from handle context");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  if (machine_is_invalidated_v6_lease(machine.get())) {
+    LOG_WARN(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": refusing recently expired DHCPv6 lease");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  char *selected_mac = machine_get_discovery_mac(machine.get());
+  if (selected_mac == nullptr) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Missing selected DHCPv6 MAC");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  // Kea already has the hook-selected identity; leave the lease unchanged.
+  if (lease6->hwaddr_ && !lease6->hwaddr_->hwaddr_.empty() &&
+      lease6->hwaddr_->toText(false) == selected_mac) {
+    machine_free_discovery_mac(selected_mac);
+    return 0;
+  }
+
+  // If DUID fallback recovers the same selected MAC, expiry can stay scoped
+  // without forcing a synthetic hwaddr into leases that Kea left empty.
+  if ((!lease6->hwaddr_ || lease6->hwaddr_->hwaddr_.empty()) &&
+      lease6->duid_) {
+    const auto &duid = lease6->duid_->getDuid();
+    char *duid_mac = carbide_mac_from_duid(nullable_data(duid), duid.size());
+    if (duid_mac != nullptr && std::string(duid_mac) == selected_mac) {
+      carbide_free_mac_string(duid_mac);
+      machine_free_discovery_mac(selected_mac);
+      return 0;
+    }
+    if (duid_mac != nullptr) {
+      carbide_free_mac_string(duid_mac);
+    }
+  }
+
+  try {
+    HWAddr hwaddr = HWAddr::fromText(selected_mac, HTYPE_ETHER);
+    lease6->hwaddr_.reset(new HWAddr(hwaddr));
+    handle.setArgument("lease6", lease6);
+  } catch (...) {
+    LOG_ERROR(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": Failed to persist selected DHCPv6 MAC");
+    machine_free_discovery_mac(selected_mac);
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  machine_free_discovery_mac(selected_mac);
+  return 0;
+}
+
+// Decode the API-selected IPv6 address from a Machine context.
+bool machine_ipv6_address(Machine *machine,
+                          isc::asiolink::IOAddress &carbide_addr) {
+  uint8_t carbide_bytes[IPV6_ADDR_SIZEB] = {0};
+  if (!machine_get_interface_address_ipv6(machine, carbide_bytes,
+                                          IPV6_ADDR_SIZEB)) {
+    return false;
+  }
+
+  carbide_addr =
+      isc::asiolink::IOAddress::fromBytes(AF_INET6, carbide_bytes);
+  return true;
+}
+
+// Return true when Kea is about to send an address that is not API-owned.
+// This can happen when Kea reuses an existing IA_NA after renew/rebind refused
+// an unsupported address migration.
+bool response6_has_stale_ia_na_address(Pkt6Ptr response6_ptr,
+                                       const isc::asiolink::IOAddress &carbide_addr,
+                                       std::string &detail) {
+  OptionPtr ia_option = response6_ptr->getOption(D6O_IA_NA);
+  if (!ia_option) {
+    return false;
+  }
+
+  Option6IAPtr ia_na = boost::dynamic_pointer_cast<Option6IA>(ia_option);
+  if (!ia_na) {
+    detail = "IA_NA option has unexpected type";
+    return true;
+  }
+
+  OptionPtr iaaddr_option = ia_na->getOption(D6O_IAADDR);
+  if (!iaaddr_option) {
+    return false;
+  }
+
+  Option6IAAddrPtr iaaddr =
+      boost::dynamic_pointer_cast<Option6IAAddr>(iaaddr_option);
+  if (!iaaddr) {
+    detail = "IAADDR option has unexpected type";
+    return true;
+  }
+
+  if (iaaddr->getAddress() != carbide_addr) {
+    detail = "Kea response address " + iaaddr->getAddress().toText() +
+             " does not match Carbide address " + carbide_addr.toText();
+    return true;
+  }
+
+  return false;
+}
+
+// Override a proposed DHCPv6 allocation before Kea persists a new lease.
+int override_lease6_address(CalloutHandle &handle, Lease6Ptr lease6,
+                            const std::string &hook_name,
+                            const std::string &detail) {
+  isc::asiolink::IOAddress carbide_addr("::");
+  if (get_carbide_lease6_address(handle, lease6, hook_name, carbide_addr) !=
+      0) {
+    return 1;
+  }
+
+  if (set_lease6_selected_hwaddr(handle, lease6, hook_name) != 0) {
+    return 1;
+  }
+
+  if (lease6->addr_ != carbide_addr) {
+    LOG_INFO(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": overriding " + lease6->addr_.toText() + " -> " +
+             carbide_addr.toText() + detail);
+    lease6->addr_ = carbide_addr;
+    handle.setArgument("lease6", lease6);
+  } else {
+    LOG_INFO(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": lease addr already matches Carbide (" +
+             carbide_addr.toText() + ")");
+  }
+
+  return 0;
+}
+
+// Refuse unsupported in-place migration of an existing DHCPv6 lease address.
+int refuse_lease6_address_migration(CalloutHandle &handle, Lease6Ptr lease6,
+                                    const std::string &hook_name) {
+  isc::asiolink::IOAddress carbide_addr("::");
+  if (get_carbide_lease6_address(handle, lease6, hook_name, carbide_addr) !=
+      0) {
+    return 1;
+  }
+
+  // RENEW/REBIND extends an existing address-indexed lease. Changing addr_
+  // here asks Kea to update a lease under a different key, which memfile
+  // rejects.
+  if (lease6->addr_ != carbide_addr) {
+    LOG_WARN(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+        .arg(hook_name + ": refusing to migrate existing lease " +
+             lease6->addr_.toText() + " -> " + carbide_addr.toText());
+    // Kea's public hook surface does not expose a safe lease re-key here.
+    // Drop instead of sending a successful renewal for the API-stale address.
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    return 1;
+  }
+
+  // Even steady-state renew/rebind can have Kea's configured mac-sources copy
+  // a DUID-derived hwaddr onto the lease. Restore the hook-selected identity.
+  if (set_lease6_selected_hwaddr(handle, lease6, hook_name) != 0) {
+    return 1;
+  }
+
+  LOG_INFO(logger, "LOG_CARBIDE_LEASE6_OVERRIDE: %1")
+      .arg(hook_name + ": lease addr already matches Carbide (" +
+           carbide_addr.toText() + ")");
+  return 0;
+}
+
+// Notify Carbide when Kea reclaims a DHCPv6 lease that still has a scoped
+// client identity.
+int handle_carbide_lease6_end(CalloutHandle &handle,
+                              const std::string &hook_name) {
+  Lease6Ptr lease6;
+  handle.getArgument("lease6", lease6);
+
+  if (!lease6) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR)
+        .arg(hook_name + ": missing lease6 argument");
+    return 0;
+  }
+
+  std::string ip_str = lease6->addr_.toText();
+  // DHCPv6 identifies clients by DUID, but Kea still records the
+  // client's hardware address on the lease when available.
+  std::string mac_str;
+  if (lease6->hwaddr_ && !lease6->hwaddr_->hwaddr_.empty()) {
+    mac_str = lease6->hwaddr_->toText(false);
+  } else if (lease6->duid_) {
+    // DHCPv6 leases commonly have no hwaddr_; DUID-LL/LLT still lets NICo
+    // scope expiry to the same (ip, mac) pair as DHCPv4.
+    const auto &duid = lease6->duid_->getDuid();
+    char *duid_mac = carbide_mac_from_duid(nullable_data(duid), duid.size());
+    if (duid_mac != nullptr) {
+      mac_str = duid_mac;
+      carbide_free_mac_string(duid_mac);
+    }
+  }
+  LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE)
+      .arg(hook_name + ": " + ip_str);
+
+  // Address-only expiry is unsafe for hook-originated DHCPv6 reclamation:
+  // Kea can remove client identity from declined leases before expiry.
+  if (mac_str.empty()) {
+    LOG_WARN(logger, "LOG_CARBIDE_LEASE6_EXPIRE: %1")
+        .arg(hook_name + ": skipping API lease expiry for " + ip_str +
+             " because Kea did not provide a client MAC");
+    return 0;
+  }
+
+  size_t invalidated =
+      carbide_invalidate_v6_lease_cache(ip_str.c_str(), mac_str.c_str());
+  auto result = carbide_expire_lease(ip_str.c_str(), mac_str.c_str());
+  if (result == LeaseExpirationResult::FeatureDisabled) {
+    // The API is still authoritative when expiry handling is disabled, so the
+    // pre-call tombstone must not block a subsequent API-selected lease.
+    carbide_clear_v6_lease_cache_invalidation(ip_str.c_str(),
+                                              mac_str.c_str());
+  } else if (result != LeaseExpirationResult::InvalidAddress) {
+    // Keep the tombstone even on API errors: the API may have committed the
+    // deletion before a response was lost.
+    invalidated +=
+        carbide_invalidate_v6_lease_cache(ip_str.c_str(), mac_str.c_str());
+  }
+  if (result != LeaseExpirationResult::Success &&
+      result != LeaseExpirationResult::FeatureDisabled) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR)
+        .arg(hook_name + ": " + ip_str);
+  }
+  LOG_INFO(logger, "LOG_CARBIDE_LEASE6_EXPIRE: %1")
+      .arg(hook_name + ": invalidated " + std::to_string(invalidated) +
+           " DHCPv6 lease cache entries for " + ip_str);
+
+  return 0;
 }
 
 extern "C" {
@@ -581,7 +1034,8 @@ int lease4_expire(CalloutHandle &handle) {
 
   auto result = carbide_expire_lease(
       ip_str.c_str(), mac_str.empty() ? nullptr : mac_str.c_str());
-  if (result != LeaseExpirationResult::Success) {
+  if (result != LeaseExpirationResult::Success &&
+      result != LeaseExpirationResult::FeatureDisabled) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
   }
 
@@ -740,31 +1194,221 @@ int lease4_renew(CalloutHandle &handle) {
   return 0;
 }
 
-int lease6_expire(CalloutHandle &handle) {
-  Lease6Ptr lease6;
-  handle.getArgument("lease6", lease6);
+int pkt6_receive(CalloutHandle &handle) {
+  Pkt6Ptr query6_ptr;
+  handle.getArgument("query6", query6_ptr);
 
-  if (!lease6) {
-    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR)
-        .arg("missing lease6 argument");
+  carbide_increment_total_requests();
+
+  if (!query6_ptr) {
+    LOG_ERROR(logger, "LOG_CARBIDE_PKT6_RECEIVE: missing query6 argument");
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    record_dropped_v6_request("invalid_packet");
+    return 1;
+  }
+
+  LOG_INFO(logger, "LOG_CARBIDE_PKT6_RECEIVE: %1")
+      .arg(query6_ptr->toText());
+
+  size_t relay_count = query6_ptr->relay_info_.size();
+  if (relay_count == 0) {
+    LOG_ERROR(logger, "LOG_CARBIDE_PKT6_RECEIVE: Received a non-relayed packet, dropping it");
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    record_dropped_v6_request("NonRelayedPacket");
     return 0;
   }
 
-  std::string ip_str = lease6->addr_.toText();
-  // DHCPv6 identifies clients by DUID, but Kea still records the
-  // client's hardware address on the lease when available.
-  std::string mac_str;
-  if (lease6->hwaddr_ && !lease6->hwaddr_->hwaddr_.empty()) {
-    mac_str = lease6->hwaddr_->toText(false);
-  }
-  LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE).arg(ip_str);
+  uint8_t hop_count = 0;
+  OptionBuffer relay_link;
+  OptionBuffer interface_id;
+  OptionBuffer remote_id;
+  OptionBuffer client_link_layer;
 
-  auto result = carbide_expire_lease(
-      ip_str.c_str(), mac_str.empty() ? nullptr : mac_str.c_str());
-  if (result != LeaseExpirationResult::Success) {
-    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
+  const auto &relay = query6_ptr->relay_info_.front();
+  hop_count = relay.hop_count_;
+  relay_link = relay.linkaddr_.toBytes();
+  interface_id = option_data(relay, D6O_INTERFACE_ID);
+  remote_id = option_data(relay, D6O_REMOTE_ID);
+  client_link_layer = option_data(relay, D6O_CLIENT_LINKLAYER_ADDR);
+
+  Machine *machine = nullptr;
+  V6HookResult result = carbide_pkt6_receive(
+      nullable_data(query6_ptr->data_), query6_ptr->data_.size(), relay_count,
+      hop_count, nullable_data(relay_link), relay_link.size(),
+      nullable_data(interface_id), interface_id.size(), nullable_data(remote_id),
+      remote_id.size(), nullable_data(client_link_layer),
+      client_link_layer.size(), &machine);
+
+  if (result == V6HookResult::Success && machine != nullptr) {
+    boost::shared_ptr<Machine> machinePtr(machine, [](Machine *ptr) {
+      machine_free(ptr);
+    });
+    handle.setContext("machine", machinePtr);
+    // CONFIRM cache hits must be visible as top-level Success in pkt6_send.
+    if (query6_ptr->getType() == DHCPV6_CONFIRM) {
+      handle.setContext("confirm_on_link", true);
+    }
+    return 0;
   }
 
+  if (result == V6HookResult::Ignore) {
+    handle.setContext("lease_end_message_validated", true);
+    return 0;
+  }
+
+  if (result == V6HookResult::ConfirmNotOnLink) {
+    handle.setContext("confirm_not_on_link", true);
+    return 0;
+  }
+
+  if (result == V6HookResult::Success && machine == nullptr) {
+    result = V6HookResult::InvalidMachinePointer;
+  }
+
+  LOG_ERROR(logger,
+            "LOG_CARBIDE_PKT6_RECEIVE: Error while executing DHCPv6 discovery: %1, machine_ptr=%2")
+      .arg(carbide_v6_hook_result_as_str(result))
+      .arg(machine);
+  if (machine != nullptr) {
+    machine_free(machine);
+  }
+  handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+  record_dropped_v6_request(carbide_v6_hook_result_as_str(result));
+  return 1;
+}
+
+int lease6_select(CalloutHandle &handle) {
+  Lease6Ptr lease6;
+  handle.getArgument("lease6", lease6);
+
+  bool fake_allocation = false;
+  try {
+    handle.getArgument("fake_allocation", fake_allocation);
+  } catch (...) {
+    // Some Kea versions may not always pass this, that's fine.
+  }
+
+  return override_lease6_address(
+      handle, lease6, "lease6_select",
+      fake_allocation ? " (SOLICIT, not persisted)" : " (REQUEST, will persist)");
+}
+
+int lease6_renew(CalloutHandle &handle) {
+  Lease6Ptr lease6;
+  handle.getArgument("lease6", lease6);
+
+  return refuse_lease6_address_migration(handle, lease6, "lease6_renew");
+}
+
+int lease6_rebind(CalloutHandle &handle) {
+  Lease6Ptr lease6;
+  handle.getArgument("lease6", lease6);
+
+  return refuse_lease6_address_migration(handle, lease6, "lease6_rebind");
+}
+
+// Final DHCPv6 send-path guard: drop unsafe responses, apply hook-managed
+// status/options, and count replies that Kea is allowed to send.
+int pkt6_send(CalloutHandle &handle) {
+  // Recover Kea's request/response pair. query6 can be absent on some error
+  // paths, but response6 is required because this hook mutates the outbound
+  // packet.
+  Pkt6Ptr query6_ptr, response6_ptr;
+  try {
+    handle.getArgument("query6", query6_ptr);
+  } catch (...) {
+    query6_ptr.reset();
+  }
+  handle.getArgument("response6", response6_ptr);
+
+  if (!response6_ptr) {
+    LOG_ERROR(logger, "LOG_CARBIDE_PKT6_SEND: missing response6 argument");
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    return 1;
+  }
+
+  // CONFIRM cache validation can produce a status-only response without a
+  // Machine context.
+  bool confirm_not_on_link = false;
+  try {
+    handle.getContext("confirm_not_on_link", confirm_not_on_link);
+  } catch (...) {
+    confirm_not_on_link = false;
+  }
+
+  if (confirm_not_on_link) {
+    add_status6(response6_ptr, STATUS_NotOnLink, "not on link");
+    record_v6_reply_sent(handle, response6_ptr);
+    return 0;
+  }
+
+  bool confirm_on_link = false;
+  try {
+    handle.getContext("confirm_on_link", confirm_on_link);
+  } catch (...) {
+    confirm_on_link = false;
+  }
+
+  // RELEASE/DECLINE already passed receive-side validation. Let Kea send its
+  // reply unchanged and only record the send-side metric.
+  bool lease_end_message_validated = false;
+  try {
+    handle.getContext("lease_end_message_validated",
+                      lease_end_message_validated);
+  } catch (...) {
+    lease_end_message_validated = false;
+  }
+  if (lease_end_message_validated) {
+    record_v6_reply_sent(handle, response6_ptr);
+    return 0;
+  }
+
+  // All remaining response paths need the API-selected Machine record for
+  // stale-address checks and DHCPv6 service option rendering.
+  boost::shared_ptr<Machine> machine;
+  try {
+    handle.getContext("machine", machine);
+  } catch (...) {
+    machine.reset();
+  }
+  if (!machine) {
+    LOG_ERROR(logger, "LOG_CARBIDE_PKT6_SEND: Missing machine object from handle context");
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    return 1;
+  }
+
+  // If Kea reuses a lease address after we refused renewal migration, fail
+  // closed instead of sending an address the API no longer owns.
+  isc::asiolink::IOAddress carbide_addr("::");
+  if (machine_ipv6_address(machine.get(), carbide_addr)) {
+    std::string stale_address_detail;
+    if (response6_has_stale_ia_na_address(response6_ptr, carbide_addr,
+                                          stale_address_detail)) {
+      LOG_ERROR(logger, "LOG_CARBIDE_PKT6_SEND: %1")
+          .arg("dropping DHCPv6 response with non-authoritative IA_NA: " +
+               stale_address_detail);
+      handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+      return 1;
+    }
+  }
+
+  // Kea does not synthesize this for the hook-managed CONFIRM cache path.
+  if (confirm_on_link) {
+    add_status6(response6_ptr, STATUS_Success, "success");
+  }
+
+  set_options_v6(handle, query6_ptr, response6_ptr, machine.get());
+
+  // Record the final outbound packet after hook-managed options/status have
+  // been applied.
+  LOG_INFO(logger, "LOG_CARBIDE_PKT6_SEND: %1")
+      .arg(response6_ptr->toText());
+
+  record_v6_reply_sent(handle, response6_ptr);
   return 0;
+}
+
+int lease6_expire(CalloutHandle &handle) {
+  return handle_carbide_lease6_end(handle, "lease6_expire");
 }
 }

--- a/crates/dhcp/src/kea/callouts.h
+++ b/crates/dhcp/src/kea/callouts.h
@@ -19,11 +19,14 @@
 #define CALLOUTS_H
 
 #include <asiolink/io_address.h>
+#include <dhcp/dhcp6.h>
 #include <dhcp/pkt4.h>
+#include <dhcp/pkt6.h>
 #include <dhcpsrv/lease.h>
 #include <hooks/hooks.h>
 #include <log/logger.h>
 #include <log/macros.h>
+#include <sys/socket.h>
 #include <string>
 
 #include <dhcp/option4_addrlst.h>
@@ -108,6 +111,11 @@ int lease4_select(CalloutHandle &handle);
 int lease4_renew(CalloutHandle &handle);
 int pkt4_send(CalloutHandle &handle);
 int lease4_expire(CalloutHandle &handle);
+int pkt6_receive(CalloutHandle &handle);
+int lease6_select(CalloutHandle &handle);
+int lease6_renew(CalloutHandle &handle);
+int lease6_rebind(CalloutHandle &handle);
+int pkt6_send(CalloutHandle &handle);
 int lease6_expire(CalloutHandle &handle);
 }
 

--- a/crates/dhcp/src/kea/loader.cc
+++ b/crates/dhcp/src/kea/loader.cc
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-#include <hooks/hooks.h>
-#include <log/logger.h>
-#include <log/macros.h>
 #include <asiolink/io_address.h>
 #include <asiolink/io_error.h>
+#include <hooks/hooks.h>
+#include <hooks/server_hooks.h>
+#include <log/logger.h>
+#include <log/macros.h>
 
 #include "carbide_logger.h"
 #include "callouts.h"
@@ -30,127 +31,196 @@ isc::log::Logger loader_logger("kea-shim-loader");
 using namespace isc::hooks;
 using namespace isc::data;
 
+using StringSetter = void (*)(const char *);
+using ValidatedStringSetter = bool (*)(const char *);
+using BoolSetter = void (*)(bool);
+
+enum class KeaDhcpFamily { V4, V6, Unsupported };
+
+KeaDhcpFamily configured_family() {
+  const auto &hooks = ServerHooks::getServerHooks();
+  const bool has_v4_hooks = hooks.findIndex("pkt4_receive") >= 0;
+  const bool has_v6_hooks = hooks.findIndex("pkt6_receive") >= 0;
+
+  // Each Kea daemon registers only its family-specific packet hook set.
+  if (has_v4_hooks && !has_v6_hooks) {
+    return KeaDhcpFamily::V4;
+  }
+  if (has_v6_hooks && !has_v4_hooks) {
+    return KeaDhcpFamily::V6;
+  }
+  return KeaDhcpFamily::Unsupported;
+}
+
+bool set_string_parameter(LibraryHandle *handle, const char *name,
+                          StringSetter setter) {
+  ConstElementPtr value = handle->getParameter(name);
+  if (!value) {
+    return true;
+  }
+  if (value->getType() != Element::string) {
+    LOG_ERROR(loader_logger, "Invalid type for hook parameter %1").arg(name);
+    return false;
+  }
+
+  setter(value->stringValue().c_str());
+  return true;
+}
+
+bool set_validated_string_parameter(LibraryHandle *handle, const char *name,
+                                    ValidatedStringSetter setter) {
+  ConstElementPtr value = handle->getParameter(name);
+  if (!value) {
+    return true;
+  }
+  if (value->getType() != Element::string) {
+    LOG_ERROR(loader_logger, "Invalid type for hook parameter %1").arg(name);
+    return false;
+  }
+
+  if (!setter(value->stringValue().c_str())) {
+    LOG_ERROR(loader_logger, "Invalid value for hook parameter %1").arg(name);
+    return false;
+  }
+  return true;
+}
+
+bool set_bool_parameter(LibraryHandle *handle, const char *name,
+                        BoolSetter setter) {
+  ConstElementPtr value = handle->getParameter(name);
+  if (!value) {
+    return true;
+  }
+  if (value->getType() != Element::boolean) {
+    LOG_ERROR(loader_logger, "Invalid type for hook parameter %1").arg(name);
+    return false;
+  }
+
+  setter(value->boolValue());
+  return true;
+}
+
+bool configure_common(LibraryHandle *handle) {
+  // Both Kea daemons need the Carbide API and metrics endpoint.
+  return set_string_parameter(handle, "carbide-api-url", carbide_set_config_api) &&
+         set_validated_string_parameter(handle, "carbide-metrics-endpoint",
+                                        carbide_set_config_metrics_endpoint);
+}
+
+bool configure_v4(LibraryHandle *handle) {
+  ConstElementPtr next_server =
+      handle->getParameter("carbide-provisioning-server-ipv4");
+  if (next_server) {
+    if (next_server->getType() != Element::string) {
+      LOG_ERROR(loader_logger, "Invalid type for hook parameter %1")
+          .arg("carbide-provisioning-server-ipv4");
+      return false;
+    }
+    try {
+      auto nextserver_ipv4 =
+          isc::asiolink::IOAddress(next_server->stringValue());
+
+      if (!nextserver_ipv4.isV4()) {
+        LOG_ERROR(loader_logger, isc::log::LOG_CARBIDE_INVALID_NEXTSERVER_IPV4)
+            .arg("");
+        return false;
+      }
+      carbide_set_config_next_server_ipv4(nextserver_ipv4.toUint32());
+    } catch (const isc::asiolink::IOError &e) {
+      LOG_ERROR(loader_logger, isc::log::LOG_CARBIDE_INVALID_NEXTSERVER_IPV4)
+          .arg(e.getMessage());
+      return false;
+    }
+  }
+
+  // Existing DHCPv4 params keep their carbide-* names for compatibility.
+  if (!set_string_parameter(handle, "carbide-ntpserver", carbide_set_config_ntp) ||
+      !set_string_parameter(handle, "carbide-nameservers",
+                            carbide_set_config_name_servers) ||
+      !set_string_parameter(handle, "carbide-mqtt-server",
+                            carbide_set_config_mqtt_server)) {
+    return false;
+  }
+
+  handle->registerCallout("pkt4_receive", pkt4_receive);
+  // lease4_select fires between pkt4_receive and pkt4_send, and is the
+  // only place where we can override the IP that Kea will persist into
+  // its lease memfile.
+  handle->registerCallout("lease4_select", lease4_select);
+  // lease4_renew is the renewal-time side of lease4_select.
+  handle->registerCallout("lease4_renew", lease4_renew);
+  handle->registerCallout("pkt4_send", pkt4_send);
+  handle->registerCallout("lease4_expire", lease4_expire);
+  return true;
+}
+
+bool configure_v6(LibraryHandle *handle) {
+  // New DHCPv6 hook params intentionally use hook-* names.
+  if (!set_validated_string_parameter(handle, "hook-dns-servers-ipv6",
+                                      hook_set_config_dns_servers_ipv6) ||
+      !set_validated_string_parameter(handle, "hook-ntp-servers-ipv6",
+                                      hook_set_config_ntp_servers_ipv6) ||
+      !set_validated_string_parameter(
+          handle, "hook-provisioning-server-ipv6",
+          hook_set_config_provisioning_server_ipv6) ||
+      !set_bool_parameter(handle, "hook-rapid-commit-v6",
+                          hook_set_config_rapid_commit_v6)) {
+    return false;
+  }
+
+  handle->registerCallout("pkt6_receive", pkt6_receive);
+  handle->registerCallout("lease6_select", lease6_select);
+  handle->registerCallout("lease6_renew", lease6_renew);
+  handle->registerCallout("lease6_rebind", lease6_rebind);
+  handle->registerCallout("pkt6_send", pkt6_send);
+  handle->registerCallout("lease6_expire", lease6_expire);
+  return true;
+}
+
 extern "C" {
-	int shim_version() {
-		return KEA_HOOKS_VERSION;
-	}
+int shim_version() {
+  return KEA_HOOKS_VERSION;
+}
 
-	int shim_load(void *handle_ptr) {
-		if (!handle_ptr) {
-			LOG_INFO(loader_logger, isc::log::LOG_CARBIDE_INVALID_HANDLE);
-			return 1;
-		}
+int shim_load(void *handle_ptr) {
+  if (!handle_ptr) {
+    LOG_INFO(loader_logger, isc::log::LOG_CARBIDE_INVALID_HANDLE);
+    return 1;
+  }
 
-		LibraryHandle *handle = static_cast<LibraryHandle *>(handle_ptr);
+  LibraryHandle *handle = static_cast<LibraryHandle *>(handle_ptr);
 
-		LOG_INFO(loader_logger, isc::log::LOG_CARBIDE_INITIALIZATION);
+  LOG_INFO(loader_logger, isc::log::LOG_CARBIDE_INITIALIZATION);
 
-		ConstElementPtr next_server  = handle->getParameter("carbide-provisioning-server-ipv4");
-		if (next_server) {
-			if(next_server->getType() != Element::string) {
-				// TODO(ajf): handle invalid data here
-				return (1);
-			} else {
-				try {
-					auto nextserver_ipv4 = isc::asiolink::IOAddress(next_server->stringValue());
+  auto family = configured_family();
+  // Family-specific validation must happen before common metrics startup,
+  // because the metrics thread is process-lifetime once started.
+  if (family == KeaDhcpFamily::V4) {
+    if (!configure_v4(handle)) {
+      return 1;
+    }
+  } else if (family == KeaDhcpFamily::V6) {
+    if (!configure_v6(handle)) {
+      return 1;
+    }
+  } else {
+    LOG_ERROR(loader_logger, "Unsupported Kea DHCP hook set");
+    return 1;
+  }
 
-					if (nextserver_ipv4.isV4()) {
-						carbide_set_config_next_server_ipv4(nextserver_ipv4.toUint32());
-					} else {
-						LOG_ERROR(loader_logger, isc::log::LOG_CARBIDE_INVALID_NEXTSERVER_IPV4).arg("");
-						return 1;
-					}
+  // TODO(ajf): add config options for mutual TLS authentication to the API
+  if (!configure_common(handle)) {
+    return 1;
+  }
 
-				} catch(const isc::asiolink::IOError &e) {
-					LOG_ERROR(loader_logger, isc::log::LOG_CARBIDE_INVALID_NEXTSERVER_IPV4).arg(e.getMessage());
-					return 1;
-				}
-			}
-		}
+  return 0;
+}
 
-		// TODO(ajf): add config options for mutual TLS authentication to the API
+int shim_unload() {
+  return 0;
+}
 
-		ConstElementPtr api_endpoint = handle->getParameter("carbide-api-url");
-		if (api_endpoint) {
-			if(api_endpoint->getType() != Element::string) {
-				// TODO: handle invalid data type for carbide-api-url
-				return (1);
-			} else {
-				// TODO: proper logging
-				carbide_set_config_api(api_endpoint->stringValue().c_str());
-			}
-		}
-
-        ConstElementPtr ntpservers = handle->getParameter("carbide-ntpserver");
-        if (ntpservers) {
-            if(ntpservers->getType() != Element::string) {
-                // TODO: handle invalid data type for ntpserver
-                return (1);
-            } else {
-                // TODO: proper logging
-                carbide_set_config_ntp(ntpservers->stringValue().c_str());
-            }
-        }
-
-        ConstElementPtr nameservers = handle->getParameter("carbide-nameservers");
-        if (nameservers) {
-            if(nameservers->getType() != Element::string) {
-                // TODO: handle invalid data type for nameservers
-                return (1);
-            } else {
-                // TODO: proper logging
-                carbide_set_config_name_servers(nameservers->stringValue().c_str());
-            }
-        }
-
-        ConstElementPtr mqtt_server = handle->getParameter("carbide-mqtt-server");
-        if (mqtt_server) {
-            if(mqtt_server->getType() != Element::string) {
-                // TODO: handle invalid data type for mqtt_server.
-                return (1);
-            } else {
-                // TODO: proper logging
-                carbide_set_config_mqtt_server(mqtt_server->stringValue().c_str());
-            }
-        }
-
-        ConstElementPtr metrics_endpoint = handle->getParameter("carbide-metrics-endpoint");
-        if (metrics_endpoint) {
-            if(metrics_endpoint->getType() != Element::string) {
-                // TODO: handle invalid data type for carbide-metrics-endpoint
-                return (1);
-            } else {
-                // TODO: proper logging
-                carbide_set_config_metrics_endpoint(metrics_endpoint->stringValue().c_str());
-            }
-        }
-
-		handle->registerCallout("pkt4_receive", pkt4_receive);
-		// lease4_select fires between pkt4_receive and pkt4_send, and is the
-		// only place where we can override the IP that Kea will persist into
-		// its lease memfile. The pkt4_send hook still runs and still sets
-		// yiaddr/options on the outgoing packet, but lease4_select is what
-		// keeps the Kea memfile aligned with the NICo database regardless of
-		// what address the client requested (option 50 / ciaddr), because
-        // just because the client requested it doesn't mean that's what
-        // they're going to get, and that's ok.
-		handle->registerCallout("lease4_select", lease4_select);
-		// lease4_renew is the renewal-time side of lease4_select.
-		// Together they keep the Kea memfile aligned with the NICo
-		// database through both initial allocation and renewal.
-		handle->registerCallout("lease4_renew", lease4_renew);
-		handle->registerCallout("pkt4_send", pkt4_send);
-		handle->registerCallout("lease4_expire", lease4_expire);
-		handle->registerCallout("lease6_expire", lease6_expire);
-
-		return 0;
-	}
-
-	int shim_unload() {
-		return 0;
-	}
-
-	int shim_multi_threading_compatible() {
-		return (1);
-	}
+int shim_multi_threading_compatible() {
+  return (1);
+}
 }

--- a/crates/dhcp/src/lease_expiration.rs
+++ b/crates/dhcp/src/lease_expiration.rs
@@ -28,8 +28,9 @@ use crate::{CONFIG, CarbideDhcpContext, tls};
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LeaseExpirationResult {
     Success = 0,
-    InvalidAddress = 1,
-    ApiError = 2,
+    FeatureDisabled = 1,
+    InvalidAddress = 2,
+    ApiError = 3,
 }
 
 /// Called from the C++ lease4_expire / lease6_expire callouts to release
@@ -104,6 +105,7 @@ fn expire_lease_at(
                 }
                 rpc::ExpireDhcpLeaseStatus::FeatureDisabled => {
                     log::info!("Feature is disabled at NICo");
+                    return LeaseExpirationResult::FeatureDisabled;
                 }
             }
             LeaseExpirationResult::Success

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -14,14 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+//! Kea DHCP hook library for Carbide.
+//!
+//! Example Kea configurations live in `examples/kea-dhcp4-carbide.conf` and
+//! `examples/kea-dhcp6-carbide.conf`.
+
 use std::ffi::CStr;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::AtomicI64;
 use std::sync::{Arc, RwLock};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use forge_tls::default as tls_default;
 use libc::c_char;
+use mac_address::MacAddress;
 use metrics_endpoint::HealthController;
 use once_cell::sync::Lazy;
 use rpc::forge_tls_client::ForgeClientConfig;
@@ -29,10 +36,12 @@ use tokio::runtime::{Builder, Runtime};
 
 mod cache;
 mod discovery;
+mod discovery_v6;
 mod kea;
 mod kea_logger;
 mod lease_expiration;
 mod machine;
+mod machine_v6;
 mod vendor_class;
 
 // Should be #[cfg(test)] but tests/integration_test.rs also uses it
@@ -49,9 +58,13 @@ static LOGGER: kea_logger::KeaLogger = kea_logger::KeaLogger;
 pub struct CarbideDhcpContext {
     api_endpoint: String,
     nameservers: Vec<Ipv4Addr>,
+    dns_servers_ipv6: Vec<Ipv6Addr>,
     mqtt_server: Option<String>,
     ntpservers: Vec<Ipv4Addr>,
+    ntp_servers_ipv6: Vec<Ipv6Addr>,
     provisioning_server_ipv4: Option<Ipv4Addr>,
+    provisioning_server_ipv6: Option<Ipv6Addr>,
+    rapid_commit_v6: bool,
     forge_root_ca_path: String,
     forge_client_cert_path: String,
     forge_client_key_path: String,
@@ -70,11 +83,28 @@ pub struct CarbideDhcpMetrics {
     certificate_expiration_value: Arc<AtomicI64>,
 }
 
+const METRICS_INIT_TIMEOUT: Duration = Duration::from_secs(5);
+const METRICS_INIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+fn wait_for_metrics_initialization() -> bool {
+    let deadline = Instant::now() + METRICS_INIT_TIMEOUT;
+    loop {
+        if CONFIG.read().unwrap().metrics.is_some() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(METRICS_INIT_POLL_INTERVAL);
+    }
+}
+
 impl Default for CarbideDhcpContext {
     fn default() -> Self {
         Self {
             api_endpoint: "https://[::1]:1079".to_string(),
             nameservers: vec![Ipv4Addr::new(1, 1, 1, 1)],
+            dns_servers_ipv6: Vec::new(),
             forge_root_ca_path: std::env::var("FORGE_ROOT_CAFILE_PATH")
                 .unwrap_or_else(|_| tls_default::ROOT_CA.to_string()),
             forge_client_cert_path: std::env::var("FORGE_CLIENT_CERT_PATH")
@@ -86,8 +116,11 @@ impl Default for CarbideDhcpContext {
                 Ipv4Addr::new(172, 20, 0, 26),
                 Ipv4Addr::new(172, 20, 0, 27),
             ], // local ntp servers
+            ntp_servers_ipv6: Vec::new(),
             mqtt_server: None,
             provisioning_server_ipv4: None,
+            provisioning_server_ipv6: None,
+            rapid_commit_v6: false,
             metrics_endpoint: None,
             metrics: None,
             health_controller: None,
@@ -113,17 +146,23 @@ pub(crate) fn format_ipv4_list(addresses: &[Ipv4Addr]) -> String {
         .join(",")
 }
 
+/// Parse a comma-separated list of IPv6 addresses from hook configuration.
+pub(crate) fn parse_ipv6_list(addresses: &str) -> Result<Vec<Ipv6Addr>, std::net::AddrParseError> {
+    addresses
+        .split(',')
+        .map(str::trim)
+        .filter(|address| !address.is_empty())
+        .map(str::parse)
+        .collect()
+}
+
 impl CarbideDhcpContext {
     pub fn get_tokio_runtime() -> &'static Runtime {
         static TOKIO: Lazy<Runtime> = Lazy::new(|| {
-            let runtime = Builder::new_current_thread()
+            Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .expect("unable to build runtime?");
-
-            thread::spawn(metrics::metrics_server);
-
-            runtime
+                .expect("unable to build runtime?")
         });
 
         &TOKIO
@@ -205,24 +244,155 @@ pub unsafe extern "C" fn carbide_set_config_ntp(ntpservers: *const c_char) {
     }
 }
 
-/// Take the config parameter from Kea and configure it as our metrics endpoint
+/// Return a UTF-8 hook parameter string from a C pointer.
+///
+/// # Safety
+/// `value` must be null only for invalid input, or point to a valid null-terminated C string.
+unsafe fn hook_parameter_string(value: *const c_char, name: &str) -> Option<String> {
+    if value.is_null() {
+        log::error!("missing value for hook parameter {name}");
+        return None;
+    }
+
+    match unsafe { CStr::from_ptr(value) }.to_str() {
+        Ok(value) => Some(value.to_owned()),
+        Err(err) => {
+            log::error!("failed to parse hook parameter {name} as UTF-8: {err}");
+            None
+        }
+    }
+}
+
+/// Take IPv6 DNS servers for DHCPv6 option rendering.
+///
+/// # Safety
+/// Function is unsafe as it dereferences a raw pointer given to it. Caller is responsible
+/// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hook_set_config_dns_servers_ipv6(servers: *const c_char) -> bool {
+    unsafe {
+        let Some(servers_str) = hook_parameter_string(servers, "hook-dns-servers-ipv6") else {
+            return false;
+        };
+        match parse_ipv6_list(&servers_str) {
+            Ok(servers) => {
+                CONFIG.write().unwrap().dns_servers_ipv6 = servers;
+                true
+            }
+            Err(err) => {
+                log::error!("failed to parse DHCPv6 DNS server configuration {servers_str}: {err}");
+                false
+            }
+        }
+    }
+}
+
+/// Take IPv6 NTP servers for DHCPv6 option rendering.
+///
+/// # Safety
+/// Function is unsafe as it dereferences a raw pointer given to it. Caller is responsible
+/// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hook_set_config_ntp_servers_ipv6(servers: *const c_char) -> bool {
+    unsafe {
+        let Some(servers_str) = hook_parameter_string(servers, "hook-ntp-servers-ipv6") else {
+            return false;
+        };
+        match parse_ipv6_list(&servers_str) {
+            Ok(servers) => {
+                CONFIG.write().unwrap().ntp_servers_ipv6 = servers;
+                true
+            }
+            Err(err) => {
+                log::error!("failed to parse DHCPv6 NTP server configuration {servers_str}: {err}");
+                false
+            }
+        }
+    }
+}
+
+/// Take the optional IPv6 provisioning-server address reserved for future DHCPv6 boot options.
+///
+/// # Safety
+/// Function is unsafe as it dereferences a raw pointer given to it. Caller is responsible
+/// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn hook_set_config_provisioning_server_ipv6(
+    provisioning_server: *const c_char,
+) -> bool {
+    unsafe {
+        let Some(provisioning_server_str) =
+            hook_parameter_string(provisioning_server, "hook-provisioning-server-ipv6")
+        else {
+            return false;
+        };
+        if provisioning_server_str.trim().is_empty() {
+            CONFIG.write().unwrap().provisioning_server_ipv6 = None;
+            return true;
+        }
+
+        match provisioning_server_str.parse::<Ipv6Addr>() {
+            Ok(provisioning_server) => {
+                CONFIG.write().unwrap().provisioning_server_ipv6 = Some(provisioning_server);
+                true
+            }
+            Err(err) => {
+                log::error!(
+                    "failed to parse DHCPv6 provisioning-server configuration {provisioning_server_str}: {err}"
+                );
+                false
+            }
+        }
+    }
+}
+
+/// Set whether DHCPv6 rapid-commit rendering is enabled.
+///
+/// Rapid commit stays disabled by default for this milestone; the setter is
+/// present so the Kea parameter is validated and ready for the later gate.
+#[unsafe(no_mangle)]
+pub extern "C" fn hook_set_config_rapid_commit_v6(enabled: bool) {
+    if enabled {
+        log::warn!("DHCPv6 rapid-commit is configured but remains disabled for this milestone");
+    }
+    CONFIG.write().unwrap().rapid_commit_v6 = false;
+}
+
+/// Take the config parameter from Kea and configure it as our metrics endpoint.
+///
+/// Returns false when the endpoint cannot be parsed, allowing Kea load to fail
+/// before the process-lifetime metrics server starts.
 ///
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible
 /// to validate that the pointer passed to it meets the necessary conditions to be dereferenced.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn carbide_set_config_metrics_endpoint(endpoint: *const c_char) {
+pub unsafe extern "C" fn carbide_set_config_metrics_endpoint(endpoint: *const c_char) -> bool {
     unsafe {
-        let config_metrics_endpoint = CStr::from_ptr(endpoint).to_str().unwrap().to_owned();
+        let Some(config_metrics_endpoint) =
+            hook_parameter_string(endpoint, "carbide-metrics-endpoint")
+        else {
+            return false;
+        };
         match config_metrics_endpoint.parse::<SocketAddr>() {
             Ok(metrics_endpoint) => {
+                // Store the endpoint before starting the process-lifetime metrics server.
                 log::info!("metrics endpoint: {config_metrics_endpoint}");
                 CONFIG.write().unwrap().metrics_endpoint = Some(metrics_endpoint);
-                // this will initiate metrics server
-                CarbideDhcpContext::get_tokio_runtime();
+                static METRICS_SERVER: Lazy<()> = Lazy::new(|| {
+                    let _ = thread::spawn(metrics::metrics_server);
+                });
+                Lazy::force(&METRICS_SERVER);
+                if !wait_for_metrics_initialization() {
+                    log::warn!(
+                        "metrics endpoint configured but metrics did not initialize within {METRICS_INIT_TIMEOUT:?}"
+                    );
+                }
+                true
             }
             Err(err) => {
                 log::error!("failed to parse metrics endpoint {config_metrics_endpoint} : {err}");
+                false
             }
         }
     }
@@ -271,11 +441,119 @@ pub extern "C" fn carbide_increment_reply_sent(message_type: u8) {
     metrics::increment_reply_sent(metrics::ReplyMessageType::from(message_type));
 }
 
+/// Increments counter for number of DHCPv6 replies sent, labelled by the
+/// response's message type. `message_type` is the raw DHCPv6 message-type code
+/// from the response packet (`Pkt6::getType()`); the mapping onto the bounded
+/// label lives in [`metrics::V6ReplyMessageType`].
+///
+/// # Safety
+///
+/// None
+#[unsafe(no_mangle)]
+pub extern "C" fn carbide_increment_v6_reply_sent(message_type: u8) {
+    metrics::increment_v6_reply_sent(metrics::V6ReplyMessageType::from(message_type));
+}
+
+/// Increments counter for number of dropped DHCPv6 requests.
+///
+/// # Safety
+///
+/// None
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_increment_dropped_v6_requests(reason: *const c_char) {
+    let reason = if reason.is_null() {
+        metrics::V6DropReason::Unknown
+    } else {
+        unsafe { CStr::from_ptr(reason) }
+            .to_str()
+            .map_or(metrics::V6DropReason::Unknown, metrics::V6DropReason::from)
+    };
+    metrics::increment_dropped_v6_requests(reason);
+}
+
+/// Invalidates DHCPv6 lease-cache entries for an expired lease.
+///
+/// # Safety
+///
+/// `ip_address` and `mac_address` must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_invalidate_v6_lease_cache(
+    ip_address: *const c_char,
+    mac_address: *const c_char,
+) -> usize {
+    if ip_address.is_null() || mac_address.is_null() {
+        return 0;
+    }
+
+    let Ok(ip_address) = unsafe { CStr::from_ptr(ip_address) }.to_str() else {
+        return 0;
+    };
+    let Ok(mac_address) = unsafe { CStr::from_ptr(mac_address) }.to_str() else {
+        return 0;
+    };
+    match (
+        ip_address.parse::<Ipv6Addr>(),
+        mac_address.parse::<MacAddress>(),
+    ) {
+        (Ok(ip_address), Ok(mac_address)) => cache::invalidate_v6_lease(ip_address, mac_address),
+        (ip_result, mac_result) => {
+            log::warn!(
+                "Unable to invalidate DHCPv6 lease cache for expired lease: ip={ip_address} ip_error={:?} mac={mac_address} mac_error={:?}",
+                ip_result.err(),
+                mac_result.err()
+            );
+            0
+        }
+    }
+}
+
+/// Clears the recent-expiry DHCPv6 lease cache tombstone for a lease.
+///
+/// # Safety
+///
+/// `ip_address` and `mac_address` must be valid null-terminated C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_clear_v6_lease_cache_invalidation(
+    ip_address: *const c_char,
+    mac_address: *const c_char,
+) -> bool {
+    if ip_address.is_null() || mac_address.is_null() {
+        return false;
+    }
+
+    let Ok(ip_address) = unsafe { CStr::from_ptr(ip_address) }.to_str() else {
+        return false;
+    };
+    let Ok(mac_address) = unsafe { CStr::from_ptr(mac_address) }.to_str() else {
+        return false;
+    };
+    match (
+        ip_address.parse::<Ipv6Addr>(),
+        mac_address.parse::<MacAddress>(),
+    ) {
+        (Ok(ip_address), Ok(mac_address)) => {
+            cache::clear_v6_lease_invalidation(ip_address, mac_address)
+        }
+        (ip_result, mac_result) => {
+            log::warn!(
+                "Unable to clear DHCPv6 lease cache invalidation: ip={ip_address} ip_error={:?} mac={mac_address} mac_error={:?}",
+                ip_result.err(),
+                mac_result.err()
+            );
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::ffi::CString;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
-    use super::{format_ipv4_list, parse_ipv4_list};
+    use super::{
+        format_ipv4_list, hook_set_config_dns_servers_ipv6, hook_set_config_ntp_servers_ipv6,
+        hook_set_config_provisioning_server_ipv6, parse_ipv4_list, parse_ipv6_list,
+    };
 
     #[test]
     fn parses_comma_separated_ipv4_list() {
@@ -315,5 +593,36 @@ mod tests {
         let addresses = [Ipv4Addr::new(1, 1, 1, 1), Ipv4Addr::new(8, 8, 8, 8)];
 
         assert_eq!(format_ipv4_list(&addresses), "1.1.1.1,8.8.8.8");
+    }
+
+    #[test]
+    fn parses_comma_separated_ipv6_list() {
+        let addresses = parse_ipv6_list("2001:db8::1, 2001:db8::2").unwrap();
+
+        assert_eq!(
+            addresses,
+            vec![
+                "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+                "2001:db8::2".parse::<Ipv6Addr>().unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_non_ipv6_list_entries() {
+        assert!(parse_ipv6_list("2001:db8::1,1.1.1.1").is_err());
+        assert!(parse_ipv6_list("2001:db8::1,not-an-ip").is_err());
+    }
+
+    #[test]
+    fn v6_hook_setters_report_invalid_addresses() {
+        let invalid_list = CString::new("2001:db8::1,not-an-ip").unwrap();
+        let invalid_address = CString::new("not-an-ip").unwrap();
+
+        // Invalid present hook values must fail Kea load instead of leaving
+        // missing or stale DHCPv6 option state behind.
+        assert!(!unsafe { hook_set_config_dns_servers_ipv6(invalid_list.as_ptr()) });
+        assert!(!unsafe { hook_set_config_ntp_servers_ipv6(invalid_list.as_ptr()) });
+        assert!(!unsafe { hook_set_config_provisioning_server_ipv6(invalid_address.as_ptr()) });
     }
 }

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use std::ffi::CString;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ptr;
 
 use ::rpc::forge as rpc;
@@ -23,9 +23,40 @@ use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
 use MachineArchitecture::*;
 use ipnetwork::IpNetwork;
 
-use crate::CONFIG;
 use crate::discovery::Discovery;
 use crate::vendor_class::{MachineArchitecture, VendorClass};
+use crate::{CONFIG, cache};
+
+/// Rust-owned byte buffer returned across the C ABI for DHCP option payloads.
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct DhcpByteBuffer {
+    pub ptr: *mut u8,
+    pub len: usize,
+}
+
+impl DhcpByteBuffer {
+    /// Return an empty buffer for omitted DHCPv6 options.
+    fn empty() -> Self {
+        Self {
+            ptr: ptr::null_mut(),
+            len: 0,
+        }
+    }
+
+    /// Move option payload bytes into an FFI-safe buffer owned by Rust.
+    fn from_vec(bytes: Vec<u8>) -> Self {
+        if bytes.is_empty() {
+            return Self::empty();
+        }
+
+        let mut bytes = bytes.into_boxed_slice();
+        let ptr = bytes.as_mut_ptr();
+        let len = bytes.len();
+        std::mem::forget(bytes);
+        Self { ptr, len }
+    }
+}
 
 /// Machine: a machine that's currently trying to boot something
 ///
@@ -154,6 +185,41 @@ pub extern "C" fn machine_get_interface_address(ctx: *mut Machine) -> u32 {
     0
 }
 
+/// Write the machine's assigned IPv6 address into a caller-provided 16-byte buffer.
+///
+/// Returns false when Carbide did not return a parseable IPv6 address.
+///
+/// # Safety
+/// This function dereferences a pointer to a Machine object and writes to `addr_out`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn machine_get_interface_address_ipv6(
+    ctx: *mut Machine,
+    addr_out: *mut u8,
+    addr_out_len: usize,
+) -> bool {
+    if ctx.is_null() || addr_out.is_null() || addr_out_len != 16 {
+        return false;
+    }
+
+    let machine = unsafe { &mut *ctx };
+    match machine.inner.address.parse::<IpAddr>() {
+        Ok(IpAddr::V6(address)) => {
+            unsafe {
+                std::ptr::copy_nonoverlapping(address.octets().as_ptr(), addr_out, 16);
+            }
+            true
+        }
+        Ok(IpAddr::V4(address)) => {
+            log::error!("Address ({address}) is an IPv4 address, which is not supported here.");
+            false
+        }
+        Err(error) => {
+            log::error!("Address value in deserialized protobuf is not an IP address: {error}");
+            false
+        }
+    }
+}
+
 /// Get the machine fqdn
 ///
 /// # Safety
@@ -275,6 +341,87 @@ pub extern "C" fn machine_get_ntpservers(ctx: *mut Machine) -> *mut libc::c_char
     ntpservers.into_raw()
 }
 
+/// Return DHCPv6 option 23 payload bytes for configured DNS servers.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_get_dns_servers_ipv6(ctx: *mut Machine) -> DhcpByteBuffer {
+    assert!(!ctx.is_null());
+
+    let servers = CONFIG.read().unwrap().dns_servers_ipv6.clone();
+    DhcpByteBuffer::from_vec(flatten_ipv6_addresses(&servers))
+}
+
+/// Return DHCPv6 option 56 payload bytes for NTP server suboptions.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_get_ntp_servers_ipv6(ctx: *mut Machine) -> DhcpByteBuffer {
+    assert!(!ctx.is_null());
+
+    // DHCPv6 option 56 is hook-context sourced; DhcpRecord NTP stays v4-only.
+    let servers = CONFIG.read().unwrap().ntp_servers_ipv6.clone();
+    DhcpByteBuffer::from_vec(ntp_server_option_payload(&servers))
+}
+
+/// Return DHCPv6 option 24 payload bytes derived from the machine FQDN.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_get_domain_search_ipv6(ctx: *mut Machine) -> DhcpByteBuffer {
+    assert!(!ctx.is_null());
+
+    let machine = unsafe { &*ctx };
+    match parent_domain(&machine.inner.fqdn).and_then(encode_domain_name) {
+        Some(bytes) => DhcpByteBuffer::from_vec(bytes),
+        None => DhcpByteBuffer::empty(),
+    }
+}
+
+/// Return DHCPv6 option 39 payload bytes derived from the machine FQDN.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_get_client_fqdn_ipv6(ctx: *mut Machine) -> DhcpByteBuffer {
+    assert!(!ctx.is_null());
+
+    let machine = unsafe { &*ctx };
+    match encode_domain_name(&machine.inner.fqdn) {
+        Some(mut bytes) => {
+            // RFC 4704 option 39 starts with a flags byte; C++ replaces this
+            // placeholder with the client request's negotiation flags.
+            bytes.insert(0, 0);
+            DhcpByteBuffer::from_vec(bytes)
+        }
+        None => DhcpByteBuffer::empty(),
+    }
+}
+
+/// Return whether DHCPv6 rapid commit option rendering is enabled.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_get_rapid_commit_v6(ctx: *mut Machine) -> bool {
+    assert!(!ctx.is_null());
+
+    CONFIG.read().unwrap().rapid_commit_v6
+}
+
+/// Write the configured DHCPv6 provisioning-server address into a caller-provided 16-byte buffer.
+///
+/// Returns false when the hook parameter is unset.
+///
+/// # Safety
+/// This function writes to `addr_out` when a provisioning-server address is configured.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn machine_get_provisioning_server_ipv6(
+    addr_out: *mut u8,
+    addr_out_len: usize,
+) -> bool {
+    if addr_out.is_null() || addr_out_len != 16 {
+        return false;
+    }
+
+    let Some(provisioning_server) = CONFIG.read().unwrap().provisioning_server_ipv6 else {
+        return false;
+    };
+
+    unsafe {
+        std::ptr::copy_nonoverlapping(provisioning_server.octets().as_ptr(), addr_out, 16);
+    }
+    true
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_get_mqtt_server(ctx: *mut Machine) -> *mut libc::c_char {
     assert!(!ctx.is_null());
@@ -300,6 +447,30 @@ pub extern "C" fn machine_get_client_type(ctx: *mut Machine) -> *mut libc::c_cha
         Some(vc) => CString::new(vc.id.clone()).unwrap(),
     };
     vendor_class.into_raw()
+}
+
+/// Return the hook-selected discovery MAC associated with this Machine.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_get_discovery_mac(ctx: *mut Machine) -> *mut libc::c_char {
+    if ctx.is_null() {
+        return ptr::null_mut();
+    }
+
+    let machine = unsafe { &mut *ctx };
+    CString::new(machine.discovery_info.mac_address.to_string())
+        .unwrap()
+        .into_raw()
+}
+
+/// Return whether this Machine points at a recently expired DHCPv6 lease.
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_is_invalidated_v6_lease(ctx: *mut Machine) -> bool {
+    if ctx.is_null() {
+        return false;
+    }
+
+    let machine = unsafe { &mut *ctx };
+    cache::machine_matches_invalidated_v6_lease(machine)
 }
 
 /// Get the broadcast address.
@@ -350,6 +521,18 @@ pub extern "C" fn machine_free_client_type(client_type: *mut libc::c_char) {
     };
 }
 
+/// Free a discovery MAC string returned by [`machine_get_discovery_mac`].
+#[unsafe(no_mangle)]
+pub extern "C" fn machine_free_discovery_mac(mac_address: *mut libc::c_char) {
+    unsafe {
+        if mac_address.is_null() {
+            return;
+        }
+
+        drop(CString::from_raw(mac_address))
+    };
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn machine_free_fqdn(fqdn: *mut libc::c_char) {
     unsafe {
@@ -381,6 +564,23 @@ pub extern "C" fn machine_free_ntpservers(ntpservers: *mut libc::c_char) {
 
         drop(CString::from_raw(ntpservers))
     };
+}
+
+/// Free a byte buffer returned by a DHCPv6 option getter.
+///
+/// # Safety
+/// The buffer must have been returned by this crate and not freed before.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn machine_free_dhcp_byte_buffer(buffer: DhcpByteBuffer) {
+    if buffer.ptr.is_null() || buffer.len == 0 {
+        return;
+    }
+
+    unsafe {
+        drop(Box::from_raw(std::ptr::slice_from_raw_parts_mut(
+            buffer.ptr, buffer.len,
+        )));
+    }
 }
 
 /// Invoke the discovery process
@@ -420,6 +620,57 @@ pub extern "C" fn machine_get_interface_mtu(ctx: *mut Machine) -> u16 {
     unsafe { (*ctx).inner.mtu as u16 }
 }
 
+/// Encode a DHCPv6 flat list of IPv6 addresses.
+fn flatten_ipv6_addresses(addresses: &[Ipv6Addr]) -> Vec<u8> {
+    addresses
+        .iter()
+        .flat_map(|address| address.octets())
+        .collect()
+}
+
+/// Encode DHCPv6 option 56 NTP server suboptions.
+fn ntp_server_option_payload(addresses: &[Ipv6Addr]) -> Vec<u8> {
+    addresses
+        .iter()
+        .flat_map(|address| {
+            let mut payload = Vec::with_capacity(20);
+            // RFC 5908 separates unicast server addresses from multicast
+            // addresses even though both payloads are IPv6 addresses.
+            let suboption = if address.is_multicast() { 2u16 } else { 1u16 };
+            payload.extend_from_slice(&suboption.to_be_bytes());
+            payload.extend_from_slice(&16u16.to_be_bytes());
+            payload.extend_from_slice(&address.octets());
+            payload
+        })
+        .collect()
+}
+
+/// Return the parent domain of an FQDN for DHCPv6 domain-search.
+fn parent_domain(fqdn: &str) -> Option<&str> {
+    let fqdn = fqdn.trim_end_matches('.');
+    fqdn.split_once('.').map(|(_, domain)| domain)
+}
+
+/// Encode a DNS name in uncompressed RFC 1035 wire format.
+fn encode_domain_name(name: &str) -> Option<Vec<u8>> {
+    let name = name.trim_end_matches('.');
+    if name.is_empty() {
+        return None;
+    }
+
+    let mut out = Vec::new();
+    for label in name.split('.') {
+        if label.is_empty() || label.len() > 63 {
+            return None;
+        }
+        out.push(label.len() as u8);
+        out.extend_from_slice(label.as_bytes());
+    }
+    out.push(0);
+
+    (out.len() <= 255).then_some(out)
+}
+
 /// Free the Machine object.
 ///
 /// # Safety
@@ -443,14 +694,17 @@ pub extern "C" fn machine_free(ctx: *mut Machine) {
 #[cfg(test)]
 mod test {
     use std::ffi::CString;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
     use std::str::FromStr;
 
     use rpc::forge as rpc;
 
     use crate::carbide_set_config_ntp;
     use crate::discovery::Discovery;
-    use crate::machine::{Machine, machine_get_filename, machine_get_ntpservers};
+    use crate::machine::{
+        Machine, encode_domain_name, flatten_ipv6_addresses, machine_get_filename,
+        machine_get_ntpservers, ntp_server_option_payload, parent_domain,
+    };
     use crate::vendor_class::VendorClass;
 
     #[test]
@@ -576,5 +830,42 @@ mod test {
         let raw = machine_get_ntpservers(&mut *machine);
         let cstr = unsafe { CString::from_raw(raw) };
         assert_eq!(cstr.to_str().unwrap(), "10.0.0.2,10.0.0.3");
+    }
+
+    #[test]
+    fn encodes_ipv6_address_lists_for_dhcp_options() {
+        // DHCPv6 option 23 is a flat sequence of 16-byte IPv6 addresses.
+        let addresses = [
+            "2001:db8::1".parse::<Ipv6Addr>().unwrap(),
+            "2001:db8::2".parse::<Ipv6Addr>().unwrap(),
+        ];
+
+        assert_eq!(flatten_ipv6_addresses(&addresses).len(), 32);
+    }
+
+    #[test]
+    fn encodes_ntp_server_suboptions() {
+        // RFC 5908 option 56 wraps each server address in a suboption TLV.
+        let addresses = [
+            "2001:db8::123".parse::<Ipv6Addr>().unwrap(),
+            "ff05::101".parse::<Ipv6Addr>().unwrap(),
+        ];
+        let payload = ntp_server_option_payload(&addresses);
+
+        assert_eq!(&payload[..4], &[0, 1, 0, 16]);
+        assert_eq!(&payload[4..20], &addresses[0].octets());
+        assert_eq!(&payload[20..24], &[0, 2, 0, 16]);
+        assert_eq!(&payload[24..], &addresses[1].octets());
+    }
+
+    #[test]
+    fn encodes_fqdn_options_as_dns_names() {
+        // Domain-search uses the parent domain while client-fqdn uses the
+        // full hostname domain name.
+        assert_eq!(parent_domain("host.forge.local"), Some("forge.local"));
+        assert_eq!(
+            encode_domain_name("forge.local").unwrap(),
+            b"\x05forge\x05local\0".to_vec()
+        );
     }
 }

--- a/crates/dhcp/src/machine_v6.rs
+++ b/crates/dhcp/src/machine_v6.rs
@@ -1,0 +1,612 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use ::rpc::forge as rpc;
+use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
+use dhcproto::v6::MessageType;
+use ipnetwork::IpNetwork;
+
+use crate::discovery::Discovery;
+use crate::discovery_v6::{
+    RelayContext, V6DecodeError, V6Discovery, decode_with_relay_context, message_kind_for,
+};
+use crate::machine::Machine;
+use crate::metrics::set_service_healthy;
+use crate::{CONFIG, CarbideDhcpContext, cache, tls};
+
+/// Result values returned to the C++ DHCPv6 hook callouts.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum V6HookResult {
+    Success = 0,
+    Ignore = 1,
+    ConfirmNotOnLink = 2,
+    InvalidPacket = 3,
+    NestedRelay = 4,
+    NoMacNoOption79 = 5,
+    UnsupportedDuid = 6,
+    UnsupportedMessage = 7,
+    InvalidMachinePointer = 8,
+    FetchMachineError = 9,
+    TooManyFailuresError = 10,
+}
+
+/// Return a stable C string for a DHCPv6 hook result.
+#[unsafe(no_mangle)]
+pub extern "C" fn carbide_v6_hook_result_as_str(result: V6HookResult) -> *const libc::c_char {
+    // If you add a variant here, keep the string null-terminated for C.
+    match result {
+        V6HookResult::Success => "success\0",
+        V6HookResult::Ignore => "ignore\0",
+        V6HookResult::ConfirmNotOnLink => "confirm_not_on_link\0",
+        V6HookResult::InvalidPacket => "invalid_packet\0",
+        V6HookResult::NestedRelay => "nested_relay\0",
+        V6HookResult::NoMacNoOption79 => "no_mac_no_option79\0",
+        V6HookResult::UnsupportedDuid => "unsupported_duid\0",
+        V6HookResult::UnsupportedMessage => "unsupported_message\0",
+        V6HookResult::InvalidMachinePointer => "invalid_machine_pointer\0",
+        V6HookResult::FetchMachineError => "fetch_machine_error\0",
+        V6HookResult::TooManyFailuresError => "too_many_failures_error\0",
+    }
+    .as_ptr()
+    .cast()
+}
+
+/// Build the Carbide DHCP discovery request for a decoded DHCPv6 packet.
+pub fn build_discovery(v6: &V6Discovery) -> rpc::DhcpDiscovery {
+    rpc::DhcpDiscovery {
+        mac_address: v6.selected_mac.to_string(),
+        relay_address: v6
+            .relay_link
+            .map(|addr| addr.to_string())
+            .unwrap_or_default(),
+        vendor_string: v6.vendor_class.clone(),
+        link_address: v6.relay_link.map(|addr| addr.to_string()),
+        circuit_id: v6.interface_id.as_deref().map(hex_encode),
+        remote_id: v6.remote_id.as_deref().map(hex_encode),
+        desired_address: v6.desired_addr.map(|addr| addr.to_string()),
+        address_family: Some(rpc::AddressFamily::V6 as i32),
+        message_kind: message_kind_for(v6.message_type, v6.has_ia_na).map(|kind| kind as i32),
+        duid: Some(v6.duid.clone()),
+    }
+}
+
+impl Machine {
+    /// Fetch a DHCPv6 machine record from Carbide using the decoded v6 discovery.
+    pub async fn try_fetch_v6(
+        discovery: V6Discovery,
+        carbide_api_url: &str,
+        client_config: &ForgeClientConfig,
+    ) -> Result<Self, String> {
+        let api_config = ApiConfig::new(carbide_api_url, client_config);
+        match forge_tls_client::ForgeTlsClient::retry_build(&api_config).await {
+            Ok(mut client) => {
+                let request = tonic::Request::new(build_discovery(&discovery));
+                client
+                    .discover_dhcp(request)
+                    .await
+                    .map(|response| Machine {
+                        inner: response.into_inner(),
+                        // Machine is shared with the DHCPv4 path and still
+                        // stores the legacy Discovery shape for option/cache
+                        // helpers; the RPC above carries the v6-only fields.
+                        discovery_info: legacy_discovery(&discovery),
+                        vendor_class: None,
+                    })
+                    .map_err(|error| {
+                        format!("unable to discover DHCPv6 machine via Carbide: {error:?}")
+                    })
+            }
+            Err(err) => Err(format!("unable to connect to Carbide API: {err:?}")),
+        }
+    }
+}
+
+/// Build the legacy IPv4-shaped discovery snapshot kept on Machine handles.
+fn legacy_discovery(discovery: &V6Discovery) -> Discovery {
+    Discovery {
+        relay_address: Ipv4Addr::UNSPECIFIED,
+        mac_address: discovery.selected_mac,
+        _client_system: None,
+        vendor_class: discovery.vendor_class.clone(),
+        link_select_address: None,
+        circuit_id: discovery.interface_id.as_deref().map(hex_encode),
+        remote_id: discovery.remote_id.as_deref().map(hex_encode),
+        desired_address: None,
+    }
+}
+
+/// Encode opaque relay identifiers as lower-case hexadecimal strings.
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Decode a DHCPv6 packet, call Carbide when appropriate, and return a Machine handle.
+///
+/// # Safety
+///
+/// All pointer/length pairs must either be null with length 0 or point to valid readable memory
+/// for the given length. `machine_ptr_out` must point to writable memory for a `Machine *`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn carbide_pkt6_receive(
+    packet_ptr: *const u8,
+    packet_len: usize,
+    relay_count: usize,
+    relay_hop_count: u8,
+    relay_link_ptr: *const u8,
+    relay_link_len: usize,
+    interface_id_ptr: *const u8,
+    interface_id_len: usize,
+    remote_id_ptr: *const u8,
+    remote_id_len: usize,
+    client_link_layer_ptr: *const u8,
+    client_link_layer_len: usize,
+    machine_ptr_out: *mut *mut Machine,
+) -> V6HookResult {
+    unsafe {
+        if machine_ptr_out.is_null() {
+            return V6HookResult::InvalidMachinePointer;
+        }
+        *machine_ptr_out = std::ptr::null_mut();
+
+        let packet = match slice_from_ffi(packet_ptr, packet_len) {
+            Some(packet) => packet,
+            None => return V6HookResult::InvalidPacket,
+        };
+        let relay_context = match relay_context_from_ffi(
+            relay_count,
+            relay_hop_count,
+            relay_link_ptr,
+            relay_link_len,
+            interface_id_ptr,
+            interface_id_len,
+            remote_id_ptr,
+            remote_id_len,
+            client_link_layer_ptr,
+            client_link_layer_len,
+        ) {
+            Some(context) => context,
+            None => return V6HookResult::InvalidPacket,
+        };
+        if relay_context.relay_count == 0 {
+            log::warn!("dropping non-relayed DHCPv6 packet");
+            return V6HookResult::InvalidPacket;
+        }
+
+        let discovery_result = decode_with_relay_context(packet, &relay_context);
+        let discovery = match discovery_result {
+            Ok(discovery) => discovery,
+            Err(err) => {
+                log_v6_decode_error(&err, relay_context.link_address);
+                return decode_error_to_result(err);
+            }
+        };
+
+        match discovery.message_type {
+            // RELEASE/DECLINE are receive-side validation only. Kea owns the
+            // immediate reply, and Carbide/API synchronization happens, if
+            // enabled, through lease-end hooks instead of discovery.
+            MessageType::Release | MessageType::Decline => V6HookResult::Ignore,
+            MessageType::Confirm => fetch_machine_from_cache(&discovery, machine_ptr_out)
+                .unwrap_or(V6HookResult::ConfirmNotOnLink),
+            _ => fetch_machine(discovery, machine_ptr_out),
+        }
+    }
+}
+
+/// Emit a focused log message for DHCPv6 decode failures.
+fn log_v6_decode_error(err: &V6DecodeError, relay_link: Option<Ipv6Addr>) {
+    match err {
+        V6DecodeError::RelayHopCountExceeded(hop_count) => {
+            log::warn!("dropping DHCPv6 relay packet with unsupported hop_count={hop_count}");
+        }
+        V6DecodeError::NestedRelay => {
+            log::warn!("dropping nested DHCPv6 relay packet");
+        }
+        V6DecodeError::NoMacNoOption79 => match relay_link {
+            Some(relay_link) => log::warn!(
+                "dropping DHCPv6 packet from relay {relay_link} with non-MAC DUID and no RFC 6939 option 79"
+            ),
+            None => log::warn!(
+                "dropping DHCPv6 packet with non-MAC DUID and no RFC 6939 option 79; relay unknown"
+            ),
+        },
+        V6DecodeError::UnsupportedDuid => {
+            log::warn!("dropping DHCPv6 packet with malformed or unsupported DUID");
+        }
+        other => {
+            log::debug!("dropping unsupported DHCPv6 packet: {other:?}");
+        }
+    }
+}
+
+/// Translate a decode error into the FFI result understood by C++ callouts.
+fn decode_error_to_result(err: V6DecodeError) -> V6HookResult {
+    match err {
+        V6DecodeError::NestedRelay | V6DecodeError::RelayHopCountExceeded(_) => {
+            V6HookResult::NestedRelay
+        }
+        V6DecodeError::NoMacNoOption79 => V6HookResult::NoMacNoOption79,
+        V6DecodeError::UnsupportedDuid | V6DecodeError::MissingDuid => {
+            V6HookResult::UnsupportedDuid
+        }
+        V6DecodeError::UnsupportedMessage(_) => V6HookResult::UnsupportedMessage,
+        V6DecodeError::MalformedPacket => V6HookResult::InvalidPacket,
+    }
+}
+
+/// Return a cached DHCPv6 Machine for CONFIRM when the segment still matches.
+fn fetch_machine_from_cache(
+    discovery: &V6Discovery,
+    machine_ptr_out: *mut *mut Machine,
+) -> Option<V6HookResult> {
+    let link_address = IpAddr::V6(discovery.relay_link.unwrap_or(Ipv6Addr::UNSPECIFIED));
+    let circuit_id = discovery.interface_id.as_deref().map(hex_encode);
+    let remote_id = discovery.remote_id.as_deref().map(hex_encode);
+    let vendor_id = discovery.vendor_class.as_deref().unwrap_or("");
+
+    // Prefer the exact cache key when CONFIRM repeats the original vendor
+    // class from SOLICIT/REQUEST.
+    match cache::get_classed(
+        rpc::AddressFamily::V6,
+        cache::CacheClass::Lease,
+        discovery.selected_mac,
+        link_address,
+        &circuit_id,
+        &remote_id,
+        vendor_id,
+    ) {
+        Some(cache::CacheEntry {
+            status: cache::CacheEntryStatus::ValidEntry(machine),
+            ..
+        }) => {
+            if confirm_addresses_on_link(discovery, &machine) {
+                unsafe {
+                    *machine_ptr_out = Box::into_raw(machine);
+                }
+                Some(V6HookResult::Success)
+            } else {
+                log::warn!(
+                    "DHCPv6 CONFIRM for {:?} is not on cached link prefix {}",
+                    discovery.ia_addrs,
+                    machine.inner.prefix
+                );
+                None
+            }
+        }
+        // CONFIRM often omits vendor class. When the exact key misses, search
+        // otherwise-identical lease entries across vendor variants and accept
+        // only if they resolve to the same on-link API lease context.
+        _ => fetch_machine_from_cache_any_vendor(
+            discovery,
+            machine_ptr_out,
+            link_address,
+            &circuit_id,
+            &remote_id,
+        ),
+    }
+}
+
+fn fetch_machine_from_cache_any_vendor(
+    discovery: &V6Discovery,
+    machine_ptr_out: *mut *mut Machine,
+    link_address: IpAddr,
+    circuit_id: &Option<String>,
+    remote_id: &Option<String>,
+) -> Option<V6HookResult> {
+    let matches = cache::get_classed_any_vendor(
+        rpc::AddressFamily::V6,
+        cache::CacheClass::Lease,
+        discovery.selected_mac,
+        link_address,
+        circuit_id,
+        remote_id,
+    );
+    let mut candidate: Option<Box<Machine>> = None;
+    for entry in matches {
+        let cache::CacheEntryStatus::ValidEntry(machine) = entry.status else {
+            continue;
+        };
+        if !confirm_addresses_on_link(discovery, &machine) {
+            log::warn!("DHCPv6 CONFIRM matched a vendor-class cache entry that is not on-link");
+            return None;
+        }
+
+        // Vendor class is optional on CONFIRM. Multiple cache variants are
+        // equivalent only when they still point at the same API lease context.
+        if let Some(existing) = &candidate {
+            if machine.inner.address != existing.inner.address
+                || machine.inner.prefix != existing.inner.prefix
+                || machine.inner.machine_interface_id != existing.inner.machine_interface_id
+                || machine.inner.segment_id != existing.inner.segment_id
+            {
+                log::warn!(
+                    "DHCPv6 CONFIRM matched conflicting vendor-class cache entries; failing closed"
+                );
+                return None;
+            }
+        } else {
+            candidate = Some(machine);
+        }
+    }
+
+    let machine = candidate?;
+    unsafe {
+        *machine_ptr_out = Box::into_raw(machine);
+    }
+    Some(V6HookResult::Success)
+}
+
+/// Fetch and cache a DHCPv6 Machine from Carbide for request-like messages.
+fn fetch_machine(discovery: V6Discovery, machine_ptr_out: *mut *mut Machine) -> V6HookResult {
+    let url = &CONFIG.read().unwrap().api_endpoint;
+    let link_address = IpAddr::V6(discovery.relay_link.unwrap_or(Ipv6Addr::UNSPECIFIED));
+    let cache_class = cache_class_for(&discovery);
+    let circuit_id = discovery.interface_id.as_deref().map(hex_encode);
+    let remote_id = discovery.remote_id.as_deref().map(hex_encode);
+    let vendor_id = discovery.vendor_class.as_deref().unwrap_or("").to_string();
+    let selected_mac = discovery.selected_mac;
+    let mut cache_entry_status = cache::CacheEntryStatus::DiscoveryFailing(0);
+
+    if let Some(cache_entry) = cache::get_classed(
+        rpc::AddressFamily::V6,
+        cache_class,
+        selected_mac,
+        link_address,
+        &circuit_id,
+        &remote_id,
+        &vendor_id,
+    ) {
+        match cache_entry.status {
+            cache::CacheEntryStatus::ValidEntry(machine) => {
+                log::info!(
+                    "returning cached DHCPv6 response for ({selected_mac}, {link_address}, {circuit_id:?}, {vendor_id})."
+                );
+                unsafe {
+                    *machine_ptr_out = Box::into_raw(machine);
+                }
+                return V6HookResult::Success;
+            }
+            cache::CacheEntryStatus::DiscoveryFailing(count) => {
+                log::info!(
+                    "retrying carbide-api DHCPv6 for ({selected_mac}, {link_address}, {circuit_id:?}, {vendor_id}). failure count: {count}."
+                );
+                cache_entry_status = cache_entry.status;
+            }
+            cache::CacheEntryStatus::DiscoveryFailed => {
+                log::info!(
+                    "too many DHCPv6 failures for ({selected_mac}, {link_address}, {circuit_id:?}, {vendor_id})."
+                );
+                return V6HookResult::TooManyFailuresError;
+            }
+        }
+    }
+
+    // Tonic is async, but Kea calls us synchronously from its hook thread.
+    let runtime = CarbideDhcpContext::get_tokio_runtime();
+    let forge_client_config = tls::build_forge_client_config();
+    match runtime.block_on(Machine::try_fetch_v6(discovery, url, &forge_client_config)) {
+        Ok(machine) => {
+            // Expiry tombstones protect against stale hook-cache reuse. A fresh
+            // API response is authoritative, even if the allocator chooses the
+            // same address again for the same MAC.
+            if let Ok(IpAddr::V6(address)) = machine.inner.address.parse::<IpAddr>()
+                && cache::clear_v6_lease_invalidation(address, selected_mac)
+            {
+                log::info!(
+                    "accepting fresh DHCPv6 API response for recently expired lease: mac={} address={}",
+                    selected_mac,
+                    machine.inner.address
+                );
+            }
+            handle_api_invalidation(&machine);
+            cache::put_classed(
+                cache::CacheScope {
+                    address_family: rpc::AddressFamily::V6,
+                    cache_class,
+                },
+                selected_mac,
+                link_address,
+                circuit_id,
+                remote_id,
+                &vendor_id,
+                cache::CacheEntryStatus::ValidEntry(Box::new(machine.clone())),
+            );
+            unsafe {
+                *machine_ptr_out = Box::into_raw(Box::new(machine));
+            }
+            V6HookResult::Success
+        }
+        Err(error) => {
+            log::error!(
+                "Error getting DHCPv6 info from machine discovery: mac={selected_mac} addr={link_address} err={error} api_url={url}"
+            );
+            cache::put_classed(
+                cache::CacheScope {
+                    address_family: rpc::AddressFamily::V6,
+                    cache_class,
+                },
+                selected_mac,
+                link_address,
+                circuit_id,
+                remote_id,
+                &vendor_id,
+                cache_entry_status.increment_fails(),
+            );
+            V6HookResult::FetchMachineError
+        }
+    }
+}
+
+/// Restart Kea when the API reports a DHCP record invalidated after startup.
+fn handle_api_invalidation(machine: &Machine) {
+    // Match the v4 path: if API says Kea's cache may be stale, mark the
+    // service unhealthy and ask Kea to restart gracefully.
+    let Some(last_invalidation) = machine.inner.last_invalidation_time.as_ref() else {
+        return;
+    };
+    let startup_time = CONFIG.read().unwrap().startup_time;
+    if let Ok(last_invalidation) = chrono::DateTime::<chrono::Utc>::try_from(*last_invalidation)
+        && last_invalidation >= startup_time
+    {
+        log::error!(
+            "Restarting KEA since invalidation was reported by Carbide. Startup: {}. Last_Invalidation: {}",
+            startup_time.to_rfc3339(),
+            last_invalidation.to_rfc3339()
+        );
+        set_service_healthy(false);
+        unsafe {
+            libc::kill(libc::getpid(), libc::SIGTERM);
+        }
+    }
+}
+
+fn cache_class_for(discovery: &V6Discovery) -> cache::CacheClass {
+    match message_kind_for(discovery.message_type, discovery.has_ia_na) {
+        Some(rpc::MessageKind::V6InfoRequest) => cache::CacheClass::OptionsOnly,
+        _ => cache::CacheClass::Lease,
+    }
+}
+
+fn confirm_addresses_on_link(discovery: &V6Discovery, machine: &Machine) -> bool {
+    if discovery.ia_addrs.is_empty() {
+        return false;
+    }
+
+    match machine.inner.prefix.parse::<IpNetwork>() {
+        Ok(IpNetwork::V6(prefix)) => discovery.ia_addrs.iter().all(|addr| prefix.contains(*addr)),
+        Ok(IpNetwork::V4(prefix)) => {
+            log::warn!("DHCPv6 CONFIRM cache entry has IPv4 prefix {prefix}");
+            false
+        }
+        Err(error) => {
+            log::warn!(
+                "DHCPv6 CONFIRM cache entry has invalid prefix {}: {error}",
+                machine.inner.prefix
+            );
+            false
+        }
+    }
+}
+
+/// Borrow a byte slice from a C pointer/length pair.
+unsafe fn slice_from_ffi<'a>(ptr: *const u8, len: usize) -> Option<&'a [u8]> {
+    if ptr.is_null() {
+        (len == 0).then_some(&[])
+    } else {
+        Some(unsafe { std::slice::from_raw_parts(ptr, len) })
+    }
+}
+
+/// Build RelayContext from Kea-owned C pointer/length fields.
+#[allow(clippy::too_many_arguments)]
+unsafe fn relay_context_from_ffi(
+    relay_count: usize,
+    hop_count: u8,
+    relay_link_ptr: *const u8,
+    relay_link_len: usize,
+    interface_id_ptr: *const u8,
+    interface_id_len: usize,
+    remote_id_ptr: *const u8,
+    remote_id_len: usize,
+    client_link_layer_ptr: *const u8,
+    client_link_layer_len: usize,
+) -> Option<RelayContext> {
+    let relay_link = match unsafe { slice_from_ffi(relay_link_ptr, relay_link_len) }? {
+        [] => None,
+        bytes if bytes.len() == 16 => Some(Ipv6Addr::from(<[u8; 16]>::try_from(bytes).ok()?)),
+        _ => return None,
+    };
+
+    Some(RelayContext {
+        relay_count,
+        hop_count,
+        link_address: relay_link,
+        interface_id: non_empty_vec(unsafe { slice_from_ffi(interface_id_ptr, interface_id_len) }?),
+        remote_id: non_empty_vec(unsafe { slice_from_ffi(remote_id_ptr, remote_id_len) }?),
+        client_link_layer: non_empty_vec(unsafe {
+            slice_from_ffi(client_link_layer_ptr, client_link_layer_len)
+        }?),
+    })
+}
+
+/// Copy non-empty option payload bytes into an owned Vec.
+fn non_empty_vec(bytes: &[u8]) -> Option<Vec<u8>> {
+    (!bytes.is_empty()).then(|| bytes.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use dhcproto::v6::MessageType;
+
+    use super::*;
+    use crate::discovery_v6::V6Discovery;
+
+    fn discovery(message_type: MessageType, has_ia_na: bool) -> V6Discovery {
+        V6Discovery {
+            selected_mac: "02:00:00:00:00:01".parse().unwrap(),
+            duid_mac: Some("02:00:00:00:00:01".parse().unwrap()),
+            duid: vec![0, 3, 0, 1, 2, 0, 0, 0, 0, 1],
+            message_type,
+            relay_link: Some("2001:db8::1".parse().unwrap()),
+            vendor_class: Some("HTTPClient::7::".to_string()),
+            interface_id: Some(b"eth0".to_vec()),
+            remote_id: Some(b"rack-a".to_vec()),
+            desired_addr: Some("2001:db8::42".parse().unwrap()),
+            ia_addrs: vec!["2001:db8::42".parse().unwrap()],
+            has_ia_na,
+            client_link_layer: None,
+        }
+    }
+
+    #[test]
+    fn builds_stateful_v6_discovery_request() {
+        // The hook owns the v6 transport fields before calling the API.
+        let request = build_discovery(&discovery(MessageType::Solicit, true));
+
+        assert_eq!(request.mac_address, "02:00:00:00:00:01");
+        assert_eq!(request.relay_address, "2001:db8::1");
+        assert_eq!(request.link_address.as_deref(), Some("2001:db8::1"));
+        assert_eq!(request.circuit_id.as_deref(), Some("65746830"));
+        assert_eq!(request.remote_id.as_deref(), Some("7261636b2d61"));
+        assert_eq!(request.desired_address.as_deref(), Some("2001:db8::42"));
+        assert_eq!(request.address_family, Some(rpc::AddressFamily::V6 as i32));
+        assert_eq!(
+            request.message_kind,
+            Some(rpc::MessageKind::V6Solicit as i32)
+        );
+        assert_eq!(request.duid, Some(vec![0, 3, 0, 1, 2, 0, 0, 0, 0, 1]));
+    }
+
+    #[test]
+    fn maps_request_like_messages_to_existing_v6_request_kind() {
+        // The current proto intentionally collapses REQUEST/RENEW/REBIND.
+        for message_type in [
+            MessageType::Request,
+            MessageType::Renew,
+            MessageType::Rebind,
+        ] {
+            let request = build_discovery(&discovery(message_type, true));
+
+            assert_eq!(
+                request.message_kind,
+                Some(rpc::MessageKind::V6Request as i32)
+            );
+        }
+    }
+}

--- a/crates/dhcp/src/metrics.rs
+++ b/crates/dhcp/src/metrics.rs
@@ -71,6 +71,30 @@ impl From<u8> for ReplyMessageType {
     }
 }
 
+/// The DHCPv6 message type of an outgoing response, as a bounded metric label.
+///
+/// Built from the raw DHCPv6 message-type code Kea reports for the response
+/// (`Pkt6::getType()`). Kea represents relay envelopes separately, so this
+/// label intentionally describes the inner response type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum V6ReplyMessageType {
+    Advertise,
+    Reply,
+    Reconfigure,
+    Other,
+}
+
+impl From<u8> for V6ReplyMessageType {
+    fn from(message_type_code: u8) -> Self {
+        match message_type_code {
+            2 => Self::Advertise,    // DHCPV6_ADVERTISE
+            7 => Self::Reply,        // DHCPV6_REPLY
+            10 => Self::Reconfigure, // DHCPV6_RECONFIGURE
+            _ => Self::Other,
+        }
+    }
+}
+
 /// Why the hook dropped or refused a DHCP request, as the bounded `reason`
 /// label on the grandfathered `carbide-dhcp.dropped_requests` counter.
 ///
@@ -188,6 +212,83 @@ impl From<&str> for DropReason {
     }
 }
 
+/// Why the DHCPv6 hook dropped a request, as the bounded `reason` label on
+/// `carbide_dropped_v6_requests_total`.
+///
+/// These labels intentionally follow the existing DHCPv6 snake_case contract,
+/// except `NonRelayedPacket`, which is shared with the v4 drop path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum V6DropReason {
+    NonRelayedPacket,
+    Success,
+    Ignore,
+    ConfirmNotOnLink,
+    InvalidPacket,
+    NestedRelay,
+    NoMacNoOption79,
+    UnsupportedDuid,
+    UnsupportedMessage,
+    InvalidMachinePointer,
+    FetchMachineError,
+    TooManyFailuresError,
+    Unknown,
+}
+
+impl V6DropReason {
+    /// Every variant, as the single source for FFI string mapping and tests.
+    const ALL: [Self; 13] = [
+        Self::NonRelayedPacket,
+        Self::Success,
+        Self::Ignore,
+        Self::ConfirmNotOnLink,
+        Self::InvalidPacket,
+        Self::NestedRelay,
+        Self::NoMacNoOption79,
+        Self::UnsupportedDuid,
+        Self::UnsupportedMessage,
+        Self::InvalidMachinePointer,
+        Self::FetchMachineError,
+        Self::TooManyFailuresError,
+        Self::Unknown,
+    ];
+
+    /// The exact metric `reason` label value accepted from the Kea FFI.
+    const fn as_label(self) -> &'static str {
+        match self {
+            Self::NonRelayedPacket => "NonRelayedPacket",
+            Self::Success => "success",
+            Self::Ignore => "ignore",
+            Self::ConfirmNotOnLink => "confirm_not_on_link",
+            Self::InvalidPacket => "invalid_packet",
+            Self::NestedRelay => "nested_relay",
+            Self::NoMacNoOption79 => "no_mac_no_option79",
+            Self::UnsupportedDuid => "unsupported_duid",
+            Self::UnsupportedMessage => "unsupported_message",
+            Self::InvalidMachinePointer => "invalid_machine_pointer",
+            Self::FetchMachineError => "fetch_machine_error",
+            Self::TooManyFailuresError => "too_many_failures_error",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl LabelValue for V6DropReason {
+    fn label_value(&self) -> StringValue {
+        StringValue::from(self.as_label())
+    }
+}
+
+impl From<&str> for V6DropReason {
+    /// Maps an FFI reason string onto the v6 taxonomy; anything unrecognized
+    /// buckets to [`V6DropReason::Unknown`].
+    fn from(reason: &str) -> Self {
+        Self::ALL
+            .into_iter()
+            .find(|candidate| candidate.as_label() == reason)
+            .unwrap_or(Self::Unknown)
+    }
+}
+
 /// A DHCP request reached the hook's `pkt4_receive` callout, whatever becomes
 /// of it next.
 #[derive(Event)]
@@ -218,6 +319,20 @@ pub struct DhcpRequestDropped {
     pub reason: DropReason,
 }
 
+/// The DHCPv6 hook dropped a packet before Kea could safely answer it.
+#[derive(Event)]
+#[event(
+    name = "carbide_dropped_v6_requests_total",
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of dropped DHCPv6 requests, by reason."
+)]
+pub struct DhcpV6RequestDropped {
+    #[label]
+    pub reason: V6DropReason,
+}
+
 /// A fully assembled DHCP reply left `pkt4_send` for transmission: an `offer`
 /// proposes a lease, an `ack` commits one, a `nak` refuses one.
 ///
@@ -234,6 +349,20 @@ pub struct DhcpRequestDropped {
 pub struct DhcpReplySent {
     #[label]
     pub message_type: ReplyMessageType,
+}
+
+/// A fully assembled DHCPv6 response left `pkt6_send` for transmission.
+#[derive(Event)]
+#[event(
+    name = "carbide_dhcp_v6_replies_sent_total",
+    component = "carbide-dhcp",
+    log = off,
+    metric = counter,
+    describe = "Number of DHCPv6 replies sent, by response message type."
+)]
+pub struct DhcpV6ReplySent {
+    #[label]
+    pub message_type: V6ReplyMessageType,
 }
 
 pub async fn certificate_loop() {
@@ -409,6 +538,20 @@ pub fn increment_reply_sent(message_type: ReplyMessageType) {
     }
 }
 
+/// Increment the DHCPv6 reply-sent counter for an outgoing response type.
+pub fn increment_v6_reply_sent(message_type: V6ReplyMessageType) {
+    if metrics_initialized() {
+        emit(DhcpV6ReplySent { message_type });
+    }
+}
+
+/// Increment the DHCPv6-specific dropped-request counter for a reason label.
+pub fn increment_dropped_v6_requests(reason: V6DropReason) {
+    if metrics_initialized() {
+        emit(DhcpV6RequestDropped { reason });
+    }
+}
+
 pub fn set_service_ready(ready: bool) {
     if let Some(health_controller) = &CONFIG
         .read()
@@ -497,6 +640,45 @@ mod tests {
                 },
             ],
             ReplyMessageType::from,
+        );
+    }
+
+    #[test]
+    fn v6_reply_message_type_maps_dhcpv6_response_codes_and_buckets_the_rest() {
+        check_values(
+            [
+                Check {
+                    scenario: "ADVERTISE (2)",
+                    input: 2u8,
+                    expect: V6ReplyMessageType::Advertise,
+                },
+                Check {
+                    scenario: "REPLY (7)",
+                    input: 7,
+                    expect: V6ReplyMessageType::Reply,
+                },
+                Check {
+                    scenario: "RECONFIGURE (10)",
+                    input: 10,
+                    expect: V6ReplyMessageType::Reconfigure,
+                },
+                Check {
+                    scenario: "RELAY-REPLY (13) is an outer wire envelope",
+                    input: 13,
+                    expect: V6ReplyMessageType::Other,
+                },
+                Check {
+                    scenario: "SOLICIT (1) is not a response type",
+                    input: 1,
+                    expect: V6ReplyMessageType::Other,
+                },
+                Check {
+                    scenario: "unknown code buckets as other",
+                    input: 250,
+                    expect: V6ReplyMessageType::Other,
+                },
+            ],
+            V6ReplyMessageType::from,
         );
     }
 
@@ -643,7 +825,96 @@ mod tests {
         assert_eq!(DropReason::from("SomeFutureReason"), DropReason::Unknown);
     }
 
-    /// All three packet counters are metric-only: one emit moves exactly its
+    /// Pins every DHCPv6 `reason` label rendering. These strings come from
+    /// `V6HookResult` and must remain the exact bytes tests and dashboards use.
+    #[test]
+    fn v6_drop_reason_renders_the_contract_strings_byte_identically() {
+        check_values(
+            [
+                Check {
+                    scenario: "shared non-relayed packet reason",
+                    input: V6DropReason::NonRelayedPacket,
+                    expect: "NonRelayedPacket",
+                },
+                Check {
+                    scenario: "success",
+                    input: V6DropReason::Success,
+                    expect: "success",
+                },
+                Check {
+                    scenario: "ignore",
+                    input: V6DropReason::Ignore,
+                    expect: "ignore",
+                },
+                Check {
+                    scenario: "confirm not on link",
+                    input: V6DropReason::ConfirmNotOnLink,
+                    expect: "confirm_not_on_link",
+                },
+                Check {
+                    scenario: "invalid packet",
+                    input: V6DropReason::InvalidPacket,
+                    expect: "invalid_packet",
+                },
+                Check {
+                    scenario: "nested relay",
+                    input: V6DropReason::NestedRelay,
+                    expect: "nested_relay",
+                },
+                Check {
+                    scenario: "no MAC and no option 79",
+                    input: V6DropReason::NoMacNoOption79,
+                    expect: "no_mac_no_option79",
+                },
+                Check {
+                    scenario: "unsupported DUID",
+                    input: V6DropReason::UnsupportedDuid,
+                    expect: "unsupported_duid",
+                },
+                Check {
+                    scenario: "unsupported message",
+                    input: V6DropReason::UnsupportedMessage,
+                    expect: "unsupported_message",
+                },
+                Check {
+                    scenario: "invalid machine pointer",
+                    input: V6DropReason::InvalidMachinePointer,
+                    expect: "invalid_machine_pointer",
+                },
+                Check {
+                    scenario: "fetch machine error",
+                    input: V6DropReason::FetchMachineError,
+                    expect: "fetch_machine_error",
+                },
+                Check {
+                    scenario: "too many failures",
+                    input: V6DropReason::TooManyFailuresError,
+                    expect: "too_many_failures_error",
+                },
+                Check {
+                    scenario: "unknown bucket",
+                    input: V6DropReason::Unknown,
+                    expect: "unknown",
+                },
+            ],
+            V6DropReason::as_label,
+        );
+    }
+
+    /// Every known v6 FFI reason maps onto a bounded label and renders back
+    /// unchanged, so adding a future v6 result cannot silently mint labels.
+    #[test]
+    fn v6_drop_reason_label_value_renders_as_label_for_every_variant() {
+        for reason in V6DropReason::ALL {
+            assert_eq!(
+                reason.label_value().as_str(),
+                reason.as_label(),
+                "{reason:?}"
+            );
+        }
+    }
+
+    /// Packet counters are metric-only: one emit moves exactly its
     /// counter -- under the exposed name dashboards use -- and builds no log
     /// line at all (the Kea process has no tracing subscriber; the C++ log
     /// lines remain the log side).
@@ -655,8 +926,14 @@ mod tests {
             emit(DhcpRequestDropped {
                 reason: DropReason::TooManyFailuresError,
             });
+            emit(DhcpV6RequestDropped {
+                reason: V6DropReason::NestedRelay,
+            });
             emit(DhcpReplySent {
                 message_type: ReplyMessageType::Offer,
+            });
+            emit(DhcpV6ReplySent {
+                message_type: V6ReplyMessageType::Reply,
             });
         });
 
@@ -674,8 +951,22 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
+                "carbide_dropped_v6_requests_total",
+                &[("reason", "nested_relay")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
                 "carbide_dhcp_replies_sent_total",
                 &[("message_type", "offer")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_replies_sent_total",
+                &[("message_type", "reply")]
             ),
             1.0
         );
@@ -683,10 +974,10 @@ mod tests {
 
     /// The C++ callouts reach the counters through the FFI layer: reason
     /// strings map onto the bounded taxonomy (unknown ones bucket), the raw
-    /// Kea message-type code maps onto the reply label, and nothing records
-    /// until `metrics_server` has initialized metrics -- the gate that also
-    /// guarantees the global meter provider is installed before the first
-    /// emit.
+    /// Kea message-type codes map onto their family-specific reply labels,
+    /// and nothing records until `metrics_server` has initialized metrics --
+    /// the gate that also guarantees the global meter provider is installed
+    /// before the first emit.
     #[test]
     fn ffi_increments_gate_on_initialization_and_map_their_arguments() {
         let metrics = MetricsCapture::start();
@@ -697,8 +988,10 @@ mod tests {
         unsafe {
             crate::carbide_increment_total_requests();
             crate::carbide_increment_dropped_requests(c"NonRelayedPacket".as_ptr());
+            crate::carbide_increment_dropped_v6_requests(c"nested_relay".as_ptr());
         }
         crate::carbide_increment_reply_sent(5);
+        crate::carbide_increment_v6_reply_sent(7);
         assert_eq!(
             metrics.counter_delta("carbide_dhcp_requests_total", &[]),
             0.0
@@ -707,6 +1000,20 @@ mod tests {
             metrics.counter_delta(
                 "carbide_dhcp_replies_sent_total",
                 &[("message_type", "ack")]
+            ),
+            0.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dropped_v6_requests_total",
+                &[("reason", "nested_relay")]
+            ),
+            0.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_replies_sent_total",
+                &[("message_type", "reply")]
             ),
             0.0
         );
@@ -721,8 +1028,11 @@ mod tests {
             crate::carbide_increment_total_requests();
             crate::carbide_increment_dropped_requests(c"NonRelayedPacket".as_ptr());
             crate::carbide_increment_dropped_requests(c"NotAReasonWeKnow".as_ptr());
+            crate::carbide_increment_dropped_v6_requests(c"nested_relay".as_ptr());
+            crate::carbide_increment_dropped_v6_requests(c"not_a_v6_reason".as_ptr());
         }
         crate::carbide_increment_reply_sent(5); // DHCPACK
+        crate::carbide_increment_v6_reply_sent(7); // DHCPV6_REPLY
 
         assert_eq!(
             metrics.counter_delta("carbide_dhcp_requests_total", &[]),
@@ -744,8 +1054,29 @@ mod tests {
         );
         assert_eq!(
             metrics.counter_delta(
+                "carbide_dropped_v6_requests_total",
+                &[("reason", "nested_relay")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dropped_v6_requests_total",
+                &[("reason", "unknown")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
                 "carbide_dhcp_replies_sent_total",
                 &[("message_type", "ack")]
+            ),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dhcp_v6_replies_sent_total",
+                &[("message_type", "reply")]
             ),
             1.0
         );

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -22,7 +22,7 @@
 /// Module only included if #cfg(test)
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::net::{SocketAddr, SocketAddrV4};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -46,10 +46,37 @@ pub const ENDPOINT_DISCOVER_DHCP: &str = "/forge.Forge/DiscoverDhcp";
 pub const ENDPOINT_EXPIRE_DHCP_LEASE: &str = "/forge.Forge/ExpireDhcpLease";
 
 // Contents of the response
-const DHCP_RESPONSE_FQDN: &str = "december-nitrogen.forge.local";
+pub const DHCP_RESPONSE_FQDN: &str = "december-nitrogen.forge.local";
 const DHCP_RESPONSE_ADDR_PREFIX: &str = "172.20.0";
+const DHCP_V6_RESPONSE_PREFIX: &str = "2001:db8::";
+pub const DHCP_V6_RESPONSE_NTP_SERVERS: [&str; 2] = ["2001:db8::124", "2001:db8::125"];
 
 pub fn base_dhcp_response(mac_address: MacAddress) -> rpc::DhcpRecord {
+    base_dhcp_response_for_family(mac_address, rpc::AddressFamily::V4)
+}
+
+pub fn base_dhcp_response_for_family(
+    mac_address: MacAddress,
+    address_family: rpc::AddressFamily,
+) -> rpc::DhcpRecord {
+    let (address, prefix, gateway, ntp_servers) = match address_family {
+        rpc::AddressFamily::V6 => (
+            address_to_offer_v6(mac_address),
+            "2001:db8::/64".to_string(),
+            None,
+            DHCP_V6_RESPONSE_NTP_SERVERS
+                .iter()
+                .map(ToString::to_string)
+                .collect(),
+        ),
+        _ => (
+            address_to_offer(mac_address),
+            "172.20.0.0/24".to_string(),
+            Some("172.20.0.1".to_string()),
+            vec!["198.51.100.10".to_string(), "198.51.100.11".to_string()],
+        ),
+    };
+
     rpc::DhcpRecord {
         machine_id: None,
         machine_interface_id: Some("88750d14-00fa-4d21-9fbc-d562046bc194".parse().unwrap()),
@@ -57,35 +84,40 @@ pub fn base_dhcp_response(mac_address: MacAddress) -> rpc::DhcpRecord {
         subdomain_id: Some("023138e1-ebf1-4ef7-8a2c-bbce928a1601".parse().unwrap()),
         fqdn: DHCP_RESPONSE_FQDN.to_string(),
         mac_address: mac_address.to_string(),
-        address: address_to_offer(mac_address),
+        address,
         mtu: 1490,
-        prefix: "172.20.0.0/24".to_string(),
-        gateway: Some("172.20.0.1".to_string()),
+        prefix,
+        gateway,
         booturl: None,
         last_invalidation_time: None,
-        ntp_servers: vec!["198.51.100.10".to_string(), "198.51.100.11".to_string()],
+        ntp_servers,
     }
 }
 
 // Encode a DhcpRecord to match gRPC HTTP/2 DATA frame that API server (via hyper) produces.
 pub fn dhcp_response(mac_address_str: &str) -> Vec<u8> {
-    dhcp_response_with_override(mac_address_str, None)
+    dhcp_response_with_override(mac_address_str, None, None, rpc::AddressFamily::V4)
 }
 
-/// Same as `dhcp_response` but allows the caller to override the `address`
-/// field on the response. `Some("")` is meaningful: it simulates a Machine
-/// that has no IPv4 binding (which the lease4 hooks should treat as
-/// "refuse to allocate").
+/// Same as `dhcp_response` but allows selected response fields to be overridden.
+///
+/// `Some("")` is meaningful for `address_override`: it simulates a Machine that
+/// has no address binding.
 pub fn dhcp_response_with_override(
     mac_address_str: &str,
     address_override: Option<String>,
+    fqdn_override: Option<String>,
+    address_family: rpc::AddressFamily,
 ) -> Vec<u8> {
     let mac_address = mac_address_str.parse::<MacAddress>().unwrap();
 
-    let mut r = base_dhcp_response(mac_address);
+    let mut r = base_dhcp_response_for_family(mac_address, address_family);
 
     if let Some(addr) = address_override {
         r.address = addr;
+    }
+    if let Some(fqdn) = fqdn_override {
+        r.fqdn = fqdn;
     }
 
     // Specialization of response based on mac address
@@ -108,9 +140,98 @@ pub fn dhcp_response_with_override(
     out
 }
 
+fn validate_discovery_contract(
+    discovery: &rpc::DhcpDiscovery,
+) -> (rpc::AddressFamily, Option<rpc::MessageKind>) {
+    let routing_address = discovery
+        .link_address
+        .as_deref()
+        .unwrap_or(&discovery.relay_address);
+
+    match (discovery.address_family, discovery.message_kind) {
+        (None, None) => {
+            assert!(
+                routing_address.parse::<Ipv4Addr>().is_ok(),
+                "legacy DiscoverDhcp calls must route with IPv4 relay/link address: {routing_address}"
+            );
+            assert!(
+                discovery.duid.is_none(),
+                "legacy IPv4 DiscoverDhcp calls must not include a DUID"
+            );
+            (rpc::AddressFamily::V4, None)
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            panic!("address_family and message_kind must be provided together")
+        }
+        (Some(address_family), Some(message_kind)) => {
+            let address_family = rpc::AddressFamily::try_from(address_family)
+                .expect("DiscoverDhcp address_family must be known");
+            let message_kind = rpc::MessageKind::try_from(message_kind)
+                .expect("DiscoverDhcp message_kind must be known");
+            assert_ne!(
+                address_family,
+                rpc::AddressFamily::Unspecified,
+                "DiscoverDhcp address_family must be specified"
+            );
+            assert_ne!(
+                message_kind,
+                rpc::MessageKind::Unspecified,
+                "DiscoverDhcp message_kind must be specified"
+            );
+
+            match address_family {
+                rpc::AddressFamily::V4 => {
+                    assert_eq!(
+                        message_kind,
+                        rpc::MessageKind::V4Discover,
+                        "ADDRESS_FAMILY_V4 requires MESSAGE_KIND_V4_DISCOVER"
+                    );
+                    assert!(
+                        routing_address.parse::<Ipv4Addr>().is_ok(),
+                        "ADDRESS_FAMILY_V4 requires an IPv4 relay/link address: {routing_address}"
+                    );
+                    assert!(
+                        discovery.duid.is_none(),
+                        "DHCPv4 DiscoverDhcp calls must not include a DUID"
+                    );
+                }
+                rpc::AddressFamily::V6 => {
+                    assert!(
+                        matches!(
+                            message_kind,
+                            rpc::MessageKind::V6Solicit
+                                | rpc::MessageKind::V6Request
+                                | rpc::MessageKind::V6InfoRequest
+                        ),
+                        "ADDRESS_FAMILY_V6 requires a DHCPv6 message_kind"
+                    );
+                    assert!(
+                        routing_address.parse::<Ipv6Addr>().is_ok(),
+                        "ADDRESS_FAMILY_V6 requires an IPv6 relay/link address: {routing_address}"
+                    );
+                    assert!(
+                        discovery
+                            .duid
+                            .as_deref()
+                            .is_some_and(|duid| !duid.is_empty()),
+                        "DHCPv6 DiscoverDhcp calls must include a non-empty DUID"
+                    );
+                }
+                rpc::AddressFamily::Unspecified => unreachable!(),
+            }
+
+            (address_family, Some(message_kind))
+        }
+    }
+}
+
 // Given a MAC address, make the IP address we should offer it
 fn address_to_offer(mac: MacAddress) -> String {
     format!("{}.{}", DHCP_RESPONSE_ADDR_PREFIX, mac.bytes()[5])
+}
+
+fn address_to_offer_v6(mac: MacAddress) -> String {
+    format!("{}{:x}", DHCP_V6_RESPONSE_PREFIX, mac.bytes()[5])
 }
 
 // Does this Machine the result we expected?
@@ -125,10 +246,14 @@ pub struct MockAPIServer {
     tx: Option<tokio::sync::oneshot::Sender<()>>,
     local_addr: String,
     inject_failure: Arc<Mutex<bool>>,
+    discoveries: Arc<Mutex<Vec<rpc::DhcpDiscovery>>>,
+    expired_leases: Arc<Mutex<Vec<rpc::ExpireDhcpLeaseRequest>>>,
     /// Per-MAC override for the `address` field of the DhcpRecord response.
-    /// A value of `""` is meaningful: it simulates a Machine with no IPv4
-    /// binding, which the lease4_* hooks should treat as "refuse to allocate".
+    /// A value of `""` is meaningful: it simulates a Machine with no address
+    /// binding, which allocation hooks should treat as "refuse to allocate".
     address_overrides: Arc<Mutex<HashMap<String, String>>>,
+    /// Per-MAC override for the `fqdn` field of the DhcpRecord response.
+    fqdn_overrides: Arc<Mutex<HashMap<String, String>>>,
 }
 
 #[derive(Debug)]
@@ -155,8 +280,14 @@ impl MockAPIServer {
         let i2 = inject_failure.clone();
         let calls = Arc::new(Mutex::new(HashMap::new()));
         let c2 = calls.clone();
+        let discoveries = Arc::new(Mutex::new(Vec::new()));
+        let d2 = discoveries.clone();
+        let expired_leases = Arc::new(Mutex::new(Vec::new()));
+        let e2 = expired_leases.clone();
         let address_overrides = Arc::new(Mutex::new(HashMap::<String, String>::new()));
         let a2 = address_overrides.clone();
+        let fqdn_overrides = Arc::new(Mutex::new(HashMap::<String, String>::new()));
+        let f2 = fqdn_overrides.clone();
         let listener = TcpListener::bind(addr).await.unwrap();
         let local_addr = listener.local_addr().unwrap().to_string();
         let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
@@ -164,7 +295,10 @@ impl MockAPIServer {
             loop {
                 let c3 = c2.clone();
                 let i3 = i2.clone();
+                let d3 = d2.clone();
+                let e3 = e2.clone();
                 let a3 = a2.clone();
+                let f3 = f2.clone();
                 tokio::select! {
                     result = listener.accept() => {
                         let (stream, _) = result.unwrap();
@@ -172,9 +306,12 @@ impl MockAPIServer {
                             http2::Builder::new(TokioExecutor::new()).serve_connection(TokioIo::new(stream), service_fn(move |req: Request<body::Incoming>| {
                                 let c3 = c3.clone();
                                 let i3 = i3.clone();
+                                let d3 = d3.clone();
+                                let e3 = e3.clone();
                                 let a3 = a3.clone();
+                                let f3 = f3.clone();
                                 async move {
-                                    Ok::<Response<GrpcBody>, hyper::Error>(MockAPIServer::handler(req, c3.clone(), i3.clone(), a3.clone()).await.unwrap())
+                                    Ok::<Response<GrpcBody>, hyper::Error>(MockAPIServer::handler(req, c3.clone(), i3.clone(), d3.clone(), e3.clone(), a3.clone(), f3.clone()).await.unwrap())
                                 }
                             })).await.inspect_err(|e| eprintln!("ERROR: {e:?}")).unwrap()
                         });
@@ -193,17 +330,30 @@ impl MockAPIServer {
             local_addr: format!("http://{local_addr}"),
             tx: Some(tx),
             inject_failure,
+            discoveries,
+            expired_leases,
             address_overrides,
+            fqdn_overrides,
         }
     }
 
     /// Override what address the mock returns for a specific MAC on subsequent
-    /// `DiscoverDhcp` calls. Pass `""` to simulate "Machine has no IPv4 binding".
+    /// `DiscoverDhcp` calls. Pass `""` to simulate "Machine has no address binding".
     pub fn set_address_override(&self, mac_address: &str, address: &str) {
         self.address_overrides
             .lock()
             .unwrap()
-            .insert(mac_address.to_string(), address.to_string());
+            .insert(normalized_mac_key(mac_address), address.to_string());
+    }
+
+    /// Override what FQDN the mock returns for a specific MAC on subsequent
+    /// `DiscoverDhcp` calls. Pass `""` to simulate an options-only record with
+    /// no API-owned hostname.
+    pub fn set_fqdn_override(&self, mac_address: &str, fqdn: &str) {
+        self.fqdn_overrides
+            .lock()
+            .unwrap()
+            .insert(normalized_mac_key(mac_address), fqdn.to_string());
     }
 
     // The HTTP address of the server
@@ -225,11 +375,22 @@ impl MockAPIServer {
         }
     }
 
+    pub fn discoveries(&self) -> Vec<rpc::DhcpDiscovery> {
+        self.discoveries.lock().unwrap().clone()
+    }
+
+    pub fn expired_leases(&self) -> Vec<rpc::ExpireDhcpLeaseRequest> {
+        self.expired_leases.lock().unwrap().clone()
+    }
+
     async fn handler(
         req: Request<Incoming>,
         calls: Arc<Mutex<HashMap<String, usize>>>,
         fail: Arc<Mutex<bool>>,
+        discoveries: Arc<Mutex<Vec<rpc::DhcpDiscovery>>>,
+        expired_leases: Arc<Mutex<Vec<rpc::ExpireDhcpLeaseRequest>>>,
         address_overrides: Arc<Mutex<HashMap<String, String>>>,
+        fqdn_overrides: Arc<Mutex<HashMap<String, String>>>,
     ) -> Result<Response<GrpcBody>, MockAPIServerError> {
         let path = req.uri().path();
         calls
@@ -246,13 +407,20 @@ impl MockAPIServer {
                     Err(MockAPIServerError::MockAPIFetchMachineError)
                 } else {
                     Ok(grpc_response(
-                        MockAPIServer::discover_dhcp(req, address_overrides).await,
+                        MockAPIServer::discover_dhcp(
+                            req,
+                            discoveries,
+                            address_overrides,
+                            fqdn_overrides,
+                        )
+                        .await,
                     ))
                 }
             }
             ENDPOINT_EXPIRE_DHCP_LEASE => {
                 let input_bytes = req.into_body().collect().await.unwrap().to_bytes();
                 let request = rpc::ExpireDhcpLeaseRequest::decode(input_bytes.slice(5..)).unwrap();
+                expired_leases.lock().unwrap().push(request.clone());
                 respond(rpc::ExpireDhcpLeaseResponse {
                     ip_address: request.ip_address,
                     status: rpc::ExpireDhcpLeaseStatus::Released.into(),
@@ -268,19 +436,41 @@ impl MockAPIServer {
 
     async fn discover_dhcp(
         req: Request<Incoming>,
+        discoveries: Arc<Mutex<Vec<rpc::DhcpDiscovery>>>,
         address_overrides: Arc<Mutex<HashMap<String, String>>>,
+        fqdn_overrides: Arc<Mutex<HashMap<String, String>>>,
     ) -> Vec<u8> {
         let input_bytes = req.into_body().collect().await.unwrap().to_bytes();
 
         // slice is to strip the gRPC parts: 1 byte is_compressed and a 4 byte message length
         let disco = rpc::DhcpDiscovery::decode(input_bytes.slice(5..)).unwrap();
+        let (address_family, message_kind) = validate_discovery_contract(&disco);
+        discoveries.lock().unwrap().push(disco.clone());
+        let mac_key = normalized_mac_key(&disco.mac_address);
         let override_for_mac = address_overrides
             .lock()
             .unwrap()
-            .get(&disco.mac_address)
-            .cloned();
-        dhcp_response_with_override(&disco.mac_address, override_for_mac)
+            .get(&mac_key)
+            .cloned()
+            .or_else(|| {
+                (address_family == rpc::AddressFamily::V6
+                    && message_kind == Some(rpc::MessageKind::V6InfoRequest))
+                .then_some(String::new())
+            });
+        let fqdn_override_for_mac = fqdn_overrides.lock().unwrap().get(&mac_key).cloned();
+
+        dhcp_response_with_override(
+            &disco.mac_address,
+            override_for_mac,
+            fqdn_override_for_mac,
+            address_family,
+        )
     }
+}
+
+/// Return a stable mock map key for MAC strings that may differ only by case.
+fn normalized_mac_key(mac_address: &str) -> String {
+    mac_address.to_ascii_lowercase()
 }
 
 impl Drop for MockAPIServer {

--- a/crates/dhcp/tests/common/dhcpv6_factory.rs
+++ b/crates/dhcp/tests/common/dhcpv6_factory.rs
@@ -1,0 +1,676 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::net::Ipv6Addr;
+
+use dhcproto::v6::{
+    DhcpOption, IAAddr, IANA, IAPD, IATA, Message, MessageType, OptionCode, UnknownOption,
+};
+use dhcproto::{Decodable, Decoder, Encodable, Encoder};
+
+pub const RELAY_ADDR: &str = "::1";
+
+const RELAY_FORW: u8 = 12;
+const RELAY_REPL: u8 = 13;
+const HTYPE_ETHERNET: u16 = 1;
+
+pub struct DHCPv6Factory {}
+
+impl DHCPv6Factory {
+    /// Relay link-address used by generated Relay-Forward packets.
+    pub const RELAY_LINK_ADDR: &str = "2001:db8::1";
+
+    /// Hex-encoded relay interface-id expected by the API.
+    pub const RELAY_INTERFACE_ID_HEX: &str = "65746830";
+
+    /// Hex-encoded relay remote-id expected by the API.
+    pub const RELAY_REMOTE_ID_HEX: &str = "7261636b2d61";
+
+    /// Return the stable locally-administered MAC used for one test client.
+    pub fn mac(idx: u8) -> [u8; 6] {
+        [0x02, 0x00, 0x00, 0x00, 0x00, idx]
+    }
+
+    /// Return the mock API address for a client index.
+    pub fn mock_addr(idx: u8) -> Ipv6Addr {
+        Ipv6Addr::from(0x20010db8000000000000000000000000u128 + idx as u128)
+    }
+
+    /// Return the colon-separated MAC string used by the mock API.
+    pub fn mac_string(idx: u8) -> String {
+        format!("02:00:00:00:00:{idx:02x}")
+    }
+
+    /// Return a raw RFC 4704 client-FQDN payload with non-zero flags.
+    pub fn client_fqdn_payload() -> Vec<u8> {
+        let mut payload = vec![0x01];
+        payload.extend_from_slice(&[
+            9, b't', b'e', b's', b't', b'-', b'h', b'o', b's', b't', 5, b'f', b'o', b'r', b'g',
+            b'e', 5, b'l', b'o', b'c', b'a', b'l', 0,
+        ]);
+        payload
+    }
+
+    /// Build a DUID-LL identity for one test client.
+    pub fn duid_ll(idx: u8) -> Vec<u8> {
+        let mut duid = vec![0, 3];
+        duid.extend_from_slice(&HTYPE_ETHERNET.to_be_bytes());
+        duid.extend_from_slice(&Self::mac(idx));
+        duid
+    }
+
+    /// Return the hex-encoded DUID-LL identity for one test client.
+    pub fn duid_ll_hex(idx: u8) -> String {
+        Self::duid_hex(&Self::duid_ll(idx))
+    }
+
+    /// Return the hex-encoded representation of a raw DUID.
+    pub fn duid_hex(duid: &[u8]) -> String {
+        duid.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    /// Build a DUID-LLT identity for one test client.
+    pub fn duid_llt(idx: u8) -> Vec<u8> {
+        let mut duid = vec![0, 1];
+        duid.extend_from_slice(&HTYPE_ETHERNET.to_be_bytes());
+        duid.extend_from_slice(&1u32.to_be_bytes());
+        duid.extend_from_slice(&Self::mac(idx));
+        duid
+    }
+
+    /// Build a DUID-EN identity with the requested total byte length.
+    pub fn duid_en(len: usize) -> Vec<u8> {
+        // Type 2 plus enterprise-number form the minimum DUID-EN prefix.
+        let mut duid = vec![0, 2, 0, 0, 0, 1];
+        duid.resize(len, 0xaa);
+        duid
+    }
+
+    /// Build a valid DUID-UUID identity with no embedded MAC.
+    pub fn duid_uuid(idx: u8) -> Vec<u8> {
+        vec![0, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, idx]
+    }
+
+    /// Build a malformed UUID DUID that should be rejected before option 79.
+    pub fn truncated_duid_uuid() -> Vec<u8> {
+        vec![0, 4, 0, 1, 2, 3]
+    }
+
+    /// Build a stateful SOLICIT with IA_NA.
+    pub fn solicit(idx: u8) -> Vec<u8> {
+        Self::relay_wrap(Self::stateful_solicit_message(idx), true)
+    }
+
+    /// Build a stateful SOLICIT with a caller-supplied relay hop count.
+    pub fn solicit_with_hop_count(idx: u8, hop_count: u8) -> Vec<u8> {
+        Self::relay_wrap_with_hop_count(Self::stateful_solicit_message(idx), true, hop_count)
+    }
+
+    /// Build a SOLICIT wrapped by two Relay-Forward envelopes.
+    pub fn solicit_with_nested_relay(idx: u8) -> Vec<u8> {
+        let inner = Self::relay_wrap(Self::stateful_solicit_message(idx), true);
+        Self::relay_wrap_payload(&inner, idx, true, 0)
+    }
+
+    /// Build a stateful SOLICIT without relay option 79.
+    pub fn solicit_without_relay_option79(idx: u8) -> Vec<u8> {
+        Self::relay_wrap(Self::stateful_solicit_message(idx), false)
+    }
+
+    /// Build a stateful SOLICIT carrying vendor-class option 16.
+    pub fn solicit_with_vendor_class(idx: u8, vendor_class: &[u8]) -> Vec<u8> {
+        let mut message = Self::stateful_solicit_message(idx);
+        Self::add_vendor_class(&mut message, vendor_class);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a SOLICIT using a caller-supplied DUID and relay option-79 policy.
+    pub fn solicit_with_duid(idx: u8, duid: Vec<u8>, relay_option79: bool) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::client_message(idx, MessageType::Solicit, duid, None, true, false),
+            relay_option79,
+        )
+    }
+
+    /// Build a SOLICIT with a spoofed client-supplied option 79 only.
+    pub fn solicit_with_inner_option79(idx: u8, duid: Vec<u8>) -> Vec<u8> {
+        let mut message = Self::client_message(idx, MessageType::Solicit, duid, None, true, false);
+        message
+            .opts_mut()
+            .insert(DhcpOption::Unknown(UnknownOption::new(
+                OptionCode::ClientLinklayerAddr,
+                Self::option79_payload(idx),
+            )));
+        Self::relay_wrap(message, false)
+    }
+
+    /// Build a SOLICIT carrying rapid-commit.
+    pub fn rapid_commit_solicit(idx: u8) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::client_message(
+                idx,
+                MessageType::Solicit,
+                Self::duid_ll(idx),
+                None,
+                true,
+                true,
+            ),
+            true,
+        )
+    }
+
+    /// Build a stateless SOLICIT with no IA_NA.
+    pub fn stateless_solicit(idx: u8) -> Vec<u8> {
+        Self::relay_wrap(Self::stateless_solicit_message(idx), true)
+    }
+
+    /// Build a SOLICIT carrying unsupported IA_TA.
+    pub fn solicit_with_ia_ta(idx: u8) -> Vec<u8> {
+        // Omit IA_NA so the packet only exercises the unsupported IA_TA path.
+        let mut message = Self::stateless_solicit_message(idx);
+        Self::add_ia_ta(&mut message, idx);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a SOLICIT carrying supported IA_NA plus unsupported IA_TA.
+    pub fn solicit_with_ia_na_and_ia_ta(idx: u8) -> Vec<u8> {
+        // Keep IA_NA present to exercise mixed-container rejection.
+        let mut message = Self::stateful_solicit_message(idx);
+        Self::add_ia_ta(&mut message, idx);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a SOLICIT carrying unsupported IA_PD.
+    pub fn solicit_with_ia_pd(idx: u8) -> Vec<u8> {
+        // Omit IA_NA so the packet only exercises the unsupported IA_PD path.
+        let mut message = Self::stateless_solicit_message(idx);
+        Self::add_ia_pd(&mut message, idx);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a SOLICIT carrying supported IA_NA plus unsupported IA_PD.
+    pub fn solicit_with_ia_na_and_ia_pd(idx: u8) -> Vec<u8> {
+        // Keep IA_NA present to exercise mixed-container rejection.
+        let mut message = Self::stateful_solicit_message(idx);
+        Self::add_ia_pd(&mut message, idx);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a SOLICIT carrying more than one IA_NA container.
+    pub fn solicit_with_multiple_ia_na(idx: u8) -> Vec<u8> {
+        // The API contract has one selected address, so multiple IA_NA
+        // containers must be rejected before lease override.
+        let mut message = Self::stateful_solicit_message(idx);
+        message.opts_mut().insert(DhcpOption::IANA(IANA {
+            id: idx as u32 + 1,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        }));
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build an INFORMATION-REQUEST.
+    pub fn information_request(idx: u8) -> Vec<u8> {
+        Self::relay_wrap(Self::information_request_message(idx), true)
+    }
+
+    /// Build an INFORMATION-REQUEST carrying client option 39.
+    pub fn information_request_with_client_fqdn(idx: u8) -> Vec<u8> {
+        let mut message = Self::information_request_message(idx);
+        Self::add_client_fqdn(&mut message);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a REQUEST selecting the advertised server and address.
+    pub fn request(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::message_with_server_and_address(idx, MessageType::Request, server_id, address),
+            true,
+        )
+    }
+
+    /// Build a REQUEST with no IA_NA.
+    pub fn request_without_ia_na(idx: u8) -> Vec<u8> {
+        // REQUEST is stateful; this intentionally omits IA_NA to verify drop behavior.
+        Self::relay_wrap(
+            Self::client_message(
+                idx,
+                MessageType::Request,
+                Self::duid_ll(idx),
+                None,
+                false,
+                false,
+            ),
+            true,
+        )
+    }
+
+    /// Build a REQUEST without relay option 79.
+    pub fn request_without_relay_option79(
+        idx: u8,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+    ) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::message_with_server_and_address(idx, MessageType::Request, server_id, address),
+            false,
+        )
+    }
+
+    /// Build a REQUEST using a caller-supplied DUID and relay option-79 policy.
+    pub fn request_with_duid(
+        idx: u8,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+        duid: Vec<u8>,
+        relay_option79: bool,
+    ) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::client_message(
+                idx,
+                MessageType::Request,
+                duid,
+                Some((server_id, address)),
+                true,
+                false,
+            ),
+            relay_option79,
+        )
+    }
+
+    /// Build a REQUEST carrying vendor-class option 16.
+    pub fn request_with_vendor_class(
+        idx: u8,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+        vendor_class: &[u8],
+    ) -> Vec<u8> {
+        let mut message =
+            Self::message_with_server_and_address(idx, MessageType::Request, server_id, address);
+        Self::add_vendor_class(&mut message, vendor_class);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a RENEW for an existing lease.
+    pub fn renew(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::message_with_server_and_address(idx, MessageType::Renew, server_id, address),
+            true,
+        )
+    }
+
+    /// Build a RENEW using a caller-supplied DUID and relay option-79 policy.
+    pub fn renew_with_duid(
+        idx: u8,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+        duid: Vec<u8>,
+        relay_option79: bool,
+    ) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::client_message(
+                idx,
+                MessageType::Renew,
+                duid,
+                Some((server_id, address)),
+                true,
+                false,
+            ),
+            relay_option79,
+        )
+    }
+
+    /// Build a REBIND for an existing lease.
+    pub fn rebind(idx: u8, address: Ipv6Addr) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::client_message_with_address(idx, MessageType::Rebind, address, None),
+            true,
+        )
+    }
+
+    /// Build a RELEASE for an existing lease.
+    pub fn release(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::message_with_server_and_address(idx, MessageType::Release, server_id, address),
+            true,
+        )
+    }
+
+    /// Build a RELEASE with a caller-supplied relay hop count.
+    pub fn release_with_hop_count(
+        idx: u8,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+        hop_count: u8,
+    ) -> Vec<u8> {
+        Self::relay_wrap_with_hop_count(
+            Self::message_with_server_and_address(idx, MessageType::Release, server_id, address),
+            true,
+            hop_count,
+        )
+    }
+
+    /// Build a RELEASE carrying unsupported IA_TA alongside the released IA_NA.
+    pub fn release_with_ia_ta(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+        // Lease-end messages are Kea protocol handling; extra IA_TA must not
+        // make the Carbide hook call discovery or drop before Kea responds.
+        let mut message =
+            Self::message_with_server_and_address(idx, MessageType::Release, server_id, address);
+        Self::add_ia_ta(&mut message, idx);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a DECLINE for an unusable offered lease.
+    pub fn decline(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::message_with_server_and_address(idx, MessageType::Decline, server_id, address),
+            true,
+        )
+    }
+
+    /// Build a DECLINE carrying unsupported IA_PD alongside the declined IA_NA.
+    pub fn decline_with_ia_pd(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+        // Lease-end messages are Kea protocol handling; extra IA_PD must not
+        // make the Carbide hook call discovery or drop before Kea responds.
+        let mut message =
+            Self::message_with_server_and_address(idx, MessageType::Decline, server_id, address);
+        Self::add_ia_pd(&mut message, idx);
+        Self::relay_wrap(message, true)
+    }
+
+    /// Build a DECLINE with a caller-supplied relay hop count.
+    pub fn decline_with_hop_count(
+        idx: u8,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+        hop_count: u8,
+    ) -> Vec<u8> {
+        Self::relay_wrap_with_hop_count(
+            Self::message_with_server_and_address(idx, MessageType::Decline, server_id, address),
+            true,
+            hop_count,
+        )
+    }
+
+    /// Build a CONFIRM for an address the client wants to keep using.
+    pub fn confirm(idx: u8, address: Ipv6Addr) -> Vec<u8> {
+        Self::relay_wrap(
+            Self::client_message_with_address(idx, MessageType::Confirm, address, None),
+            true,
+        )
+    }
+
+    /// Build the default stateful SOLICIT message used by most lease tests.
+    fn stateful_solicit_message(idx: u8) -> Message {
+        Self::client_message(
+            idx,
+            MessageType::Solicit,
+            Self::duid_ll(idx),
+            None,
+            true,
+            false,
+        )
+    }
+
+    /// Build the default stateless SOLICIT message used by options-only tests.
+    fn stateless_solicit_message(idx: u8) -> Message {
+        Self::client_message(
+            idx,
+            MessageType::Solicit,
+            Self::duid_ll(idx),
+            None,
+            false,
+            false,
+        )
+    }
+
+    /// Build the default INFORMATION-REQUEST message used by options-only tests.
+    fn information_request_message(idx: u8) -> Message {
+        Self::client_message(
+            idx,
+            MessageType::InformationRequest,
+            Self::duid_ll(idx),
+            None,
+            false,
+            false,
+        )
+    }
+
+    /// Build a default-DUID message that selects a server-owned IA_NA address.
+    fn message_with_server_and_address(
+        idx: u8,
+        message_type: MessageType,
+        server_id: Vec<u8>,
+        address: Ipv6Addr,
+    ) -> Message {
+        Self::client_message(
+            idx,
+            message_type,
+            Self::duid_ll(idx),
+            Some((server_id, address)),
+            true,
+            false,
+        )
+    }
+
+    fn client_message_with_address(
+        idx: u8,
+        message_type: MessageType,
+        address: Ipv6Addr,
+        server_id: Option<Vec<u8>>,
+    ) -> Message {
+        let mut message = Message::new_with_id(message_type, [0xaa, 0xbb, idx]);
+        message
+            .opts_mut()
+            .insert(DhcpOption::ClientId(Self::duid_ll(idx)));
+        if let Some(server_id) = server_id {
+            message.opts_mut().insert(DhcpOption::ServerId(server_id));
+        }
+        let mut ia_na = IANA {
+            id: idx as u32,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        };
+        ia_na.opts.insert(DhcpOption::IAAddr(IAAddr {
+            addr: address,
+            preferred_life: 0,
+            valid_life: 0,
+            opts: Default::default(),
+        }));
+        message.opts_mut().insert(DhcpOption::IANA(ia_na));
+        message
+    }
+
+    fn add_client_fqdn(message: &mut Message) {
+        message
+            .opts_mut()
+            .insert(DhcpOption::Unknown(UnknownOption::new(
+                OptionCode::ClientFqdn,
+                Self::client_fqdn_payload(),
+            )));
+    }
+
+    /// Add an unsupported IA_TA option to a DHCPv6 test message.
+    fn add_ia_ta(message: &mut Message, idx: u8) {
+        // IA_TA is intentionally unsupported by Carbide's DHCPv6 API path.
+        message.opts_mut().insert(DhcpOption::IATA(IATA {
+            id: idx as u32,
+            opts: Default::default(),
+        }));
+    }
+
+    /// Add an unsupported IA_PD option to a DHCPv6 test message.
+    fn add_ia_pd(message: &mut Message, idx: u8) {
+        // IA_PD is intentionally unsupported by Carbide's DHCPv6 API path.
+        message.opts_mut().insert(DhcpOption::IAPD(IAPD {
+            id: idx as u32,
+            t1: 0,
+            t2: 0,
+            opts: Default::default(),
+        }));
+    }
+
+    fn add_vendor_class(message: &mut Message, vendor_class: &[u8]) {
+        let mut payload = 32473u32.to_be_bytes().to_vec();
+        payload.extend_from_slice(&(vendor_class.len() as u16).to_be_bytes());
+        payload.extend_from_slice(vendor_class);
+        message
+            .opts_mut()
+            .insert(DhcpOption::Unknown(UnknownOption::new(
+                OptionCode::VendorClass,
+                payload,
+            )));
+    }
+
+    /// Decode Kea's Relay-Reply and return the inner DHCPv6 message.
+    pub fn decode_reply(packet: &[u8]) -> Result<Message, eyre::Report> {
+        match packet.first().copied() {
+            Some(RELAY_REPL) => {
+                let relay_msg = Self::relay_msg_payload(packet)
+                    .ok_or_else(|| eyre::eyre!("relay reply did not include relay-msg"))?;
+                Message::decode(&mut Decoder::new(relay_msg))
+                    .map_err(|err| eyre::eyre!("failed to decode inner DHCPv6 message: {err}"))
+            }
+            Some(_) => Message::decode(&mut Decoder::new(packet))
+                .map_err(|err| eyre::eyre!("failed to decode DHCPv6 message: {err}")),
+            None => Err(eyre::eyre!("empty DHCPv6 response")),
+        }
+    }
+
+    /// Extract the IAADDR from the first IA_NA option.
+    pub fn ia_addr(message: &Message) -> Option<Ipv6Addr> {
+        match message.opts().get(OptionCode::IANA) {
+            Some(DhcpOption::IANA(ia_na)) => match ia_na.opts.get(OptionCode::IAAddr) {
+                Some(DhcpOption::IAAddr(addr)) => Some(addr.addr),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Extract the server-id option needed for REQUEST/RENEW/RELEASE.
+    pub fn server_id(message: &Message) -> Vec<u8> {
+        match message.opts().get(OptionCode::ServerId) {
+            Some(DhcpOption::ServerId(server_id)) => server_id.clone(),
+            other => panic!("DHCPv6 response did not include server-id: {other:?}"),
+        }
+    }
+
+    fn client_message(
+        idx: u8,
+        message_type: MessageType,
+        duid: Vec<u8>,
+        server_and_addr: Option<(Vec<u8>, Ipv6Addr)>,
+        include_ia_na: bool,
+        rapid_commit: bool,
+    ) -> Message {
+        let mut message = Message::new_with_id(message_type, [0xaa, 0xbb, idx]);
+        message.opts_mut().insert(DhcpOption::ClientId(duid));
+        if let Some((server_id, _)) = &server_and_addr {
+            message
+                .opts_mut()
+                .insert(DhcpOption::ServerId(server_id.clone()));
+        }
+        if include_ia_na {
+            let mut ia_na = IANA {
+                id: idx as u32,
+                t1: 0,
+                t2: 0,
+                opts: Default::default(),
+            };
+            if let Some((_, address)) = server_and_addr {
+                ia_na.opts.insert(DhcpOption::IAAddr(IAAddr {
+                    addr: address,
+                    preferred_life: 300,
+                    valid_life: 600,
+                    opts: Default::default(),
+                }));
+            }
+            message.opts_mut().insert(DhcpOption::IANA(ia_na));
+        }
+        if rapid_commit {
+            message.opts_mut().insert(DhcpOption::RapidCommit);
+        }
+        message
+    }
+
+    fn relay_wrap(message: Message, relay_option79: bool) -> Vec<u8> {
+        Self::relay_wrap_with_hop_count(message, relay_option79, 0)
+    }
+
+    fn relay_wrap_with_hop_count(message: Message, relay_option79: bool, hop_count: u8) -> Vec<u8> {
+        let mut inner = Vec::new();
+        message.encode(&mut Encoder::new(&mut inner)).unwrap();
+        Self::relay_wrap_payload(&inner, message.xid()[2], relay_option79, hop_count)
+    }
+
+    /// Wrap raw DHCPv6 payload bytes in one Relay-Forward envelope.
+    fn relay_wrap_payload(payload: &[u8], idx: u8, relay_option79: bool, hop_count: u8) -> Vec<u8> {
+        let mut out = vec![RELAY_FORW, hop_count];
+        out.extend_from_slice(&Self::RELAY_LINK_ADDR.parse::<Ipv6Addr>().unwrap().octets());
+        out.extend_from_slice(&Ipv6Addr::LOCALHOST.octets());
+        out.extend_from_slice(&Self::raw_option(OptionCode::InterfaceId, b"eth0"));
+        out.extend_from_slice(&Self::raw_option(OptionCode::RemoteId, b"rack-a"));
+        if relay_option79 {
+            out.extend_from_slice(&Self::raw_option(
+                OptionCode::ClientLinklayerAddr,
+                &Self::option79_payload(idx),
+            ));
+        }
+        out.extend_from_slice(&Self::raw_option(OptionCode::RelayMsg, payload));
+        out
+    }
+
+    fn relay_msg_payload(packet: &[u8]) -> Option<&[u8]> {
+        if packet.len() < 34 {
+            return None;
+        }
+
+        let mut options = &packet[34..];
+        while options.len() >= 4 {
+            let code = u16::from_be_bytes([options[0], options[1]]);
+            let len = u16::from_be_bytes([options[2], options[3]]) as usize;
+            options = &options[4..];
+            if options.len() < len {
+                return None;
+            }
+            let (payload, rest) = options.split_at(len);
+            if code == u16::from(OptionCode::RelayMsg) {
+                return Some(payload);
+            }
+            options = rest;
+        }
+
+        None
+    }
+
+    fn option79_payload(idx: u8) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(8);
+        payload.extend_from_slice(&HTYPE_ETHERNET.to_be_bytes());
+        payload.extend_from_slice(&Self::mac(idx));
+        payload
+    }
+
+    fn raw_option(code: OptionCode, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(&u16::from(code).to_be_bytes());
+        out.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+}

--- a/crates/dhcp/tests/common/kea_v6.rs
+++ b/crates/dhcp/tests/common/kea_v6.rs
@@ -1,0 +1,595 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use super::dhcpv6_factory::RELAY_ADDR;
+
+const KEA_READY_TIMEOUT: Duration = Duration::from_secs(15);
+const KEA_START_ATTEMPTS: usize = 5;
+const KEA_EXIT_SETTLE: Duration = Duration::from_millis(100);
+const KEA_SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
+const KEA_SHUTDOWN_POLL: Duration = Duration::from_millis(50);
+const METRICS_READY_CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
+/// DHCPv6 DNS servers configured through hook context.
+pub const HOOK_DNS_SERVERS_IPV6: [&str; 1] = ["2001:db8::53"];
+/// DHCPv6 NTP servers configured through hook context.
+pub const HOOK_NTP_SERVERS_IPV6: [&str; 1] = ["2001:db8::123"];
+
+// Real Kea children share process-global hook/logger/metrics state through the
+// loaded cdylib, so serialize them instead of running multiple daemons at once.
+static KEA6_RUN_GATE: OnceLock<Kea6RunGate> = OnceLock::new();
+
+/// Kea expired-lease processing knobs used by tests that force quick reclamation.
+#[derive(Debug, Clone, Copy)]
+pub struct Kea6ExpiredLeasesProcessing {
+    pub reclaim_timer_wait_time: u16,
+    pub flush_reclaimed_timer_wait_time: u16,
+    pub hold_reclaimed_time: u32,
+    pub max_reclaim_leases: u32,
+    pub max_reclaim_time: u16,
+    pub unwarned_reclaim_cycles: u16,
+}
+
+/// Runtime configuration overrides for the DHCPv6 integration-test Kea process.
+#[derive(Debug, Clone, Copy)]
+pub struct Kea6Config {
+    pub preferred_lifetime: u32,
+    pub valid_lifetime: u32,
+    pub renew_timer: u32,
+    pub rebind_timer: u32,
+    pub mac_sources: Option<&'static [&'static str]>,
+    pub expired_leases_processing: Option<Kea6ExpiredLeasesProcessing>,
+}
+
+impl Default for Kea6Config {
+    fn default() -> Self {
+        Self {
+            preferred_lifetime: 3600,
+            valid_lifetime: 7200,
+            renew_timer: 1800,
+            rebind_timer: 2880,
+            mac_sources: None,
+            expired_leases_processing: None,
+        }
+    }
+}
+
+struct Kea6RunGate {
+    state: Mutex<Kea6RunState>,
+    available: Condvar,
+}
+
+#[derive(Default)]
+struct Kea6RunState {
+    running: bool,
+}
+
+struct Kea6RunPermit {
+    gate: &'static Kea6RunGate,
+}
+
+impl Kea6RunGate {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(Kea6RunState::default()),
+            available: Condvar::new(),
+        }
+    }
+
+    fn acquire(&'static self) -> Kea6RunPermit {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while state.running {
+            state = self
+                .available
+                .wait(state)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        state.running = true;
+
+        Kea6RunPermit { gate: self }
+    }
+
+    fn release(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.running = false;
+        self.available.notify_one();
+    }
+}
+
+impl Drop for Kea6RunPermit {
+    fn drop(&mut self) {
+        self.gate.release();
+    }
+}
+
+pub struct Kea6 {
+    temp_conf_file: PathBuf,
+    dhcp_in_port: u16,
+    dhcp_out_port: u16,
+    dhcp_in_port_reservation: Option<UdpSocket>,
+    metrics_endpoint: SocketAddr,
+    metrics_endpoint_reservation: Option<TcpListener>,
+    temp_base_directory: TempDir,
+    process: Option<Child>,
+    logs: Arc<Mutex<Vec<String>>>,
+    _run_permit: Option<Kea6RunPermit>,
+}
+
+struct Kea6Ports {
+    dhcp_in_port: u16,
+    dhcp_out_port: u16,
+}
+
+impl Kea6 {
+    /// Reserve dynamic DHCPv6 ports, start Kea, and return a connected relay socket.
+    pub fn start(
+        api_server_url: &str,
+        lease_file: Option<&Path>,
+    ) -> Result<(Kea6, UdpSocket), eyre::Report> {
+        Self::start_with_config(api_server_url, lease_file, Kea6Config::default())
+    }
+
+    /// Start Kea with launch-time overrides such as lifetimes, mac-sources, and expiry processing.
+    pub fn start_with_config(
+        api_server_url: &str,
+        lease_file: Option<&Path>,
+        config: Kea6Config,
+    ) -> Result<(Kea6, UdpSocket), eyre::Report> {
+        // Acquire the gate before reserving ports so blocked tests do not hold
+        // loopback DHCP/metrics reservations while another Kea child runs.
+        let run_permit = KEA6_RUN_GATE.get_or_init(Kea6RunGate::new).acquire();
+
+        // Reserve both ends of the relayed test flow before writing config so
+        // Kea's command-line receive port and relay reply port stay paired.
+        let relay_socket = UdpSocket::bind(format!("[{RELAY_ADDR}]:0"))?;
+        let dhcp_out_port = relay_socket.local_addr()?.port();
+        let (dhcp_in_port, dhcp_in_port_reservation) = Self::reserve_dhcp_in_port()?;
+        let (metrics_endpoint, metrics_endpoint_reservation) = Self::reserve_metrics_endpoint()?;
+
+        let mut kea = Kea6::new_inner(
+            api_server_url,
+            Kea6Ports {
+                dhcp_in_port,
+                dhcp_out_port,
+            },
+            Some(dhcp_in_port_reservation),
+            metrics_endpoint,
+            Some(metrics_endpoint_reservation),
+            lease_file,
+            config,
+        )?;
+        kea.run(run_permit)?;
+        relay_socket.connect(format!("[{RELAY_ADDR}]:{}", kea.dhcp_in_port))?;
+
+        Ok((kea, relay_socket))
+    }
+
+    fn new_inner(
+        api_server_url: &str,
+        ports: Kea6Ports,
+        dhcp_in_port_reservation: Option<UdpSocket>,
+        metrics_endpoint: SocketAddr,
+        metrics_endpoint_reservation: Option<TcpListener>,
+        lease_file: Option<&Path>,
+        config: Kea6Config,
+    ) -> Result<Kea6, eyre::Report> {
+        let temp_base_directory = tempfile::tempdir()?;
+        let temp_conf_file = temp_base_directory.path().join("kea-dhcp6.conf");
+
+        // Use a caller-supplied memfile only when a test needs to inspect
+        // lease persistence across Kea restarts.
+        let lease_file = lease_file
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| temp_base_directory.path().join("kea-leases6.csv"));
+
+        let mut temp_conf_fd = File::create(&temp_conf_file)?;
+        temp_conf_fd.write_all(
+            Kea6::config(api_server_url, &lease_file, metrics_endpoint, config).as_bytes(),
+        )?;
+
+        // Close the config before spawning Kea so the child reads complete JSON.
+        drop(temp_conf_fd);
+
+        Ok(Kea6 {
+            temp_conf_file,
+            temp_base_directory,
+            dhcp_in_port: ports.dhcp_in_port,
+            dhcp_out_port: ports.dhcp_out_port,
+            dhcp_in_port_reservation,
+            metrics_endpoint,
+            metrics_endpoint_reservation,
+            process: None,
+            logs: Arc::new(Mutex::new(Vec::new())),
+            _run_permit: None,
+        })
+    }
+
+    fn reserve_dhcp_in_port() -> Result<(u16, UdpSocket), eyre::Report> {
+        // Hold the port until the child process starts so parallel local
+        // activity is less likely to steal it between config generation and
+        // Kea's bind.
+        let dhcp_in_port_reservation = UdpSocket::bind("[::1]:0")?;
+        let dhcp_in_port = dhcp_in_port_reservation.local_addr()?.port();
+
+        Ok((dhcp_in_port, dhcp_in_port_reservation))
+    }
+
+    fn reserve_metrics_endpoint() -> Result<(SocketAddr, TcpListener), eyre::Report> {
+        let reservation = TcpListener::bind("[::1]:0")?;
+        let endpoint = reservation.local_addr()?;
+
+        Ok((endpoint, reservation))
+    }
+
+    fn refresh_dhcp_in_port(&mut self) -> Result<(), eyre::Report> {
+        // Kea may fail before binding a reserved dynamic port; retry with a
+        // fresh receive port while keeping the same config directory/memfile.
+        let (dhcp_in_port, dhcp_in_port_reservation) = Self::reserve_dhcp_in_port()?;
+
+        self.dhcp_in_port = dhcp_in_port;
+        self.dhcp_in_port_reservation = Some(dhcp_in_port_reservation);
+
+        Ok(())
+    }
+
+    fn run(&mut self, run_permit: Kea6RunPermit) -> Result<(), eyre::Report> {
+        let mut run_permit = Some(run_permit);
+        let mut last_exit = None;
+        for attempt in 1..=KEA_START_ATTEMPTS {
+            match self.run_once()? {
+                Some(status) => {
+                    last_exit = Some((self.dhcp_in_port, status));
+                    if attempt == KEA_START_ATTEMPTS {
+                        break;
+                    }
+
+                    // A failed early start usually means a transient bind or
+                    // config-load failure; report the child status and retry
+                    // with a new receive port before giving up.
+                    println!(
+                        "KEA6 exited before binding DHCP port {} on attempt {attempt}/{KEA_START_ATTEMPTS}: {status}; retrying with a fresh DHCP receive port",
+                        self.dhcp_in_port
+                    );
+                    self.refresh_dhcp_in_port()?;
+                }
+                None => {
+                    self._run_permit = run_permit.take();
+                    return Ok(());
+                }
+            }
+        }
+
+        let (port, status) = last_exit.expect("at least one Kea6 start attempt should have run");
+        Err(eyre::eyre!(
+            "Kea6 exited before binding DHCP port {port} after {KEA_START_ATTEMPTS} attempts: {status}"
+        ))
+    }
+
+    fn run_once(&mut self) -> Result<Option<ExitStatus>, eyre::Report> {
+        // Release our reservations immediately before spawn; from this point
+        // Kea must own those sockets for readiness checks to pass.
+        drop(self.dhcp_in_port_reservation.take());
+        drop(self.metrics_endpoint_reservation.take());
+
+        // Point Kea runtime files at the per-test temp dir instead of system
+        // paths that unprivileged integration tests cannot safely share.
+        let mut process = Command::new("/usr/sbin/kea-dhcp6")
+            .env("KEA_PIDFILE_DIR", self.temp_base_directory.path())
+            .env("KEA_LOCKFILE_DIR", self.temp_base_directory.path())
+            .arg("-c")
+            .arg(self.temp_conf_file.as_os_str())
+            .arg("-p")
+            .arg(self.dhcp_in_port.to_string())
+            .arg("-P")
+            .arg(self.dhcp_out_port.to_string())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        let stdout = BufReader::new(process.stdout.take().unwrap());
+        let stderr = BufReader::new(process.stderr.take().unwrap());
+        let stdout_logs = self.logs.clone();
+        // Keep child logs in memory so tests can assert warnings and failures
+        // include useful diagnostics. These reader threads end at pipe EOF.
+        thread::spawn(move || {
+            for line in stdout.lines() {
+                let line = line.unwrap();
+                stdout_logs
+                    .lock()
+                    .unwrap()
+                    .push(format!("KEA6 STDOUT: {line}"));
+                println!("KEA6 STDOUT: {line}");
+            }
+        });
+        let stderr_logs = self.logs.clone();
+        thread::spawn(move || {
+            for line in stderr.lines() {
+                let line = line.unwrap();
+                stderr_logs
+                    .lock()
+                    .unwrap()
+                    .push(format!("KEA6 STDERR: {line}"));
+                println!("KEA6 STDERR: {line}");
+            }
+        });
+
+        self.process = Some(process);
+
+        let deadline = Instant::now() + KEA_READY_TIMEOUT;
+        loop {
+            thread::sleep(Duration::from_millis(100));
+            if let Some(status) = self.process.as_mut().unwrap().try_wait()? {
+                self.process = None;
+                return Ok(Some(status));
+            }
+
+            // Once binding our probe socket fails with AddrInUse, Kea owns the
+            // DHCP receive port. Metrics still initializes separately below.
+            match UdpSocket::bind(format!("[::1]:{}", self.dhcp_in_port)) {
+                Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                    // After the DHCP bind appears ready, give Kea a short
+                    // window to fail startup before declaring the harness ready.
+                    thread::sleep(KEA_EXIT_SETTLE);
+                    if let Some(status) = self.process.as_mut().unwrap().try_wait()? {
+                        self.process = None;
+                        return Ok(Some(status));
+                    }
+                    if let Some(status) = self.wait_for_metrics_endpoint(deadline)? {
+                        return Ok(Some(status));
+                    }
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => return Err(eyre::eyre!("Unexpected error probing Kea6 readiness: {e}")),
+            }
+            if Instant::now() >= deadline {
+                self.stop_process();
+                return Err(eyre::eyre!(
+                    "Kea6 did not bind DHCP port {} within {KEA_READY_TIMEOUT:?}",
+                    self.dhcp_in_port
+                ));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn wait_for_metrics_endpoint(
+        &mut self,
+        deadline: Instant,
+    ) -> Result<Option<ExitStatus>, eyre::Report> {
+        loop {
+            // The hook initializes metrics asynchronously after loading; wait
+            // for the endpoint so metric assertions do not race initialization.
+            if TcpStream::connect_timeout(&self.metrics_endpoint, METRICS_READY_CONNECT_TIMEOUT)
+                .is_ok()
+            {
+                return Ok(None);
+            }
+            if let Some(status) = self.process.as_mut().unwrap().try_wait()? {
+                self.process = None;
+                return Ok(Some(status));
+            }
+            if Instant::now() >= deadline {
+                self.stop_process();
+                return Err(eyre::eyre!(
+                    "Kea6 did not bind metrics endpoint {} within {KEA_READY_TIMEOUT:?}",
+                    self.metrics_endpoint
+                ));
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    pub fn wait_for_log(&self, needle: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self
+                .logs
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|line| line.contains(needle))
+            {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    pub fn metrics_endpoint(&self) -> SocketAddr {
+        self.metrics_endpoint
+    }
+
+    /// Restart the same Kea6 config and memfile, clearing process-local hook cache.
+    pub fn restart(&mut self) -> Result<(), eyre::Report> {
+        let run_permit = self
+            ._run_permit
+            .take()
+            .expect("Kea6 restart requires an active run permit");
+
+        // The cache under test lives inside the child process, not the memfile.
+        self.stop_process();
+        self.logs.lock().unwrap().clear();
+        match self.run_once()? {
+            Some(status) => Err(eyre::eyre!("Kea6 exited during restart: {status}")),
+            None => {
+                self._run_permit = Some(run_permit);
+                Ok(())
+            }
+        }
+    }
+
+    fn stop_process(&mut self) {
+        if let Some(process) = &mut self.process {
+            // Prefer Kea's shutdown path so hook-library cleanup runs; kill is
+            // only a fallback for a child that ignores SIGTERM.
+            unsafe {
+                libc::kill(process.id() as i32, libc::SIGTERM);
+            }
+
+            let deadline = Instant::now() + KEA_SHUTDOWN_GRACE;
+            loop {
+                match process.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) if Instant::now() < deadline => thread::sleep(KEA_SHUTDOWN_POLL),
+                    Ok(None) => {
+                        process.kill().unwrap();
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+        }
+        self.process = None;
+    }
+
+    fn config(
+        api_server_url: &str,
+        lease_file: &Path,
+        metrics_endpoint: SocketAddr,
+        config: Kea6Config,
+    ) -> String {
+        let hook_lib = hook_library_path();
+        let metrics_endpoint = metrics_endpoint.to_string();
+        let mut dhcp6 = json!({
+            "interfaces-config": {
+                // DHCPv6 binds interface-only selectors to link-local
+                // addresses; the harness sends relayed traffic to ::1.
+                "interfaces": [ "lo/::1" ]
+            },
+            // DHCPv6 otherwise persists its generated server DUID under
+            // /var/lib/kea, which unprivileged integration tests cannot write.
+            "server-id": {
+                "type": "LL",
+                "htype": 1,
+                "identifier": "000102030405",
+                "persist": false
+            },
+            // Persist the memfile so restart and lease-inspection tests observe
+            // Kea's on-disk state; tempdir cleanup still bounds artifacts.
+            "lease-database": {
+                "type": "memfile",
+                "persist": true,
+                "name": lease_file.to_string_lossy(),
+                "lfc-interval": 3600
+            },
+            "preferred-lifetime": config.preferred_lifetime,
+            "valid-lifetime": config.valid_lifetime,
+            "renew-timer": config.renew_timer,
+            "rebind-timer": config.rebind_timer,
+            // Match the v4 test/example quarantine instead of Kea's much
+            // longer DHCPv6 default, so delayed DECLINE behavior is comparable.
+            "decline-probation-period": 900,
+            "hooks-libraries": [
+                {
+                    "library": hook_lib,
+                    "parameters": {
+                        "carbide-api-url": api_server_url,
+                        "carbide-metrics-endpoint": metrics_endpoint,
+                        "hook-dns-servers-ipv6": HOOK_DNS_SERVERS_IPV6.join(","),
+                        "hook-ntp-servers-ipv6": HOOK_NTP_SERVERS_IPV6.join(","),
+                        // Keep optional v6 parameters explicit so loader
+                        // parsing is exercised even when the option is off.
+                        "hook-provisioning-server-ipv6": "",
+                        "hook-rapid-commit-v6": false
+                    }
+                }
+            ],
+            "subnet6": [
+                {
+                    "subnet": "::/0",
+                    "pools": [{
+                        "pool": "2001:db8::1-2001:db8::ffff"
+                    }]
+                }
+            ],
+            "loggers": [
+                {
+                    "name": "kea-dhcp6",
+                    "output_options": [{"output": "stdout"}],
+                    "severity": "WARN",
+                    "debuglevel": 99
+                },
+                {
+                    "name": "kea-dhcp6.carbide-rust",
+                    "output_options": [{"output": "stdout"}],
+                    "severity": "WARN",
+                    "debuglevel": 10
+                },
+                {
+                    "name": "kea-dhcp6.carbide-callouts",
+                    "output_options": [{"output": "stdout"}],
+                    "severity": "WARN",
+                    "debuglevel": 10
+                }
+            ]
+        });
+        if let Some(expiration) = config.expired_leases_processing {
+            // Most tests use normal lease lifetimes; expiry tests override this
+            // block to make Kea reclaim leases within the test timeout.
+            dhcp6["expired-leases-processing"] = json!({
+                "reclaim-timer-wait-time": expiration.reclaim_timer_wait_time,
+                "flush-reclaimed-timer-wait-time": expiration.flush_reclaimed_timer_wait_time,
+                "hold-reclaimed-time": expiration.hold_reclaimed_time,
+                "max-reclaim-leases": expiration.max_reclaim_leases,
+                "max-reclaim-time": expiration.max_reclaim_time,
+                "unwarned-reclaim-cycles": expiration.unwarned_reclaim_cycles
+            });
+        }
+        if let Some(mac_sources) = config.mac_sources {
+            // Identity tests pin mac-sources to force Kea's stored hwaddr down
+            // specific option79-vs-DUID paths.
+            dhcp6["mac-sources"] = json!(mac_sources);
+        }
+        let conf = json!({ "Dhcp6": dhcp6 });
+        conf.to_string()
+    }
+}
+
+impl Drop for Kea6 {
+    fn drop(&mut self) {
+        self.stop_process();
+    }
+}
+
+fn hook_library_path() -> String {
+    // Build the current hook before Kea starts; accepting an existing release
+    // artifact can make debug test runs exercise stale hook code.
+    test_cdylib::build_current_project()
+        .to_string_lossy()
+        .into_owned()
+}

--- a/crates/dhcp/tests/common/mod.rs
+++ b/crates/dhcp/tests/common/mod.rs
@@ -14,8 +14,147 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#[allow(dead_code)]
 mod dhcp_factory;
+#[allow(dead_code)]
+mod dhcpv6_factory;
+#[allow(dead_code)]
 pub(crate) mod kea;
+#[allow(dead_code)]
+pub(crate) mod kea_v6;
 
+use std::io::{Read, Write};
+use std::net::{Ipv6Addr, SocketAddr, TcpStream};
+use std::time::{Duration, Instant};
+
+use dhcp::mock_api_server::DHCP_RESPONSE_FQDN;
+#[allow(unused_imports)]
 pub use dhcp_factory::DHCPFactory;
+use dhcproto::v6::{DhcpOption, Message, NtpSuboption, OptionCode};
+#[allow(unused_imports)]
+pub use dhcpv6_factory::DHCPv6Factory;
+#[allow(unused_imports)]
 pub use kea::Kea;
+#[allow(unused_imports)]
+pub use kea_v6::{
+    HOOK_DNS_SERVERS_IPV6, HOOK_NTP_SERVERS_IPV6, Kea6, Kea6Config, Kea6ExpiredLeasesProcessing,
+};
+
+#[allow(dead_code)]
+const METRICS_READ_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Return the DHCPv6 dropped-request counter value for a reason label.
+#[allow(dead_code)]
+pub fn v6_drop_metric_value(endpoint: SocketAddr, reason: &str) -> f64 {
+    scrape_metrics(endpoint)
+        .map(|metrics| drop_counter_value(&metrics, reason))
+        .unwrap_or(0.0)
+}
+
+/// Wait until the DHCPv6 dropped-request counter reaches the expected value.
+#[allow(dead_code)]
+pub fn wait_for_v6_drop_metric_at_least(
+    endpoint: SocketAddr,
+    reason: &str,
+    minimum: f64,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if v6_drop_metric_value(endpoint, reason) >= minimum {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Scrape the Prometheus text endpoint from a Kea child process.
+#[allow(dead_code)]
+fn scrape_metrics(endpoint: SocketAddr) -> Option<String> {
+    let mut stream = TcpStream::connect_timeout(&endpoint, METRICS_READ_TIMEOUT).ok()?;
+    stream.set_read_timeout(Some(METRICS_READ_TIMEOUT)).ok()?;
+    stream
+        .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .ok()?;
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).ok()?;
+    Some(response)
+}
+
+/// Return the parsed DHCPv6 dropped-request counter value for a reason label.
+#[allow(dead_code)]
+fn drop_counter_value(metrics: &str, reason: &str) -> f64 {
+    let prefix = format!("carbide_dropped_v6_requests_total{{reason=\"{reason}\"}} ");
+    metrics
+        .lines()
+        .filter_map(|line| line.strip_prefix(&prefix))
+        .filter_map(|value| value.split_whitespace().next())
+        .filter_map(|value| value.parse::<f64>().ok())
+        .sum()
+}
+
+/// Assert that the DHCPv6 response carries hook-configured DNS servers.
+#[allow(dead_code)]
+pub fn assert_hook_v6_dns_servers(response: &Message) {
+    // Keep the expected value tied to the Kea test config, not mock API data.
+    let expected = HOOK_DNS_SERVERS_IPV6
+        .into_iter()
+        .map(|server| server.parse::<Ipv6Addr>().unwrap())
+        .collect::<Vec<_>>();
+
+    match response.opts().get(OptionCode::DomainNameServers) {
+        Some(DhcpOption::DomainNameServers(servers)) => assert_eq!(servers, &expected),
+        other => panic!("DHCPv6 response did not include DNS servers: {other:?}"),
+    }
+}
+
+/// Assert that the DHCPv6 response carries the API-owned parent domain.
+#[allow(dead_code)]
+pub fn assert_api_v6_domain_search(response: &Message) {
+    // DHCPv6 domain-search uses the trusted parent domain from the API FQDN.
+    let expected = DHCP_RESPONSE_FQDN
+        .split_once('.')
+        .map(|(_, domain)| format!("{domain}."))
+        .expect("mock DHCP FQDN must include a parent domain");
+
+    let actual = match response.opts().get(OptionCode::DomainSearchList) {
+        Some(DhcpOption::DomainSearchList(names)) => {
+            names.iter().map(|name| name.to_ascii()).collect::<Vec<_>>()
+        }
+        other => panic!("DHCPv6 response did not include domain search: {other:?}"),
+    };
+    assert_eq!(actual, vec![expected]);
+}
+
+/// Assert that the DHCPv6 response carries hook-configured NTP servers.
+#[allow(dead_code)]
+pub fn assert_hook_v6_ntp_servers(response: &Message) {
+    // Keep the expected value tied to the Kea test config, not API mock data.
+    let expected = HOOK_NTP_SERVERS_IPV6
+        .into_iter()
+        .map(|server| server.parse::<Ipv6Addr>().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(ntp_server_addresses(response), expected);
+}
+
+/// Return IPv6 NTP server addresses from a DHCPv6 option 56 response.
+#[allow(dead_code)]
+fn ntp_server_addresses(response: &Message) -> Vec<Ipv6Addr> {
+    match response.opts().get(OptionCode::NtpServer) {
+        Some(DhcpOption::NtpServer(suboptions)) => suboptions
+            .iter()
+            .filter_map(|option| match option {
+                NtpSuboption::ServerAddress(address) | NtpSuboption::MulticastAddress(address) => {
+                    Some(*address)
+                }
+                NtpSuboption::FQDN(_) => None,
+            })
+            .collect(),
+        other => panic!("DHCPv6 response did not include NTP server addresses: {other:?}"),
+    }
+}

--- a/crates/dhcp/tests/identity_v6_test.rs
+++ b/crates/dhcp/tests/identity_v6_test.rs
@@ -1,0 +1,302 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use dhcp::mock_api_server::{self, ENDPOINT_DISCOVER_DHCP};
+use dhcproto::v6;
+use rpc::forge as rpc;
+
+mod common;
+
+use common::{DHCPv6Factory, Kea6, v6_drop_metric_value, wait_for_v6_drop_metric_at_least};
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const LOG_TIMEOUT: Duration = Duration::from_secs(2);
+const METRIC_TIMEOUT: Duration = Duration::from_secs(5);
+const DUID_MAX_LEN: usize = 128;
+
+fn send_and_recv(socket: &UdpSocket, packet: Vec<u8>) -> Option<v6::Message> {
+    socket.send(&packet).unwrap();
+    let mut buf = [0u8; 1500];
+    let n = socket.recv(&mut buf).ok()?;
+    Some(DHCPv6Factory::decode_reply(&buf[..n]).unwrap())
+}
+
+struct Harness {
+    _rt: tokio::runtime::Runtime,
+    api_server: mock_api_server::MockAPIServer,
+    _kea: Kea6,
+    socket: UdpSocket,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let (_kea, socket) = Kea6::start(api_server.local_http_addr(), None).unwrap();
+        socket.set_read_timeout(Some(READ_TIMEOUT)).unwrap();
+
+        Harness {
+            _rt: rt,
+            api_server,
+            _kea,
+            socket,
+        }
+    }
+
+    fn last_discovery(&self) -> rpc::DhcpDiscovery {
+        self.api_server.discoveries().last().unwrap().clone()
+    }
+
+    fn wait_for_log(&self, needle: &str) -> bool {
+        self._kea.wait_for_log(needle, LOG_TIMEOUT)
+    }
+
+    fn wait_for_drop_metric(&self, reason: &str) -> bool {
+        wait_for_v6_drop_metric_at_least(self._kea.metrics_endpoint(), reason, 1.0, METRIC_TIMEOUT)
+    }
+
+    /// Return the current DHCPv6 dropped-request counter value for a reason label.
+    fn drop_metric_value(&self, reason: &str) -> f64 {
+        v6_drop_metric_value(self._kea.metrics_endpoint(), reason)
+    }
+
+    /// Wait until the DHCPv6 dropped-request counter reaches the expected value.
+    fn wait_for_drop_metric_at_least(&self, reason: &str, minimum: f64) -> bool {
+        wait_for_v6_drop_metric_at_least(
+            self._kea.metrics_endpoint(),
+            reason,
+            minimum,
+            METRIC_TIMEOUT,
+        )
+    }
+}
+
+#[test]
+fn duid_llt_selects_embedded_link_layer_mac() -> Result<(), eyre::Report> {
+    let idx = 0x50;
+    let h = Harness::new();
+
+    // DUID-LLT skips the timestamp and selects the embedded Ethernet MAC.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_duid(idx, DHCPv6Factory::duid_llt(idx), false),
+    )
+    .expect("kea did not respond to DUID-LLT SOLICIT");
+    assert_eq!(response.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(
+        h.last_discovery().mac_address,
+        DHCPv6Factory::mac_string(idx)
+    );
+    assert_eq!(
+        h.last_discovery().message_kind,
+        Some(rpc::MessageKind::V6Solicit as i32)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn non_mac_duid_without_relay_option79_is_dropped() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+
+    // A valid UUID DUID still needs relay-supplied option 79 to choose a MAC row.
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::solicit_with_duid(0x51, DHCPv6Factory::duid_uuid(0x51), false),
+        )
+        .is_none()
+    );
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+    assert!(h.wait_for_log("no_mac_no_option79"));
+    assert!(h.wait_for_log("relay 2001:db8::1 with non-MAC DUID and no RFC 6939 option 79"));
+    assert!(h.wait_for_drop_metric("no_mac_no_option79"));
+
+    Ok(())
+}
+
+#[test]
+fn client_supplied_option79_is_not_trusted() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+
+    // Inner option 79 is client-controlled and must not satisfy identity selection.
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::solicit_with_inner_option79(0x52, DHCPv6Factory::duid_uuid(0x52)),
+        )
+        .is_none()
+    );
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+    assert!(h.wait_for_log("no_mac_no_option79"));
+    assert!(h.wait_for_drop_metric("no_mac_no_option79"));
+
+    Ok(())
+}
+
+#[test]
+fn relay_option79_selects_mac_for_valid_non_mac_duid() -> Result<(), eyre::Report> {
+    let idx = 0x53;
+    let h = Harness::new();
+
+    // Relay option 79 supplies the sending link-layer MAC for UUID DUIDs.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_duid(idx, DHCPv6Factory::duid_uuid(idx), true),
+    )
+    .expect("kea did not respond to relay-option79 SOLICIT");
+    assert_eq!(response.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(
+        h.last_discovery().mac_address,
+        DHCPv6Factory::mac_string(idx)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn relay_option79_wins_when_duid_mac_disagrees() -> Result<(), eyre::Report> {
+    let relay_idx = 0x54;
+    let duid_idx = 0x55;
+    let h = Harness::new();
+
+    // Relay option 79 is the sending link and intentionally wins over DUID MAC.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_duid(relay_idx, DHCPv6Factory::duid_ll(duid_idx), true),
+    )
+    .expect("kea did not respond to disagreeing DUID/option79 SOLICIT");
+    assert_eq!(response.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(
+        h.last_discovery().mac_address,
+        DHCPv6Factory::mac_string(relay_idx)
+    );
+    assert!(h.wait_for_log("option 79 MAC"));
+    assert!(h.wait_for_log("disagrees with DUID MAC"));
+
+    Ok(())
+}
+
+#[test]
+fn malformed_duid_is_dropped_before_api_call() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+
+    // Malformed DUIDs are unsupported even if relay option 79 is present.
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::solicit_with_duid(0x56, DHCPv6Factory::truncated_duid_uuid(), true),
+        )
+        .is_none()
+    );
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+    assert!(h.wait_for_log("unsupported_duid"));
+    assert!(h.wait_for_log("malformed or unsupported DUID"));
+    assert!(h.wait_for_drop_metric("unsupported_duid"));
+
+    Ok(())
+}
+
+#[test]
+fn duid_en_length_boundary_is_enforced_before_api_call() -> Result<(), eyre::Report> {
+    let accepted_idx = 0x57;
+    let rejected_idx = 0x58;
+    let h = Harness::new();
+
+    // A max-length DUID-EN is valid only when relay option 79 supplies the MAC.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_duid(accepted_idx, DHCPv6Factory::duid_en(DUID_MAX_LEN), true),
+    )
+    .expect("kea did not respond to max-length DUID-EN SOLICIT");
+    assert_eq!(response.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(
+        h.last_discovery().mac_address,
+        DHCPv6Factory::mac_string(accepted_idx)
+    );
+    assert_eq!(
+        h.last_discovery().duid.as_ref().map(Vec::len),
+        Some(DUID_MAX_LEN)
+    );
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // One byte over Kea's DUID cap is malformed even with relay option 79.
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::solicit_with_duid(
+                rejected_idx,
+                DHCPv6Factory::duid_en(DUID_MAX_LEN + 1),
+                true,
+            ),
+        )
+        .is_none()
+    );
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls
+    );
+    assert!(h.wait_for_log("unsupported_duid"));
+    assert!(h.wait_for_drop_metric("unsupported_duid"));
+
+    Ok(())
+}
+
+#[test]
+fn unsupported_ia_shapes_are_dropped_before_api_call() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+    let mut expected_drops = h.drop_metric_value("unsupported_message");
+
+    // Unsupported IA-only and IA-less stateful packets must not reach the API.
+    for packet in [
+        DHCPv6Factory::solicit_with_ia_ta(0x59),
+        DHCPv6Factory::solicit_with_ia_pd(0x5a),
+        DHCPv6Factory::request_without_ia_na(0x5b),
+    ] {
+        assert!(send_and_recv(&h.socket, packet).is_none());
+        expected_drops += 1.0;
+        assert!(h.wait_for_drop_metric_at_least("unsupported_message", expected_drops));
+    }
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+
+    Ok(())
+}
+
+#[test]
+fn mixed_ia_na_and_unsupported_ia_is_dropped_before_api_call() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+    let mut expected_drops = h.drop_metric_value("unsupported_message");
+
+    // Mixed or multiple IA containers are ambiguous for one API allocation.
+    for packet in [
+        DHCPv6Factory::solicit_with_ia_na_and_ia_ta(0x5c),
+        DHCPv6Factory::solicit_with_ia_na_and_ia_pd(0x5d),
+        DHCPv6Factory::solicit_with_multiple_ia_na(0x5e),
+    ] {
+        assert!(send_and_recv(&h.socket, packet).is_none());
+        expected_drops += 1.0;
+        assert!(h.wait_for_drop_metric_at_least("unsupported_message", expected_drops));
+    }
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+
+    Ok(())
+}

--- a/crates/dhcp/tests/info_request_v6_test.rs
+++ b/crates/dhcp/tests/info_request_v6_test.rs
@@ -1,0 +1,229 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::fs;
+use std::net::UdpSocket;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use dhcp::mock_api_server::{self, DHCP_RESPONSE_FQDN};
+use dhcproto::v6::{self, DhcpOption, OptionCode};
+use rpc::forge as rpc;
+
+mod common;
+
+use common::{
+    DHCPv6Factory, Kea6, assert_api_v6_domain_search, assert_hook_v6_dns_servers,
+    assert_hook_v6_ntp_servers,
+};
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+
+fn send_and_recv(socket: &UdpSocket, packet: Vec<u8>) -> Option<v6::Message> {
+    socket.send(&packet).unwrap();
+    let mut buf = [0u8; 1500];
+    let n = socket.recv(&mut buf).ok()?;
+    Some(DHCPv6Factory::decode_reply(&buf[..n]).unwrap())
+}
+
+struct Harness {
+    _rt: tokio::runtime::Runtime,
+    api_server: mock_api_server::MockAPIServer,
+    _kea: Kea6,
+    socket: UdpSocket,
+    _lease_dir: tempfile::TempDir,
+    lease_file_path: PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let lease_dir = tempfile::tempdir().unwrap();
+        let lease_file_path = lease_dir.path().join("kea-leases6.csv");
+
+        let (kea, socket) =
+            Kea6::start(api_server.local_http_addr(), Some(&lease_file_path)).unwrap();
+        socket.set_read_timeout(Some(READ_TIMEOUT)).unwrap();
+
+        Harness {
+            _rt: rt,
+            api_server,
+            _kea: kea,
+            socket,
+            _lease_dir: lease_dir,
+            lease_file_path,
+        }
+    }
+
+    fn assert_no_lease_written(&self) {
+        let contents = fs::read_to_string(&self.lease_file_path).unwrap_or_default();
+        let active_na_leases = contents
+            .lines()
+            .filter(|line| {
+                let columns = line.split(',').collect::<Vec<_>>();
+                if columns.len() < 14 {
+                    return false;
+                }
+
+                // Kea memfile rows encode active IA_NA leases as type 0 with
+                // a positive lifetime and normal state, independent of prefix.
+                let valid_lifetime = columns[2].parse::<u32>().ok();
+                let lease_type = columns[6].parse::<u32>().ok();
+                let state = columns[13].parse::<u32>().ok();
+
+                valid_lifetime.is_some_and(|lifetime| lifetime > 0)
+                    && lease_type == Some(0)
+                    && state == Some(0)
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            active_na_leases.is_empty(),
+            "stateless DHCPv6 exchange should not persist active IA_NA leases: {active_na_leases:?}\nmemfile:\n{contents}"
+        );
+    }
+}
+
+fn client_fqdn_payload(response: &v6::Message) -> Option<&[u8]> {
+    match response.opts().get(OptionCode::ClientFqdn) {
+        Some(DhcpOption::Unknown(option)) => Some(option.data()),
+        _ => None,
+    }
+}
+
+/// Return an RFC 4704 option 39 payload for a dotted FQDN.
+fn fqdn_payload(flags: u8, fqdn: &str) -> Vec<u8> {
+    // RFC 4704 carries flags followed by DNS label-length encoding.
+    let mut payload = vec![flags];
+    for label in fqdn.split('.') {
+        payload.push(label.len() as u8);
+        payload.extend_from_slice(label.as_bytes());
+    }
+    payload.push(0);
+    payload
+}
+
+fn assert_stateless_response(h: &Harness, response: &v6::Message, expected_type: v6::MessageType) {
+    // Stateless flows should call the API as observation and not carry IA_NA.
+    assert_eq!(response.msg_type(), expected_type);
+    assert_eq!(DHCPv6Factory::ia_addr(response), None);
+    let discovery = h.api_server.discoveries().last().unwrap().clone();
+    assert_eq!(
+        discovery.message_kind,
+        Some(rpc::MessageKind::V6InfoRequest as i32)
+    );
+
+    // The hook should still render service options on the response.
+    assert_hook_v6_dns_servers(response);
+    assert_api_v6_domain_search(response);
+    assert_hook_v6_ntp_servers(response);
+}
+
+#[test]
+fn information_request_is_observed_without_allocating_a_lease() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+
+    // INFORMATION-REQUEST should be observed as V6InfoRequest.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::information_request_with_client_fqdn(0x30),
+    )
+    .expect("kea did not respond to INFORMATION-REQUEST");
+    assert_stateless_response(&h, &response, v6::MessageType::Reply);
+    let requested_flags = DHCPv6Factory::client_fqdn_payload()[0];
+    let expected_client_fqdn = fqdn_payload(requested_flags, DHCP_RESPONSE_FQDN);
+    assert_eq!(
+        client_fqdn_payload(&response),
+        Some(expected_client_fqdn.as_slice())
+    );
+    h.assert_no_lease_written();
+
+    Ok(())
+}
+
+#[test]
+fn information_request_with_empty_api_fqdn_does_not_echo_client_fqdn() -> Result<(), eyre::Report> {
+    let idx = 0x33;
+    let h = Harness::new();
+    h.api_server
+        .set_fqdn_override(&DHCPv6Factory::mac_string(idx), "");
+
+    // Empty FQDN models anonymous reserved-segment options-only records.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::information_request_with_client_fqdn(idx),
+    )
+    .expect("kea did not respond to INFORMATION-REQUEST with empty API FQDN");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&response), None);
+
+    // Client FQDN is untrusted; an empty API FQDN removes option 39 instead of echoing.
+    assert!(response.opts().get(OptionCode::ClientFqdn).is_none());
+    assert_hook_v6_ntp_servers(&response);
+    h.assert_no_lease_written();
+
+    Ok(())
+}
+
+#[test]
+fn stateless_solicit_is_observed_without_allocating_a_lease() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+
+    // SOLICIT without IA_NA follows the same information-only path.
+    let response = send_and_recv(&h.socket, DHCPv6Factory::stateless_solicit(0x31))
+        .expect("kea did not respond to stateless SOLICIT");
+    assert_stateless_response(&h, &response, v6::MessageType::Advertise);
+    assert!(response.opts().get(OptionCode::ClientFqdn).is_none());
+    h.assert_no_lease_written();
+
+    Ok(())
+}
+
+#[test]
+fn options_only_and_stateful_v6_requests_do_not_share_cache() -> Result<(), eyre::Report> {
+    let idx = 0x32;
+    let h = Harness::new();
+
+    // Options-only observation returns no address and must not poison the
+    // following stateful allocation cache entry for the same identity.
+    let info_response = send_and_recv(&h.socket, DHCPv6Factory::information_request(idx))
+        .expect("kea did not respond to INFORMATION-REQUEST");
+    assert_stateless_response(&h, &info_response, v6::MessageType::Reply);
+    assert_eq!(
+        h.api_server
+            .calls_for(mock_api_server::ENDPOINT_DISCOVER_DHCP),
+        1
+    );
+
+    let solicit_response = send_and_recv(&h.socket, DHCPv6Factory::solicit(idx))
+        .expect("kea did not respond to stateful SOLICIT after options-only request");
+    assert_eq!(solicit_response.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(
+        DHCPv6Factory::ia_addr(&solicit_response),
+        Some(DHCPv6Factory::mock_addr(idx))
+    );
+    assert_eq!(
+        h.api_server
+            .calls_for(mock_api_server::ENDPOINT_DISCOVER_DHCP),
+        2
+    );
+
+    Ok(())
+}

--- a/crates/dhcp/tests/lease6_hook_test.rs
+++ b/crates/dhcp/tests/lease6_hook_test.rs
@@ -1,0 +1,967 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::net::{Ipv6Addr, UdpSocket};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use dhcp::mock_api_server::{self, ENDPOINT_DISCOVER_DHCP, ENDPOINT_EXPIRE_DHCP_LEASE};
+use dhcproto::v6::{self, DhcpOption, OptionCode, Status};
+use rpc::forge as rpc;
+
+mod common;
+
+use common::{
+    DHCPv6Factory, Kea6, Kea6Config, Kea6ExpiredLeasesProcessing, assert_api_v6_domain_search,
+    assert_hook_v6_dns_servers, assert_hook_v6_ntp_servers, v6_drop_metric_value,
+    wait_for_v6_drop_metric_at_least,
+};
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const MEMFILE_TIMEOUT: Duration = Duration::from_secs(2);
+const EXPIRE_TIMEOUT: Duration = Duration::from_secs(15);
+const METRIC_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+struct Lease6Entry {
+    address: Ipv6Addr,
+    duid: String,
+    valid_lifetime: u32,
+    lease_type: u32,
+    hwaddr: String,
+    state: u32,
+}
+
+impl Lease6Entry {
+    fn is_active_na_for(&self, address: Ipv6Addr, duid_hex: &str) -> bool {
+        self.address == address
+            && self.valid_lifetime > 0
+            && self.lease_type == 0
+            && self.state == 0
+            && normalize_hex(&self.duid) == normalize_hex(duid_hex)
+    }
+}
+
+fn normalize_hex(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_hexdigit())
+        .map(|ch| ch.to_ascii_lowercase())
+        .collect()
+}
+
+fn same_mac_text(actual: &str, expected: &str) -> bool {
+    actual.eq_ignore_ascii_case(expected)
+}
+
+fn send_and_recv(socket: &UdpSocket, packet: Vec<u8>) -> Option<v6::Message> {
+    socket.send(&packet).unwrap();
+    let mut buf = [0u8; 1500];
+    let n = socket.recv(&mut buf).ok()?;
+    Some(DHCPv6Factory::decode_reply(&buf[..n]).unwrap())
+}
+
+struct Harness {
+    _rt: tokio::runtime::Runtime,
+    api_server: mock_api_server::MockAPIServer,
+    _kea: Kea6,
+    socket: UdpSocket,
+    _lease_dir: tempfile::TempDir,
+    lease_file_path: PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        Self::new_with_config(Kea6Config::default())
+    }
+
+    fn new_with_config(config: Kea6Config) -> Self {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+        let lease_dir = tempfile::tempdir().unwrap();
+        let lease_file_path = lease_dir.path().join("kea-leases6.csv");
+
+        let (kea, socket) =
+            Kea6::start_with_config(api_server.local_http_addr(), Some(&lease_file_path), config)
+                .unwrap();
+        socket.set_read_timeout(Some(READ_TIMEOUT)).unwrap();
+
+        Harness {
+            _rt: rt,
+            api_server,
+            _kea: kea,
+            socket,
+            _lease_dir: lease_dir,
+            lease_file_path,
+        }
+    }
+
+    /// Read Kea's append-only lease journal as current lease state.
+    fn read_leases(&self) -> Vec<Lease6Entry> {
+        let Ok(file) = File::open(&self.lease_file_path) else {
+            return Vec::new();
+        };
+
+        let mut current_by_address = BTreeMap::new();
+        for lease in BufReader::new(file)
+            .lines()
+            .map_while(Result::ok)
+            .filter_map(|line| {
+                let columns = line.split(',').collect::<Vec<_>>();
+                if columns.len() < 14 {
+                    return None;
+                }
+
+                Some(Lease6Entry {
+                    address: columns[0].parse().ok()?,
+                    duid: columns[1].to_string(),
+                    valid_lifetime: columns[2].parse().ok()?,
+                    lease_type: columns[6].parse().ok()?,
+                    hwaddr: columns[12].to_string(),
+                    state: columns[13].parse().ok()?,
+                })
+            })
+        {
+            current_by_address.insert(lease.address, lease);
+        }
+
+        current_by_address
+            .into_values()
+            .filter(|lease| lease.valid_lifetime > 0)
+            .collect()
+    }
+
+    fn active_leases(&self, address: Ipv6Addr, duid_hex: &str) -> Vec<Lease6Entry> {
+        self.read_leases()
+            .into_iter()
+            .filter(|lease| lease.is_active_na_for(address, duid_hex))
+            .collect()
+    }
+
+    fn wait_for_active_lease(&self, address: Ipv6Addr, duid_hex: &str) -> Option<Lease6Entry> {
+        let deadline = Instant::now() + MEMFILE_TIMEOUT;
+        loop {
+            let leases = self.active_leases(address, duid_hex);
+            assert!(
+                leases.len() <= 1,
+                "expected at most one active Kea lease for {address}/{duid_hex}, found {leases:?}"
+            );
+            if let Some(lease) = leases.into_iter().next() {
+                return Some(lease);
+            }
+            if Instant::now() >= deadline {
+                return None;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Assert that a lease-end message did not call discovery or expiry APIs.
+    fn assert_no_lease_end_api_calls(&self, discover_calls: usize, context: &str) {
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(
+            self.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+            discover_calls,
+            "{context}: lease-end message should not call API discovery"
+        );
+        assert_eq!(
+            self.api_server.calls_for(ENDPOINT_EXPIRE_DHCP_LEASE),
+            0,
+            "{context}"
+        );
+        assert!(
+            self.api_server.expired_leases().is_empty(),
+            "{context}: mock API recorded expiry payloads"
+        );
+    }
+
+    /// Wait for one scoped expiry RPC and reject unsafe address-only expiry for the same IP.
+    fn wait_for_scoped_expire_rpc(&self, address: Ipv6Addr, mac_address: &str) -> bool {
+        let deadline = Instant::now() + EXPIRE_TIMEOUT;
+        loop {
+            let expired = self.api_server.expired_leases();
+            assert!(
+                expired
+                    .iter()
+                    .all(|request| request.ip_address == address.to_string()
+                        && request
+                            .mac_address
+                            .as_deref()
+                            .is_some_and(|actual| same_mac_text(actual, mac_address))),
+                "lease6_expire sent an unexpected expiry RPC while waiting for {address}: {expired:?}"
+            );
+            if expired.len() == 1 {
+                return true;
+            }
+            assert!(
+                expired.len() <= 1,
+                "lease6_expire sent duplicate expiry RPCs for {address}: {expired:?}"
+            );
+            if Instant::now() >= deadline {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+/// Assert that the Kea-to-API path preserved the Relay-Forward metadata.
+fn assert_v6_discovery_metadata(
+    h: &Harness,
+    discovery_index: usize,
+    idx: u8,
+    expected_kind: rpc::MessageKind,
+) {
+    let discoveries = h.api_server.discoveries();
+    let discovery = discoveries
+        .get(discovery_index)
+        .unwrap_or_else(|| panic!("missing DHCPv6 discovery #{discovery_index}: {discoveries:?}"));
+    let expected_duid = DHCPv6Factory::duid_ll(idx);
+
+    // The relay link-address is the API routing key for relayed DHCPv6.
+    assert_eq!(discovery.relay_address, DHCPv6Factory::RELAY_LINK_ADDR);
+    assert_eq!(
+        discovery.link_address.as_deref(),
+        Some(DHCPv6Factory::RELAY_LINK_ADDR)
+    );
+
+    // Opaque relay identifiers are hex-encoded before crossing the API boundary.
+    assert_eq!(
+        discovery.circuit_id.as_deref(),
+        Some(DHCPv6Factory::RELAY_INTERFACE_ID_HEX)
+    );
+    assert_eq!(
+        discovery.remote_id.as_deref(),
+        Some(DHCPv6Factory::RELAY_REMOTE_ID_HEX)
+    );
+
+    // DHCPv6 identity must reach the API exactly, not just as a selected MAC.
+    assert_eq!(discovery.duid.as_deref(), Some(expected_duid.as_slice()));
+    assert_eq!(
+        discovery.address_family,
+        Some(rpc::AddressFamily::V6 as i32)
+    );
+    assert_eq!(discovery.message_kind, Some(expected_kind as i32));
+}
+
+fn establish_lease(h: &Harness, idx: u8) -> (Vec<u8>, std::net::Ipv6Addr) {
+    let expected_addr = DHCPv6Factory::mock_addr(idx);
+
+    // SOLICIT -> ADVERTISE should carry the address selected by Carbide.
+    let advertise = send_and_recv(&h.socket, DHCPv6Factory::solicit(idx))
+        .expect("kea did not respond to SOLICIT");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(expected_addr));
+    assert_default_ia_lifetimes(&advertise);
+    assert_v6_service_options(&advertise);
+    assert_v6_discovery_metadata(h, 0, idx, rpc::MessageKind::V6Solicit);
+    let server_id = DHCPv6Factory::server_id(&advertise);
+
+    // REQUEST asks for a different Kea-pool address; the hook must still
+    // persist the API-assigned address from the cached discovery.
+    let requested_addr = format!("2001:db8::f0{idx:02x}").parse().unwrap();
+    assert_ne!(requested_addr, expected_addr);
+    let reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request(idx, server_id.clone(), requested_addr),
+    )
+    .expect("kea did not respond to REQUEST");
+    assert_eq!(reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&reply), Some(expected_addr));
+    assert_default_ia_lifetimes(&reply);
+    assert_v6_service_options(&reply);
+    let expected_duid = DHCPv6Factory::duid_ll_hex(idx);
+    h.wait_for_active_lease(expected_addr, &expected_duid)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected one active Kea memfile lease for address {expected_addr} and DUID {expected_duid}"
+            )
+        });
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        1,
+        "SOLICIT and REQUEST should share the coarse Lease cache entry"
+    );
+
+    (server_id, expected_addr)
+}
+
+/// Assert that the DHCPv6 response carries a specific top-level status code.
+fn assert_status_code(response: &v6::Message, expected: Status) {
+    match response.opts().get(OptionCode::StatusCode) {
+        Some(DhcpOption::StatusCode(status)) => assert_eq!(status.status, expected),
+        other => panic!("expected DHCPv6 status {expected:?}, got {other:?}"),
+    }
+}
+
+/// Assert that Kea-owned IA_NA lifetimes remain tied to the default v6 config.
+fn assert_default_ia_lifetimes(response: &v6::Message) {
+    let expected = Kea6Config::default();
+    match response.opts().get(OptionCode::IANA) {
+        Some(DhcpOption::IANA(ia_na)) => match ia_na.opts.get(OptionCode::IAAddr) {
+            Some(DhcpOption::IAAddr(addr)) => {
+                assert_eq!(addr.preferred_life, expected.preferred_lifetime);
+                assert_eq!(addr.valid_life, expected.valid_lifetime);
+            }
+            other => panic!("DHCPv6 response did not include IAADDR: {other:?}"),
+        },
+        other => panic!("DHCPv6 response did not include IA_NA: {other:?}"),
+    }
+}
+
+/// Assert that stateful DHCPv6 replies carry the configured service options.
+fn assert_v6_service_options(response: &v6::Message) {
+    assert_hook_v6_dns_servers(response);
+    assert_api_v6_domain_search(response);
+    assert_hook_v6_ntp_servers(response);
+}
+
+/// Return a Kea6 config with short timers so lease expiry runs during tests.
+fn short_expiry_config() -> Kea6Config {
+    Kea6Config {
+        preferred_lifetime: 3,
+        valid_lifetime: 4,
+        renew_timer: 1,
+        rebind_timer: 2,
+        mac_sources: None,
+        expired_leases_processing: Some(Kea6ExpiredLeasesProcessing {
+            reclaim_timer_wait_time: 1,
+            flush_reclaimed_timer_wait_time: 1,
+            hold_reclaimed_time: 0,
+            max_reclaim_leases: 10,
+            max_reclaim_time: 100,
+            unwarned_reclaim_cycles: 1,
+        }),
+    }
+}
+
+/// Return short-expiry config that prevents Kea from persisting a derived hwaddr.
+fn short_expiry_no_hwaddr_config() -> Kea6Config {
+    Kea6Config {
+        // Exclude DUID and RFC6939 option 79 so lease6_expire must use its
+        // own DUID fallback or skip unsafe unscoped expiry.
+        mac_sources: Some(&["ipv6-link-local"]),
+        ..short_expiry_config()
+    }
+}
+
+/// Return short-expiry config that makes Kea derive hwaddr from DUID.
+fn short_expiry_duid_hwaddr_config() -> Kea6Config {
+    Kea6Config {
+        // Force the Kea-derived lease hwaddr to disagree with relay option 79.
+        mac_sources: Some(&["duid"]),
+        ..short_expiry_config()
+    }
+}
+
+#[test]
+fn lease6_select_renew_and_rebind_keep_kea_on_carbide_address() -> Result<(), eyre::Report> {
+    let idx = 0x20;
+    let h = Harness::new();
+    let (server_id, expected_addr) = establish_lease(&h, idx);
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // RENEW should reuse the cached Machine and still reply with the same address.
+    let renew = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::renew(idx, server_id, expected_addr),
+    )
+    .expect("kea did not respond to RENEW");
+    assert_eq!(renew.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&renew), Some(expected_addr));
+    assert_v6_service_options(&renew);
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls,
+        "RENEW should not make a fresh API call while the hook cache is valid"
+    );
+
+    // REBIND follows the same V6Request path and lease override behavior.
+    let rebind = send_and_recv(&h.socket, DHCPv6Factory::rebind(idx, expected_addr))
+        .expect("kea did not respond to REBIND");
+    assert_eq!(rebind.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&rebind), Some(expected_addr));
+    assert_v6_service_options(&rebind);
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls,
+        "REBIND should not make a fresh API call while the hook cache is valid"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn renew_and_rebind_cache_misses_drop_address_migration() -> Result<(), eyre::Report> {
+    let idx = 0x2a;
+    let mut h = Harness::new();
+    let (server_id, original_addr) = establish_lease(&h, idx);
+    let expected_duid = DHCPv6Factory::duid_ll_hex(idx);
+    let mac_address = DHCPv6Factory::mac_string(idx);
+
+    // Restarting Kea clears the hook process cache while preserving memfile state.
+    let renewed_addr = "2001:db8::aa20".parse::<Ipv6Addr>()?;
+    h.api_server
+        .set_address_override(&mac_address, &renewed_addr.to_string());
+    h._kea.restart()?;
+    let renew_discovery_index = h.api_server.discoveries().len();
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // RENEW should fetch a fresh V6Request record, then fail closed instead
+    // of renewing Kea's existing address with an API-stale value.
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::renew(idx, server_id, original_addr),
+        )
+        .is_none(),
+        "cache-miss RENEW address migration should be dropped"
+    );
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls + 1
+    );
+    assert_v6_discovery_metadata(&h, renew_discovery_index, idx, rpc::MessageKind::V6Request);
+    h.wait_for_active_lease(original_addr, &expected_duid)
+        .unwrap_or_else(|| {
+            panic!(
+                "dropped RENEW migration should leave stale lease {original_addr} for DUID {expected_duid}"
+            )
+        });
+    assert!(
+        h.active_leases(renewed_addr, &expected_duid).is_empty(),
+        "RENEW must not persist migrated API address {renewed_addr} during renewal"
+    );
+    drop(h);
+
+    // Use an independent harness so establish_lease keeps its first-discovery
+    // and single-cache-hit assertions while REBIND exercises the same guard.
+    let idx = 0x2c;
+    let mut h = Harness::new();
+    let (_, original_addr) = establish_lease(&h, idx);
+    let expected_duid = DHCPv6Factory::duid_ll_hex(idx);
+    let mac_address = DHCPv6Factory::mac_string(idx);
+
+    // Restarting Kea clears the hook process cache while preserving memfile state.
+    let rebound_addr = "2001:db8::bb20".parse::<Ipv6Addr>()?;
+    h.api_server
+        .set_address_override(&mac_address, &rebound_addr.to_string());
+    h._kea.restart()?;
+    let rebind_discovery_index = h.api_server.discoveries().len();
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // REBIND should use the same fail-closed guard without persisting the API
+    // address over Kea's existing address-indexed lease.
+    assert!(
+        send_and_recv(&h.socket, DHCPv6Factory::rebind(idx, original_addr)).is_none(),
+        "cache-miss REBIND address migration should be dropped"
+    );
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls + 1
+    );
+    assert_v6_discovery_metadata(&h, rebind_discovery_index, idx, rpc::MessageKind::V6Request);
+    h.wait_for_active_lease(original_addr, &expected_duid)
+        .unwrap_or_else(|| {
+            panic!(
+                "dropped REBIND migration should leave stale lease {original_addr} for DUID {expected_duid}"
+            )
+        });
+    assert!(
+        h.active_leases(rebound_addr, &expected_duid).is_empty(),
+        "REBIND must not persist migrated API address {rebound_addr} during renewal"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn release_preserves_the_api_v6_allocation() -> Result<(), eyre::Report> {
+    let idx = 0x21;
+    let h = Harness::new();
+    let (server_id, expected_addr) = establish_lease(&h, idx);
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+    let released_addr = expected_addr;
+    let expected_addr = expected_addr.to_string();
+
+    // RELEASE is a client lease-state signal, not an API deallocation; extra
+    // unsupported IA_TA must still pass through to Kea protocol handling.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::release_with_ia_ta(idx, server_id, released_addr),
+    )
+    .expect("kea did not respond to RELEASE");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    h.assert_no_lease_end_api_calls(
+        discover_calls,
+        &format!("RELEASE should not call API discovery or expiry for allocation {expected_addr}"),
+    );
+
+    Ok(())
+}
+
+#[test]
+fn decline_preserves_the_api_v6_allocation() -> Result<(), eyre::Report> {
+    let idx = 0x24;
+    let h = Harness::new();
+    let (server_id, expected_addr) = establish_lease(&h, idx);
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+    let declined_addr = expected_addr;
+    let expected_addr = expected_addr.to_string();
+
+    // DECLINE is a client conflict signal, not an API deallocation; extra
+    // unsupported IA_PD must still pass through to Kea protocol handling.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::decline_with_ia_pd(idx, server_id, declined_addr),
+    )
+    .expect("kea did not respond to DECLINE");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    h.assert_no_lease_end_api_calls(
+        discover_calls,
+        &format!("DECLINE should not call API discovery or expiry for allocation {expected_addr}"),
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lease6_expire_uses_duid_fallback_when_kea_lease_has_no_hwaddr() -> Result<(), eyre::Report> {
+    let idx = 0x29;
+    let h = Harness::new_with_config(short_expiry_no_hwaddr_config());
+    let expected_addr = DHCPv6Factory::mock_addr(idx);
+
+    let advertise = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_without_relay_option79(idx),
+    )
+    .expect("kea did not respond to SOLICIT without relay option 79");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(expected_addr));
+    assert_v6_service_options(&advertise);
+    assert_v6_discovery_metadata(&h, 0, idx, rpc::MessageKind::V6Solicit);
+    let server_id = DHCPv6Factory::server_id(&advertise);
+
+    let reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request_without_relay_option79(idx, server_id, expected_addr),
+    )
+    .expect("kea did not respond to REQUEST without relay option 79");
+    assert_eq!(reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&reply), Some(expected_addr));
+    assert_v6_service_options(&reply);
+
+    let expected_duid = DHCPv6Factory::duid_ll_hex(idx);
+    let lease = h
+        .wait_for_active_lease(expected_addr, &expected_duid)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected active Kea memfile lease for address {expected_addr} and DUID {expected_duid}"
+            )
+        });
+    assert!(
+        lease.hwaddr.trim().is_empty(),
+        "expected Kea lease to omit hwaddr so lease6_expire must fall back to DUID, got {lease:?}"
+    );
+    assert!(
+        h.wait_for_scoped_expire_rpc(expected_addr, &DHCPv6Factory::mac_string(idx)),
+        "lease6_expire should call API expiry for {expected_addr} scoped by DUID-derived MAC"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lease6_expire_invalidates_v6_lease_cache_before_retry() -> Result<(), eyre::Report> {
+    let idx = 0x2d;
+    let h = Harness::new_with_config(short_expiry_config());
+    let first_addr = DHCPv6Factory::mock_addr(idx);
+
+    // Establish a short-lived lease and wait for expiry to release the API allocation.
+    let advertise = send_and_recv(&h.socket, DHCPv6Factory::solicit(idx))
+        .expect("kea did not respond to short-lived SOLICIT");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(first_addr));
+    let server_id = DHCPv6Factory::server_id(&advertise);
+
+    let reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request(idx, server_id, first_addr),
+    )
+    .expect("kea did not respond to short-lived REQUEST");
+    assert_eq!(reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&reply), Some(first_addr));
+    assert!(
+        h.wait_for_scoped_expire_rpc(first_addr, &DHCPv6Factory::mac_string(idx)),
+        "lease6_expire should release {first_addr} before retry"
+    );
+
+    // A retry before the 60-second cache TTL must fetch the API again rather
+    // than resurrect the released address from the hook cache.
+    let retry_addr = "2001:db8::cc20".parse::<Ipv6Addr>()?;
+    h.api_server
+        .set_address_override(&DHCPv6Factory::mac_string(idx), &retry_addr.to_string());
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    let retry_advertise = send_and_recv(&h.socket, DHCPv6Factory::solicit(idx))
+        .expect("kea did not respond to retry SOLICIT after expiry");
+    assert_eq!(retry_advertise.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(DHCPv6Factory::ia_addr(&retry_advertise), Some(retry_addr));
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls + 1,
+        "expiry must invalidate the cached DHCPv6 Machine before retry"
+    );
+    let retry_server_id = DHCPv6Factory::server_id(&retry_advertise);
+
+    let retry_reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request(idx, retry_server_id, retry_addr),
+    )
+    .expect("kea did not respond to retry REQUEST after expiry");
+    assert_eq!(retry_reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&retry_reply), Some(retry_addr));
+
+    Ok(())
+}
+
+#[test]
+fn lease6_expire_uses_option79_mac_for_non_mac_duid() -> Result<(), eyre::Report> {
+    let idx = 0x2b;
+    let h = Harness::new_with_config(short_expiry_no_hwaddr_config());
+    let duid = DHCPv6Factory::duid_en(12);
+    let expected_duid = DHCPv6Factory::duid_hex(&duid);
+    let expected_addr = DHCPv6Factory::mock_addr(idx);
+
+    // A non-MAC DUID can be served through relay option 79; expiry must reuse
+    // that hook-selected MAC rather than falling back to address-only deletion.
+    let advertise = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_duid(idx, duid.clone(), true),
+    )
+    .expect("kea did not respond to DUID-EN SOLICIT with relay option 79");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(expected_addr));
+    assert_v6_service_options(&advertise);
+    let server_id = DHCPv6Factory::server_id(&advertise);
+
+    let reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request_with_duid(idx, server_id, expected_addr, duid, true),
+    )
+    .expect("kea did not respond to DUID-EN REQUEST with relay option 79");
+    assert_eq!(reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&reply), Some(expected_addr));
+    assert_v6_service_options(&reply);
+
+    let lease = h
+        .wait_for_active_lease(expected_addr, &expected_duid)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected active Kea memfile lease for address {expected_addr} and DUID {expected_duid}"
+            )
+        });
+    assert!(
+        lease.hwaddr.trim() == DHCPv6Factory::mac_string(idx),
+        "expected Kea lease to store hook-selected option79 MAC, got {lease:?}"
+    );
+    assert!(
+        h.wait_for_scoped_expire_rpc(expected_addr, &DHCPv6Factory::mac_string(idx)),
+        "lease6_expire should call API expiry for {expected_addr} scoped by option79 MAC"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn lease6_expire_uses_option79_mac_when_duid_mac_disagrees() -> Result<(), eyre::Report> {
+    let option79_idx = 0x2e;
+    let duid_idx = 0x2f;
+    let h = Harness::new_with_config(short_expiry_duid_hwaddr_config());
+    let duid = DHCPv6Factory::duid_ll(duid_idx);
+    let expected_duid = DHCPv6Factory::duid_hex(&duid);
+    let expected_addr = DHCPv6Factory::mock_addr(option79_idx);
+    let option79_mac = DHCPv6Factory::mac_string(option79_idx);
+
+    // Kea is configured to derive hwaddr from DUID, but Carbide identity
+    // selection deliberately trusts relay option 79 when the two disagree.
+    let advertise = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_duid(option79_idx, duid.clone(), true),
+    )
+    .expect("kea did not respond to DUID/option79 disagreement SOLICIT");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(expected_addr));
+    assert!(
+        same_mac_text(&h.api_server.discoveries()[0].mac_address, &option79_mac),
+        "API allocation should be owned by relay option79 MAC"
+    );
+    let server_id = DHCPv6Factory::server_id(&advertise);
+
+    let reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request_with_duid(option79_idx, server_id, expected_addr, duid, true),
+    )
+    .expect("kea did not respond to DUID/option79 disagreement REQUEST");
+    assert_eq!(reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&reply), Some(expected_addr));
+    let renew_server_id = DHCPv6Factory::server_id(&reply);
+
+    // RENEW runs after Kea has copied its configured DUID-derived hwaddr onto
+    // the lease; the hook must restore the option79 identity again.
+    let renew = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::renew_with_duid(
+            option79_idx,
+            renew_server_id,
+            expected_addr,
+            DHCPv6Factory::duid_ll(duid_idx),
+            true,
+        ),
+    )
+    .expect("kea did not respond to DUID/option79 disagreement RENEW");
+    assert_eq!(renew.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&renew), Some(expected_addr));
+
+    let lease = h
+        .wait_for_active_lease(expected_addr, &expected_duid)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected active Kea memfile lease for address {expected_addr} and DUID {expected_duid}"
+            )
+        });
+    assert!(
+        same_mac_text(lease.hwaddr.trim(), &option79_mac),
+        "lease expiry must use the same selected MAC as allocation"
+    );
+    assert!(
+        h.wait_for_scoped_expire_rpc(expected_addr, &option79_mac),
+        "lease6_expire should call API expiry for {expected_addr} scoped by option79 MAC"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn nested_relay_solicit_is_dropped_loudly_before_api_call() -> Result<(), eyre::Report> {
+    let h = Harness::new();
+    let mut expected_drops = v6_drop_metric_value(h._kea.metrics_endpoint(), "nested_relay");
+
+    // Multi-hop and nested Relay-Forward packets must be rejected by the hook,
+    // not silently lost before the required observability signal.
+    for packet in [
+        DHCPv6Factory::solicit_with_hop_count(0x2c, 2),
+        DHCPv6Factory::solicit_with_nested_relay(0x2d),
+    ] {
+        assert!(send_and_recv(&h.socket, packet).is_none());
+        expected_drops += 1.0;
+        assert!(wait_for_v6_drop_metric_at_least(
+            h._kea.metrics_endpoint(),
+            "nested_relay",
+            expected_drops,
+            METRIC_TIMEOUT,
+        ));
+    }
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+
+    Ok(())
+}
+
+#[test]
+fn lease_end_messages_with_unsupported_hop_count_are_dropped() -> Result<(), eyre::Report> {
+    let idx = 0x27;
+    let h = Harness::new();
+    let (server_id, expected_addr) = establish_lease(&h, idx);
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::release_with_hop_count(idx, server_id.clone(), expected_addr, 2),
+        )
+        .is_none()
+    );
+    h.assert_no_lease_end_api_calls(
+        discover_calls,
+        "unsupported-hop RELEASE should be dropped before API discovery or expiry",
+    );
+
+    assert!(
+        send_and_recv(
+            &h.socket,
+            DHCPv6Factory::decline_with_hop_count(idx, server_id, expected_addr, 2),
+        )
+        .is_none()
+    );
+    h.assert_no_lease_end_api_calls(
+        discover_calls,
+        "unsupported-hop DECLINE should be dropped before API discovery or expiry",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn confirm_cache_hit_replies_without_not_on_link() -> Result<(), eyre::Report> {
+    let idx = 0x22;
+    let h = Harness::new();
+    let (_, expected_addr) = establish_lease(&h, idx);
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // CONFIRM is cache-only: a matching cached lease should stay on-link.
+    let response = send_and_recv(&h.socket, DHCPv6Factory::confirm(idx, expected_addr))
+        .expect("kea did not respond to CONFIRM cache hit");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    assert_status_code(&response, Status::Success);
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls,
+        "CONFIRM cache hit should not make a fresh API call"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn confirm_cache_hit_tolerates_absent_optional_vendor_class() -> Result<(), eyre::Report> {
+    let idx = 0x26;
+    let h = Harness::new();
+
+    let advertise = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_vendor_class(idx, b"HTTPClient"),
+    )
+    .expect("kea did not respond to vendor-class SOLICIT");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    let expected_addr = DHCPv6Factory::mock_addr(idx);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(expected_addr));
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // The vendor class is optional client metadata. CONFIRM often omits it,
+    // so the cache hit should be accepted when the IA address remains on-link.
+    let response = send_and_recv(&h.socket, DHCPv6Factory::confirm(idx, expected_addr))
+        .expect("kea did not respond to CONFIRM without vendor class");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    assert_status_code(&response, Status::Success);
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls
+    );
+
+    Ok(())
+}
+
+#[test]
+fn confirm_cache_hit_tolerates_multiple_vendor_class_variants() -> Result<(), eyre::Report> {
+    let idx = 0x28;
+    let h = Harness::new();
+
+    // Cache one API lease through a SOLICIT with one vendor class.
+    let advertise = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::solicit_with_vendor_class(idx, b"HTTPClient-A"),
+    )
+    .expect("kea did not respond to vendor-class SOLICIT");
+    assert_eq!(advertise.msg_type(), v6::MessageType::Advertise);
+    let expected_addr = DHCPv6Factory::mock_addr(idx);
+    assert_eq!(DHCPv6Factory::ia_addr(&advertise), Some(expected_addr));
+    let server_id = DHCPv6Factory::server_id(&advertise);
+
+    // Cache the same API lease through a REQUEST with a different vendor class.
+    let reply = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::request_with_vendor_class(idx, server_id, expected_addr, b"HTTPClient-B"),
+    )
+    .expect("kea did not respond to vendor-class REQUEST");
+    assert_eq!(reply.msg_type(), v6::MessageType::Reply);
+    assert_eq!(DHCPv6Factory::ia_addr(&reply), Some(expected_addr));
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+    assert_eq!(discover_calls, 2);
+    let discoveries = h.api_server.discoveries();
+    assert_eq!(discoveries.len(), 2);
+    assert_v6_discovery_metadata(&h, 0, idx, rpc::MessageKind::V6Solicit);
+    assert_v6_discovery_metadata(&h, 1, idx, rpc::MessageKind::V6Request);
+    assert_eq!(
+        discoveries[0].vendor_string.as_deref(),
+        Some("HTTPClient-A")
+    );
+    assert_eq!(
+        discoveries[1].vendor_string.as_deref(),
+        Some("HTTPClient-B")
+    );
+
+    // CONFIRM often omits vendor class; equivalent cache variants should not
+    // force NotOnLink when they agree on the API lease context.
+    let response = send_and_recv(&h.socket, DHCPv6Factory::confirm(idx, expected_addr))
+        .expect("kea did not respond to CONFIRM without vendor class");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    assert_status_code(&response, Status::Success);
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls
+    );
+
+    Ok(())
+}
+
+#[test]
+/// CONFIRM must reject cached-client addresses outside the API-owned prefix.
+fn confirm_cache_hit_with_off_prefix_address_replies_not_on_link() -> Result<(), eyre::Report> {
+    let idx = 0x25;
+    let h = Harness::new();
+    let (_, _) = establish_lease(&h, idx);
+    let discover_calls = h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP);
+
+    // Identity alone is not enough; the confirmed address must be on the
+    // cached API prefix.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::confirm(idx, "2001:db9::1".parse()?),
+    )
+    .expect("kea did not respond to off-prefix CONFIRM");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    assert_status_code(&response, Status::NotOnLink);
+    assert_eq!(
+        h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP),
+        discover_calls
+    );
+
+    Ok(())
+}
+
+#[test]
+fn confirm_cache_miss_replies_not_on_link_without_api_call() -> Result<(), eyre::Report> {
+    let idx = 0x23;
+    let h = Harness::new();
+
+    // Without a cached discovery, CONFIRM should fail closed as NotOnLink.
+    let response = send_and_recv(
+        &h.socket,
+        DHCPv6Factory::confirm(idx, DHCPv6Factory::mock_addr(idx)),
+    )
+    .expect("kea did not respond to CONFIRM cache miss");
+    assert_eq!(response.msg_type(), v6::MessageType::Reply);
+    assert_status_code(&response, Status::NotOnLink);
+    assert_eq!(h.api_server.calls_for(ENDPOINT_DISCOVER_DHCP), 0);
+
+    Ok(())
+}

--- a/crates/dhcp/tests/rapid_commit_v6_test.rs
+++ b/crates/dhcp/tests/rapid_commit_v6_test.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use dhcp::mock_api_server;
+use dhcproto::v6;
+
+mod common;
+
+use common::{DHCPv6Factory, Kea6};
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+
+fn send_and_recv(socket: &UdpSocket, packet: Vec<u8>) -> Option<v6::Message> {
+    socket.send(&packet).unwrap();
+    let mut buf = [0u8; 1500];
+    let n = socket.recv(&mut buf).ok()?;
+    Some(DHCPv6Factory::decode_reply(&buf[..n]).unwrap())
+}
+
+#[test]
+fn rapid_commit_option_is_ignored_while_hook_param_is_off() -> Result<(), eyre::Report> {
+    // Start Kea with hook-rapid-commit-v6=false from the v6 harness config.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+    let (_kea, socket) = Kea6::start(api_server.local_http_addr(), None)?;
+    socket.set_read_timeout(Some(READ_TIMEOUT))?;
+
+    // Rapid-commit is deferred, so SOLICIT still gets ADVERTISE instead of REPLY.
+    let response = send_and_recv(&socket, DHCPv6Factory::rapid_commit_solicit(0x40))
+        .expect("kea did not respond to rapid-commit SOLICIT");
+    assert_eq!(response.msg_type(), v6::MessageType::Advertise);
+
+    Ok(())
+}

--- a/dev/deployment/localdev/Dockerfile.runtime-container.localdev
+++ b/dev/deployment/localdev/Dockerfile.runtime-container.localdev
@@ -34,7 +34,8 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -
   iproute2 \
   iputils-ping \
   kea-dev \
-  kea-dhcp4-server  \
+  kea-dhcp4-server \
+  kea-dhcp6-server \
   libssl-dev \
   libudev1 \
   ca-certificates \

--- a/dev/docker/Dockerfile.build-container-aarch64
+++ b/dev/docker/Dockerfile.build-container-aarch64
@@ -44,6 +44,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 		jq \
 		kea-dev \
 		kea-dhcp4-server \
+		kea-dhcp6-server \
 		libboost-dev \
 		libgrpc-dev \
 		libopenipmi-dev \

--- a/dev/docker/Dockerfile.build-container-x86_64
+++ b/dev/docker/Dockerfile.build-container-x86_64
@@ -45,6 +45,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update && \
 	jq \
 	kea-dev \
 	kea-dhcp4-server \
+	kea-dhcp6-server \
 	libboost-dev \
 	libgrpc-dev \
 	libopenipmi-dev \

--- a/dev/docker/Dockerfile.pxe-build-container
+++ b/dev/docker/Dockerfile.pxe-build-container
@@ -36,6 +36,7 @@ RUN apt-get update && \
 	build-essential \
 	kea-dev \
 	kea-dhcp4-server \
+	kea-dhcp6-server \
 	libboost-dev \
 	libgrpc-dev \
 	libgrpc++-dev \

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -63,6 +63,8 @@ RUN echo "$(date): Start runtime container build"
 COPY --from=builder ["/carbide/target/bin/carbide-api", "/carbide/target/bin/carbide", "/carbide/target/bin/carbide-dns", "/carbide/target/bin/nico-admin-cli", "/carbide/target/bin/carbide-dsx-exchange-consumer", "/carbide/target/bin/forge-dpu-agent", "/carbide/target/bin/forge-dhcp-server", "/carbide/target/bin/forge-hw-health", "/carbide/target/bin/forge-log-parser", "/carbide/target/bin/ssh-console", "/carbide/target/bin/carbide-bmc-proxy", "/opt/carbide/"]
 # Note: aarch64 uses different library path than x86_64
 COPY --from=builder /carbide/target/bin/libdhcp.so /usr/lib/aarch64-linux-gnu/kea/hooks
+RUN mkdir -p /usr/lib/kea/hooks && \
+    ln -sf /usr/lib/aarch64-linux-gnu/kea/hooks/libdhcp.so /usr/lib/kea/hooks/libdhcp.so
 RUN ln -s /opt/carbide/nico-admin-cli /opt/carbide/carbide-admin-cli && \
     ln -s /opt/carbide/nico-admin-cli /opt/carbide/forge-admin-cli
 

--- a/dev/docker/Dockerfile.release-container-sa-x86_64
+++ b/dev/docker/Dockerfile.release-container-sa-x86_64
@@ -85,6 +85,8 @@ RUN echo "$(date): Start runtime container build"
 
 COPY --from=builder ["/carbide/target/bin/carbide-api", "/carbide/target/bin/carbide", "/carbide/target/bin/carbide-dns", "/carbide/target/bin/nico-admin-cli", "/carbide/target/bin/carbide-dsx-exchange-consumer", "/carbide/target/bin/forge-dpu-agent", "/carbide/target/bin/forge-dhcp-server", "/carbide/target/bin/forge-hw-health", "/carbide/target/bin/forge-log-parser", "/carbide/target/bin/ssh-console", "/carbide/target/bin/carbide-bmc-proxy", "/opt/carbide/"]
 COPY --from=builder /carbide/target/bin/libdhcp.so /usr/lib/x86_64-linux-gnu/kea/hooks
+RUN mkdir -p /usr/lib/kea/hooks && \
+    ln -sf /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so /usr/lib/kea/hooks/libdhcp.so
 RUN ln -s /opt/carbide/nico-admin-cli /opt/carbide/carbide-admin-cli && \
     ln -s /opt/carbide/nico-admin-cli /opt/carbide/forge-admin-cli
 

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -62,6 +62,8 @@ RUN echo "$(date): Start runtime container build"
 
 COPY --from=builder ["/carbide/target/bin/carbide-api", "/carbide/target/bin/carbide", "/carbide/target/bin/carbide-dns", "/carbide/target/bin/nico-admin-cli", "/carbide/target/bin/carbide-dsx-exchange-consumer", "/carbide/target/bin/forge-dpu-agent", "/carbide/target/bin/forge-dhcp-server", "/carbide/target/bin/forge-hw-health", "/carbide/target/bin/forge-log-parser", "/carbide/target/bin/ssh-console", "/carbide/target/bin/carbide-bmc-proxy", "/opt/carbide/"]
 COPY --from=builder /carbide/target/bin/libdhcp.so /usr/lib/x86_64-linux-gnu/kea/hooks
+RUN mkdir -p /usr/lib/kea/hooks && \
+    ln -sf /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so /usr/lib/kea/hooks/libdhcp.so
 RUN ln -s /opt/carbide/nico-admin-cli /opt/carbide/carbide-admin-cli && \
     ln -s /opt/carbide/nico-admin-cli /opt/carbide/forge-admin-cli
 

--- a/dev/docker/Dockerfile.runtime-container-aarch64
+++ b/dev/docker/Dockerfile.runtime-container-aarch64
@@ -52,6 +52,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt-get update && \
 		iproute2 \
 		iputils-ping \
 		kea-dhcp4-server \
+		kea-dhcp6-server \
 		kea-ctrl-agent \
 		libaio1 \
 		libc-ares2 \
@@ -68,4 +69,3 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt-get update && \
 		tpm2-tools \
 		zlib1g && \
 	rm -rf /var/lib/apt/lists/*
-

--- a/dev/docker/Dockerfile.runtime-container-x86_64
+++ b/dev/docker/Dockerfile.runtime-container-x86_64
@@ -52,7 +52,8 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt-get update && \
 		iproute2 \
 		iputils-ping \
 		kea-dhcp4-server \
-    kea-ctrl-agent \
+		kea-dhcp6-server \
+		kea-ctrl-agent \
 		libaio1 \
 		libc-ares2 \
 		libgrpc++1.51 \


### PR DESCRIPTION
<!-- Describe what this PR does -->
Adds DHCPv6 support to the Kea hook path by decoding DHCPv6 client identity and relay metadata in Rust, routing v6 discoveries through the existing Carbide DHCP API/cache flow, and wiring Kea pkt6_receive, lease6_select, pkt6_send, and lease6_expire.

Also adds v6 hook  configuration, DHCPv6 option rendering, address-family-aware cache keys, v6 mock API responses, and an example kea-dhcp6 hook config.

## Related issues
<!-- Refer to existing GitHub issues here -->

https://github.com/NVIDIA/infra-controller/issues/2385

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

Closes https://github.com/NVIDIA/infra-controller/issues/2385
