### PR TITLE
fix: stop counting a failed Vault get_credentials read as a success

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,6 +2937,7 @@ dependencies = [
  "figment",
  "hex",
  "mac_address",
+ "mockito",
  "notify",
  "opentelemetry 0.32.0",
  "p256 0.14.0-rc.9",

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -56,7 +56,9 @@ carbide-instrument = { path = "../instrument" }
 carbide-uuid = { path = "../uuid" }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+mockito = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -504,8 +504,13 @@ impl VaultTask<Option<Credentials>> for GetCredentialsHelper<'_, '_> {
             duration_ms: elapsed_request_duration,
         });
 
-        let credentials = match vault_response {
-            Ok(creds) => Ok(Some(creds)),
+        match vault_response {
+            Ok(creds) => {
+                emit(VaultRequestSucceeded {
+                    request_type: VaultRequestType::GetCredentials,
+                });
+                Ok(Some(creds))
+            }
             Err(ce) => {
                 let status_code = record_vault_client_error(&ce, VaultRequestType::GetCredentials);
                 match status_code {
@@ -526,12 +531,7 @@ impl VaultTask<Option<Credentials>> for GetCredentialsHelper<'_, '_> {
                     }
                 }
             }
-        };
-
-        emit(VaultRequestSucceeded {
-            request_type: VaultRequestType::GetCredentials,
-        });
-        credentials
+        }
     }
 }
 
@@ -1312,5 +1312,142 @@ mod tests {
             ],
             |status| status.label_value().to_string(),
         );
