### PR TITLE
fix: reconcile the DHCP replies-sent counter's HELP across its two crates

### DIFF
--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -159,7 +159,7 @@ pub struct DhcpPacketDropped {
     component = "nico-dhcp",
     log = off,
     metric = counter,
-    describe = "Number of DHCP replies successfully sent, by reply message type."
+    describe = "Number of DHCP replies sent, by reply message type."
 )]
 pub struct DhcpReplySent {
     #[label]


### PR DESCRIPTION
`carbide_dhcp_replies_sent_total` is emitted by two separate binaries -- the DHCP relay in `crates/dhcp` and the standalone DHCP server in `crates/dhcp-server` -- which declared it with divergent HELP text ("replies sent" vs "replies successfully sent"). Same metric, same meaning, two strings, so a scraper sees inconsistent HELP depending on which process it hits.

The two are the same metric legitimately exported by two processes, so this unifies the description rather than renaming: `dhcp-server`'s "successfully" is redundant (packets that never get a reply are counted separately under its own drop counter), so it now matches `dhcp`'s shorter wording.

- `crates/dhcp-server/src/metrics.rs`: drop "successfully" from the `replies_sent` describe so both crates declare identical HELP.

The counter isn't exercised by `test_integration`, so it isn't in `core_metrics.md` today and there's no catalogue regen here. When #3463's doc-gate documents it, the reconciled HELP is what it will record; if #3463 lands first, this rebases so the catalogue row reads "sent".

This supports #3461