### PR TITLE
docs(api): separate host DPU policy from observed device mode

### DIFF
--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -875,8 +875,8 @@ impl SiteExplorerInstruments {
                 .u64_observable_gauge("carbide_site_explorer_dpu_migration_signals_count")
                 .with_description(
                     "Number of DPU NIC-mode migration signals by signal type -- mode-mismatch found, \
-                     set_nic_mode issued, reset requested, and zero-DPU registered for a NicMode \
-                     host.",
+                     set_nic_mode issued, reset requested, and zero-DPU registered for a host \
+                     whose DPU policy is nic.",
                 )
                 .with_callback(move |observer| {
                     metrics.if_available(|metrics, attrs| {

--- a/docs/development/new_hardware_support.md
+++ b/docs/development/new_hardware_support.md
@@ -218,7 +218,7 @@ target/debug/bmc-explorer-cli \
   <bmc-ip>
 ```
 
-`--boot-mac` is the MAC address of the interface from which the host is expected to boot. For the common managed-DPU configuration, use the host-facing `pf0` MAC of the primary DPU; for an integrated-NIC configuration, use the NIC selected as the primary boot interface. Use the same MAC for exploration, machine setup, setup status, and boot-order tests. Omit it only when the platform does not require a selected boot interface. See [Boot Interfaces and DPU Modes](../provisioning/boot-interfaces-and-dpu-modes.md) for how NICo selects and persists this value.
+`--boot-mac` is the MAC address of the interface from which the host is expected to boot. For the common managed-DPU configuration, use the host-facing `pf0` MAC of the primary DPU; for an integrated-NIC configuration, use the NIC selected as the primary boot interface. Use the same MAC for exploration, machine setup, setup status, and boot-order tests. Omit it only when the platform does not require a selected boot interface. See [Boot Interfaces and DPU Policies](../provisioning/boot-interfaces-and-dpu-modes.md) for how NICo selects and persists this value.
 
 `--bmc-port` is the (optional) port on which the BMC listens. HTTPS port 443 is the default; use `--bmc-port <port>` for a BMC listening elsewhere.
 
@@ -386,4 +386,3 @@ To add one:
 1. Wire the variant through `crates/bmc-mock/src/machine_info.rs`: DPU count and type, vendor and product identity, Redfish version, manager, system, chassis, discovery, firmware inventory, and OEM behavior should match the live BMC responses relevant to the test.
 
 1. Add focused tests for the behavior the hardware contribution changes, such as vendor detection, inventory, NIC-mode detection, or provisioning.
-

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -49,7 +49,19 @@ In current deployments, the DPU is a [NVIDIA BlueField-2 or BlueField-3](https:/
 
 ### BlueField
 
-The NVIDIA DPU family used by NICo for tenant isolation and site management. A BlueField card has its own ARM complex, BMC, NIC firmware, and OS image. NICo provisions and manages the BlueField side of each ManagedHost before making the Host available to tenants.
+The NVIDIA accelerator and SuperNIC product family used by NICo for networking, tenant isolation, and site management. DPU-capable BlueField products have an Arm complex, BMC, NIC firmware, and OS image that NICo can provision and manage. NIC-only SuperNIC products do not expose that switchable DPU execution environment to NICo.
+
+### Host DPU Policy
+
+The operator's desired treatment of DPU hardware on a host. `HostDpuPolicy` has three values: `Manage`, which at the site or resolved level lets NICo provision and attach the DPUs; `Nic`, which asks NICo to run physically present DPU hardware as plain NICs; and `Ignore`, which tells NICo not to configure or attach DPU hardware. For backward compatibility, a per-host `Manage` declaration inherits the site policy rather than overriding it. This policy is intent, not a hardware observation.
+
+### BlueField Operating Mode
+
+The optional operating mode reported by a DPU-capable BlueField product's own BMC. When available, `BlueFieldOperatingMode` is either `Dpu` or `Nic`. NICo compares this observed state with the host DPU policy when deciding whether a DPU-capable card needs reconfiguration. NIC-only SuperNIC products do not need to report a switchable DPU mode. Existing protobuf and Redfish boundaries retain the legacy `NicMode` name for compatibility; model code uses `BlueFieldOperatingMode` so observed state is not confused with desired policy.
+
+### Mellanox/BlueField Device Kind
+
+The factory product classification NICo derives from a card's part number, independently of its current operating mode. Model code calls this `MlxDeviceKind`; some historical variant and protobuf names contain `Mode`, but those names are retained only for compatibility and identify a SKU rather than observed state. A DPU-capable product can therefore remain the same device kind when reconfigured from DPU mode to NIC mode. NIC-only SuperNIC products are classified by product without implying that they can enter DPU mode; future CX8 and CX9 SuperNIC support follows this model.
 
 ## REST API Services and Binaries
 
@@ -148,7 +160,7 @@ A VPC virtualization type for tenant instances on zero-DPU hosts. A Flat VPC is 
 
 ### Zero-DPU Host
 
-A managed host that NICo operates without a NICo-managed DPU — either a host with no DPU hardware (`no_dpu`) or a host whose BlueField DPU is run as a plain NIC (`nic_mode`). NICo does not build an overlay for a zero-DPU host; its tenant instances attach directly to HostInband underlay segments and belong to Flat VPCs. DPU mode is set site-wide or per host in the API server configuration.
+A managed host that NICo operates without a NICo-managed DPU — either a host whose DPU policy is `ignore`, or a host whose BlueField DPU is run as a plain NIC through `nic`. NICo does not build an overlay for a zero-DPU host; its tenant instances attach directly to HostInband underlay segments and belong to Flat VPCs. DPU policy is set site-wide in the API server configuration or per host on its Expected Machine. `rack_management_enabled` does not itself make a host zero-DPU; rack-manager deployments must also resolve the applicable DPU policy to `nic`.
 
 ### HBN in NICo
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -114,7 +114,7 @@ navigation:
           path: provisioning/ingesting-hosts-rest-api.md
         - page: Site Setup API Parity
           path: provisioning/site-setup-api-parity.md
-        - page: Boot Interfaces and DPU Modes
+        - page: Boot Interfaces and DPU Policies
           path: provisioning/boot-interfaces-and-dpu-modes.md
         - page: Machine Validation
           path: provisioning/machine-validation.md

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-add.md
@@ -16,7 +16,7 @@ nico-admin-cli-expected-machine-add - Add expected machine
 \[**--host_nics**\] \[**--rack_id**\]
 \[**--default_pause_ingestion_and_poweron**\] \[**--dpf-enabled**\]
 \[**--extended**\] \[**--bmc-ip-address**\]
-\[**--bmc-retain-credentials**\] \[**--dpu-mode**\]
+\[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
 \[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
@@ -114,23 +114,23 @@ factory-default credentials in Vault as-is\
 
 - false
 
-**--dpu-mode** *\<DPU_MODE\>*  
-Per-host DPU operating mode. \`dpu-mode\` (default): DPUs are managed by
-NICo; \`nic-mode\`: DPU hardware present but treated as a plain NIC;
-\`no-dpu\`: no DPU hardware at all. Unset defers to the site-wide
-\`\[site_explorer\] dpu_mode\` setting (which itself falls back to
-\`dpu-mode\` when not set).\
+**--dpu-policy** *\<DPU_POLICY\>*\
+Per-host DPU policy. \`manage\` (default): inherit the site policy,
+which defaults to managing DPUs; \`nic\`: configure DPU hardware
+as plain NICs; \`ignore\`: do not configure or attach DPU hardware.
+Unset defers to the site-wide \`\[site_explorer\] dpu_policy\` setting.
+The previous \`use-as-nic\` value remains accepted as an alias. The legacy
+\`--dpu-mode\` flag also remains accepted: \`dpu-mode\` maps to \`manage\`,
+\`nic-mode\` to \`nic\`, and \`no-dpu\` to \`ignore\`.\
 
 \
 *Possible values:*
 
-- unspecified
+- manage
 
-- dpu-mode
+- nic
 
-- nic-mode
-
-- no-dpu
+- ignore
 
 **--disable-lockdown** *\<DISABLE_LOCKDOWN\>*  
 If true, do not lock down the server as part of lifecycle management
@@ -163,7 +163,7 @@ Print help (see a summary with -h)
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --meta-name MyMachine --label DATACENTER:XYZ --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --bmc-ip-address 192.0.2.20
-nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --dpu-mode nic-mode
+nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 --dpu-policy nic
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
+++ b/docs/manuals/nico-admin-cli/commands/expected-machine/expected-machine-patch.md
@@ -17,7 +17,7 @@ update, preserves unprovided fields).
 \[**--meta-description**\] \[**--label**\] \[**--sku-id**\]
 \[**--rack-id**\] \[**--default_pause_ingestion_and_poweron**\]
 \[**--dpf-enabled**\] \[**--bmc-ip-address**\] \[**--extended**\]
-\[**--bmc-retain-credentials**\] \[**--dpu-mode**\]
+\[**--bmc-retain-credentials**\] \[**--dpu-policy**\]
 \[**--disable-lockdown**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
@@ -120,22 +120,23 @@ factory-default credentials in Vault as-is\
 
 - false
 
-**--dpu-mode** *\<DPU_MODE\>*  
-Per-host DPU operating mode. \`dpu-mode\` (default): DPUs are managed by
-NICo; \`nic-mode\`: DPU hardware present but treated as a plain NIC;
-\`no-dpu\`: no DPU hardware at all. Unset preserves the existing
-per-host value.\
+**--dpu-policy** *\<DPU_POLICY\>*\
+Per-host DPU policy. \`manage\`: inherit the site policy, which defaults
+to managing DPUs; \`nic\`: configure DPU hardware as plain NICs;
+\`ignore\`: do not configure or attach DPU hardware. Unset preserves the
+existing per-host value. The previous \`use-as-nic\` value remains accepted
+as an alias. The legacy \`--dpu-mode\` flag also remains accepted:
+\`dpu-mode\` maps to \`manage\`, \`nic-mode\` to \`nic\`, and \`no-dpu\`
+to \`ignore\`.\
 
 \
 *Possible values:*
 
-- unspecified
+- manage
 
-- dpu-mode
+- nic
 
-- nic-mode
-
-- no-dpu
+- ignore
 
 **--disable-lockdown** *\<DISABLE_LOCKDOWN\>*  
 If true, do not lock down the server as part of lifecycle management
@@ -168,7 +169,7 @@ Print help (see a summary with -h)
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine patch --id 12345678-1234-5678-90ab-cdef01234567 --sku-id DGX-H100-640GB
 nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --bmc-username admin --bmc-password mynewpassword
-nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --dpu-mode no-dpu
+nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 --dpu-policy ignore
 ```
 
 ---

--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -70,7 +70,8 @@ abbreviated as `…/nico/...` thereafter.
 
 | Task | Role | Interface |
 |---|---|---|
-| Put hosts in NIC / no-DPU mode (site-wide `dpu_mode`, per-host `ExpectedMachine.dpu_mode`) | Operator | **TOML** — Day 0 / rare; API restart |
+| Set hosts to `nic` or `ignore` through the site-wide `dpu_policy` | Operator | **TOML** — Day 0 / rare; API restart |
+| Set one host's DPU policy with `--dpu-policy` | Operator | **`nico-admin-cli`** (`em add` / `em patch`) — updating the declaration needs no API restart; applying a changed policy to an already-ingested host requires [force-delete and re-ingestion](../../provisioning/boot-interfaces-and-dpu-modes.md#35-flipping-a-dpu-to-nic-mode) |
 | Declare `HostInband` underlay segments | Operator | **TOML** (`[networks.<name>]`, `type = "hostinband"`) — Day 0 |
 | Create an additional `HostInband` segment after initial setup | Operator | **Restart-applied TOML** (`[networks]`), or runtime **`nico-admin-cli`** (`network-segment create`) — see [Configuring HostInband Segments](#2-configuring-hostinband-network-segments) |
 | Inspect / delete a `HostInband` segment | Operator | **`nico-admin-cli`** (`network-segment show` / `delete`) |
@@ -99,34 +100,53 @@ are running without a NICo-managed DPU, the underlay segments those hosts sit on
 are declared as `HostInband` segments, and (optionally) instance types exist so
 tenants can request the right machines.
 
-### 1. Put hosts in NIC or no-DPU mode
+### 1. Set the host DPU policy
 
-Whether a host is a "zero-DPU" host is decided by its **DPU mode**, which has
-three values:
+Whether NICo treats a host as a "zero-DPU" host is decided by its **DPU policy**,
+which has three values:
 
-| `dpu_mode` value | Meaning |
+| `dpu_policy` value | Meaning |
 |---|---|
-| `dpu_mode` | *(default)* The DPU is managed by NICo: BFB/firmware upgrades, HBN deployment, DPU agent, and the tenant overlay all apply. |
-| `nic_mode` | A DPU is physically present but is operated as a plain NIC. NICo skips DPU provisioning and overlay management for the host. |
-| `no_dpu` | The host has no DPU hardware; its NIC sits directly on the underlay. |
+| `manage` | *(site/effective default)* The DPU is managed by NICo: BFB/firmware upgrades, HBN deployment, DPU agent, and the tenant overlay all apply. A per-host `manage` declaration inherits the site policy rather than overriding it. |
+| `nic` | A DPU is physically present but should be operated as a plain NIC. NICo skips DPU provisioning and overlay management for the host. |
+| `ignore` | NICo does not configure or attach DPU hardware. Use this for a host without DPUs or when installed DPUs should be intentionally ignored. |
 
-Both `nic_mode` and `no_dpu` make the host a **zero-DPU host** for the purposes
+Both `nic` and `ignore` make the host a **zero-DPU host** for the purposes
 of Flat VPCs: NICo does not manage an overlay for it, and its only valid tenant
 attachments are `HostInband` segments.
 
-Set the mode in either of two places, with the per-host value taking precedence:
+Set the policy in either of two places. Per-host `nic` and `ignore`
+override the site-wide setting; per-host `manage` or an omitted per-host value
+instead defers to the site-wide setting for backward compatibility:
 
 - **Site-wide**, in the API server configuration:
 
   ```toml
   [site_explorer]
-  dpu_mode = "nic_mode"   # or "no_dpu"; omit entirely for the default "dpu_mode"
+  dpu_policy = "nic"   # or "ignore"; omit entirely for the default "manage"
   ```
 
-- **Per host**, on the host's `ExpectedMachine` entry, via the `dpu_mode` field.
-  An explicit per-host `nic_mode` or `no_dpu` always wins over the site-wide
-  setting; a per-host default (or no entry) defers to the site-wide value, which
-  in turn defaults to managed `dpu_mode`.
+- **Per host**, on the host's `ExpectedMachine` entry, via the admin CLI's
+  `--dpu-policy` option or the `dpu_policy` key in admin JSON. Per-host
+  `nic` and `ignore` override the site-wide setting; for backward
+  compatibility, per-host `manage` or an omitted policy defers to the site-wide
+  value, which defaults to `manage`.
+
+Existing configuration and admin JSON input remain readable: the previous
+`dpu_policy` value `use_as_nic` remains accepted, as do the legacy `dpu_mode`
+key and values `dpu_mode`, `nic_mode`, and `no_dpu`, which map to `manage`,
+`nic`, and `ignore`, respectively. The admin CLI likewise accepts the previous
+`use-as-nic` value and `--dpu-mode dpu-mode|nic-mode|no-dpu`; use
+`--dpu-policy manage|nic|ignore` for new automation.
+
+The Forge RPC intentionally retains `ExpectedMachine.dpu_mode` (field 16,
+`DpuMode`) as its stable compatibility surface. Direct gRPC clients continue to
+send `DPU_MODE`, `NIC_MODE`, or `NO_DPU`; NICo translates those values at the
+RPC boundary to the internal `manage`, `nic`, and `ignore` policies.
+`HostDpuPolicy` and `dpu_policy` are model, configuration, admin-CLI, and admin
+JSON vocabulary rather than Forge protobuf symbols. Responses translate
+non-default policies back through `dpu_mode`; the default `manage` policy might
+leave that field unset.
 
 Two related Day-0 settings matter for zero-DPU sites:
 
@@ -135,10 +155,11 @@ Two related Day-0 settings matter for zero-DPU sites:
   regular `Admin` segment type for their admin-network attachment.
 - **`rack_management_enabled`** (top-level, default `false`). This is the
   standalone / air-gapped rack-manager mode for GB200/GB300/VR144 deployments.
-  It runs DPUs in NIC mode and disables DPU BFB/firmware upgrades, HBN
-  deployment, the DPU agent, and the tenant DPU overlay — i.e. it is one of the
-  ways a whole site ends up as zero-DPU hosts. Enable it only when running NICo
-  with Rack Manager for those platforms.
+  It is not a DPU-policy override: rack-manager deployments that run DPUs as
+  NICs must also set `[site_explorer] dpu_policy = "nic"` (or set that
+  policy per host). The resulting `nic` policy produces zero-DPU hosts;
+  the rack-management flag alone does not. Enable the flag only when running
+  NICo with Rack Manager for those platforms.
 
 Because a zero-DPU host has no DPU to DHCP and identify host NICs for it, the
 host's data-NIC **MAC addresses must be registered** on its `ExpectedMachine`
@@ -147,8 +168,10 @@ one NIC per host is marked the **primary** (boot) interface. NICo records each
 registered host NIC as an interface bound to a `HostInband` segment, which is
 what the tenant's instance later attaches to.
 
-These are TOML / expected-machine settings and therefore Day-0 (or rare,
-restart-applied) changes.
+Site-wide TOML changes are Day-0 (or rare, restart-applied) changes. Per-host
+Expected Machine declarations can be updated through the admin CLI without an
+API restart; applying a changed policy to an already-ingested host requires
+force-delete and re-ingestion.
 
 ### 2. Configuring HostInband network segments
 
@@ -241,7 +264,7 @@ or `nicocli` (its wrapper), which expose the full surface:
 For a zero-DPU site, create instance type(s) describing the zero-DPU machines'
 capabilities and associate those machines, so tenants can request instances of
 that type. The instance type itself does **not** carry a "no-DPU" flag — what
-makes a host zero-DPU is its `dpu_mode` (above). The instance type simply selects
+makes a host zero-DPU is its `dpu_policy` (above). The instance type simply selects
 which machines are allocatable; whether the selected host is zero-DPU then
 governs the network model at allocation time.
 
@@ -409,9 +432,10 @@ operator SDN integration can tie its switch-side configuration to the VPC.
 
 **Operator — site is Flat-ready:**
 
-1. Hosts resolve to a zero-DPU mode. Confirm the intended hosts report
-   `nic_mode` or `no_dpu` (per-host `ExpectedMachine.dpu_mode`, or the site-wide
-   `[site_explorer] dpu_mode`).
+1. Confirm each intended host's effective policy resolves to `nic` or
+   `ignore` after applying per-host and site-wide inheritance. Per-host
+   `nic` and `ignore` win; per-host `manage` or an omitted value inherits
+   `[site_explorer] dpu_policy`.
 2. `HostInband` segments exist. `nico-admin-cli network-segment show` lists the
    declared segments with the expected prefix, gateway, and a VLAN/VNI assigned.
 3. Each zero-DPU host's data-NIC MACs are registered, and the host shows

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -224,7 +224,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_create_machines_latency_milliseconds</td><td>histogram</td><td>The time it took to perform create_machines inside site-explorer</td></tr>
 <tr><td>carbide_site_explorer_created_machines_count</td><td>gauge</td><td>Number of machine pairs created by Site Explorer after identification</td></tr>
 <tr><td>carbide_site_explorer_created_power_shelves_count</td><td>gauge</td><td>Number of power shelves created by Site Explorer after identification</td></tr>
-<tr><td>carbide_site_explorer_dpu_migration_signals_count</td><td>gauge</td><td>Number of DPU NIC-mode migration signals by signal type -- mode-mismatch found, set_nic_mode issued, reset requested, and zero-DPU registered for a NicMode host.</td></tr>
+<tr><td>carbide_site_explorer_dpu_migration_signals_count</td><td>gauge</td><td>Number of DPU NIC-mode migration signals by signal type -- mode-mismatch found, set_nic_mode issued, reset requested, and zero-DPU registered for a host whose DPU policy is nic.</td></tr>
 <tr><td>carbide_site_explorer_enabled</td><td>gauge</td><td>Whether site-explorer is enabled (1) or paused (0)</td></tr>
 <tr><td>carbide_site_explorer_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one site explorer iteration</td></tr>
 <tr><td>carbide_site_explorer_last_run_status</td><td>gauge</td><td>The status of the latest Site Explorer run</td></tr>

--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -1,10 +1,10 @@
-# Boot Interfaces and DPU Modes
+# Boot Interfaces and DPU Policies
 
-This guide explains how NICo decides **which interface a host boots from**, how a host's **DPUs are managed**, and how operators configure both through the Expected Machines table. It is the deep companion to [Ingesting Hosts](ingesting-hosts.md): that page covers the end-to-end ingest flow and the basic `expected_machines.json`; this page covers the per-host and per-NIC knobs (`dpu_mode`, `host_nics`), **what the defaults do when you set nothing**, and how a boot device is chosen and applied behind the scenes.
+This guide explains how NICo decides **which interface a host boots from**, how a host's **DPUs are managed**, and how operators configure both through the Expected Machines table. It is the deep companion to [Ingesting Hosts](ingesting-hosts.md): that page covers the end-to-end ingest flow and the basic `expected_machines.json`; this page covers the per-host and per-NIC knobs (`dpu_policy`, `host_nics`), **what the defaults do when you set nothing**, and how a boot device is chosen and applied behind the scenes.
 
 For the DHCP and network-segment substrate these knobs sit on (how a relay's `giaddr` maps to a segment), see [IP and Network Configuration](ip-and-network-configuration.md).
 
-> **Who should read this.** Operators configuring hosts for ingestion, and anyone debugging "why did this host boot from *that* interface?" **Most hosts need no configuration here** — the defaults handle the common managed-DPU case. Reach for the knobs in [Section 2](#2-configuring-via-expected-machines-and-the-defaults) and [Section 3](#3-scenarios) only for NIC-mode, zero-DPU, or integrated-NIC hosts. [Sections 6](#6-behind-the-scenes-how-a-boot-device-is-chosen-and-set)–[7](#7-the-boot-interface-data-model) explain the machinery when you need to trace a problem.
+> **Who should read this.** Operators configuring hosts for ingestion, and anyone debugging "why did this host boot from *that* interface?" **Most hosts need no configuration here** — the defaults handle the common managed-DPU case. Reach for the knobs in [Section 2](#2-configuring-via-expected-machines-and-the-defaults) and [Section 3](#3-scenarios) only for `nic`, `ignore`, or integrated-NIC hosts. [Sections 6](#6-behind-the-scenes-how-a-boot-device-is-chosen-and-set)–[7](#7-the-boot-interface-data-model) explain the machinery when you need to trace a problem.
 
 ---
 
@@ -14,10 +14,16 @@ Historically, two separate decisions were conflated into "what kind of host is t
 
 | Axis | Question | Controlled by |
 |---|---|---|
-| **DPU management** | Does NICo manage this host's DPUs (upgrade them, run agents, serve the host's admin network over the DPU overlay)? | `dpu_mode` |
+| **DPU management** | Does NICo manage this host's DPUs (upgrade them, run agents, and attach them to the ManagedHost)? | `dpu_policy` |
 | **Boot interface** | Which NIC does the host OS actually boot from and run its management network on? | the host's **primary** interface |
 
 A "normal" host couples them (managed DPU + boot through that DPU). But they are independent: you can keep a host's DPUs **managed** and still boot it from a plain **integrated NIC**. This guide treats the two axes separately, because the configuration knobs are separate.
+
+The policy is also separate from the card's current hardware state. NICo models
+operator intent as `HostDpuPolicy::{Manage, Nic, Ignore}` and the mode
+reported by a BlueField as `BlueFieldOperatingMode::{Dpu, Nic}`. Existing
+protobuf and Redfish boundaries retain the legacy `NicMode` name for
+compatibility, but model code does not use that name for observed state.
 
 ### Network segment types
 
@@ -44,23 +50,41 @@ Boot and DPU configuration is **declarative**: you describe the host in the Expe
 
 ### If you set nothing (the default)
 
-**Most hosts need zero boot/DPU configuration.** With no `dpu_mode` and no `host_nics`:
+**Most hosts with DPU hardware need zero boot/DPU configuration.** Outside rack-manager deployments, when neither the host nor the site sets `dpu_policy`, and the host has no `host_nics` declaration:
 
-- `dpu_mode` defaults to **`dpu_mode`** (managed) — NICo ingests and manages the host's DPUs, and the host boots through its primary DPU on the **Admin** network.
+- The effective `dpu_policy` resolves to **`manage`** — NICo ingests and manages the host's DPUs, and the host boots through its primary DPU on the **Admin** network.
 - Site-explorer **auto-selects the boot interface**: the lowest-PCI DPU host-PF (the NIC a DPU presents to the host).
 - The host's IP comes from whichever segment its DHCP relay lands in (see [IP and Network Configuration](ip-and-network-configuration.md)).
 
-So a standard DPU host is handled entirely by defaults. The knobs below exist for the hosts that *don't* fit that mold.
+So a standard DPU host is handled entirely by defaults. A host without DPU hardware must instead use `dpu_policy: ignore` and declare a primary HostInband NIC as described in [3.2](#32-zero-dpu-host-no-dpu-hardware). The knobs below exist for the hosts that *don't* fit the standard-DPU mold.
 
-### `dpu_mode`
+`rack_management_enabled` is a separate deployment-mode setting, not another
+DPU policy, and it does not override this resolution. Rack-manager deployments
+that operate DPUs as NICs must also set the site-wide `dpu_policy` (or each
+host's policy) to `nic`. If rack management is enabled while both policy
+levels remain unset, the effective policy is still `manage` and the Admin-network
+default above still applies.
 
-| Value (JSON / CLI) | Meaning |
-|---|---|
-| `dpu_mode` / `dpu-mode` (default) | DPUs are managed by NICo; the host boots through its primary DPU on the Admin overlay. |
-| `nic_mode` / `nic-mode` | DPU hardware is present but treated as a **plain NIC**. Site-explorer explores it but does **not** link or manage it; the host boots on **HostInband**. |
-| `no_dpu` / `no-dpu` | No DPU hardware at all — a plain host NIC on **HostInband**. DPU exploration is skipped entirely. |
+### `dpu_policy`
 
-**Resolution order:** a per-host `dpu_mode` on the Expected Machine wins; if unset, the site-wide `[site_explorer] dpu_mode` setting applies; if that too is unset, the default is `dpu_mode`.
+| JSON/TOML value | CLI value | Meaning |
+|---|---|---|
+| `manage` (site/effective default) | `manage` | DPU hardware is expected and managed by NICo. With no declared primary host NIC, the default boot interface is the primary DPU host-PF on the Admin overlay; a declared integrated primary can instead boot on HostInband. A host without DPU hardware must use `ignore` and declare a primary HostInband NIC. A per-host `manage` declaration inherits the site policy rather than overriding it. |
+| `nic` | `nic` | DPU hardware is present but should operate as a **plain NIC**. Site-explorer explores it but does **not** link or manage it; the host boots on **HostInband**. |
+| `ignore` | `ignore` | NICo does not configure or attach DPU hardware. Use this for a host without DPUs or when installed DPUs should be intentionally ignored; the host boots through a plain NIC on **HostInband**. |
+
+**Resolution order:** per-host `nic` and `ignore` policies override the site. For backward compatibility, per-host `manage` (like an omitted per-host policy) defers to the site-wide `[site_explorer] dpu_policy`; if the site policy is also unset, the result is `manage`.
+
+Compatibility declarations remain accepted when deserializing configuration and admin JSON input: the previous `dpu_policy` value `use_as_nic` remains accepted, and the legacy `dpu_mode` key with values `dpu_mode`, `nic_mode`, and `no_dpu` maps to `manage`, `nic`, and `ignore`, respectively. The admin CLI likewise accepts the previous `use-as-nic` value and legacy `--dpu-mode dpu-mode|nic-mode|no-dpu` forms, but new automation should use `--dpu-policy manage|nic|ignore`.
+
+The Forge RPC intentionally retains `ExpectedMachine.dpu_mode` (field 16,
+`DpuMode`) as its stable compatibility surface. Direct gRPC clients continue to
+send `DPU_MODE`, `NIC_MODE`, or `NO_DPU`; NICo translates those values at the
+RPC boundary to the internal `manage`, `nic`, and `ignore` policies.
+`HostDpuPolicy` and `dpu_policy` are model, configuration, admin-CLI, and admin
+JSON vocabulary rather than Forge protobuf symbols. Responses translate
+non-default policies back through `dpu_mode`; the default `manage` policy might
+leave that field unset.
 
 ### `host_nics` (per-NIC declaration)
 
@@ -76,7 +100,7 @@ The optional `host_nics` array declares specifics for individual host NICs. Each
 
 > **What `network_segment_type` actually does.** A NIC's segment is normally determined by its DHCP relay: NICo picks the segment whose prefix *contains* the relay address. Where segment prefixes **nest or overlap** — for example a `/27` HostInband segment inside a `/24` underlay — one relay matches several segments. `network_segment_type` narrows that to the segment of the named type. If a relay maps unambiguously to one segment (the common case), this field is unnecessary.
 
-**JSON** (an Expected Machine entry):
+**Admin JSON** (an Expected Machine entry):
 
 ```json
 {
@@ -84,7 +108,7 @@ The optional `host_nics` array declares specifics for individual host NICs. Each
   "bmc_username": "root",
   "bmc_password": "default-password1",
   "chassis_serial_number": "SERIAL-1",
-  "dpu_mode": "dpu_mode",
+  "dpu_policy": "manage",
   "host_nics": [
     {
       "mac_address": "C4:5A:B1:C8:38:10",
@@ -102,7 +126,7 @@ nico-admin-cli -a <api-url> em add \
   --bmc-mac-address C4:5A:B1:C8:38:0D \
   --bmc-username root --bmc-password default-password1 \
   --chassis-serial-number SERIAL-1 \
-  --dpu-mode dpu-mode \
+  --dpu-policy manage \
   --host_nics '[{"mac_address":"C4:5A:B1:C8:38:10","primary":true,"network_segment_type":"host_inband"}]'
 ```
 
@@ -116,15 +140,15 @@ Concrete recipes for the cases beyond the default. All assume the rest of the Ex
 
 ### 3.1 Standard DPU host
 
-Nothing to configure. Managed DPUs, boot through the primary DPU on Admin. This is the default.
+With the site policy unset or set to `manage`, there is nothing to configure. DPUs are managed and the host boots through the primary DPU on Admin.
 
 ### 3.2 Zero-DPU host (no DPU hardware)
 
-A plain server with one or more host NICs and no DPU. Declare `no_dpu` and mark the boot NIC primary:
+A plain server with one or more host NICs and no DPU. Declare `ignore` and mark the boot NIC primary:
 
 ```json
 {
-  "dpu_mode": "no_dpu",
+  "dpu_policy": "ignore",
   "host_nics": [
     { "mac_address": "AA:BB:CC:00:00:10", "primary": true, "network_segment_type": "host_inband" }
   ]
@@ -135,11 +159,11 @@ The host boots from that NIC on HostInband and gets its IP from central NICo DHC
 
 ### 3.3 DPU in NIC mode
 
-The host has DPU hardware, but you want it treated as a plain NIC (not managed). Declare `nic_mode`. Site-explorer still explores the DPU (and will issue the mode flip — see [3.5](#35-flipping-a-dpu-to-nic-mode)) but does not link it as a managed machine; the host boots HostInband:
+The host has DPU hardware, but you want it treated as a plain NIC (not managed). Declare `nic`. Site-explorer still explores the DPU (and will issue the physical mode flip — see [3.5](#35-flipping-a-dpu-to-nic-mode)) but does not link it as a managed machine; the host boots HostInband:
 
 ```json
 {
-  "dpu_mode": "nic_mode",
+  "dpu_policy": "nic",
   "host_nics": [
     { "mac_address": "AA:BB:CC:00:00:20", "primary": true, "network_segment_type": "host_inband" }
   ]
@@ -148,11 +172,11 @@ The host has DPU hardware, but you want it treated as a plain NIC (not managed).
 
 ### 3.4 Boot an integrated NIC while keeping the DPUs managed
 
-This is the case where the two axes genuinely diverge: the host has cabled, explorable DPUs you **want managed** (for the data plane), but you want the host OS to boot from a **plain integrated NIC** rather than through a DPU. Declare `dpu_mode` (managed) *and* mark the integrated NIC primary on HostInband:
+This is the case where the two axes genuinely diverge: the host has cabled, explorable DPUs you **want managed** (for the data plane), but you want the host OS to boot from a **plain integrated NIC** rather than through a DPU. First ensure the site-wide policy is unset or `manage`; a per-host `manage` declaration inherits the site and cannot override `nic` or `ignore`. Then leave the host policy unset (or explicitly set `manage`) and mark the integrated NIC primary on HostInband:
 
 ```json
 {
-  "dpu_mode": "dpu_mode",
+  "dpu_policy": "manage",
   "host_nics": [
     { "mac_address": "AA:BB:CC:00:00:30", "primary": true, "network_segment_type": "host_inband" }
   ]
@@ -161,14 +185,14 @@ This is the case where the two axes genuinely diverge: the host has cabled, expl
 
 NICo keeps the DPUs explored, linked, and underlay-addressed (running agents for the data plane), but the host boots from the integrated NIC. The DPU-backed admin links are kept but go **dormant** — the host's admin/boot path is the HostInband NIC.
 
-> Previously this required faking `no_dpu`/`nic_mode`, which threw away DPU management to get integrated boot. The two are now decoupled.
+> Previously this required selecting an unmanaged-DPU policy, which threw away DPU management to get integrated boot. The two are now decoupled.
 
 ### 3.5 Flipping a DPU to NIC mode
 
-To change a host that's already ingested (e.g. from managed-DPU to NIC mode), update its Expected Machine `dpu_mode`, then force-delete and let it re-ingest so site-explorer re-explores and applies the new mode:
+To change a host that's already ingested (e.g. from managed-DPU to NIC mode), update its Expected Machine policy with `--dpu-policy`, then force-delete and let it re-ingest so site-explorer re-explores and applies the new physical mode:
 
 ```bash
-nico-admin-cli -a <api-url> em patch --bmc-mac-address <bmc-mac> --dpu-mode nic-mode
+nico-admin-cli -a <api-url> em patch --bmc-mac-address <bmc-mac> --dpu-policy nic
 nico-admin-cli -a <api-url> machine force-delete --machine <machine-id> --delete-interfaces
 ```
 
@@ -184,10 +208,10 @@ All of these are **admin-only**; the Forge gRPC service enforces admin authoriza
 
 | admin-cli | Forge RPC | Purpose |
 |---|---|---|
-| `em add …` | `AddExpectedMachine` | Add one host (BMC creds, `--dpu-mode`, `--host_nics`, metadata). |
+| `em add …` | `AddExpectedMachine` | Add one host (BMC creds, `--dpu-policy`, `--host_nics`, metadata). |
 | `em show [--bmc-mac-address <mac>]` | `GetAllExpectedMachines` / `GetExpectedMachine` | List all, or show one. Add `-f json` to export. |
 | `em update --filename <json>` | `UpdateExpectedMachine` | Full replacement of one entry from JSON. |
-| `em patch --bmc-mac-address <mac> …` | `UpdateExpectedMachine` | Partial update (e.g. `--dpu-mode`), preserving other fields. |
+| `em patch --bmc-mac-address <mac> …` | `UpdateExpectedMachine` | Partial update (e.g. `--dpu-policy`), preserving other fields. |
 | `em delete --bmc-mac-address <mac>` | `DeleteExpectedMachine` | Remove one entry. |
 | `em replace-all --filename <json>` | (bulk) | Replace the entire table from a file. |
 | `em erase` | (bulk) | Erase the entire table. |
@@ -219,7 +243,7 @@ All of these are **admin-only**; the Forge gRPC service enforces admin authoriza
 
 ## 5. Web UI
 
-The NICo admin web UI (`/admin/…`) is primarily for **visibility**, with a focused set of boot/ingestion actions. **There is no DPU-mode-switching control in the UI** — change `dpu_mode` via Expected Machines (CLI/JSON) as in [Section 2](#2-configuring-via-expected-machines-and-the-defaults).
+The NICo admin web UI (`/admin/…`) is primarily for **visibility**, with a focused set of boot/ingestion actions. **There is no DPU-policy control in the UI** — change `dpu_policy` via Expected Machines (CLI/JSON) as in [Section 2](#2-configuring-via-expected-machines-and-the-defaults).
 
 **View:**
 
@@ -266,8 +290,8 @@ At each boot-config step the controller resolves the target via `load_boot_predi
 1. The host's **own owned interface row** (`machine_interfaces`), if it has a boot interface — used once the host has taken its first DHCP lease.
 2. Otherwise, the **boot prediction** (`pick_boot_prediction`) — used *before* the first lease.
 3. Otherwise, a classification:
-   - **AwaitingNic** — a zero-DPU/NIC-mode host whose boot NIC hasn't appeared yet; wait.
-   - **Missing** — a host that *should* have a boot interface (it has DPUs) but doesn't; a fault to investigate.
+   - **AwaitingNic** — a zero-DPU host using `ignore` or `nic` whose boot NIC hasn't appeared yet; wait.
+   - **Missing** — a host with managed DPUs has neither an owned primary interface nor a usable prediction; a fault to investigate. This includes a managed-DPU host declared to boot from an integrated HostInband NIC if that declaration did not produce a prediction.
 
 > **Key timing.** A host has no `machine_interfaces` row until its first DHCP lease. Predictions are what let the controller configure boot **before** that lease. Once the host leases and the prediction is promoted to an owned row, the **owned row supersedes** the prediction.
 
@@ -275,7 +299,7 @@ At each boot-config step the controller resolves the target via `load_boot_predi
 
 - `configure_host_bios` (at `WaitingForPlatformConfiguration`) calls Redfish `machine_setup` with the resolved boot interface; on Dell this schedules a BIOS job (`WaitingForBiosJob`).
 - `PollingBiosSetup` verifies the BIOS settings took.
-- `SetBootOrder` sets the host boot order via Redfish — **DPU-first** for DPU hosts; for zero-DPU/NIC-mode hosts it targets the resolved HostInband interface (a "no DPU" response from the BMC is expected and treated as success).
+- `SetBootOrder` targets the resolved primary interface via Redfish. In the default managed-DPU topology that is the primary DPU host-PF; for a declared integrated primary or a host using `ignore` or `nic`, it is the resolved HostInband interface. A "no DPU" response from the BMC is expected and treated as success only for a host with no managed DPUs.
 - On a reprovision repair, `check_host_boot_config` re-checks BIOS + boot order and only remediates if they drifted.
 
 ---
@@ -339,7 +363,8 @@ To inspect the boot interface itself — every store (managed, predicted, explor
 | Symptom | Likely cause / action |
 |---|---|
 | `boot_interface_mac_mismatch` (pairing blocker) | The host's boot MAC doesn't match any discovered DPU's pf0 MAC. Expected for an integrated-NIC host — declare the integrated NIC `primary` (see [3.4](#34-boot-an-integrated-nic-while-keeping-the-dpus-managed)); otherwise check the exploration reports. See [Ingesting Hosts → pairing blockers](ingesting-hosts.md#common-blockers-during-host--dpu-pairing). |
-| Host stuck waiting for a boot NIC | A zero-DPU/NIC-mode host whose boot NIC hasn't leased yet (`AwaitingNic`). Confirm the NIC is cabled and DHCP-reachable on its HostInband segment. |
+| Host stuck waiting for a boot NIC | A host using `ignore` or `nic` whose boot NIC hasn't leased yet (`AwaitingNic`). Confirm the NIC is cabled and DHCP-reachable on its HostInband segment. |
+| `Missing boot interface` for a managed-DPU host | The host has neither an owned primary interface nor a usable prediction. For an integrated-NIC boot, confirm `host_nics` declares exactly one `primary` NIC and that site-explorer created its HostInband prediction; otherwise investigate DPU pairing and promotion. |
 | Boot interface wrong after a DPU↔NIC-mode flip | Use **Restore Boot Interface** in the web UI, or re-ingest ([3.5](#35-flipping-a-dpu-to-nic-mode)). |
 | Boot interface disabled or no longer the boot device after a DPU replacement (notably on Dell) | The replacement DPU came up in InfiniBand (VPI) link type. NICo self-heals this: DPU cloud-init normalizes the ports to Ethernet and reboots before management-network setup runs, and DPU reprovision then repairs the host BIOS/boot-order configuration automatically — no manual action is needed. If it persists, confirm the DPU ran the normalization (`/var/log/forge/link-type.log` on the DPU) and re-ingest. |
 | DPU mode "unknown" (`dpu_nic_mode_unknown`) | DPU BMC firmware too old to report mode. Install a fresh DPU OS — see [Ingesting Hosts](ingesting-hosts.md#dpu-related-issues-installing-a-fresh-dpu-os). |

--- a/docs/provisioning/ingesting-hosts.md
+++ b/docs/provisioning/ingesting-hosts.md
@@ -212,6 +212,41 @@ Only registered Expected Machines will be ingested.
 
 For optional REST fields and batch JSON examples, use [Ingesting Hosts (REST API)](ingesting-hosts-rest-api.md#registering-expected-machines).
 
+### Per-Host Fields With the Admin CLI
+
+Some per-host settings are not exposed through the REST API or `nicocli`. To set them, use the admin CLI's `expected-machine` command (`em`), which reads a snake_case `expected_machines.json` file and applies the whole table at once:
+
+- **`dpu_policy`** (`"manage"` | `"nic"` | `"ignore"`): Per-host policy for managing DPU hardware. `nic` and `ignore` override the site policy; `manage` or an omitted field inherits the site-wide policy, which defaults to `manage`. The previous `"use_as_nic"` value is still accepted, as are manifests using the `dpu_mode` key with `"dpu_mode"`, `"nic_mode"`, or `"no_dpu"` values.
+- **`dpf_enabled`** (bool): Enable or disable DPF for this host.
+- **`bmc_retain_credentials`** (bool): Skip BMC password rotation.
+- **`default_pause_ingestion_and_poweron`** (bool): Pause ingestion and power-on for this host.
+- **`bmc_ip_address`** (string): Static BMC IP, which pre-allocates a machine interface.
+- **`host_lifecycle_profile.disable_lockdown`** (bool, default `false`): When `true`, the state machine does not lock down the host during lifecycle management, which suits automation workflows that keep lockdown disabled.
+
+Each manifest entry combines the required BMC credentials with any of these fields:
+
+```json
+{
+  "expected_machines": [
+    {
+      "bmc_mac_address": "C4:5A:B1:C8:38:0D",
+      "bmc_username": "root",
+      "bmc_password": "default-password1",
+      "chassis_serial_number": "SERIAL-1",
+      "dpu_policy": "nic"
+    }
+  ]
+}
+```
+
+Apply the manifest with the admin CLI:
+
+```bash
+nico-admin-cli -a <api-url> em replace-all --filename expected_machines.json
+```
+
+Because `em replace-all` sets the entire table, include every host in the file. To change one entry in place, use `nico-admin-cli em patch` (for example, `nico-admin-cli em patch --bmc-mac-address <bmc-mac> --dpu-policy nic`).
+
 ## Approve all Machines for Ingestion
 
 NICo uses Measured Boot using the on-host Trusted Platform Module (TPM) v2.0 to enforce cryptographic identity of the host hardware and firmware. The following command configures NICo to approve all pending machines based on PCR Registers 0, 3, 5, and 6:


### PR DESCRIPTION
The provisioning, ingestion, Flat VPC, glossary, metrics, and admin CLI docs now use `HostDpuPolicy::{Manage, Nic, Ignore}` for desired behavior and `BlueFieldOperatingMode::{Dpu, Nic}` for observed hardware state.

Canonical configuration and JSON use `dpu_policy = "nic"`; canonical CLI examples use `--dpu-policy nic`. The previous `use_as_nic` / `use-as-nic` values remain documented as accepted aliases.

The Forge compatibility contract is explicit: direct gRPC clients continue to use `ExpectedMachine.dpu_mode` field 16 and the original `DpuMode` values, which NICo translates into the internal policy vocabulary at the RPC boundary. Legacy configuration, admin JSON, and CLI inputs remain documented alongside the canonical vocabulary.

This is the separately reviewed documentation companion to #3453 and **must merge after #3453**. Until the code PR lands, this docs branch intentionally documents config, CLI, and model names introduced there.

Validation:

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `git diff --check`
- Pandoc parsing of every changed Markdown file
- link, anchor, generated CLI reference, and compatibility-vocabulary review

This supports https://github.com/NVIDIA/infra-controller/issues/3472

Closes #3472
