### PR TITLE
refactor: emit the secrets client counters through the instrumentation framework

### DIFF
--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -261,14 +261,11 @@ pub async fn run(
             &cancel_token,
         )?;
 
-        let pg_mgr = Arc::new(
-            crate::secrets::PostgresCredentialManager::new(
-                db_pool.clone(),
-                routing.clone(),
-                kms.clone(),
-            )
-            .with_metrics(crate::secrets::SecretsMetrics::new(&metrics.meter)),
-        );
+        let pg_mgr = Arc::new(crate::secrets::PostgresCredentialManager::new(
+            db_pool.clone(),
+            routing.clone(),
+            kms.clone(),
+        ));
         tracing::info!(
             active_provider = %secrets_config.kms.active,
             backends = ?secrets_config.backends,

--- a/crates/api-core/src/secrets/metrics.rs
+++ b/crates/api-core/src/secrets/metrics.rs
@@ -15,67 +15,103 @@
  * limitations under the License.
  */
 
+//! The Postgres secrets backend's instrumentation events, under
+//! `carbide_api_secrets_*` with an `operation` label (get/set/create/delete):
+//! an operation is counted the moment it starts, then counted again as a
+//! success or a failure and timed once. Every event is metric-only -- the
+//! secrets code logs its own detail elsewhere -- so each is `log = off`.
+
 use std::time::Instant;
 
-use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Histogram, Meter};
+use carbide_instrument::{Event, LabelValue, emit};
 
-/// Request, outcome, and duration instruments for the Postgres secrets
-/// backend, under `carbide-api.secrets.*` with an `operation` label
-/// (get/set/create/delete).
-#[derive(Clone)]
-pub struct SecretsMetrics {
-    requests: Counter<u64>,
-    successes: Counter<u64>,
-    failures: Counter<u64>,
-    duration: Histogram<u64>,
+/// The secrets operation, as the bounded `operation` metric label. Each
+/// variant renders to the exact string the counters have always reported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub enum SecretsOperation {
+    Get,
+    Set,
+    Create,
+    Delete,
 }
 
-impl SecretsMetrics {
-    /// Create the instruments from an OpenTelemetry meter.
-    pub fn new(meter: &Meter) -> Self {
-        Self {
-            requests: meter
-                .u64_counter("carbide-api.secrets.requests")
-                .with_description("Total number of Postgres secrets operations attempted.")
-                .build(),
-            successes: meter
-                .u64_counter("carbide-api.secrets.requests.succeeded")
-                .with_description("Number of Postgres secrets operations that succeeded.")
-                .build(),
-            failures: meter
-                .u64_counter("carbide-api.secrets.requests.failed")
-                .with_description("Number of Postgres secrets operations that failed.")
-                .build(),
-            duration: meter
-                .u64_histogram("carbide-api.secrets.request_duration")
-                .with_description("Duration of Postgres secrets operations, in milliseconds.")
-                .with_unit("ms")
-                .build(),
-        }
-    }
+/// A Postgres secrets operation was attempted; counted the moment it starts.
+#[derive(Event)]
+#[event(
+    name = "carbide_api_secrets_requests_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Total number of Postgres secrets operations attempted."
+)]
+struct SecretsRequestStarted {
+    #[label]
+    operation: SecretsOperation,
+}
+
+/// A Postgres secrets operation completed successfully.
+#[derive(Event)]
+#[event(
+    name = "carbide_api_secrets_requests_succeeded_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Number of Postgres secrets operations that succeeded."
+)]
+struct SecretsRequestSucceeded {
+    #[label]
+    operation: SecretsOperation,
+}
+
+/// A Postgres secrets operation failed -- it left scope without succeeding.
+#[derive(Event)]
+#[event(
+    name = "carbide_api_secrets_requests_failed_total",
+    component = "nico-api",
+    log = off,
+    metric = counter,
+    describe = "Number of Postgres secrets operations that failed."
+)]
+struct SecretsRequestFailed {
+    #[label]
+    operation: SecretsOperation,
+}
+
+/// How long a Postgres secrets operation took, in whole milliseconds,
+/// recorded once on either the success or the failure path. The elapsed time
+/// is truncated to whole milliseconds before it is observed, so the recorded
+/// sample is the same integer the counter has always reported.
+#[derive(Event)]
+#[event(
+    name = "carbide_api_secrets_request_duration_milliseconds",
+    component = "nico-api",
+    log = off,
+    metric = histogram,
+    describe = "Duration of Postgres secrets operations, in milliseconds."
+)]
+struct SecretsRequestDuration {
+    #[label]
+    operation: SecretsOperation,
+    #[observation]
+    duration_ms: u64,
 }
 
 /// Times one secrets operation and records its outcome exactly once: call
