### PR TITLE
refactor: emit the DSX event-bus publish counter through the instrumentation framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,8 @@ name = "carbide-mqtt-common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "carbide-instrument",
+ "carbide-test-support",
  "mqttea",
  "opentelemetry 0.32.0",
  "tokio",

--- a/crates/api-core/src/mqtt_state_change_hook/hook.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/hook.rs
@@ -20,7 +20,7 @@
 use std::time::Duration;
 
 use carbide_mqtt_common::hook::{MqttPublisher, QueuedMessage, process_events};
-use carbide_mqtt_common::metrics::MqttHookMetrics;
+use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
 use carbide_uuid::machine::MachineId;
 use model::machine::ManagedHostState;
 use opentelemetry::metrics::Meter;
@@ -64,7 +64,8 @@ impl MqttStateChangeHook {
         cancel_token: CancellationToken,
     ) -> Self {
         let (sender, receiver) = mpsc::channel(queue_capacity);
-        let metrics = MqttHookMetrics::new(meter, sender.downgrade(), "managed_host");
+        let metrics =
+            MqttHookMetrics::new(meter, sender.downgrade(), PublishComponent::ManagedHost);
         join_set.spawn(process_events(
             receiver,
             client,

--- a/crates/api-core/src/mqtt_state_change_hook/republisher.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/republisher.rs
@@ -20,13 +20,12 @@
 use std::time::Duration;
 
 use carbide_mqtt_common::hook::{MqttPublisher, publish_with_deadline};
-use carbide_mqtt_common::metrics::MqttHookMetrics;
+use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Utc};
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use health_report::HealthReport;
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostState};
-use opentelemetry::metrics::Meter;
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
@@ -72,8 +71,8 @@ impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
     /// Reuses the change-hook publish metrics (`carbide_dsx_event_bus_publish_count`)
     /// under the `managed_host_republish` component so periodic publishes can be
     /// told apart from change-driven ones on dashboards.
-    pub fn new(publisher: P, params: ManagedHostStateRepublisherParams, meter: &Meter) -> Self {
-        let metrics = MqttHookMetrics::without_queue_depth(meter, "managed_host_republish");
+    pub fn new(publisher: P, params: ManagedHostStateRepublisherParams) -> Self {
+        let metrics = MqttHookMetrics::without_queue_depth(PublishComponent::ManagedHostRepublish);
         Self {
             publisher,
             db_pool: params.db_pool,
@@ -324,18 +323,13 @@ mod tests {
 
     use carbide_uuid::machine::{MachineIdSource, MachineType};
     use mqttea::MqtteaClientError;
-    use opentelemetry::global;
     use tokio::sync::Barrier;
 
     use super::*;
     use crate::cfg::file::PublishRate;
 
-    fn test_meter() -> Meter {
-        global::meter("republisher-test")
-    }
-
     fn test_metrics() -> MqttHookMetrics {
-        MqttHookMetrics::without_queue_depth(&test_meter(), "managed_host_republish_test")
+        MqttHookMetrics::without_queue_depth(PublishComponent::ManagedHostRepublish)
     }
 
     fn test_machine_id() -> MachineId {

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1227,7 +1227,6 @@ async fn initialize_and_start_controllers<'a>(
                     config: config.periodic_state_republish.clone(),
                     host_health_config: carbide_config.host_health,
                 },
-                &meter,
             )
             .start(join_set, cancel_token.clone())?;
 

--- a/crates/mqtt-common/Cargo.toml
+++ b/crates/mqtt-common/Cargo.toml
@@ -25,7 +25,12 @@ authors.workspace = true
 mqttea = { path = "../mqttea", default-features = false }
 
 async-trait = { workspace = true }
+carbide-instrument = { path = "../instrument" }
 opentelemetry = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }

--- a/crates/mqtt-common/src/metrics.rs
+++ b/crates/mqtt-common/src/metrics.rs
@@ -17,16 +17,82 @@
 
 //! Metrics for the DSX Exchange Event Bus MQTT hook.
 
+use carbide_instrument::{Event, LabelValue};
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Meter};
+use opentelemetry::metrics::Meter;
 use tokio::sync::mpsc::WeakSender;
+
+/// The publishing path behind a DSX Exchange Event Bus publish, as the bounded
+/// `component` metric label. Each variant renders to the exact value the
+/// counter (and the queue-depth gauge) has always reported.
+///
+/// The set is closed: every construction site in the tree passes one of these
+/// three, so the label is a framework `#[label]` rather than a free `&str`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum PublishComponent {
+    /// The BMS DSX Exchange publisher (`carbide-rack`).
+    Bms,
+    /// The change-driven managed-host state hook (`carbide-api-core`).
+    ManagedHost,
+    /// The periodic managed-host state republisher (`carbide-api-core`).
+    ManagedHostRepublish,
+}
+
+/// The outcome of a publish attempt, as the bounded `status` metric label. Each
+/// variant renders to the exact value the counter has always reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum PublishStatus {
+    /// The message was published within its deadline.
+    Ok,
+    /// The bounded queue was full, so the message was dropped.
+    Overflow,
+    /// The publish did not complete before its deadline.
+    Timeout,
+    /// The broker rejected the publish.
+    PublishError,
+    /// The message could not be serialized.
+    SerializationError,
+}
+
+/// A publish attempt against the DSX Exchange Event Bus, counted by publishing
+/// path and outcome.
+///
+/// `name_unchecked` keeps the grandfathered exposed name byte-for-byte. The
+/// counter has always registered `carbide_dsx_event_bus_publish_count` -- a
+/// `_count` suffix, not the framework's conventional `_total` -- and the
+/// OpenTelemetry Prometheus exporter appends its own `_total`, so `/metrics`
+/// shows `carbide_dsx_event_bus_publish_count_total`. The framework strips a
+/// trailing `_total` before registering; this name has none, so it registers
+/// exactly the old instrument name and the exporter reproduces the exact
+/// exposed series. The convention check would otherwise reject a counter name
+/// that does not end in `_total`.
+///
+/// Metric-only (`log = off`): every emit sits beside the `tracing` line it has
+/// always had, which is left untouched -- this event moves only the counter.
+///
+/// The `component =` attribute is the framework's owning-subsystem const, used
+/// by tooling and never emitted as a label; the metric's own `component` label
+/// is the per-path discriminator field below.
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_event_bus_publish_count",
+    name_unchecked,
+    component = "nico-mqtt-common",
+    log = off,
+    metric = counter,
+    describe = "Total number of MQTT publish attempts"
+)]
+struct DsxEventBusPublish {
+    #[label]
+    component: PublishComponent,
+    #[label]
+    status: PublishStatus,
+}
 
 /// Metrics for the MQTT state change hook.
 #[derive(Clone)]
 pub struct MqttHookMetrics {
-    /// Counter for publish attempts, with status label for success/error.
-    publish_count: Counter<u64>,
-    component: &'static str,
+    component: PublishComponent,
 }
 
 impl MqttHookMetrics {
@@ -37,7 +103,7 @@ impl MqttHookMetrics {
     pub fn new<T: Send + 'static>(
         meter: &Meter,
         sender: WeakSender<T>,
-        component: &'static str,
+        component: PublishComponent,
     ) -> Self {
         // Get max_capacity once at construction (upgrade will succeed since sender still exists)
         let max_capacity = sender.upgrade().map(|s| s.max_capacity()).unwrap_or(0);
@@ -53,63 +119,149 @@ impl MqttHookMetrics {
                     .upgrade()
                     .map(|s| max_capacity - s.capacity())
                     .unwrap_or(0);
-                observer.observe(depth as u64, &[KeyValue::new("component", component)]);
+                observer.observe(
+                    depth as u64,
+                    &[KeyValue::new("component", component.label_value())],
+                );
             })
             .build();
 
-        Self {
-            publish_count: Self::build_publish_count(meter),
-            component,
-        }
+        Self { component }
     }
 
     /// Create metrics for a publisher that does not buffer messages in a
     /// bounded queue, so no queue-depth gauge is registered. Used by the
     /// periodic state republisher, which publishes directly from its sweep.
