### PR TITLE
fix: bump libredfish to v0.44.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6684,7 +6684,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.18#855c57dc567301f36801ac39c3a00432b17de08f"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.19#b52345f45212c674245dffb6053b34dec53ac57b"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.18" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.19" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.1" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
## Summary

- bump libredfish from v0.44.18 to v0.44.19
- include Dell HTTP boot-option compatibility for both the legacy exact display name and the suffix added by newer firmware

Upstream fix: https://github.com/NVIDIA/libredfish/pull/102
Issue: https://github.com/NVIDIA/libredfish/issues/101

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --locked -p carbide-redfish`
- `cargo check --locked -p carbide-redfish -p carbide-machine-controller -p carbide-api-core` (Linux)
- `cargo make --no-workspace clippy-flow` (Linux)