### PR TITLE
refactor: emit dsx-exchange-consumer counters through the instrumentation framework

### DIFF
--- a/crates/dsx-exchange-consumer/Cargo.toml
+++ b/crates/dsx-exchange-consumer/Cargo.toml
@@ -60,6 +60,7 @@ mqttea = { path = "../mqttea" }
 carbide-version = { path = "../version" }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 
 [lints]

--- a/crates/dsx-exchange-consumer/src/health_updater.rs
+++ b/crates/dsx-exchange-consumer/src/health_updater.rs
@@ -19,6 +19,7 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::emit;
 use health_report::{HealthAlertClassification, HealthProbeAlert, HealthReport};
 use moka::future::Cache;
 use moka::ops::compute::Op;
@@ -29,6 +30,7 @@ use crate::ConsumerMetrics;
 use crate::api_client::{HEALTH_REPORT_SOURCE, RackHealthReportSink};
 use crate::config::CacheConfig;
 use crate::messages::{FaultValue, LeakMetadata, LeakPointType, ValueMessage};
+use crate::metrics::{MessageDeduplicated, MessageProcessed};
 use crate::mqtt_consumer::MqttMessage;
 
 /// Health status updater that processes MQTT messages and updates the API.
@@ -160,7 +162,7 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
                     if let Some(entry) = &maybe_entry
                         && *entry.value() == value
                     {
-                        metrics.record_dedup_skipped();
+                        emit(MessageDeduplicated);
                         tracing::trace!(
                             point_path = %point_path,
                             point_type = %metadata.point_type,
@@ -208,7 +210,7 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
 
         match result {
             Ok(_) => {
-                self.metrics.record_message_processed();
+                emit(MessageProcessed);
             }
             Err(_) => {
                 // API call failed - will retry on next message

--- a/crates/dsx-exchange-consumer/src/lib.rs
+++ b/crates/dsx-exchange-consumer/src/lib.rs
@@ -87,13 +87,7 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
     // Connect to MQTT and get message receiver. mqttea tracks subscriptions
     // and replays them after reconnect when the broker reports that the
     // previous session was not resumed.
-    let rx = mqtt_consumer::connect(
-        &config.mqtt,
-        consumer_metrics.clone(),
-        &meter,
-        credential_manager.clone(),
-    )
-    .await?;
+    let rx = mqtt_consumer::connect(&config.mqtt, &meter, credential_manager.clone()).await?;
 
     // Set up API client and create health updater
     let join_updater = if let Some(api_config) = config.carbide_api {

--- a/crates/dsx-exchange-consumer/src/metrics.rs
+++ b/crates/dsx-exchange-consumer/src/metrics.rs
@@ -19,6 +19,7 @@
 
 use std::hash::Hash;
 
+use carbide_instrument::Event;
 use moka::future::Cache;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Meter};
@@ -61,63 +62,97 @@ where
         .build();
 }
 
-/// Consumer metrics using OpenTelemetry counters.
+// The four message counters are `carbide-instrument` events. Their exposed
+// names are grandfathered, and `name_unchecked` keeps them byte-identical:
+// the pre-framework counters registered names that already ended in `_total`,
+// and the OpenTelemetry Prometheus exporter appends its own `_total` to every
+// counter -- so `/metrics` has always shown a doubled `_total_total` suffix.
+// The framework strips one `_total` before registering and the exporter
+// re-appends it, reproducing the exact name every existing dashboard and alert
+// already selects on.
+
+/// An MQTT message reached a subscription handler, before any queueing.
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_exchange_consumer_messages_received_total_total",
+    name_unchecked,
+    component = "nico-dsx-exchange-consumer",
+    log = off,
+    metric = counter,
+    describe = "Total number of MQTT messages received"
+)]
+pub struct MessageReceived;
+
+/// A message was correlated with its metadata and its rack health update
+/// applied (or its alert cleared).
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_exchange_consumer_messages_processed_total_total",
+    name_unchecked,
+    component = "nico-dsx-exchange-consumer",
+    log = off,
+    metric = counter,
+    describe = "Total number of messages successfully processed"
+)]
+pub struct MessageProcessed;
+
+/// The bounded internal queue was full, so an incoming message was dropped.
+///
+/// Metric-only: the `tracing::warn!` at each drop site is unchanged, so this
+/// event only moves the counter beside it.
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_exchange_consumer_messages_dropped_total_total",
+    name_unchecked,
+    component = "nico-dsx-exchange-consumer",
+    log = off,
+    metric = counter,
+    describe = "Total number of messages dropped due to queue overflow"
+)]
+pub struct MessageDropped;
+
+/// A value matched the state already cached for its point, so no API update
+/// was sent.
+///
+/// Metric-only: the `tracing::trace!` at the dedup site is unchanged, so this
+/// event only moves the counter beside it.
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_exchange_consumer_dedup_skipped_total_total",
+    name_unchecked,
+    component = "nico-dsx-exchange-consumer",
+    log = off,
+    metric = counter,
+    describe = "Total number of messages skipped due to deduplication"
+)]
+pub struct MessageDeduplicated;
+
+/// Consumer metrics that remain hand-rolled OpenTelemetry counters.
+///
+/// Only `alerts_detected` stays here: its `point_type` label is a
+/// caller-supplied string that needs a bounded mapping before it can become a
+/// framework event, which is tracked separately. The message counters are the
+/// `carbide-instrument` events above.
 ///
 /// Cloning is cheap and correct: OpenTelemetry counters are internally Arc'd,
 /// so clones share the same underlying metric instances.
 #[derive(Clone)]
 pub struct ConsumerMetrics {
-    messages_received: Counter<u64>,
-    messages_processed: Counter<u64>,
-    messages_dropped: Counter<u64>,
     alerts_detected: Counter<u64>,
-    dedup_skipped: Counter<u64>,
 }
 
 impl ConsumerMetrics {
     pub fn new(meter: &Meter) -> Self {
         Self {
-            messages_received: meter
-                .u64_counter(format!("{METRICS_PREFIX}_messages_received_total"))
-                .with_description("Total number of MQTT messages received")
-                .build(),
-            messages_processed: meter
-                .u64_counter(format!("{METRICS_PREFIX}_messages_processed_total"))
-                .with_description("Total number of messages successfully processed")
-                .build(),
-            messages_dropped: meter
-                .u64_counter(format!("{METRICS_PREFIX}_messages_dropped_total"))
-                .with_description("Total number of messages dropped due to queue overflow")
-                .build(),
             alerts_detected: meter
                 .u64_counter(format!("{METRICS_PREFIX}_alerts_detected_total"))
                 .with_description("Total number of leak alerts detected")
                 .build(),
-            dedup_skipped: meter
-                .u64_counter(format!("{METRICS_PREFIX}_dedup_skipped_total"))
-                .with_description("Total number of messages skipped due to deduplication")
-                .build(),
         }
-    }
-
-    pub fn record_message_received(&self) {
-        self.messages_received.add(1, &[]);
-    }
-
-    pub fn record_message_processed(&self) {
-        self.messages_processed.add(1, &[]);
-    }
-
-    pub fn record_message_dropped(&self) {
-        self.messages_dropped.add(1, &[]);
     }
 
     pub fn record_alert_detected(&self, point_type: &str) {
         self.alerts_detected
             .add(1, &[KeyValue::new("point_type", point_type.to_string())]);
-    }
-
-    pub fn record_dedup_skipped(&self) {
-        self.dedup_skipped.add(1, &[]);
     }
 }