+    }
+
+    /// Builds a `VaultClient` pointed at a plaintext `mockito` server, so the
+    /// get-credentials helper's real `kv2::read` round-trips through a response
+    /// we control. An `http://` address skips TLS, so no CA wiring is needed.
+    fn mock_backed_vault_client(
+        server: &mockito::ServerGuard,
+    ) -> std::sync::Arc<vaultrs::client::VaultClient> {
+        use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
+
+        let settings = VaultClientSettingsBuilder::default()
+            .address(server.url())
+            .token("test-token")
+            .verify(false)
+            .build()
+            .expect("vault client settings for mock server");
+        std::sync::Arc::new(VaultClient::new(settings).expect("vault client for mock server"))
+    }
+
+    /// A failed `get_credentials` read counts the attempt, times it once, and
+    /// moves ONLY the failed counter (carrying the HTTP status code) -- never
+    /// the succeeded counter -- while a successful read moves the succeeded
+    /// counter and leaves the failed one alone. Regression: the helper used to
+    /// emit `VaultRequestSucceeded` unconditionally after the response match, so
+    /// a failed read double-counted as both failed and succeeded, corrupting the
+    /// success/error split for `request_type="get_credentials"`.
+    #[tokio::test]
+    async fn get_credentials_failed_read_counts_failed_not_succeeded() {
+        use carbide_instrument::testing::MetricsCapture;
+
+        use super::{GetCredentialsHelper, VaultTask};
+        use crate::credentials::CredentialKey;
+
+        let mount = "secret".to_string();
+        let key = CredentialKey::UfmAuth {
+            fabric: "regression".to_string(),
+        };
+        let get = &[("request_type", "get_credentials")][..];
+        let failed_403 = &[
+            ("request_type", "get_credentials"),
+            ("http_response_status_code", "403"),
+        ][..];
+
+        // A non-404 error (here 403) must surface as an error and move the
+        // failed counter with its status code -- and must NOT move succeeded.
+        {
+            let mut server = mockito::Server::new_async().await;
+            let _mock = server
+                .mock("GET", mockito::Matcher::Any)
+                .with_status(403)
+                .with_header("content-type", "application/json")
+                .with_body(r#"{"errors":["permission denied"]}"#)
+                .create_async()
+                .await;
+
+            let helper = GetCredentialsHelper {
+                kv_mount_location: &mount,
+                key: &key,
+            };
+
+            let metrics = MetricsCapture::start();
+            let result = helper.execute(mock_backed_vault_client(&server)).await;
+
+            assert!(result.is_err(), "a 403 read must surface as an error");
+            assert_eq!(
+                metrics.counter_delta("carbide_api_vault_requests_failed_total", failed_403),
+                1.0,
+                "a failed read must move the failed counter once with its status code; exposition:\n{}",
+                metrics.render()
+            );
+            assert_eq!(
+                metrics.counter_delta("carbide_api_vault_requests_succeeded_total", get),
+                0.0,
+                "a failed read must not move the succeeded counter",
+            );
+            assert_eq!(
+                metrics.counter_delta("carbide_api_vault_requests_attempted_total", get),
+                1.0,
+                "every read counts exactly one attempt",
+            );
+            assert_eq!(
+                metrics
+                    .histogram_count_delta("carbide_api_vault_request_duration_milliseconds", get),
+                1,
+                "every read records exactly one duration observation",
+            );
+        }
+
+        // A successful read moves the succeeded counter and leaves the failed
+        // series untouched.
+        {
+            let mut server = mockito::Server::new_async().await;
+            let _mock = server
+                .mock("GET", mockito::Matcher::Any)
+                .with_status(200)
+                .with_header("content-type", "application/json")
+                .with_body(
+                    r#"{"request_id":"test","lease_id":"","lease_duration":0,"renewable":false,"data":{"data":{"UsernamePassword":{"username":"u","password":"p"}},"metadata":{"created_time":"2024-01-01T00:00:00Z","deletion_time":"","custom_metadata":null,"destroyed":false,"version":1}}}"#,
+                )
+                .create_async()
+                .await;
+
+            let helper = GetCredentialsHelper {
+                kv_mount_location: &mount,
+                key: &key,
+            };
+
+            let metrics = MetricsCapture::start();
+            let result = helper.execute(mock_backed_vault_client(&server)).await;
+
+            assert!(
+                matches!(&result, Ok(Some(_))),
+                "a 200 read with a valid body must succeed, got {result:?}"
+            );
+            assert_eq!(
+                metrics.counter_delta("carbide_api_vault_requests_succeeded_total", get),
+                1.0,
+                "a successful read must move the succeeded counter once; exposition:\n{}",
+                metrics.render()
+            );
+            assert_eq!(
+                metrics.counter_delta("carbide_api_vault_requests_failed_total", failed_403),
+                0.0,
+                "a successful read must not move the failed counter",
+            );
+            assert_eq!(
+                metrics.counter_delta("carbide_api_vault_requests_attempted_total", get),
+                1.0,
+                "every read counts exactly one attempt",
+            );
+            assert_eq!(
+                metrics
+                    .histogram_count_delta("carbide_api_vault_request_duration_milliseconds", get),
+                1,
+                "every read records exactly one duration observation",
+            );
+        }
     }
 }


### PR DESCRIPTION
`GetCredentialsHelper::execute` recorded `VaultRequestSucceeded` unconditionally after matching on the Vault response, so a read that FAILED incremented both the failed and the succeeded counter for `request_type = "get_credentials"`. The other four Vault operations don't have this -- they emit succeeded only after a `?` that short-circuits on error; `get_credentials` was the outlier because it binds the response in a value-producing `match` (to turn a 404 into `Ok(None)`) and then emitted succeeded past it.

This moves the succeeded emit into the `Ok(creds)` arm so it fires only on a genuine read. The attempted and duration signals are untouched, and a not-found now counts as failed-only -- restoring `attempted == succeeded + failed` on every path.

- `crates/secrets/src/forge_vault.rs`: emit `VaultRequestSucceeded` for `GetCredentials` inside the `Ok(creds)` arm.
- Audited the four sibling helpers (set, delete, token-refresh, get-certificate) -- each already short-circuits on error before its succeeded emit, so none shares the bug.
- Regression test drives the real `execute` -> `kv2::read` path against a mock Vault and fails if the unconditional emit returns.

Mechanism-preserving: no metric name/describe/label/type change, so `core_metrics.md` is unchanged.

This supports #3452