-/// [`OperationTimer::succeed`] on the success path, and any other way out
-/// of scope -- early `?` returns included -- records a failure on drop. No
-/// instruments are touched when metrics are disabled.
+/// [`OperationTimer::succeed`] on the success path, and any other way out of
+/// scope -- early `?` returns included -- records a failure on drop. The
+/// events are metric-only; with no meter provider installed, `emit` is a
+/// no-op.
 pub struct OperationTimer {
-    metrics: Option<SecretsMetrics>,
-    operation: &'static str,
+    operation: SecretsOperation,
     started: Instant,
     completed: bool,
 }
 
 impl OperationTimer {
-    /// Start timing an operation, counting the request immediately. Pass
-    /// None to make every recording call a no-op.
-    pub fn start(metrics: Option<SecretsMetrics>, operation: &'static str) -> Self {
-        if let Some(m) = &metrics {
-            m.requests.add(1, &[KeyValue::new("operation", operation)]);
-        }
+    /// Start timing an operation, counting the attempt immediately.
+    pub fn start(operation: SecretsOperation) -> Self {
+        emit(SecretsRequestStarted { operation });
         Self {
-            metrics,
             operation,
             started: Instant::now(),
             completed: false,
@@ -85,12 +121,14 @@ impl OperationTimer {
     /// Record a successful operation and its duration.
     pub fn succeed(mut self) {
         self.completed = true;
-        if let Some(m) = &self.metrics {
-            let elapsed = self.started.elapsed().as_millis() as u64;
-            let attrs = [KeyValue::new("operation", self.operation)];
-            m.successes.add(1, &attrs);
-            m.duration.record(elapsed, &attrs);
-        }
+        let duration_ms = self.started.elapsed().as_millis() as u64;
+        emit(SecretsRequestSucceeded {
+            operation: self.operation,
+        });
+        emit(SecretsRequestDuration {
+            operation: self.operation,
+            duration_ms,
+        });
     }
 }
 
@@ -99,11 +137,59 @@ impl Drop for OperationTimer {
         if self.completed {
             return;
         }
-        if let Some(m) = &self.metrics {
-            let elapsed = self.started.elapsed().as_millis() as u64;
-            let attrs = [KeyValue::new("operation", self.operation)];
-            m.failures.add(1, &attrs);
-            m.duration.record(elapsed, &attrs);
-        }
+        let duration_ms = self.started.elapsed().as_millis() as u64;
+        emit(SecretsRequestFailed {
+            operation: self.operation,
+        });
+        emit(SecretsRequestDuration {
+            operation: self.operation,
+            duration_ms,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::LabelValue;
+    use carbide_test_support::{Check, check_values};
+
+    use super::SecretsOperation;
+
+    /// The `operation` label values are the metric contract: each variant
+    /// renders to the exact snake_case string the counters have always
+    /// reported.
+    ///
+    /// The emit conditions -- which counter fires on success versus failure,
+    /// and that the duration records once on each path without logging -- are
+    /// pinned in the `secrets_metrics` integration-test binary, which runs
+    /// alone in its own process so no other emitter moves the global series
+    /// between a capture baseline and its delta.
+    #[test]
+    fn secrets_operation_renders_expected_label_values() {
+        check_values(
+            [
+                Check {
+                    scenario: "get",
+                    input: SecretsOperation::Get,
+                    expect: "get".to_string(),
+                },
+                Check {
+                    scenario: "set",
+                    input: SecretsOperation::Set,
+                    expect: "set".to_string(),
+                },
+                Check {
+                    scenario: "create",
+                    input: SecretsOperation::Create,
+                    expect: "create".to_string(),
+                },
+                Check {
+                    scenario: "delete",
+                    input: SecretsOperation::Delete,
+                    expect: "delete".to_string(),
+                },
+            ],
+            |operation| operation.label_value().to_string(),
+        );
     }
 }

--- a/crates/api-core/src/secrets/mod.rs
+++ b/crates/api-core/src/secrets/mod.rs
@@ -53,7 +53,7 @@ pub mod routing;
 mod tests;
 
 pub use import::{import_secrets, is_vault_import_complete, mark_vault_import_complete};
-pub use metrics::{OperationTimer, SecretsMetrics};
+pub use metrics::{OperationTimer, SecretsOperation};
 pub use re_wrap::{ReWrapStaleResult, re_wrap_stale};
 pub use routing::SecretRouting;
 
@@ -163,28 +163,16 @@ pub struct PostgresCredentialManager {
     pool: PgPool,
     routing: SecretRouting,
     kms: Arc<dyn KmsBackend>,
-    metrics: Option<SecretsMetrics>,
 }
 
 impl PostgresCredentialManager {
     /// Create a manager from a pool, write routing, and KMS backend.
     pub fn new(pool: PgPool, routing: SecretRouting, kms: Arc<dyn KmsBackend>) -> Self {
-        Self {
-            pool,
-            routing,
-            kms,
-            metrics: None,
-        }
+        Self { pool, routing, kms }
     }
 
-    /// Attach metrics instruments.
-    pub fn with_metrics(mut self, metrics: SecretsMetrics) -> Self {
-        self.metrics = Some(metrics);
-        self
-    }
-
-    fn timer(&self, operation: &'static str) -> OperationTimer {
-        OperationTimer::start(self.metrics.clone(), operation)
+    fn timer(&self, operation: SecretsOperation) -> OperationTimer {
+        OperationTimer::start(operation)
     }
 
     async fn conn(&self) -> Result<sqlx::pool::PoolConnection<sqlx::Postgres>, PgSecretsError> {
@@ -351,7 +339,7 @@ impl CredentialReader for PostgresCredentialManager {
         &self,
         key: &CredentialKey,
     ) -> Result<Option<Credentials>, SecretsError> {
-        let timer = self.timer("get");
+        let timer = self.timer(SecretsOperation::Get);
         let path = key.to_key_str();
 
         let row = db::secrets::get_latest(&self.pool, &path)
@@ -392,7 +380,7 @@ impl CredentialWriter for PostgresCredentialManager {
         key: &CredentialKey,
         credentials: &Credentials,
     ) -> Result<(), SecretsError> {
-        let timer = self.timer("set");
+        let timer = self.timer(SecretsOperation::Set);
         let path = key.to_key_str();
 
         let json_bytes =
@@ -413,7 +401,7 @@ impl CredentialWriter for PostgresCredentialManager {
         key: &CredentialKey,
         credentials: &Credentials,
     ) -> Result<(), SecretsError> {
-        let timer = self.timer("create");
+        let timer = self.timer(SecretsOperation::Create);
         let path = key.to_key_str();
 
         // Encrypt before the transaction opens: the KMS call can be a
@@ -457,7 +445,7 @@ impl CredentialWriter for PostgresCredentialManager {
     }
 
     async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError> {
-        let timer = self.timer("delete");
+        let timer = self.timer(SecretsOperation::Delete);
         let path = key.to_key_str();
 
         let mut conn = self.conn().await?;

--- a/crates/api-core/tests/secrets_metrics.rs
+++ b/crates/api-core/tests/secrets_metrics.rs
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Pins the secrets timer's emit conditions -- which counter fires on success
+//! versus failure, and that the duration records once on each path with no log
+//! line -- while proving the exposed names are byte-identical to what the
+//! pre-framework hand-rolled instruments served.
+//!
+//! Its own test binary on purpose: the crate's in-process `secrets::tests`
+//! manager cases drive the same `OperationTimer`, so they emit these same
+//! global `carbide_api_secrets_*` series. `MetricsCapture` only serializes
+//! other capture users, so an exact-delta assertion would race a manager op
+//! landing between its baseline and its delta. Alone in this process, these
+//! two tests are the only emitters, and the `MetricsCapture` serial guard
+//! orders them, so the `== 1` / `== 0` deltas are deterministic.
+
+use carbide_api_core::secrets::{OperationTimer, SecretsOperation};
+use carbide_instrument::testing::{MetricsCapture, capture_logs};
+
+/// The success path counts the attempt, counts the success, and times the
+/// operation once -- never touching the failure counter -- and builds no log
+/// line, because the events are metric-only. The three counter deltas land
+/// under the exact names the pre-framework instruments served.
+#[test]
+fn succeed_counts_attempt_success_and_duration_without_logging() {
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        OperationTimer::start(SecretsOperation::Get).succeed();
+    });
+
+    assert!(
+        logs.is_empty(),
+        "log = off must not construct any log line, got {logs:?}"
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_api_secrets_requests_total",
+            &[("operation", "get")]
+        ),
+        1.0,
+        "the attempt counter must move once; exposition was:\n{}",
+        metrics.render()
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_api_secrets_requests_succeeded_total",
+            &[("operation", "get")],
+        ),
+        1.0,
+        "the success counter must move once; exposition was:\n{}",
+        metrics.render()
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_api_secrets_requests_failed_total",
+            &[("operation", "get")],
+        ),
+        0.0,
+        "the success path must not move the failure counter",
+    );
+    assert_eq!(
+        metrics.histogram_count_delta(
+            "carbide_api_secrets_request_duration_milliseconds",
+            &[("operation", "get")],
+        ),
+        1,
+        "the duration must record exactly once on the success path",
+    );
+}
+
+/// Leaving the timer's scope without calling `succeed` -- as an early `?`
+/// return would -- counts the attempt, counts a failure, and times the
+/// operation once, without touching the success counter or logging.
+#[test]
+fn drop_without_succeed_counts_attempt_failure_and_duration() {
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        let _timer = OperationTimer::start(SecretsOperation::Delete);
+    });
+
+    assert!(
+        logs.is_empty(),
+        "log = off must not construct any log line, got {logs:?}"
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_api_secrets_requests_total",
+            &[("operation", "delete")],
+        ),
+        1.0,
+        "the attempt counter must move once; exposition was:\n{}",
+        metrics.render()
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_api_secrets_requests_failed_total",
+            &[("operation", "delete")],
+        ),
+        1.0,
+        "the failure counter must move once; exposition was:\n{}",
+        metrics.render()
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_api_secrets_requests_succeeded_total",
+            &[("operation", "delete")],
+        ),
+        0.0,
+        "a dropped-as-failed timer must not move the success counter",
+    );
+    assert_eq!(
+        metrics.histogram_count_delta(
+            "carbide_api_secrets_request_duration_milliseconds",
+            &[("operation", "delete")],
+        ),
+        1,
+        "the duration must record exactly once on the failure path",
+    );
+}


### PR DESCRIPTION
The API's Postgres secrets client counted its requests -- attempts, successes, failures, and per-operation duration -- through a hand-rolled RAII timer on its own OpenTelemetry meter. It now goes through the instrumentation framework, with every exposed metric byte-for-byte identical -- names, labels, descriptions, and recorded histogram values -- and no log line touched.

- `carbide_api_secrets_requests_total`, `_requests_succeeded_total`, `_requests_failed_total`, and the `carbide_api_secrets_request_duration_milliseconds` histogram become metric-only `#[derive(Event)]` events (`log = off`), emitted from the same `OperationTimer` points as the old `.add(1)` / `.record(...)` calls -- one start, then success-or-failure with a duration, exactly as before.
- The duration records whole-millisecond `u64` values (`as_millis() as u64`) on both completion paths, so the histogram's sum and buckets are unchanged.
- The `operation` label becomes a `SecretsOperation` enum rendering to the exact `get`/`set`/`create`/`delete` in use; a table test pins the bytes.
- Dropping `SecretsMetrics` lets the meter thread go with it (`with_metrics` and its wiring in `secrets/mod.rs` and `run.rs`), since the framework events resolve the process-global meter the crate already installs. The `MetricsCapture` tests live in their own test binary so they can't race the manager tests that now emit the same series.

Tests added!

This supports https://github.com/NVIDIA/infra-controller/issues/3444
