### PR TITLE
fix(v2.0): support extended Dell HTTP boot option names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6599,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.16#211f6e8dcdf4fa59500e3308246a6bc21a24276e"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.19#b52345f45212c674245dffb6053b34dec53ac57b"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.16" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.19" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-mts-rc04" }
 ansi-to-html = "0.2.2"
 

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -155,7 +155,8 @@ pub fn bmc_vendor(r: libredfish::model::service_root::RedfishVendor) -> BMCVendo
         | RedfishVendor::NvidiaGBx00
         | RedfishVendor::NvidiaGH200
         | RedfishVendor::NvidiaGBSwitch
-        | RedfishVendor::P3809 => BMCVendor::Nvidia,
+        | RedfishVendor::P3809
+        | RedfishVendor::VeraRubin => BMCVendor::Nvidia,
         RedfishVendor::Dell => BMCVendor::Dell,
         RedfishVendor::Hpe => BMCVendor::Hpe,
         RedfishVendor::Lenovo => BMCVendor::Lenovo,

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -220,7 +220,8 @@ impl RedfishClient {
             | RedfishVendor::P3809
             | RedfishVendor::LiteOnPowerShelf
             | RedfishVendor::DeltaPowerShelf
-            | RedfishVendor::NvidiaGBx00 => {
+            | RedfishVendor::NvidiaGBx00
+            | RedfishVendor::VeraRubin => {
                 // change_password does things that require a password and DPUs need a first
                 // password use to be change, so just change it directly
                 //


### PR DESCRIPTION
Backport of #3442 to `release/v2.0`.

Newer Dell firmware appends interface details to HTTP boot-option display
names. libredfish v0.44.19 preserves the legacy exact-name match while
also accepting the suffix used by newer firmware, allowing SetBootOrder
to work with both firmware generations.

`release/v2.0` previously pinned libredfish v0.44.16, so this backport
advances it directly to v0.44.19. This also includes the changes from
v0.44.17 and v0.44.18. Because v0.44.18 introduced
`RedfishVendor::VeraRubin`, this PR also cherry-picks the compatibility
handling from #3074 required to keep the release branch compiling.

## Related issues

- Mainline dependency PR: #3442
- VeraRubin compatibility PR: #3074
- libredfish fix: https://github.com/NVIDIA/libredfish/pull/102
- libredfish issue: https://github.com/NVIDIA/libredfish/issues/101

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated in the upstream libredfish fix
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required

Validated on Linux against this backport branch:

- `cargo check --locked -p carbide-redfish -p carbide-site-explorer`
- focused Clippy for `carbide-redfish` and `carbide-site-explorer`
- `cargo make --no-workspace clippy-flow`

## Additional Notes

This PR contains two backported mainline commits:

- `bec9dfe7c` — bump libredfish to v0.44.19
- `366947aef` — handle the VeraRubin vendor variant introduced by v0.44.18

Release Management should perform the merge.