### PR TITLE
refactor: route pxe logs through the fleet's logfmt subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,12 +2656,14 @@ dependencies = [
  "carbide-version",
  "clap",
  "http-body",
+ "logfmt",
  "metrics",
  "metrics-endpoint",
  "metrics-exporter-prometheus",
  "mime",
  "pin-project-lite",
  "prometheus",
+ "rand 0.10.1",
  "serde",
  "tempfile",
  "tera",
@@ -2672,6 +2674,8 @@ dependencies = [
  "tower-http",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/pxe/Cargo.toml
+++ b/crates/pxe/Cargo.toml
@@ -35,6 +35,7 @@ carbide-utils = { path = "../utils", default-features = false }
 carbide-version = { path = "../version" }
 carbide-rpc = { path = "../rpc" }
 carbide-uuid = { path = "../uuid" }
+logfmt = { path = "../logfmt" }
 metrics-endpoint = { path = "../metrics-endpoint" }
 # [end-local-dependencies]
 
@@ -50,6 +51,7 @@ metrics-exporter-prometheus = { workspace = true }
 mime = { workspace = true }
 pin-project-lite = { workspace = true }
 prometheus = { workspace = true }
+rand = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 tera = { workspace = true }
 tokio = { workspace = true }
@@ -59,6 +61,8 @@ tower = { workspace = true }
 tower-http = { features = ["fs"], workspace = true }
 tower-layer = { workspace = true }
 tower-service = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { features = ["v4", "serde"], workspace = true }
 
 [build-dependencies]

--- a/crates/pxe/src/extractors/machine.rs
+++ b/crates/pxe/src/extractors/machine.rs
@@ -44,9 +44,10 @@ impl FromRequestParts<AppState> for Machine {
         let mut client = forge_tls_client::ForgeTlsClient::retry_build(&api_config)
             .await
             .map_err(|err| {
-                eprintln!(
-                    "error connecting to forge api from pxe - {:?} - url: {:?}",
-                    err, state.runtime_config.internal_api_url
+                tracing::error!(
+                    error = ?err,
+                    url = ?state.runtime_config.internal_api_url,
+                    "error connecting to forge api from pxe"
                 );
                 PxeRequestError::MissingClientConfig
             })?;

--- a/crates/pxe/src/main.rs
+++ b/crates/pxe/src/main.rs
@@ -27,6 +27,10 @@ use common::AppState;
 use tera::Tera;
 use tower_http::services::ServeDir;
 use tower_layer::Layer;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 mod common;
 mod config;
@@ -49,24 +53,30 @@ struct Args {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opts = Args::parse();
     if opts.version {
+        // The --version flag writes the bare version to stdout by design (a
+        // machine-readable value, not a log line), so it stays a println.
         println!("{}", carbide_version::version!());
         return Ok(());
     }
 
+    setup_tracing()?;
+
     let static_path = std::path::Path::new(&opts.static_dir);
     if !&static_path.exists() {
-        println!(
-            "Static path {} does not exist. Creating directory",
-            &static_path.display()
+        tracing::info!(
+            static_path = %static_path.display(),
+            "static path does not exist; creating directory"
         );
 
         match std::fs::create_dir_all(static_path) {
-            Ok(_) => println!("Directory {}, created", &static_path.display()),
-            Err(e) => eprintln!("Could not create directory: {e}"),
+            Ok(_) => {
+                tracing::info!(static_path = %static_path.display(), "created static directory")
+            }
+            Err(e) => tracing::error!(error = %e, "could not create static directory"),
         }
     }
 
-    println!("Start carbide-pxe version {}", carbide_version::version!());
+    tracing::info!(version = %carbide_version::version!(), "starting carbide-pxe");
     let prometheus_handle = metrics::setup_prometheus();
 
     // The instrumentation framework's events resolve their instruments from
@@ -75,6 +85,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // alive for the process lifetime -- dropping it stops collection.
     let otel_metrics = metrics_endpoint::new_metrics_setup("carbide-pxe", "carbide", true)
         .expect("unable to install the OTel meter provider?");
+
+    // Bind the log-events counter -- installed as a subscriber layer in
+    // setup_tracing so it counts from startup -- to the meter now that the
+    // provider exists, so carbide_log_events_total exports pxe's log volume and
+    // error rate like every other fleet binary.
+    carbide_instrument::log_events::register(&otel_metrics.meter);
 
     let runtime_config =
         config::RuntimeConfig::from_env().expect("unable to build runtime config?");
@@ -124,7 +140,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(socket_addr)
         .await
         .map_err(|err| {
-            eprintln!("unable to bind to tcp listener with error: {err}");
+            tracing::error!(error = %err, "unable to bind tcp listener");
             err
         })?;
 
@@ -133,6 +149,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         final_app.into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await?;
+
+    Ok(())
+}
+
+/// Installs the tracing subscriber that emits logs in the fleet's logfmt
+/// format, tagged with the `nico-pxe` component, plus the log-events counting
+/// layer that feeds the fleet-standard `carbide_log_events_total` counter.
+/// Matches the other carbide binaries: an `INFO` default with the usual
+/// dependency caps, overridable via `RUST_LOG`. The counter is bound to the
+/// meter by `log_events::register` in `main`, once the provider exists.
+fn setup_tracing() -> Result<(), Box<dyn std::error::Error>> {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy()
+        .add_directive("hyper=warn".parse()?)
+        .add_directive("h2=warn".parse()?)
+        .add_directive("tower=warn".parse()?)
+        .add_directive("rustls=warn".parse()?)
+        .add_directive("tokio_util::codec=warn".parse()?);
+
+    // Counts every log line into carbide_log_events_total from startup; the
+    // counts are exposed once main() installs the meter provider. The env
+    // filter sits on the registry as a global filter so the counting layer and
+    // the logfmt output see exactly the same events.
+    let log_events = carbide_instrument::LogEventsMetric::new("nico-pxe");
+    tracing_subscriber::registry()
+        .with(log_events.layer())
+        .with(
+            logfmt::layer()
+                .with_event_fields([logfmt::EventField::with_default("component", "nico-pxe")]),
+        )
+        .with(env_filter)
+        .try_init()?;
 
     Ok(())
 }

--- a/crates/pxe/src/middleware/logging.rs
+++ b/crates/pxe/src/middleware/logging.rs
@@ -14,145 +14,77 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::BTreeMap;
 use std::net::SocketAddr;
 
 use axum::extract::{ConnectInfo, Request};
 use axum::middleware::Next;
 use axum::response::Response;
+use tracing::Instrument;
 
+/// Emits one request log line through the fleet's logfmt subscriber.
+///
+/// Opens an `info` span named `request` around the downstream handler and
+/// records the method, path, query, client address, and the request and
+/// response headers of interest on it. The logfmt layer renders the span on
+/// close as a `level=SPAN span_name=request ...` line, giving it the
+/// `component` tag, level filtering, `span_id` correlation, and timing every
+/// other span in the fleet gets.
 pub(crate) async fn logger(
     ConnectInfo(socket_addr): ConnectInfo<SocketAddr>,
     request: Request,
     next: Next,
 ) -> Response {
-    let mut props = BTreeMap::new();
-    props.insert("level", "SPAN".to_string());
-    props.insert("span_name", "request".to_string());
-
-    props.insert("request_method", request.method().to_string());
-    props.insert("request_path", request.uri().path().to_string());
-    props.insert(
-        "request_query",
-        request
-            .uri()
-            .query()
-            .map(|q| q.to_string())
-            .unwrap_or_default(),
+    // A per-request correlation id, matching the fleet's request logging
+    // (api-core's `LogService`). The logfmt layer surfaces it as `span_id` on
+    // the span line and on every child event, so a request and the logs emitted
+    // while serving it share one key.
+    let span_id = format!("{:#x}", u64::from_le_bytes(rand::random::<[u8; 8]>()));
+    let span = tracing::info_span!(
+        "request",
+        span_id,
+        remote_ip = %socket_addr.ip(),
+        remote_port = socket_addr.port(),
+        request_method = %request.method(),
+        request_path = request.uri().path(),
+        request_query = request.uri().query().unwrap_or_default(),
+        request_headers_host = tracing::field::Empty,
+        "request_headers_content-length" = tracing::field::Empty,
+        "request_headers_user-agent" = tracing::field::Empty,
+        response_status = tracing::field::Empty,
+        "response_headers_content-length" = tracing::field::Empty,
     );
+
+    // Header fields are only surfaced when present, matching what the request
+    // actually carried; an absent header leaves its `Empty` placeholder unset,
+    // so the logfmt layer omits it.
     if let Some(host) = request.headers().get("Host").and_then(|h| h.to_str().ok()) {
-        props.insert("request_headers_host", host.to_string());
+        span.record("request_headers_host", host);
     }
     if let Some(content_length) = request
         .headers()
         .get("Content-Length")
         .and_then(|h| h.to_str().ok())
     {
-        props.insert("request_headers_content-length", content_length.to_string());
+        span.record("request_headers_content-length", content_length);
     }
     if let Some(user_agent) = request
         .headers()
         .get("User-Agent")
         .and_then(|h| h.to_str().ok())
     {
-        props.insert("request_headers_user-agent", user_agent.to_string());
+        span.record("request_headers_user-agent", user_agent);
     }
 
-    let response = next.run(request).await;
+    let response = next.run(request).instrument(span.clone()).await;
 
-    props.insert("response_status", response.status().as_str().to_string());
+    span.record("response_status", response.status().as_str());
     if let Some(content_length) = response
         .headers()
         .get("Content-Length")
         .and_then(|h| h.to_str().ok())
     {
-        props.insert(
-            "response_headers_content-length",
-            content_length.to_string(),
-        );
+        span.record("response_headers_content-length", content_length);
     }
-
-    props.insert("remote_ip", socket_addr.ip().to_string());
-    props.insert("remote_port", socket_addr.port().to_string());
-
-    let formatted = render_logfmt(&props);
-    println!("{formatted}");
 
     response
-}
-
-/// Renders a list of key-value pairs into a logfmt string
-fn render_logfmt(props: &BTreeMap<&'static str, String>) -> String {
-    let mut msg = String::new();
-
-    for (key, value) in props {
-        if !msg.is_empty() {
-            msg.push(' ');
-        }
-        msg += key;
-        msg.push('=');
-        let needs_quotes = value.is_empty()
-            || value
-                .as_bytes()
-                .iter()
-                .any(|c| *c <= b' ' || matches!(*c, b'=' | b'"'));
-
-        if needs_quotes {
-            msg.push('"');
-        }
-
-        msg.push_str(&value.escape_debug().to_string());
-
-        if needs_quotes {
-            msg.push('"');
-        }
-    }
-
-    msg
-}
-
-#[cfg(test)]
-mod tests {
-    use carbide_test_support::value_scenarios;
-
-    use super::*;
-
-    fn render(entries: Vec<(&'static str, &'static str)>) -> String {
-        let mut props = BTreeMap::new();
-        for (key, value) in entries {
-            props.insert(key, value.to_string());
-        }
-        render_logfmt(&props)
-    }
-
-    #[test]
-    fn renders_logfmt() {
-        value_scenarios!(
-            render:
-            "plain values" {
-                vec![
-                    ("method", "GET"),
-                    ("path", "/boot"),
-                    ("remote_ip", "127.0.0.1"),
-                ] => "method=GET path=/boot remote_ip=127.0.0.1".to_string(),
-            }
-
-            "quoted values" {
-                vec![
-                    ("method", "GET"),
-                    ("path", "/boot"),
-                    ("remote_ip", "127.0.0.1"),
-                    ("z", "with whitespace"),
-                    ("e", ""),
-                ] => "e=\"\" method=GET path=/boot remote_ip=127.0.0.1 z=\"with whitespace\"".to_string(),
-            }
-
-            "escaped values" {
-                vec![
-                    ("message", "quoted \"value\""),
-                    ("path", "a=b"),
-                ] => "message=\"quoted \\\"value\\\"\" path=\"a=b\"".to_string(),
-            }
-        );
-    }
 }

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -62,11 +62,11 @@ fn generate_forge_agent_config(
 /// missing, the client receives the same generic error template, and the
 /// caller says which missing data it was -- the reason label carries the
 /// per-site truth while the response stays generic.
-fn print_and_generate_generic_error(
+fn log_and_generate_generic_error(
     error: String,
     reason: OutcomeReason,
 ) -> (String, HashMap<String, String>) {
-    eprintln!("{error}");
+    tracing::error!(error = %error, "cloud-init request could not be served");
     emit(PxeBootOutcome {
         endpoint: BootEndpoint::CloudInit,
         reason,
@@ -248,12 +248,12 @@ pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoRes
                             state.clone(),
                         )
                     }
-                    None => print_and_generate_generic_error(
+                    None => log_and_generate_generic_error(
                         format!("The interface ID should not be null: {interface:?}"),
                         OutcomeReason::InterfaceNotFound,
                     ),
                 },
-                (interface, domain) => print_and_generate_generic_error(
+                (interface, domain) => log_and_generate_generic_error(
                     format!("The interface and domain were not found: {interface:?}, {domain:?}"),
                     OutcomeReason::InterfaceNotFound,
                 ),
@@ -279,7 +279,7 @@ pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoRes
 
 pub async fn meta_data(machine: Machine, state: State<AppState>) -> impl IntoResponse {
     let (template_key, template_data) = match machine.instructions.metadata {
-        None => print_and_generate_generic_error(
+        None => log_and_generate_generic_error(
             format!("No metadata was found for machine {machine:?}"),
             OutcomeReason::MetadataNotFound,
         ),

--- a/crates/pxe/src/routes/ipxe.rs
+++ b/crates/pxe/src/routes/ipxe.rs
@@ -166,7 +166,7 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
             let instructions = pxe_response
                 .map(|resp| resp.pxe_script)
                 .unwrap_or_else(|err| {
-                    eprintln!("{err}");
+                    tracing::error!(error = %err, "failed to fetch custom ipxe script");
                     format!(
                         r#"
 echo Failed to fetch custom_ipxe: {err} ||

--- a/crates/pxe/src/routes/metrics.rs
+++ b/crates/pxe/src/routes/metrics.rs
@@ -37,7 +37,7 @@ async fn metrics(state: State<AppState>) -> ([(axum::http::HeaderName, &'static 
         Ok(()) => exposition.push_str(&String::from_utf8_lossy(&buffer)),
         // Keep the scrape serveable: on an encode failure the OTel section
         // is absent from this response rather than corrupting it.
-        Err(error) => eprintln!("unable to encode the OTel metrics registry: {error}"),
+        Err(error) => tracing::error!(error = %error, "unable to encode the OTel metrics registry"),
     }
 
     // The official Prometheus exposition content type. The endpoint has

--- a/crates/pxe/src/routes/tls.rs
+++ b/crates/pxe/src/routes/tls.rs
@@ -40,7 +40,7 @@ async fn root_ca(headers: HeaderMap, state: State<AppState>) -> impl IntoRespons
     {
         Ok(response) => response.into_response(),
         Err(err) => {
-            eprintln!("Error reading root ca cert file: {err}");
+            tracing::error!(error = %err, "error reading root ca cert file");
             let response = Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(Body::from("error reading root ca cert file?"))


### PR DESCRIPTION
PXE was the last binary logging through raw `println!`/`eprintln!` -- its lines had no level, no component, no span_id, and bypassed every filter. It now installs the same instrumentation subscriber as the rest of the fleet, tagged with the `nico-pxe` component, so its output is filterable and greppable like everything else and its warning/error rate feeds the fleet-wide `carbide_log_events_total` signal (pxe was the one binary missing from it).

- `setup_tracing()` installs the fleet-standard subscriber at startup -- the `logfmt` layer, the `LogEventsMetric` counting layer, and an `EnvFilter` at INFO (`RUST_LOG`-overridable, with the usual per-dependency caps). The log-events counter is an already-documented metric joining pxe's own `/metrics`, so `core_metrics.md` is untouched.
- The twelve logging prints become structured `tracing` calls at the right level: seven `error!` (with the error and any URL as fields), three `info!`, and the request logger's hand-rolled logfmt renderer becomes a real `info_span!("request", ...)` -- now carrying a per-request `span_id` (matching api-core's request middleware) so the request line and its child events share a correlation key.
- The one surviving `println!` is `--version`, machine-readable stdout by design.

This supports https://github.com/NVIDIA/infra-controller/issues/3180
