### PR TITLE
bug: dpf: Fix reading BMC firmware version for BF4.

### DIFF
--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -632,6 +632,15 @@ pub struct FwFilter {
     only_uefi: bool,
 }
 
+/// True if a firmware-inventory id refers to the BMC firmware. BF3 exposes it
+/// as `"BMC_Firmware"`; BF4 uses exactly `"BlueField_FW_BMC_0"`. Matching the
+/// full BF4 id (via `ends_with`, allowing an optional path prefix) excludes
+/// unrelated components — including `"..._FW_BMC_0_x"` / `"..._FW_BMC_01"` and
+/// any other id that merely ends in `"FW_BMC_0"`.
+fn is_bmc_firmware_id(id: &str) -> bool {
+    id.contains("BMC_Firmware") || id.ends_with("BlueField_FW_BMC_0")
+}
+
 async fn show_all_fws(redfish: Box<dyn Redfish>, f: FwFilter) -> Result<(), RedfishError> {
     let fws: Vec<String> = redfish.get_software_inventories().await?;
     let mut fws_info: Vec<SoftwareInventory> = Vec::new();
@@ -645,11 +654,11 @@ async fn show_all_fws(redfish: Box<dyn Redfish>, f: FwFilter) -> Result<(), Redf
     }
 
     if f.only_bmc {
-        if !fws.contains(&"BMC_Firmware".to_string()) {
+        if !fws.iter().any(|id| is_bmc_firmware_id(id)) {
             println!("BMC FW is not found");
             return Err(RedfishError::NoContent);
         }
-        fws_info.retain(|f| f.id.contains("BMC_Firmware"));
+        fws_info.retain(|f| is_bmc_firmware_id(&f.id));
     }
 
     if f.only_dpu_os {
@@ -976,4 +985,23 @@ fn convert_chassis_to_nice_table(chassis_vec: Vec<Chassis>) -> Box<Table> {
         ]);
     }
     table.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_bmc_firmware_id;
+
+    #[test]
+    fn is_bmc_firmware_id_matches_bf3_and_bf4_only() {
+        // BF3 id and BF4 id are recognized.
+        assert!(is_bmc_firmware_id("BMC_Firmware"));
+        assert!(is_bmc_firmware_id("BlueField_FW_BMC_0"));
+
+        // Not the BMC firmware: unrelated components, slot/backup variants, or
+        // any id that merely ends in "FW_BMC_0".
+        assert!(!is_bmc_firmware_id("DPU_OS"));
+        assert!(!is_bmc_firmware_id("BlueField_FW_BMC_0_ERoT"));
+        assert!(!is_bmc_firmware_id("BlueField_FW_BMC_01"));
+        assert!(!is_bmc_firmware_id("Something_FW_BMC_0"));
+    }
 }

--- a/crates/api-model/src/bmc_info.rs
+++ b/crates/api-model/src/bmc_info.rs
@@ -40,8 +40,13 @@ pub struct BmcInfo {
 impl BmcInfo {
     pub fn supports_bfb_install(&self) -> bool {
         self.firmware_version.as_ref().is_some_and(|v| {
-            version_compare::compare_to(v.to_lowercase().replace("bf-", ""), "24.10", Cmp::Ge)
-                .is_ok_and(|r| r)
+            // `firmware_version` is normalized to a numeric version by
+            // `dpu_bmc_version` (the generation prefix "bf-"/"bf4-" is stripped);
+            // strip here too in case it arrives raw from another source. BFB
+            // install requires firmware >= 24.10; BF4 firmware is year-based
+            // (>= 26.x) so it always clears this gate.
+            let version = v.to_lowercase().replace("bf4-", "").replace("bf-", "");
+            version_compare::compare_to(version, "24.10", Cmp::Ge).is_ok_and(|r| r)
         })
     }
 }
@@ -98,5 +103,42 @@ impl FromStr for UserRoles {
                 "Unknown role found in database: {x}"
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bmc_with_firmware(version: Option<&str>) -> BmcInfo {
+        BmcInfo {
+            firmware_version: version.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn supports_bfb_install_bf4() {
+        // BF4 firmware is year-based (>= 26.x) and clears the 24.10 gate.
+        // In the real flow `dpu_bmc_version` strips the "bf4-" prefix, so the
+        // stored version is numeric; a raw "BF4-…" string works too.
+        assert!(bmc_with_firmware(Some("26.04-8")).supports_bfb_install());
+        assert!(bmc_with_firmware(Some("BF4-26.04-8")).supports_bfb_install());
+    }
+
+    #[test]
+    fn supports_bfb_install_bf3_gated_on_version() {
+        // BF3 firmware "BF-<ver>" is supported at/after 24.10.
+        assert!(bmc_with_firmware(Some("BF-25.10-9")).supports_bfb_install());
+        assert!(bmc_with_firmware(Some("BF-24.10-0")).supports_bfb_install());
+        // Already-stripped numeric form (as dpu_bmc_version returns) also works.
+        assert!(bmc_with_firmware(Some("25.10-9")).supports_bfb_install());
+        // Older BF3 firmware is not supported.
+        assert!(!bmc_with_firmware(Some("BF-24.04-1")).supports_bfb_install());
+    }
+
+    #[test]
+    fn supports_bfb_install_absent_firmware_is_false() {
+        assert!(!bmc_with_firmware(None).supports_bfb_install());
     }
 }

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1100,11 +1100,18 @@ impl EndpointExplorationReport {
         Some(
             self.get_inventory_map()
                 .iter()
-                .find(|s| s.0.contains("BMC_Firmware"))
+                // BF3 exposes BMC firmware as inventory id "BMC_Firmware"; BF4
+                // uses exactly "BlueField_FW_BMC_0". Matching the full BF4 id
+                // (via `ends_with`) excludes unrelated components — including
+                // "FW_BMC_0_x" / "FW_BMC_01" and any other id merely ending in
+                // "FW_BMC_0". Both ids are unique per report, so `find` selects
+                // the single BMC firmware entry unambiguously.
+                .find(|s| s.0.contains("BMC_Firmware") || s.0.ends_with("BlueField_FW_BMC_0"))
                 .and_then(|value| value.1.version.as_ref())
                 .unwrap_or(&"0".to_string())
                 .to_lowercase()
-                .replace("bf-", ""),
+                .replace("bf-", "")
+                .replace("bf4-", ""),
         )
     }
 


### PR DESCRIPTION
Fix reading BMC firmware version.
In case of BF4, the BMC version starts with `bf4-` and the endpoint is different than BF3, ends with `FW_BMC_0`

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