--- a/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
+++ b/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
@@ -19,15 +19,17 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::emit;
 use carbide_secrets::credentials::CredentialReader;
 use mqttea::QoS;
 use mqttea::client::{ClientOptions, MqtteaClient};
 use mqttea::registry::JsonRegistration;
 use tokio::sync::mpsc;
 
+use crate::DsxConsumerError;
 use crate::config::{MqttAuthMode, MqttConfig};
 use crate::messages::{LeakMetadata, ValueMessage};
-use crate::{ConsumerMetrics, DsxConsumerError};
+use crate::metrics::{MessageDropped, MessageReceived};
 
 /// Message types received from MQTT.
 #[derive(Debug, Clone)]
@@ -50,7 +52,6 @@ pub enum MqttMessage {
 /// drop-on-overflow.
 pub async fn connect(
     config: &MqttConfig,
-    metrics: ConsumerMetrics,
     meter: &opentelemetry::metrics::Meter,
     credential_reader: Arc<dyn CredentialReader>,
 ) -> Result<mpsc::Receiver<MqttMessage>, DsxConsumerError> {
@@ -94,12 +95,11 @@ pub async fn connect(
     client
         .on_message::<LeakMetadata, _, _>({
             let tx = tx.clone();
-            let metrics = metrics.clone();
             move |_client, metadata, topic| {
-                metrics.record_message_received();
+                emit(MessageReceived);
                 let msg = MqttMessage::Metadata { topic, metadata };
                 if tx.try_send(msg).is_err() {
-                    metrics.record_message_dropped();
+                    emit(MessageDropped);
                     tracing::warn!("Message queue full, dropping metadata message");
                 }
                 std::future::ready(())
@@ -110,10 +110,10 @@ pub async fn connect(
     // Register handler for value messages
     client
         .on_message::<ValueMessage, _, _>(move |_client, value, topic| {
-            metrics.record_message_received();
+            emit(MessageReceived);
             let msg = MqttMessage::Value { topic, value };
             if tx.try_send(msg).is_err() {
-                metrics.record_message_dropped();
+                emit(MessageDropped);
                 tracing::warn!("Message queue full, dropping value message");
             }
             std::future::ready(())

--- a/crates/dsx-exchange-consumer/tests/dedup_trace.rs
+++ b/crates/dsx-exchange-consumer/tests/dedup_trace.rs
@@ -1,0 +1,137 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Proves the reshape left the dedup site's log line byte-identical: converting
+//! the counter to a metric-only event kept the `tracing::trace!` beside it, so
+//! the dedup branch still emits exactly one "Deduplicating unchanged value"
+//! line at TRACE with its original fields.
+//!
+//! Its own test binary on purpose: `tracing` caches callsite interest the first
+//! time a callsite is hit, so a `capture_logs` (thread-local) subscriber only
+//! sees the trace when nothing else raced to that callsite first. Alone in this
+//! process, the drive below is that first hit.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use carbide_dsx_exchange_consumer::api_client::RackHealthReportSink;
+use carbide_dsx_exchange_consumer::config::CacheConfig;
+use carbide_dsx_exchange_consumer::health_updater::HealthUpdater;
+use carbide_dsx_exchange_consumer::messages::{FaultValue, LeakMetadata, ValueMessage};
+use carbide_dsx_exchange_consumer::mqtt_consumer::MqttMessage;
+use carbide_dsx_exchange_consumer::{ConsumerMetrics, DsxConsumerError};
+use carbide_instrument::testing::capture_logs;
+use health_report::HealthReport;
+use tokio::sync::mpsc;
+
+/// Accepts every report so the first value caches and the identical second one
+/// takes the dedup branch.
+struct OkSink;
+
+#[async_trait]
+impl RackHealthReportSink for OkSink {
+    async fn insert_rack_health_report(
+        &self,
+        _rack_id: &str,
+        _report: HealthReport,
+    ) -> Result<(), DsxConsumerError> {
+        Ok(())
+    }
+
+    async fn remove_rack_health_report(&self, _rack_id: &str) -> Result<(), DsxConsumerError> {
+        Ok(())
+    }
+}
+
+fn faulting_value() -> ValueMessage {
+    ValueMessage {
+        value: FaultValue::Faulting,
+        timestamp: chrono::Utc::now(),
+    }
+}
+
+#[test]
+fn dedup_site_keeps_its_trace_verbatim() {
+    let logs = capture_logs(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("current-thread runtime");
+        rt.block_on(async {
+            let meter = opentelemetry::global::meter("dedup-trace-test");
+            let updater = HealthUpdater::new(
+                "BMS/v1/".to_string(),
+                CacheConfig {
+                    metadata_ttl: Duration::from_secs(3600),
+                    value_state_ttl: Duration::from_secs(3600),
+                },
+                Arc::new(OkSink),
+                ConsumerMetrics::new(&meter),
+                meter.clone(),
+            );
+
+            // Drive the real message loop through its public `run`: cache the
+            // metadata, process the first faulting value, then feed an identical
+            // second value that takes the dedup branch and logs the trace.
+            let (tx, rx) = mpsc::channel(16);
+            tx.send(MqttMessage::Metadata {
+                topic: "BMS/v1/site/rack/point/Metadata".to_string(),
+                metadata: LeakMetadata {
+                    point_type: "LeakDetectRack".to_string(),
+                    object_type: "Rack".to_string(),
+                    rack_name: "Rack-001".to_string(),
+                    rack_id: "rack-001".to_string(),
+                },
+            })
+            .await
+            .unwrap();
+            tx.send(MqttMessage::Value {
+                topic: "BMS/v1/site/rack/point/Value".to_string(),
+                value: faulting_value(),
+            })
+            .await
+            .unwrap();
+            tx.send(MqttMessage::Value {
+                topic: "BMS/v1/site/rack/point/Value".to_string(),
+                value: faulting_value(),
+            })
+            .await
+            .unwrap();
+            drop(tx);
+
+            updater.run(rx).await;
+        });
+    });
+
+    let dedup: Vec<_> = logs
+        .iter()
+        .filter(|line| line.message == "Deduplicating unchanged value")
+        .collect();
+    assert_eq!(dedup.len(), 1, "expected one dedup trace; got {logs:?}");
+    assert_eq!(dedup[0].level, tracing::Level::TRACE);
+    // The original trace's fields ride the line unchanged.
+    assert!(
+        dedup[0]
+            .fields
+            .contains(&("point_type".to_string(), "LeakDetectRack".to_string())),
+        "dedup fields: {:?}",
+        dedup[0].fields
+    );
+    assert!(dedup[0].fields.iter().any(|(key, _)| key == "point_path"));
+    assert!(dedup[0].fields.iter().any(|(key, _)| key == "value"));
+}

--- a/crates/dsx-exchange-consumer/tests/metric_exposition.rs
+++ b/crates/dsx-exchange-consumer/tests/metric_exposition.rs
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Pins the exposed names of the four message-counter events byte-for-byte to
+//! what the pre-framework hand-rolled counters served, so the conversion never
+//! renames a metric a dashboard or alert selects on.
+//!
+//! One test in its own binary (its own process-global registry) keeps the
+//! `counter_delta` measurements deterministic: the crate's other unit tests
+//! emit these same events, but from a different test process.
+
+use carbide_dsx_exchange_consumer::metrics::{
+    MessageDeduplicated, MessageDropped, MessageProcessed, MessageReceived,
+};
+use carbide_instrument::emit;
+use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+/// Emitting each event once moves exactly its counter, under the doubled
+/// `_total_total` name the OTel Prometheus exporter has always produced for
+/// these counters (the register name already ended in `_total`, and the
+/// exporter appends another). All four events are metric-only (`log = off`):
+/// the WARN at each drop site and the TRACE at the dedup site are plain
+/// `tracing` lines the reshape left untouched, so they stay at the call sites,
+/// not on the events (the dedup line is exercised in `health_updater.rs`).
+#[test]
+fn message_events_preserve_names_and_are_metric_only() {
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(MessageReceived);
+        emit(MessageProcessed);
+        emit(MessageDropped);
+        emit(MessageDeduplicated);
+    });
+
+    // Exposed names are byte-identical to the pre-conversion counters.
+    for name in [
+        "carbide_dsx_exchange_consumer_messages_received_total_total",
+        "carbide_dsx_exchange_consumer_messages_processed_total_total",
+        "carbide_dsx_exchange_consumer_messages_dropped_total_total",
+        "carbide_dsx_exchange_consumer_dedup_skipped_total_total",
+    ] {
+        assert_eq!(
+            metrics.counter_delta(name, &[]),
+            1.0,
+            "expected {name} to move by 1; exposition was:\n{}",
+            metrics.render()
+        );
+    }
+
+    // The single-`_total` name never appears -- that would be a rename.
+    assert_eq!(
+        metrics.counter_delta("carbide_dsx_exchange_consumer_messages_received_total", &[]),
+        0.0
+    );
+
+    // Metric-only: the events build no log line, so the drop WARN and dedup
+    // TRACE are never doubled -- only the untouched call-site `tracing` lines
+    // remain.
+    assert!(logs.is_empty(), "events must be metric-only: {logs:?}");
+}


### PR DESCRIPTION
The DSX exchange consumer's message counters were hand-rolled straight onto an OpenTelemetry meter. Four of them now go through the instrumentation framework like the rest of the fleet -- every exposed metric byte-for-byte identical, and every log line left exactly as it was.

- `messages_received`, `messages_processed`, `messages_dropped`, and `dedup_skipped` become metric-only `#[derive(Event)]` events (`log = off`), emitted at the same sites as the old `record_*` calls. The queue-full `warn!` lines and the dedup `trace!` stay put, verbatim, so each counter rides alongside its log exactly as before.
- These counters are exposed with a doubled suffix today (`..._messages_received_total_total`): the instruments were registered with a name already ending in `_total`, and the exporter appends another. The events reproduce that exposition exactly via `name_unchecked`; de-doubling is tracked separately as a deliberate, dashboard-coordinated change in #3431.
- `alerts_detected` stays hand-rolled -- its `point_type` label is a caller-supplied string that needs a bounded mapping, its own change.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3427