-    pub fn without_queue_depth(meter: &Meter, component: &'static str) -> Self {
-        Self {
-            publish_count: Self::build_publish_count(meter),
-            component,
-        }
+    pub fn without_queue_depth(component: PublishComponent) -> Self {
+        Self { component }
     }
 
-    fn build_publish_count(meter: &Meter) -> Counter<u64> {
-        meter
-            .u64_counter("carbide_dsx_event_bus_publish_count")
-            .with_description("Total number of MQTT publish attempts")
-            .build()
-    }
-
-    fn attrs(&self, status: &'static str) -> [KeyValue; 2] {
-        [
-            KeyValue::new("component", self.component),
-            KeyValue::new("status", status),
-        ]
+    /// Count one publish attempt for this component with the given outcome.
+    fn record(&self, status: PublishStatus) {
+        carbide_instrument::emit(DsxEventBusPublish {
+            component: self.component,
+            status,
+        });
     }
 
     /// Record a successful publish.
     pub fn record_success(&self) {
-        self.publish_count.add(1, &self.attrs("ok"));
+        self.record(PublishStatus::Ok);
     }
 
     /// Record that an event was dropped due to queue overflow.
     pub fn record_overflow(&self) {
-        self.publish_count.add(1, &self.attrs("overflow"));
+        self.record(PublishStatus::Overflow);
     }
 
     /// Record a publish timeout.
     pub fn record_timeout(&self) {
-        self.publish_count.add(1, &self.attrs("timeout"));
+        self.record(PublishStatus::Timeout);
     }
 
     /// Record an MQTT publish error.
     pub fn record_publish_error(&self) {
-        self.publish_count.add(1, &self.attrs("publish_error"));
+        self.record(PublishStatus::PublishError);
     }
 
     /// Record a serialization failure.
     pub fn record_serialization_error(&self) {
-        self.publish_count
-            .add(1, &self.attrs("serialization_error"));
+        self.record(PublishStatus::SerializationError);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::LabelValue;
+    use carbide_instrument::testing::MetricsCapture;
+    use carbide_test_support::{Check, check_values};
+
+    use super::{DsxEventBusPublish, PublishComponent, PublishStatus};
+
+    /// The `status` label values are the metric's contract: each variant renders
+    /// to the exact string the publish counter has always reported.
+    #[test]
+    fn publish_status_renders_expected_label_values() {
+        check_values(
+            [
+                Check {
+                    scenario: "success",
+                    input: PublishStatus::Ok,
+                    expect: "ok".to_string(),
+                },
+                Check {
+                    scenario: "queue overflow",
+                    input: PublishStatus::Overflow,
+                    expect: "overflow".to_string(),
+                },
+                Check {
+                    scenario: "publish timeout",
+                    input: PublishStatus::Timeout,
+                    expect: "timeout".to_string(),
+                },
+                Check {
+                    scenario: "publish error",
+                    input: PublishStatus::PublishError,
+                    expect: "publish_error".to_string(),
+                },
+                Check {
+                    scenario: "serialization error",
+                    input: PublishStatus::SerializationError,
+                    expect: "serialization_error".to_string(),
+                },
+            ],
+            |status| status.label_value().to_string(),
+        );
+    }
+
+    /// The `component` label values are the metric's contract: each variant
+    /// renders to the exact string the publish counter and queue-depth gauge
+    /// have always reported.
+    #[test]
+    fn publish_component_renders_expected_label_values() {
+        check_values(
+            [
+                Check {
+                    scenario: "bms publisher",
+                    input: PublishComponent::Bms,
+                    expect: "bms".to_string(),
+                },
+                Check {
+                    scenario: "change-driven managed host hook",
+                    input: PublishComponent::ManagedHost,
+                    expect: "managed_host".to_string(),
+                },
+                Check {
+                    scenario: "periodic managed host republisher",
+                    input: PublishComponent::ManagedHostRepublish,
+                    expect: "managed_host_republish".to_string(),
+                },
+            ],
+            |component| component.label_value().to_string(),
+        );
+    }
+
+    /// The exposed series is the metric's contract. Emitting the event moves the
+    /// grandfathered `carbide_dsx_event_bus_publish_count` counter, and the
+    /// Prometheus exporter's appended `_total` makes the exposed name
+    /// `carbide_dsx_event_bus_publish_count_total` -- byte-for-byte what the
+    /// hand-rolled counter exported before the framework conversion, under the
+    /// same `component` and `status` labels.
+    #[test]
+    fn publish_event_exposes_grandfathered_count_series() {
+        let metrics = MetricsCapture::start();
+
+        carbide_instrument::emit(DsxEventBusPublish {
+            component: PublishComponent::ManagedHost,
+            status: PublishStatus::PublishError,
+        });
+
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_dsx_event_bus_publish_count_total",
+                &[("component", "managed_host"), ("status", "publish_error")],
+            ),
+            1.0,
+        );
     }
 }

