### PR TITLE
feat: surface the swallowed errors across the fleet

### DIFF
--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -526,7 +526,8 @@ pub(crate) async fn get_switch_nvos_credentials(
             db::ObjectColumnFilter::One(db::switch::IdColumn, &switch_id),
         )
         .await?;
-        let _ = txn.rollback().await;
+        txn.rollback_or_log("read-only load of switch for credential lookup")
+            .await;
 
         let switch = switches
             .first()

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -590,7 +590,8 @@ async fn process_batch_operations(
                     }
                 },
                 Err(e) => {
-                    let _ = txn.rollback().await;
+                    txn.rollback_or_log("expected-machine write after operation failure")
+                        .await;
                     results.push(build_failure_result(id, format!("Operation failed: {}", e)));
                 }
             }
@@ -624,7 +625,8 @@ async fn process_batch_operations(
         )
         .await
         {
-            let _ = txn.rollback().await;
+            txn.rollback_or_log("expected-machine write after operation failure")
+                .await;
             return Err(e);
         }
         results.push(build_success_result(machine_for_result));

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -278,7 +278,8 @@ pub(crate) async fn find_by_ids(
     for snapshot in snapshots.into_iter() {
         instances.push(snapshot_to_instance(snapshot)?);
     }
-    let _ = txn.rollback().await;
+    txn.rollback_or_log("read-only load of instances by id")
+        .await;
 
     Ok(Response::new(rpc::InstanceList { instances }))
 }

--- a/crates/api-core/src/handlers/power_shelf.rs
+++ b/crates/api-core/src/handlers/power_shelf.rs
@@ -138,7 +138,8 @@ pub async fn find_by_ids(
     )
     .await?;
 
-    let _ = txn.rollback().await;
+    txn.rollback_or_log("read-only load of power shelves by id")
+        .await;
 
     let power_shelves = convert_power_shelves(power_shelf_list)?;
 

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -125,7 +125,7 @@ pub async fn find_by_ids(
         result.push(rack.into());
     }
 
-    let _ = txn.rollback().await;
+    txn.rollback_or_log("read-only load of racks by id").await;
 
     Ok(Response::new(rpc::RackList { racks: result }))
 }

--- a/crates/api-core/src/handlers/switch.rs
+++ b/crates/api-core/src/handlers/switch.rs
@@ -176,7 +176,8 @@ pub async fn find_by_ids(
             .map(|row| (row.switch_id, row))
             .collect();
 
-    let _ = txn.rollback().await;
+    txn.rollback_or_log("read-only load of switches by id")
+        .await;
 
     let switches: Vec<rpc::Switch> = switch_list
         .into_iter()

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -691,6 +691,31 @@ impl<'a> Transaction<'a> {
         })
     }
 
+    // This function can just async when
+    // https://github.com/rust-lang/rust/issues/110011 will be
+    // implemented
+    /// Roll back the transaction, logging a warning tagged with `context` if
+    /// the rollback itself fails, rather than propagating -- for read-only or
+    /// cleanup paths where the caller can't act on a rollback error but must
+    /// not swallow it.
+    #[track_caller]
+    pub fn rollback_or_log(
+        self,
+        context: &'static str,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
+        let loc = Location::caller();
+        Box::pin(async move {
+            if let Err(e) = self
+                .inner
+                .rollback()
+                .await
+                .map_err(|e| DatabaseError::txn_rollback(e, loc))
+            {
+                tracing::warn!(error = %e, context, "Failed to roll back transaction");
+            }
+        })
+    }
+
     pub fn as_pgconn(&mut self) -> &mut sqlx::PgConnection {
         &mut self.inner
     }

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -99,18 +99,48 @@ fn wait_for_metrics_initialization() -> bool {
     }
 }
 