--- a/crates/rack/src/bms_client.rs
+++ b/crates/rack/src/bms_client.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use bms_dsx_exchange::{BmsDsxExchangePublisher, Publication, PublisherConfig, SourceUpdate};
 use carbide_mqtt_common::hook::MqttPublisher;
-use carbide_mqtt_common::metrics::MqttHookMetrics;
+use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
 use carbide_uuid::rack::RackId;
 use chrono::Utc;
 use db::db_read::PgPoolReader;
@@ -79,7 +79,7 @@ impl BmsDsxExchangeHandle {
             .heartbeat_interval
             .min(publisher_config.republish_interval);
         let (sender, receiver) = mpsc::channel(queue_capacity);
-        let metrics = MqttHookMetrics::new(meter, sender.downgrade(), "bms");
+        let metrics = MqttHookMetrics::new(meter, sender.downgrade(), PublishComponent::Bms);
 
         let handle = Arc::new(BmsDsxExchangeHandle { sender });
 
@@ -398,7 +398,8 @@ mod tests {
         let mut join_set = JoinSet::new();
         let cancel_token = CancellationToken::new();
         let (sender, receiver) = mpsc::channel(32);
-        let metrics = MqttHookMetrics::new(&test_meter(), sender.downgrade(), "bms-test");
+        let metrics =
+            MqttHookMetrics::new(&test_meter(), sender.downgrade(), PublishComponent::Bms);
 
         join_set.spawn(run_worker(
             receiver,


### PR DESCRIPTION
The DSX event-bus publish hook counted every publish -- by component and outcome -- through a hand-rolled counter shared across three crates. It now goes through the instrumentation framework like the rest of the fleet, with the exposed metric byte-for-byte identical and no log line touched.

- `carbide_dsx_event_bus_publish_count` becomes a metric-only `#[derive(Event)]` event (`log = off`), emitted from the same `record_*` points as the old `.add(1)` calls. Its name ends in `_count`, so `name_unchecked` keeps the grandfathered exposed series exactly.
- Both labels become bounded `LabelValue` enums rendering to the exact strings in use: `status` (ok / overflow / timeout / publish_error / serialization_error) and `component` (bms / managed_host / managed_host_republish). The three construction sites now pass the matching `PublishComponent` variant instead of a free string; table tests pin both vocabularies.
- The `carbide_dsx_event_bus_queue_depth` observable gauge is left as-is (periodic state); only its component label now renders through the same enum, identically.
- Every `debug!`/`warn!`/`error!` beside a publish count stays exactly as it was.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3445