+/// Read a TLS file path from the environment, falling back to the built-in
+/// default when the variable is unset, unreadable, or explicitly empty --
+/// `std::env::var` returns `Ok("")` for an empty variable, and an empty path
+/// must not reach the client config.
+fn forge_tls_path(var: &str, default: &str, label: &str) -> String {
+    match std::env::var(var) {
+        Ok(path) if !path.is_empty() => return path,
+        Ok(_) => {
+            log::warn!(
+                "{var} is set but empty; falling back to the built-in default {label} at {default}"
+            )
+        }
+        Err(e) => {
+            log::warn!(
+                "{var} unset or unreadable ({e}); falling back to the built-in default {label} at {default}"
+            )
+        }
+    }
+    default.to_string()
+}
+
 impl Default for CarbideDhcpContext {
     fn default() -> Self {
         Self {
             api_endpoint: "https://[::1]:1079".to_string(),
             nameservers: vec![Ipv4Addr::new(1, 1, 1, 1)],
             dns_servers_ipv6: Vec::new(),
-            forge_root_ca_path: std::env::var("FORGE_ROOT_CAFILE_PATH")
-                .unwrap_or_else(|_| tls_default::ROOT_CA.to_string()),
-            forge_client_cert_path: std::env::var("FORGE_CLIENT_CERT_PATH")
-                .unwrap_or_else(|_| tls_default::CLIENT_CERT.to_string()),
-            forge_client_key_path: std::env::var("FORGE_CLIENT_KEY_PATH")
-                .unwrap_or_else(|_| tls_default::CLIENT_KEY.to_string()),
+            forge_root_ca_path: forge_tls_path(
+                "FORGE_ROOT_CAFILE_PATH",
+                tls_default::ROOT_CA,
+                "root CA",
+            ),
+            forge_client_cert_path: forge_tls_path(
+                "FORGE_CLIENT_CERT_PATH",
+                tls_default::CLIENT_CERT,
+                "client certificate",
+            ),
+            forge_client_key_path: forge_tls_path(
+                "FORGE_CLIENT_KEY_PATH",
+                tls_default::CLIENT_KEY,
+                "client key",
+            ),
             ntpservers: vec![
                 Ipv4Addr::new(172, 20, 0, 24),
                 Ipv4Addr::new(172, 20, 0, 26),

--- a/crates/dsx-exchange-consumer/Cargo.toml
+++ b/crates/dsx-exchange-consumer/Cargo.toml
@@ -62,6 +62,7 @@ carbide-version = { path = "../version" }
 [dev-dependencies]
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/dsx-exchange-consumer/src/health_updater.rs
+++ b/crates/dsx-exchange-consumer/src/health_updater.rs
@@ -30,7 +30,9 @@ use crate::ConsumerMetrics;
 use crate::api_client::{HEALTH_REPORT_SOURCE, RackHealthReportSink};
 use crate::config::CacheConfig;
 use crate::messages::{FaultValue, LeakMetadata, LeakPointType, ValueMessage};
-use crate::metrics::{MessageAge, MessageDeduplicated, MessageProcessed};
+use crate::metrics::{
+    HealthReportPersistFailed, MessageAge, MessageDeduplicated, MessageProcessed,
+};
 use crate::mqtt_consumer::MqttMessage;
 
 /// Health status updater that processes MQTT messages and updates the API.
@@ -221,8 +223,14 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
             Ok(_) => {
                 emit(MessageProcessed);
             }
-            Err(_) => {
-                // API call failed - will retry on next message
+            Err(e) => {
+                // Surface the persist failure and count it. The value re-arrives
+                // on the next message, so processing still retries -- but the
+                // drop is now visible instead of silently discarded.
+                emit(HealthReportPersistFailed {
+                    rack_id: metadata.rack_id.clone(),
+                    error: e.to_string(),
+                });
             }
         }
     }

--- a/crates/dsx-exchange-consumer/src/metrics.rs
+++ b/crates/dsx-exchange-consumer/src/metrics.rs
@@ -169,6 +169,33 @@ pub struct MessageAge {
     pub age: std::time::Duration,
 }
 
+/// A rack health report could not be persisted to the Carbide API -- either a
+/// coolant-leak override insert or its clearing removal failed. The value
+/// re-arrives on the next message, so processing still retries, but a rising
+/// rate is safety-relevant: leak state is not reaching the API. Logs the
+/// failure and moves the counter from one `emit`.
+///
+/// Unlike the grandfathered counters above, this is a new metric, so it uses
+/// the standard checked name: the exporter appends the single `_total` that
+/// `/metrics` shows.
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_exchange_consumer_health_report_persist_failures_total",
+    component = "nico-dsx-exchange-consumer",
+    log = warn,
+    metric = counter,
+    message = "Failed to persist rack health report",
+    describe = "Number of rack health report persist failures against the Carbide API"
+)]
+pub struct HealthReportPersistFailed {
+    /// The rack whose health report could not be persisted.
+    #[context]
+    pub rack_id: String,
+    /// The API error that prevented the persist.
+    #[context]
+    pub error: String,
+}
+
 /// Consumer metrics that remain hand-rolled OpenTelemetry counters.
 ///
 /// Only `alerts_detected` stays here: its `point_type` label is a

--- a/crates/dsx-exchange-consumer/tests/metric_exposition.rs
+++ b/crates/dsx-exchange-consumer/tests/metric_exposition.rs
@@ -20,15 +20,18 @@
 //! registering and the OTel Prometheus exporter appends exactly one, so
 //! `/metrics` shows one suffix, not the historical doubled `_total_total`.
 //!
-//! One test in its own binary (its own process-global registry) keeps the
-//! `counter_delta` measurements deterministic: the crate's other unit tests
-//! emit these same events, but from a different test process.
+//! These tests live in their own binary (its own process-global registry) to
+//! keep the `counter_delta` measurements deterministic: the crate's other unit
+//! tests emit these same events -- the message counters here, and the
+//! health-report persist failure below -- but from a different test process, so
+//! they cannot advance a shared counter between a test's baseline and delta.
 
 use carbide_dsx_exchange_consumer::metrics::{
-    MessageDeduplicated, MessageDropped, MessageProcessed, MessageReceived,
+    HealthReportPersistFailed, MessageDeduplicated, MessageDropped, MessageProcessed,
+    MessageReceived,
 };
 use carbide_instrument::emit;
-use carbide_instrument::testing::{MetricsCapture, capture_logs};
+use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
 
 /// Emitting each event once moves exactly its counter, under the single
 /// `_total` name the OTel Prometheus exporter produces (the framework strips
@@ -80,4 +83,44 @@ fn message_events_expose_single_total_names_and_are_metric_only() {
     // TRACE are never doubled -- only the untouched call-site `tracing` lines
     // remain.
     assert!(logs.is_empty(), "events must be metric-only: {logs:?}");
+}
+
+/// A persist failure writes the WARN line carrying the rack id and error, and
+/// moves `carbide_dsx_exchange_consumer_health_report_persist_failures_total` once --
+/// the "log it AND count it" the safety-relevant drop needs. Isolated here
+/// because `health_updater`'s failure-path unit tests emit this same event
+/// without a `MetricsCapture`; from a shared process they could advance the
+/// zero-label counter between this test's baseline and delta.
+#[test]
+fn health_report_persist_failed_logs_warn_and_counts() {
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(HealthReportPersistFailed {
+            rack_id: "rack-42".to_string(),
+            error: "API call failed: deadline exceeded".to_string(),
+        });
+    });
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].level, tracing::Level::WARN);
+    assert_eq!(logs[0].message, "Failed to persist rack health report");
+    fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
+        log.fields
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+    }
+    assert_eq!(field(&logs[0], "rack_id"), Some("rack-42"));
+    assert_eq!(
+        field(&logs[0], "error"),
+        Some("API call failed: deadline exceeded")
+    );
+
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_dsx_exchange_consumer_health_report_persist_failures_total",
+            &[],
+        ),
+        1.0
+    );
 }

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -207,15 +207,23 @@ impl SyncLogFileWriter {
 
         tracing::info!(file_size_bytes = self.current_size, "rotating log file");
 
-        // flush and drop the current file handle before renaming
-        if let Some(mut file) = self.current_file.take() {
-            let _ = file.flush();
+        // Flush and drop the current handle before renaming. If the flush fails
+        // we would rename a file still missing its buffered bytes, so keep the
+        // writer and defer rotation to the next write instead of losing them.
+        if let Some(mut file) = self.current_file.take()
+            && let Err(e) = file.flush()
+        {
+            tracing::warn!(error = %e, "failed to flush log file; deferring rotation");
+            self.current_file = Some(file);
+            return Ok(());
         }
 
         let current_path = self.log_path();
 
         if self.max_backups == 0 {
-            let _ = fs::remove_file(&current_path);
+            if let Err(e) = fs::remove_file(&current_path) {
+                tracing::warn!(error = %e, path = %current_path.display(), "failed to remove current log file during rotation");
+            }
         } else {
             self.shift_backups(&current_path);
         }
@@ -229,19 +237,31 @@ impl SyncLogFileWriter {
         for i in (1..self.max_backups).rev() {
             let from = self.rotated_path(i);
             let to = self.rotated_path(i + 1);
-            if from.exists() {
-                let _ = fs::rename(&from, &to);
+            match fs::rename(&from, &to) {
+                Ok(()) => {}
+                // No backup at this index yet -- nothing to shift.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    tracing::warn!(error = %e, from = %from.display(), to = %to.display(), "failed to shift rotated log file");
+                }
             }
         }
 
         // current -> .1
         let backup = self.rotated_path(1);
-        let _ = fs::rename(current_path, &backup);
+        if let Err(e) = fs::rename(current_path, &backup) {
+            tracing::warn!(error = %e, from = %current_path.display(), to = %backup.display(), "failed to rotate current log file to backup");
+        }
 
         // prune the oldest backup beyond the limit
         let oldest = self.rotated_path(self.max_backups + 1);
-        if oldest.exists() {
-            let _ = fs::remove_file(&oldest);
+        match fs::remove_file(&oldest) {
+            Ok(()) => {}
+            // Nothing beyond the limit to prune.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(error = %e, path = %oldest.display(), "failed to prune oldest rotated log file");
+            }
         }
     }
 }

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -195,6 +195,13 @@ async fn create_and_register_dpudevices_and_dpunode(
             .and_then(|x| x.dmi_data.as_ref())
             .map(|x| x.product_serial.as_str())
             .unwrap_or_default();
+        if serial_number.is_empty() {
+            tracing::warn!(
+                dpu_machine_id = %dpu.id,
+                host_machine_id = %state.host_snapshot.id,
+                "DPU product serial is missing; registering DPU device with DPF using an empty serial"
+            );
+        }
         let device_info = carbide_dpf::DpuDeviceInfo {
             device_id: dpf_id(dpu)?,
             dpu_bmc_ip: bmc_ip(dpu)?,

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -2317,13 +2317,53 @@ impl PreingestionManagerStatic {
                 }
             };
 
+            /// Which capture setup failed, forcing the subprocess cleanup.
+            enum CaptureFailure {
+                Stdout,
+                Stderr,
+            }
+
+            impl std::fmt::Display for CaptureFailure {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    f.write_str(match self {
+                        CaptureFailure::Stdout => "STDOUT capture failure",
+                        CaptureFailure::Stderr => "STDERR capture failure",
+                    })
+                }
+            }
+
+            // Kill then reap `child`, warning -- but not failing -- if either
+            // step errors. `context` names which capture setup failed, rendered
+            // via its `Display`.
+            async fn kill_and_reap(
+                child: &mut tokio::process::Child,
+                address: &str,
+                context: CaptureFailure,
+            ) {
+                if let Err(e) = child.kill().await {
+                    tracing::warn!(
+                        %address,
+                        %context,
+                        error = %e,
+                        "Upgrade script cleanup: failed to kill subprocess"
+                    );
+                }
+                if let Err(e) = child.wait().await {
+                    tracing::warn!(
+                        %address,
+                        %context,
+                        error = %e,
+                        "Upgrade script cleanup: failed to reap subprocess"
+                    );
+                }
+            }
+
             let Some(stdout) = cmd.stdout.take() else {
                 tracing::error!(
                     bmc_ip_address = address.as_str(),
                     "Upgrade script stdout creation failed"
                 );
-                let _ = cmd.kill().await;
-                let _ = cmd.wait().await;
+                kill_and_reap(&mut cmd, &address, CaptureFailure::Stdout).await;
                 upgrade_script_state.completed(address, false);
                 return;
             };
@@ -2334,8 +2374,7 @@ impl PreingestionManagerStatic {
                     bmc_ip_address = address.as_str(),
                     "Upgrade script stderr creation failed"
                 );
-                let _ = cmd.kill().await;
-                let _ = cmd.wait().await;
+                kill_and_reap(&mut cmd, &address, CaptureFailure::Stderr).await;
                 upgrade_script_state.completed(address, false);
                 return;
             };
@@ -2353,7 +2392,13 @@ impl PreingestionManagerStatic {
             while let Some(line) = lines.next_line().await.unwrap_or(None) {
                 tracing::info!("Upgrade script {address} {line}");
             }
-            let _ = tokio::join!(thread);
+            if let Err(e) = thread.await {
+                tracing::warn!(
+                    %address,
+                    error = %e,
+                    "Upgrade script STDERR logging task did not complete cleanly"
+                );
+            }
 
             match cmd.wait().await {
                 Err(e) => {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -351,6 +351,23 @@ pub struct SiteExplorer {
     // rms_client: Option<Arc<dyn RmsApi>>,
 }
 
+/// Which transport a BMC reset was issued through, rendered as the `method` log
+/// field on [`SiteExplorer::record_bmc_reset_outcome`].
+#[derive(Debug, Clone, Copy)]
+enum BmcResetMethod {
+    Ipmitool,
+    Redfish,
+}
+
+impl std::fmt::Display for BmcResetMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            BmcResetMethod::Ipmitool => "ipmitool",
+            BmcResetMethod::Redfish => "redfish",
+        })
+    }
+}
+
 impl SiteExplorer {
     const ITERATION_WORK_KEY: &'static str = "SiteExplorer::run_single_iteration";
     const SITE_EXPLORER_HEALTH_REPORT_WRITE_BATCH_SIZE: usize = 500;
@@ -2615,6 +2632,27 @@ impl SiteExplorer {
         Ok(index)
     }
 
+    /// Record the outcome of a BMC-reset attempt: count only a reset that
+    /// actually happened (so `bmc_reset_count` tracks successes, not attempts)
+    /// and log the failure otherwise. Returns whether the reset succeeded.
+    fn record_bmc_reset_outcome(
+        outcome: SiteExplorerResult<()>,
+        via: BmcResetMethod,
+        address: IpAddr,
+        metrics: &mut SiteExplorationMetrics,
+    ) -> bool {
+        match outcome {
+            Ok(()) => {
+                metrics.bmc_reset_count += 1;
+                true
+            }
+            Err(err) => {
+                tracing::error!(%address, method = %via, error = %err, "Site Explorer failed to reset BMC");
+                false
+            }
+        }
+    }
+
     pub async fn handle_redfish_error(
         &self,
         endpoint: &Endpoint<'_>,
@@ -2800,36 +2838,23 @@ impl SiteExplorer {
         }
 
         if time_since_redfish_bmc_reset > reset_rate_limit
-            && self
-                .redfish_reset_bmc(endpoint)
-                .await
-                .map_err(|err| {
-                    tracing::error!(
-                        bmc_ip_address = %endpoint.address,
-                        error = %err,
-                        "Site Explorer failed to reset BMC through redfish"
-                    )
-                })
-                .is_ok()
+            && Self::record_bmc_reset_outcome(
+                self.redfish_reset_bmc(endpoint).await,
+                BmcResetMethod::Redfish,
+                endpoint.address,
+                metrics,
+            )
         {
-            metrics.bmc_reset_count += 1;
             return;
         }
 
-        if time_since_ipmitool_bmc_reset > reset_rate_limit
-            && self
-                .ipmitool_reset_bmc(endpoint)
-                .await
-                .map_err(|err| {
-                    tracing::error!(
-                        bmc_ip_address = %endpoint.address,
-                        error = %err,
-                        "Site Explorer failed to reset BMC through ipmitool"
-                    )
-                })
-                .is_ok()
-        {
-            metrics.bmc_reset_count += 1;
+        if time_since_ipmitool_bmc_reset > reset_rate_limit {
+            Self::record_bmc_reset_outcome(
+                self.ipmitool_reset_bmc(endpoint).await,
+                BmcResetMethod::Ipmitool,
+                endpoint.address,
+                metrics,
+            );
         }
     }
 
@@ -4156,6 +4181,113 @@ mod tests {
         let mac: MacAddress = "a0:88:c2:46:0c:68".parse().unwrap();
         assert_eq!(mac_to_u64(mac), 0x0000_a088_c246_0c68);
         assert_eq!(u64_to_mac(mac_to_u64(mac)), mac);
+    }
+
+    /// The BMC-reset counter tracks resets that happened: a successful reset
+    /// moves `bmc_reset_count`, a failed reset leaves it and logs the failure
+    /// instead. This pins that semantics -- the one the ipmitool path used to
+    /// get wrong, counting every attempt -- across both transports, and checks
+    /// the failure log carries the transport, address, and error.
+    #[test]
+    fn bmc_reset_counter_counts_successes_not_attempts() {
+        use carbide_instrument::testing::{CapturedLog, capture_logs};
+
+        /// One reset outcome to record. A success moves `bmc_reset_count` and
+        /// logs nothing; a failure leaves the counter and emits the ERROR line,
+        /// whose `error` field is `expect_error` (`None` on the success rows).
+        struct Case {
+            name: &'static str,
+            method: BmcResetMethod,
+            outcome: SiteExplorerResult<()>,
+            expect_succeeded: bool,
+            expect_count: usize,
+            expect_error: Option<&'static str>,
+        }
+
+        let addr: IpAddr = "127.0.0.1".parse().unwrap();
+
+        let cases = [
+            Case {
+                name: "ipmitool success counts, logs nothing",
+                method: BmcResetMethod::Ipmitool,
+                outcome: Ok(()),
+                expect_succeeded: true,
+                expect_count: 1,
+                expect_error: None,
+            },
+            Case {
+                name: "ipmitool failure logs, does not count",
+                method: BmcResetMethod::Ipmitool,
+                outcome: Err(SiteExplorerError::internal(
+                    "simulated ipmitool failure".to_string(),
+                )),
+                expect_succeeded: false,
+                expect_count: 0,
+                expect_error: Some("internal error: simulated ipmitool failure"),
+            },
+            Case {
+                name: "redfish success counts, logs nothing",
+                method: BmcResetMethod::Redfish,
+                outcome: Ok(()),
+                expect_succeeded: true,
+                expect_count: 1,
+                expect_error: None,
+            },
+            Case {
+                name: "redfish failure logs, does not count",
+                method: BmcResetMethod::Redfish,
+                outcome: Err(SiteExplorerError::internal(
+                    "simulated redfish failure".to_string(),
+                )),
+                expect_succeeded: false,
+                expect_count: 0,
+                expect_error: Some("internal error: simulated redfish failure"),
+            },
+        ];
+
+        fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
+            log.fields
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.as_str())
+        }
+
+        for case in cases {
+            let Case {
+                name,
+                method,
+                outcome,
+                expect_succeeded,
+                expect_count,
+                expect_error,
+            } = case;
+
+            // Fresh metrics per case so the counter reads as this outcome alone.
+            let mut metrics = SiteExplorationMetrics::new();
+            let mut succeeded = false;
+            let logs = capture_logs(|| {
+                succeeded =
+                    SiteExplorer::record_bmc_reset_outcome(outcome, method, addr, &mut metrics);
+            });
+
+            assert_eq!(succeeded, expect_succeeded, "{name}");
+            assert_eq!(metrics.bmc_reset_count, expect_count, "{name}");
+
+            match expect_error {
+                None => assert!(logs.is_empty(), "{name}: a success must not log: {logs:?}"),
+                Some(expect_error) => {
+                    assert_eq!(logs.len(), 1, "{name}");
+                    let log = &logs[0];
+                    let method = method.to_string();
+                    let address = addr.to_string();
+                    assert_eq!(log.level, tracing::Level::ERROR, "{name}");
+                    assert_eq!(log.message, "Site Explorer failed to reset BMC", "{name}");
+                    assert_eq!(field(log, "method"), Some(method.as_str()), "{name}");
+                    assert_eq!(field(log, "address"), Some(address.as_str()), "{name}");
+                    assert_eq!(field(log, "error"), Some(expect_error), "{name}");
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -673,7 +673,7 @@ impl SiteExplorerInstruments {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge("carbide_site_explorer_bmc_reset_count")
-                .with_description("Number of BMC resets initiated in the last SiteExplorer run")
+                .with_description("Number of successful BMC resets in the last SiteExplorer run")
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {
                         observer.observe(metrics.bmc_reset_count as u64, attrs);

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -147,7 +147,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>Number of expected machines by SKU ID and device type</td></tr>
 <tr><td>carbide_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>Number of Host+DPU pairs identified in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_bmc_password_rotations_total</td><td>counter</td><td>Number of BMC root password rotations onto the site-wide credential, by outcome</td></tr>
-<tr><td>carbide_site_explorer_bmc_reset_count</td><td>gauge</td><td>Number of BMC resets initiated in the last SiteExplorer run</td></tr>
+<tr><td>carbide_site_explorer_bmc_reset_count</td><td>gauge</td><td>Number of successful BMC resets in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_create_machines</td><td>gauge</td><td>Whether site-explorer machine creation is enabled (1) or disabled (0)</td></tr>
 <tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it took to perform create_machines inside site-explorer</td></tr>
 <tr><td>carbide_site_explorer_created_machines_count</td><td>gauge</td><td>Number of machine pairs created by Site Explorer after identification</td></tr>


### PR DESCRIPTION
A handful of fallible operations were silent in both pipelines -- no log, no metric -- so observability couldn't see them at all, including a rack health-report persist failure discarded with `Err(_) => { /* will retry */ }`. Every one now logs, and the one whose failure rate is worth watching also counts.

- `carbide_dsx_exchange_consumer_health_report_persist_failures_total` -- the dsx health-report persist failure now emits a single framework event that both warns and counts (rack id and error ride as log context). It's the one failure here worth a rate.
- The silently-dropped failures now warn: the read-only and error-unwinding `txn.rollback()` drops in the instance / power-shelf / expected-machine handlers; the DHCP TLS-material reads that fall back to a built-in default cert; the empty product serial fed into DPF; the preingestion subprocess kill/wait drops; and the health log-file flush, rotate, and prune drops. Each keeps its crate's logging convention, and the error-unwinding rollbacks log without clobbering the original error being returned.
- The site-explorer `bmc_reset_count` counted attempts, not successes: the ipmitool reset dropped its result with `.ok()` while the counter ticked regardless. A shared `record_bmc_reset_outcome` now increments only on success and logs the failure, and both the ipmitool and Redfish paths route through it -- so the counter finally means what its name says, with no rename.

The MQTT state-change send drop the issue pointed at turned out to be a test mock; the production send path already logs and meters every outcome, so nothing was left silent there.

> Note: this and #3465 both touch `dsx-exchange-consumer/tests/metric_exposition.rs`. Whichever merges second wants #3465's de-doubled message-events assertions plus this PR's `health_report_persist_failed` test -- I'll reconcile at rebase time.

This supports #3179