### PR TITLE
refactor: make tracing logs consistently structured and searchable

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -162,26 +162,79 @@ count, like per-machine or per-instance attributes.
 All services should emit logs in "logfmt" syntax. This structured logging format allows administrators to efficiently
 search logs by certain attributes (key/value pairs).
 
-When writing log messages, prefer placing common fields as attributes passed to tracing function, instead of using
-string interpolation. For example:
+Tracing events must use a stable, human-readable string literal for the message and record dynamic operational values
+as structured fields whenever a meaningful field name can be derived. Do not interpolate such values into the message,
+including when the event already contains other structured fields.
+
+Describe the event in the message; do not narrate fields that already describe themselves. For example, prefer
+`info!(%domain_id, "Domain created")` over `info!(%domain_id, "Domain created with ID")`, and prefer
+`info!(%instance_id, %ip_address, "Instance is terminating")` over a message ending in `"at address"`. Keep wording
+that conveys a relationship, source, destination, or behavior that the field names alone do not express.
+
+Use native field shorthand for types that implement `tracing::Value`, `%field` for `Display`, and `?field` for `Debug`.
+Use consistent semantic field names rather than incidental local variable names; for example, record an error held in
+`e` as `error = %e`. Do not reuse formatter metadata keys such as `level`, `msg`, `location`, or `span_id`; choose a
+domain-specific key such as `configured_log_level` or `error_location` instead.
+
+Field names are part of the operational interface: dashboards, alerts, and ad hoc searches depend on them. The table
+below defines the common vocabulary. It is not an exhaustive schema -- event-specific fields should still describe
+their values precisely -- but do not introduce an alias for one of these concepts.
+
+| Concept | Field name | Notes |
+|---|---|---|
+| Rust error | `error` | Normalize incidental bindings such as `e` and `err` with `error = %e`. Supplemental forms such as `error_chain` may accompany, but not replace, `error`. |
+| gRPC status code | `grpc_status_code` | Keep the transport namespace explicit; do not shorten it to `code`. |
+| HTTP status | `http_status` | Use for the complete HTTP status or its numeric code; do not introduce `status_code` aliases. |
+| Domain explanation | `reason` | Use for an outcome or persisted explanation that is not a Rust error. Keep typed domain fields such as `failure_cause` when that is the model's actual name. |
+| IP address | `ip_address` | Add a semantic role when known, such as `bmc_ip_address`, `source_ip_address`, or `host_bmc_ip_address`; do not shorten it to `ip` or `addr`. |
+| MAC address | `mac_address` | Add a semantic role when known, such as `bmc_mac_address` or `interface_mac_address`; do not shorten it to `mac`. |
+| Socket or service address | role-specific `*_address` | Prefer names such as `listen_address`, `peer_address`, `metrics_address`, or `endpoint_address`; reserve `*_ip_address` for an IP without a port. |
+| Entity state | role-specific `*_state` | Prefer `machine_state` or `instance_state` over bare `state`. Use `previous_state`, `next_state`, and `target_state` for transitions. |
+| Cardinality | `<thing>_count` | Name what is counted; avoid bare `count`, `total`, or `num_*`. Put qualifiers before the noun, as in `pending_partition_count`. |
+| Quantity | `<thing>_<unit>` | Include the unit when it is not encoded by the type, such as `file_size_bytes`, `retry_delay_seconds`, or `elapsed_milliseconds`. |
+| Command | `command` | Do not introduce local abbreviations such as `cmd`. Use the same full-word rule for keys such as `interface_name` and `firmware_type`. |
+
+For a typed identifier, derive the default field name from the Rust type name in snake case. Common examples include
+`MachineId` -> `machine_id`, `MachineInterfaceId` -> `machine_interface_id`, `InstanceId` -> `instance_id`, `VpcId` ->
+`vpc_id`, `VpcPrefixId` -> `vpc_prefix_id`, `NetworkSegmentId` -> `network_segment_id`, `NetworkPrefixId` ->
+`network_prefix_id`, `DpaInterfaceId` -> `dpa_interface_id`, `ExtensionServiceId` -> `extension_service_id`,
+`SpxPartitionId` -> `spx_partition_id`, `IBPartitionId` -> `ib_partition_id`, and `NvLinkLogicalPartitionId` ->
+`nvlink_logical_partition_id`. Preserve established product tokenization in field names; for example, the `NvLink`
+product name remains the single token `nvlink` rather than `nv_link`.
+
+Use a role qualifier when it distinguishes multiple values of the same type or preserves important lifecycle context,
+as in `host_machine_id`, `dpu_machine_id`, `source_machine_id`, or `failed_machine_id`. Otherwise prefer the type-derived
+name. Avoid bare or abbreviated identifiers such as `id`, `segment_id`, `dpa_id`, and `service_id` when the concrete
+identifier type is known. For network segments specifically, use `network_segment`, `network_segment_id`, and
+`network_segment_name` for the value, identifier, and name respectively.
+
+For example:
 
 ```rust
-fn avoid(machine_id: MachineId) {
+fn avoid(machine_id: MachineId, attempt_number: u32) {
     if let Err(e) = process_machine(machine_id) {
-        tracing::error!("process_machine failed for {machine_id}: {e}");
+        tracing::error!(
+            "failed to process machine {machine_id} on attempt {attempt_number}: {e}"
+        );
     }
 }
-fn prefer(machine_id: MachineId) {
+fn prefer(machine_id: MachineId, attempt_number: u32) {
     if let Err(e) = process_machine(machine_id) {
-        tracing::error!(%machine_id, error=%e, "process_machine failed");
+        tracing::error!(
+            %machine_id,
+            attempt_number,
+            error = %e,
+            "failed to process machine",
+        );
     }
 }
-
 ```
 
-This helps in log parsing, especially when we want to find logs corresponding to a given machine_id. `error` and
-`machine_id` are probably the two most important examples, but try to express other relevant data as fields instead of
-using interpolation if it makes sense.
+Keep intentional presentation formatting intact when the rendered text is itself the payload, such as CLI output,
+aligned tables, or multi-line displays. Passthrough helpers and macros whose purpose is to forward caller-supplied text
+unchanged are also exempt from the literal-message requirement. Preserve special or custom formatting when converting
+it would change behavior; add structured fields alongside it when that can be done without changing the rendered
+output.
 
 ## Core API handlers
 

--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -432,7 +432,10 @@ pub async fn get_next_free_machine(
     flat_vpc_id: Option<VpcId>,
 ) -> Option<Machine> {
     while let Some(id) = machine_ids.pop_front() {
-        tracing::debug!("Checking {}", id);
+        tracing::debug!(
+            machine_id = %id,
+            "Checking machine",
+        );
         if let Ok(machine) = api_client.get_machine(id).await {
             if machine.state != "Ready" {
                 tracing::debug!("Machine is not ready");

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -186,7 +186,7 @@ impl ApiClient {
                 return Err(CarbideCliError::UuidNotFound);
             }
             Err(err) => {
-                tracing::error!(%err, "identify_uuid error calling grpc identify_uuid");
+                tracing::error!(error = %err, "identify_uuid error calling grpc identify_uuid");
                 return Err(CarbideCliError::GenericError(err.to_string()));
             }
         };
@@ -194,8 +194,9 @@ impl ApiClient {
             Ok(ot) => ot,
             Err(e) => {
                 tracing::error!(
-                    "Invalid UuidType from carbide api: {}",
-                    uuid_details.object_type
+                    object_type = uuid_details.object_type,
+                    error = %e,
+                    "Invalid UUID type from Carbide API",
                 );
                 return Err(CarbideCliError::GenericError(e.to_string()));
             }
@@ -218,7 +219,7 @@ impl ApiClient {
                 return Err(CarbideCliError::MacAddressNotFound);
             }
             Err(err) => {
-                tracing::error!(%err, "identify_mac error calling grpc identify_mac");
+                tracing::error!(error = %err, "identify_mac error calling grpc identify_mac");
                 return Err(CarbideCliError::GenericError(err.to_string()));
             }
         };
@@ -226,8 +227,9 @@ impl ApiClient {
             Ok(ot) => ot,
             Err(e) => {
                 tracing::error!(
-                    "Invalid MachineOwner from carbide api: {}",
-                    mac_details.object_type
+                    object_type = mac_details.object_type,
+                    error = %e,
+                    "Invalid machine owner from Carbide API",
                 );
                 return Err(CarbideCliError::GenericError(e.to_string()));
             }
@@ -254,7 +256,7 @@ impl ApiClient {
                 return Err(CarbideCliError::SerialNumberNotFound);
             }
             Err(err) => {
-                tracing::error!(%err, "identify_serial error calling grpc identify_serial");
+                tracing::error!(error = %err, "identify_serial error calling grpc identify_serial");
                 return Err(CarbideCliError::GenericError(err.to_string()));
             }
         };
@@ -1585,7 +1587,7 @@ impl ApiClient {
             } else {
                 vf_network_segment_ids.len() / pf_network_segment_ids.len()
             };
-            tracing::debug!("VFs per PF: {vfs_per_pf}");
+            tracing::debug!(vfs_per_pf, "VFs per PF",);
 
             let mut next_device_instance = HashMap::new();
 
@@ -1684,7 +1686,7 @@ impl ApiClient {
                 // pf_vpc_prefix_ids is checked for empty above (len() cannot be 0)
                 vf_vpc_prefix_ids.len() / pf_vpc_prefix_ids.len()
             };
-            tracing::debug!("VFs per PF: {vfs_per_pf}");
+            tracing::debug!(vfs_per_pf, "VFs per PF",);
             let mut vf_chunk_iter = vf_vpc_prefix_ids.chunks(vfs_per_pf);
             let mut ipv6_vf_chunk_iter = allocate_instance.ipv6_vf_prefix_id.chunks(vfs_per_pf);
             for (map_index, i) in discovery_info
@@ -1729,7 +1731,10 @@ impl ApiClient {
                             }),
                         routing_profile: None,
                     };
-                    tracing::debug!("Adding interface: {:?}", new_interface);
+                    tracing::debug!(
+                        new_interface = ?new_interface,
+                        "Adding interface",
+                    );
 
                     interface_configs.push(new_interface);
 
@@ -1761,12 +1766,18 @@ impl ApiClient {
                                 routing_profile: None,
                             };
                             vf_function_id += 1;
-                            tracing::debug!("Adding interface: {:?}", new_interface);
+                            tracing::debug!(
+                                new_interface = ?new_interface,
+                                "Adding interface",
+                            );
                             interface_configs.push(new_interface);
                         }
                     }
                 } else {
-                    tracing::debug!("No pci device info for interface: {i:?}");
+                    tracing::debug!(
+                        interface = ?i,
+                        "No PCI device info",
+                    );
                 }
             }
 

--- a/crates/agent/src/agent_platform.rs
+++ b/crates/agent/src/agent_platform.rs
@@ -65,16 +65,16 @@ impl ManagedFile {
         if !destination_exists {
             safe_copy(self.path.as_path(), source_path).inspect(|_| {
                 tracing::info!(
-                    "Copied file contents from {src} to {dst}",
-                    src = source_path.display(),
-                    dst = self.path.display()
+                    source_path = %source_path.display(),
+                    destination_path = %self.path.display(),
+                    "Copied file contents"
                 );
             })
         } else {
             tracing::debug!(
-                "File {dst} already exists, will not be updated from {src}",
-                src = source_path.display(),
-                dst = self.path.display()
+                source_path = %source_path.display(),
+                destination_path = %self.path.display(),
+                "File already exists, will not be updated"
             );
             Ok(())
         }

--- a/crates/agent/src/astra_weave.rs
+++ b/crates/agent/src/astra_weave.rs
@@ -292,10 +292,7 @@ async fn create_weave_ew_vpc_virtual_networks(
             continue;
         }
 
-        tracing::info!(
-            "Created virtual network from astra attachment status {:?}",
-            astra_attachment_status
-        );
+        tracing::info!(?astra_attachment_status, "Created virtual network");
     }
 
     Ok(())
@@ -340,8 +337,8 @@ async fn delete_stale_weave_ew_vpc_virtual_networks(
         match weave_ew_vpc_delete_virtual_network(socket_path, delete_vni_req).await {
             Ok(_) => {
                 tracing::info!(
-                    "Deleted stale virtual network {:?} from DOCA Weave server",
-                    virtual_network
+                    ?virtual_network,
+                    "Deleted stale virtual network from DOCA Weave server"
                 );
             }
             Err(err) => {
@@ -566,8 +563,8 @@ async fn create_or_recreate_weave_ew_vpc_astra_attachment(
     }
 
     tracing::info!(
-        "Created virtual network attachment for attachment status {:?}",
-        astra_attachment_status
+        ?astra_attachment_status,
+        "Created virtual network attachment"
     );
 
     Ok(())
@@ -625,8 +622,8 @@ async fn delete_stale_weave_ew_vpc_astra_attachments(
             Ok(_) => {
                 deleted_attachment_ids.insert(del_attachment_id);
                 tracing::info!(
-                    "Deleted stale virtual network attachment {:?} from DOCA Weave server",
-                    virtual_network_attachment
+                    ?virtual_network_attachment,
+                    "Deleted stale virtual network attachment from DOCA Weave server"
                 );
             }
             Err(err) => {
@@ -699,8 +696,8 @@ pub async fn delete_match_attachment_with_vni_changed(
         Ok(_) => {
             deleted_attachment_ids.insert(delete_attachment_id);
             tracing::info!(
-                "Deleted mismatched virtual network attachment {:?} from DOCA Weave server",
-                match_attachment.as_ref().unwrap()
+                ?match_attachment,
+                "Deleted mismatched virtual network attachment from DOCA Weave server"
             );
         }
         Err(err) => {
@@ -835,7 +832,8 @@ async fn build_synced_astra_config_status_if_version_unchanged(
     // the astra config despite the matching revision, fall back to a full
     // reconcile (return None) rather than erroring, so the drift is repaired.
     tracing::trace!(
-        "AstraConfig version {nico_spx_version} has no changes, copying attachment status"
+        spx_version = %nico_spx_version,
+        "AstraConfig version has no changes, copying attachment status"
     );
     match sync_astra_config_status_from_weave_ew_vpc_attachments(
         astra_config,
@@ -845,7 +843,8 @@ async fn build_synced_astra_config_status_if_version_unchanged(
         Err(err) => {
             tracing::warn!(
                 error = format!("{err:#}"),
-                "AstraConfig version {nico_spx_version} matches, but DOCA Weave state drifted; running full reconcile"
+                spx_version = %nico_spx_version,
+                "AstraConfig version matches, but DOCA Weave state drifted; running full reconcile"
             );
             Ok(None)
         }

--- a/crates/agent/src/containerd/container.rs
+++ b/crates/agent/src/containerd/container.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
-use tracing::log::error;
+use tracing::error;
 
 use crate::containerd::image::{Image, ImageNameComponent};
 use crate::containerd::{BashCommand, Command};
@@ -226,7 +226,7 @@ async fn get_container_images() -> eyre::Result<String> {
         let test_data_dir = PathBuf::from(TEST_DATA_DIR);
 
         std::fs::read_to_string(test_data_dir.join("container_images.json")).map_err(|e| {
-            error!("Could not read container_images.json: {e}");
+            error!(error = %e, "Could not read container_images.json");
             eyre::eyre!("Could not read container_images.json: {}", e)
         })
     } else {
@@ -235,7 +235,7 @@ async fn get_container_images() -> eyre::Result<String> {
             .run()
             .await
             .map_err(|e| {
-                error!("Could not read container_images.json: {e}");
+                error!(error = %e, "Could not read container_images.json");
                 eyre::eyre!("Could not read container_images.json: {}", e)
             })?;
         Ok(result)
@@ -250,7 +250,7 @@ async fn get_containers() -> eyre::Result<String> {
         println!("Path: {}", test_data_dir.join("containers.json").display());
 
         std::fs::read_to_string(test_data_dir.join("containers.json")).map_err(|e| {
-            error!("Could not read containers.json: {e}");
+            error!(error = %e, "Could not read containers.json");
             eyre::eyre!("Could not read containers.json: {}", e)
         })
     } else {
@@ -259,7 +259,7 @@ async fn get_containers() -> eyre::Result<String> {
             .run()
             .await
             .map_err(|e| {
-                error!("Could not read containers.json: {e}");
+                error!(error = %e, "Could not read containers.json");
                 eyre::eyre!("Could not read containers.json: {}", e)
             })?;
         Ok(result)
@@ -274,7 +274,7 @@ async fn get_pod_containers(pod_id: &str) -> eyre::Result<String> {
         println!("Path: {}", test_data_dir.join("containers.json").display());
 
         std::fs::read_to_string(test_data_dir.join("containers.json")).map_err(|e| {
-            error!("Could not read containers.json: {e}");
+            error!(error = %e, "Could not read containers.json");
             eyre::eyre!("Could not read containers.json: {}", e)
         })
     } else {
@@ -284,7 +284,7 @@ async fn get_pod_containers(pod_id: &str) -> eyre::Result<String> {
             .run()
             .await
             .map_err(|e| {
-                error!("Could not read containers.json: {e}");
+                error!(error = %e, "Could not read containers.json");
                 eyre::eyre!("Could not read containers.json: {}", e)
             })?;
         Ok(result)
@@ -343,9 +343,9 @@ mod tests {
     #[tokio::test]
     async fn test_find_container_by_name() {
         let containers = Containers::list().await.expect("Could not get containers");
-        tracing::info!("Container: {:?}", containers);
+        tracing::info!(?containers, "Listed containers");
         let container = containers.find_by_name("doca-hbn").unwrap();
-        tracing::info!("Container: {:?}", container);
+        tracing::info!(?container, "Found container by name");
         assert_eq!(container.metadata.name, "doca-hbn");
         assert_eq!(container.state, ContainerState::Running);
     }

--- a/crates/agent/src/containerd/image.rs
+++ b/crates/agent/src/containerd/image.rs
@@ -19,7 +19,7 @@ use std::fmt::{Display, Formatter};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tracing::log::trace;
+use tracing::trace;
 
 /// Represents the individual components of a container image name.
 /// e.g.
@@ -76,7 +76,7 @@ where
     let vec: Vec<String> = Vec::deserialize(deserializer)?;
     let initial: Vec<ImageNameComponent> = Vec::new();
 
-    trace!("Container name component: {vec:?}");
+    trace!(image_name_components = ?vec, "Container name component");
     vec.iter().try_fold(initial, |mut accum, value| {
         let re = Regex::new(r#"(.+)\/(.+):(.+)"#).unwrap();
         re.captures(value.as_str())

--- a/crates/agent/src/dhcp_server_grpc_client.rs
+++ b/crates/agent/src/dhcp_server_grpc_client.rs
@@ -132,7 +132,9 @@ pub async fn get_dhcp_timestamps(
             let id = e
                 .host_interface_id
                 .parse::<MachineInterfaceId>()
-                .map_err(|err| tracing::warn!("Skipping unparseable host_interface_id: {err}"))
+                .map_err(
+                    |err| tracing::warn!(error = %err, "Skipping unparseable host_interface_id"),
+                )
                 .ok()?;
             Some(::rpc::forge::LastDhcpRequest {
                 host_interface_id: Some(id),

--- a/crates/agent/src/dpu/interface.rs
+++ b/crates/agent/src/dpu/interface.rs
@@ -23,7 +23,7 @@ use carbide_utils::none_if_empty::NoneIfEmpty;
 use eyre::WrapErr;
 use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
-use tracing::log::error;
+use tracing::error;
 
 use crate::dpu::link::IpLink;
 use crate::dpu::{Action, DpuNetworkInterfaces};
@@ -68,11 +68,7 @@ impl Interface {
                         if let Some(networks) = networks
                             && !networks.is_empty()
                         {
-                            tracing::info!(
-                                "Adding addresses {:?} to Interface {:?}",
-                                networks,
-                                interface
-                            );
+                            tracing::info!(?networks, interface_name = %interface, "Adding addresses");
 
                             for network in networks {
                                 Interface::ip_addrs_add(&interface, network).await?;
@@ -113,8 +109,9 @@ impl Interface {
                         Interface::find_common_addresses(&current_addresses, &proposed_addresses)
                     {
                         tracing::trace!(
-                            "Proposed addresses already present on interface {interface}: {:?}",
-                            common_networks
+                            interface_name = %interface,
+                            ?common_networks,
+                            "Proposed addresses already present"
                         );
 
                         // If the proposed addresses are already present on the interface
@@ -124,8 +121,9 @@ impl Interface {
                         proposed_addresses.retain(|x| !common_networks.contains(x));
                     }
                     tracing::trace!(
-                        "Proposed addresses needing to be added to {interface}: {:?}",
-                        proposed_addresses
+                        interface_name = %interface,
+                        ?proposed_addresses,
+                        "Proposed addresses needing to be added"
                     );
                     let entry = interface_plan.entry(Action::Add).or_default();
                     entry.insert(interface.to_string(), Some(proposed_addresses.clone()));
@@ -133,7 +131,7 @@ impl Interface {
             }
         } else {
             tracing::error!(
-                interface,
+                interface_name = interface,
                 "FMDS cannot add IP address to non-existent interface"
             );
         }
@@ -146,7 +144,7 @@ impl Interface {
             let test_data_dir = PathBuf::from(crate::dpu::ARMOS_TEST_DATA_DIR);
 
             std::fs::read_to_string(test_data_dir.join("ipaddr.json")).map_err(|e| {
-                error!("Could not read ipaddr.json: {e}");
+                error!(error = %e, "Could not read ipaddr.json");
                 eyre::eyre!("Could not read ipaddr.json: {}", e)
             })
         } else {
@@ -167,7 +165,7 @@ impl Interface {
 
     pub async fn current_addresses(interface: &str) -> eyre::Result<Vec<IpInterface>> {
         let data = Self::ip_addrs(interface).await?;
-        tracing::trace!("interface data from ip addr show: {data:?}");
+        tracing::trace!(ip_address_data = ?data, "interface data from ip addr show");
         serde_json::from_str::<Vec<IpInterface>>(&data).map_err(|err| eyre::eyre!(err))
     }
 
@@ -185,7 +183,7 @@ impl Interface {
         cmd.kill_on_drop(true);
 
         let cmd_str = pretty_cmd(cmd.as_std());
-        tracing::trace!("Running command: {:?}", cmd_str);
+        tracing::trace!(command = ?cmd_str, "Running command");
 
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
@@ -195,7 +193,7 @@ impl Interface {
         if output.status.success() {
             Ok(true)
         } else {
-            tracing::error!("Failed to add address: {:?}", fout);
+            tracing::error!(command_output = ?fout, "Failed to add address");
             Ok(false)
         }
     }
@@ -204,7 +202,7 @@ impl Interface {
         interface: &str,
     ) -> eyre::Result<Vec<IpInterfaceAddress>> {
         let data = Self::ip_addrs(interface).await?;
-        tracing::trace!("interfaces data from ip show: {:?}", data);
+        tracing::trace!(ip_link_data = ?data, "interfaces data from ip show");
         let data =
             serde_json::from_str::<Vec<IpInterface>>(&data).map_err(|err| eyre::eyre!(err))?;
         let filtered_list: Vec<_> = data
@@ -326,7 +324,7 @@ mod tests {
         let interface = Interface::get_addresses_for_interface(HBNDeviceNames::hbn_23().sfs[0])
             .await
             .unwrap();
-        tracing::trace!("Interface: {:?}", interface);
+        tracing::trace!(?interface, "Interface");
 
         assert_eq!(interface[0].prefixlen, 30);
         assert_eq!(interface[0].local, IpAddr::from([192, 168, 0, 1]));
@@ -338,7 +336,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        tracing::trace!("Link: {:?}", link);
+        tracing::trace!(?link, "Link");
         assert_eq!(link.ifindex, 16);
     }
 

--- a/crates/agent/src/dpu/link.rs
+++ b/crates/agent/src/dpu/link.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 
 use eyre::Context;
 use serde::{Deserialize, Serialize};
-use tracing::log::error;
+use tracing::error;
 
 use crate::pretty_cmd;
 
@@ -42,7 +42,7 @@ pub struct IpLink {
 impl IpLink {
     pub async fn get_link_by_name(interface: &str) -> eyre::Result<Option<IpLink>> {
         let data = Self::ip_links().await?;
-        tracing::trace!("interfaces data from ip show: {:?}", data);
+        tracing::trace!(ip_link_data = ?data, "interfaces data from ip show");
         let data = serde_json::from_str::<Vec<IpLink>>(&data).map_err(|err| eyre::eyre!(err));
         data.map(|i| {
             i.into_iter()
@@ -54,7 +54,7 @@ impl IpLink {
             let test_data_dir = PathBuf::from(crate::dpu::ARMOS_TEST_DATA_DIR);
 
             std::fs::read_to_string(test_data_dir.join("iplink.json")).map_err(|e| {
-                error!("Could not read iplink.json: {e}");
+                error!(error = %e, "Could not read iplink.json");
                 eyre::eyre!("Could not read iplink.json: {}", e)
             })
         } else {

--- a/crates/agent/src/dpu/route.rs
+++ b/crates/agent/src/dpu/route.rs
@@ -24,7 +24,7 @@ use std::process::ExitStatus;
 use eyre::Context;
 use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
-use tracing::log::error;
+use tracing::error;
 
 use crate::dpu::Action;
 use crate::pretty_cmd;
@@ -94,7 +94,7 @@ impl Route {
             entry.extend(routes);
         }
 
-        tracing::trace!("Route plan: {:?}", plan);
+        tracing::trace!(route_plan = ?plan, "Route plan");
         Ok(plan)
     }
 
@@ -104,7 +104,7 @@ impl Route {
                 Action::Add => {
                     if !routes.is_empty() {
                         for r in routes {
-                            tracing::info!("Adding route to Dpu: {:?}", r);
+                            tracing::info!(route = ?r, "Adding route to Dpu");
                             Self::ip_route_add(r.dst, r.dev.as_deref(), r.prefsrc, r.gateway)
                                 .await?;
                         }
@@ -113,7 +113,7 @@ impl Route {
                 Action::Remove => {
                     if !routes.is_empty() {
                         for r in routes {
-                            tracing::info!("Removing route from Dpu: {:?}", r);
+                            tracing::info!(route = ?r, "Removing route from Dpu");
                             Self::ip_route_del(r.dst, r.dev.as_deref(), r.prefsrc, r.gateway)
                                 .await?;
                         }
@@ -129,7 +129,7 @@ impl Route {
             let test_data_dir = PathBuf::from(crate::dpu::ARMOS_TEST_DATA_DIR);
 
             std::fs::read_to_string(test_data_dir.join("iproute.json")).map_err(|e| {
-                error!("Could not read iproute.json: {e}");
+                error!(error = %e, "Could not read iproute.json");
                 eyre::eyre!("Could not read iproute.json: {}", e)
             })
         } else {
@@ -173,7 +173,7 @@ impl Route {
         cmd.kill_on_drop(true);
 
         let cmd_str = pretty_cmd(cmd.as_std());
-        tracing::trace!("Running command: {:?}", cmd_str);
+        tracing::trace!(command = ?cmd_str, "Running command");
 
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
@@ -183,7 +183,7 @@ impl Route {
         if output.status.success() {
             Ok(true)
         } else {
-            tracing::error!("Failed to add route: {:?}", fout);
+            tracing::error!(command_output = ?fout, "Failed to add route");
             Ok(false)
         }
     }
@@ -212,7 +212,7 @@ impl Route {
         cmd.kill_on_drop(true);
 
         let cmd_str = pretty_cmd(cmd.as_std());
-        tracing::trace!("Running command: {:?}", cmd_str);
+        tracing::trace!(command = ?cmd_str, "Running command");
 
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
@@ -222,14 +222,14 @@ impl Route {
         if output.status == ExitStatus::from_raw(0) {
             Ok(true)
         } else {
-            tracing::error!("Failed to remove route: {:?}", fout);
+            tracing::error!(command_output = ?fout, "Failed to remove route");
             Ok(false)
         }
     }
 
     pub async fn current_routes(interface: &str) -> eyre::Result<Vec<IpRoute>> {
         let data = Self::ip_route(interface).await?;
-        tracing::trace!("route data from ip route show: {:?}", data);
+        tracing::trace!(route_data = ?data, "route data from ip route show");
         let mut data =
             serde_json::from_str::<Vec<IpRoute>>(&data).map_err(|err| eyre::eyre!(err))?;
 
@@ -362,6 +362,6 @@ mod tests {
         assert_eq!(add[0], new_proposed_route1);
         assert_eq!(remove[0], route_to_remove);
 
-        tracing::trace!("Full Plan: {:?}", plan);
+        tracing::trace!(route_plan = ?plan, "Full Plan");
     }
 }

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -92,10 +92,10 @@ impl InterfaceState {
             // Execute command only if interface state is changed.
             let mut cmd = needed_state.command();
             tracing::info!(
-                "Updating interface state from {:?} to {:?} with command: {:?}",
-                current_state,
-                needed_state,
-                cmd
+                current_interface_state = ?current_state,
+                target_interface_state = ?needed_state,
+                command = ?cmd,
+                "Updating interface state"
             );
             let result = cmd.output().await?;
             if !result.status.success() {
@@ -684,7 +684,11 @@ pub async fn update_nvue(
                     if !skip_post {
                         let cmd = acl_rules::RELOAD_CMD;
                         if let Err(err) = hbn::run_in_container_shell(cmd).await {
-                            tracing::error!("running nvue extra acl post '{}': {err:#}", cmd);
+                            tracing::error!(
+                                command = %cmd,
+                                error = format!("{err:#}"),
+                                "running nvue extra acl post"
+                            );
                         }
                         path_acl.del("BAK");
                     }
@@ -692,7 +696,7 @@ pub async fn update_nvue(
                 // ACLs didn't need changing, should be always this except on first boot
                 Ok(false) => {}
                 // Log the error but continue so that we get network working
-                Err(err) => tracing::error!("write nvue extra ACL: {err:#}"),
+                Err(err) => tracing::error!(error = format!("{err:#}"), "write nvue extra ACL"),
             }
 
             // nvue can save a copy of the config here. If that exists nvue uses it on boot.
@@ -702,8 +706,9 @@ pub async fn update_nvue(
                 && let Err(err) = fs::remove_file(&saved_config)
             {
                 tracing::warn!(
-                    "Failed removing old startup.yaml at {}: {err:#}",
-                    saved_config.display()
+                    saved_config_path = %saved_config.display(),
+                    error = format!("{err:#}"),
+                    "Failed removing old startup.yaml"
                 );
             }
 
@@ -827,7 +832,13 @@ pub async fn update_traffic_intercept_bridging(
             };
 
             interface_to_bridge.get(&name).map(|bridging| {
-                tracing::debug!("update_traffic_intercept_bridging representor={name} bridge={} vni={} gateway={}", bridging.bridge, i.vni, i.gateway);
+                tracing::debug!(
+                    representor = %name,
+                    bridge = %bridging.bridge,
+                    vni = i.vni,
+                    gateway = %i.gateway,
+                    "Created traffic-intercept bridge mapping"
+                );
                 traffic_intercept_bridging::TrafficInterceptBridgeMapping {
                     bridge: bridging.bridge.clone(),
                     patch_port: bridging.patch_port.clone(),
@@ -1297,7 +1308,11 @@ pub async fn interfaces(
                     Some(vlan_fdb) => match tenant_vf_mac(vlan_fdb).await {
                         Ok(mac) => Some(mac.to_string()),
                         Err(err) => {
-                            tracing::error!(%err, vlan_id=iface.vlan_id, "Error fetching tenant VF MAC");
+                            tracing::error!(
+                                error = %err,
+                                vlan_id = iface.vlan_id,
+                                "Error fetching tenant VF MAC"
+                            );
                             None
                         }
                     },
@@ -1403,7 +1418,7 @@ pub async fn reset(hbn_root: &Path, skip_post: bool) {
 
     let err_message = errs.join(", ");
     if !err_message.is_empty() {
-        tracing::error!(err_message);
+        tracing::error!(error = %err_message, "Failed to reset network configuration");
     }
 }
 
@@ -1428,7 +1443,11 @@ fn write_dhcp_v4_server_config(
             dhcp_relay_path.del("BAK");
         }
         Ok(false) => {}
-        Err(err) => tracing::warn!("Write blank DHCP relay {dhcp_relay_path}: {err:#}"),
+        Err(err) => tracing::warn!(
+            %dhcp_relay_path,
+            error = format!("{err:#}"),
+            "Write blank DHCP relay"
+        ),
     }
 
     let interfaces = if nc.use_admin_network {
@@ -1515,7 +1534,11 @@ fn write_dhcp_v4_server_config(
             dhcp_server_path.server.del("BAK");
         }
         Ok(false) => {}
-        Err(err) => tracing::error!("Write DHCP server {}: {err:#}", dhcp_server_path.server),
+        Err(err) => tracing::error!(
+            dhcp_server_path = %dhcp_server_path.server,
+            error = format!("{err:#}"),
+            "Write DHCP server"
+        ),
     }
 
     let next_contents = dhcp::build_server_config(
@@ -1537,8 +1560,9 @@ fn write_dhcp_v4_server_config(
         }
         Ok(false) => {}
         Err(err) => tracing::error!(
-            "Write DHCP server config {}: {err:#}",
-            dhcp_server_path.config
+            dhcp_server_config_path = %dhcp_server_path.config,
+            error = format!("{err:#}"),
+            "Write DHCP server config"
         ),
     }
 
@@ -1555,8 +1579,9 @@ fn write_dhcp_v4_server_config(
         }
         Ok(false) => {}
         Err(err) => tracing::error!(
-            "Write DHCP server host config {}: {err:#}",
-            dhcp_server_path.host_config
+            dhcp_server_host_config_path = %dhcp_server_path.host_config,
+            error = format!("{err:#}"),
+            "Write DHCP server host config"
         ),
     }
 
@@ -1599,7 +1624,7 @@ fn write(
     if !has_changed {
         return Ok(false);
     }
-    tracing::debug!("Applying new {file_type} config");
+    tracing::debug!(%file_type, "Applying new config");
 
     let path_bak = path.backup();
     if path.0.exists() {
@@ -1730,9 +1755,9 @@ async fn tenant_vf_mac(vlan_fdb: &[Fdb]) -> eyre::Result<&str> {
 
     if !ip_out.status.success() {
         tracing::debug!(
-            "STDERR {}: {}",
-            super::pretty_cmd(cmd.as_std()),
-            String::from_utf8_lossy(&ip_out.stderr)
+            command = %super::pretty_cmd(cmd.as_std()),
+            stderr = %String::from_utf8_lossy(&ip_out.stderr),
+            "STDERR"
         );
         return Err(eyre::eyre!(
             "{} for cmd '{}'",
@@ -1843,7 +1868,11 @@ impl FPath {
             match fs::remove_file(&p) {
                 Ok(_) => true,
                 Err(err) => {
-                    tracing::warn!("Failed removing {}: {err}.", p.display());
+                    tracing::warn!(
+                        file_path = %p.display(),
+                        error = %err,
+                        "Failed to remove file"
+                    );
                     false
                 }
             }
@@ -1896,10 +1925,14 @@ fn cleanup_old_acls(hbn_root: &Path) {
         if p.exists() {
             match fs::remove_file(p) {
                 Ok(_) => {
-                    tracing::info!("Cleaned up old ACL file {}", p.display());
+                    tracing::info!(acl_file_path = %p.display(), "Cleaned up old ACL file");
                 }
                 Err(err) => {
-                    tracing::warn!("Failed removing old ACL file {}: {err}.", p.display());
+                    tracing::warn!(
+                        acl_file_path = %p.display(),
+                        error = %err,
+                        "Failed removing old ACL file."
+                    );
                 }
             }
         }

--- a/crates/agent/src/extension_services/dpu_extension_service_observability.rs
+++ b/crates/agent/src/extension_services/dpu_extension_service_observability.rs
@@ -146,7 +146,10 @@ pub fn build(
 pub async fn validate() -> eyre::Result<bool> {
     let mut cmd = tokio::process::Command::new(OTEL_CONTRIB_VALIDATE_BIN);
     let cmd_str = super::super::pretty_cmd(cmd.as_std());
-    tracing::debug!("running otel validation commands: {cmd_str}");
+    tracing::debug!(
+        command = cmd_str.as_str(),
+        "running otel validation commands"
+    );
 
     // Invoke the validation command and allow a few seconds for completion.
     // The validation should be immediate (under a second), but a few seconds of buffer
@@ -159,12 +162,10 @@ pub async fn validate() -> eyre::Result<bool> {
 
     if !out.status.success() {
         tracing::error!(
-            " STDOUT {cmd_str}: {}",
-            String::from_utf8_lossy(&out.stdout)
-        );
-        tracing::error!(
-            " STDERR {cmd_str}: {}",
-            String::from_utf8_lossy(&out.stderr)
+            command = cmd_str.as_str(),
+            stdout = %String::from_utf8_lossy(&out.stdout),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "OTel validation command failed"
         );
 
         return Ok(false);

--- a/crates/agent/src/extension_services/k8s_pod_handler.rs
+++ b/crates/agent/src/extension_services/k8s_pod_handler.rs
@@ -188,8 +188,8 @@ impl KubernetesPodServicesHandler {
     /// Restart a systemd service and apply changes to the service configuration.
     async fn systemctl_restart(&self, service: &str) -> Result<()> {
         tracing::debug!(
-            "systemctl daemon-reload and restart {} to apply changes",
-            service
+            service,
+            "systemctl daemon-reload and restart to apply changes"
         );
 
         // Run systemctl daemon-reload
@@ -201,7 +201,7 @@ impl KubernetesPodServicesHandler {
 
         if !daemon_reload.status.success() {
             let stderr = String::from_utf8_lossy(&daemon_reload.stderr);
-            tracing::warn!("systemctl daemon-reload failed: {}", stderr);
+            tracing::warn!(%stderr, "systemctl daemon-reload failed");
         }
 
         // Run systemctl restart <service>
@@ -216,7 +216,7 @@ impl KubernetesPodServicesHandler {
             return Err(eyre::eyre!("Failed to restart {}: {}", service, stderr));
         }
 
-        tracing::debug!("Successfully restarted {}", service);
+        tracing::debug!(%service, "Successfully restarted");
 
         Ok(())
     }
@@ -294,10 +294,10 @@ impl KubernetesPodServicesHandler {
             })?;
 
         tracing::debug!(
-            "Pod spec for service {} V{} written successfully at {}",
-            service.id,
-            service.version,
-            pod_spec_path.display()
+            extension_service_id = %service.id,
+            service_version = %service.version,
+            pod_spec_path = %pod_spec_path.display(),
+            "Pod spec written successfully"
         );
 
         Ok(())
@@ -310,18 +310,18 @@ impl KubernetesPodServicesHandler {
         match fs::remove_file(&pod_spec_path).await {
             Ok(()) => {
                 tracing::debug!(
-                    "Pod spec for service {} V{} removed successfully at {}",
-                    service_id,
+                    extension_service_id = service_id,
                     service_version,
-                    pod_spec_path.display()
+                    pod_spec_path = %pod_spec_path.display(),
+                    "Pod spec removed successfully"
                 );
             }
             Err(e) if e.kind() == ErrorKind::NotFound => {
                 tracing::debug!(
-                    "Pod spec for service {} V{} already gone (nothing to remove) at {}",
-                    service_id,
+                    extension_service_id = service_id,
                     service_version,
-                    pod_spec_path.display()
+                    pod_spec_path = %pod_spec_path.display(),
+                    "Pod spec already gone (nothing to remove)"
                 );
             }
             Err(e) => {
@@ -478,9 +478,9 @@ impl KubernetesPodServicesHandler {
         } else {
             let stderr = String::from_utf8_lossy(&output.stderr);
             tracing::debug!(
-                "go-template inspect failed for container {}: {}",
                 container_id,
-                stderr
+                %stderr,
+                "go-template inspect failed"
             );
         }
 
@@ -960,13 +960,13 @@ JSON
             std::fs::write(KUBELET_SYSTEMD_OVERRIDE_FILE, override_content)
                 .wrap_err("Failed to write kubelet systemd override file")?;
             tracing::debug!(
-                "Written kubelet systemd override to {}",
-                KUBELET_SYSTEMD_OVERRIDE_FILE
+                kubelet_systemd_override_path = KUBELET_SYSTEMD_OVERRIDE_FILE,
+                "Written kubelet systemd override"
             );
         } else {
             tracing::debug!(
-                "Kubelet systemd override already up to date at {}",
-                KUBELET_SYSTEMD_OVERRIDE_FILE
+                kubelet_systemd_override_path = KUBELET_SYSTEMD_OVERRIDE_FILE,
+                "Kubelet systemd override already up to date"
             );
         }
 
@@ -1131,17 +1131,17 @@ Environment="NO_PROXY=127.0.0.1,localhost,.svc,.svc.cluster.local"
                 KUBELET_SYSTEMD_OVERRIDE_FILE,
             ] {
                 match std::fs::remove_file(path) {
-                    Ok(_) => tracing::debug!("Removed {}", path),
+                    Ok(_) => tracing::debug!(path, "Removed"),
                     Err(e) if e.kind() == ErrorKind::NotFound => {
-                        tracing::debug!("{} already absent", path);
+                        tracing::debug!(path, "already absent");
                     }
                     Err(e) => return Err(eyre::eyre!("Failed to remove {}: {}", path, e)),
                 }
             }
         } else {
             tracing::debug!(
-                "Configuring credential provider for {} registries or organizations",
-                credential_list.len()
+                registry_count = credential_list.len(),
+                "Configuring credential provider for registries or organizations"
             );
 
             // Create credential directory structure
@@ -1162,8 +1162,8 @@ Environment="NO_PROXY=127.0.0.1,localhost,.svc,.svc.cluster.local"
                 .wrap_err("Failed to write credential provider config")?;
 
             tracing::debug!(
-                "Written credential provider config to {}",
-                KUBELET_POD_IMAGE_CRED_CONFIG_FILE
+                credential_provider_config_path = KUBELET_POD_IMAGE_CRED_CONFIG_FILE,
+                "Written credential provider config"
             );
 
             // Write kubelet systemd override to configure image credential provider
@@ -1185,8 +1185,8 @@ Environment="NO_PROXY=127.0.0.1,localhost,.svc,.svc.cluster.local"
             }
 
             tracing::debug!(
-                "Written credential provider script to {}",
-                KUBELET_POD_IMAGE_CRED_PROVIDER_FILE
+                credential_provider_script_path = KUBELET_POD_IMAGE_CRED_PROVIDER_FILE,
+                "Written credential provider script"
             );
         }
 
@@ -1222,8 +1222,9 @@ Environment="NO_PROXY=127.0.0.1,localhost,.svc,.svc.cluster.local"
                     }
                 } else if observability.configs.len() > MAX_OBSERVABILITY_CONFIG_PER_SERVICE {
                     tracing::error!(
-                        "number of observability configs for service `{}` exceeds the limit of {MAX_OBSERVABILITY_CONFIG_PER_SERVICE}",
-                        service.id
+                        extension_service_id = %service.id,
+                        limit = MAX_OBSERVABILITY_CONFIG_PER_SERVICE,
+                        "Number of observability configs exceeds the limit"
                     );
 
                     // We protect against this case in the API layer, so this case,
@@ -1348,7 +1349,7 @@ impl ExtensionServiceHandler for KubernetesPodServicesHandler {
     /// This reconciles the /etc/kubelet.d directory with the desired services
     async fn update_active_services(&mut self, services: &[ServiceConfig]) -> Result<()> {
         if let Err(e) = self.update_services(services).await {
-            tracing::error!("Failed to update active services: {}", e);
+            tracing::error!(error = %e, "Failed to update active services");
         }
         Ok(())
     }

--- a/crates/agent/src/hbn.rs
+++ b/crates/agent/src/hbn.rs
@@ -49,7 +49,7 @@ impl<'a> RunCommandPredicate<'a> {
     /// ENV::VAR `IGNORE_MGMT_VRF` dictates which command predicate to use
     pub fn new(container_id: &'a str) -> Self {
         let ignore_mgmt_vrf = std::env::var("IGNORE_MGMT_VRF").is_ok();
-        tracing::trace!("RunCommandPredicate: IGNORE_MGMT_VRF is {ignore_mgmt_vrf}");
+        tracing::trace!(ignore_mgmt_vrf, "RunCommandPredicate: IGNORE_MGMT_VRF");
 
         match ignore_mgmt_vrf {
             true => Self {
@@ -117,7 +117,7 @@ pub async fn run_in_container(
     let cmd = crictl.args(args);
     cmd.kill_on_drop(true);
     let cmd_str = super::pretty_cmd(cmd.as_std());
-    tracing::trace!("run_in_container: {cmd_str}");
+    tracing::trace!(command = cmd_str.as_str(), "run_in_container");
 
     let cmd_res = timeout(TIMEOUT_CONTAINER_CMD, cmd.output())
         .await
@@ -128,7 +128,11 @@ pub async fn run_in_container(
     let stdout = String::from_utf8_lossy(&out.stdout).to_string();
 
     if need_success && !out.status.success() {
-        tracing::debug!("STDERR {cmd_str}: {}", stderr);
+        tracing::debug!(
+            command = cmd_str.as_str(),
+            stderr = stderr.as_str(),
+            "Container command failed"
+        );
         return Err(eyre::eyre!(
             "cmd '{cmd_str}' failed with status: {}, stderr: {}, stdout: {}",
             out.status, // includes the string "exit status"
@@ -200,10 +204,9 @@ impl HBNContainerFileConfigs {
             // replaced.
             l => {
                 tracing::info!(
-                    "HBN container ID {c} is new to us, updating its neighbor \
-                    learning config (previous container ID was {l})",
-                    c = current_container_id.as_str(),
-                    l = l.map_or("None", |s| s.as_str())
+                    container_id = current_container_id.as_str(),
+                    previous_container_id = l.map_or("None", |s| s.as_str()),
+                    "HBN container ID is new to us, updating its neighbor learning config"
                 );
                 set_strict_neighbor_learning(current_container_id.as_str())
                     .await

--- a/crates/agent/src/health.rs
+++ b/crates/agent/src/health.rs
@@ -202,7 +202,10 @@ async fn check_hbn_services_running(
     {
         Ok(s) => s,
         Err(err) => {
-            tracing::warn!("check_hbn_services_running supervisorctl status: {err}");
+            tracing::warn!(
+                error = %err,
+                "Failed to get supervisorctl status for HBN health check"
+            );
             failed(
                 hr,
                 probe_ids::SupervisorctlStatus.clone(),
@@ -215,7 +218,10 @@ async fn check_hbn_services_running(
     let st = match parse_status(&sctl) {
         Ok(s) => s,
         Err(err) => {
-            tracing::warn!("check_hbn_services_running supervisorctl status parse: {err}");
+            tracing::warn!(
+                error = %err,
+                "Failed to parse supervisorctl status for HBN health check"
+            );
             failed(
                 hr,
                 probe_ids::SupervisorctlStatus.clone(),
@@ -231,7 +237,11 @@ async fn check_hbn_services_running(
         match st.status_of(&service) {
             SctlState::Running => passed(hr, probe_ids::ServiceRunning.clone(), Some(service)),
             status => {
-                tracing::warn!("check_hbn_services_running {service}: {status}");
+                tracing::warn!(
+                    service = service.as_str(),
+                    service_state = %status,
+                    "HBN service is not running"
+                );
                 failed(
                     hr,
                     probe_ids::ServiceRunning.clone(),
@@ -255,7 +265,10 @@ async fn check_dhcp_server(hr: &mut health_report::HealthReport, container_id: &
     {
         Ok(s) => s,
         Err(err) => {
-            tracing::warn!("check_hbn_services_running supervisorctl status: {err}");
+            tracing::warn!(
+                error = %err,
+                "Failed to get supervisorctl status for DHCP health check"
+            );
             failed(
                 hr,
                 probe_ids::SupervisorctlStatus.clone(),
@@ -268,7 +281,10 @@ async fn check_dhcp_server(hr: &mut health_report::HealthReport, container_id: &
     let st = match parse_status(&sctl) {
         Ok(s) => s,
         Err(err) => {
-            tracing::warn!("check_hbn_services_running supervisorctl status parse: {err}");
+            tracing::warn!(
+                error = %err,
+                "Failed to parse supervisorctl status for DHCP health check"
+            );
             failed(
                 hr,
                 probe_ids::SupervisorctlStatus.clone(),
@@ -306,12 +322,12 @@ async fn check_ifreload(hr: &mut health_report::HealthReport, container_id: &str
             if stdout.is_empty() {
                 passed(hr, probe_ids::Ifreload.clone(), None);
             } else {
-                tracing::warn!("check_ifreload: {stdout}");
+                tracing::warn!(stdout = stdout.as_str(), "ifreload syntax check failed");
                 failed(hr, probe_ids::Ifreload.clone(), None, stdout);
             }
         }
         Err(err) => {
-            tracing::warn!("check_ifreload: {err}");
+            tracing::warn!(error = %err, "ifreload syntax check failed");
             failed(hr, probe_ids::Ifreload.clone(), None, err.to_string());
         }
     }
@@ -341,7 +357,7 @@ fn check_files(hr: &mut health_report::HealthReport, hbn_root: &Path, expected_f
         let stat = match std::fs::metadata(path) {
             Ok(s) => s,
             Err(err) => {
-                tracing::warn!("check_files {filename}: {err}");
+                tracing::warn!(filename, error = %err, "Failed to read file metadata");
                 failed(
                     hr,
                     probe_ids::FileIsValid.clone(),
@@ -355,8 +371,10 @@ fn check_files(hr: &mut health_report::HealthReport, hbn_root: &Path, expected_f
             dhcp_server_size = stat.len();
         } else if stat.len() < MIN_SIZE {
             tracing::warn!(
-                "check_files {filename}: Too small {} < {MIN_SIZE} bytes",
-                stat.len()
+                filename,
+                file_size_bytes = stat.len(),
+                minimum_file_size_bytes = MIN_SIZE,
+                "file is too small"
             );
             failed(
                 hr,
@@ -373,7 +391,12 @@ fn check_files(hr: &mut health_report::HealthReport, hbn_root: &Path, expected_f
     }
 
     if dhcp_server_size < MIN_SIZE {
-        tracing::warn!("check_files {DHCP_SERVER_FILE}: Too small");
+        tracing::warn!(
+            filename = DHCP_SERVER_FILE,
+            file_size_bytes = dhcp_server_size,
+            minimum_file_size_bytes = MIN_SIZE,
+            "file is too small"
+        );
         failed(
             hr,
             probe_ids::FileIsValid.clone(),
@@ -415,9 +438,9 @@ async fn check_restricted_mode(hr: &mut health_report::HealthReport) {
     };
     if !out.status.success() {
         tracing::debug!(
-            "STDERR {}: {}",
-            super::pretty_cmd(cmd.as_std()),
-            String::from_utf8_lossy(&out.stderr)
+            command = %super::pretty_cmd(cmd.as_std()),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "STDERR"
         );
         failed(
             hr,
@@ -499,9 +522,9 @@ async fn check_disk_utilization(hr: &mut health_report::HealthReport) {
     };
     if !out.status.success() {
         tracing::debug!(
-            "STDERR {}: {}",
-            super::pretty_cmd(cmd.as_std()),
-            String::from_utf8_lossy(&out.stderr)
+            command = %super::pretty_cmd(cmd.as_std()),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "STDERR"
         );
         failed(
             hr,
@@ -576,7 +599,7 @@ fn parse_disk_utilization(df_out: &str) -> eyre::Result<DiskUtilizations> {
     for line in df_out.lines().skip(1) {
         let parts: Vec<&str> = line.split_ascii_whitespace().collect();
         if parts.len() < 6 {
-            tracing::warn!("du status line too short: '{line}'");
+            tracing::warn!(line, "df output line too short");
             continue;
         }
 
@@ -590,7 +613,7 @@ fn parse_disk_utilization(df_out: &str) -> eyre::Result<DiskUtilizations> {
         let utilization: u32 = match utilization.parse() {
             Ok(u) => u,
             Err(_) => {
-                tracing::warn!("Can not parse disk utilization in line '{line}'");
+                tracing::warn!(line, "Can not parse disk utilization in line");
                 continue;
             }
         };
@@ -615,7 +638,7 @@ fn parse_status(status_out: &str) -> eyre::Result<SctlStatus> {
     for line in status_out.lines() {
         let parts: Vec<&str> = line.split_ascii_whitespace().collect();
         if parts.len() < 2 {
-            tracing::warn!("supervisorctl status line too short: '{line}'");
+            tracing::warn!(line, "supervisorctl status line too short");
             continue;
         }
         let state: SctlState = match parts[1].parse() {
@@ -623,8 +646,9 @@ fn parse_status(status_out: &str) -> eyre::Result<SctlStatus> {
             Err(_err) => {
                 // unreachable but future proof. SctlState::from_str is currently infallible.
                 tracing::warn!(
-                    "supervisorctl status invalid state '{}' in line '{line}'",
-                    parts[1]
+                    supervisor_state = parts[1],
+                    line,
+                    "supervisorctl status invalid state in line"
                 );
                 continue;
             }
@@ -657,7 +681,7 @@ impl FromStr for SctlState {
             "EXITED" => Self::Exited,
             "FATAL" => Self::Fatal,
             _ => {
-                tracing::warn!("Unknown supervisorctl status '{s}'");
+                tracing::warn!(supervisor_state = s, "Unknown supervisorctl status");
                 Self::Unknown
             }
         })

--- a/crates/agent/src/health/bgp.rs
+++ b/crates/agent/src/health/bgp.rs
@@ -61,7 +61,7 @@ pub async fn check_bgp_stats(
             hbn_device_names,
         ),
         Err(err) => {
-            tracing::warn!("check_network_stats show bgp summary: {err}");
+            tracing::warn!(error = %err, "Failed to fetch BGP summary");
             health_data.other_errors.push(err.to_string());
         }
     };
@@ -73,7 +73,7 @@ pub fn check_daemon_enabled(hr: &mut health_report::HealthReport, hbn_daemons_fi
     let daemons = match std::fs::read_to_string(hbn_daemons_file) {
         Ok(s) => s,
         Err(err) => {
-            tracing::warn!("check_bgp_daemon_enabled: {err}");
+            tracing::warn!(error = %err, "Failed to read BGP daemon configuration");
             failed(
                 hr,
                 probe_ids::BgpDaemonEnabled.clone(),

--- a/crates/agent/src/host_machine_id.rs
+++ b/crates/agent/src/host_machine_id.rs
@@ -93,7 +93,7 @@ pub async fn get_host_machine_id_retry(
         )
         .await
         .map_err(|e| {
-            tracing::warn!("get_host_machine_id() failed: {:?}", e);
+            tracing::warn!(error = ?e, "Failed to get host machine ID");
             e
         })?
         .ok_or(eyre::eyre!("get_host_machine_id() got no value"))

--- a/crates/agent/src/instance_metadata_endpoint.rs
+++ b/crates/agent/src/instance_metadata_endpoint.rs
@@ -124,12 +124,12 @@ impl InstanceMetadataRouterState for InstanceMetadataRouterStateImpl {
 
         let mut client = create_forge_client(&self.forge_api, &self.forge_client_config).await?;
 
-        let timestamp = phone_home(&mut client, &self.machine_id).await?.to_string() + "\n";
+        let timestamp = phone_home(&mut client, &self.machine_id).await?;
 
         tracing::info!(
-            "Successfully phoned home for Machine {} at {}",
-            self.machine_id,
-            timestamp
+            machine_id = %self.machine_id,
+            %timestamp,
+            "Successfully phoned home"
         );
 
         Ok(())

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -264,7 +264,11 @@ impl WithTracingLayer for Router {
         let layer = tower_http::trace::TraceLayer::new_for_http()
             .on_request(move |request: &Request<AxumBody>, _span: &Span| {
                 metrics.http_counter.add(1, &[]);
-                tracing::info!("started {} {}", request.method(), request.uri().path())
+                tracing::info!(
+                    method = %request.method(),
+                    request_path = %request.uri().path(),
+                    "HTTP request started"
+                )
             })
             .on_response(
                 move |_response: &Response<AxumBody>, latency: Duration, _span: &Span| {
@@ -273,7 +277,10 @@ impl WithTracingLayer for Router {
                         .http_req_latency_histogram
                         .record(latency.as_secs_f64() * 1000.0, &[]);
 
-                    tracing::info!("response generated in {:?}", latency)
+                    tracing::info!(
+                        latency_milliseconds = latency.as_secs_f64() * 1000.0,
+                        "HTTP response generated"
+                    )
                 },
             );
 

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -129,7 +129,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
         .machine_identity
         .validate()
         .map_err(|e| eyre::eyre!("invalid [machine-identity] in agent config: {e}"))?;
-    tracing::info!("Using configuration from {path}: {agent:?}");
+    tracing::info!(config_path = path.as_str(), ?agent, "Using configuration");
 
     if agent.machine.is_fake_dpu {
         tracing::warn!("Pretending local host is a DPU. Dev only.");
@@ -243,7 +243,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                 None => NetworkPingerType::OobNetBind,
             };
 
-            tracing::info!("Using {}", pinger_type);
+            tracing::info!(%pinger_type, "Using pinger");
             let pinger: Arc<dyn Ping> = Arc::from(pinger_type);
 
             let mut network_monitor =
@@ -299,7 +299,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
             {
                 Ok(id) => id,
                 Err(e) => {
-                    tracing::error!("get_host_machine_id_retry() failed: {:?}", e);
+                    tracing::error!(error = ?e, "Failed to get host machine ID after retries");
                     return Err(e);
                 }
             };

--- a/crates/agent/src/machine_inventory_updater.rs
+++ b/crates/agent/src/machine_inventory_updater.rs
@@ -38,8 +38,8 @@ pub struct MachineInventoryUpdaterConfig {
 
 pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<()> {
     tracing::trace!(
-        "Updating machine inventory for machine: {}",
-        config.machine_id
+        machine_id = %config.machine_id,
+        "Updating machine inventory"
     );
 
     let machine_id = config.machine_id;
@@ -50,7 +50,7 @@ pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<
 
         let images = container::Images::list().await?;
 
-        tracing::trace!("Containers: {:?}", containers);
+        tracing::trace!(?containers, "Containers");
 
         let mut result: Vec<ContainerSummary> = Vec::new();
 
@@ -104,8 +104,8 @@ pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<
     .await
     {
         tracing::error!(
-            "Error while executing update_agent_reported_inventory: {:#}",
-            e
+            error = ?e,
+            "Failed to update agent-reported inventory"
         );
     } else {
         tracing::debug!("Successfully updated machine inventory");
@@ -134,12 +134,23 @@ async fn update_agent_reported_inventory(
         }
     };
 
-    tracing::trace!("update_machine_inventory: {:?}", inventory_report);
+    let software_component_count = inventory_report
+        .inventory
+        .as_ref()
+        .map_or(0, |inventory| inventory.components.len());
+    tracing::trace!(
+        machine_id = ?inventory_report.machine_id,
+        software_component_count,
+        "Updating machine inventory"
+    );
 
     let request = tonic::Request::new(inventory_report);
     match client.update_agent_reported_inventory(request).await {
         Ok(response) => {
-            tracing::trace!("update_agent_reported_inventory response: {:?}", response);
+            tracing::trace!(
+                ?response,
+                "Received agent-reported inventory update response"
+            );
             Ok(())
         }
         Err(err) => Err(eyre::eyre!(

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -41,7 +41,7 @@ use mac_address::MacAddress;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tracing::log::error;
+use tracing::error;
 use version_compare::Version;
 
 use crate::command_line::HbnConfigMode;
@@ -149,7 +149,7 @@ pub async fn setup_and_run(
                 if let Err(e) = metrics_endpoint::run_metrics_endpoint(&metrics_config).await {
                     tracing::error!(
                         error = format!("{e:#}"),
-                        "Prometheus /metrics endpoint exited with error"
+                        "Prometheus /metrics endpoint exited"
                     );
                 }
             });
@@ -180,7 +180,8 @@ pub async fn setup_and_run(
             Ok(fmds_client) => FmdsUpdater::External(Box::new(fmds_client)),
             Err(e) => {
                 tracing::warn!(
-                    "Failed to connect to external FMDS service: {e:#}, falling back to embedded"
+                    error = format!("{e:#}"),
+                    "Failed to connect to external FMDS service, falling back to embedded"
                 );
                 FmdsUpdater::Embedded(instance_metadata_state.clone())
             }
@@ -193,7 +194,7 @@ pub async fn setup_and_run(
                 instance_metadata_state.clone(),
             )
             .unwrap_or_else(|e| {
-                tracing::warn!("Failed to run metadata service: {:#}", e);
+                tracing::warn!(error = format!("{e:#}"), "Failed to run metadata service");
             });
         }
         tracing::info!("Using FmdsUpdater::Embedded FMDS service");
@@ -208,7 +209,10 @@ pub async fn setup_and_run(
             metrics.record_agent_start_time(timestamp);
         }
         Err(e) => {
-            tracing::warn!("Error calculating process start timestamp: {e:#}");
+            tracing::warn!(
+                error = format!("{e:#}"),
+                "Error calculating process start timestamp"
+            );
         }
     }
 
@@ -217,7 +221,10 @@ pub async fn setup_and_run(
             metrics.record_machine_boot_time(timestamp);
         }
         Err(e) => {
-            tracing::warn!("Error getting host boot timestamp: {e:#}");
+            tracing::warn!(
+                error = format!("{e:#}"),
+                "Error getting host boot timestamp"
+            );
         }
     }
 
@@ -237,7 +244,7 @@ pub async fn setup_and_run(
         // turn it into an unhealthy status that gets reported to the
         // API, so we're not going to do much more than log this for
         // now.
-        tracing::error!("Couldn't ensure DOCA pods: {e}");
+        tracing::error!(error = %e, "Couldn't ensure DOCA pods");
     }
 
     let fmds_minimum_hbn_version = Version::from(FMDS_MINIMUM_HBN_VERSION).ok_or(eyre::eyre!(
@@ -250,7 +257,7 @@ pub async fn setup_and_run(
     if options.agent_platform_type.is_dpu_os()
         && let Err(err) = crate::ovs::set_vswitchd_yield().await
     {
-        tracing::warn!(%err, "Failed asking ovs_vswitchd to not use 100% of a CPU core. Non-fatal.");
+        tracing::warn!(error = %err, "Failed asking ovs_vswitchd to not use 100% of a CPU core. Non-fatal.");
         // We have eight cores. Letting ovs_vswitchd have one is OK.
     };
 
@@ -287,7 +294,7 @@ pub async fn setup_and_run(
     {
         Ok(id) => id,
         Err(e) => {
-            tracing::error!("get_host_machine_id_retry() failed: {:?}", e);
+            tracing::error!(error = ?e, "Failed to get host machine ID after retries");
             return Err(e);
         }
     };
@@ -306,7 +313,7 @@ pub async fn setup_and_run(
     if options.agent_platform_type.is_dpu_os()
         && let Err(e) = lldp::set_lldp_system_description(&machine_id)
     {
-        tracing::warn!("Couldn't update LLDP system description: {e}")
+        tracing::warn!(error = %e, "Couldn't update LLDP system description")
     }
 
     let periodic_config_reader = periodic_config_fetcher.reader();
@@ -343,7 +350,7 @@ pub async fn setup_and_run(
 
     let network_monitor_handle: Option<JoinHandle<()>> = match network_pinger_type {
         Some(pinger_type) => {
-            tracing::debug!("Starting network monitor with {} pinger", pinger_type);
+            tracing::debug!(%pinger_type, "Starting network monitor");
             let mut network_monitor = network_monitor::NetworkMonitor::new(
                 machine_id,
                 Some(network_monitor_metrics_state),
@@ -597,7 +604,10 @@ async fn fetch_last_dhcp_requests(dhcp_grpc_server: Option<&str>) -> Vec<rpc::La
         return match crate::dhcp_server_grpc_client::get_dhcp_timestamps(addr).await {
             Ok(requests) => requests,
             Err(e) => {
-                tracing::warn!("Failed to fetch DHCP timestamps via gRPC: {e:#}");
+                tracing::warn!(
+                    error = format!("{e:#}"),
+                    "Failed to fetch DHCP timestamps via gRPC"
+                );
                 vec![]
             }
         };
@@ -606,8 +616,9 @@ async fn fetch_last_dhcp_requests(dhcp_grpc_server: Option<&str>) -> Vec<rpc::La
     let mut dhcp_timestamps = DhcpTimestamps::new(DhcpTimestampsFilePath::Dpu);
     if let Err(e) = dhcp_timestamps.read() {
         tracing::warn!(
-            "Failed to read from {}: {e}",
-            DhcpTimestampsFilePath::Dpu.path_str()
+            dhcp_timestamps_path = %DhcpTimestampsFilePath::Dpu.path_str(),
+            error = %e,
+            "Failed to read DHCP timestamps file"
         );
     }
     dhcp_timestamps
@@ -719,7 +730,7 @@ impl MainLoop {
                 self.ovs_restart_retry_backoff = None;
             }
         }
-        tracing::info!("Done with Restart OVS can_ack_network_config is {can_ack_network_config}");
+        tracing::info!(can_ack_network_config, "Finished restarting OVS");
 
         can_ack_network_config
     }
@@ -746,7 +757,10 @@ impl MainLoop {
             self.forge_client_config.client_cert_expiry();
 
         let fabric_interfaces = get_fabric_interfaces_data().await.unwrap_or_else(|err| {
-            tracing::warn!("Error getting link data for fabric interfaces: {err:#}");
+            tracing::warn!(
+                error = format!("{err:#}"),
+                "Error getting link data for fabric interfaces"
+            );
             vec![]
         });
 
@@ -832,11 +846,13 @@ impl MainLoop {
                         && let Err(e) = self.hbn_file_configs.ensure_configs().await
                     {
                         tracing::error!(
-                            "Error from HBNContainerFileConfigs::ensure_configs(): {e}"
+                            machine_id = %self.machine_id,
+                            error = %e,
+                            "Failed to ensure HBN container file configuration"
                         );
                     }
 
-                    tracing::trace!("Desired network config is {conf:?}");
+                    tracing::trace!(network_config = ?conf, "Desired network config");
                     // Get the actual virtualization type to use for configuring
                     // an interface, where we'll default to reading the one provided
                     // by the Carbide API, with the ability to override via RunOptions.
@@ -856,8 +872,8 @@ impl MainLoop {
                     let update_result = if self.current_network_version.matches_versions_from(&conf)
                     {
                         tracing::debug!(
-                            "No configuration change, skipping HBN updates: {:?}",
-                            &self.current_network_version
+                            current_network_version = ?self.current_network_version,
+                            "No configuration change, skipping HBN updates"
                         );
                         Ok(false)
                     } else {
@@ -871,7 +887,7 @@ impl MainLoop {
 
                             let fmds_interface_plan =
                                 Interface::plan(self.hbn_device_names.sfs[0], network_plan).await?;
-                            tracing::trace!("Interface plan: {:?}", fmds_interface_plan);
+                            tracing::trace!(interface_plan = ?fmds_interface_plan, "Interface plan");
 
                             // Generate the fmds route plan from conf.tenant_interfaces[n].address
                             // the plan is applied when the nvue template is written
@@ -880,7 +896,7 @@ impl MainLoop {
                                 &proposed_routes,
                             )
                             .await?;
-                            tracing::trace!("Route plan: {:?}", route_plan);
+                            tracing::trace!(route_plan = ?route_plan, "Route plan");
 
                             // Apply the interface plan. This is where we actually configure
                             // the FMDS phone home interface on the DPU.
@@ -1138,7 +1154,7 @@ impl MainLoop {
             if let Err(err) =
                 machine_inventory_updater::single_run(&self.inventory_updater_config).await
             {
-                tracing::error!(%err, "machine_inventory_updater error");
+                tracing::error!(error = %err, "machine_inventory_updater error");
             }
         }
 
@@ -1168,7 +1184,7 @@ impl MainLoop {
             is_healthy,
             has_changed_configs,
             self.seen_blank,
-            num_health_probe_alerts = health_alerts.len(),
+            health_probe_alert_count = health_alerts.len(),
             health_probe_alerts = {
                 let mut result = String::new();
                 for alert in health_alerts.iter() {
@@ -1237,7 +1253,7 @@ impl MainLoop {
                 }
                 Err(e) => {
                     tracing::error!(
-                        self.forge_api_server,
+                        forge_api_server = %self.forge_api_server,
                         error = format!("{e:#}"), // we need alt display for wrap_err_with to work well
                         "upgrade_check failed"
                     );
@@ -1281,8 +1297,8 @@ fn effective_virtualization_type(
         .or(virtualization_type_from_remote)
         .unwrap_or_else(|| {
             tracing::warn!(
-                "Missing network_virtualization_type, defaulting to {}",
-                VpcVirtualizationType::EthernetVirtualizer
+                default_virtualization_type = %VpcVirtualizationType::EthernetVirtualizer,
+                "Missing network_virtualization_type, defaulting"
             );
             VpcVirtualizationType::EthernetVirtualizer
         });
@@ -1319,10 +1335,10 @@ fn ack_network_config_update(
                                 != managed_host_instance_network_config_version
                             {
                                 tracing::warn!(
-                                    "Different instance network config version received. GetManagedHostNetworkConfig: {}, FindInstanceByMachineId: {}, Reporting: {}",
-                                    managed_host_instance_network_config_version,
-                                    instance_metadata_network_config_version,
-                                    reported_instance_network_config_version,
+                                    managed_host_version = %managed_host_instance_network_config_version,
+                                    instance_metadata_version = %instance_metadata_network_config_version,
+                                    reported_version = %reported_instance_network_config_version,
+                                    "Different instance network config version received"
                                 );
                             }
                             reported_instance_network_config_version.version_string()
@@ -1370,7 +1386,7 @@ async fn plan_fmds_armos_routing(
         .iter()
         .find_map(|e| e.addr_info.iter().find(|i| i.family == "inet"));
 
-    tracing::trace!("fmds_interface: {:?}", fmds_interface);
+    tracing::trace!(?fmds_interface, "fmds_interface");
 
     if let Some(ipinterface) = fmds_interface {
         for route in proposed_routes {
@@ -1463,9 +1479,7 @@ async fn get_fabric_interfaces_data()
                 .and_then(|address| address.first())
                 .map(|first_byte| is_universal_unicast(*first_byte))
                 .unwrap_or_else(|| {
-                    tracing::warn!(
-                        "The MAC address for interface {interface_name} was missing or empty"
-                    );
+                    tracing::warn!(interface_name, "The MAC address was missing or empty");
                     false
                 });
 
@@ -1507,7 +1521,7 @@ async fn hack_dpu_os_to_load_atf_uefi_with_specific_versions() -> eyre::Result<(
         let test_data_dir = PathBuf::from(crate::dpu::ARMOS_TEST_DATA_DIR);
 
         std::fs::read_to_string(test_data_dir.join("bfvcheck.out")).map_err(|e| {
-            error!("Could not read bfvcheck.out: {e}");
+            error!(error = %e, "Could not read bfvcheck.out");
             eyre::eyre!("Could not read bfvcheck.out: {}", e)
         })?
     } else {

--- a/crates/agent/src/managed_files.rs
+++ b/crates/agent/src/managed_files.rs
@@ -88,7 +88,7 @@ pub fn main_sync(sync_options: SyncOptions, machine_id: &MachineId, host_machine
         ),
     ]);
     if let Err(e) = duppet::sync(duppet_files, sync_options) {
-        tracing::error!("error during duppet run: {}", e)
+        tracing::error!(error = %e, "error during duppet run")
     }
 }
 

--- a/crates/agent/src/mtu.rs
+++ b/crates/agent/src/mtu.rs
@@ -29,7 +29,10 @@ pub async fn ensure() -> eyre::Result<()> {
         let current = get_mtu(iface).await?;
         if current != CORRECT_MTU {
             tracing::info!(
-                "Interface {iface} has incorrect MTU {current}. Setting to {CORRECT_MTU}."
+                interface_name = iface,
+                current_mtu = current,
+                target_mtu = CORRECT_MTU,
+                "Interface has incorrect MTU. Setting target MTU."
             );
             set_mtu(iface, CORRECT_MTU).await?;
         }
@@ -53,9 +56,9 @@ async fn get_mtu(iface: &str) -> eyre::Result<usize> {
         Ok(o[0].mtu)
     } else {
         tracing::debug!(
-            "STDERR {}: {}",
-            super::pretty_cmd(cmd.as_std()),
-            String::from_utf8_lossy(&out.stderr)
+            command = %super::pretty_cmd(cmd.as_std()),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "MTU query command failed"
         );
         Err(eyre::eyre!(
             "{} for cmd '{}'",
@@ -73,9 +76,9 @@ async fn set_mtu(iface: &str, mtu: usize) -> eyre::Result<()> {
         Ok(())
     } else {
         tracing::debug!(
-            "STDERR {}: {}",
-            super::pretty_cmd(cmd.as_std()),
-            String::from_utf8_lossy(&out.stderr)
+            command = %super::pretty_cmd(cmd.as_std()),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "MTU update command failed"
         );
         Err(eyre::eyre!(
             "{} for cmd '{}'",

--- a/crates/agent/src/netlink.rs
+++ b/crates/agent/src/netlink.rs
@@ -227,7 +227,8 @@ pub async fn get_all_interface_links() -> Result<HashMap<String, InterfaceLinkDa
                 None => {
                     let idx = link_message.header.index;
                     tracing::warn!(
-                        "Network interface with index {idx} doesn't have a name (no IfName attribute)"
+                        interface_index = idx,
+                        "Network interface doesn't have a name (no IfName attribute)"
                     );
                     None
                 }

--- a/crates/agent/src/network_monitor.rs
+++ b/crates/agent/src/network_monitor.rs
@@ -131,7 +131,10 @@ impl NetworkMonitor {
                 loopback_ip = Some(dpu_info.ip);
             }
             Err(e) => {
-                tracing::debug!("Network monitor failed to get dpu info list from API {}", e);
+                tracing::debug!(
+                    error = %e,
+                    "Network monitor failed to get dpu info list from API"
+                );
             }
         }
 
@@ -152,7 +155,10 @@ impl NetworkMonitor {
                             loopback_ip = Some(dpu_info.ip);
                         }
                         Err(e) => {
-                            tracing::debug!("Network monitor failed to get dpu info list from API {}", e);
+                            tracing::debug!(
+                                error = %e,
+                                "Network monitor failed to get dpu info list from API"
+                            );
                             peer_dpus = Vec::new();
                             loopback_ip = None;
                         }
@@ -201,7 +207,7 @@ impl NetworkMonitor {
                         metrics.update_network_reachable_map(reachable_map);
                     }
                 }
-                Err(e) => tracing::error!("Failed to run network check: {}", e),
+                Err(e) => tracing::error!(error = %e, "Failed to run network check"),
             }
             elapsed_time = start_time.elapsed();
         }
@@ -223,14 +229,17 @@ impl NetworkMonitor {
         {
             Ok((dpu_info, new_peer_dpus)) => (dpu_info.ip, new_peer_dpus),
             Err(e) => {
-                tracing::error!("Network monitor failed to get dpu info list from API {}", e);
+                tracing::error!(
+                    error = %e,
+                    "Network monitor failed to get dpu info list from API"
+                );
                 return;
             }
         };
 
         match self.monitor_concurrent(&peer_dpus, loopback_ip).await {
             Ok(results) => self.format_results(&results, loopback_ip.to_string()),
-            Err(e) => tracing::error!("Failed to run network check: {}", e),
+            Err(e) => tracing::error!(error = %e, "Failed to run network check"),
         }
     }
 
@@ -284,8 +293,8 @@ impl NetworkMonitor {
         let results = recv_task.await.map_err(|err| {
             self.record_error_metrics(NetworkMonitorError::TaskJoinError, None);
             tracing::error!(
-                "Failed to join task spawned for collecting ping result: {}",
-                err
+                error = %err,
+                "Failed to join task spawned for collecting ping result"
             );
             err
         })?;
@@ -327,7 +336,7 @@ impl NetworkMonitor {
 
         match serde_json::to_string_pretty(&final_result) {
             Ok(json) => println!("{json}"),
-            Err(e) => tracing::error!("Failed to serialize results to JSON: {}", e),
+            Err(e) => tracing::error!(error = %e, "Failed to serialize results to JSON"),
         }
     }
 

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -938,7 +938,11 @@ pub async fn apply(hbn_root: &Path, config_path: &super::FPath) -> eyre::Result<
             Ok(applied)
         }
         Err(err) => {
-            tracing::error!("update_nvue post command failed: {err:#}");
+            tracing::error!(
+                error = %err,
+                error_chain = format!("{err:#}").replace('\n', "; "),
+                "NVUE post command failed"
+            );
 
             // If the config apply failed, we won't be using it, so move it out
             // of the way to an .error file for others to enjoy (while attempting
@@ -948,8 +952,9 @@ pub async fn apply(hbn_root: &Path, config_path: &super::FPath) -> eyre::Result<
                 && let Err(e) = fs::remove_file(path_error.clone())
             {
                 tracing::warn!(
-                    "Failed to remove previous error file ({}): {e}",
-                    path_error.display()
+                    error_file_path = %path_error.display(),
+                    error = %e,
+                    "Failed to remove previous error file"
                 );
             }
 

--- a/crates/agent/src/ovs.rs
+++ b/crates/agent/src/ovs.rs
@@ -36,7 +36,7 @@ pub async fn set_vswitchd_yield() -> eyre::Result<()> {
         .arg("other_config:pmd-sleep-max=100")
         .kill_on_drop(true);
     let cmd_str = super::pretty_cmd(cmd.as_std());
-    tracing::trace!("set_ovs_vswitchd_yield running: {cmd_str}");
+    tracing::trace!(command = cmd_str.as_str(), "set_ovs_vswitchd_yield running");
 
     // It takes less than 1s, so allow up to 5
     let out = tokio::time::timeout(std::time::Duration::from_secs(5), cmd.output())
@@ -45,12 +45,10 @@ pub async fn set_vswitchd_yield() -> eyre::Result<()> {
         .wrap_err("Error running command")?;
     if !out.status.success() {
         tracing::error!(
-            " STDOUT {cmd_str}: {}",
-            String::from_utf8_lossy(&out.stdout)
-        );
-        tracing::error!(
-            " STDERR {cmd_str}: {}",
-            String::from_utf8_lossy(&out.stderr)
+            command = cmd_str.as_str(),
+            stdout = %String::from_utf8_lossy(&out.stdout),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "OVS command failed"
         );
         eyre::bail!("Failed running ovs-vsctl command. Check logs for stdout/stderr.");
     }

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -111,7 +111,7 @@ impl PeriodicConfigFetcher {
         let sitename = match fetch_sitename(&forge_client_config, &config.forge_api).await {
             Ok(sn) => sn,
             Err(e) => {
-                warn!("Unable to fetch sitename. Error {}", e);
+                warn!(error = %e, "Unable to fetch sitename");
                 None
             }
         };
@@ -190,8 +190,8 @@ async fn single_fetch(
     }
 
     trace!(
-        "Fetching periodic configuration for Machine {}",
-        state.config.machine_id
+        machine_id = %state.config.machine_id,
+        "Fetching periodic configuration"
     );
 
     match fetch(
@@ -213,22 +213,24 @@ async fn single_fetch(
                 }
                 Err(err) => {
                     error!(
-                        "Failed to fetch the latest configuration: {err}.\n Will retry in {:?}",
-                        state.config.config_fetch_interval
+                        error = %err,
+                        retry_interval_seconds = state.config.config_fetch_interval.as_secs_f64(),
+                        "Failed to fetch the latest configuration. Will retry"
                     );
                 }
             };
         }
         Err(err) => match err.downcast_ref::<tonic::Status>() {
             Some(grpc_status) if grpc_status.code() == tonic::Code::NotFound => {
-                warn!("DPU not found: {}", state.config.machine_id);
+                warn!(machine_id = %state.config.machine_id, "DPU not found");
                 state.netconf.store(None);
                 state.instmeta.store(None);
             }
             _ => {
                 error!(
-                    "Failed to fetch the latest configuration. Will retry in {:?}. {err:#?}",
-                    state.config.config_fetch_interval
+                    retry_interval_seconds = state.config.config_fetch_interval.as_secs_f64(),
+                    error = ?err,
+                    "Failed to fetch the latest configuration. Will retry"
                 );
             }
         },
@@ -289,7 +291,7 @@ pub fn instance_metadata_from_instance(
     let devices = match extract_instance_ib_config(&instance) {
         Ok(value) => Some(value),
         Err(e) => {
-            trace!("Failed to fetch IB config: {}", e.to_string());
+            trace!(error = %e, "Failed to fetch IB config");
             None
         }
     };

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -97,7 +97,7 @@ pub fn setup_agent_run_env(
     }
 
     let hbn_root = td.path();
-    tracing::info!("Using hbn_root: {:?}", hbn_root);
+    tracing::info!(?hbn_root, "Using HBN root");
     fs::create_dir_all(hbn_root.join("etc/frr"))?;
     fs::create_dir_all(hbn_root.join("etc/network"))?;
     fs::create_dir_all(hbn_root.join("etc/supervisor/conf.d"))?;

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -336,7 +336,7 @@ async fn run_common_parts(
     // Start forge-dpu-agent
     tokio::spawn(async move {
         if let Err(e) = crate::start(opts).await {
-            tracing::error!("Failed to start DPU agent: {:#}", e);
+            tracing::error!(error = ?e, "Failed to start DPU agent");
         }
     });
 
@@ -1029,7 +1029,7 @@ async fn handle_find_interfaces() -> impl axum::response::IntoResponse {
 }
 
 async fn handler(uri: Uri) -> impl IntoResponse {
-    tracing::debug!("general handler: {:?}", uri);
+    tracing::debug!(?uri, "General request handler received request");
     StatusCode::NOT_FOUND
 }
 

--- a/crates/agent/src/tests/test_network_monitor.rs
+++ b/crates/agent/src/tests/test_network_monitor.rs
@@ -182,7 +182,7 @@ async fn handle_version() -> impl IntoResponse {
 }
 
 async fn handler(uri: Uri) -> impl IntoResponse {
-    tracing::debug!("general handler: {:?}", uri);
+    tracing::debug!(?uri, "General request handler received request");
     StatusCode::NOT_FOUND
 }
 
@@ -323,7 +323,7 @@ impl Ping for MockPinger {
         dpu_info: DpuInfo,
         _interface: IpAddr,
     ) -> Result<DpuPingResult, (NetworkMonitorError, eyre::Report)> {
-        info!("Received ping request for {}", dpu_info);
+        info!(%dpu_info, "Received ping request");
         let ping_result = DpuPingResult {
             dpu_info,
             success_count: 1,

--- a/crates/agent/src/traffic_intercept_bridging.rs
+++ b/crates/agent/src/traffic_intercept_bridging.rs
@@ -98,7 +98,10 @@ pub async fn apply(sh_path: &super::FPath) -> eyre::Result<()> {
             Ok(())
         }
         Err(err) => {
-            tracing::error!("update_intercept_bridging command failed: {err:#}");
+            tracing::error!(
+                error = format!("{err:#}"),
+                "update_intercept_bridging command failed"
+            );
 
             // If the config apply failed, we won't be using it, so move it out
             // of the way to an .error file for others to enjoy (while attempting
@@ -108,8 +111,9 @@ pub async fn apply(sh_path: &super::FPath) -> eyre::Result<()> {
                 && let Err(e) = fs::remove_file(path_error.clone())
             {
                 tracing::warn!(
-                    "Failed to remove previous error file ({}): {e}",
-                    path_error.display()
+                    error_file_path = %path_error.display(),
+                    error = %e,
+                    "Failed to remove previous error file"
                 );
             }
 
@@ -141,7 +145,10 @@ pub async fn run_apply(sh_path: &super::FPath) -> eyre::Result<()> {
     let mut cmd = tokio::process::Command::new("bash");
     cmd.arg(sh_path.to_string()).kill_on_drop(true);
     let cmd_str = super::pretty_cmd(cmd.as_std());
-    tracing::debug!("running intercept bridging commands: {cmd_str}");
+    tracing::debug!(
+        command = cmd_str.as_str(),
+        "running intercept bridging commands"
+    );
 
     let out = tokio::time::timeout(std::time::Duration::from_secs(3), cmd.output())
         .await
@@ -150,12 +157,10 @@ pub async fn run_apply(sh_path: &super::FPath) -> eyre::Result<()> {
 
     if !out.status.success() {
         tracing::error!(
-            " STDOUT {cmd_str}: {}",
-            String::from_utf8_lossy(&out.stdout)
-        );
-        tracing::error!(
-            " STDERR {cmd_str}: {}",
-            String::from_utf8_lossy(&out.stderr)
+            command = cmd_str.as_str(),
+            stdout = %String::from_utf8_lossy(&out.stdout),
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "Intercept bridging command failed"
         );
 
         let path_error = sh_path.with_ext("error");

--- a/crates/agent/src/upgrade.rs
+++ b/crates/agent/src/upgrade.rs
@@ -69,7 +69,10 @@ pub async fn upgrade(
         Err(err) => match err.downcast_ref::<tonic::Status>() {
             Some(grpc_status) if grpc_status.code() == tonic::Code::Internal => {
                 // If something is wrong on the server wait for that to be fixed
-                tracing::error!("Internal server error, will not upgrade. {err:#}");
+                tracing::error!(
+                    error = ?err,
+                    "Internal server error, will not upgrade."
+                );
                 UpgradeCheckResult {
                     should_upgrade: false,
                     ..Default::default()
@@ -77,7 +80,10 @@ pub async fn upgrade(
             }
             _ => {
                 // If something is broken in dpu-agent we need to replace it
-                tracing::error!("Failed upgrade check, forcing upgrade: {err:#}");
+                tracing::error!(
+                    error = ?err,
+                    "Failed upgrade check, forcing upgrade"
+                );
                 UpgradeCheckResult {
                     should_upgrade: true,
                     ..Default::default()
@@ -107,9 +113,10 @@ pub async fn upgrade(
         && let Err(err) = fs::rename(&binary_path, &backup)
     {
         tracing::warn!(
-            "Failed backing up current binary: 'mv {} {}', {err}",
-            binary_path.display(),
-            backup.display()
+            source = %binary_path.display(),
+            destination = %backup.display(),
+            error = %err,
+            "Failed backing up current binary"
         );
         // keep going - if the rename fails we still want the upgrade
     }
@@ -121,12 +128,12 @@ pub async fn upgrade(
         local_build = carbide_version::v!(build_version),
         remote_build = resp.server_version,
         to_package_version = resp.package_version,
-        upgrade_cmd,
+        command = upgrade_cmd,
         version = carbide_version::v!(build_version),
         "Upgrading myself, goodbye.",
     );
     if let Err(err) = clear_apt_metadata_cache() {
-        tracing::warn!(%err, "Failed clearing apt metadata cache");
+        tracing::warn!(error = %err, "Failed clearing apt metadata cache");
         // try the upgrade anyway
     }
     match run_upgrade_cmd(&upgrade_cmd).await {
@@ -136,7 +143,7 @@ pub async fn upgrade(
             Ok(true)
         }
         Err(err) => {
-            tracing::error!(upgrade_cmd, err = format!("{err:#}"), "Upgrade failed");
+            tracing::error!(command = upgrade_cmd, error = ?err, "Upgrade failed");
             if override_upgrade_cmd.is_none() {
                 fs::rename(backup, binary_path)?;
             }
@@ -244,8 +251,14 @@ async fn run_upgrade_cmd(upgrade_cmd: &str) -> eyre::Result<()> {
         .wrap_err("Timeout")?
         .wrap_err("Error running command")?;
     if !out.status.success() {
-        tracing::error!(" STDOUT: {}", String::from_utf8_lossy(&out.stdout));
-        tracing::error!(" STDERR: {}", String::from_utf8_lossy(&out.stderr));
+        tracing::error!(
+            stdout = %String::from_utf8_lossy(&out.stdout),
+            "Upgrade command stdout"
+        );
+        tracing::error!(
+            stderr = %String::from_utf8_lossy(&out.stderr),
+            "Upgrade command stderr"
+        );
         eyre::bail!("Failed running upgrade command. Check logs for stdout/stderr.");
     }
     Ok(())

--- a/crates/agent/src/util.rs
+++ b/crates/agent/src/util.rs
@@ -178,12 +178,12 @@ impl ServiceAddresses {
             .await
             .wrap_err("DNS resolver for carbide-pxe")?;
         // This log should be removed after some time.
-        tracing::info!(?pxe_ips, "Pxe server resolved");
+        tracing::info!(pxe_ip_addresses = ?pxe_ips, "Pxe server resolved");
 
         let ntpservers = match url_resolver.resolve("carbide-ntp.forge").await {
             Ok(x) => {
                 // This log should be removed after some time.
-                tracing::info!(?x, "NTP servers resolved.");
+                tracing::info!(ntp_server_ip_addresses = ?x, "NTP servers resolved.");
                 x
             }
             Err(e) => {

--- a/crates/agent/src/weave_ew_vpc_mock_server.rs
+++ b/crates/agent/src/weave_ew_vpc_mock_server.rs
@@ -71,7 +71,7 @@ impl NetworkIsolationService for DummyNetworkIsolationService {
         request: Request<proto::DeleteVirtualNetworkRequest>,
     ) -> Result<Response<proto::DeleteVirtualNetworkResponse>, Status> {
         let req = request.into_inner();
-        tracing::info!(id = %req.id, "Deleting virtual network");
+        tracing::info!(virtual_network_id = %req.id, "Deleting virtual network");
         Ok(Response::new(proto::DeleteVirtualNetworkResponse {}))
     }
 
@@ -80,7 +80,7 @@ impl NetworkIsolationService for DummyNetworkIsolationService {
         request: Request<proto::GetVirtualNetworkRequest>,
     ) -> Result<Response<proto::GetVirtualNetworkResponse>, Status> {
         let req = request.into_inner();
-        tracing::info!(id = %req.id, "Getting virtual network");
+        tracing::info!(virtual_network_id = %req.id, "Getting virtual network");
 
         let vn = proto::VirtualNetwork {
             metadata: Some(proto::ObjectMetadata {
@@ -188,7 +188,10 @@ impl NetworkIsolationService for DummyNetworkIsolationService {
         request: Request<proto::DeleteVirtualNetworkAttachmentRequest>,
     ) -> Result<Response<proto::DeleteVirtualNetworkAttachmentResponse>, Status> {
         let req = request.into_inner();
-        tracing::info!(id = %req.id, "Deleting virtual network attachment");
+        tracing::info!(
+            virtual_network_attachment_id = %req.id,
+            "Deleting virtual network attachment"
+        );
         Ok(Response::new(
             proto::DeleteVirtualNetworkAttachmentResponse {},
         ))
@@ -199,7 +202,10 @@ impl NetworkIsolationService for DummyNetworkIsolationService {
         request: Request<proto::GetVirtualNetworkAttachmentRequest>,
     ) -> Result<Response<proto::GetVirtualNetworkAttachmentResponse>, Status> {
         let req = request.into_inner();
-        tracing::info!(id = %req.id, "Getting virtual network attachment");
+        tracing::info!(
+            virtual_network_attachment_id = %req.id,
+            "Getting virtual network attachment"
+        );
 
         let vna = proto::VirtualNetworkAttachment {
             metadata: Some(proto::ObjectMetadata {

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3619,7 +3619,7 @@ impl Api {
                     // don't raise the "not set" warning on a transient secrets failure.
                     tracing::warn!(
                         key = %key.to_key_str(),
-                        %err,
+                        error = %err,
                         "could not verify default credential presence",
                     );
                 }

--- a/crates/api-core/src/attestation/measured_boot.rs
+++ b/crates/api-core/src/attestation/measured_boot.rs
@@ -199,7 +199,10 @@ pub fn cli_make_cred(
         "tpm2 makecredential -u {ek_file_path_str} -s {session_key_path_str} -n {ak_name_hex} -o {cred_out_path_str} -G rsa -V --tcti=none"
     );
 
-    tracing::debug!("make credential command is {}", cmd_str);
+    tracing::debug!(
+        command = %cmd_str,
+        "make credential command",
+    );
     // execute the makecredential command
     let output = Command::new("sh")
         .arg("-c")
@@ -213,8 +216,8 @@ pub fn cli_make_cred(
 
     if !output.stderr.is_empty() {
         tracing::error!(
-            "tpm2 makecredential returned error: {}",
-            String::from_utf8_lossy(output.stderr.as_slice())
+            error = %String::from_utf8_lossy(output.stderr.as_slice()),
+            "tpm2 makecredential returned error",
         );
     }
 

--- a/crates/api-core/src/attestation/tpm_ca_cert.rs
+++ b/crates/api-core/src/attestation/tpm_ca_cert.rs
@@ -77,18 +77,18 @@ pub async fn match_insert_new_ek_cert_status_against_ca(
                     ca_id = Some(ca_cert_db_entry.id);
                 }
                 Err(e) => tracing::error!(
-                    "Could not verify signature for EK cert serial - {}, issuer - {}, supposedly signed by CA subject - {}, error: {}",
-                    ek_cert.raw_serial_as_string(),
-                    ek_cert.issuer.to_string(),
-                    ca_cert.subject.to_string(),
-                    e
+                    ek_certificate_serial = %ek_cert.raw_serial_as_string(),
+                    issuer = %ek_cert.issuer.to_string(),
+                    subject = %ca_cert.subject.to_string(),
+                    error = %e,
+                    "Could not verify signature for EK certificate",
                 ),
             }
         }
         None => tracing::info!(
-            "No CA cert found for EK cert: serial - {}, issuer - {}",
-            ek_cert.raw_serial_as_string(),
-            ek_cert.issuer.to_string()
+            ek_certificate_serial = %ek_cert.raw_serial_as_string(),
+            issuer = %ek_cert.issuer.to_string(),
+            "No CA certificate found for EK certificate",
         ),
     }
 
@@ -111,10 +111,10 @@ pub async fn match_insert_new_ek_cert_status_against_ca(
         .await?;
 
         tracing::info!(
-            "Set CA verification status to {} for EK serial - {}, issuer - {}",
             found_signing_ca,
-            ek_cert.raw_serial_as_string(),
-            ek_cert.issuer.to_string()
+            ek_certificate_serial = %ek_cert.raw_serial_as_string(),
+            issuer = %ek_cert.issuer.to_string(),
+            "Set CA verification status for EK certificate",
         );
     } else {
         // we must insert the new entry entirely
@@ -154,10 +154,10 @@ pub async fn match_insert_new_ek_cert_status_against_ca(
         .await?;
 
         tracing::info!(
-            "Added new CA verification status for EK serial - {}, issuer - {}, status is {}",
-            ek_cert.raw_serial_as_string(),
-            ek_cert.issuer.to_string(),
-            found_signing_ca
+            ek_certificate_serial = %ek_cert.raw_serial_as_string(),
+            issuer = %ek_cert.issuer.to_string(),
+            found_signing_ca,
+            "Added new CA verification status for EK certificate",
         );
     }
 
@@ -188,11 +188,11 @@ pub async fn match_update_existing_ek_cert_status_against_ca(
     // verify signature
     if let Err(e) = ek_cert.verify_signature(Some(ca_cert.public_key())) {
         tracing::error!(
-            "Could not verify signature for EK cert serial - {}, issuer - {}, supposedly signed by CA subject - {}, error: {}",
-            ek_cert.raw_serial_as_string(),
-            ek_cert.issuer.to_string(),
-            ca_cert.subject.to_string(),
-            e
+            ek_certificate_serial = %ek_cert.raw_serial_as_string(),
+            issuer = %ek_cert.issuer.to_string(),
+            subject = %ca_cert.subject.to_string(),
+            error = %e,
+            "Could not verify signature for EK certificate",
         );
         return Ok(false); // nothing more to do here
     }
@@ -215,9 +215,9 @@ pub async fn match_update_existing_ek_cert_status_against_ca(
     })?;
 
     tracing::info!(
-        "Set CA verification status to true for EK serial - {}, issuer - {}",
-        ek_cert.raw_serial_as_string(),
-        ek_cert.issuer.to_string()
+        ek_certificate_serial = %ek_cert.raw_serial_as_string(),
+        issuer = %ek_cert.issuer.to_string(),
+        "Set CA verification status for EK certificate",
     );
 
     Ok(true)

--- a/crates/api-core/src/credentials/bmc_session_manager.rs
+++ b/crates/api-core/src/credentials/bmc_session_manager.rs
@@ -346,7 +346,7 @@ impl BmcSessionManager {
                         if let Err(err) = prior_session.delete().await {
                             tracing::warn!(
                                 error = ?err,
-                                %bmc_mac,
+                                bmc_mac_address = %bmc_mac,
                                 spiffe_service_id,
                                 session = %prior_id,
                                 "failed to revoke prior BMC session; \
@@ -355,7 +355,7 @@ impl BmcSessionManager {
                         }
                     } else {
                         tracing::info!(
-                            %bmc_mac,
+                            bmc_mac_address = %bmc_mac,
                             spiffe_service_id,
                             session = %prior_id,
                             "prior BMC session no longer present in Sessions collection; \
@@ -366,7 +366,7 @@ impl BmcSessionManager {
                 Err(err) => {
                     tracing::warn!(
                         error = ?err,
-                        %bmc_mac,
+                        bmc_mac_address = %bmc_mac,
                         spiffe_service_id,
                         "failed to list BMC sessions for prior-session revoke; continuing"
                     );
@@ -406,7 +406,7 @@ impl BmcSessionManager {
             if let Err(revoke_err) = created.delete().await {
                 tracing::warn!(
                     error = ?revoke_err,
-                    %bmc_mac,
+                    bmc_mac_address = %bmc_mac,
                     spiffe_service_id,
                     session = %location,
                     "failed to revoke just-created session after store upsert failed; \
@@ -449,8 +449,8 @@ impl BmcSessionManager {
                 let newly_cached = self.no_session_service.lock().await.insert(bmc_mac);
                 if newly_cached {
                     tracing::info!(
-                        %bmc_mac,
-                        %bmc_addr,
+                        bmc_mac_address = %bmc_mac,
+                        bmc_address = %bmc_addr,
                         "BMC does not expose Redfish SessionService; serving basic-auth credentials for the remainder of this process lifetime"
                     );
                 }
@@ -483,7 +483,7 @@ impl BmcSessionManager {
         if let Err(err) = self.store.delete_by_mac(bmc_mac).await {
             tracing::warn!(
                 error = %err,
-                %bmc_mac,
+                bmc_mac_address = %bmc_mac,
                 "failed to delete BMC session rows during flush_mac; continuing"
             );
         }
@@ -500,7 +500,7 @@ impl BmcSessionManager {
     async fn clear_no_session_service(&self, bmc_mac: MacAddress) {
         if self.no_session_service.lock().await.remove(&bmc_mac) {
             tracing::info!(
-                %bmc_mac,
+                bmc_mac_address = %bmc_mac,
                 "BmcSessionManager: forgetting cached `no SessionService` decision; \
                  next issue_credentials will re-probe"
             );
@@ -538,10 +538,10 @@ impl BmcSessionManager {
         if entry.consecutive_unauthorized >= self.lockout_threshold && entry.tripped_at.is_none() {
             entry.tripped_at = Some(Instant::now());
             tracing::warn!(
-                %bmc_mac,
-                status,
-                consecutive_unauthorized = entry.consecutive_unauthorized,
-                threshold = self.lockout_threshold,
+                bmc_mac_address = %bmc_mac,
+                http_status = status,
+                consecutive_unauthorized_count = entry.consecutive_unauthorized,
+                lockout_threshold_count = self.lockout_threshold,
                 "BmcSessionManager: lockout-avoidance breaker tripped"
             );
             return Some(BmcSessionError::AvoidLockout {
@@ -555,7 +555,10 @@ impl BmcSessionManager {
 
     async fn clear_lockout(&self, bmc_mac: MacAddress) {
         if self.lockouts.lock().await.remove(&bmc_mac).is_some() {
-            tracing::info!(%bmc_mac, "BmcSessionManager: lockout-avoidance breaker cleared");
+            tracing::info!(
+                bmc_mac_address = %bmc_mac,
+                "BmcSessionManager: lockout-avoidance breaker cleared"
+            );
         }
     }
 

--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -55,8 +55,9 @@ pub async fn create_initial_domain(
         let names: Vec<String> = domains.into_iter().map(|d| d.name).collect();
         if !names.iter().any(|n| n == domain_name) {
             tracing::warn!(
-                "Initial domain name '{domain_name}' in config file does not match existing database domains: {:?}",
-                names
+                domain_name,
+                domains = ?names,
+                "Initial domain name in config file does not match existing database domains",
             );
         }
         Ok(false)
@@ -96,7 +97,10 @@ pub async fn create_initial_networks(
             // Network segments are only created the first time we start carbide-api;
             // `reconcile_network_defs` above has already recorded the snapshot if
             // it was missing (the backfill path).
-            tracing::debug!("Network segment {name} exists");
+            tracing::debug!(
+                network_segment_name = %name,
+                "Network segment exists",
+            );
             continue;
         }
 
@@ -129,12 +133,19 @@ pub async fn create_initial_networks(
         // the id because `network_def.segment_id` is FK-bound to it.
         let segment_id = ns.id;
         // update_network_segments_svi_ip will take care of allocating svi ip.
-        tracing::info!("Creating network segment {name} from config: {ns:?}");
+        tracing::info!(
+            network_segment_name = %name,
+            network_segment = ?ns,
+            "Creating network segment from config",
+        );
         crate::handlers::network_segment::save(api, &mut txn, ns, true, false).await?;
         // Snapshot the network definition in the same transaction as the network_segment row,
         // so the two stay consistent across restarts.
         db::network_segment::insert_network_def(&mut txn, name, segment_id, def).await?;
-        tracing::info!("Created network segment {name}");
+        tracing::info!(
+            network_segment_name = %name,
+            "Created network segment",
+        );
     }
 
     ensure_static_assignments_segment(api, &mut txn, Some(domain_id)).await?;
@@ -154,7 +165,10 @@ pub async fn create_initial_vpcs(
             .await
             .is_ok_and(|v| !v.is_empty())
         {
-            tracing::debug!("VPC {name} exists");
+            tracing::debug!(
+                vpc_name = %name,
+                "VPC exists",
+            );
             continue;
         }
 
@@ -194,7 +208,10 @@ pub async fn create_initial_vpcs(
         }
 
         db::vpc::persist(vpc, VpcStatus { vni: Some(vni) }, &mut txn).await?;
-        tracing::info!("Created VPC {name}");
+        tracing::info!(
+            vpc_name = %name,
+            "Created VPC",
+        );
     }
 
     txn.commit().await?;
@@ -246,7 +263,10 @@ pub async fn ensure_static_assignments_segment(
         allocation_strategy: model::network_segment::AllocationStrategy::Reserved,
     };
     crate::handlers::network_segment::save(api, txn, ns, true, false).await?;
-    tracing::info!("Created internal {segment_name} segment for holding static assignments");
+    tracing::info!(
+        network_segment_name = segment_name,
+        "Created internal segment for holding static assignments",
+    );
 
     Ok(())
 }
@@ -311,8 +331,9 @@ pub async fn update_network_segments_svi_ip(db_pool: &Pool<Postgres>) -> Result<
             }
             Err(err) => {
                 tracing::error!(
-                    "Updating SVI IP filed for segment: {} - Error: {err}",
-                    segment.id
+                    network_segment_id = %segment.id,
+                    error = %err,
+                    "Failed to update SVI IP",
                 );
                 txn.rollback().await?;
             }

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -287,8 +287,8 @@ async fn ensure_dhcp_address_for_family(
     }
 
     tracing::info!(
-        interface_id = %machine_interface.id,
-        %parsed_mac,
+        machine_interface_id = %machine_interface.id,
+        client_mac_address = %parsed_mac,
         ?address_family,
         "Interface missing DHCP address for family, allocating from segment"
     );
@@ -419,9 +419,9 @@ async fn handle_dhcp_from_dpa(
         // Log cases where len is neither 0 nor 1.
         if !dpa_ifs.is_empty() {
             tracing::error!(
-                "handle_dpa_message -  invalid dpa_ifs len from find_by_mac_addr maddr: {} len: {}",
-                macaddr,
-                dpa_ifs.len()
+                mac_address = %macaddr,
+                dpa_interface_count = dpa_ifs.len(),
+                "Unexpected number of DPA interfaces found",
             );
         }
         return Ok(None);
@@ -685,8 +685,8 @@ pub async fn discover_dhcp(
             // Fall through so the existing global MAC guard rejects or handles
             // static-assignment moves exactly as IPv4/stateful DHCP does.
             tracing::debug!(
-                %parsed_mac,
-                segment_id = %segment.id,
+                client_mac_address = %parsed_mac,
+                network_segment_id = %segment.id,
                 "DHCPv6 options request will use global MAC segment reconciliation"
             );
         } else if segment.config.allocation_strategy == AllocationStrategy::Reserved

--- a/crates/api-core/src/dhcp/v6.rs
+++ b/crates/api-core/src/dhcp/v6.rs
@@ -72,7 +72,7 @@ pub async fn observe_slaac_address(
     // future segment flag can be added without auditing DHCP call sites.
     let Some(prefix) = segment.slaac_eligible() else {
         tracing::debug!(
-            segment_id = %segment.id,
+            network_segment_id = %segment.id,
             allocation_strategy = ?segment.config.allocation_strategy,
             prefixes = ?segment.prefixes,
             "DHCPv6 SLAAC observation skipped because segment is not SLAAC-eligible"

--- a/crates/api-core/src/dpa/handler.rs
+++ b/crates/api-core/src/dpa/handler.rs
@@ -48,19 +48,20 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
     let tokens: Vec<&str> = topic.split("/").collect();
     if tokens.len() < 3 {
         tracing::error!(
-            "handle_dpa_message: token len {} is unusable topic: {}",
-            tokens.len(),
-            topic
+            token_count = tokens.len(),
+            topic = %topic,
+            "DPA MQTT topic has too few path segments",
         );
         return;
     }
 
     let macaddr = match MacAddress::from_str(tokens[2]) {
         Ok(m) => m,
-        Err(_e) => {
+        Err(error) => {
             tracing::error!(
-                "handle_dpa_message: Unable to parse mac addr: {}",
-                tokens[2]
+                mac_address = tokens[2],
+                error = %error,
+                "Failed to parse DPA MAC address from MQTT topic",
             );
             return;
         }
@@ -68,8 +69,8 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
 
     if message.metadata.is_none() || message.pf_info.is_none() {
         tracing::error!(
-            "handle_dpa_message: message metadata or pf_info is empty: {:#?}",
-            message
+            dpa_message = ?message,
+            "DPA message is missing metadata or PF info",
         );
         return;
     }
@@ -79,7 +80,10 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
     let mut txn = match services.database_connection.begin().await {
         Ok(t) => t,
         Err(e) => {
-            tracing::error!("handle_dpa_message: Unable to start txn: {:#?}", e);
+            tracing::error!(
+                error = ?e,
+                "Failed to start DPA message database transaction",
+            );
             return;
         }
     };
@@ -88,8 +92,9 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
         Ok(ifs) => ifs,
         Err(e) => {
             tracing::error!(
-                "handle_dpa_message: Error for mac {macaddr} from find_by_mac_addr {:#?}",
-                e
+                mac_address = %macaddr,
+                error = ?e,
+                "Failed to find DPA interface",
             );
             return;
         }
@@ -97,8 +102,9 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
 
     if dpa_ifs.len() != 1 {
         tracing::error!(
-            "handle_dpa_message: invalid dpa_ifs len from find_by_mac_addr maddr {macaddr} len {:#?}",
-            dpa_ifs.len()
+            mac_address = %macaddr,
+            dpa_interface_count = dpa_ifs.len(),
+            "Found an invalid DPA interface count",
         );
         return;
     }
@@ -110,9 +116,9 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
         Ok(ncv) => ncv,
         Err(e) => {
             tracing::error!(
-                "handle_dpa_message: Error parsing config version from DPA Ack msg {:#?} {:#?}",
-                message,
-                e
+                dpa_message = ?message,
+                error = ?e,
+                "Failed to parse DPA acknowledgment config version",
             );
             ConfigVersion::invalid()
         }
@@ -135,15 +141,25 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
             Ok(p) => p,
             Err(e) => {
                 tracing::error!(
-                    "handle_dpa_message: Error for vni {vni} from find_by_vni {:#?}",
-                    e
+                    vni = vni,
+                    error = ?e,
+                    "Failed to find SPX partition",
                 );
                 return;
             }
         };
 
-        if partition.len() != 1 {
-            tracing::error!("handle_dpa_message: SPX partition with vni {vni} is not found");
+        if partition.is_empty() {
+            tracing::error!(vni, "SPX partition not found");
+            return;
+        }
+
+        if partition.len() > 1 {
+            tracing::error!(
+                vni,
+                spx_partition_count = partition.len(),
+                "Multiple SPX partitions found",
+            );
             return;
         }
 
@@ -151,13 +167,14 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
         spx_partition_id = spx_partition.id;
 
         tracing::debug!(
-            "handle_dpa_message: SPX partition with vni {vni} found: {:#?}",
-            spx_partition
+            vni = vni,
+            spx_partition = ?spx_partition,
+            "SPX partition found",
         );
     } else {
         tracing::debug!(
-            "handle_dpa_message: received vni 0 in DPA message {:#?}",
-            message
+            dpa_message = ?message,
+            "DPA message has zero VNI",
         );
     }
 
@@ -186,15 +203,21 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
     {
         Ok(m) => m,
         Err(e) => {
-            tracing::error!("handle_dpa_message: Error for machine {:#?}", e);
+            tracing::error!(
+                machine_id = %dpa_if.machine_id,
+                dpa_interface_id = %dpa_if.id,
+                error = ?e,
+                "Failed to find machine",
+            );
             return;
         }
     };
 
     if machine.is_none() {
         tracing::error!(
-            "handle_dpa_message: Machine not found for DPA interface {:#?}",
-            dpa_if
+            machine_id = %dpa_if.machine_id,
+            dpa_interface_id = %dpa_if.id,
+            "Machine not found",
         );
         return;
     }
@@ -233,20 +256,19 @@ async fn handle_dpa_message(services: Arc<Api>, message: SetVni, topic: String) 
     .await
     {
         Ok(_r) => {
-            let res = txn.commit().await;
-            if res.is_err() {
+            if let Err(error) = txn.commit().await {
                 tracing::error!(
-                    "handle_dpa_message: txn commit error for msg {:#?} res {:#?}",
-                    message,
-                    res
+                    dpa_message = ?message,
+                    error = ?error,
+                    "Failed to commit DPA message transaction",
                 );
             }
         }
         Err(e) => {
             tracing::error!(
-                "handle_dpa_message: update_network_observation error for msg {:#?} {:#?}",
-                message,
-                e
+                dpa_message = ?message,
+                error = ?e,
+                "Failed to update DPA network observation",
             );
         }
     }
@@ -306,7 +328,10 @@ pub async fn start_dpa_handler(
                 })
                 .await
                 {
-                    tracing::error!("handle_dpa_message failed: {e}");
+                    tracing::error!(
+                        error = %e,
+                        "Failed to handle DPA message",
+                    );
                 }
             }
         })
@@ -330,9 +355,9 @@ pub async fn start_dpa_handler(
                 || publish_stats.total_published != last_sent
             {
                 tracing::debug!(
-                    received = queue_stats.total_processed,
-                    sent = publish_stats.total_published,
-                    pending = queue_stats.pending_messages,
+                    processed_message_count = queue_stats.total_processed,
+                    published_message_count = publish_stats.total_published,
+                    pending_message_count = queue_stats.pending_messages,
                     "DPA MQTT client stats"
                 );
                 last_processed = queue_stats.total_processed;

--- a/crates/api-core/src/dynamic_settings.rs
+++ b/crates/api-core/src/dynamic_settings.rs
@@ -72,7 +72,10 @@ impl DynamicSettings {
                     }
 
                     if let Err(err) = log_filter.reset_if_expired() {
-                        tracing::error!("Failed resetting log level: {err}");
+                        tracing::error!(
+                            error = %err,
+                            "Failed resetting log level",
+                        );
                     }
                 }
             })

--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -447,7 +447,7 @@ fn log_carbide_error(error: &CarbideError, schema: &OperatorErrorSchema) {
             error_code = %schema.error_code,
             mitigation = %schema.mitigation_for_log(),
             text = %schema.text,
-            location = %location,
+            error_location = %location,
             handler = %handler,
             "Request failed"
         );

--- a/crates/api-core/src/handlers/api.rs
+++ b/crates/api-core/src/handlers/api.rs
@@ -106,9 +106,9 @@ pub(crate) fn set_dynamic_config(
                 ))
             })?;
             tracing::info!(
-                "Log filter updated to '{}'; global log level: {}",
-                req.value,
-                tracing_subscriber::filter::LevelFilter::current()
+                log_filter = %req.value,
+                configured_log_level = %tracing_subscriber::filter::LevelFilter::current(),
+                "Log filter updated",
             );
         }
         rpc::ConfigSetting::CreateMachines => {
@@ -121,7 +121,10 @@ pub(crate) fn set_dynamic_config(
             api.dynamic_settings
                 .create_machines
                 .store(is_enabled, Ordering::Relaxed);
-            tracing::info!("site-explorer create_machines updated to '{}'", req.value);
+            tracing::info!(
+                create_machines = is_enabled,
+                "site-explorer create_machines setting updated",
+            );
         }
         rpc::ConfigSetting::SiteExplorerEnabled => {
             let is_enabled = req.value.parse::<bool>().map_err(|err| {
@@ -133,7 +136,10 @@ pub(crate) fn set_dynamic_config(
             api.dynamic_settings
                 .site_explorer_enabled
                 .store(is_enabled, Ordering::Relaxed);
-            tracing::info!("site-explorer enabled updated to '{}'", req.value);
+            tracing::info!(
+                site_explorer_enabled = is_enabled,
+                "site-explorer enabled setting updated",
+            );
         }
         rpc::ConfigSetting::BmcProxy => {
             let Some(true) = api.runtime_config.site_explorer.allow_changing_bmc_proxy else {
@@ -157,7 +163,10 @@ pub(crate) fn set_dynamic_config(
                     .bmc_proxy
                     .store(Arc::new(Some(host_port_pair)));
             }
-            tracing::info!("site-explorer create_machines updated to '{}'", req.value);
+            tracing::info!(
+                bmc_proxy = %req.value,
+                "BMC proxy setting updated",
+            );
         }
         rpc::ConfigSetting::TracingEnabled => {
             if !api.runtime_config.tracing.allow_runtime_changes {

--- a/crates/api-core/src/handlers/astra.rs
+++ b/crates/api-core/src/handlers/astra.rs
@@ -71,8 +71,8 @@ pub(crate) async fn get_astra_config(
 
     if dpa_interfaces.is_empty() {
         tracing::info!(
-            "No Astra NICs found in host {:#?}, skipping Astra config retrieval",
-            snapshot.host_snapshot.id
+            machine_id = %snapshot.host_snapshot.id,
+            "No Astra NICs found; skipping Astra config retrieval",
         );
         return Ok(None);
     }
@@ -102,8 +102,8 @@ pub(crate) async fn get_astra_config(
             let Some(instance) = instance else {
                 // If use_admin_network is false, we expect an instance to be associated with the host.
                 tracing::error!(
-                    "DPA interface {:#?} is not associated with an instance",
-                    dpa_interface.id
+                    dpa_interface_id = %dpa_interface.id,
+                    "DPA interface is not associated with an instance",
                 );
                 continue;
             };
@@ -121,9 +121,9 @@ pub(crate) async fn get_astra_config(
                     })
             else {
                 tracing::info!(
-                    "SPX attachment {:#?} is not found in instance id {:#?}",
-                    dpa_interface.mac_address,
-                    instance.id
+                    mac_address = %dpa_interface.mac_address,
+                    instance_id = %instance.id,
+                    "SPX attachment was not found",
                 );
                 continue;
             };
@@ -136,13 +136,19 @@ pub(crate) async fn get_astra_config(
             )
             .await?;
             if dpa_vni.is_empty() {
-                tracing::error!("SPX partition {:#?} is not found", spx_partition_id);
+                tracing::error!(
+                    %spx_partition_id,
+                    "SPX partition is not found",
+                );
                 continue;
             }
 
             let dpa_vni = dpa_vni[0].vni.unwrap_or(0);
             if dpa_vni == 0 {
-                tracing::error!("SPX partition {:#?} has no DPA VNI", spx_partition_id);
+                tracing::error!(
+                    %spx_partition_id,
+                    "SPX partition has no DPA VNI",
+                );
                 continue;
             }
 
@@ -243,8 +249,8 @@ pub(crate) async fn process_astra_config_status(
             .and_then(|status| AstraPhase::try_from(status.phase).ok())
         else {
             tracing::info!(
-                "Astra status {:#?} is not READY or DELETING, skipping Astra config status processing",
-                obs
+                astra_status_observation = ?obs,
+                "Astra status is not READY or DELETING, skipping Astra config status processing",
             );
             continue;
         };
@@ -256,9 +262,9 @@ pub(crate) async fn process_astra_config_status(
             Ok(ncv) => ncv,
             Err(e) => {
                 tracing::error!(
-                    "process_astra_config_status: Error parsing config version from DPA Ack msg {:#?} {:#?}",
-                    obs,
-                    e
+                    astra_status_observation = ?obs,
+                    error = ?e,
+                    "Failed to parse Astra DPA acknowledgment config version",
                 );
                 ConfigVersion::invalid()
             }
@@ -280,8 +286,9 @@ pub(crate) async fn process_astra_config_status(
                 Ok(p) => p,
                 Err(e) => {
                     tracing::error!(
-                        "process_astra_config_status: Error for vni {vni} from find_byi {:#?}",
-                        e
+                        vni,
+                        error = ?e,
+                        "Failed to find SPX partition",
                     );
                     continue;
                 }
@@ -290,8 +297,9 @@ pub(crate) async fn process_astra_config_status(
             if partition.len() != 1 {
                 // Given a VNI, we expect exactly one partition to be found.
                 tracing::error!(
-                    "process_astra_config_status: multiple SPX partitions with vni {vni} found, len: {:#?}",
-                    partition.len()
+                    vni,
+                    spx_partition_count = partition.len(),
+                    "Unexpected number of SPX partitions found",
                 );
                 continue;
             }
@@ -300,13 +308,14 @@ pub(crate) async fn process_astra_config_status(
             spx_partition_id = spx_partition.id;
 
             tracing::debug!(
-                "process_astra_config_status: SPX partition with vni {vni} found: {:#?}",
-                spx_partition
+                vni,
+                spx_partition = ?spx_partition,
+                "Found SPX partition",
             );
         } else {
             tracing::debug!(
-                "process_astra_config_status: received vni 0 in DPA message {:#?}",
-                obs
+                astra_status_observation = ?obs,
+                "Received VNI zero in Astra status observation",
             );
         }
 
@@ -321,9 +330,9 @@ pub(crate) async fn process_astra_config_status(
             .find(|dpa_interface| dpa_interface.mac_address == obs_mac)
         else {
             tracing::info!(
-                "DPA interface {:#?} is not found in host {:#?}",
-                obs.mac_address,
-                snapshot.host_snapshot.id
+                mac_address = %obs.mac_address,
+                machine_id = %snapshot.host_snapshot.id,
+                "DPA interface was not found",
             );
             continue;
         };

--- a/crates/api-core/src/handlers/attestation.rs
+++ b/crates/api-core/src/handlers/attestation.rs
@@ -344,8 +344,8 @@ pub(crate) async fn attest_quote(
 
     if attestation_failed {
         tracing::info!(
-            "Attestation failed for machine with id {} - not vending any certs",
-            machine_id
+            machine_id = %machine_id,
+            "Attestation failed; not vending any certificates",
         );
         return Ok(Response::new(rpc::AttestQuoteResponse {
             success: false,
@@ -364,9 +364,9 @@ pub(crate) async fn attest_quote(
     };
 
     tracing::info!(
-        "Attestation succeeded for machine with id {} - sending a cert back. Attestion_enabled is {}",
-        machine_id,
-        api.runtime_config.attestation_enabled
+        machine_id = %machine_id,
+        attestation_enabled = api.runtime_config.attestation_enabled,
+        "Attestation succeeded; sending a certificate",
     );
     Ok(Response::new(rpc::AttestQuoteResponse {
         success: true,

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -202,9 +202,9 @@ pub(crate) async fn admin_bmc_reset(
     let endpoint_address = bmc_endpoint_request.ip_address.clone();
 
     tracing::info!(
-        "Resetting BMC (ipmi tool: {}): {}",
-        req.use_ipmitool,
-        endpoint_address
+        use_ipmitool = req.use_ipmitool,
+        bmc_ip_address = %endpoint_address,
+        "Resetting BMC",
     );
 
     if req.use_ipmitool {
@@ -214,9 +214,9 @@ pub(crate) async fn admin_bmc_reset(
     }
 
     tracing::info!(
-        "BMC Reset (ipmi tool: {}) request succeeded to {}",
-        req.use_ipmitool,
-        endpoint_address
+        use_ipmitool = req.use_ipmitool,
+        bmc_ip_address = %endpoint_address,
+        "BMC reset request succeeded",
     );
 
     Ok(Response::new(rpc::AdminBmcResetResponse {}))
@@ -246,8 +246,8 @@ pub(crate) async fn disable_secure_boot(
 
     let endpoint_address = bmc_endpoint_request.ip_address.clone();
     tracing::info!(
-        "disable_secure_boot request succeeded to {}",
-        endpoint_address
+        bmc_ip_address = %endpoint_address,
+        "Disable secure boot request succeeded",
     );
 
     Ok(Response::new(rpc::DisableSecureBootResponse {}))
@@ -286,9 +286,9 @@ pub(crate) async fn lockdown(
 
     let endpoint_address = bmc_endpoint_request.ip_address.clone();
     tracing::info!(
-        "lockdown {} request succeeded to {}",
-        action.to_string().to_lowercase(),
-        endpoint_address
+        action = %action.to_string().to_lowercase(),
+        bmc_ip_address = %endpoint_address,
+        "lockdown request succeeded",
     );
 
     Ok(Response::new(rpc::LockdownResponse {}))
@@ -356,8 +356,8 @@ pub(crate) async fn enable_infinite_boot(
 
     let endpoint_address = bmc_endpoint_request.ip_address.clone();
     tracing::info!(
-        "enable_infinite_boot request succeeded to {}",
-        endpoint_address
+        bmc_ip_address = %endpoint_address,
+        "Enable infinite boot request succeeded",
     );
 
     Ok(Response::new(rpc::EnableInfiniteBootResponse {}))
@@ -395,9 +395,9 @@ pub(crate) async fn is_infinite_boot_enabled(
         .map_err(|e| CarbideError::internal(e.to_string()))?;
 
     tracing::info!(
-        "is_infinite_boot_enabled request succeeded to {}, result: {:?}",
-        bmc_endpoint_request.ip_address,
-        is_enabled
+        bmc_ip_address = %bmc_endpoint_request.ip_address,
+        is_enabled,
+        "Infinite boot status request succeeded",
     );
 
     Ok(Response::new(rpc::IsInfiniteBootEnabledResponse {
@@ -430,7 +430,10 @@ pub(crate) async fn machine_setup(
 
     let endpoint_address = &bmc_endpoint_request.ip_address;
 
-    tracing::info!("Starting Machine Setup for BMC: {}", endpoint_address);
+    tracing::info!(
+        bmc_ip_address = %endpoint_address,
+        "Starting machine setup",
+    );
 
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
@@ -456,7 +459,10 @@ pub(crate) async fn machine_setup(
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
 
-    tracing::info!("Machine Setup request succeeded to {}", endpoint_address);
+    tracing::info!(
+        bmc_ip_address = %endpoint_address,
+        "Machine setup request succeeded",
+    );
 
     Ok(Response::new(rpc::MachineSetupResponse {}))
 }
@@ -487,8 +493,8 @@ pub(crate) async fn set_dpu_first_boot_order(
     let endpoint_address = &bmc_endpoint_request.ip_address;
 
     tracing::info!(
-        "Setting DPU first in boot order for BMC: {}",
-        endpoint_address
+        bmc_ip_address = %endpoint_address,
+        "Setting DPU first in boot order",
     );
 
     let entered_mac = req
@@ -524,8 +530,8 @@ pub(crate) async fn set_dpu_first_boot_order(
         .map_err(|e| CarbideError::internal(e.to_string()))?;
 
     tracing::info!(
-        "Set DPU first in boot order request succeeded to {}",
-        endpoint_address
+        bmc_ip_address = %endpoint_address,
+        "Set DPU first in boot order request succeeded",
     );
 
     Ok(Response::new(rpc::SetDpuFirstBootOrderResponse {}))
@@ -927,8 +933,10 @@ pub(crate) async fn create_bmc_user(
     };
 
     tracing::info!(
-        "Creating BMC User {} ({role}) on {endpoint_address}",
-        req.create_username,
+        username = %req.create_username,
+        role = %role,
+        bmc_ip_address = %endpoint_address,
+        "Creating BMC user",
     );
 
     do_create_bmc_user(
@@ -941,8 +949,10 @@ pub(crate) async fn create_bmc_user(
     .await?;
 
     tracing::info!(
-        "Successfully created BMC User {} ({role}) on {endpoint_address}",
-        req.create_username
+        username = %req.create_username,
+        role = %role,
+        bmc_ip_address = %endpoint_address,
+        "Successfully created BMC user",
     );
 
     Ok(Response::new(rpc::CreateBmcUserResponse {}))
@@ -972,15 +982,17 @@ pub(crate) async fn delete_bmc_user(
     let endpoint_address = &bmc_endpoint_request.ip_address;
 
     tracing::info!(
-        "Deleting BMC User {} on {endpoint_address}",
-        req.delete_username,
+        username = %req.delete_username,
+        bmc_ip_address = %endpoint_address,
+        "Deleting BMC user",
     );
 
     do_delete_bmc_user(api, &bmc_endpoint_request, &req.delete_username).await?;
 
     tracing::info!(
-        "Successfully deleted BMC User {} on {endpoint_address}",
-        req.delete_username
+        username = %req.delete_username,
+        bmc_ip_address = %endpoint_address,
+        "Successfully deleted BMC user",
     );
 
     Ok(Response::new(rpc::DeleteBmcUserResponse {}))
@@ -1016,14 +1028,14 @@ pub(crate) async fn set_bmc_root_password(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    tracing::info!(%bmc_addr, "Setting BMC root password");
+    tracing::info!(bmc_address = %bmc_addr, "Setting BMC root password");
 
     api.endpoint_explorer
         .set_bmc_root_password(bmc_addr, &machine_interface, &req.new_password)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
 
-    tracing::info!(%bmc_addr, "Successfully set BMC root password");
+    tracing::info!(bmc_address = %bmc_addr, "Successfully set BMC root password");
 
     Ok(Response::new(rpc::SetBmcRootPasswordResponse {}))
 }
@@ -1056,7 +1068,7 @@ pub(crate) async fn probe_bmc_vendor(
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
 
-    tracing::info!(%bmc_addr, %vendor, "Probed BMC vendor");
+    tracing::info!(bmc_address = %bmc_addr, %vendor, "Probed BMC vendor");
 
     Ok(Response::new(rpc::ProbeBmcVendorResponse {
         vendor: vendor.to_string(),

--- a/crates/api-core/src/handlers/bmc_metadata.rs
+++ b/crates/api-core/src/handlers/bmc_metadata.rs
@@ -83,7 +83,7 @@ pub(crate) async fn get_inner(
                     .unwrap_or_default(),
                 bmc_endpoint_request.ip_address
             );
-            tracing::error!(e);
+            tracing::error!(error = %e, "Invalid BMC MAC address");
             CarbideError::internal(e)
         })?;
 

--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -168,7 +168,7 @@ pub(crate) async fn resolve_cloud_init_instructions(
                 tracing::info!(
                     instance_id=%instance.id,
                     machine_id=%instance.machine_id,
-                    state=%managed_host_state,
+                    managed_host_state = %managed_host_state,
                     "cloud-init instructions: machine is not Assigned/Ready, using discovery cloud-init"
                 );
                 let machine_interface = resolve_machine_interface(&mut *conn, client_ip).await?;

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -931,7 +931,7 @@ async fn resolve_switch_endpoints(
                 id: row.switch_id,
                 reason: "NVOS MAC or IP not available".into(),
             };
-            tracing::warn!(%u, "skipping switch");
+            tracing::warn!(switch_id = %u.id, reason = %u.reason, "skipping switch");
             unresolved.push(u);
             resolved_ids.insert(row.switch_id);
             continue;
@@ -950,7 +950,7 @@ async fn resolve_switch_endpoints(
                     id: row.switch_id,
                     reason: format!("BMC credentials unavailable: {e}"),
                 };
-                tracing::warn!(%u, "skipping switch");
+                tracing::warn!(switch_id = %u.id, reason = %u.reason, "skipping switch");
                 unresolved.push(u);
                 continue;
             }
@@ -965,7 +965,7 @@ async fn resolve_switch_endpoints(
                         id: row.switch_id,
                         reason: format!("NVOS credentials unavailable: {e}"),
                     };
-                    tracing::warn!(%u, "skipping switch");
+                    tracing::warn!(switch_id = %u.id, reason = %u.reason, "skipping switch");
                     unresolved.push(u);
                     continue;
                 }
@@ -989,14 +989,14 @@ async fn resolve_switch_endpoints(
                 id: *id,
                 reason: "switch not found in database".into(),
             };
-            tracing::warn!(%u, "skipping switch");
+            tracing::warn!(switch_id = %u.id, reason = %u.reason, "skipping switch");
             unresolved.push(u);
         }
     }
 
     if !unresolved.is_empty() {
         tracing::warn!(
-            count = unresolved.len(),
+            unresolved_switch_count = unresolved.len(),
             "some switches could not be resolved to endpoints"
         );
     }
@@ -1039,21 +1039,23 @@ async fn resolve_power_shelf_endpoints(
     for row in rows {
         resolved_ids.insert(row.power_shelf_id);
 
-        let pmc_credentials =
-            match fetch_powershelf_pmc_credentials(api.credential_manager.as_ref(), row.pmc_mac)
-                .await
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    let u = UnresolvedDevice {
-                        id: row.power_shelf_id,
-                        reason: format!("PMC credentials unavailable: {e}"),
-                    };
-                    tracing::warn!(%u, "skipping power shelf");
-                    unresolved.push(u);
-                    continue;
-                }
-            };
+        let pmc_credentials = match fetch_powershelf_pmc_credentials(
+            api.credential_manager.as_ref(),
+            row.pmc_mac,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                let u = UnresolvedDevice {
+                    id: row.power_shelf_id,
+                    reason: format!("PMC credentials unavailable: {e}"),
+                };
+                tracing::warn!(power_shelf_id = %u.id, reason = %u.reason, "skipping power shelf");
+                unresolved.push(u);
+                continue;
+            }
+        };
 
         mac_to_id.insert(row.pmc_mac, row.power_shelf_id);
         endpoints.push(PowerShelfEndpoint {
@@ -1071,14 +1073,14 @@ async fn resolve_power_shelf_endpoints(
                 id: *id,
                 reason: "power shelf not found in database".into(),
             };
-            tracing::warn!(%u, "skipping power shelf");
+            tracing::warn!(power_shelf_id = %u.id, reason = %u.reason, "skipping power shelf");
             unresolved.push(u);
         }
     }
 
     if !unresolved.is_empty() {
         tracing::warn!(
-            count = unresolved.len(),
+            unresolved_power_shelf_count = unresolved.len(),
             "some power shelves could not be resolved to endpoints"
         );
     }
@@ -1184,7 +1186,7 @@ async fn resolve_compute_tray_endpoints(
 
     if !unresolved.is_empty() {
         tracing::warn!(
-            count = unresolved.len(),
+            unresolved_compute_tray_count = unresolved.len(),
             "some compute trays could not be resolved to endpoints"
         );
     }
@@ -1441,7 +1443,7 @@ pub(crate) async fn component_power_control(
 
                 tracing::info!(
                     backend = cm.nv_switch.name(),
-                    count = endpoints.resolved.endpoints.len(),
+                    switch_count = endpoints.resolved.endpoints.len(),
                     ?action,
                     "power control for switches"
                 );
@@ -1486,7 +1488,7 @@ pub(crate) async fn component_power_control(
 
             tracing::info!(
                 backend = cm.power_shelf.name(),
-                count = endpoints.resolved.endpoints.len(),
+                power_shelf_count = endpoints.resolved.endpoints.len(),
                 ?action,
                 "power control for power shelves"
             );
@@ -1577,7 +1579,7 @@ pub(crate) async fn component_power_control(
 
                 tracing::info!(
                     backend = cm.compute_tray.name(),
-                    count = resolved.resolved.endpoints.len(),
+                    compute_tray_count = resolved.resolved.endpoints.len(),
                     ?action,
                     "power control for compute trays"
                 );
@@ -1663,7 +1665,7 @@ pub(crate) async fn component_configure_switch_certificate(
 
     tracing::info!(
         backend = cm.nv_switch.name(),
-        count = endpoints.resolved.endpoints.len(),
+        switch_count = endpoints.resolved.endpoints.len(),
         "configure switch certificate for switches"
     );
 
@@ -1747,7 +1749,8 @@ async fn power_control_health_override(
         tracing::warn!(
             %machine_id,
             error = %e,
-            "failed to {action} health report override for power control"
+            action,
+            "Failed to apply health report override for power control",
         );
     }
 
@@ -1776,7 +1779,7 @@ async fn request_re_exploration(api: &Api, ips: &[IpAddr]) {
         })
         .await;
     if let Err(e) | Ok(Err(e)) = result {
-        tracing::warn!(?e, "failed to request re-exploration after power control");
+        tracing::warn!(error = ?e, "failed to request re-exploration after power control");
     }
 }
 

--- a/crates/api-core/src/handlers/dns.rs
+++ b/crates/api-core/src/handlers/dns.rs
@@ -40,7 +40,7 @@ async fn lookup_soa_record(
     db: impl DbReader<'_>,
     query_name: &str,
 ) -> Result<DnsResourceRecordReply, tonic::Status> {
-    tracing::debug!("Looking up SOA record for {}", query_name);
+    tracing::debug!(query_name, "Looking up SOA record",);
     let record = resource_record::get_soa_record(db, query_name)
         .await
         .map_err(CarbideError::from)?
@@ -64,7 +64,7 @@ async fn lookup_records_by_qname(
     txn: impl DbReader<'_>,
     query_name: &str,
 ) -> Result<Vec<DnsResourceRecordReply>, tonic::Status> {
-    tracing::debug!("Looking up records for {}", query_name);
+    tracing::debug!(query_name, "Looking up DNS records",);
 
     // dns_records view expects trailing dots (FQDN format)
     let qname_with_dot = if !query_name.ends_with('.') {
@@ -136,7 +136,7 @@ pub async fn get_all_domains(
     )
     .await?;
 
-    tracing::debug!(count = domains.len(), "Found domains");
+    tracing::debug!(domain_count = domains.len(), "Found domains");
     for domain in &domains {
         tracing::debug!(
             domain_id = %domain.id,
@@ -154,7 +154,7 @@ pub async fn get_all_domains(
     let response = protos::dns::GetAllDomainsResponse { result };
 
     tracing::debug!(
-        count = response.result.len(),
+        domain_info_count = response.result.len(),
         "Formatted DomainInfo response"
     );
     Ok(Response::new(response))

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -479,7 +479,10 @@ pub(crate) async fn get_managed_host_network_config_inner(
                 dpu_snapshot.id
             );
 
-            tracing::error!(message);
+            tracing::error!(
+                dpu_machine_id = %dpu_snapshot.id,
+                "FNN-configured DPU has no ASN"
+            );
             CarbideError::internal(message)
         })?
     } else {
@@ -890,7 +893,7 @@ pub(crate) async fn record_dpu_network_status(
         && machine_obs.network_config_version.as_ref() == Some(&dpu_machine.network_config.version)
     {
         tracing::info!(
-            dpu_id = %dpu_machine_id,
+            dpu_machine_id = %dpu_machine_id,
             network_config_version = %dpu_machine.network_config.version,
             agent_version = ?machine_obs.agent_version,
             "Clearing use_admin_network_changed after matching-version ACK; OVS restart may have been skipped by agents that do not support the flag"

--- a/crates/api-core/src/handlers/dpu_remediation.rs
+++ b/crates/api-core/src/handlers/dpu_remediation.rs
@@ -37,7 +37,10 @@ pub fn external_user_name<T>(request: &Request<T>) -> Result<String, CarbideErro
         .and_then(|auth_context| auth_context.get_external_user_name())
         .map(String::from)
     {
-        tracing::info!("remediation_rpc_name_from_cert: {}", external_user_name);
+        tracing::info!(
+            external_user_name = %external_user_name,
+            "Resolved remediation RPC user name from certificate",
+        );
         Ok(external_user_name)
     } else {
         Err(CarbideError::ClientCertificateMissingInformation(

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -151,8 +151,8 @@ pub(crate) async fn create_missing_from(
     for expected_machine in expected_machines {
         if existing_macs.contains(&expected_machine.bmc_mac_address.to_string()) {
             tracing::debug!(
-                "Not overwriting expected-machine with mac_addr: {}",
-                expected_machine.bmc_mac_address
+                bmc_mac_address = %expected_machine.bmc_mac_address,
+                "Expected machine already exists; not overwriting",
             );
             continue;
         }

--- a/crates/api-core/src/handlers/extension_service.rs
+++ b/crates/api-core/src/handlers/extension_service.rs
@@ -142,9 +142,9 @@ pub(crate) async fn create(
                         .await
                 {
                     tracing::warn!(
-                        "Failed to delete credential for extension service {} after transaction failure: {}",
-                        service_id,
-                        delete_err
+                        extension_service_id = %service_id,
+                        error = %delete_err,
+                        "Failed to delete extension service credential after transaction failure",
                     );
                 }
             }
@@ -389,9 +389,9 @@ pub(crate) async fn update(
                             .await
                     {
                         tracing::warn!(
-                            "Failed to delete credential for extension service {} after transaction failure: {}",
-                            service_id,
-                            delete_err
+                            extension_service_id = %service_id,
+                            error = %delete_err,
+                            "Failed to delete extension service credential after transaction failure",
                         );
                     }
                 }
@@ -523,10 +523,10 @@ pub(crate) async fn delete(
                 delete_extension_service_credential(&api.credential_manager, credential_key).await
             {
                 tracing::warn!(
-                    "Failed to delete credential for extension service {} version {}: {}",
-                    service_id,
-                    version,
-                    e
+                    extension_service_id = %service_id,
+                    version = %version,
+                    error = %e,
+                    "Failed to delete extension service credential",
                 );
             }
         }

--- a/crates/api-core/src/handlers/finder.rs
+++ b/crates/api-core/src/handlers/finder.rs
@@ -143,7 +143,7 @@ pub(crate) async fn identify_serial(
 
     if machine_ids.len() > 1 {
         tracing::warn!(
-            matches = machine_ids.len(),
+            matching_machine_count = machine_ids.len(),
             serial_number = req.serial_number,
             "identify_serial: More than one match"
         );
@@ -242,8 +242,8 @@ async fn search(
                 1 => vec_out.remove(0),
                 _ => {
                     tracing::warn!(
-                        ip,
-                        matched_pools = vec_out.len(),
+                        ip_address = ip,
+                        matching_resource_pool_count = vec_out.len(),
                         "Multiple resource pools match this IP. This seems like a mistake. Using only first.",
                     );
                     vec_out.remove(0)
@@ -515,12 +515,17 @@ async fn by_mac(
         }
         Ok(interfaces) => {
             tracing::error!(
-                "Found {} MachineInterface entries for MAC address {mac}. Should be impossible",
-                interfaces.len()
+                interface_count = interfaces.len(),
+                mac_address = %mac,
+                "Found machine interface entries; should be impossible",
             );
         }
         Err(err) => {
-            tracing::error!(%err, %mac, "DB error db::machine_interface::find_by_mac_address");
+            tracing::error!(
+                error = %err,
+                mac_address = %mac,
+                "DB error db::machine_interface::find_by_mac_address"
+            );
         }
     }
 
@@ -545,11 +550,16 @@ async fn by_mac(
             [iface] => return Ok(Some((iface.id.to_string(), rpc::MacOwner::DpaInterface))),
             [] => {} // expected, continue to search other object types
             _ => tracing::error!(
-                "Found {} DpaInterfaces entries for MAC address {mac}. Should be impossible",
-                ifs.len()
+                dpa_interface_count = ifs.len(),
+                mac_address = %mac,
+                "Found DPA interface entries; should be impossible",
             ),
         },
-        Err(e) => tracing::error!("by_mac - Error from find_by_mac_addr for DPA: {e}"),
+        Err(e) => tracing::error!(
+            mac_address = %mac,
+            error = %e,
+            "Failed to find DPA interface",
+        ),
     };
 
     // Any other MAC addresses to search?

--- a/crates/api-core/src/handlers/firmware.rs
+++ b/crates/api-core/src/handlers/firmware.rs
@@ -59,10 +59,10 @@ pub(crate) async fn set_firmware_update_time_window(
     let mut txn = api.txn_begin().await?;
 
     tracing::info!(
-        "set_firmware_update_time_window: Setting update start/end ({:?} {:?}) for {:?}",
-        chrono::Utc.timestamp_opt(start, 0),
-        chrono::Utc.timestamp_opt(end, 0),
-        request.machine_ids
+        start_time = ?chrono::Utc.timestamp_opt(start, 0),
+        end_time = ?chrono::Utc.timestamp_opt(end, 0),
+        machine_ids = ?request.machine_ids,
+        "Setting firmware update time window",
     );
 
     db::machine::update_firmware_update_time_window_start_end(

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -181,7 +181,7 @@ pub(crate) async fn batch_allocate(
     }
 
     tracing::info!(
-        count = batch_request.instance_requests.len(),
+        instance_request_count = batch_request.instance_requests.len(),
         "Received batch instance allocation request"
     );
 
@@ -224,7 +224,7 @@ pub(crate) async fn batch_allocate(
         })?;
 
     tracing::info!(
-        count = instances.len(),
+        instance_count = instances.len(),
         "Successfully allocated batch of instances"
     );
 
@@ -448,8 +448,8 @@ fn log_delete_attribution(delete_attribution: Option<&rpc::DeleteAttribution>) {
     };
 
     tracing::info!(
-        org = %initiated_by.org,
-        org_display_name = %initiated_by.org_display_name,
+        organization = %initiated_by.org,
+        organization_display_name = %initiated_by.org_display_name,
         user_id = %initiated_by.user_id,
         tenant_id = %initiated_by.tenant_id,
         "Instance delete attribution"
@@ -1027,7 +1027,11 @@ pub(crate) async fn invoke_power(
                 .await
                 .map_err(|err| {
                     // print actual error for debugging, but don't leak internal info to user.
-                    tracing::error!(machine=%machine_id, "{:?}", err);
+                    tracing::error!(
+                        machine_id = %machine_id,
+                        error = ?err,
+                        "failed to approve DPU reprovision request",
+                    );
 
                     // TODO: What does this error actually mean
                     CarbideError::internal(
@@ -1042,7 +1046,11 @@ pub(crate) async fn invoke_power(
                 .await
                 .map_err(|err| {
                     // print actual error for debugging, but don't leak internal info to user.
-                    tracing::error!(machine=%machine_id, "{:?}", err);
+                    tracing::error!(
+                        machine_id = %machine_id,
+                        error = ?err,
+                        "failed to approve host reprovision request",
+                    );
 
                     CarbideError::internal(
                         "Internal Failure. Try again after some time.".to_string(),
@@ -1184,7 +1192,10 @@ pub(crate) async fn update_instance_config(
         Some(config) => config.try_into().map_err(CarbideError::from)?,
     };
 
-    tracing::info!("SPX update_instance_config config: {:?}", config.spxconfig);
+    tracing::info!(
+        spx_config = ?config.spxconfig,
+        "Updating instance SPX config",
+    );
 
     // Network validation is done only if network update is requested.
     config
@@ -1370,16 +1381,16 @@ pub(crate) async fn update_instance_config(
     .await?;
 
     tracing::debug!(
-        "Updating instance {} with NVLink config {:?}",
-        instance.id,
-        config.nvlink
+        instance_id = %instance.id,
+        nvlink = ?config.nvlink,
+        "Updating instance NVLink configuration",
     );
     update_instance_nvlink_config(&mh_snapshot, &instance, &config.nvlink, &mut txn).await?;
 
     tracing::debug!(
-        "Updating instance {} with Spx config {:?}",
-        instance.id,
-        config.spxconfig
+        instance_id = %instance.id,
+        spx_config = ?config.spxconfig,
+        "Updating instance SPX configuration",
     );
     update_instance_spx_config(&mh_snapshot, &instance, &mut config.spxconfig, &mut txn).await?;
 

--- a/crates/api-core/src/handlers/instance_type.rs
+++ b/crates/api-core/src/handlers/instance_type.rs
@@ -596,7 +596,9 @@ pub(crate) async fn associate_machines(
 
     if ids.len() != machine_versions.len() {
         tracing::error!(
-            "Not all machine's instances updated. This should never happen because we take row-lock. Something is terribly wrong. ids: {ids:?}; versions: {machine_versions:?}"
+            ids = ?ids,
+            machine_versions = ?machine_versions,
+            "Not all machine-to-instance-type associations were updated; row locking should have prevented this",
         )
     }
 
@@ -700,7 +702,7 @@ pub(crate) async fn remove_machine_association(
 
         // Check if the new machine count would drop below the sum of active allocation counts.
         if new_total_machine_count < total_allocations {
-            let matchine_id = machine.id;
+            let machine_id = machine.id;
             // # enforce_if_present:  If allocations are found for instance type ID, enforce it; otherwise, it's like no limits.
             // # always:              Enforce allocations.  If none are found, its a constraint value of 0 (i.e., you get nothing).
             // # warn_only (default): Don't enforce, but log what would have happened if they were enforced.
@@ -716,10 +718,10 @@ pub(crate) async fn remove_machine_association(
                     ).into());
                 }
                 (false, ComputeAllocationEnforcement::EnforceIfPresent) => {
-                    tracing::debug!(%matchine_id, %instance_type_id, "EnforceIfPresent set but no allocations seen during machine removal from instance type");
+                    tracing::debug!(%machine_id, %instance_type_id, "EnforceIfPresent set but no allocations seen during machine removal from instance type");
                 }
                 (_, ComputeAllocationEnforcement::WarnOnly) => {
-                    tracing::warn!(%matchine_id, %instance_type_id, "request to remove machine from instance type would reduce associated machine count below current tenant allocations count but enforcement is not enabled");
+                    tracing::warn!(%machine_id, %instance_type_id, "request to remove machine from instance type would reduce associated machine count below current tenant allocations count but enforcement is not enabled");
                 }
             }
         }

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -23,7 +23,6 @@ use ::rpc::model::machine::ManagedHostStateSnapshotRpc;
 use carbide_redfish::libredfish::RedfishAuth;
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey};
 use carbide_uuid::machine::MachineId;
-use itertools::Itertools;
 use libredfish::SystemPowerControl;
 use model::hardware_info::MachineNvLinkInfo;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -345,8 +344,11 @@ pub(crate) async fn admin_force_delete_machine(
         .unwrap_or("unknown");
 
     tracing::info!(
-        "admin_force_delete_machine query='{query}' machine_id={} serial='{serial}' issued_by={issued_by:?}",
-        machine.id
+        query = %query,
+        machine_id = %machine.id,
+        serial,
+        issued_by = ?issued_by,
+        "Admin force-delete machine request",
     );
 
     if machine.instance_type_id.is_some() {
@@ -363,7 +365,11 @@ pub(crate) async fn admin_force_delete_machine(
     let dpu_machines;
     if machine.is_dpu() {
         if let Some(host) = db::machine::find_host_by_dpu_machine_id(&mut txn, &machine.id).await? {
-            tracing::info!("Found host Machine {:?}", machine.id.to_string());
+            tracing::info!(
+                host_machine_id = %host.id,
+                dpu_machine_id = %machine.id,
+                "Found host machine",
+            );
             // Get all DPUs attached to this host, in case there are more than one.
             dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &host.id).await?;
             host_machine = Some(host);
@@ -374,8 +380,8 @@ pub(crate) async fn admin_force_delete_machine(
     } else {
         dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine.id).await?;
         tracing::info!(
-            "Found dpu Machines {:?}",
-            dpu_machines.iter().map(|m| m.id.to_string()).join(", ")
+            dpu_machine_ids = ?dpu_machines.iter().map(|m| &m.id).collect::<Vec<_>>(),
+            "Found DPU machines",
         );
         host_machine = Some(machine);
     }
@@ -467,7 +473,7 @@ pub(crate) async fn admin_force_delete_machine(
             if let Some(bmc_mac_address) = machine.bmc_info.mac {
                 let ip_address = ip.to_string();
                 tracing::info!(
-                    %ip,
+                    bmc_ip_address = %ip,
                     machine_id = %machine.id,
                     "BMC IP and MAC address for machine was found. Trying to perform Bios unlock",
                 );
@@ -494,7 +500,7 @@ pub(crate) async fn admin_force_delete_machine(
                                 response.machine_unlocked = false;
                             }
                             Ok(status) => {
-                                tracing::info!(%machine_id, ?status, "Unlocking BIOS");
+                                tracing::info!(%machine_id, bios_lockdown_status = ?status, "Unlocking BIOS");
                                 if let Err(e) =
                                     client.lockdown(libredfish::EnabledDisabled::Disabled).await
                                 {
@@ -584,14 +590,14 @@ pub(crate) async fn admin_force_delete_machine(
                 }
             } else {
                 tracing::warn!(
-                    "Failed to unlock this host because Forge could not retrieve the BMC MAC address for machine {}",
-                    machine.id
+                    machine_id = %machine.id,
+                    "Failed to unlock host because the BMC MAC address is missing",
                 );
             }
         } else {
             tracing::warn!(
-                "Failed to unlock this host because Forge could not retrieve the BMC IP address for machine {}",
-                machine.id
+                machine_id = %machine.id,
+                "Failed to unlock host because the BMC IP address is missing",
             );
         }
 
@@ -637,7 +643,11 @@ pub(crate) async fn admin_force_delete_machine(
     if let Some(machine) = &host_machine
         && let Some(addr) = machine.bmc_info.ip
     {
-        tracing::info!("Cleaning up explored endpoint at {addr} {}", machine.id);
+        tracing::info!(
+            bmc_ip_address = %addr,
+            machine_id = %machine.id,
+            "Cleaning up explored endpoint",
+        );
 
         // If this delete waited out a concurrent exploration rewrite, its
         // statement snapshot can miss the row that rewrite re-inserted; the
@@ -649,7 +659,11 @@ pub(crate) async fn admin_force_delete_machine(
     }
     for dpu_machine in dpu_machines.iter() {
         if let Some(addr) = dpu_machine.bmc_info.ip {
-            tracing::info!("Cleaning up explored endpoint at {addr} {}", dpu_machine.id);
+            tracing::info!(
+                bmc_ip_address = %addr,
+                machine_id = %dpu_machine.id,
+                "Cleaning up explored endpoint",
+            );
 
             db::explored_endpoints::delete(&mut txn, addr).await?;
         }
@@ -692,9 +706,9 @@ pub(crate) async fn admin_force_delete_machine(
         {
             // just log the error and carry on
             tracing::error!(
-                "Could not remove EK cert status for machine with id {}: {}",
-                machine.id,
-                e
+                machine_id = %machine.id,
+                error = %e,
+                "Could not remove EK certificate status",
             );
         }
     }
@@ -818,9 +832,9 @@ fn snapshot_map_to_rpc_machines(
 async fn clear_bmc_credentials(api: &Api, machine: &Machine) -> Result<(), CarbideError> {
     if let Some(mac_address) = machine.bmc_info.mac {
         tracing::info!(
-            "Cleaning up BMC credentials in vault at {} for machine {}",
-            mac_address,
-            machine.id
+            bmc_mac_address = %mac_address,
+            machine_id = %machine.id,
+            "Cleaning up BMC credentials in vault",
         );
         crate::handlers::credential::delete_bmc_root_credentials_by_mac(api, mac_address).await?;
     }
@@ -875,16 +889,16 @@ pub async fn get_machine_position_info(
             .filter_map(|(machine_id, ip_opt)| match ip_opt {
                 Some(ip_str) => ip_str.parse().ok().or_else(|| {
                     tracing::warn!(
-                        "Failed to parse BMC IP '{}' for machine {}",
-                        ip_str,
-                        machine_id
+                        bmc_ip_address = %ip_str,
+                        machine_id = %machine_id,
+                        "Failed to parse BMC IP",
                     );
                     None
                 }),
                 None => {
                     tracing::warn!(
-                        "Machine {} has topology but no BMC IP configured",
-                        machine_id
+                        machine_id = %machine_id,
+                        "Machine has topology but no BMC IP configured",
                     );
                     None
                 }

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -127,8 +127,8 @@ pub(crate) async fn discover_machine(
     db::machine_interface::lock_all_admin_segments(&mut txn).await?;
 
     tracing::debug!(
-        ?remote_ip,
-        ?interface_id,
+        remote_ip_address = ?remote_ip,
+        machine_interface_id = ?interface_id,
         "discover_machine loading interface"
     );
 
@@ -362,7 +362,7 @@ pub(crate) async fn discover_machine(
             .await?;
 
             tracing::info!(
-                ?mi_id,
+                machine_interface_id = ?mi_id,
                 machine_id = %proactive_machine.id,
                 "Created host machine proactively",
             );
@@ -417,10 +417,10 @@ pub(crate) async fn discover_machine(
         )
     } else {
         tracing::info!(
-            "Attestation enabled is {}. Is_DPU is {}. Vending certs to machine with id {}",
-            api.runtime_config.attestation_enabled,
-            hardware_info.is_dpu(),
-            stable_machine_id,
+            attestation_enabled = api.runtime_config.attestation_enabled,
+            is_dpu = hardware_info.is_dpu(),
+            %stable_machine_id,
+            "Vending attestation certificates",
         );
 
         None

--- a/crates/api-core/src/handlers/machine_identity.rs
+++ b/crates/api-core/src/handlers/machine_identity.rs
@@ -194,8 +194,8 @@ pub(crate) async fn sign_machine_identity(
             .await
             .inspect_err(|e| {
                 tracing::error!(
-                    org_id = %identity_row.organization_id.as_str(),
-                    message = %e.message(),
+                    organization_id = %identity_row.organization_id.as_str(),
+                    error = %e.message(),
                     "tenant signing key decrypt failed"
                 );
             })
@@ -244,8 +244,8 @@ pub(crate) async fn sign_machine_identity(
         .await
         .inspect_err(|e| {
             tracing::error!(
-                org_id = %identity_row.organization_id.as_str(),
-                message = %e.message(),
+                organization_id = %identity_row.organization_id.as_str(),
+                error = %e.message(),
                 "token delegation auth config decrypt failed"
             );
         })?;

--- a/crates/api-core/src/handlers/machine_interface.rs
+++ b/crates/api-core/src/handlers/machine_interface.rs
@@ -209,7 +209,7 @@ pub(crate) async fn find_bmc_ips(
                 Ok(ip) => vec![ip],
                 Err(e) => {
                     tracing::warn!(
-                        %bmc_ip,
+                        bmc_ip_address = %bmc_ip,
                         error = %e,
                         "BMC IP from machine_interfaces did not parse; skipping"
                     );

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -74,8 +74,8 @@ pub async fn update_preallocated_machine_interface(
 
             tracing::info!(
                 %bmc_mac_address,
-                %bmc_ip,
-                interface_id = %iface.id,
+                bmc_ip_address = %bmc_ip,
+                machine_interface_id = %iface.id,
                 "Assigned static address to existing interface without addresses"
             );
         } else {
@@ -84,7 +84,7 @@ pub async fn update_preallocated_machine_interface(
             // The caller updates the expected data table; we just log.
             tracing::info!(
                 %bmc_mac_address,
-                %bmc_ip,
+                bmc_ip_address = %bmc_ip,
                 existing_addresses = ?iface.addresses,
                 "Interface already has addresses, updated expected data only"
             );
@@ -105,8 +105,8 @@ pub async fn update_preallocated_machine_interface(
 
         tracing::info!(
             %bmc_mac_address,
-            %bmc_ip,
-            segment_id = %segment.id,
+            bmc_ip_address = %bmc_ip,
+            network_segment_id = %segment.id,
             "Pre-allocated static machine interface"
         );
     }
@@ -143,10 +143,10 @@ pub async fn assign_static_address(
         )
         .await?;
         tracing::info!(
-            %interface_id,
+            machine_interface_id = %interface_id,
             %ip_address,
-            old_segment_id = %current_iface.segment_id,
-            new_segment_id = %target_segment.id,
+            previous_network_segment_id = %current_iface.segment_id,
+            next_network_segment_id = %target_segment.id,
             "Moved interface to correct segment for static address"
         );
     }
@@ -154,7 +154,7 @@ pub async fn assign_static_address(
     txn.commit().await?;
 
     let status: rpc::AssignStaticAddressStatus = result.into();
-    tracing::info!(%interface_id, %ip_address, ?status, "Static address assignment");
+    tracing::info!(machine_interface_id = %interface_id, %ip_address, assignment_status = ?status, "Static address assignment");
 
     Ok(Response::new(rpc::AssignStaticAddressResponse {
         interface_id: Some(interface_id),
@@ -183,10 +183,10 @@ pub async fn remove_static_address(
     txn.commit().await?;
 
     let status = if deleted {
-        tracing::info!(%interface_id, %ip_address, "Removed static address");
+        tracing::info!(machine_interface_id = %interface_id, %ip_address, "Removed static address");
         rpc::RemoveStaticAddressStatus::Removed
     } else {
-        tracing::info!(%interface_id, %ip_address, "Static address not found");
+        tracing::info!(machine_interface_id = %interface_id, %ip_address, "Static address not found");
         rpc::RemoveStaticAddressStatus::NotFound
     };
 

--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -208,12 +208,12 @@ pub(crate) async fn forge_agent_control(
                     },
             } => {
                 tracing::info!(
-                    " context : {} id: {} is_enabled: {}, completed {}, total {}",
-                    context,
-                    id,
-                    is_enabled,
-                    completed,
-                    total,
+                    context = %context,
+                    machine_validation_id = %id,
+                    is_enabled = *is_enabled,
+                    completed_validation_count = *completed,
+                    total_validation_count = *total,
+                    "Machine validation progress reported by scout",
                 );
                 if *is_enabled {
                     db::machine_validation::update_status(
@@ -289,9 +289,9 @@ pub(crate) async fn forge_agent_control(
                 let last_cleanup_time = host_machine.last_cleanup_time;
                 let state_version = host_machine.state.version;
                 tracing::info!(
-                    "last_cleanup_time: {:?}, state_version: {:?}",
-                    last_cleanup_time,
-                    state_version
+                    last_cleanup_time = ?last_cleanup_time,
+                    machine_state_version = ?state_version,
+                    "Checking whether machine cleanup is current",
                 );
                 // Check scout has already cleaned up the machine
                 if last_cleanup_time.unwrap_or_default() > state_version.timestamp() {
@@ -305,9 +305,9 @@ pub(crate) async fn forge_agent_control(
                 bom_validating_state: BomValidating::UpdatingInventory(_),
             } => {
                 tracing::info!(
-                    "Request Discovery {} < {}",
-                    machine.last_discovery_time.unwrap_or_default(),
-                    machine.current_version().timestamp()
+                    last_discovery_time = %machine.last_discovery_time.unwrap_or_default(),
+                    current_version_time = %machine.current_version().timestamp(),
+                    "Checking whether machine discovery is stale",
                 );
                 if machine.last_discovery_time.unwrap_or_default()
                     < machine.current_version().timestamp()
@@ -325,7 +325,11 @@ pub(crate) async fn forge_agent_control(
                 match crate::handlers::svpc::process_scout_req(api, machine_id).await {
                     Ok(action) => (action, None),
                     Err(e) => {
-                        tracing::error!("Error returned from process_scout_req: {e}");
+                        tracing::error!(
+                            machine_id = %machine_id,
+                            error = %e,
+                            "Failed to process Scout request",
+                        );
                         (Action::noop(), None)
                     }
                 }
@@ -349,7 +353,8 @@ pub(crate) async fn forge_agent_control(
                     Ok(task) => Action::FirmwareUpgrade(fac::FirmwareUpgrade { task: Some(task) }),
                     Err(e) => {
                         tracing::warn!(
-                            "Could not deserialize firmware upgrade task, sending no-op action to scout: {e}"
+                            error = %e,
+                            "Could not deserialize firmware upgrade task, sending no-op action to scout",
                         );
                         Action::noop()
                     }
@@ -362,7 +367,7 @@ pub(crate) async fn forge_agent_control(
                 tracing::info!(
                     machine_id = %machine.id,
                     machine_type = "Host",
-                    %state,
+                    agent_control_state = %state,
                     "forge agent control",
                 );
                 (Action::noop(), Some(txn))

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -82,13 +82,13 @@ pub(crate) async fn mark_machine_validation_complete(
     let machine = match db::machine::find_by_validation_id(&mut txn, validation_id).await? {
         Some(machine) => machine,
         None => {
-            tracing::error!(%validation_id, "validation id not found");
+            tracing::error!(machine_validation_id = %validation_id, "validation id not found");
             return Err(CarbideError::InvalidArgument("wrong validation ID".to_string()).into());
         }
     };
 
     if machine.id != machine_id {
-        tracing::error!(validation_id = %validation_id, machine_id = %machine_id, "Validation ID does not belong to provided Machine ID");
+        tracing::error!(machine_validation_id = %validation_id, machine_id = %machine_id, "Validation ID does not belong to provided Machine ID");
         return Err(CarbideError::InvalidArgument(
             "Validation ID does not belong to provided Machine ID".to_string(),
         )
@@ -121,7 +121,7 @@ pub(crate) async fn mark_machine_validation_complete(
     if !completed {
         tracing::info!(
             %machine_id,
-            %validation_id,
+            machine_validation_id = %validation_id,
             "machine validation completion ignored because run is no longer active"
         );
         txn.commit().await?;
@@ -252,26 +252,30 @@ pub(crate) async fn persist_validation_result(
 
     let validation_result: MachineValidationResult = result.try_into()?;
 
-    tracing::trace!(validation_id = %validation_result.validation_id);
+    tracing::trace!(
+        machine_validation_id = %validation_result.validation_id,
+        "Received machine validation result"
+    );
 
     let mut txn = api.txn_begin().await?;
 
-    let machine =
-        match db::machine::find_by_validation_id(&mut txn, &validation_result.validation_id).await?
-        {
-            Some(machine) => machine,
-            None => {
-                tracing::error!(%validation_result.validation_id, "validation id not found");
-                return Err(
-                    CarbideError::InvalidArgument("wrong validation ID".to_string()).into(),
-                );
-            }
-        };
+    let machine = match db::machine::find_by_validation_id(
+        &mut txn,
+        &validation_result.validation_id,
+    )
+    .await?
+    {
+        Some(machine) => machine,
+        None => {
+            tracing::error!(machine_validation_id = %validation_result.validation_id, "validation id not found");
+            return Err(CarbideError::InvalidArgument("wrong validation ID".to_string()).into());
+        }
+    };
     let machine_validation =
         db::machine_validation::find_by_id(&mut txn, &validation_result.validation_id).await?;
     if !db::machine_validation::is_active(&machine_validation) {
         tracing::info!(
-            validation_id = %validation_result.validation_id,
+            machine_validation_id = %validation_result.validation_id,
             machine_id = %machine.id,
             "machine validation result ignored because run is no longer active"
         );
@@ -284,13 +288,19 @@ pub(crate) async fn persist_validation_result(
         ManagedHostState::Validation { validation_state } => {
             match validation_state {
                 ValidationState::MachineValidation { .. } => {
-                    tracing::info!("machine state is  {}", machine.current_state());
+                    tracing::info!(
+                        machine_state = %machine.current_state(),
+                        "Machine is in validation state",
+                    );
                     //Continue to persist data
                 }
             }
         }
         _ => {
-            tracing::error!("invalid host machine state {}", machine.current_state());
+            tracing::error!(
+                machine_state = %machine.current_state(),
+                "invalid host machine state",
+            );
             return Err(
                 CarbideError::InvalidArgument("wrong host machine state".to_string()).into(),
             );
@@ -303,7 +313,7 @@ pub(crate) async fn persist_validation_result(
         db::machine_validation_execution::record_result(&mut txn, &validation_result).await?;
     if !first_terminal_report {
         tracing::info!(
-            validation_id = %validation_result.validation_id,
+            machine_validation_id = %validation_result.validation_id,
             machine_id = %machine.id,
             test_id = ?validation_result.test_id,
             "machine validation result ignored because attempt was already terminal"
@@ -666,7 +676,10 @@ pub(crate) async fn on_demand_machine_validation(
             {
                 let msg =
                     format!("On demand machine validation for {machine_id} is already scheduled.");
-                tracing::error!(msg);
+                tracing::error!(
+                    %machine_id,
+                    "On-demand machine validation is already scheduled"
+                );
                 return Err(CarbideError::InvalidArgument(msg).into());
             }
             // Check state
@@ -680,7 +693,10 @@ pub(crate) async fn on_demand_machine_validation(
                         let msg = format!(
                             "On demand machine validation for {machine_id} is already scheduled."
                         );
-                        tracing::error!(msg);
+                        tracing::error!(
+                            %machine_id,
+                            "On-demand machine validation is already scheduled"
+                        );
                         return Err(CarbideError::InvalidArgument(msg).into());
                     }
                     let allowed_tests: Vec<String> = req
@@ -700,7 +716,10 @@ pub(crate) async fn on_demand_machine_validation(
                         },
                     )
                     .await?;
-                    tracing::trace!(validation_id = %validation_id);
+                    tracing::trace!(
+                        machine_validation_id = %validation_id,
+                        "Created on-demand machine validation run"
+                    );
 
                     // Update machine_validation_request.
                     db::machine::set_machine_validation_request(&mut txn, &machine_id, true)
@@ -720,7 +739,12 @@ pub(crate) async fn on_demand_machine_validation(
                         ManagedHostState::Ready,
                         machine.current_state()
                     );
-                    tracing::warn!(msg);
+                    tracing::warn!(
+                        %machine_id,
+                        required_state = %ManagedHostState::Ready,
+                        machine_state = %machine.current_state(),
+                        "On-demand machine validation requires a different machine state"
+                    );
                     Err(CarbideError::InvalidArgument(msg).into())
                 }
             }
@@ -1030,9 +1054,9 @@ pub async fn apply_config_on_startup(
             for test_config in &config.tests {
                 if let Some(test) = tests.iter().find(|t| t.test_id == test_config.id) {
                     tracing::info!(
-                        "Updating test '{}' to state {} from config",
-                        test.test_id,
-                        test_config.enable
+                        test_id = %test.test_id,
+                        enable = test_config.enable,
+                        "Updating test to state from config",
                     );
 
                     machine_validation_suites::enable_disable(
@@ -1065,9 +1089,9 @@ pub async fn apply_config_on_startup(
                 };
 
                 tracing::info!(
-                    "Setting test '{}' to state {} (EnableAll mode)",
-                    test.test_id,
-                    enable_state
+                    test_id = %test.test_id,
+                    test_enable_state = enable_state,
+                    "Setting test to state (EnableAll mode)",
                 );
 
                 machine_validation_suites::enable_disable(
@@ -1099,9 +1123,9 @@ pub async fn apply_config_on_startup(
                 };
 
                 tracing::info!(
-                    "Setting test '{}' to state {} (DisableAll mode)",
-                    test.test_id,
-                    enable_state
+                    test_id = %test.test_id,
+                    test_enable_state = enable_state,
+                    "Setting test to state (DisableAll mode)",
                 );
 
                 machine_validation_suites::enable_disable(

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -220,7 +220,7 @@ async fn set_primary_interface_core(
     let boot_interface_id = new_primary_interface.boot_interface_id.clone();
 
     tracing::info!(
-        host = %host_machine_id,
+        machine_id = %host_machine_id,
         new_primary = %new_primary_interface_id,
         previous_primary = ?current_primary_interface_id,
         "moving the host's primary (boot) interface",

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -821,7 +821,10 @@ pub(crate) async fn on_demand_rack_maintenance(
         return Err(status);
     }
 
-    tracing::info!("On-demand maintenance scheduled for rack {}", rack_id,);
+    tracing::info!(
+        rack_id = %rack_id,
+        "On-demand maintenance scheduled",
+    );
 
     Ok(Response::new(rpc::RackMaintenanceOnDemandResponse {}))
 }

--- a/crates/api-core/src/handlers/redfish.rs
+++ b/crates/api-core/src/handlers/redfish.rs
@@ -271,7 +271,12 @@ pub async fn redfish_apply_action(
                 // Enclosing function may have returned. Nowhere to return error to.
                 update_response_in_tx(&pool, request, index, response)
                     .await
-                    .inspect_err(|e| tracing::error!("Error applying redfish action: {e}"))
+                    .inspect_err(|e| {
+                        tracing::error!(
+                            error = %e,
+                            "Error applying redfish action",
+                        )
+                    })
                     .ok();
             }
         });
@@ -313,7 +318,11 @@ async fn handle_request(
         (Err(error), _) | (_, Some(error)) => {
             // Make a UUID for easy log correlation
             let failure_uuid = Uuid::new_v4();
-            tracing::error!("Redfish client creation failure {failure_uuid}: {error}");
+            tracing::error!(
+                failure_uuid = %failure_uuid,
+                error = %error,
+                "Redfish client creation failure",
+            );
 
             // Set the "response" to indicate we couldn't get a redfish client. Don't
             // leak error string in case of credentials/etc.
@@ -453,7 +462,7 @@ pub(crate) async fn create_client(
         let client = match builder.build() {
             Ok(client) => client,
             Err(err) => {
-                tracing::error!(%err, "build_http_client");
+                tracing::error!(error = %err, "build_http_client");
                 return Err(CarbideError::internal(format!(
                     "Http building failed: {err}"
                 )));

--- a/crates/api-core/src/handlers/scout_stream.rs
+++ b/crates/api-core/src/handlers/scout_stream.rs
@@ -57,7 +57,10 @@ pub(crate) async fn scout_stream(
         }
     };
 
-    tracing::info!("scout agent connected for machine: {machine_id}");
+    tracing::info!(
+        machine_id = %machine_id,
+        "Scout agent connected",
+    );
 
     // Now we create channels for bidirectional communication. The API
     // will receive on one side, process whatever is packed into the oneof field
@@ -84,7 +87,10 @@ pub(crate) async fn scout_stream(
 
         // If/when the connection breaks, unregister the scout
         // agent connection from the connection registry.
-        tracing::info!("scout agent disconnected for machine: {machine_id}");
+        tracing::info!(
+            machine_id = %machine_id,
+            "Scout agent disconnected",
+        );
         registry_clone.unregister(machine_id).await;
     });
 

--- a/crates/api-core/src/handlers/secrets.rs
+++ b/crates/api-core/src/handlers/secrets.rs
@@ -65,9 +65,9 @@ pub(crate) async fn re_wrap_secrets(
     })?;
 
     tracing::info!(
-        re_wrapped = result.re_wrapped,
-        already_current = result.already_current,
-        stale_remaining = result.stale_remaining,
+        rewrapped_secret_count = result.re_wrapped,
+        already_current_secret_count = result.already_current,
+        remaining_stale_secret_count = result.stale_remaining,
         "secrets re-wrap completed"
     );
 

--- a/crates/api-core/src/handlers/site_explorer.rs
+++ b/crates/api-core/src/handlers/site_explorer.rs
@@ -257,7 +257,10 @@ pub(crate) async fn clear_site_exploration_error(
     // actually retries preingestion instead of requiring a force-delete of the
     // endpoint. Non-failed states are left untouched.
     if db::explored_endpoints::reset_failed_preingestion(bmc_ip, &mut txn).await? {
-        tracing::info!("Reset failed preingestion to initial for {bmc_ip} on error clear");
+        tracing::info!(
+            bmc_ip_address = %bmc_ip,
+            "Reset failed preingestion to initial after clearing the site exploration error",
+        );
     }
 
     txn.commit().await?;

--- a/crates/api-core/src/handlers/spx_partition.rs
+++ b/crates/api-core/src/handlers/spx_partition.rs
@@ -60,7 +60,7 @@ async fn allocate_dpa_vni(
                 tracing::error!(
                     owner_id,
                     pool = source_pool.name(),
-                    value = requested_vni,
+                    requested_vni,
                     "invalid pool value requested, cannot allocate"
                 );
                 CarbideError::FailedPrecondition(format!(

--- a/crates/api-core/src/handlers/svpc.rs
+++ b/crates/api-core/src/handlers/svpc.rs
@@ -67,8 +67,8 @@ pub(crate) async fn process_scout_req(
 
     if dpa_snapshots.is_empty() {
         tracing::error!(
-            "process_scout_req no dpa_snapshots for machine: {:#?}",
-            machine_id
+            %machine_id,
+            "No DPA snapshots found",
         );
         return Ok(fac::Action::noop());
     }
@@ -113,7 +113,10 @@ pub(crate) async fn process_scout_req(
             Ok(action) => device_actions.push(action),
             Err(e) => {
                 // Would only happen if the op is an ApplyProfile command with invalid YAML
-                tracing::error!("process_scout_req Error encoding DpaCommand for dpa: {e}");
+                tracing::error!(
+                    error = %e,
+                    "Failed to encode DPA command",
+                );
             }
         }
     }
@@ -193,8 +196,8 @@ fn build_apply_firmware_command<'a>(
         {
             tracing::info!(
                 %machine_id, %pci_name, %part_number, %psid,
-                observed_fw_version = ?device_info.fw_version_current,
-                expected_fw_version = %fw_profile.firmware_spec.version,
+                observed_firmware_version = ?device_info.fw_version_current,
+                expected_firmware_version = %fw_profile.firmware_spec.version,
                 "firmware already at target version, skipping"
             );
             return None;
@@ -270,7 +273,7 @@ fn build_apply_profile_command(
     let serialized_profile = SerializableProfile::from_profile(mlxconfig_profile).map_err(|e| {
         tracing::error!(
             %machine_id, %pci_name, %profile_name,
-            %e,
+            error = %e,
             "failed to serialize mlxconfig profile"
         );
         CarbideError::Internal {
@@ -355,7 +358,7 @@ async fn process_mlx_observation(
     let req = request.into_inner();
 
     let Some(rep) = req.report else {
-        tracing::error!("process_mlx_observation without report req: {:#?}", req);
+        tracing::error!("MLX observation request is missing its report");
         return Err(CarbideError::GenericErrorFromReport(eyre!(
             "process_mlx_observation without report req: {:#?}",
             req
@@ -364,8 +367,8 @@ async fn process_mlx_observation(
 
     let Some(machine_id) = rep.machine_id else {
         tracing::error!(
-            "process_mlx_observation without machine_id report: {:#?}",
-            rep
+            observation_count = rep.observations.len(),
+            "MLX device report is missing its machine ID",
         );
         return Err(CarbideError::GenericErrorFromReport(eyre!(
             "process_mlx_observation without machine_id report: {:#?}",
@@ -383,8 +386,8 @@ async fn process_mlx_observation(
 
     if dpa_snapshots.is_empty() {
         tracing::error!(
-            "process_mlx_observation no dpa snapshots for machine: {:#?}",
-            machine_id
+            %machine_id,
+            "No DPA snapshots found",
         );
         return Err(CarbideError::GenericErrorFromReport(eyre!(
             "process_mlx_observation no dpa snapshots for machine: {:#?}",
@@ -394,8 +397,9 @@ async fn process_mlx_observation(
 
     if rep.observations.is_empty() {
         tracing::error!(
-            "process_mlx_observation no observations in report: {:#?}",
-            rep
+            %machine_id,
+            observation_count = rep.observations.len(),
+            "MLX device report contains no observations",
         );
         return Err(CarbideError::GenericErrorFromReport(eyre!(
             "process_mlx_observation no observations in report: {:#?}",
@@ -406,8 +410,8 @@ async fn process_mlx_observation(
     for obs in rep.observations {
         let Some(devinfo) = obs.device_info else {
             tracing::error!(
-                "process_mlx_observation no device_info observation: {:#?}",
-                obs
+                %machine_id,
+                "MLX device observation contains no device info",
             );
             continue;
         };
@@ -416,9 +420,10 @@ async fn process_mlx_observation(
             Ok(dpa) => dpa,
             Err(e) => {
                 tracing::error!(
-                    "process_mlx_observation dpa not found for device {:#?} error: {:#?}",
-                    devinfo,
-                    e
+                    pci_name = %devinfo.pci_name,
+                    mac_address = %devinfo.base_mac,
+                    error = %e,
+                    "DPA interface not found",
                 );
                 continue;
             }
@@ -426,8 +431,11 @@ async fn process_mlx_observation(
 
         if dpa.interface_type != DpaInterfaceType::Svpc {
             tracing::error!(
-                "process_mlx_observation dpa interface type is not Svpc, skipping: {:#?}",
-                dpa
+                dpa_interface_id = %dpa.id,
+                %machine_id,
+                pci_name = %dpa.pci_name,
+                interface_type = ?dpa.interface_type,
+                "DPA interface is not an SVPC interface; skipping",
             );
             continue;
         }
@@ -446,7 +454,10 @@ async fn process_mlx_observation(
             let ls = match DpaLockMode::try_from(lock_status) {
                 Ok(ls) => ls,
                 Err(e) => {
-                    tracing::error!("process_mlx_observation Error from LockStatus::try_from {e}");
+                    tracing::error!(
+                        error = %e,
+                        "Failed to convert DPA lock status",
+                    );
                     continue;
                 }
             };
@@ -474,7 +485,10 @@ async fn process_mlx_observation(
         match dpa_interface::update_card_state(&mut txn, dpa).await {
             Ok(_id) => (),
             Err(e) => {
-                tracing::error!("process_mlx_observation update_card_state error: {e}");
+                tracing::error!(
+                    error = %e,
+                    "Failed to update DPA card state",
+                );
             }
         }
     }
@@ -503,9 +517,9 @@ pub(crate) async fn publish_mlx_device_report(
             .try_into()
             .map_err(|e: String| CarbideError::Internal { message: e })?;
         tracing::info!(
-            "received MlxDeviceReport hostname={} device_count={}",
-            report.hostname,
-            report.devices.len(),
+            hostname = %report.hostname,
+            device_count = report.devices.len(),
+            "received MlxDeviceReport",
         );
 
         // Without a machine_id, we can't create dpa interfaces
@@ -555,7 +569,7 @@ pub(crate) async fn publish_mlx_device_report(
                     match crate::handlers::dpa::ensure_interface(api, new_interface).await {
                         Ok(ensured) => {
                             tracing::info!(
-                                dpa_id = %ensured.id,
+                                dpa_interface_id = %ensured.id,
                                 machine_id = %ensured.machine_id,
                                 pci_name = %ensured.pci_name,
                                 mac_address = %ensured.mac_address,
@@ -567,7 +581,7 @@ pub(crate) async fn publish_mlx_device_report(
                             tracing::warn!(
                                 %machine_id,
                                 %device_info.pci_name,
-                                %e,
+                                error = %e,
                                 "failed to ensure dpa interface"
                             );
                             continue;
@@ -583,7 +597,7 @@ pub(crate) async fn publish_mlx_device_report(
                         tracing::warn!(
                             mac_address = %ensured_interface.mac_address,
                             pci_name = %ensured_interface.pci_name,
-                            %e,
+                            error = %e,
                             "failed to begin txn for device info update"
                         );
                         continue;
@@ -603,7 +617,7 @@ pub(crate) async fn publish_mlx_device_report(
                             tracing::warn!(
                                 mac_address = %ensured_interface.mac_address,
                                 pci_name = %ensured_interface.pci_name,
-                                %e,
+                                error = %e,
                                 "failed to commit device info update"
                             );
                         }
@@ -612,7 +626,7 @@ pub(crate) async fn publish_mlx_device_report(
                         tracing::warn!(
                             mac_address = %ensured_interface.mac_address,
                             pci_name = %ensured_interface.pci_name,
-                            %e,
+                            error = %e,
                             "failed to update device info"
                         );
                     }
@@ -620,11 +634,16 @@ pub(crate) async fn publish_mlx_device_report(
             }
 
             tracing::info!(
-                "spx nics count: {spx_nics} machine_id: {:#?}",
-                report.machine_id
+                spx_nic_count = spx_nics,
+                %machine_id,
+                "counted SPX NICs",
             );
         } else {
-            tracing::warn!("MlxDeviceReport without machine_id: {:#?}", report);
+            tracing::warn!(
+                hostname = %report.hostname,
+                device_count = report.devices.len(),
+                "MLX device report is missing its machine ID",
+            );
         }
     } else {
         tracing::warn!("no embedded MlxDeviceReport published");

--- a/crates/api-core/src/handlers/tenant_identity_config.rs
+++ b/crates/api-core/src/handlers/tenant_identity_config.rs
@@ -66,8 +66,8 @@ async fn tenant_identity_with_decrypted_token_delegation(
     .await
     .inspect_err(|e| {
         tracing::error!(
-            org_id = %cfg.organization_id.as_str(),
-            message = %e.message(),
+            organization_id = %cfg.organization_id.as_str(),
+            error = %e.message(),
             "token delegation auth config decrypt failed"
         );
     })?;

--- a/crates/api-core/src/handlers/tenant_keyset.rs
+++ b/crates/api-core/src/handlers/tenant_keyset.rs
@@ -50,7 +50,7 @@ pub(crate) async fn create(
         organization_id = keyset_request.keyset_identifier.organization_id.to_string(),
         keyset_id = keyset_request.keyset_identifier.keyset_id,
         public_key_suffixes = PublicKeySuffixes(public_keys).to_string(),
-        public_key_suffixes_num = public_keys.len(),
+        public_key_suffix_count = public_keys.len(),
         version = keyset_request.version,
         "Tenant keyset created"
     );
@@ -142,7 +142,7 @@ pub(crate) async fn update(
         organization_id = update_request.keyset_identifier.organization_id.to_string(),
         keyset_id = update_request.keyset_identifier.keyset_id,
         public_key_suffixes = PublicKeySuffixes(public_keys).to_string(),
-        public_key_suffixes_num = public_keys.len(),
+        public_key_suffix_count = public_keys.len(),
         version = update_request.version,
         "Tenant keyset updated"
     );

--- a/crates/api-core/src/handlers/uefi.rs
+++ b/crates/api-core/src/handlers/uefi.rs
@@ -241,7 +241,10 @@ pub(crate) async fn clear_host_uefi_password(
         .client_by_info(&bmc_access_info)
         .await
         .map_err(|e| {
-            tracing::error!("unable to create redfish client: {}", e);
+            tracing::error!(
+                error = %e,
+                "unable to create redfish client",
+            );
             CarbideError::Internal {
                 message: format!(
                     "Could not create connection to Redfish API to {machine_id}, check logs"
@@ -254,7 +257,7 @@ pub(crate) async fn clear_host_uefi_password(
         .clear_host_uefi_password(redfish_client.as_ref(), clear_credentials)
         .await
         .map_err(|e| {
-            tracing::error!(%e, "Failed to run clear_host_uefi_password call");
+            tracing::error!(error = %e, "Failed to run clear_host_uefi_password call");
             CarbideError::internal(format!(
                 "Failed redfish clear_host_uefi_password subtask: {e}"
             ))
@@ -350,7 +353,10 @@ pub(crate) async fn set_host_uefi_password(
         .client_by_info(&bmc_access_info)
         .await
         .map_err(|e| {
-            tracing::error!("unable to create redfish client: {}", e);
+            tracing::error!(
+                error = %e,
+                "unable to create redfish client",
+            );
             CarbideError::RedfishClientCreation {
                 inner: e.into(),
                 machine_id,
@@ -362,7 +368,7 @@ pub(crate) async fn set_host_uefi_password(
         .uefi_setup(redfish_client.as_ref(), false, host_uefi_credentials)
         .await
         .map_err(|e| {
-            tracing::error!(%e, "Failed to run uefi_setup call");
+            tracing::error!(error = %e, "Failed to run uefi_setup call");
             CarbideError::internal(format!("Failed redfish uefi_setup subtask: {e}"))
         })?;
     // uefi_setup returns a BMC job_id; the password change completes
@@ -392,7 +398,10 @@ pub(crate) async fn set_host_uefi_password(
     })
     .await?
     .map_err(|e| {
-        tracing::error!("Failed to update bios_password_set_time: {}", e);
+        tracing::error!(
+            error = %e,
+            "Failed to update bios_password_set_time",
+        );
         CarbideError::Internal {
             message: format!("Failed to update BIOS password timestamp: {e}"),
         }

--- a/crates/api-core/src/handlers/vpc.rs
+++ b/crates/api-core/src/handlers/vpc.rs
@@ -440,7 +440,7 @@ async fn allocate_vpc_vni(
                 tracing::error!(
                     owner_id,
                     pool = source_pool.name(),
-                    value = requested_vni,
+                    requested_vni,
                     "invalid pool value requested, cannot allocate"
                 );
                 CarbideError::FailedPrecondition(format!(

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -443,9 +443,9 @@ pub fn allocate_ib_port_guid(
     let mut guids: Vec<String> = Vec::new();
     for request in &mut updated_ib_config.ib_interfaces {
         tracing::debug!(
-            "request IB device:{}, device_instance:{}",
-            request.device.clone(),
-            request.device_instance
+            device = %request.device,
+            device_instance = request.device_instance,
+            "Requested InfiniBand device",
         );
 
         // TOTO: will support VF in the future. Currently, it will return err when the function_id is not PF.
@@ -461,7 +461,10 @@ pub fn allocate_ib_port_guid(
                 request.pf_guid = Some(ib.guid.clone());
                 request.guid = Some(ib.guid.clone());
                 guids.push(ib.guid.clone());
-                tracing::debug!("select IB device GUID {}", ib.guid.clone());
+                tracing::debug!(
+                    ib_guid = %ib.guid,
+                    "select IB device GUID",
+                );
             } else {
                 return Err(CarbideError::InvalidArgument(format!(
                     "not enough ib device {} (machine {})",
@@ -732,7 +735,11 @@ pub async fn batch_allocate_instances(
             })?;
 
         if let Err(e) = mh_snapshot.is_usable_as_instance(request.allow_unhealthy_machine) {
-            tracing::error!(%machine_id, "Host can not be used as instance due to reason: {}", e);
+            tracing::error!(
+                %machine_id,
+                error = %e,
+                "Host can not be used as instance due to reason",
+            );
             return Err(match e {
                 NotAllocatableReason::InvalidState(s) => CarbideError::InvalidArgument(format!(
                     "Could not create instance on machine {machine_id} given machine state {s:?}"
@@ -1278,7 +1285,8 @@ pub async fn batch_validate_spx_partition_ownership(
     for (partition_id, expected_tenant) in validations {
         let partition = partition_map.get(partition_id).ok_or_else(|| {
             tracing::error!(
-                "batch_validate_spx_partition_ownership partition not found: {partition_id}"
+                spx_partition_id = %partition_id,
+                "SPX partition not found while validating ownership",
             );
             ConfigValidationError::invalid_value(format!(
                 "SPX partition {partition_id} is not created"
@@ -1287,7 +1295,8 @@ pub async fn batch_validate_spx_partition_ownership(
 
         if &partition.tenant_organization_id != *expected_tenant {
             tracing::error!(
-                "batch_validate_spx_partition_ownership partition not owned by the tenant: {partition_id}"
+                spx_partition_id = %partition_id,
+                "SPX partition is not owned by the tenant",
             );
             return Err(CarbideError::InvalidArgument(format!(
                 "SPX Partition {partition_id} is not owned by the tenant {expected_tenant}",
@@ -1394,8 +1403,8 @@ pub fn sort_spx_by_slot(spx_hw_info_vec: &[DpaInterface]) -> HashMap<String, Vec
             entry.push(spx);
         } else {
             tracing::info!(
-                "sort_spx_by_slot device_description is not found: {:#?}",
-                spx
+                spx = ?spx,
+                "SPX device description is missing",
             );
         }
     }
@@ -1411,17 +1420,17 @@ pub fn allocate_spx_port_mac(
     let mut updated_spx_config = spx_config.clone();
 
     tracing::debug!(
-        "allocate_spx_port_mac dev len: {:#?}",
-        mh_snapshot.dpa_interface_snapshots.len()
+        dpa_interface_snapshot_count = mh_snapshot.dpa_interface_snapshots.len(),
+        "Allocating SPX port MAC addresses",
     );
 
     let mut seen_device_instances = HashSet::new();
     for att in &updated_spx_config.spx_attachments {
         if !seen_device_instances.insert((att.device.clone(), att.device_instance)) {
             tracing::error!(
-                "allocate_spx_port_mac duplicate SPX attachment for device {} instance {}",
-                att.device,
-                att.device_instance
+                device = %att.device,
+                device_instance = att.device_instance,
+                "Duplicate SPX attachment",
             );
             return Err(CarbideError::InvalidArgument(format!(
                 "duplicate SPX attachment for device {} instance {}",
@@ -1454,9 +1463,9 @@ pub fn allocate_spx_port_mac(
                 sorted_spxs.remove(spx_attachment.device_instance as usize);
             } else {
                 tracing::error!(
-                    "allocate_spx_port_mac SPX device {} has no instance {}",
-                    spx_attachment.device,
-                    spx_attachment.device_instance
+                    device = %spx_attachment.device,
+                    device_instance = spx_attachment.device_instance,
+                    "SPX device has no matching instance",
                 );
                 return Err(CarbideError::InvalidArgument(format!(
                     "SPX device {} has no instance {}",
@@ -1465,9 +1474,9 @@ pub fn allocate_spx_port_mac(
             }
         } else {
             tracing::error!(
-                "allocate_spx_port_mac No SPX device with name {} in machine {}",
-                spx_attachment.device,
-                mh_snapshot.host_snapshot.id
+                device = %spx_attachment.device,
+                machine_id = %mh_snapshot.host_snapshot.id,
+                "SPX device not found",
             );
             return Err(CarbideError::InvalidArgument(format!(
                 "No SPX device with name {} in machine {}",

--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -200,7 +200,10 @@ impl PxeInstructions {
         machine_type: MachineType,
     ) -> String {
         tracing::info!(
-            "machine_type: {machine_type}; machine interface ID: {machine_interface_id}; mac address: {mac_address}"
+            machine_type = %machine_type,
+            machine_interface_id = %machine_interface_id,
+            mac_address = %mac_address,
+            "machine network boot parameters",
         );
         match arch {
             rpc::MachineArchitecture::Arm => {
@@ -342,9 +345,9 @@ exit ||
                     ));
                 } else {
                     tracing::warn!(
-                        "Unsupported DPU type. Product is '{}', but architecture is {:?}",
-                        product,
-                        target.arch,
+                        product = %product,
+                        arch = ?target.arch,
+                        "Unsupported DPU type",
                     )
                 }
             };
@@ -362,7 +365,7 @@ exit ||
             else {
                 // This only happens if someone powered on a host manually before we ingested it,
                 // which is unlikely but possible.
-                tracing::info!(interface = ?interface, "Request for PXE instructions for unknown interface, skipping PXE boot");
+                tracing::info!(machine_interface = ?interface, "Request for PXE instructions for unknown interface, skipping PXE boot");
                 return Ok(UNKNOWN_HOST_INSTRUCTIONS.to_string());
             };
 
@@ -393,7 +396,7 @@ exit ||
                 "Invalid machine id. Not found in db.".to_string(),
             ))?;
 
-        tracing::info!(machine_id = %machine.id, interface_id = %target.interface_id, state=%machine.current_state(), "Found existing machine for pxe instructions");
+        tracing::info!(machine_id = %machine.id, machine_interface_id = %target.interface_id, machine_state = %machine.current_state(), "Found existing machine for pxe instructions");
         // DPUs need to boot twice during initial discovery. Both reboots require
         // that the DPU gets pxe instructions.
         //

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -143,9 +143,9 @@ fn get_tls_acceptor(tls_config: &ApiTlsConfig) -> Option<TlsAcceptor> {
             .build()
             .inspect_err(|error| {
                 tracing::error!(
-                    "Could not build client cert verifier. Does root CA file at {} contain no root trust anchors? {}",
-                    tls_config.root_cafile_path,
-                    error
+                    root_cafile_path = %tls_config.root_cafile_path,
+                    error = %error,
+                    "Could not build client certificate verifier; the root CA file may contain no trust anchors",
                 );
             })
             .ok()?;
@@ -284,9 +284,7 @@ pub async fn start(
         .as_ref()
         .and_then(|c| c.trust.as_ref())
         .cloned()
-        .inspect(|trust_config| {
-            tracing::info!("TrustConfig rendered from config: {trust_config:?}")
-        })
+        .inspect(|trust_config| tracing::info!(?trust_config, "TrustConfig rendered from config",))
         .map(SpiffeContext::try_from)
         .transpose()?
         .ok_or(CarbideError::InvalidConfiguration(
@@ -355,125 +353,157 @@ pub async fn start(
     let mut tls_acceptor_created = Instant::now();
     let mut initialize_tls_acceptor = true;
 
-    join_set.build_task().name("listener accept loop").spawn(async move {
-        while let Some(incoming_connection) = cancel_token.run_until_cancelled(listener.accept()).await {
-            carbide_instrument::emit(TlsConnectionAttempted);
-            let (conn, addr) = match incoming_connection {
-                Ok(incoming) => incoming,
-                Err(e) => {
-                    tracing::error!(error = %e, "Error accepting connection");
-                    carbide_instrument::emit(TlsConnectionFailed {
-                        reason: ConnectionFailReason::TcpConnectionFailure,
-                    });
-                    continue;
+    join_set
+        .build_task()
+        .name("listener accept loop")
+        .spawn(async move {
+            while let Some(incoming_connection) =
+                cancel_token.run_until_cancelled(listener.accept()).await
+            {
+                carbide_instrument::emit(TlsConnectionAttempted);
+                let (conn, addr) = match incoming_connection {
+                    Ok(incoming) => incoming,
+                    Err(e) => {
+                        tracing::error!(error = %e, "Error accepting connection");
+                        carbide_instrument::emit(TlsConnectionFailed {
+                            reason: ConnectionFailReason::TcpConnectionFailure,
+                        });
+                        continue;
+                    }
+                };
+
+                // TODO: RT: change the subroutine to return the certificate's parsed expiration from
+                // the file on disk and only refresh if it's actually necessary to do so,
+                // and emit a metric for the remaining duration on the cert
+
+                // hard refresh our certs every five minutes
+                // they may have been rewritten on disk by cert-manager and we want to honor the new cert.
+                if let (Some(tls_config), true) = (
+                    tls_config.as_ref(),
+                    initialize_tls_acceptor
+                        || tls_acceptor_created.elapsed()
+                            > tokio::time::Duration::from_secs(5 * 60),
+                ) {
+                    carbide_instrument::emit(TlsCertsRefreshed);
+                    initialize_tls_acceptor = false;
+                    tls_acceptor_created = Instant::now();
+
+                    tls_acceptor = tokio::task::Builder::new()
+                        .name("get_tls_acceptor refresh")
+                        .spawn_blocking({
+                            let tls_config = tls_config.clone();
+                            move || get_tls_acceptor(&tls_config)
+                        })
+                        // Safety: spawn_blocking only returns Error if run outside the tokio runtime
+                        .expect("Failed to spawn blocking task")
+                        .await
+                        // Safety: Awaiting a JoinHandle only fails if the task panicked, and we want to
+                        // propagate panics
+                        .expect("task panicked");
                 }
-            };
 
-            // TODO: RT: change the subroutine to return the certificate's parsed expiration from
-            // the file on disk and only refresh if it's actually necessary to do so,
-            // and emit a metric for the remaining duration on the cert
+                let tls_acceptor = tls_acceptor.clone();
+                let http = http.clone();
+                let app = app.clone();
 
-            // hard refresh our certs every five minutes
-            // they may have been rewritten on disk by cert-manager and we want to honor the new cert.
-            if let (Some(tls_config), true) = (
-                tls_config.as_ref(),
-                initialize_tls_acceptor
-                    || tls_acceptor_created.elapsed() > tokio::time::Duration::from_secs(5 * 60),
-            ) {
-                carbide_instrument::emit(TlsCertsRefreshed);
-                initialize_tls_acceptor = false;
-                tls_acceptor_created = Instant::now();
+                tokio::task::Builder::new()
+                    .name("http conn handler")
+                    .spawn(async move {
+                        if let Some(tls_acceptor) = tls_acceptor {
+                            match tls_acceptor.accept(conn).await {
+                                Ok(conn) => {
+                                    let conn = TokioIo::new(conn);
+                                    carbide_instrument::emit(TlsConnectionSucceeded);
 
-                tls_acceptor = tokio::task::Builder::new()
-                    .name("get_tls_acceptor refresh")
-                    .spawn_blocking({
-                        let tls_config = tls_config.clone();
-                        move || get_tls_acceptor(&tls_config)
-                    })
-                    // Safety: spawn_blocking only returns Error if run outside the tokio runtime
-                    .expect("Failed to spawn blocking task")
-                    .await
-                    // Safety: Awaiting a JoinHandle only fails if the task panicked, and we want to
-                    // propagate panics
-                    .expect("task panicked");
-            }
+                                    let (_, session) = conn.inner().get_ref();
+                                    let connection_attributes = {
+                                        let peer_address = addr;
+                                        let peer_certificates = session
+                                            .peer_certificates()
+                                            .unwrap_or_default()
+                                            .to_vec();
+                                        Arc::new(ConnectionAttributes {
+                                            peer_address,
+                                            peer_certificates,
+                                        })
+                                    };
+                                    let conn_attrs_extension_layer =
+                                        AddExtensionLayer::new(connection_attributes);
 
-            let tls_acceptor = tls_acceptor.clone();
-            let http = http.clone();
-            let app = app.clone();
+                                    let app_with_ext = tower::ServiceBuilder::new()
+                                        .layer(conn_attrs_extension_layer)
+                                        .service(app);
 
-            tokio::task::Builder::new().name("http conn handler").spawn(async move {
-                if let Some(tls_acceptor) = tls_acceptor {
-                    match tls_acceptor.accept(conn).await {
-                        Ok(conn) => {
-                            let conn = TokioIo::new(conn);
+                                    if let Err(error) = http
+                                        .serve_connection(
+                                            conn,
+                                            TowerToHyperService::new(app_with_ext),
+                                        )
+                                        .await
+                                    {
+                                        tracing::debug!(
+                                            %error,
+                                            error_debug = ?error,
+                                            "error servicing tls http request",
+                                        );
+                                    }
+                                }
+                                Err(error) => {
+                                    tracing::error!(
+                                        %error,
+                                        peer_address = %addr,
+                                        "error accepting tls connection"
+                                    );
+                                    carbide_instrument::emit(TlsConnectionFailed {
+                                        reason: ConnectionFailReason::TlsConnectionFailure,
+                                    });
+                                }
+                            }
+                        } else {
+                            // servicing without tls -- HTTP only
                             carbide_instrument::emit(TlsConnectionSucceeded);
 
-                            let (_, session) = conn.inner().get_ref();
-                            let connection_attributes = {
-                                let peer_address = addr;
-                                let peer_certificates =
-                                    session.peer_certificates().unwrap_or_default().to_vec();
-                                Arc::new(ConnectionAttributes {
-                                    peer_address,
-                                    peer_certificates,
-                                })
-                            };
                             let conn_attrs_extension_layer =
-                                AddExtensionLayer::new(connection_attributes);
+                                AddExtensionLayer::new(Arc::new(ConnectionAttributes {
+                                    peer_address: addr,
+                                    peer_certificates: vec![],
+                                }));
+
+                            let conn = TokioIo::new(conn);
 
                             let app_with_ext = tower::ServiceBuilder::new()
                                 .layer(conn_attrs_extension_layer)
                                 .service(app);
 
-                            if let Err(error) = http.serve_connection(conn, TowerToHyperService::new(app_with_ext)).await {
-                                tracing::debug!(%error, "error servicing tls http request: {error:?}");
+                            let result = if serve_plaintext_via_http1 {
+                                // Serve the connection as HTTP/1.1 and allow upgrading to HTTP/2
+                                http1::Builder::new()
+                                    .serve_connection(conn, TowerToHyperService::new(app_with_ext))
+                                    .with_upgrades()
+                                    .await
+                            } else {
+                                // Serve the connection as HTTP/2, which will fail if the initial
+                                // request is HTTP/1.1 (which is the default behavior for web browsers,
+                                // curl, etc.)
+                                http.serve_connection(conn, TowerToHyperService::new(app_with_ext))
+                                    .await
+                            };
+
+                            if let Err(error) = result {
+                                tracing::debug!(
+                                    error = %error,
+                                    error_debug = ?error,
+                                    "error servicing plain http connection",
+                                );
                             }
                         }
-                        Err(error) => {
-                            tracing::error!(%error, address = %addr, "error accepting tls connection");
-                            carbide_instrument::emit(TlsConnectionFailed {
-                                reason: ConnectionFailReason::TlsConnectionFailure,
-                            });
-                        }
-                    }
-                } else {
-                    // servicing without tls -- HTTP only
-                    carbide_instrument::emit(TlsConnectionSucceeded);
+                    })
+                    // Safety: This should only fail if called outside a tokio runtime
+                    .expect("could not spawn task to handle HTTP connection");
+            }
 
-                    let conn_attrs_extension_layer =
-                        AddExtensionLayer::new(Arc::new(ConnectionAttributes {
-                            peer_address: addr,
-                            peer_certificates: vec![],
-                        }));
-
-                    let conn = TokioIo::new(conn);
-
-                    let app_with_ext = tower::ServiceBuilder::new()
-                        .layer(conn_attrs_extension_layer)
-                        .service(app);
-
-                    let result = if serve_plaintext_via_http1 {
-                        // Serve the connection as HTTP/1.1 and allow upgrading to HTTP/2
-                        http1::Builder::new().serve_connection(conn, TowerToHyperService::new(app_with_ext)).with_upgrades().await
-                    } else {
-                        // Serve the connection as HTTP/2, which will fail if the initial
-                        // request is HTTP/1.1 (which is the default behavior for web browsers,
-                        // curl, etc.)
-                        http.serve_connection(conn, TowerToHyperService::new(app_with_ext)).await
-                    };
-
-                    if let Err(error) = result {
-                        tracing::debug!(%error, "error servicing plain http connection: {error:?}");
-                    }
-                }
-            })
-                // Safety: This should only fail if called outside a tokio runtime
-                .expect("could not spawn task to handle HTTP connection");
-        }
-
-        tracing::info!("carbide-api shutting down");
-    })?;
+            tracing::info!("carbide-api shutting down");
+        })?;
 
     Ok(())
 }

--- a/crates/api-core/src/logging/setup.rs
+++ b/crates/api-core/src/logging/setup.rs
@@ -208,7 +208,10 @@ pub fn setup_logging(
             LevelFilter::current()
         ))
     } else {
-        tracing::info!("current log level: {}", LevelFilter::current());
+        tracing::info!(
+            configured_log_level = %LevelFilter::current(),
+            "current log level",
+        );
         Ok(Logging {
             filter: ActiveLevel::new(
                 initial_log_filter,

--- a/crates/api-core/src/machine_identity/token_exchange.rs
+++ b/crates/api-core/src/machine_identity/token_exchange.rs
@@ -126,7 +126,7 @@ pub(crate) async fn token_exchange_request(
     if !status.is_success() {
         let snippet = String::from_utf8_lossy(&bytes[..bytes.len().min(512)]);
         tracing::warn!(
-            status = %status,
+            http_status = %status,
             body_prefix = %snippet,
             "token exchange endpoint returned error"
         );

--- a/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
@@ -70,7 +70,10 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
             match dpu_machine_update::get_reprovisioning_machines(txn).await {
                 Ok(current_updating_machines) => current_updating_machines,
                 Err(e) => {
-                    tracing::warn!("Error getting outstanding reprovisioning count: {}", e);
+                    tracing::warn!(
+                        error = %e,
+                        "Error getting outstanding reprovisioning count",
+                    );
                     vec![]
                 }
             };
@@ -166,7 +169,10 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
     async fn clear_completed_updates(&self, txn: &mut PgConnection) -> CarbideResult<()> {
         let updated_machines =
             dpu_machine_update::get_updated_machines(txn, self.config.host_health).await?;
-        tracing::debug!("found {} updated machines", updated_machines.len());
+        tracing::debug!(
+            updated_machine_count = updated_machines.len(),
+            "found updated machines",
+        );
         for updated_machine in updated_machines {
             if self
                 .config
@@ -179,7 +185,8 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
                 {
                     tracing::warn!(
                         machine_id = %updated_machine.dpu_machine_id,
-                        "Failed to remove machine update markers: {}", e
+                        error = %e,
+                        "Failed to remove machine update markers",
                     );
                 } else if let Ok(mut reported) = self.reported_wrong_versions.lock() {
                     reported.retain(|(dpu, _)| *dpu != updated_machine.dpu_machine_id);
@@ -295,7 +302,10 @@ impl DpuNicFirmwareUpdate {
         ) {
             Ok(machine_updates) => machine_updates,
             Err(e) => {
-                tracing::warn!("Failed to find machines needing updates: {}", e);
+                tracing::warn!(
+                    error = %e,
+                    "Failed to find machines needing updates",
+                );
                 vec![]
             }
         }

--- a/crates/api-core/src/machine_update_manager/host_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/host_firmware.rs
@@ -73,7 +73,10 @@ impl MachineUpdateModule for HostFirmwareUpdate {
             if firmware_catalog_last_read.as_ref() != Some(&catalog_marker) {
                 // Save the firmware config in an SQL table so that we can filter for hosts with non-matching firmware there.
                 let fw_config_snapshot = self.effective_firmware_config_snapshot(&mut txn).await?;
-                tracing::info!("Firmware config now: {:?}", fw_config_snapshot);
+                tracing::info!(
+                    firmware_config_snapshot = ?fw_config_snapshot,
+                    "Firmware config now",
+                );
                 let models = fw_config_snapshot.into_values().collect::<Vec<_>>();
                 desired_firmware::snapshot_desired_firmware(&mut txn, &models).await?;
                 *firmware_catalog_last_read = Some(catalog_marker);
@@ -183,7 +186,7 @@ impl HostFirmwareUpdate {
         meter: opentelemetry::metrics::Meter,
         firmware_config: FirmwareConfig,
     ) -> Option<Self> {
-        tracing::info!("Using firmware configuration: {firmware_config:?}");
+        tracing::info!(?firmware_config, "Using firmware configuration",);
 
         let metrics = HostFirmwareUpdateMetrics::new();
         metrics.register_callbacks(&meter);

--- a/crates/api-core/src/machine_update_manager/mod.rs
+++ b/crates/api-core/src/machine_update_manager/mod.rs
@@ -245,7 +245,10 @@ impl MachineUpdateManager {
             if (current_updating_machines.len() as i32) >= max_concurrent_updates {
                 break;
             }
-            tracing::debug!("in progress: {:?}", current_updating_machines);
+            tracing::debug!(
+                current_updating_machines = ?current_updating_machines,
+                "Machine updates in progress",
+            );
             let available_updates = max_concurrent_updates - current_updating_machines.len() as i32;
 
             let updates_started = update_module
@@ -256,7 +259,10 @@ impl MachineUpdateManager {
                     &snapshots,
                 )
                 .await?;
-            tracing::debug!("started: {:?}", updates_started);
+            tracing::debug!(
+                updates_started = ?updates_started,
+                "Machine updates started",
+            );
 
             updates_started_count += updates_started.len();
 

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -281,10 +281,10 @@ impl MachineValidationManager {
         )
         .await?;
         tracing::debug!(
-            "MachineValidation metrics: completed {} failed {} in_progress {}",
-            metrics.completed_validation,
-            metrics.failed_validation,
-            metrics.in_progress_validation,
+            completed_validation_count = metrics.completed_validation,
+            failed_validation_count = metrics.failed_validation,
+            in_progress_validation_count = metrics.in_progress_validation,
+            "Machine validation metrics computed",
         );
         self.metric_holder.update_metrics(metrics);
 
@@ -504,7 +504,7 @@ async fn reconcile_stale_validation(
     .await?
     else {
         tracing::debug!(
-            validation_id = %validation.id,
+            machine_validation_id = %validation.id,
             "skipping stale machine validation because it is no longer active or stale"
         );
         return Ok(None);
@@ -548,7 +548,7 @@ async fn record_failed_validation_side_effects(
 
     let Some(machine) = db::machine::find_by_validation_id(txn, &validation.id).await? else {
         tracing::warn!(
-            validation_id = %validation.id,
+            machine_validation_id = %validation.id,
             machine_id = %validation.machine_id,
             "failed machine validation has no owning machine"
         );

--- a/crates/api-core/src/measured_boot/metrics_collector/mod.rs
+++ b/crates/api-core/src/measured_boot/metrics_collector/mod.rs
@@ -100,7 +100,10 @@ impl MeasuredBootMetricsCollector {
     async fn run(&self, cancel_token: CancellationToken) {
         loop {
             if let Err(e) = self.run_single_iteration().await {
-                tracing::warn!("MeasuredBootMetricsCollector error: {}", e);
+                tracing::warn!(
+                    error = %e,
+                    "MeasuredBootMetricsCollector error",
+                );
             }
 
             tokio::select! {

--- a/crates/api-core/src/mqtt_state_change_hook/hook.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/hook.rs
@@ -100,7 +100,10 @@ impl StateChangeHook<MachineId, ManagedHostState> for MqttStateChangeHook {
                     deadline,
                 };
                 if let Err(e) = self.sender.try_send(queued) {
-                    tracing::warn!("MQTT state change event dropped (queue full): {e}");
+                    tracing::warn!(
+                        error = %e,
+                        "MQTT state change event dropped (queue full)",
+                    );
                     self.metrics.record_overflow();
                 }
             }

--- a/crates/api-core/src/mqtt_state_change_hook/republisher.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/republisher.rs
@@ -95,9 +95,9 @@ impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
     ) -> std::io::Result<()> {
         if self.config.enabled {
             tracing::info!(
-                interval_secs = self.config.publish_interval().as_secs(),
+                interval_seconds = self.config.publish_interval().as_secs(),
                 scope = ?self.config.scope,
-                healthy_republish_every = self.config.healthy_republish_every,
+                healthy_republish_interval_sweeps = self.config.healthy_republish_every,
                 max_publishes_per_second = self.config.max_publishes_per_second.0,
                 "Starting periodic managed host state republisher"
             );
@@ -238,9 +238,9 @@ impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
         }
 
         tracing::info!(
-            total,
-            published,
-            skipped_healthy,
+            total_host_count = total,
+            published_host_count = published,
+            skipped_healthy_host_count = skipped_healthy,
             publish_healthy,
             scope = ?self.config.scope,
             "Managed host state republish sweep complete"

--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -131,12 +131,15 @@ pub async fn run(
     // Redact credentials before printing the config
     let print_config = carbide_config.redacted();
 
-    tracing::info!("Using configuration: {:#?}", print_config);
     tracing::info!(
-        "Tokio worker thread count: {} (num_cpus::get()={}, TOKIO_WORKER_THREADS={})",
-        tokio::runtime::Handle::current().metrics().num_workers(),
-        num_cpus::get(),
-        std::env::var("TOKIO_WORKER_THREADS").unwrap_or_else(|_| "UNSET".to_string())
+        print_config = ?print_config,
+        "Using configuration",
+    );
+    tracing::info!(
+        worker_count = tokio::runtime::Handle::current().metrics().num_workers(),
+        cpu_count = num_cpus::get(),
+        tokio_worker_threads = %std::env::var("TOKIO_WORKER_THREADS").unwrap_or_else(|_| "UNSET".to_string()),
+        "Tokio worker thread configuration",
     );
 
     let metrics = create_metrics()?;
@@ -176,7 +179,11 @@ pub async fn run(
                 )
                 .await
                 {
-                    tracing::error!("Metrics endpoint failed with error: {}", e);
+                    tracing::error!(
+                        metrics_address = %metrics_address,
+                        error = %e,
+                        "Metrics endpoint failed",
+                    );
                 }
             }
         })?;
@@ -197,7 +204,7 @@ pub async fn run(
     );
 
     tracing::info!(
-        address = carbide_config.listen.to_string(),
+        listen_address = carbide_config.listen.to_string(),
         build_version = carbide_version::v!(build_version),
         build_date = carbide_version::v!(build_date),
         rust_version = carbide_version::v!(rust_version),
@@ -630,7 +637,7 @@ async fn import_vault_secrets_once(
     }
 
     tracing::info!(
-        count = vault_secrets.len(),
+        vault_secret_count = vault_secrets.len(),
         approach = ?secrets_config.import_approach,
         "Importing secrets from vault"
     );
@@ -647,8 +654,8 @@ async fn import_vault_secrets_once(
     .wrap_err("vault secret import")?;
 
     tracing::info!(
-        imported = result.imported,
-        skipped = result.skipped,
+        imported_secret_count = result.imported,
+        skipped_secret_count = result.skipped,
         "Vault secret import completed"
     );
 

--- a/crates/api-core/src/scout_stream.rs
+++ b/crates/api-core/src/scout_stream.rs
@@ -100,7 +100,10 @@ impl ConnectionRegistry {
                 };
 
                 let Some(response) = response else {
-                    tracing::info!("scout agent connection closed (machine_id={machine_id})");
+                    tracing::info!(
+                        %machine_id,
+                        "Scout agent connection closed",
+                    );
                     break;
                 };
 
@@ -115,12 +118,18 @@ impl ConnectionRegistry {
                 if let Some(sender) = flows.remove(&flow_uuid) {
                     if let Err(send_err) = sender.send(response) {
                         tracing::warn!(
-                            "error relaying flow response (machine_id={machine_id}, flow_uuid={flow_uuid}): {send_err:?}"
+                            %machine_id,
+                            %flow_uuid,
+                            error = ?send_err,
+                            "Failed to relay Scout flow response",
                         );
                     }
                 } else {
                     tracing::warn!(
-                        "dropping flow response for unknown flow_uuid (machine_id={machine_id}, flow_uuid={flow_uuid}): {response:?}"
+                        %machine_id,
+                        %flow_uuid,
+                        ?response,
+                        "Dropping response for unknown Scout flow",
                     );
                 }
             }
@@ -128,18 +137,25 @@ impl ConnectionRegistry {
 
         let mut connections = self.connections.write().await;
         connections.insert(machine_id, connection);
-        tracing::info!("registered scout agent connection for machine: {machine_id}");
+        tracing::info!(
+            %machine_id,
+            "Scout agent connection registered",
+        );
     }
 
     // unregister removes a scout agent connection from the registry.
     pub async fn unregister(&self, machine_id: MachineId) -> bool {
         let mut connections = self.connections.write().await;
         if connections.remove(&machine_id).is_some() {
-            tracing::info!("unregistered scout agent connection for machine: {machine_id}");
+            tracing::info!(
+                %machine_id,
+                "Scout agent connection unregistered",
+            );
             true
         } else {
             tracing::info!(
-                "could not unregister scout agent connection for machine (not found): {machine_id}"
+                %machine_id,
+                "Scout agent connection was not registered",
             );
             false
         }
@@ -199,7 +215,9 @@ impl ConnectionRegistry {
 
         // And now the request to the scout agent.
         tracing::info!(
-            "sending request to scout agent (machine_id={machine_id}, flow_uuid={flow_uuid})"
+            %machine_id,
+            %flow_uuid,
+            "Sending request to Scout agent",
         );
 
         connection_tx.send(Ok(request)).await.map_err(|e| CarbideError::Internal {
@@ -232,7 +250,10 @@ impl ConnectionRegistry {
         connections
             .iter()
             .map(|(machine_id, conn)| {
-                tracing::debug!("active scout stream connection: {}", conn.machine_id);
+                tracing::debug!(
+                    machine_id = %conn.machine_id,
+                    "active scout stream connection",
+                );
                 (*machine_id, conn.connected_at)
             })
             .collect()
@@ -247,13 +268,18 @@ fn extract_flow_uuid(
 ) -> Result<uuid::Uuid, ()> {
     let flow_uuid_pb = response.flow_uuid.as_ref().ok_or_else(|| {
         tracing::warn!(
-            "dropping flow response with empty flow_uuid (machine_id={machine_id}): {response:?}"
+            %machine_id,
+            ?response,
+            "Dropping Scout flow response with empty flow UUID",
         );
     })?;
 
     flow_uuid_pb.clone().try_into().map_err(|e| {
         tracing::warn!(
-            "failed to decode flow_uuid (machine_id={machine_id}): {flow_uuid_pb:?}: {e:?}"
+            %machine_id,
+            ?flow_uuid_pb,
+            error = ?e,
+            "Failed to decode Scout flow UUID",
         );
     })
 }

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -157,7 +157,10 @@ pub fn parse_carbide_config(
         .iter()
         .filter(|(_, host)| host.vendor == bmc_vendor::BMCVendor::Unknown)
     {
-        tracing::error!("Host firmware configuration has invalid vendor for {label}")
+        tracing::error!(
+            label = %label,
+            "Host firmware configuration has invalid vendor",
+        )
     }
 
     // If the carbide config does not say whether to allow dynamically changing the bmc_proxy or
@@ -244,7 +247,10 @@ pub fn parse_carbide_config(
         .wrap_err("Invalid configuration"));
     }
 
-    tracing::trace!("Carbide config: {:#?}", config.redacted());
+    tracing::trace!(
+        config = ?config.redacted(),
+        "Carbide config",
+    );
     Ok(Arc::new(config))
 }
 
@@ -552,10 +558,10 @@ pub async fn start_api(
         {
             Ok(cm) => {
                 tracing::info!(
-                    "Component manager configured (nv_switch={}, power_shelf={}, compute_tray={})",
-                    cm.nv_switch.name(),
-                    cm.power_shelf.name(),
-                    cm.compute_tray.name()
+                    nv_switch_backend = cm.nv_switch.name(),
+                    power_shelf_backend = cm.power_shelf.name(),
+                    compute_tray_backend = cm.compute_tray.name(),
+                    "Component manager configured",
                 );
                 Some(cm)
             }
@@ -571,8 +577,8 @@ pub async fn start_api(
                 // TODO: make the three backends individually optional so a bad
                 // config for one backend does not disable the others.
                 tracing::error!(
-                    "Component manager NOT initialized; failed to build one of the \
-                     nv-switch / power-shelf / compute-tray backends: {e}"
+                    error = %e,
+                    "Component manager NOT initialized; failed to build one of the nv-switch / power-shelf / compute-tray backends",
                 );
                 None
             }
@@ -919,8 +925,7 @@ impl<'a> SeedData<'a> {
                         object_kind = %kind,
                         object_name = %name,
                         source = %source,
-                        "{kind} `{name}` is defined in {source}. Defining initial objects in {source} \
-                         is deprecated; move the definitions into `initial_objects_file`.",
+                        "Initial object is defined in a deprecated configuration source; move the definition into `initial_objects_file`.",
                     );
                 }
                 Ok(Cow::Borrowed(cc))
@@ -973,8 +978,7 @@ impl<'a> SeedData<'a> {
                         object_kind = %kind,
                         object_name = %name,
                         source = %source,
-                        "{kind} `{name}` is still defined in {source}. \
-                         Move it into initial_objects_file to silence this warning.",
+                        "Initial object is still defined in a deprecated configuration source; move it into `initial_objects_file`.",
                     );
                 }
                 Ok(merged)
@@ -1027,7 +1031,10 @@ async fn initialize_and_start_controllers<'a>(
     if let Some(domain_name) = &carbide_config.initial_domain_name
         && db_init::create_initial_domain(db_pool.clone(), domain_name).await?
     {
-        tracing::info!("Created initial domain {domain_name}");
+        tracing::info!(
+            domain_name = %domain_name,
+            "Created initial domain",
+        );
     }
 
     // Probe the helm-chart layout first, then the forged-kustomize layout.
@@ -1047,14 +1054,18 @@ async fn initialize_and_start_controllers<'a>(
             .await
             .wrap_err_with(|| format!("Failed to read {path_used}"))?;
         let expected_machines = serde_json::from_str::<Vec<ExpectedMachine>>(file_str.as_str()).inspect_err(|err| {
-                tracing::error!("expected_machines.json file exists, but unable to parse expected_machines file, nothing was written to db, bailing: {err}.");
+                tracing::error!(
+                    error = %err,
+                    "expected_machines.json file exists, but unable to parse expected_machines file, nothing was written to db, bailing.",
+                );
             })?;
         let mut txn = Transaction::begin(db_pool).await?;
         crate::handlers::expected_machine::create_missing_from(&mut txn, &expected_machines)
             .await
             .inspect_err(|err| {
                 tracing::error!(
-                    "Unable to update database from expected_machines list, bailing: {err}"
+                    error = %err,
+                    "Unable to update database from expected_machines list, bailing",
                 );
             })?;
         txn.commit().await?;
@@ -1142,7 +1153,10 @@ async fn initialize_and_start_controllers<'a>(
     .await?;
 
     if let Err(e) = update_dpu_asns(db_pool, common_pools).await {
-        tracing::warn!("Failed to update ASN for DPUs: {e}");
+        tracing::warn!(
+            error = %e,
+            "Failed to update ASN for DPUs",
+        );
     }
 
     let downloader = FirmwareDownloader::new();
@@ -1195,9 +1209,9 @@ async fn initialize_and_start_controllers<'a>(
             client.register_metrics(&meter, "dsx_event_bus");
 
             tracing::info!(
-                "DSX Exchange Event Bus enabled, publishing to {}:{}",
-                config.mqtt_endpoint,
-                config.mqtt_broker_port
+                mqtt_endpoint = %config.mqtt_endpoint,
+                mqtt_broker_port = config.mqtt_broker_port,
+                "DSX Exchange Event Bus enabled",
             );
 
             let bms_client = BmsDsxExchangeHandle::new(

--- a/crates/api-core/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/dpu.rs
@@ -62,7 +62,10 @@ pub async fn create_dpu_machine_in_waiting_for_network_install(
 }
 
 pub async fn create_machine_inventory(env: &TestEnv, machine_id: MachineId) {
-    tracing::debug!("Creating machine inventory for {}", machine_id);
+    tracing::debug!(
+        machine_id = %machine_id,
+        "Creating machine inventory",
+    );
     env.api
         .update_agent_reported_inventory(Request::new(rpc::forge::DpuAgentInventoryReport {
             machine_id: Some(machine_id),

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -2315,10 +2315,10 @@ pub async fn network_configured_with_health_and_ext_services(
         astra_config_status: None,
     };
     tracing::trace!(
-        "network_configured machine={} instance_network={} instance={}",
-        status.network_config_version.as_ref().unwrap(),
-        instance_network_config_version.clone().unwrap_or_default(),
-        instance_config_version.clone().unwrap_or_default(),
+        network_config_version = %status.network_config_version.as_ref().unwrap(),
+        instance_network_config_version = ?instance_network_config_version,
+        instance_config_version = ?instance_config_version,
+        "machine network configured",
     );
     let _ = env
         .api
@@ -2645,7 +2645,10 @@ pub async fn reboot_completed(
     env: &TestEnv,
     machine_id: carbide_uuid::machine::MachineId,
 ) -> rpc::forge::MachineRebootCompletedResponse {
-    tracing::info!("Machine ={} rebooted", machine_id);
+    tracing::info!(
+        machine_id = %machine_id,
+        "Machine rebooted",
+    );
     env.api
         .reboot_completed(Request::new(rpc::forge::MachineRebootCompletedRequest {
             machine_id: Some(machine_id),

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -1340,7 +1340,10 @@ impl<'a> MockExploredHost<'a> {
             let sku = db::sku::generate_sku_from_machine(txn.as_mut(), host_machine_id)
                 .await
                 .unwrap();
-            tracing::info!("creating sku: {}", sku.id);
+            tracing::info!(
+                sku_id = %sku.id,
+                "creating sku",
+            );
             db::sku::create(&mut txn, &sku).await.unwrap();
 
             tracing::info!("assigning sku");

--- a/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
@@ -90,14 +90,19 @@ impl TestMachine {
     }
 
     pub async fn reboot_completed(&self) -> rpc::forge::MachineRebootCompletedResponse {
-        tracing::info!("Machine ={} rebooted", self.id);
-        self.api
+        let response = self
+            .api
             .reboot_completed(Request::new(rpc::forge::MachineRebootCompletedRequest {
                 machine_id: self.id.into(),
             }))
             .await
             .unwrap()
-            .into_inner()
+            .into_inner();
+        tracing::info!(
+            machine_id = %self.id,
+            "Machine rebooted",
+        );
+        response
     }
 
     pub async fn forge_agent_control(&self) -> rpc::forge::ForgeAgentControlResponse {

--- a/crates/api-core/src/tests/dns.rs
+++ b/crates/api-core/src/tests/dns.rs
@@ -59,7 +59,10 @@ async fn test_dns(pool: sqlx::PgPool) {
     let fqdn2 = interface2.fqdn;
     let ip2 = interface2.address;
 
-    tracing::info!("FQDN1: {}", fqdn1);
+    tracing::info!(
+        fqdn1 = %fqdn1,
+        "FQDN1",
+    );
     let dns_record = api
         .lookup_record(tonic::Request::new(
             rpc::protos::dns::DnsResourceRecordLookupRequest {
@@ -74,8 +77,14 @@ async fn test_dns(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .into_inner();
-    tracing::info!("DNS Record: {:?}", dns_record);
-    tracing::info!("IP: {}", ip1);
+    tracing::info!(
+        dns_record = ?dns_record,
+        "DNS Record",
+    );
+    tracing::info!(
+        ip1 = %ip1,
+        "IP",
+    );
     assert_eq!(
         ip1.split('/').collect::<Vec<&str>>()[0],
         &*dns_record.records[0].content
@@ -227,7 +236,10 @@ async fn test_dns(pool: sqlx::PgPool) {
             .unwrap()
             .into_inner();
 
-        tracing::info!("Status: {:?}", status);
+        tracing::info!(
+            dns_lookup_response = ?status,
+            "Status",
+        );
         assert_eq!(status.records.len(), 0);
     }
 }

--- a/crates/api-core/src/tests/dpu_reprovisioning.rs
+++ b/crates/api-core/src/tests/dpu_reprovisioning.rs
@@ -1514,7 +1514,7 @@ async fn test_reboot_no_retry_during_firmware_update(pool: sqlx::PgPool) {
     let dpu = mh.dpu().db_machine(&mut txn).await;
     let last_reboot_requested = host.last_reboot_requested.as_ref().unwrap();
 
-    tracing::info!("power request: {:?}", last_reboot_requested);
+    tracing::info!(?last_reboot_requested, "power request",);
     assert!(matches!(
         host.last_reboot_requested.as_ref().unwrap().mode,
         MachineLastRebootRequestedMode::Reboot
@@ -2113,7 +2113,11 @@ async fn test_instance_reprov_restart_failed_impl(pool: sqlx::PgPool) {
 
     let dpu = mh.dpu().db_machine(&mut txn).await;
 
-    tracing::info!(machine_id = %dpu.id, "{} {}", dpu.current_state(), "curr state:");
+    tracing::info!(
+        machine_id = %dpu.id,
+        dpu_state = %dpu.current_state(),
+        "current DPU state",
+    );
 
     assert!(matches!(
         dpu.current_state(),

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -1072,7 +1072,10 @@ async fn test_instance_dns_resolution(_: PgPoolOptions, options: PgConnectOption
         .unwrap()
         .into_inner();
 
-    tracing::info!("dns_record is {:?}: ", dns_record);
+    tracing::info!(
+        dns_record = ?dns_record,
+        "Fetched DNS record",
+    );
     assert_eq!(dns_record.records.first().unwrap().content, "192.0.2.3");
 
     //DHCP response uses hostname set during allocation

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -1390,8 +1390,8 @@ async fn test_managed_host_network_status(pool: sqlx::PgPool) {
     assert_eq!(response.instances.len(), 1);
     let instance = &response.instances[0];
     tracing::info!(
-        "instance_network_config_version: {}",
-        instance.network_config_version
+        network_config_version = %instance.network_config_version,
+        "Instance network config version",
     );
     assert_eq!(
         instance.status.as_ref().unwrap().configs_synced,

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -236,7 +236,10 @@ pub mod tests {
             &mh.host().id,
             3,
             |machine| {
-                tracing::info!("waiting for inventory update: {}", machine.current_state());
+                tracing::info!(
+                    machine_state = %machine.current_state(),
+                    "waiting for inventory update",
+                );
                 matches!(
                     machine.current_state(),
                     ManagedHostState::BomValidating {
@@ -484,9 +487,15 @@ pub mod tests {
         actual_sku.created = expected_sku.created;
 
         let actual_sku_json: String = serde_json::ser::to_string_pretty(&actual_sku)?;
-        tracing::info!("actual_sku_json: {}", actual_sku_json);
+        tracing::info!(
+            actual_sku_json = %actual_sku_json,
+            "Serialized actual SKU",
+        );
         let expected_sku_json = serde_json::ser::to_string_pretty(&expected_sku)?;
-        tracing::info!("expected_sku_json: {}", expected_sku_json);
+        tracing::info!(
+            expected_sku_json = %expected_sku_json,
+            "Serialized expected SKU",
+        );
 
         assert_eq!(actual_sku_json, expected_sku_json);
 
@@ -1288,7 +1297,10 @@ pub mod tests {
             .pop()
             .unwrap();
 
-        tracing::info!("SKU1: {:?}", original_sku);
+        tracing::info!(
+            original_sku = ?original_sku,
+            "Original SKU before mismatch",
+        );
 
         let mut broken_sku = original_sku.clone();
         broken_sku.id = "Broken SKU".to_string();
@@ -1296,7 +1308,10 @@ pub mod tests {
 
         db::sku::create(&mut txn, &broken_sku).await?;
 
-        tracing::info!("SKU2: {:?}", broken_sku);
+        tracing::info!(
+            broken_sku = ?broken_sku,
+            "Broken SKU after mismatch",
+        );
 
         db::machine::unassign_sku(&mut txn, &machine_id).await?;
         db::machine::assign_sku(&mut txn, &machine_id, &broken_sku.id).await?;

--- a/crates/api-core/tests/integration/machine_bmc_metadata.rs
+++ b/crates/api-core/tests/integration/machine_bmc_metadata.rs
@@ -100,7 +100,12 @@ async fn fetch_bmc_credentials(pool: PgPool) {
     ]
     .into_iter()
     {
-        tracing::info!("Looking up credentials for {:?}", request);
+        let lookup_selector = if request.machine_id.is_some() {
+            "machine_id"
+        } else {
+            "bmc_endpoint"
+        };
+        tracing::info!(lookup_selector, "Looking up BMC credentials");
         let metadata = env
             .api()
             .get_bmc_meta_data(tonic::Request::new(request))

--- a/crates/api-db/src/bmc_metadata.rs
+++ b/crates/api-db/src/bmc_metadata.rs
@@ -32,7 +32,10 @@ async fn update_bmc_network_into_topologies(
             "BMC Info in machine_topologies does not have a MAC address for machine {machine_id}"
         )));
     }
-    tracing::info!("put bmc_info: {:?}", bmc_info);
+    tracing::info!(
+        bmc_info = ?bmc_info,
+        "Updating BMC info",
+    );
 
     // A entry with same machine id is already created by discover_machine call.
     // Just update json by adding a ipmi_ip entry.
@@ -123,10 +126,10 @@ pub async fn enrich_mac_address(
             let bmc_mac_address = bmc_machine_interface.mac_address;
 
             tracing::info!(
-                "{} is enriching BMC Info for machine {} with a BMC mac address of {:#?}",
-                caller,
-                machine_id,
-                bmc_machine_interface.mac_address,
+                caller = %caller,
+                machine_id = %machine_id,
+                mac_address = ?bmc_machine_interface.mac_address,
+                "Enriching BMC information",
             );
             bmc_info.mac = Some(bmc_mac_address);
             bmc_info.machine_interface_id = Some(bmc_machine_interface.id);
@@ -136,9 +139,10 @@ pub async fn enrich_mac_address(
         } else {
             // This should never happen. Should we return an error here?
             tracing::info!(
-                "{} failed to enrich the BMC Info for machine {} with a MAC: cannot cannot find a machine interface with IP address {bmc_ip_address}",
-                caller,
-                machine_id
+                caller = %caller,
+                machine_id = %machine_id,
+                bmc_ip_address = %bmc_ip_address,
+                "Failed to enrich BMC information: machine interface not found",
             );
         }
     }

--- a/crates/api-db/src/carbide_version.rs
+++ b/crates/api-db/src/carbide_version.rs
@@ -61,7 +61,8 @@ pub async fn observe_as_latest_version(
     } else if superseded_count > 1 {
         tracing::warn!(
             version,
-            "observed a new forge version, superseded {superseded_count} versions"
+            superseded_version_count = superseded_count,
+            "observed a new forge version, superseded versions",
         );
     }
 

--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -102,7 +102,7 @@ pub async fn find_record(
      COALESCE(q_type, CASE WHEN family(resource_record) = 6 THEN 'AAAA' ELSE 'A' END) as q_type
      from dns_records WHERE q_name=$1"#;
 
-    tracing::info!("Looking up record using query_name: {}", query_name);
+    tracing::info!(query_name, "Looking up DNS record",);
     let result = sqlx::query_as::<_, DbResourceRecord>(query)
         .bind(query_name)
         .fetch_all(txn)

--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -315,8 +315,8 @@ pub async fn create_missing_from(
     for expected_power_shelf in expected_power_shelves {
         if existing_map.contains_key(&expected_power_shelf.bmc_mac_address.to_string()) {
             tracing::debug!(
-                "Not overwriting expected-power-shelf with mac_addr: {}",
-                expected_power_shelf.bmc_mac_address.to_string()
+                bmc_mac_address = %expected_power_shelf.bmc_mac_address,
+                "Expected power shelf already exists; not overwriting",
             );
             continue;
         }

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -511,8 +511,8 @@ pub async fn create_missing_from(
     for expected_switch in expected_switches {
         if existing_map.contains_key(&expected_switch.bmc_mac_address.to_string()) {
             tracing::debug!(
-                "Not overwriting expected-switch with mac_addr: {}",
-                expected_switch.bmc_mac_address.to_string()
+                bmc_mac_address = %expected_switch.bmc_mac_address,
+                "Expected switch already exists; not overwriting",
             );
             continue;
         }

--- a/crates/api-db/src/host_naming/mod.rs
+++ b/crates/api-db/src/host_naming/mod.rs
@@ -697,7 +697,7 @@ async fn claim_bare_serial_hostname(
             )));
         }
         tracing::info!(
-            interface_id = %sibling.id,
+            machine_interface_id = %sibling.id,
             hostname = %bare,
             renamed = %renamed,
             "reclaiming the bare serial name from a demoted interface of the same machine"

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -250,7 +250,7 @@ fn build_operating_system_for_snapshot(
         }
         _ => {
             tracing::warn!(
-                os_id = %os_row.id,
+                operating_system_id = %os_row.id,
                 os_type = %os_row.type_,
                 "unexpected operating_system type, falling back to inline iPXE"
             );
@@ -501,8 +501,9 @@ pub async fn update_phone_home_last_contact(
         .map_err(|e| DatabaseError::query(query, e))?;
 
     tracing::info!(
-        "Phone home last contact updated for instance {}",
-        query_result.0
+        instance_id = %instance_id,
+        phone_home_last_contact = %query_result.0,
+        "Phone home last contact updated",
     );
     Ok(query_result.0)
 }
@@ -519,7 +520,10 @@ pub async fn clear_phone_home_last_contact(
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
 
-    tracing::info!("Phone home last contact cleared for instance {instance_id}");
+    tracing::info!(
+        instance_id = %instance_id,
+        "Phone home last contact cleared",
+    );
     Ok(())
 }
 
@@ -1186,8 +1190,9 @@ pub async fn batch_update_spx_config(
     // Verify all rows were updated (version check passed)
     if result.rows_affected() != expected_count {
         tracing::error!(
-            "batch_update_spx_config affected != expected: {:#?} != {expected_count}",
-            result.rows_affected()
+            affected_row_count = result.rows_affected(),
+            expected_row_count = expected_count,
+            "SPX config batch update affected an unexpected number of rows",
         );
         return Err(DatabaseError::FailedPrecondition(
             "Spx config version mismatch during batch update".to_string(),

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -402,7 +402,7 @@ pub async fn allocate(
 
         if segment.prefixes.is_empty() {
             tracing::error!(
-                segment_id = %segment.id,
+                network_segment_id = %segment.id,
                 "No prefix is attached to segment.",
             );
             return Err(DatabaseError::FindOneReturnedNoResultsError(
@@ -425,7 +425,7 @@ pub async fn allocate(
                         ConfigValidationError::NetworkSegmentUnavailableOnHost,
                     )) => {
                         tracing::debug!(
-                            segment_id = %segment.id,
+                            network_segment_id = %segment.id,
                             prefix = %prefix.prefix,
                             "Host has no address in this prefix, skipping.",
                         );

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -534,7 +534,12 @@ impl From<DatabaseError> for tonic::Status {
             if f.len() == 2 {
                 let handler = f[0].trim();
                 let location = f[1].trim().replace("at ", "");
-                tracing::error!("{from} location={location} handler='{handler}'");
+                tracing::error!(
+                    error = %from,
+                    error_location = %location,
+                    handler,
+                    "database error conversion",
+                );
                 true
             } else {
                 false
@@ -546,7 +551,7 @@ impl From<DatabaseError> for tonic::Status {
         if !printed {
             match from {
                 DatabaseError::NotImplemented => {}
-                _ => tracing::error!("{from}"),
+                _ => tracing::error!(error = %from, "database error conversion"),
             }
         }
 

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -109,7 +109,7 @@ pub async fn get_or_create(
         if existing_machine.is_none() {
             tracing::warn!(
                 %machine_id,
-                interface_id = %interface.id,
+                machine_interface_id = %interface.id,
                 "Interface ID refers to missing machine",
             );
             return Err(DatabaseError::NotFoundError {
@@ -1033,8 +1033,8 @@ pub async fn update_spx_status_observation(
     observation: &MachineSpxStatusObservation,
 ) -> Result<(), DatabaseError> {
     tracing::debug!(
-        "update_spx_status_observation: observation {:#?}",
-        observation
+        observation = ?observation,
+        "updating SPX status observation",
     );
     let query = "UPDATE machines SET spx_status_observation = $1::json WHERE id = $2 AND
                 (spx_status_observation->>'observed_at' IS NULL OR spx_status_observation->>'observed_at' <= $3) RETURNING id";
@@ -1058,7 +1058,12 @@ async fn debug_failed_machine_status_update(
 ) {
     let serialized_data =
         serde_json::to_string_pretty(column_data).unwrap_or_else(|_| "Invalid".to_string());
-    tracing::error!(machine_id=%machine_id, column_name, "Failed to update column. New column data: {serialized_data}");
+    tracing::error!(
+        machine_id=%machine_id,
+        column_name,
+        serialized_data = %serialized_data,
+        "Failed to update column. New column data",
+    );
     // Dump the raw Machine state for debugging purposes
     let query = "SELECT * from machines WHERE id = $1";
     match sqlx::query(query)
@@ -1067,13 +1072,19 @@ async fn debug_failed_machine_status_update(
         .await
     {
         Ok(Some(row)) => {
-            tracing::error!("Machine Data: {:?}", row);
+            tracing::error!(
+                row = ?row,
+                "Machine Data",
+            );
         }
         Ok(None) => {
             tracing::error!("No Machine Data");
         }
         Err(e) => {
-            tracing::error!("Failed to load Machine Data. Error: {e}");
+            tracing::error!(
+                error = %e,
+                "Failed to load machine data",
+            );
         }
     }
 }
@@ -1564,7 +1575,11 @@ pub async fn create(
             {
                 Ok(asn) => Some(asn as i64),
                 Err(e) => {
-                    tracing::info!("Failed to allocate asn for dpu {stable_machine_id}: {e}");
+                    tracing::info!(
+                        stable_machine_id = %stable_machine_id,
+                        error = %e,
+                        "Failed to allocate asn for dpu",
+                    );
                     None
                 }
             }
@@ -2096,7 +2111,7 @@ pub async fn update_state(
     .ok_or_else(|| DatabaseError::new("crate::machine::find_one", sqlx::Error::RowNotFound))?;
 
     let version = host.current_version().increment();
-    tracing::info!(machine_id = %host.id, ?new_state, "Updating host state");
+    tracing::info!(machine_id = %host.id, next_state = ?new_state, "Updating host state");
     advance(&host, txn, new_state, Some(version)).await?;
 
     // Keep both host and dpu's states in sync.

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -609,7 +609,8 @@ async fn find_or_create_machine_interface_inner(
         None => {
             tracing::info!(
                 %mac_address,
-                "Found no existing machine with mac address {mac_address} using networks with relays {relaystr}",
+                relays = ?relays,
+                "No existing machine found",
             );
             let mut interface = validate_existing_mac_and_create_inner(
                 &mut *txn,
@@ -630,7 +631,7 @@ async fn find_or_create_machine_interface_inner(
                 n => {
                     tracing::warn!(
                         %mac_address,
-                        relay_ips = %relaystr,
+                        relay_ip_addresses = %relaystr,
                         matching_interface_count = n,
                         expected_interface_count = 1,
                         "Unexpected number of machine interfaces for MAC while machine is already known",
@@ -667,7 +668,8 @@ pub async fn find_or_create_observed_machine_interface(
         None => {
             tracing::info!(
                 %mac_address,
-                "Found no existing machine with mac address {mac_address} using networks with relays {relaystr}",
+                relays = ?relays,
+                "No existing machine found",
             );
 
             // Return an existing row when the MAC is already known on this segment.
@@ -737,7 +739,7 @@ pub async fn find_or_create_observed_machine_interface(
                 n => {
                     tracing::warn!(
                         %mac_address,
-                        relay_ips = %relaystr,
+                        relay_ip_addresses = %relaystr,
                         matching_interface_count = n,
                         expected_interface_count = 1,
                         "Unexpected number of machine interfaces for MAC while machine is already known",
@@ -797,7 +799,7 @@ pub async fn network_segments_for_dhcp_relays(
                 .any(|segment| segment.config.segment_type != network_segment_type)
         {
             tracing::warn!(
-                relay_ips = %relays.iter().join(", "),
+                relay_ip_addresses = %relays.iter().join(", "),
                 expected_network_segment_type = %network_segment_type,
                 exact_segment_ids = %exact_segments.iter().map(|segment| segment.id.to_string()).join(", "),
                 exact_segment_types = %exact_segments
@@ -1202,8 +1204,8 @@ async fn preallocate_machine_interface_with_type(
         Ok(_) => {
             tracing::info!(
                 %mac_address,
-                %static_ip,
-                segment_id = %segment.id,
+                static_ip_address = %static_ip,
+                network_segment_id = %segment.id,
                 "Pre-allocated static machine interface"
             );
             Ok(())
@@ -1947,8 +1949,8 @@ pub async fn find_by_ip_or_id(
     {
         // remove debug message by Apr 2024
         tracing::debug!(
-            interface_id = %interface.id,
-            %remote_ip,
+            machine_interface_id = %interface.id,
+            remote_ip_address = %remote_ip,
             "Loaded interface by remote IP"
         );
         return Ok(interface);
@@ -2070,7 +2072,7 @@ pub async fn move_predicted_machine_interface_to_machine(
     tracing::info!(
         machine_id=%predicted_machine_interface.machine_id,
         mac_address=%predicted_machine_interface.mac_address,
-        %relay_ip,
+        relay_ip_address = %relay_ip,
         "Got DHCP from predicted machine interface, moving to machine"
     );
     let Some(network_segment) = crate::network_segment::for_relay(txn, relay_ip).await? else {
@@ -2963,8 +2965,8 @@ async fn reconcile_interface_segment(
 
         tracing::info!(
             mac_address = %existing_interface.mac_address,
-            old_segment_id = %existing_interface.segment_id,
-            new_segment_id = %relay_segment.id,
+            previous_network_segment_id = %existing_interface.segment_id,
+            next_network_segment_id = %relay_segment.id,
             "Moving interface from static-assignments into DHCP-managed segment"
         );
         update_segment_id(

--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -128,8 +128,9 @@ pub async fn create_or_update_with_bom_validation(
         let age = Utc::now() - topology.updated;
         if bom_validation_enabled && age > TimeDelta::days(1) {
             tracing::debug!(
-                "Received inventory update from {}, bom_validation is enabled, existing data is old, updating",
-                machine_id
+                machine_id = %machine_id,
+                inventory_age_days = age.num_days(),
+                "Received stale inventory update while BOM validation is enabled",
             );
             set_topology_update_needed(txn, machine_id, true).await?;
         }

--- a/crates/api-db/src/measured_boot/bundle.rs
+++ b/crates/api-db/src/measured_boot/bundle.rs
@@ -563,8 +563,8 @@ async fn find_closest_bundle(
 
     if active_bundles.is_empty() {
         tracing::info!(
-            "No Active or Obsolete bundles were found for profile_id {0}",
-            profile_id
+            measurement_system_profile_id = %profile_id,
+            "No active or obsolete measured boot bundles found",
         );
         return Ok(None);
     }

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -506,7 +506,7 @@ pub async fn reconcile_network_defs(
                 } else {
                     tracing::warn!(
                         network_name = name,
-                        count = candidates.len(),
+                        matching_network_segment_count = candidates.len(),
                         "Backfill skipped: multiple network_segments share this name; \
                          operator must reconcile by hand",
                     );

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -581,7 +581,7 @@ async fn define_by_prefix(
             tracing::debug!(
                 pool_name = name,
                 prefix,
-                num_values,
+                value_count = num_values,
                 "Populated IPv4 resource pool from prefix"
             );
         }
@@ -596,7 +596,7 @@ async fn define_by_prefix(
             tracing::debug!(
                 pool_name = name,
                 prefix,
-                num_values,
+                value_count = num_values,
                 "Populated IPv6 resource pool from prefix"
             );
         }
@@ -616,8 +616,8 @@ async fn define_by_prefix(
             tracing::debug!(
                 pool_name = name,
                 prefix,
-                delegate_len,
-                num_values,
+                delegation_prefix_length = delegate_len,
+                value_count = num_values,
                 "Populated IPv6 prefix delegation pool"
             );
         }
@@ -656,7 +656,7 @@ async fn define_by_range(
                 pool_name = name,
                 range_start,
                 range_end,
-                num_values,
+                value_count = num_values,
                 "Populated IPv4 resource pool from range"
             );
         }
@@ -672,7 +672,7 @@ async fn define_by_range(
                 pool_name = name,
                 range_start,
                 range_end,
-                num_values,
+                value_count = num_values,
                 "Populated IPv6 resource pool from range"
             );
         }
@@ -688,7 +688,7 @@ async fn define_by_range(
                 pool_name = name,
                 range_start,
                 range_end,
-                num_values,
+                value_count = num_values,
                 "Populated IPv6 prefix pool from range"
             );
         }
@@ -704,7 +704,11 @@ async fn define_by_range(
                 model::resource_pool::ValueType::Integer,
             );
             populate(&pool, txn, values, auto_assign).await?;
-            tracing::debug!(pool_name = name, num_values, "Populated int resource pool");
+            tracing::debug!(
+                pool_name = name,
+                value_count = num_values,
+                "Populated int resource pool"
+            );
         }
     }
     Ok(())

--- a/crates/api-db/src/vpc_dpu_loopback.rs
+++ b/crates/api-db/src/vpc_dpu_loopback.rs
@@ -58,8 +58,8 @@ pub async fn delete_and_deallocate(
 
         if admin_vpcs.is_empty() {
             tracing::warn!(
-                "No VPC attached to one or more admin segments: {:?}.",
-                admin_segments
+                ?admin_segments,
+                "No VPC attached to one or more admin segments.",
             );
         } else {
             // We only allow a single admin VPC, so it seems this could easily be

--- a/crates/api-db/src/work_lock_manager.rs
+++ b/crates/api-db/src/work_lock_manager.rs
@@ -151,7 +151,10 @@ async fn run_loop(
                 match try_acquire_lock(db, &work_key, keepalive_timeout).await {
                     Ok(Some(worker_id)) => {
                         reply_tx.send(Ok(worker_id)).ok();
-                        tracing::debug!("Acquired work lock {work_key}");
+                        tracing::debug!(
+                            work_key = %work_key,
+                            "Acquired work lock",
+                        );
                     }
                     Ok(None) => {
                         reply_tx
@@ -171,7 +174,11 @@ async fn run_loop(
                 release_lock(db, &work_key, worker_id)
                     .await
                     .inspect_err(|e| {
-                        tracing::error!(%work_key, "Could not release work lock: {e}");
+                        tracing::error!(
+                            %work_key,
+                            error = %e,
+                            "Could not release work lock",
+                        );
                     })
                     .ok();
                 tracing::debug!(%work_key, "Released work lock");
@@ -277,9 +284,9 @@ pub struct WorkLock {
 impl Drop for WorkLock {
     fn drop(&mut self) {
         tracing::debug!(
-            "Releasing lock for {} worker {}",
-            self.work_key,
-            self.worker_id
+            work_key = %self.work_key,
+            worker_id = %self.worker_id,
+            "Releasing work lock",
         );
 
         // Let the keepalive loop stop
@@ -293,7 +300,12 @@ impl Drop for WorkLock {
                 worker_id: self.worker_id,
             })
             .inspect_err(|e| {
-                tracing::error!("ERROR! Could not release lock for {} worker {}: WorkLockManager queue is full! Database is likely overloaded: {}", self.work_key, self.worker_id, e);
+                tracing::error!(
+                    work_key = %self.work_key,
+                    worker_id = %self.worker_id,
+                    error = %e,
+                    "Could not release work lock: WorkLockManager queue is full; database is likely overloaded",
+                );
             })
             .ok();
     }
@@ -307,36 +319,49 @@ impl WorkLock {
         keepalive_interval: Duration,
     ) -> Self {
         let (keepalive_stop_tx, mut keepalive_stop_rx) = oneshot::channel();
-        let join_handle = tokio::task::Builder::new().name(&format!("keepalive loop for {work_key} worker {worker_id}")).spawn({
-            let manager = manager.clone();
-            let work_key = work_key.clone();
-            let mut keepalive_timer = tokio::time::interval(keepalive_interval);
-            keepalive_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
-            let fut = async move {
-                loop {
-                    tokio::select! {
-                        _ = keepalive_timer.tick() => {
-                            match manager.keep_lock_alive(work_key.clone(), worker_id).await {
-                                Ok(_) => {}
-                                Err(KeepAliveError::LockLost(msg)) => {
-                                    tracing::error!("{work_key} worker {worker_id} lost lock: {msg}");
-                                    return;
-                                }
-                                Err(e) => {
-                                    tracing::error!("Error sending keepalive for {work_key} worker {worker_id} (will retry): {e}");
+        let join_handle = tokio::task::Builder::new()
+            .name(&format!("keepalive loop for {work_key} worker {worker_id}"))
+            .spawn({
+                let manager = manager.clone();
+                let work_key = work_key.clone();
+                let mut keepalive_timer = tokio::time::interval(keepalive_interval);
+                keepalive_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                let fut = async move {
+                    loop {
+                        tokio::select! {
+                            _ = keepalive_timer.tick() => {
+                                match manager.keep_lock_alive(work_key.clone(), worker_id).await {
+                                    Ok(_) => {}
+                                    Err(KeepAliveError::LockLost(msg)) => {
+                                        tracing::error!(
+                                            work_key = %work_key,
+                                            worker_id = %worker_id,
+                                            error = %msg,
+                                            "worker lost lock",
+                                        );
+                                        return;
+                                    }
+                                    Err(e) => {
+                                        tracing::error!(
+                                            work_key = %work_key,
+                                            worker_id = %worker_id,
+                                            error = %e,
+                                            "Failed to send work-lock keepalive; retrying",
+                                        );
+                                    }
                                 }
                             }
-                        }
-                        _ = &mut keepalive_stop_rx => {
-                            break;
+                            _ = &mut keepalive_stop_rx => {
+                                break;
+                            }
                         }
                     }
-                }
-            };
-            // Note: don't inherit the callers span, since child spans can't outlive their parent.
-            // This prevents a crash in tracing-subscriber.
-            fut.instrument(tracing::debug_span!(parent: None, "WorkLock keepalive loop"))
-        }).expect("could not spawn tokio task");
+                };
+                // Note: don't inherit the callers span, since child spans can't outlive their parent.
+                // This prevents a crash in tracing-subscriber.
+                fut.instrument(tracing::debug_span!(parent: None, "WorkLock keepalive loop"))
+            })
+            .expect("could not spawn tokio task");
 
         if !cfg!(test) {
             _ = join_handle;

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -675,7 +675,10 @@ async fn test_machine_a_tron_multidpu(
                 let machine_id = machine_handle
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
-                tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
+                tracing::info!(
+                    machine_id = %machine_id,
+                    "Machine has made it to Ready, allocating instance",
+                );
                 let instance_id = instance::create(
                     carbide_api_addrs,
                     &machine_id,
@@ -718,14 +721,18 @@ async fn test_machine_a_tron_multidpu(
                 assert_eq!(gateways.len(), 1);
 
                 tracing::info!(
-                    "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
+                    machine_id = %machine_id,
+                    "Machine has made it to Assigned/Ready, releasing instance",
                 );
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
 
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
-                tracing::info!("Machine {machine_id} has made it to Ready again, all done");
+                tracing::info!(
+                    machine_id = %machine_id,
+                    "Machine has made it to Ready again, all done",
+                );
                 Ok::<(), eyre::Report>(())
             }
         },
@@ -823,7 +830,10 @@ async fn test_machine_a_tron_zerodpu(
                 let machine_id = machine_handle
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
-                tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
+                tracing::info!(
+                    machine_id = %machine_id,
+                    "Machine has made it to Ready, allocating instance",
+                );
 
                 let instance_id = instance::create_with_auto_host_inband_networking(
                     carbide_api_addrs,
@@ -837,7 +847,8 @@ async fn test_machine_a_tron_zerodpu(
                     .await?;
                 assert_auto_instance_network(carbide_api_addrs, &instance_id, &flat_vpc_id).await?;
                 tracing::info!(
-                    "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
+                    machine_id = %machine_id,
+                    "Machine has made it to Assigned/Ready, releasing instance",
                 );
 
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
@@ -845,7 +856,10 @@ async fn test_machine_a_tron_zerodpu(
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
-                tracing::info!("Machine {machine_id} has made it to Ready again, all done");
+                tracing::info!(
+                    machine_id = %machine_id,
+                    "Machine has made it to Ready again, all done",
+                );
                 Ok::<(), eyre::Report>(())
             }
         },
@@ -887,7 +901,10 @@ async fn test_machine_a_tron_nic_mode(
                 let machine_id = machine_handle
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
-                tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
+                tracing::info!(
+                    machine_id = %machine_id,
+                    "Machine has made it to Ready, allocating instance",
+                );
 
                 assert_nic_mode_host(
                     carbide_api_addrs,
@@ -909,7 +926,8 @@ async fn test_machine_a_tron_nic_mode(
                     .await?;
                 assert_auto_instance_network(carbide_api_addrs, &instance_id, &flat_vpc_id).await?;
                 tracing::info!(
-                    "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
+                    machine_id = %machine_id,
+                    "Machine has made it to Assigned/Ready, releasing instance",
                 );
 
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
@@ -917,7 +935,10 @@ async fn test_machine_a_tron_nic_mode(
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
-                tracing::info!("Machine {machine_id} has made it to Ready again, all done");
+                tracing::info!(
+                    machine_id = %machine_id,
+                    "Machine has made it to Ready again, all done",
+                );
                 Ok::<(), eyre::Report>(())
             }
         },
@@ -1056,7 +1077,9 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
                 tracing::info!(
-                    "Machine {initial_machine_id} (bmc_mac {bmc_mac}) is Ready in DPU mode; flipping to NIC mode"
+                    initial_machine_id = %initial_machine_id,
+                    bmc_mac_address = %bmc_mac,
+                    "Machine is Ready in DPU mode; flipping to NIC mode",
                 );
 
                 // 2. Flip the ExpectedMachine to NIC mode. Get the current record,
@@ -1076,7 +1099,10 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     Some(&expected_machine),
                 )
                 .await?;
-                tracing::info!("ExpectedMachine for {bmc_mac} now declares NIC mode");
+                tracing::info!(
+                    bmc_mac_address = %bmc_mac,
+                    "ExpectedMachine for now declares NIC mode",
+                );
 
                 // 3. Force-delete the managed-DPU machine so site-explorer
                 //    re-ingests the host under the new declared mode. This is the
@@ -1098,7 +1124,10 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     Some(&force_delete_req),
                 )
                 .await?;
-                tracing::info!("Force-deleted machine {initial_machine_id}; awaiting re-ingestion as NicMode");
+                tracing::info!(
+                    initial_machine_id = %initial_machine_id,
+                    "Force-deleted machine; awaiting re-ingestion as NicMode",
+                );
 
                 // 4. Wait for the host to re-ingest as a zero-managed-DPU machine,
                 //    asserted directly against the database. The host's TPM-derived
@@ -1145,8 +1174,9 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
 
                     if host_exists && nic_count >= 1 && managed_dpu_count == 0 {
                         tracing::info!(
-                            "Host re-ingested as zero-managed-DPU machine {host_id} \
-                             (nic_count={nic_count}); DPU->NIC flip applied"
+                            host_machine_id = %host_id,
+                            nic_interface_count = nic_count,
+                            "Host re-ingested as a zero-managed-DPU machine; DPU-to-NIC flip applied",
                         );
                         break;
                     }
@@ -1164,7 +1194,10 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                 //    the host BMC now serves an event log so the controller's
                 //    restart verification can confirm reboots, and the zero-DPU
                 //    lockdown short-circuit lets it skip the DPU-down wait.
-                tracing::info!("Waiting for re-ingested NicMode host {host_id} to reach Ready");
+                tracing::info!(
+                    host_machine_id = %host_id,
+                    "Waiting for re-ingested NicMode host to reach Ready",
+                );
                 let ready_deadline = time::Instant::now() + Duration::from_secs(240);
                 loop {
                     let resp = api_test_helper::grpcurl::grpcurl(
@@ -1176,7 +1209,11 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     let resp: serde_json::Value = serde_json::from_str(&resp)?;
                     let state = resp["machines"][0]["state"].as_str().unwrap_or("");
                     if state == "Ready" {
-                        tracing::info!("Re-ingested NicMode host {host_id} reached Ready ({state})");
+                        tracing::info!(
+                            host_machine_id = %host_id,
+                            machine_state = state,
+                            "Re-ingested NicMode host reached Ready",
+                        );
                         break;
                     }
                     if time::Instant::now() >= ready_deadline {
@@ -1222,7 +1259,8 @@ async fn test_machine_a_tron_dual_stack(
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
                 tracing::info!(
-                    "Machine {machine_id} is Ready, allocating dual-stack instance via ipv6 config"
+                    machine_id = %machine_id,
+                    "Machine is Ready, allocating dual-stack instance via ipv6 config",
                 );
                 let instance_id = instance::create_with_vpc_prefixes(
                     carbide_api_addrs,
@@ -1280,7 +1318,9 @@ async fn test_machine_a_tron_dual_stack(
                 );
 
                 tracing::info!(
-                    "Machine {machine_id} dual-stack allocation verified: addresses = {addr_strings:?}"
+                    machine_id = %machine_id,
+                    addresses = ?addr_strings,
+                    "Machine dual-stack allocation verified",
                 );
 
                 instance::release(carbide_api_addrs, &machine_id, &instance_id, false)
@@ -1290,7 +1330,8 @@ async fn test_machine_a_tron_dual_stack(
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!(
-                    "Machine {machine_id} back to Ready after dual-stack release"
+                    machine_id = %machine_id,
+                    "Machine back to Ready after dual-stack release",
                 );
                 Ok::<(), eyre::Report>(())
             }
@@ -1329,7 +1370,8 @@ async fn test_machine_a_tron_dual_stack_l2(
                     .observed_machine_id()
                     .expect("Machine ID should be set if host is ready");
                 tracing::info!(
-                    "Machine {machine_id} is Ready, allocating dual-stack L2 instance"
+                    machine_id = %machine_id,
+                    "Machine is Ready, allocating dual-stack L2 instance",
                 );
                 let instance_id = instance::create(
                     carbide_api_addrs,
@@ -1350,17 +1392,18 @@ async fn test_machine_a_tron_dual_stack_l2(
                     .await?;
 
                 tracing::info!(
-                    "Machine {machine_id} dual-stack L2 instance allocated and reached Assigned/Ready"
+                    machine_id = %machine_id,
+                    "Machine dual-stack L2 instance allocated and reached Assigned/Ready",
                 );
 
-                instance::release(carbide_api_addrs, &machine_id, &instance_id, false)
-                    .await?;
+                instance::release(carbide_api_addrs, &machine_id, &instance_id, false).await?;
 
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
                     .await?;
                 tracing::info!(
-                    "Machine {machine_id} back to Ready after dual-stack L2 release"
+                    machine_id = %machine_id,
+                    "Machine back to Ready after dual-stack L2 release",
                 );
                 Ok::<(), eyre::Report>(())
             }

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -300,8 +300,8 @@ impl DpaInterface {
         // If we haven't yet seen any observations, we are not synced
         let Some(spx_status_observation) = spx_status_observation else {
             tracing::info!(
-                "DPA interface {dpa_id} is not synced because no SPX status observation is available",
-                dpa_id = self.id
+                dpa_interface_id = %self.id,
+                "DPA interface is not synced because no SPX status observation is available",
             );
             return false;
         };
@@ -330,10 +330,10 @@ impl DpaInterface {
             {
                 if config_version != dpa_expected_version {
                     tracing::info!(
-                        "DPA interface {dpa_id} is not synced version mismatch: {config_version} != {dpa_expected_version}",
-                        dpa_id = self.id,
-                        config_version = config_version,
-                        dpa_expected_version = dpa_expected_version
+                        dpa_interface_id = %self.id,
+                        config_version = %config_version,
+                        dpa_expected_version = %dpa_expected_version,
+                        "DPA interface is not synced version mismatch!",
                     );
                     return false;
                 }
@@ -342,9 +342,9 @@ impl DpaInterface {
         }
 
         tracing::info!(
-            "DPA interface {dpa_id} is not synced verrsion mismatch: {dpa_expected_version}",
-            dpa_id = self.id,
-            dpa_expected_version = dpa_expected_version
+            dpa_interface_id = %self.id,
+            dpa_expected_version = %dpa_expected_version,
+            "DPA interface is not synced because no matching SPX status attachment was found",
         );
 
         false

--- a/crates/api-model/src/firmware.rs
+++ b/crates/api-model/src/firmware.rs
@@ -142,9 +142,10 @@ impl Firmware {
                 .find(|&x| self.matching_version_id(&x.id, firmware_type))
             {
                 tracing::debug!(
-                    "find_version {:?}: For {firmware_type:?} found {:?}",
-                    report.machine_id,
-                    matching_inventory.version
+                    machine_id = ?report.machine_id,
+                    ?firmware_type,
+                    version = ?matching_inventory.version,
+                    "Found matching firmware version",
                 );
                 return matching_inventory.version.clone();
             };

--- a/crates/api-model/src/instance/status/infiniband.rs
+++ b/crates/api-model/src/instance/status/infiniband.rs
@@ -111,7 +111,7 @@ impl InstanceInfinibandStatus {
                     },
                     None => {
                         tracing::error!(
-                            interface = ?config.function_id,
+                            function_id = ?config.function_id,
                             ?config,
                             ?observation,
                             "Could not find matching status for interface",

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -24,7 +24,6 @@ use carbide_uuid::vpc::VpcId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use ipnetwork::IpNetwork;
-use itertools::Itertools;
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 
@@ -222,8 +221,8 @@ impl InstanceNetworkStatus {
                         > 1
                     {
                         tracing::error!(
-                            "Found multiple physical interfaces when no device specified: {:?}",
-                            config
+                            ?config,
+                            "Found multiple physical interfaces when no device specified",
                         );
                         return Self::unsynchronized_for_config(&config);
                     }
@@ -292,8 +291,8 @@ impl InstanceNetworkStatus {
 
         if !missing_dpus.is_empty() {
             tracing::info!(
-                "Missing observations for DPUs: {}",
-                missing_dpus.into_iter().join(",")
+                missing_dpu_ids = ?missing_dpus,
+                "Missing observations for DPUs",
             );
         }
 
@@ -393,11 +392,16 @@ impl InstanceInterfaceStatus {
         // if any of them were not found.
         let gateways = prefix_ids
             .iter()
-            .map(|id| if let Some(gw) = value.network_segment_gateways.remove(id) {
-                Some(gw)
-            } else {
-                tracing::warn!("Missing gateway in InstanceInterfaceConfig for network prefix {id}, gateways field will be empty.");
-                None
+            .map(|id| {
+                if let Some(gw) = value.network_segment_gateways.remove(id) {
+                    Some(gw)
+                } else {
+                    tracing::warn!(
+                        network_prefix_id = %id,
+                        "Missing gateway in InstanceInterfaceConfig; gateways field will be empty",
+                    );
+                    None
+                }
             })
             .collect::<Option<Vec<_>>>()
             .unwrap_or_default();

--- a/crates/api-model/src/instance/status/nvlink.rs
+++ b/crates/api-model/src/instance/status/nvlink.rs
@@ -72,8 +72,8 @@ impl InstanceNvLinkStatus {
                 }
                 None => {
                     tracing::error!(
-                        "could not find matching status gpu {:?}",
-                        cfg.device_instance
+                        device_instance = cfg.device_instance,
+                        "could not find matching status gpu",
                     );
                     configs_synced = SyncState::Pending;
                     InstanceNvLinkGpuStatus {

--- a/crates/api-model/src/instance/status/spx.rs
+++ b/crates/api-model/src/instance/status/spx.rs
@@ -74,8 +74,8 @@ impl InstanceSpxStatus {
                 }
                 None => {
                     tracing::error!(
-                        "could not find matching status spx attachment {:?}",
-                        cfg.device_instance
+                        device_instance = cfg.device_instance,
+                        "could not find matching status spx attachment",
                     );
                     configs_synced = SyncState::Pending;
                     InstanceSpxAttachmentStatus {

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -2561,7 +2561,8 @@ pub fn state_sla(
     {
         tracing::debug!(
             machine_id = %machine_id,
-            "Skipping state machine SLA for machine due to {exclude} classification"
+            health_alert_classification = %exclude,
+            "Skipping state machine SLA due to classification",
         );
         return StateSla::no_sla();
     }
@@ -2946,8 +2947,8 @@ pub fn dpf_based_dpu_provisioning_possible(
     // DPF should be enabled for host.
     if !state.host_snapshot.dpf.enabled {
         tracing::info!(
-            "DPF based DPU provisioning is not possible because DPF is not enabled for the host {}.",
-            state.host_snapshot.id
+            machine_id = %state.host_snapshot.id,
+            "DPF based DPU provisioning is not possible because DPF is not enabled for the host.",
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,
@@ -2970,9 +2971,8 @@ pub fn dpf_based_dpu_provisioning_possible(
             .all(|dpu| dpu.reprovision_requested.is_some())
     {
         tracing::info!(
-            "DPF based DPU reprovisioning is not possible for host {} because initial ingestion is not done with DPF \
-            and not all DPUs are being reprovisioned.",
-            state.host_snapshot.id
+            machine_id = %state.host_snapshot.id,
+            "DPF based DPU reprovisioning is not possible for host because initial ingestion is not done with DPF and not all DPUs are being reprovisioned.",
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,
@@ -2992,8 +2992,8 @@ pub fn dpf_based_dpu_provisioning_possible(
             .unwrap_or(false)
     }) {
         tracing::info!(
-            "DPF based DPU provisioning is not possible because some DPUs are Bluefield 2 in {}.",
-            state.host_snapshot.id
+            machine_id = %state.host_snapshot.id,
+            "DPF-based DPU provisioning is not possible because some DPUs are BlueField-2",
         );
         tracing::warn!(
             machine_id = %state.host_snapshot.id,

--- a/crates/api-model/src/machine/nvlink.rs
+++ b/crates/api-model/src/machine/nvlink.rs
@@ -73,8 +73,8 @@ pub fn nvlink_config_synced(
             .find(|gpu| gpu.device_instance == gpu_config.device_instance)
         else {
             tracing::error!(
-                "could not find matching status gpu {:?}",
-                gpu_config.device_instance
+                device_instance = gpu_config.device_instance,
+                "could not find matching status gpu",
             );
             return Err(NvLinkConfigNotSyncedReason(
                 "No matching NvLink status observation found for GPU in config".to_string(),

--- a/crates/api-model/src/machine/spx.rs
+++ b/crates/api-model/src/machine/spx.rs
@@ -80,8 +80,8 @@ pub fn spx_config_synced(
             conf_att.mac_address.as_deref().unwrap_or_default() == obs_att.mac_address.to_string()
         }) else {
             tracing::error!(
-                "could not find matching status instance {:?}",
-                conf_att.device_instance
+                device_instance = conf_att.device_instance,
+                "could not find matching status instance",
             );
             return Err(SpxConfigNotSyncedReason(
                 "No matching SPX status observation found for attachment in config".to_string(),

--- a/crates/api-model/src/power_manager.rs
+++ b/crates/api-model/src/power_manager.rs
@@ -117,7 +117,7 @@ pub fn get_updated_power_options_for_desired_on_state_off(
     updated_power_options.last_fetched_off_counter += 1;
     let cause =
         "Since desired state is On, but actual state is Off, skipping state machine.".to_string();
-    tracing::warn!(cause);
+    tracing::warn!(reason = %cause, "Skipping state machine");
     (
         PowerHandlingOutcome::new(Some(updated_power_options), false, Some(cause)),
         try_power_on,

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -254,9 +254,10 @@ impl ExploredEndpoint {
                 .find(|&x| fw_info.matching_version_id(&x.id, firmware_type))
             {
                 tracing::debug!(
-                    "find_version {}: For {firmware_type:?} found {:?}",
-                    self.address,
-                    matching_inventory.version
+                    bmc_ip_address = %self.address,
+                    firmware_type = ?firmware_type,
+                    version = ?matching_inventory.version,
+                    "Found matching firmware version",
                 );
                 return matching_inventory.version.as_ref();
             };
@@ -283,10 +284,11 @@ impl ExploredEndpoint {
         }
 
         tracing::debug!(
-            "find_all_versions {}: Found {} versions for {firmware_type:?}: {:?}",
-            self.address,
-            versions.len(),
-            versions
+            bmc_ip_address = %self.address,
+            version_count = versions.len(),
+            firmware_type = ?firmware_type,
+            versions = ?versions,
+            "Found firmware versions",
         );
 
         versions

--- a/crates/api-test-helper/src/domain.rs
+++ b/crates/api-test-helper/src/domain.rs
@@ -26,6 +26,9 @@ pub async fn create(carbide_api_addrs: &[SocketAddr], name: &str) -> eyre::Resul
         "name": name,
     });
     let domain_id = grpcurl_id(carbide_api_addrs, "CreateDomain", &data.to_string()).await?;
-    tracing::info!("Domain created with ID {domain_id}");
+    tracing::info!(
+        domain_id = %domain_id,
+        "Domain created",
+    );
     Ok(domain_id)
 }

--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -32,7 +32,9 @@ pub async fn create(
     keyset_ids: &[&str],
 ) -> eyre::Result<String> {
     tracing::info!(
-        "Creating instance with machine: {host_machine_id}, with network segment: {segment_id}"
+        host_machine_id = %host_machine_id,
+        network_segment_id = segment_id,
+        "Creating instance",
     );
 
     let network = serde_json::json!({
@@ -62,7 +64,9 @@ pub async fn create_with_auto_host_inband_networking(
     flat_vpc_id: &str,
 ) -> eyre::Result<String> {
     tracing::info!(
-        "Creating automatically-networked instance with machine: {host_machine_id}, with Flat VPC: {flat_vpc_id}"
+        host_machine_id = %host_machine_id,
+        flat_vpc_id,
+        "Creating automatically-networked instance",
     );
 
     let network = serde_json::json!({
@@ -120,7 +124,10 @@ async fn create_with_network(
         },
     });
     let instance_id = grpcurl_id(addrs, "AllocateInstance", &data.to_string()).await?;
-    tracing::info!("Instance created with ID {instance_id}");
+    tracing::info!(
+        instance_id = %instance_id,
+        "Instance created",
+    );
 
     if !wait_until_ready {
         return Ok(instance_id);
@@ -143,7 +150,10 @@ async fn create_with_network(
     wait_for_instance_state(addrs, &instance_id, "READY").await?;
     wait_for_state(addrs, host_machine_id, "Assigned/Ready").await?;
 
-    tracing::info!("Instance with ID {instance_id} is ready");
+    tracing::info!(
+        instance_id = %instance_id,
+        "Instance is ready",
+    );
 
     Ok(instance_id)
 }
@@ -158,7 +168,7 @@ pub async fn create_with_vpc_prefixes(
     tracing::info!(
         %host_machine_id,
         ?vpc_prefix_ids,
-        "Creating instance with VPC prefix allocation",
+        "Creating instance",
     );
 
     let v4_id = vpc_prefix_ids
@@ -198,7 +208,11 @@ pub async fn create_with_vpc_prefixes(
     });
 
     let instance_id = grpcurl_id(addrs, "AllocateInstance", &data.to_string()).await?;
-    tracing::info!("Dual-stack instance created with ID {instance_id}");
+    tracing::info!(
+        instance_id = %instance_id,
+        ?vpc_prefix_ids,
+        "Instance created",
+    );
     Ok(instance_id)
 }
 
@@ -208,13 +222,20 @@ pub async fn release(
     instance_id: &str,
     wait_until_ready: bool,
 ) -> eyre::Result<()> {
-    tracing::info!("Releasing instance {instance_id} on machine: {host_machine_id}");
+    tracing::info!(
+        instance_id,
+        host_machine_id = %host_machine_id,
+        "Releasing instance",
+    );
 
     let data = serde_json::json!({
         "id": {"value": instance_id}
     });
     let resp = grpcurl(addrs, "ReleaseInstance", Some(data)).await?;
-    tracing::info!("ReleaseInstance response: {}", resp);
+    tracing::info!(
+        release_instance_response = %resp,
+        "ReleaseInstance response",
+    );
 
     if !wait_until_ready {
         return Ok(());
@@ -240,9 +261,9 @@ pub async fn release(
             })
         });
     if let Some(ip_address) = ip_address {
-        tracing::info!("Instance with ID {instance_id} at {ip_address} is terminating");
+        tracing::info!(instance_id, ip_address, "Instance is terminating",);
     } else {
-        tracing::info!("Instance with ID {instance_id} is terminating");
+        tracing::info!(instance_id, "Instance is terminating",);
     }
 
     wait_for_state(addrs, host_machine_id, "WaitingForCleanup/HostCleanup").await?;
@@ -251,10 +272,13 @@ pub async fn release(
     });
     let response = grpcurl(addrs, "FindInstancesByIds", Some(&data)).await?;
     let resp: serde_json::Value = serde_json::from_str(&response)?;
-    tracing::info!("FindInstancesByIds Response: {}", resp);
+    tracing::info!(
+        find_instances_response = %resp,
+        "FindInstancesByIds Response",
+    );
     assert!(resp["instances"].as_array().unwrap().is_empty());
 
-    tracing::info!("Instance with ID {instance_id} is released");
+    tracing::info!(instance_id, "Instance is released",);
 
     Ok(())
 }
@@ -268,7 +292,11 @@ pub async fn phone_home(
         "instance_id": {"value": instance_id},
     });
 
-    tracing::info!(%host_machine_id, "Phoning home for instance {instance_id}");
+    tracing::info!(
+        %host_machine_id,
+        instance_id,
+        "Phoning home",
+    );
 
     grpcurl(addrs, "UpdateInstancePhoneHomeLastContact", Some(&data)).await?;
 
@@ -286,7 +314,10 @@ pub async fn get_instance_state(addrs: &[SocketAddr], instance_id: &str) -> eyre
         .as_str()
         .unwrap()
         .to_string();
-    tracing::info!("\tCurrent instance state: {state}");
+    tracing::info!(
+        instance_state = %state,
+        "Current instance state",
+    );
 
     Ok(state)
 }
@@ -327,14 +358,17 @@ pub async fn wait_for_instance_state(
 
     let mut latest_state = String::new();
 
-    tracing::info!("Waiting for Instance {instance_id} state {target_state}");
+    tracing::info!(instance_id, target_state, "Waiting for Instance state",);
     while start.elapsed() < MAX_WAIT {
         latest_state = get_instance_state(addrs, instance_id).await?;
 
         if latest_state.contains(target_state) {
             return Ok(());
         }
-        tracing::info!("\tCurrent instance state: {latest_state}");
+        tracing::info!(
+            instance_state = %latest_state,
+            "Current instance state",
+        );
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 

--- a/crates/api-test-helper/src/machine.rs
+++ b/crates/api-test-helper/src/machine.rs
@@ -50,7 +50,11 @@ pub async fn wait_for_state(
     let data = serde_json::json!({
         "machine_ids": [{"id": machine_id}],
     });
-    tracing::info!("Waiting for Machine {machine_id} state {target_state}");
+    tracing::info!(
+        machine_id = %machine_id,
+        target_state,
+        "Waiting for Machine state",
+    );
     let mut i = 0;
     while i < MAX_RETRY {
         let response = grpcurl(addrs, "FindMachinesByIds", Some(&data)).await?;
@@ -59,7 +63,7 @@ pub async fn wait_for_state(
         if state.contains(target_state) {
             break;
         }
-        tracing::info!("\tCurrent: {state}");
+        tracing::info!(machine_state = state, "\tCurrent",);
         thread::sleep(time::Duration::from_millis(500));
         i += 1;
     }

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -75,8 +75,8 @@ pub async fn run_local(
         .entries;
 
     tracing::info!(
-        "Got desired firmware versions from the server: {:?}",
-        desired_firmware
+        ?desired_firmware,
+        "Got desired firmware versions from the server",
     );
 
     let app_context = Arc::new(MachineATronContext {

--- a/crates/api-test-helper/src/subnet.rs
+++ b/crates/api-test-helper/src/subnet.rs
@@ -37,11 +37,17 @@ pub async fn create(
     });
     let segment_id =
         grpcurl_id(carbide_api_addrs, "CreateNetworkSegment", &data.to_string()).await?;
-    tracing::info!("Network Segment created with ID {segment_id}");
+    tracing::info!(
+        network_segment_id = %segment_id,
+        "Network segment created",
+    );
 
     wait_for_network_segment_state(carbide_api_addrs, &segment_id, "READY").await?;
 
-    tracing::info!("Network Segment with ID {segment_id} is ready");
+    tracing::info!(
+        network_segment_id = %segment_id,
+        "Network segment is ready",
+    );
     Ok(segment_id)
 }
 
@@ -59,7 +65,11 @@ pub async fn wait_for_network_segment_state(
     });
     let mut latest_state: String;
 
-    tracing::info!("Waiting for Network Segment {segment_id} state {target_state}");
+    tracing::info!(
+        network_segment_id = segment_id,
+        target_state,
+        "Waiting for Network Segment state",
+    );
     while start.elapsed() < MAX_WAIT {
         let response = grpcurl(addrs, "FindNetworkSegmentsByIds", Some(&data)).await?;
         let resp: serde_json::Value = serde_json::from_str(&response)?;
@@ -70,7 +80,10 @@ pub async fn wait_for_network_segment_state(
         if latest_state.contains(target_state) {
             return Ok(());
         }
-        tracing::info!("\tCurrent network segment state: {latest_state}");
+        tracing::info!(
+            network_segment_state = %latest_state,
+            "\tCurrent network segment state",
+        );
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
 
@@ -104,11 +117,17 @@ pub async fn create_dual_stack(
     });
     let segment_id =
         grpcurl_id(carbide_api_addrs, "CreateNetworkSegment", &data.to_string()).await?;
-    tracing::info!("Dual-stack network segment created with ID {segment_id}");
+    tracing::info!(
+        network_segment_id = %segment_id,
+        "Dual-stack network segment created",
+    );
 
     wait_for_network_segment_state(carbide_api_addrs, &segment_id, "READY").await?;
 
-    tracing::info!("Dual-stack network segment with ID {segment_id} is ready");
+    tracing::info!(
+        network_segment_id = %segment_id,
+        "Dual-stack network segment is ready",
+    );
     Ok(segment_id)
 }
 

--- a/crates/api-test-helper/src/tenant.rs
+++ b/crates/api-test-helper/src/tenant.rs
@@ -34,7 +34,7 @@ pub async fn create(
         }
     });
     grpcurl(carbide_api_addrs, "CreateTenant", Some(&data.to_string())).await?;
-    tracing::info!("Tenant created with name {name}");
+    tracing::info!(tenant_name = name, "Tenant created",);
     Ok(())
 }
 
@@ -69,7 +69,10 @@ pub mod keyset {
             Some(&data.to_string()),
         )
         .await?;
-        tracing::info!("Tenant keyset created with id {id}");
+        tracing::info!(
+            keyset_id = %id,
+            "Tenant keyset created",
+        );
         Ok(())
     }
 }

--- a/crates/api-test-helper/src/vpc.rs
+++ b/crates/api-test-helper/src/vpc.rs
@@ -31,7 +31,10 @@ pub async fn create(carbide_api_addrs: &[SocketAddr], tenant_org_id: &str) -> ey
         "tenantOrganizationId": tenant_org_id,
     });
     let vpc_id = grpcurl_id(carbide_api_addrs, "CreateVpc", &data.to_string()).await?;
-    tracing::info!("VPC created with ID {vpc_id}");
+    tracing::info!(
+        vpc_id = %vpc_id,
+        "VPC created",
+    );
     Ok(vpc_id)
 }
 
@@ -48,7 +51,10 @@ pub async fn create_fnn(
         "network_virtualization_type": 5, // FNN
     });
     let vpc_id = grpcurl_id(carbide_api_addrs, "CreateVpc", &data.to_string()).await?;
-    tracing::info!("FNN VPC created with ID {vpc_id}");
+    tracing::info!(
+        vpc_id = %vpc_id,
+        "FNN VPC created",
+    );
     Ok(vpc_id)
 }
 
@@ -66,6 +72,9 @@ pub async fn create_flat(
         "network_virtualization_type": 6, // FLAT
     });
     let vpc_id = grpcurl_id(carbide_api_addrs, "CreateVpc", &data.to_string()).await?;
-    tracing::info!("Flat VPC created with ID {vpc_id}");
+    tracing::info!(
+        vpc_id = %vpc_id,
+        "Flat VPC created",
+    );
     Ok(vpc_id)
 }

--- a/crates/api-test-helper/src/vpc_prefix.rs
+++ b/crates/api-test-helper/src/vpc_prefix.rs
@@ -25,7 +25,7 @@ pub async fn create(
     prefix: &str,
     name: &str,
 ) -> eyre::Result<String> {
-    tracing::info!("Creating VPC prefix {prefix} ({name})");
+    tracing::info!(prefix, vpc_prefix_name = name, "Creating VPC prefix",);
 
     let data = serde_json::json!({
         "vpc_id": { "value": vpc_id },
@@ -38,6 +38,9 @@ pub async fn create(
         },
     });
     let prefix_id = grpcurl_id(carbide_api_addrs, "CreateVpcPrefix", &data.to_string()).await?;
-    tracing::info!("VPC prefix created with ID {prefix_id}");
+    tracing::info!(
+        vpc_prefix_id = %prefix_id,
+        "VPC prefix created",
+    );
     Ok(prefix_id)
 }

--- a/crates/api-web/src/attestation.rs
+++ b/crates/api-web/src/attestation.rs
@@ -111,7 +111,7 @@ pub async fn show_attestation_results(
             Some(report) => match mbreport::MeasurementReport::from_grpc(report) {
                 Ok(report) => report,
                 Err(err) => {
-                    tracing::error!(%err, "show_attestation_results");
+                    tracing::error!(error = %err, "show_attestation_results");
                     return (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Html("Error deserializing the report".to_string()),
@@ -126,7 +126,7 @@ pub async fn show_attestation_results(
             }
         },
         Err(err) => {
-            tracing::error!(%err, "show_attestation_results");
+            tracing::error!(error = %err, "show_attestation_results");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Html("Error getting measurement report".to_string()),
@@ -146,7 +146,7 @@ pub async fn show_attestation_results(
                 Some(bundle) => match mbbundle::MeasurementBundle::from_grpc(bundle) {
                     Ok(bundle) => bundle,
                     Err(err) => {
-                        tracing::error!(%err, "show_attestation_results");
+                        tracing::error!(error = %err, "show_attestation_results");
                         return (
                             StatusCode::INTERNAL_SERVER_ERROR,
                             Html("Error deserializing the bundle".to_string()),
@@ -161,7 +161,7 @@ pub async fn show_attestation_results(
                 }
             },
             Err(err) => {
-                tracing::error!(%err, "show_attestation_results");
+                tracing::error!(error = %err, "show_attestation_results");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Html("Error getting measurement bundle".to_string()),
@@ -179,7 +179,7 @@ pub async fn show_attestation_results(
                 Some(bundle) => match mbbundle::MeasurementBundle::from_grpc(bundle) {
                     Ok(bundle) => Some(bundle),
                     Err(err) => {
-                        tracing::error!(%err, "show_attestation_results");
+                        tracing::error!(error = %err, "show_attestation_results");
                         return (
                             StatusCode::INTERNAL_SERVER_ERROR,
                             Html("Error deserializing the bundle".to_string()),
@@ -189,7 +189,7 @@ pub async fn show_attestation_results(
                 None => None,
             },
             Err(err) => {
-                tracing::error!(%err, "show_attestation_results");
+                tracing::error!(error = %err, "show_attestation_results");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Html("Error getting partially matching measurement bundle".to_string()),
@@ -212,7 +212,7 @@ pub async fn show_attestation_results(
                     match mbprofile::MeasurementSystemProfile::from_grpc(profile_pb) {
                         Ok(profile) => profile,
                         Err(err) => {
-                            tracing::error!(%err, "show_attestation_results");
+                            tracing::error!(error = %err, "show_attestation_results");
                             return (
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 Html("Error deserializing measurement system profile".to_string()),
@@ -228,7 +228,7 @@ pub async fn show_attestation_results(
                 }
             },
             Err(err) => {
-                tracing::error!(%err, "show_attestation_results");
+                tracing::error!(error = %err, "show_attestation_results");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Html("Error getting measurement system profile".to_string()),
@@ -325,7 +325,7 @@ async fn get_latest_journal_for_machine_id(
             Some(journal_proto) => match mbjournal::MeasurementJournal::from_grpc(journal_proto) {
                 Ok(journal) => journal,
                 Err(err) => {
-                    tracing::error!(%err, "get_latest_journal_for_machine_id");
+                    tracing::error!(error = %err, "get_latest_journal_for_machine_id");
                     return Err((
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Html("Failed parsing MeasurementBundle protobuf".to_string()),
@@ -340,7 +340,7 @@ async fn get_latest_journal_for_machine_id(
             }
         },
         Err(err) => {
-            tracing::error!(%err, "get_latest_journal_for_machine_id");
+            tracing::error!(error = %err, "get_latest_journal_for_machine_id");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Html("Error getting journal".to_string()),
@@ -359,7 +359,7 @@ pub async fn show_attestation_summary(AxumState(state): AxumState<Arc<Api>>) -> 
             attestations: match MachineAttestationSummaryList::try_from(response.into_inner()) {
                 Ok(attestations_list) => attestations_list.0,
                 Err(err) => {
-                    tracing::error!(%err, "show_attestation_summary");
+                    tracing::error!(error = %err, "show_attestation_summary");
                     return (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Html("Error obtaining MachineAttestationSummaryList".to_string()),
@@ -368,7 +368,7 @@ pub async fn show_attestation_summary(AxumState(state): AxumState<Arc<Api>>) -> 
             },
         },
         Err(err) => {
-            tracing::error!(%err, "show_attestation_summary");
+            tracing::error!(error = %err, "show_attestation_summary");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Html("Error calling list_attestation_summary".to_string()),
@@ -438,7 +438,7 @@ pub async fn submit_report_promotion(
             ),
         },
         Err(err) => {
-            tracing::error!(%err, "submit_report_promotion");
+            tracing::error!(error = %err, "submit_report_promotion");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Html("Error promoting report".to_string()),

--- a/crates/api-web/src/auth.rs
+++ b/crates/api-web/src/auth.rs
@@ -423,7 +423,10 @@ impl IntoResponse for AuthCallbackResponse {
         match self {
             AuthCallbackResponse::Response(response) => response,
             AuthCallbackResponse::Error(error) => {
-                tracing::error!("internal server error running auth_callback: {error}");
+                tracing::error!(
+                    error = %error,
+                    "internal server error running auth_callback",
+                );
                 (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response()
             }
         }
@@ -439,9 +442,9 @@ where
     fn from(value: (StatusCode, S)) -> Self {
         if !value.0.is_success() {
             tracing::info!(
-                "auth_callback was unsuccessful with status code {}: {}",
-                value.0.as_u16(),
-                value.1.to_string()
+                http_status = value.0.as_u16(),
+                response_detail = %value.1.to_string(),
+                "auth_callback returned an unsuccessful response",
             );
         }
         AuthCallbackResponse::Response((value.0, value.1.to_string()).into_response())
@@ -519,7 +522,7 @@ impl<'c> oauth2::AsyncHttpClient<'c> for AsyncRequestHandlerWithTimeouts<'_> {
 
             if status.is_server_error() || status.is_client_error() {
                 let body_str = std::str::from_utf8(&body).unwrap_or_default();
-                tracing::error!(body_str=%body_str,"error response when making http request for oauth2 flow");
+                tracing::error!(response_body = %body_str,"error response when making http request for oauth2 flow");
             }
 
             Ok(result.body(body).unwrap())

--- a/crates/api-web/src/compute_allocation.rs
+++ b/crates/api-web/src/compute_allocation.rs
@@ -125,7 +125,7 @@ pub async fn show(
     let (pages, allocations) = match fetch_compute_allocations(api, current_page, limit).await {
         Ok(all) => all,
         Err(err) => {
-            tracing::error!(%err, "fetch_compute_allocations");
+            tracing::error!(error = %err, "fetch_compute_allocations");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Error loading compute allocations: {err}"),

--- a/crates/api-web/src/domain.rs
+++ b/crates/api-web/src/domain.rs
@@ -38,7 +38,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let domains = match fetch_domains(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "find_domains");
+            tracing::error!(error = %err, "find_domains");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading domains").into_response();
         }
     };
@@ -52,7 +52,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let domains = match fetch_domains(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "find_domains");
+            tracing::error!(error = %err, "find_domains");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading domains").into_response();
         }
     };

--- a/crates/api-web/src/dpa.rs
+++ b/crates/api-web/src/dpa.rs
@@ -41,7 +41,7 @@ pub async fn show_dpas_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let dpas = match fetch_dpas(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_dpas");
+            tracing::error!(error = %err, "fetch_dpas");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading dpas").into_response();
         }
     };
@@ -54,7 +54,7 @@ pub async fn show_dpas_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let dpas = match fetch_dpas(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_dpas");
+            tracing::error!(error = %err, "fetch_dpas");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading DPAs").into_response();
         }
     };
@@ -156,7 +156,7 @@ pub async fn detail(
             return super::not_found_response(dpa_id);
         }
         Err(err) => {
-            tracing::error!(%err, "find_dpas_by_ids");
+            tracing::error!(error = %err, "find_dpas_by_ids");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading DPAs").into_response();
         }
     };

--- a/crates/api-web/src/dpu_versions.rs
+++ b/crates/api-web/src/dpu_versions.rs
@@ -128,7 +128,7 @@ pub async fn list_html(
     let machines = match fetch_dpus(&state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_dpus");
+            tracing::error!(error = %err, "fetch_dpus");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading DPUs").into_response();
         }
     };
@@ -146,7 +146,7 @@ pub async fn list_json(AxumState(state): AxumState<Arc<Api>>) -> impl IntoRespon
     let machines = match fetch_dpus(&state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_dpus");
+            tracing::error!(error = %err, "fetch_dpus");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading DPUs").into_response();
         }
     };

--- a/crates/api-web/src/expected_machine.rs
+++ b/crates/api-web/src/expected_machine.rs
@@ -171,7 +171,7 @@ pub async fn show_all_html(
     {
         Ok(machines) => machines,
         Err(err) => {
-            tracing::error!(%err, "get_all_expected_machines_linked");
+            tracing::error!(error = %err, "get_all_expected_machines_linked");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading expected machines from carbide-api",
@@ -194,7 +194,7 @@ pub async fn show_all_html(
     {
         Ok(list) => list,
         Err(err) => {
-            tracing::error!(%err, "get_all_unexpected_machines");
+            tracing::error!(error = %err, "get_all_unexpected_machines");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading unexpected machines from carbide-api",
@@ -216,7 +216,7 @@ pub async fn show_all_html(
     {
         Ok(last_run) => last_run.as_ref().map(Into::into),
         Err(err) => {
-            tracing::error!(%err, "get_site_explorer_last_run");
+            tracing::error!(error = %err, "get_site_explorer_last_run");
             None
         }
     };
@@ -285,7 +285,7 @@ pub async fn show_expected_machine_raw_json(AxumState(api): AxumState<Arc<Api>>)
     {
         Ok(machines) => machines,
         Err(err) => {
-            tracing::error!(%err, "show_expected_machine_raw_json");
+            tracing::error!(error = %err, "show_expected_machine_raw_json");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading expected machines from carbide-api",

--- a/crates/api-web/src/expected_power_shelf.rs
+++ b/crates/api-web/src/expected_power_shelf.rs
@@ -70,7 +70,7 @@ async fn fetch_expected_power_shelves(
     {
         Ok(response) => response.into_inner(),
         Err(err) => {
-            tracing::error!(%err, "get_all_expected_power_shelves_linked");
+            tracing::error!(error = %err, "get_all_expected_power_shelves_linked");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to list expected power shelves".to_string(),

--- a/crates/api-web/src/expected_rack.rs
+++ b/crates/api-web/src/expected_rack.rs
@@ -67,7 +67,7 @@ async fn fetch_expected_racks(
     let expected_response = match api.get_all_expected_racks(tonic::Request::new(())).await {
         Ok(response) => response.into_inner(),
         Err(err) => {
-            tracing::error!(%err, "get_all_expected_racks");
+            tracing::error!(error = %err, "get_all_expected_racks");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to list expected racks".to_string(),

--- a/crates/api-web/src/expected_switch.rs
+++ b/crates/api-web/src/expected_switch.rs
@@ -70,7 +70,7 @@ async fn fetch_expected_switches(
     {
         Ok(response) => response.into_inner(),
         Err(err) => {
-            tracing::error!(%err, "get_all_expected_switches_linked");
+            tracing::error!(error = %err, "get_all_expected_switches_linked");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to list expected switches".to_string(),

--- a/crates/api-web/src/explored_endpoint.rs
+++ b/crates/api-web/src/explored_endpoint.rs
@@ -239,7 +239,7 @@ pub async fn show_html_all(
     let report = match fetch_explored_endpoints(&state).await {
         Ok(report) => report,
         Err(err) => {
-            tracing::error!(%err, "fetch_explored_endpoints");
+            tracing::error!(error = %err, "fetch_explored_endpoints");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading site exploration report",
@@ -297,7 +297,7 @@ pub async fn show_html_paired(
     let report = match fetch_explored_endpoints(&state).await {
         Ok(report) => report,
         Err(err) => {
-            tracing::error!(%err, "fetch_explored_endpoints");
+            tracing::error!(error = %err, "fetch_explored_endpoints");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading site exploration report",
@@ -325,7 +325,7 @@ pub async fn show_html_unpaired(
     let report = match fetch_explored_endpoints(&state).await {
         Ok(report) => report,
         Err(err) => {
-            tracing::error!(%err, "fetch_explored_endpoints");
+            tracing::error!(error = %err, "fetch_explored_endpoints");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading site exploration report",
@@ -363,7 +363,7 @@ pub async fn show_html_unpaired(
             .map(|pair| pair.bmc_ip)
             .collect(),
         Err(err) => {
-            tracing::error!(%err, "find_machine_ids_by_bmc_ips");
+            tracing::error!(error = %err, "find_machine_ids_by_bmc_ips");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error find_machine_ids_by_bmc_ips",
@@ -417,7 +417,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let report = match fetch_explored_endpoints(&state).await {
         Ok(report) => report,
         Err(err) => {
-            tracing::error!(%err, "fetch_explored_endpoints");
+            tracing::error!(error = %err, "fetch_explored_endpoints");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading site exploration report",
@@ -529,7 +529,7 @@ pub async fn fetch_explored_endpoint(
     let report = match fetch_explored_endpoints(api).await {
         Ok(report) => report,
         Err(err) => {
-            tracing::error!(%err, "fetch_explored_endpoints");
+            tracing::error!(error = %err, "fetch_explored_endpoints");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading site exploration report",
@@ -581,7 +581,7 @@ pub async fn detail(
     {
         Ok(response) => response.into_inner().in_managed_host,
         Err(err) => {
-            tracing::error!(%err, "is_bmc_in_managed_host check failed");
+            tracing::error!(error = %err, "is_bmc_in_managed_host check failed");
             // Default to true if we can't determine the status so we can't delete the endpoint
             true
         }
@@ -606,7 +606,7 @@ pub async fn detail(
                 }
             }
             Err(err) => {
-                tracing::error!(%err, "find_machine_ids_by_bmc_ips");
+                tracing::error!(error = %err, "find_machine_ids_by_bmc_ips");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Error find_machine_ids_by_bmc_ips",
@@ -644,7 +644,7 @@ pub async fn detail(
                 }
             }
             Err(err) => {
-                tracing::error!(%err, endpoint_ip = %endpoint_ip, "bmc_credential_status");
+                tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "bmc_credential_status");
                 "Not Configured".to_string()
             }
         }
@@ -678,7 +678,7 @@ pub async fn re_explore(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip, "re_explore_endpoint");
+        tracing::error!(error = %err, bmc_ip_address = endpoint_ip, "re_explore_endpoint");
         return Redirect::to(&view_url);
     }
 
@@ -716,7 +716,7 @@ pub async fn refresh_endpoint(
                 tonic::Code::NotFound => StatusCode::NOT_FOUND,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             };
-            tracing::error!(%err, endpoint_ip, "refresh_endpoint");
+            tracing::error!(error = %err, bmc_ip_address = endpoint_ip, "refresh_endpoint");
             (
                 status_code,
                 Json(serde_json::json!({ "error": err.message() })),
@@ -743,7 +743,7 @@ pub async fn pause_remediation(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip, "pause_explored_endpoint_remediation");
+        tracing::error!(error = %err, bmc_ip_address = endpoint_ip, "pause_explored_endpoint_remediation");
         return Redirect::to(&view_url);
     }
 
@@ -807,7 +807,7 @@ pub async fn power_control(
     };
 
     let Some(act) = admin_power_control_request::SystemPowerControl::from_str_name(&action) else {
-        tracing::error!(endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint invalid action");
+        tracing::error!(bmc_ip_address = %endpoint_ip, action = %action, "power_control_endpoint invalid action");
         let redirect_url = ActionStatus {
             action: action_status::Type::Power,
             class: action_status::Class::Error,
@@ -857,7 +857,7 @@ pub async fn power_control(
             Redirect::to(&redirect_url).into_response()
         }
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, action = %action, "power_control_endpoint");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, action = %action, "power_control_endpoint");
             let redirect_url = ActionStatus {
                 action: action_status::Type::Power,
                 class: action_status::Class::Error,
@@ -912,7 +912,7 @@ pub async fn bmc_reset(
             Redirect::to(&redirect_url).into_response()
         }
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, use_ipmi = %use_ipmi, "bmc_reset_endpoint");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, use_ipmi = %use_ipmi, "bmc_reset_endpoint");
             let redirect_url = ActionStatus {
                 action: action_status::Type::ResetBmc,
                 class: action_status::Class::Error,
@@ -955,7 +955,7 @@ pub async fn clear_last_exploration_error(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip = %endpoint_ip, "clear_last_exploration_error_endpoint");
+        tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "clear_last_exploration_error_endpoint");
         return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
     }
 
@@ -974,7 +974,7 @@ pub async fn clear_bmc_credentials(
     let mac_address = match state.find_mac_address_by_bmc_ip(req).await {
         Ok(res) => res.into_inner().mac_address,
         Err(err) => {
-            tracing::error!(%err, "find_mac_address_by_bmc_ip");
+            tracing::error!(error = %err, "find_mac_address_by_bmc_ip");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error find_mac_address_by_bmc_ip",
@@ -992,7 +992,7 @@ pub async fn clear_bmc_credentials(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, endpoint_ip = %endpoint_ip, "clear_bmc_credentials");
+        tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "clear_bmc_credentials");
         return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
     }
 
@@ -1020,7 +1020,7 @@ pub async fn disable_secure_boot(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "disable_secure_boot");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "disable_secure_boot");
             ActionStatus {
                 action: action_status::Type::DisableSecureBoot,
                 class: action_status::Class::Error,
@@ -1058,7 +1058,7 @@ pub async fn disable_lockdown(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "disable_lockdown");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "disable_lockdown");
             ActionStatus {
                 action: action_status::Type::DisableLockdown,
                 class: action_status::Class::Error,
@@ -1096,7 +1096,7 @@ pub async fn enable_lockdown(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "enable_lockdown");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "enable_lockdown");
             ActionStatus {
                 action: action_status::Type::EnableLockdown,
                 class: action_status::Class::Error,
@@ -1125,7 +1125,7 @@ pub async fn machine_setup(
     if let Some(ref mac) = boot_interface_mac
         && mac.parse::<mac_address::MacAddress>().is_err()
     {
-        tracing::error!(endpoint_ip = %endpoint_ip, mac_address = %mac, "Invalid MAC address format");
+        tracing::error!(bmc_ip_address = %endpoint_ip, mac_address = %mac, "Invalid MAC address format");
         let status = ActionStatus {
             action: action_status::Type::MachineSetup,
             class: action_status::Class::Error,
@@ -1153,7 +1153,7 @@ pub async fn machine_setup(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "bmc_machine_setup");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "bmc_machine_setup");
             ActionStatus {
                 action: action_status::Type::MachineSetup,
                 class: action_status::Class::Error,
@@ -1183,7 +1183,7 @@ pub async fn set_dpu_first_boot_order(
     if let Some(ref mac) = boot_interface_mac
         && mac.parse::<mac_address::MacAddress>().is_err()
     {
-        tracing::error!(endpoint_ip = %endpoint_ip, mac_address = %mac, "Invalid MAC address format");
+        tracing::error!(bmc_ip_address = %endpoint_ip, mac_address = %mac, "Invalid MAC address format");
         let redirect_url = ActionStatus {
             action: action_status::Type::SetFirstBootOrder,
             class: action_status::Class::Error,
@@ -1214,7 +1214,7 @@ pub async fn set_dpu_first_boot_order(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "set_dpu_first_boot_order");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "set_dpu_first_boot_order");
             ActionStatus {
                 action: action_status::Type::SetFirstBootOrder,
                 class: action_status::Class::Error,
@@ -1264,7 +1264,7 @@ pub async fn restore_boot_interface(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "restore_boot_interface");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "restore_boot_interface");
             ActionStatus {
                 action: action_status::Type::RestoreBootInterface,
                 class: action_status::Class::Error,
@@ -1294,13 +1294,13 @@ pub async fn delete_endpoint(
     {
         Ok(response) => {
             if response.deleted {
-                tracing::info!(endpoint_ip = %endpoint_ip, "Successfully deleted explored endpoint");
+                tracing::info!(bmc_ip_address = %endpoint_ip, "Successfully deleted explored endpoint");
             } else {
-                tracing::warn!(endpoint_ip = %endpoint_ip, message = ?response.message, "Failed to delete explored endpoint");
+                tracing::warn!(bmc_ip_address = %endpoint_ip, reason = ?response.message, "Failed to delete explored endpoint");
             }
         }
         Err(err) => {
-            tracing::error!(%err, endpoint_ip = %endpoint_ip, "delete_explored_endpoint");
+            tracing::error!(error = %err, bmc_ip_address = %endpoint_ip, "delete_explored_endpoint");
             return (StatusCode::INTERNAL_SERVER_ERROR, err.message().to_owned()).into_response();
         }
     }

--- a/crates/api-web/src/firmware.rs
+++ b/crates/api-web/src/firmware.rs
@@ -72,7 +72,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let desired_firmware = match fetch_desired_firmware(&state).await {
         Ok(rows) => rows,
         Err(err) => {
-            tracing::error!(%err, "fetch desired firmware");
+            tracing::error!(error = %err, "fetch desired firmware");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading desired firmware",
@@ -91,7 +91,7 @@ pub async fn show_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let desired_firmware = match fetch_desired_firmware(&state).await {
         Ok(rows) => rows,
         Err(err) => {
-            tracing::error!(%err, "fetch desired firmware");
+            tracing::error!(error = %err, "fetch desired firmware");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading desired firmware",

--- a/crates/api-web/src/health.rs
+++ b/crates/api-web/src/health.rs
@@ -316,7 +316,7 @@ async fn fetch_machine_health_page_data(
         Ok(entries) => entries,
         Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
         Err(err) => {
-            tracing::error!(%err, %machine_id, "list_health_report_entries");
+            tracing::error!(error = %err, %machine_id, "list_health_report_entries");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -325,7 +325,7 @@ async fn fetch_machine_health_page_data(
     let history = match fetch_health_history(api, machine_id).await {
         Ok(records) => HealthHistoryTable { records },
         Err(err) => {
-            tracing::error!(%err, %machine_id, "find_machine_health_histories");
+            tracing::error!(error = %err, %machine_id, "find_machine_health_histories");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -347,7 +347,7 @@ async fn fetch_rack_health_page_data(
         Ok(entries) => entries,
         Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
         Err(err) => {
-            tracing::error!(%err, %rack_id, "list_rack_health_report_overrides");
+            tracing::error!(error = %err, %rack_id, "list_rack_health_report_overrides");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -371,7 +371,7 @@ async fn fetch_power_shelf_health_page_data(
         Ok(entries) => entries,
         Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
         Err(err) => {
-            tracing::error!(%err, %power_shelf_id, "list_power_shelf_health_reports");
+            tracing::error!(error = %err, %power_shelf_id, "list_power_shelf_health_reports");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -395,7 +395,7 @@ async fn fetch_switch_health_page_data(
         Ok(entries) => entries,
         Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
         Err(err) => {
-            tracing::error!(%err, %switch_id, "list_switch_health_reports");
+            tracing::error!(error = %err, %switch_id, "list_switch_health_reports");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -418,7 +418,7 @@ async fn fetch_nvlink_domain_health_page_data(
         Ok(entries) => entries,
         Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
         Err(err) => {
-            tracing::error!(%err, %domain_id, "list_nvlink_domain_health_reports");
+            tracing::error!(error = %err, %domain_id, "list_nvlink_domain_health_reports");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -455,7 +455,7 @@ async fn fetch_dpu_health_contributors(
         Ok(m) => m.machines,
         Err(err) if err.code() == tonic::Code::NotFound => Vec::new(),
         Err(err) => {
-            tracing::error!(%err, %host_machine_id, "find_dpu_machines_by_ids");
+            tracing::error!(error = %err, %host_machine_id, "find_dpu_machines_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -563,7 +563,7 @@ async fn fetch_machine_health_snapshot(
         Ok(mut m) => Some(m.machines.remove(0)),
         Err(err) if err.code() == tonic::Code::NotFound => None,
         Err(err) => {
-            tracing::error!(%err, %machine_id, "find_machines_by_ids");
+            tracing::error!(error = %err, %machine_id, "find_machines_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -601,7 +601,7 @@ async fn fetch_rack_aggregate_health(
         Ok(mut r) => Some(r.racks.remove(0)),
         Err(err) if err.code() == tonic::Code::NotFound => None,
         Err(err) => {
-            tracing::error!(%err, %rack_id, "find_racks_by_ids");
+            tracing::error!(error = %err, %rack_id, "find_racks_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -638,7 +638,7 @@ async fn fetch_power_shelf_aggregate_health(
         Ok(mut r) => Some(r.power_shelves.remove(0)),
         Err(err) if err.code() == tonic::Code::NotFound => None,
         Err(err) => {
-            tracing::error!(%err, %power_shelf_id, "find_power_shelves_by_ids");
+            tracing::error!(error = %err, %power_shelf_id, "find_power_shelves_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -675,7 +675,7 @@ async fn fetch_switch_aggregate_health(
         Ok(mut r) => Some(r.switches.remove(0)),
         Err(err) if err.code() == tonic::Code::NotFound => None,
         Err(err) => {
-            tracing::error!(%err, %switch_id, "find_switches_by_ids");
+            tracing::error!(error = %err, %switch_id, "find_switches_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -920,7 +920,7 @@ async fn add_health_report_for(
             (StatusCode::NOT_FOUND, format!("Not found: {object_id}")).into_response()
         }
         Err(err) => {
-            tracing::error!(%err, %object_id, object_kind, "insert_health_report");
+            tracing::error!(error = %err, %object_id, object_kind, "insert_health_report");
             (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
         Ok(_) => (StatusCode::OK, String::new()).into_response(),
@@ -1047,7 +1047,7 @@ async fn remove_health_report_for(
             (StatusCode::NOT_FOUND, format!("Not found: {object_id}")).into_response()
         }
         Err(err) => {
-            tracing::error!(%err, %object_id, object_kind, "remove_health_report");
+            tracing::error!(error = %err, %object_id, object_kind, "remove_health_report");
             (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
         Ok(_) => (StatusCode::OK, String::new()).into_response(),

--- a/crates/api-web/src/health_history.rs
+++ b/crates/api-web/src/health_history.rs
@@ -76,7 +76,7 @@ pub async fn fetch_health_records(
     let health_records = match fetch_health_history(api, &machine_id).await {
         Ok(records) => records,
         Err(err) => {
-            tracing::error!(%err, %machine_id, "find_machine_health_histories");
+            tracing::error!(error = %err, %machine_id, "find_machine_health_histories");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, String::new()));
         }
     };

--- a/crates/api-web/src/ib_fabric.rs
+++ b/crates/api-web/src/ib_fabric.rs
@@ -39,7 +39,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let fabrics = match fetch_ib_fabric_ids(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_ib_fabric_ids");
+            tracing::error!(error = %err, "fetch_ib_fabric_ids");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading IB fabrics",
@@ -56,7 +56,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let fabrics = match fetch_ib_fabric_ids(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_ib_fabric_ids");
+            tracing::error!(error = %err, "fetch_ib_fabric_ids");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading IB fabrics",

--- a/crates/api-web/src/ib_partition.rs
+++ b/crates/api-web/src/ib_partition.rs
@@ -76,7 +76,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_ib_partitions(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_ib_partitions");
+            tracing::error!(error = %err, "fetch_ib_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading IB partitions",
@@ -95,7 +95,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_ib_partitions(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_ib_partitions");
+            tracing::error!(error = %err, "fetch_ib_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading IB partitions",
@@ -301,7 +301,7 @@ pub async fn detail(
             return super::not_found_response(partition_id_string);
         }
         Err(err) => {
-            tracing::error!(%err, "find_ib_partitions");
+            tracing::error!(error = %err, "find_ib_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading IB partitions",

--- a/crates/api-web/src/instance.rs
+++ b/crates/api-web/src/instance.rs
@@ -136,7 +136,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_instances(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_instances");
+            tracing::error!(error = %err, "fetch_instances");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading instances").into_response();
         }
     };
@@ -150,7 +150,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_instances(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_instances");
+            tracing::error!(error = %err, "fetch_instances");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading instances").into_response();
         }
     };
@@ -620,7 +620,7 @@ pub async fn detail(
             return super::not_found_response(instance_id_string);
         }
         Err(err) => {
-            tracing::error!(%err, %instance_id, "find_instances");
+            tracing::error!(error = %err, %instance_id, "find_instances");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading instances").into_response();
         }
     };

--- a/crates/api-web/src/instance_type.rs
+++ b/crates/api-web/src/instance_type.rs
@@ -182,7 +182,7 @@ pub async fn show(
     let (pages, instance_types) = match fetch_instance_types(api, current_page, limit).await {
         Ok(all) => all,
         Err(err) => {
-            tracing::error!(%err, "fetch_itypes");
+            tracing::error!(error = %err, "fetch_itypes");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("Error loading instance types: {err}"),

--- a/crates/api-web/src/interface.rs
+++ b/crates/api-web/src/interface.rs
@@ -159,7 +159,7 @@ pub async fn show_html(
     let machine_interfaces = match fetch_machine_interfaces(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "find_interfaces");
+            tracing::error!(error = %err, "find_interfaces");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading machine interfaces",
@@ -179,7 +179,7 @@ pub async fn show_html(
     {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "find_domain");
+            tracing::error!(error = %err, "find_domain");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading domains").into_response();
         }
     };
@@ -213,7 +213,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let machine_interfaces = match fetch_machine_interfaces(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_machine_interfaces");
+            tracing::error!(error = %err, "fetch_machine_interfaces");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading machine interfaces",
@@ -341,7 +341,7 @@ pub async fn detail(
             return super::not_found_response(interface_id_string);
         }
         Err(err) => {
-            tracing::error!(%err, "find_interfaces");
+            tracing::error!(error = %err, "find_interfaces");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading machine interface",
@@ -351,7 +351,12 @@ pub async fn detail(
     };
 
     if machine_interfaces.interfaces.len() != 1 {
-        tracing::error!(%interface_id, "Expected exactly 1 match, found {}", machine_interfaces.interfaces.len());
+        tracing::error!(
+            machine_interface_id = %interface_id,
+            expected_interface_count = 1,
+            matching_interface_count = machine_interfaces.interfaces.len(),
+            "Unexpected number of matching interfaces",
+        );
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Expected exactly one interface to match",

--- a/crates/api-web/src/ipam.rs
+++ b/crates/api-web/src/ipam.rs
@@ -88,7 +88,7 @@ pub async fn dhcp_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let interfaces = match fetch_interfaces(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "find_interfaces for DHCP");
+            tracing::error!(error = %err, "find_interfaces for DHCP");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading DHCP allocations",
@@ -114,7 +114,7 @@ pub async fn dhcp_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let interfaces = match fetch_interfaces(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "find_interfaces for DHCP JSON");
+            tracing::error!(error = %err, "find_interfaces for DHCP JSON");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading DHCP allocations",
@@ -168,7 +168,7 @@ pub async fn dns_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     {
         Ok(d) => d,
         Err(err) => {
-            tracing::error!(%err, "fetch domains for DNS");
+            tracing::error!(error = %err, "fetch domains for DNS");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading DNS zones").into_response();
         }
     };
@@ -180,7 +180,7 @@ pub async fn dns_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         {
             Ok(r) => r,
             Err(err) => {
-                tracing::error!(%err, "fetch DNS records");
+                tracing::error!(error = %err, "fetch DNS records");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Error loading DNS records",
@@ -280,7 +280,7 @@ pub async fn underlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     {
         Ok(rows) => rows.into_iter().map(Into::into).collect(),
         Err(err) => {
-            tracing::error!(%err, "fetch underlay segments");
+            tracing::error!(error = %err, "fetch underlay segments");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading underlay segments",
@@ -373,7 +373,7 @@ pub async fn underlay_segment_html(
         Ok(mut s) if s.len() == 1 => s.remove(0),
         Ok(_) => return super::not_found_response(segment_id),
         Err(err) => {
-            tracing::error!(%err, "find_network_segments_by_ids for underlay");
+            tracing::error!(error = %err, "find_network_segments_by_ids for underlay");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading segment").into_response();
         }
     };
@@ -415,7 +415,7 @@ pub async fn underlay_segment_html(
         {
             Ok(rows) => rows.into_iter().map(Into::into).collect(),
             Err(err) => {
-                tracing::error!(%err, "fetch underlay segment addresses");
+                tracing::error!(error = %err, "fetch underlay segment addresses");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Error loading segment addresses",
@@ -480,7 +480,7 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let rpc_vpcs = match fetch_vpcs(state.clone()).await {
         Ok(v) => v,
         Err(err) => {
-            tracing::error!(%err, "fetch_vpcs for overlay");
+            tracing::error!(error = %err, "fetch_vpcs for overlay");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading VPCs").into_response();
         }
     };
@@ -497,7 +497,7 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     {
         Ok(ids) => ids,
         Err(err) => {
-            tracing::error!(%err, "search_vpc_prefixes for overlay");
+            tracing::error!(error = %err, "search_vpc_prefixes for overlay");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading VPC prefixes",
@@ -519,7 +519,7 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         {
             Ok(p) => p,
             Err(err) => {
-                tracing::error!(%err, "get_vpc_prefixes for overlay");
+                tracing::error!(error = %err, "get_vpc_prefixes for overlay");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Error loading VPC prefixes",
@@ -706,7 +706,7 @@ pub async fn overlay_prefix_html(
         Ok(mut p) if p.len() == 1 => p.remove(0),
         Ok(_) => return super::not_found_response(vpc_prefix_id),
         Err(err) => {
-            tracing::error!(%err, "get_vpc_prefixes");
+            tracing::error!(error = %err, "get_vpc_prefixes");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading VPC prefix",
@@ -750,7 +750,7 @@ pub async fn overlay_prefix_html(
             None,
         ),
         Err(err) => {
-            tracing::error!(%err, "find_vpc_prefix_state_histories");
+            tracing::error!(error = %err, "find_vpc_prefix_state_histories");
             (Vec::new(), Some(err.to_string()))
         }
     };
@@ -813,7 +813,7 @@ pub async fn overlay_prefix_html(
     {
         Ok(rows) => rows.into_iter().map(Into::into).collect(),
         Err(err) => {
-            tracing::error!(%err, "fetch segments for VPC prefix");
+            tracing::error!(error = %err, "fetch segments for VPC prefix");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading segments").into_response();
         }
     };
@@ -906,7 +906,7 @@ pub async fn overlay_segment_html(
         Ok(mut s) if s.len() == 1 => s.remove(0),
         Ok(_) => return super::not_found_response(segment_id),
         Err(err) => {
-            tracing::error!(%err, "find_network_segments_by_ids");
+            tracing::error!(error = %err, "find_network_segments_by_ids");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading segment").into_response();
         }
     };
@@ -950,7 +950,7 @@ pub async fn overlay_segment_html(
         {
             Ok(addrs) => addrs,
             Err(err) => {
-                tracing::error!(%err, "find_by_segment_id");
+                tracing::error!(error = %err, "find_by_segment_id");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Error loading segment addresses",

--- a/crates/api-web/src/ipxe_template.rs
+++ b/crates/api-web/src/ipxe_template.rs
@@ -58,7 +58,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let templates = match fetch_templates(state).await {
         Ok(t) => t,
         Err(err) => {
-            tracing::error!(%err, "list_ipxe_templates");
+            tracing::error!(error = %err, "list_ipxe_templates");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading iPXE templates",
@@ -75,7 +75,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let templates = match fetch_templates(state).await {
         Ok(t) => t,
         Err(err) => {
-            tracing::error!(%err, "list_ipxe_templates");
+            tracing::error!(error = %err, "list_ipxe_templates");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading iPXE templates",
@@ -128,7 +128,7 @@ pub async fn detail(
             return super::not_found_response(id_str);
         }
         Err(err) => {
-            tracing::error!(%err, "get_ipxe_template");
+            tracing::error!(error = %err, "get_ipxe_template");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading iPXE template",

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -408,8 +408,8 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
         }
         "none" | "" => {
             tracing::warn!(
-                "{}: admin web UI has no in-process authentication; restrict access with network policy, a private network, or an authenticating reverse proxy (for example OAuth2 Proxy)",
-                AUTH_TYPE_ENV
+                auth_type_env_var = AUTH_TYPE_ENV,
+                "admin web UI has no in-process authentication; restrict access with network policy, a private network, or an authenticating reverse proxy (for example OAuth2 Proxy)",
             );
             None
         }
@@ -875,7 +875,7 @@ pub async fn auth_oauth2(
         let now_seconds = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map_err(|e| {
-                tracing::error!(%e, "failed to get system time for oauth2 expiration check");
+                tracing::error!(error = %e, "failed to get system time for oauth2 expiration check");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?
             .as_secs();
@@ -968,7 +968,7 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
         Ok(x) if x == UpDown as i32 => "Upgrade and Downgrade",
         Ok(_) => "Unknown",
         Err(err) => {
-            tracing::error!(%err, "dpu_agent_upgrade_policy_action");
+            tracing::error!(error = %err, "dpu_agent_upgrade_policy_action");
             return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string()));
         }
     };
@@ -1008,7 +1008,7 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
     let effective = match serde_json::to_value(state.runtime_config.redacted()) {
         Ok(value) => value,
         Err(err) => {
-            tracing::error!(%err, "serializing runtime config");
+            tracing::error!(error = %err, "serializing runtime config");
             return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string()));
         }
     };

--- a/crates/api-web/src/machine.rs
+++ b/crates/api-web/src/machine.rs
@@ -189,7 +189,7 @@ pub async fn show_hosts_json(AxumState(state): AxumState<Arc<Api>>) -> Response 
     let machines = match fetch_machines(state, false, true).await {
         Ok(r) => r,
         Err(err) => {
-            tracing::error!(%err, "fetch_machines");
+            tracing::error!(error = %err, "fetch_machines");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading machines").into_response();
         }
     };
@@ -208,7 +208,7 @@ pub async fn show_dpus_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let mut machines = match fetch_machines(state, true, true).await {
         Ok(r) => r,
         Err(err) => {
-            tracing::error!(%err, "fetch_machines");
+            tracing::error!(error = %err, "fetch_machines");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading machines").into_response();
         }
     };
@@ -231,7 +231,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let machines = match fetch_machines(state, true, true).await {
         Ok(r) => r,
         Err(err) => {
-            tracing::error!(%err, "fetch_machines");
+            tracing::error!(error = %err, "fetch_machines");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading machines").into_response();
         }
     };
@@ -248,7 +248,7 @@ async fn show(
     let all_machines = match fetch_machines(state.clone(), include_dpus, false).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "find_machines");
+            tracing::error!(error = %err, "find_machines");
             return (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response();
         }
     };
@@ -345,7 +345,7 @@ pub async fn fetch_machine(
             return Err(super::not_found_response(machine_id.to_string()));
         }
         Err(err) => {
-            tracing::error!(%err, %machine_id, "find_machines_by_ids");
+            tracing::error!(error = %err, %machine_id, "find_machines_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -372,7 +372,7 @@ pub async fn fetch_instance_type_names(
         .find_instance_types_by_ids(request)
         .await
         .map_err(|err| {
-            tracing::error!(%err, "find_instance_types_by_ids");
+            tracing::error!(error = %err, "find_instance_types_by_ids");
             (StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response()
         })?
         .into_inner()
@@ -819,7 +819,7 @@ pub async fn detail(
                 }
             }
             Err(err) => {
-                tracing::warn!(%err, %machine_id, "find_instance_by_machine_id failed");
+                tracing::warn!(error = %err, %machine_id, "find_instance_by_machine_id failed");
             }
         }
     }
@@ -847,7 +847,7 @@ pub async fn detail(
                 display.available_skus = sku_ids.ids;
             }
             Err(err) => {
-                tracing::warn!(%err, %machine_id, "get_all_sku_ids failed");
+                tracing::warn!(error = %err, %machine_id, "get_all_sku_ids failed");
             }
         }
     }
@@ -881,7 +881,7 @@ pub async fn detail(
             })
             .collect(),
         Err(err) => {
-            tracing::warn!(%err, %machine_id, "get_machine_validation_runs failed");
+            tracing::warn!(error = %err, %machine_id, "get_machine_validation_runs failed");
             Vec::new() // Empty validation results on error
         }
     };
@@ -957,7 +957,7 @@ pub async fn maintenance(
         .await
         .map(|response| response.into_inner())
     {
-        tracing::error!(%err, %machine_id, "set_maintenance");
+        tracing::error!(error = %err, %machine_id, "set_maintenance");
         return Redirect::to(&view_url).into_response();
     }
 
@@ -1008,7 +1008,7 @@ pub async fn quarantine(
             .await
             .map(|_| ()),
         unknown => {
-            tracing::error!("Expected action to be 'enable' or 'disable' but got {unknown}");
+            tracing::error!(action = unknown, "Unexpected quarantine action",);
             return Redirect::to(&view_url).into_response();
         }
     };
@@ -1072,7 +1072,7 @@ pub async fn sku(
             .await
             .map(|_| "SKU association removed successfully".to_string()),
         unknown => {
-            tracing::error!("Expected SKU action to be 'assign' or 'remove' but got {unknown}");
+            tracing::error!(action = unknown, "Unexpected SKU action",);
             return Redirect::to(&view_url).into_response();
         }
     };
@@ -1085,7 +1085,7 @@ pub async fn sku(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, %machine_id, "sku action failed");
+            tracing::error!(error = %err, %machine_id, "sku action failed");
             ActionStatus {
                 action: action_status::Type::Sku,
                 class: action_status::Class::Error,
@@ -1131,7 +1131,7 @@ pub async fn set_dpu_first_boot_order(
         }
         .update_redirect_url(&view_url),
         Err(err) => {
-            tracing::error!(%err, "set_dpu_first_boot_order failed");
+            tracing::error!(error = %err, "set_dpu_first_boot_order failed");
             ActionStatus {
                 action: action_status::Type::SetDpuFirstBootOrder,
                 class: action_status::Class::Error,

--- a/crates/api-web/src/machine_validation.rs
+++ b/crates/api-web/src/machine_validation.rs
@@ -212,7 +212,7 @@ pub async fn results(
         include_history: false,
         machine_id: None,
     });
-    tracing::info!(%validation_id, "results");
+    tracing::info!(machine_validation_id = %validation_id, "results");
 
     let validation_results = match state
         .get_machine_validation_results(request)
@@ -233,7 +233,7 @@ pub async fn results(
             })
             .collect(),
         Err(err) => {
-            tracing::error!(%err, %validation_id, "get_validation_results failed");
+            tracing::error!(error = %err, machine_validation_id = %validation_id, "get_validation_results failed");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to get validation results",
@@ -296,7 +296,7 @@ pub async fn result_details(
             )
             .collect(),
         Err(err) => {
-            tracing::error!(%err, %validation_id, "get_validation_results failed");
+            tracing::error!(error = %err, machine_validation_id = %validation_id, "get_validation_results failed");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed to get validation results",
@@ -321,7 +321,7 @@ pub async fn show_tests_html(
     let validate_tests = match fetch_validation_tests(state, None).await {
         Ok(tests) => tests,
         Err(err) => {
-            tracing::error!(%err, "fetch_validation_tests");
+            tracing::error!(error = %err, "fetch_validation_tests");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading validation tests",
@@ -348,7 +348,7 @@ pub async fn show_tests_details_html(
     let validate_tests = match fetch_validation_tests(state, Some(test_id)).await {
         Ok(tests) => tests,
         Err(err) => {
-            tracing::error!(%err, "fetch_validation_tests");
+            tracing::error!(error = %err, "fetch_validation_tests");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading validation tests",
@@ -414,7 +414,7 @@ pub async fn runs(
             })
             .collect(),
         Err(err) => {
-            tracing::warn!(%err,"get_machine_validation_runs failed");
+            tracing::warn!(error = %err,"get_machine_validation_runs failed");
             Vec::new()
         }
     };
@@ -453,7 +453,7 @@ pub async fn external_configs(
             })
             .collect(),
         Err(err) => {
-            tracing::warn!(%err,"get_machine_validation_runs failed");
+            tracing::warn!(error = %err,"get_machine_validation_external_configs failed");
             Vec::new()
         }
     };

--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -417,7 +417,7 @@ pub async fn show_html(
     {
         Ok(hosts) => hosts,
         Err(err) => {
-            tracing::error!(%err, "fetch_managed_hosts");
+            tracing::error!(error = %err, "fetch_managed_hosts");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading managed hosts",
@@ -502,7 +502,10 @@ pub async fn show_html(
         }
         if active_gpu_filter != "all" {
             let Ok(gf) = active_gpu_filter.parse::<usize>() else {
-                tracing::warn!("Invalid GPU filter: '{active_gpu_filter}'");
+                tracing::warn!(
+                    active_gpu_filter = %active_gpu_filter,
+                    "Invalid GPU filter",
+                );
                 continue;
             };
             if gf != m.num_gpus {
@@ -511,7 +514,10 @@ pub async fn show_html(
         }
         if active_ib_filter != "all" {
             let Ok(ibf) = active_ib_filter.parse::<usize>() else {
-                tracing::warn!("Invalid IB IFs filter: '{active_ib_filter}'");
+                tracing::warn!(
+                    active_ib_filter = %active_ib_filter,
+                    "Invalid IB IFs filter",
+                );
                 continue;
             };
             if ibf != m.num_ib_ifs {
@@ -694,7 +700,7 @@ pub async fn show_all_json(state: AxumState<Arc<Api>>) -> Response {
     let mut managed_hosts = match fetch_managed_hosts_with_metadata(state, true).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_managed_hosts");
+            tracing::error!(error = %err, "fetch_managed_hosts");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading managed hosts",
@@ -817,7 +823,7 @@ fn mem_to_size(mem: &str) -> isize {
         .collect_tuple()
         .map(|(size, unit)| (size.parse::<f64>(), unit))
     else {
-        tracing::warn!("Invalid memory format: '{mem}'");
+        tracing::warn!(mem, "Invalid memory format",);
         return 0;
     };
 
@@ -825,7 +831,7 @@ fn mem_to_size(mem: &str) -> isize {
         "GiB" => size,
         "TiB" => size * 1024.0,
         _ => {
-            tracing::warn!("Invalid unit '{}' in mem string '{mem}'", unit);
+            tracing::warn!(unit, mem, "Invalid unit in mem string",);
             return 0;
         }
     }) as isize

--- a/crates/api-web/src/network_device.rs
+++ b/crates/api-web/src/network_device.rs
@@ -82,7 +82,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let network_devices = match fetch_network_devices(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_network_devices");
+            tracing::error!(error = %err, "fetch_network_devices");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network devices",
@@ -102,7 +102,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let network_devices = match fetch_network_devices(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_network_devices");
+            tracing::error!(error = %err, "fetch_network_devices");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network devices",

--- a/crates/api-web/src/network_security_group.rs
+++ b/crates/api-web/src/network_security_group.rs
@@ -130,7 +130,7 @@ pub async fn show(
         match fetch_network_security_groups(api, current_page, limit).await {
             Ok(all) => all,
             Err(err) => {
-                tracing::error!(%err, "fetch_nsgs");
+                tracing::error!(error = %err, "fetch_nsgs");
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Error loading network security groups: {err}"),

--- a/crates/api-web/src/network_segment.rs
+++ b/crates/api-web/src/network_segment.rs
@@ -93,7 +93,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let networks = match fetch_network_segments(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_network_segments");
+            tracing::error!(error = %err, "fetch_network_segments");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network segments",
@@ -122,7 +122,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         let mut display: NetworkSegmentRowDisplay = match n.try_into() {
             Ok(d) => d,
             Err(err) => {
-                tracing::error!(err, "skipping malformed network segment");
+                tracing::error!(error = err, "skipping malformed network segment");
                 continue;
             }
         };
@@ -149,7 +149,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let networks = match fetch_network_segments(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_network_segments");
+            tracing::error!(error = %err, "fetch_network_segments");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network segments",
@@ -362,7 +362,7 @@ pub async fn detail(
         }
         Ok(mut n) => n.network_segments.remove(0),
         Err(err) => {
-            tracing::error!(%err, "find_network_segments");
+            tracing::error!(error = %err, "find_network_segments");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network segments",
@@ -387,7 +387,7 @@ pub async fn detail(
     let mut tmpl: NetworkSegmentDetail = match segment.try_into() {
         Ok(t) => t,
         Err(err) => {
-            tracing::error!(err, "malformed network segment");
+            tracing::error!(error = err, "malformed network segment");
             return (StatusCode::INTERNAL_SERVER_ERROR, err).into_response();
         }
     };

--- a/crates/api-web/src/network_status.rs
+++ b/crates/api-web/src/network_status.rs
@@ -81,7 +81,7 @@ pub async fn show_html(
     let (pages, all_status) = match fetch_network_status(state, current_page, limit).await {
         Ok(all) => all,
         Err(err) => {
-            tracing::error!(%err, "fetch_network_status");
+            tracing::error!(error = %err, "fetch_network_status");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network status",
@@ -160,7 +160,7 @@ pub async fn show_all_json(
     let (_, all_status) = match fetch_network_status(state, current_page, limit).await {
         Ok(all) => all,
         Err(err) => {
-            tracing::error!(%err, "fetch_network_status");
+            tracing::error!(error = %err, "fetch_network_status");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading network status",

--- a/crates/api-web/src/nvlink.rs
+++ b/crates/api-web/src/nvlink.rs
@@ -187,7 +187,7 @@ pub async fn show_nvlink_logical_partitions_html(
     let partitions = match fetch_logical_partitions(state.clone(), false, None).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_logical_partitions");
+            tracing::error!(error = %err, "fetch_logical_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading logical partitions",
@@ -208,7 +208,7 @@ pub async fn show_nvlink_logical_partitions_json(
     let partitions = match fetch_logical_partitions(state, false, None).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_logical_partitions");
+            tracing::error!(error = %err, "fetch_logical_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json("Error loading logical_partitions".to_string()),
@@ -228,7 +228,7 @@ pub async fn show_nvlink_domain_health_html(
     let rows = match fetch_nvlink_domain_health_rows(&state).await {
         Ok(rows) => rows,
         Err(err) => {
-            tracing::error!(%err, "fetch_nvlink_domain_health_rows");
+            tracing::error!(error = %err, "fetch_nvlink_domain_health_rows");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading NVLink domain health",
@@ -253,7 +253,7 @@ pub async fn show_nvlink_domain_health_html(
     match tmpl.render() {
         Ok(html) => (StatusCode::OK, Html(html)).into_response(),
         Err(err) => {
-            tracing::error!(%err, "render_nvlink_domain_health");
+            tracing::error!(error = %err, "render_nvlink_domain_health");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error rendering NVLink domain health",
@@ -268,7 +268,7 @@ pub async fn show_nvlink_domain_health_json(AxumState(state): AxumState<Arc<Api>
     let rows = match fetch_nvlink_domain_health_rows(&state).await {
         Ok(rows) => rows,
         Err(err) => {
-            tracing::error!(%err, "fetch_nvlink_domain_health_rows");
+            tracing::error!(error = %err, "fetch_nvlink_domain_health_rows");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json("Error loading NVLink domain health".to_string()),
@@ -305,7 +305,7 @@ pub async fn detail(
     let partitions = match fetch_logical_partitions(state.clone(), true, Some(partitionid)).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_logical_partitions");
+            tracing::error!(error = %err, "fetch_logical_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading logical partitions",

--- a/crates/api-web/src/operating_system.rs
+++ b/crates/api-web/src/operating_system.rs
@@ -77,7 +77,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let oss = match fetch_operating_systems(state).await {
         Ok(v) => v,
         Err(err) => {
-            tracing::error!(%err, "fetch_operating_systems");
+            tracing::error!(error = %err, "fetch_operating_systems");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading operating systems",
@@ -96,7 +96,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let mut oss = match fetch_operating_systems(state).await {
         Ok(v) => v,
         Err(err) => {
-            tracing::error!(%err, "fetch_operating_systems");
+            tracing::error!(error = %err, "fetch_operating_systems");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading operating systems",
@@ -250,7 +250,7 @@ pub async fn detail(
             return super::not_found_response(os_id);
         }
         Err(err) => {
-            tracing::error!(%err, "get_operating_system");
+            tracing::error!(error = %err, "get_operating_system");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading operating system",

--- a/crates/api-web/src/power_shelf.rs
+++ b/crates/api-web/src/power_shelf.rs
@@ -50,7 +50,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let power_shelves = match fetch_power_shelves(&state).await {
         Ok(shelves) => shelves,
         Err(err) => {
-            tracing::error!(%err, "fetch_power_shelves");
+            tracing::error!(error = %err, "fetch_power_shelves");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading power shelves",
@@ -93,7 +93,7 @@ pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let power_shelves = match fetch_power_shelves(&state).await {
         Ok(shelves) => shelves,
         Err(err) => {
-            tracing::error!(%err, "fetch_power_shelves");
+            tracing::error!(error = %err, "fetch_power_shelves");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading power shelves",
@@ -203,7 +203,7 @@ pub async fn detail(
             records: records.into_iter().map(Into::into).collect(),
         },
         Err((code, err)) => {
-            tracing::error!(%code, %err, %power_shelf_id, "fetch_power_shelf_state_history_records");
+            tracing::error!(http_status = %code, error = %err, %power_shelf_id, "fetch_power_shelf_state_history_records");
             StateHistoryTable { records: vec![] }
         }
     };
@@ -231,7 +231,7 @@ async fn fetch_power_shelf(
         Ok(response) => response.into_inner(),
         Err(err) if err.code() == tonic::Code::NotFound => return Ok(None),
         Err(err) => {
-            tracing::error!(%err, %power_shelf_id, "fetch_power_shelf");
+            tracing::error!(error = %err, %power_shelf_id, "fetch_power_shelf");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response());
         }
     };

--- a/crates/api-web/src/rack.rs
+++ b/crates/api-web/src/rack.rs
@@ -74,7 +74,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_racks(&state).await {
         Ok(racks) => racks,
         Err(err) => {
-            tracing::error!(%err, "fetch_racks");
+            tracing::error!(error = %err, "fetch_racks");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading racks").into_response();
         }
     };
@@ -90,7 +90,7 @@ pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_racks(&state).await {
         Ok(racks) => racks,
         Err(err) => {
-            tracing::error!(%err, "fetch_racks");
+            tracing::error!(error = %err, "fetch_racks");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading racks").into_response();
         }
     };
@@ -150,7 +150,7 @@ pub async fn fetch_rack(
             return Ok(None);
         }
         Err(err) => {
-            tracing::error!(%err, %rack_id, "find_racks_by_ids");
+            tracing::error!(error = %err, %rack_id, "find_racks_by_ids");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, Html(err.to_string())).into_response());
         }
     };
@@ -186,7 +186,7 @@ pub async fn detail(
     let associated_machines = match fetch_machine_ids(api.clone(), rack_id.clone()).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_machine_ids");
+            tracing::error!(error = %err, "fetch_machine_ids");
             vec![]
         }
     };
@@ -194,7 +194,7 @@ pub async fn detail(
     let associated_switches = match fetch_switch_ids(&api, &rack_id).await {
         Ok(ids) => ids,
         Err(err) => {
-            tracing::error!(%err, "fetch_switch_ids");
+            tracing::error!(error = %err, "fetch_switch_ids");
             vec![]
         }
     };
@@ -202,7 +202,7 @@ pub async fn detail(
     let associated_power_shelves = match fetch_power_shelf_ids(&api, &rack_id).await {
         Ok(ids) => ids,
         Err(err) => {
-            tracing::error!(%err, "fetch_power_shelf_ids");
+            tracing::error!(error = %err, "fetch_power_shelf_ids");
             vec![]
         }
     };
@@ -247,7 +247,7 @@ pub async fn detail(
             records: records.into_iter().map(Into::into).collect(),
         },
         Err((code, err)) => {
-            tracing::error!(%code, %err, %rack_id, "fetch_rack_state_history_records");
+            tracing::error!(http_status = %code, error = %err, %rack_id, "fetch_rack_state_history_records");
             StateHistoryTable { records: vec![] }
         }
     };

--- a/crates/api-web/src/redfish_actions.rs
+++ b/crates/api-web/src/redfish_actions.rs
@@ -77,7 +77,7 @@ pub async fn query(
     {
         Ok(results) => results.into_inner().actions,
         Err(err) => {
-            tracing::error!(%err, "fetch_action_requests");
+            tracing::error!(error = %err, "fetch_action_requests");
             browser.error = Some(format!("Failed to look up action requests {err}",));
             return (StatusCode::OK, Html(browser.render().unwrap())).into_response();
         }

--- a/crates/api-web/src/redfish_browser.rs
+++ b/crates/api-web/src/redfish_browser.rs
@@ -139,7 +139,7 @@ pub async fn query(
     {
         Ok(r) => r.into_inner(),
         Err(err) => {
-            tracing::error!(%err, %bmc_ip, %browser.url, "redfish_browse");
+            tracing::error!(error = %err, bmc_ip_address = %bmc_ip, %browser.url, "redfish_browse");
             browser.error = format!("Failed to retrieve Redfish from API {err}");
             return (StatusCode::OK, Html(browser.render().unwrap())).into_response();
         }
@@ -149,7 +149,7 @@ pub async fn query(
         Ok(Some(machine_id)) => machine_id.to_string(),
         Ok(None) => String::new(),
         Err(err) => {
-            tracing::error!(%err, url = browser.url, "find_machine_id");
+            tracing::error!(error = %err, url = browser.url, "find_machine_id");
             browser.error = format!("Failed to look up Machine for URL {}", browser.url);
             return (StatusCode::OK, Html(browser.render().unwrap())).into_response();
         }
@@ -168,7 +168,7 @@ pub async fn query(
             .map(TryInto::try_into)
             .collect::<Result<_, _>>(),
         Err(err) => {
-            tracing::error!(%err, bmc_ip = browser.bmc_ip, "fetch_action_requests");
+            tracing::error!(error = %err, bmc_ip_address = browser.bmc_ip, "fetch_action_requests");
             browser.error = format!(
                 "Failed to look up action requests for bmc_ip {}",
                 browser.bmc_ip
@@ -179,7 +179,7 @@ pub async fn query(
     browser.actions.action_requests = match requests {
         Ok(ok) => ok,
         Err(err) => {
-            tracing::error!(%err, bmc_ip = browser.bmc_ip, "fetch_action_requests");
+            tracing::error!(error = %err, bmc_ip_address = browser.bmc_ip, "fetch_action_requests");
             browser.error = format!(
                 "Failed to deserialize action requests for bmc_ip {}",
                 browser.bmc_ip

--- a/crates/api-web/src/resource_pool.rs
+++ b/crates/api-web/src/resource_pool.rs
@@ -54,7 +54,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let pools = match fetch_resource_pools(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "admin_list_resource_pools");
+            tracing::error!(error = %err, "admin_list_resource_pools");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed loading resource pools",
@@ -70,7 +70,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_resource_pools(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "admin_list_resource_pools");
+            tracing::error!(error = %err, "admin_list_resource_pools");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Failed loading resource pools",

--- a/crates/api-web/src/search.rs
+++ b/crates/api-web/src/search.rs
@@ -112,12 +112,15 @@ async fn find_by_uuid(state: Arc<Api>, u: uuid::Uuid) -> Response {
             return (StatusCode::NOT_FOUND, "UUID does not match anything").into_response();
         }
         Err(err) => {
-            tracing::error!(%err, "find_by_uuid error calling grpc identify_uuid");
+            tracing::error!(error = %err, "find_by_uuid error calling grpc identify_uuid");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
     };
     let Ok(object_type) = forgerpc::UuidType::try_from(out.object_type) else {
-        tracing::error!("Invalid UuidType from carbide api: {}", out.object_type);
+        tracing::error!(
+            object_type = out.object_type,
+            "Invalid UuidType from carbide api",
+        );
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     };
     use forgerpc::UuidType::*;
@@ -152,12 +155,15 @@ async fn find_by_mac(state: Arc<Api>, mac: mac_address::MacAddress) -> impl Into
             return (StatusCode::NOT_FOUND, "MAC does not match anything").into_response();
         }
         Err(err) => {
-            tracing::error!(%err, "find_by_mac error calling grpc identify_mac");
+            tracing::error!(error = %err, "find_by_mac error calling grpc identify_mac");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
     };
     let Ok(object_type) = forgerpc::MacOwner::try_from(out.object_type) else {
-        tracing::error!("Invalid MacOwner from carbide api: {}", out.object_type);
+        tracing::error!(
+            object_type = out.object_type,
+            "Invalid MacOwner from carbide api",
+        );
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     };
     use forgerpc::MacOwner::*;
@@ -192,7 +198,7 @@ async fn find_by_serial(state: Arc<Api>, serial_number: &str) -> Option<MachineI
             None
         }
         Err(err) => {
-            tracing::info!(%err, serial_number, "find_by_serial error");
+            tracing::info!(error = %err, serial_number, "find_by_serial error");
             None
         }
     }

--- a/crates/api-web/src/sku.rs
+++ b/crates/api-web/src/sku.rs
@@ -89,7 +89,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let skus = match fetch_skus(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_skus");
+            tracing::error!(error = %err, "fetch_skus");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading skus").into_response();
         }
     };
@@ -104,7 +104,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let skus = match fetch_skus(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_skus");
+            tracing::error!(error = %err, "fetch_skus");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading SKUs").into_response();
         }
     };
@@ -203,7 +203,7 @@ pub async fn detail(
             return super::not_found_response(sku_id);
         }
         Err(err) => {
-            tracing::error!(%err, "find_skus_by_ids");
+            tracing::error!(error = %err, "find_skus_by_ids");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading SKUs").into_response();
         }
     };

--- a/crates/api-web/src/spx_partition.rs
+++ b/crates/api-web/src/spx_partition.rs
@@ -61,7 +61,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_spx_partitions(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_spx_partitions");
+            tracing::error!(error = %err, "fetch_spx_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading SPX partitions",
@@ -80,7 +80,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_spx_partitions(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_spx_partitions");
+            tracing::error!(error = %err, "fetch_spx_partitions");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading SPX partitions",

--- a/crates/api-web/src/state_history.rs
+++ b/crates/api-web/src/state_history.rs
@@ -131,6 +131,8 @@ macro_rules! define_fetch_state_history_records {
         $fn_name:ident,
         // type of the ID (MachineId, SwitchId, ...)
         id_type = $Id:ty,
+        // canonical structured log field for this ID type
+        id_log_field = $id_log_field:ident,
         // field in the request holding the vector of IDs (machine_ids, switch_ids, ...)
         id_vec_field = $ids_field:ident,
         // RPC method on Api (find_machine_state_histories, find_switch_state_histories, ...)
@@ -162,7 +164,12 @@ macro_rules! define_fetch_state_history_records {
             {
                 Ok(response) => response.into_inner().histories,
                 Err(err) => {
-                    tracing::error!(%err, %id, stringify!($api_method));
+                    tracing::error!(
+                        error = %err,
+                        $id_log_field = %id,
+                        operation = stringify!($api_method),
+                        "State history request failed"
+                    );
                     return Err((
                         http::StatusCode::INTERNAL_SERVER_ERROR,
                         concat!("Failed ", stringify!($api_method)).to_string(),
@@ -186,6 +193,7 @@ macro_rules! define_fetch_state_history_records {
 define_fetch_state_history_records!(
     fetch_machine_state_history_records,
     id_type = MachineId,
+    id_log_field = machine_id,
     id_vec_field = machine_ids,
     api_method = find_machine_state_histories,
     request_type = MachineStateHistoriesRequest,
@@ -195,6 +203,7 @@ define_fetch_state_history_records!(
 define_fetch_state_history_records!(
     fetch_power_shelf_state_history_records,
     id_type = PowerShelfId,
+    id_log_field = power_shelf_id,
     id_vec_field = power_shelf_ids,
     api_method = find_power_shelf_state_histories,
     request_type = PowerShelfStateHistoriesRequest,
@@ -204,6 +213,7 @@ define_fetch_state_history_records!(
 define_fetch_state_history_records!(
     fetch_rack_state_history_records,
     id_type = RackId,
+    id_log_field = rack_id,
     id_vec_field = rack_ids,
     api_method = find_rack_state_histories,
     request_type = RackStateHistoriesRequest,
@@ -213,6 +223,7 @@ define_fetch_state_history_records!(
 define_fetch_state_history_records!(
     fetch_switch_state_history_records,
     id_type = SwitchId,
+    id_log_field = switch_id,
     id_vec_field = switch_ids,
     api_method = find_switch_state_histories,
     request_type = SwitchStateHistoriesRequest,

--- a/crates/api-web/src/switch.rs
+++ b/crates/api-web/src/switch.rs
@@ -50,7 +50,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let switches = match fetch_switches(&state).await {
         Ok(switches) => switches,
         Err(err) => {
-            tracing::error!(%err, "fetch_switches");
+            tracing::error!(error = %err, "fetch_switches");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading switches").into_response();
         }
     };
@@ -93,7 +93,7 @@ pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let switches = match fetch_switches(&state).await {
         Ok(switches) => switches,
         Err(err) => {
-            tracing::error!(%err, "fetch_switches");
+            tracing::error!(error = %err, "fetch_switches");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading switches").into_response();
         }
     };
@@ -227,16 +227,17 @@ pub async fn detail(
         return (StatusCode::OK, Json(switch)).into_response();
     }
 
-    let history =
-        match super::state_history::fetch_switch_state_history_records(&api, &switch_id).await {
-            Ok((_switch_id, records)) => StateHistoryTable {
-                records: records.into_iter().map(Into::into).collect(),
-            },
-            Err((code, err)) => {
-                tracing::error!(%code, %err, %switch_id, "fetch_switch_state_history_records");
-                StateHistoryTable { records: vec![] }
-            }
-        };
+    let history = match super::state_history::fetch_switch_state_history_records(&api, &switch_id)
+        .await
+    {
+        Ok((_switch_id, records)) => StateHistoryTable {
+            records: records.into_iter().map(Into::into).collect(),
+        },
+        Err((code, err)) => {
+            tracing::error!(http_status = %code, error = %err, %switch_id, "fetch_switch_state_history_records");
+            StateHistoryTable { records: vec![] }
+        }
+    };
 
     let detail = SwitchDetail::new(switch, history);
     (StatusCode::OK, Html(detail.render().unwrap())).into_response()
@@ -258,7 +259,7 @@ async fn fetch_switch(api: &Api, switch_id: &str) -> Result<Option<rpc::forge::S
         Ok(response) => response.into_inner(),
         Err(err) if err.code() == tonic::Code::NotFound => return Ok(None),
         Err(err) => {
-            tracing::error!(%err, %switch_id, "fetch_switch");
+            tracing::error!(error = %err, %switch_id, "fetch_switch");
             return Err((StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response());
         }
     };

--- a/crates/api-web/src/tenant.rs
+++ b/crates/api-web/src/tenant.rs
@@ -57,7 +57,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_tenants(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_tenants");
+            tracing::error!(error = %err, "fetch_tenants");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading tenants").into_response();
         }
     };
@@ -72,7 +72,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out: forgerpc::TenantList = match fetch_tenants(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_tenants");
+            tracing::error!(error = %err, "fetch_tenants");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading tenants").into_response();
         }
     };
@@ -170,7 +170,7 @@ pub async fn detail(
             return super::not_found_response(organization_id);
         }
         Err(err) => {
-            tracing::error!(%err, %organization_id, "find_tenants");
+            tracing::error!(error = %err, %organization_id, "find_tenants");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading tenants").into_response();
         }
     };

--- a/crates/api-web/src/tenant_keyset.rs
+++ b/crates/api-web/src/tenant_keyset.rs
@@ -72,7 +72,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_keysets(state).await {
         Ok(m) => m,
         Err(err) => {
-            tracing::error!(%err, "fetch_keysets");
+            tracing::error!(error = %err, "fetch_keysets");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading keysets").into_response();
         }
     };
@@ -87,7 +87,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out: forgerpc::TenantKeySetList = match fetch_keysets(state).await {
         Ok(ks) => ks,
         Err(err) => {
-            tracing::error!(%err, "fetch_keysets");
+            tracing::error!(error = %err, "fetch_keysets");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading keysets").into_response();
         }
     };
@@ -198,7 +198,7 @@ pub async fn detail(
             return super::not_found_response(format!("{organization_id}/{keyset_id}"));
         }
         Err(err) => {
-            tracing::error!(%err, %organization_id, "find_tenant_keysets_by_ids");
+            tracing::error!(error = %err, %organization_id, "find_tenant_keysets_by_ids");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading keyset").into_response();
         }
     };

--- a/crates/api-web/src/ufm_browser.rs
+++ b/crates/api-web/src/ufm_browser.rs
@@ -60,7 +60,7 @@ pub async fn query(
     let fabric_ids = match super::ib_fabric::fetch_ib_fabric_ids(state.clone()).await {
         Ok(fabric_ids) => fabric_ids,
         Err(err) => {
-            tracing::error!(%err, "fetch_ib_fabric_ids");
+            tracing::error!(error = %err, "fetch_ib_fabric_ids");
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Error loading IB fabrics",

--- a/crates/api-web/src/vpc.rs
+++ b/crates/api-web/src/vpc.rs
@@ -102,7 +102,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let vpcs = match fetch_vpcs(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_vpcs");
+            tracing::error!(error = %err, "fetch_vpcs");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading VPCs").into_response();
         }
     };
@@ -117,7 +117,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let vpcs = match fetch_vpcs(state).await {
         Ok(n) => n,
         Err(err) => {
-            tracing::error!(%err, "fetch_vpcs");
+            tracing::error!(error = %err, "fetch_vpcs");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading VPCs").into_response();
         }
     };
@@ -257,7 +257,7 @@ pub async fn detail(
         }
         Ok(mut x) => x.vpcs.remove(0),
         Err(err) => {
-            tracing::error!(%err, "find_vpcs");
+            tracing::error!(error = %err, "find_vpcs");
             return (StatusCode::INTERNAL_SERVER_ERROR, "Error loading VPCs").into_response();
         }
     };
@@ -289,7 +289,7 @@ async fn fetch_vpc_peerings(state: Arc<Api>, vpc_id_string: String) -> Vec<VpcPe
     {
         Ok(id_list) => id_list.vpc_peering_ids,
         Err(err) => {
-            tracing::error!(%err, "find_vpc_peering_ids");
+            tracing::error!(error = %err, "find_vpc_peering_ids");
             return Vec::new();
         }
     };
@@ -309,7 +309,7 @@ async fn fetch_vpc_peerings(state: Arc<Api>, vpc_id_string: String) -> Vec<VpcPe
     {
         Ok(peerings) => peerings.vpc_peerings,
         Err(err) => {
-            tracing::error!(%err, "find_vpc_peerings_by_ids");
+            tracing::error!(error = %err, "find_vpc_peerings_by_ids");
             Vec::new()
         }
     };

--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -148,7 +148,10 @@ impl<B: Bmc> ExploredChassisCollection<B> {
                 .iter()
                 .map(|ps| format!("{}:{:?}", ps.id, ps.power_state))
                 .join(", ");
-            tracing::warn!("Delta power shelf power state is unknown: {detail}");
+            tracing::warn!(
+                power_supply_states = %detail,
+                "Delta power shelf power state is unknown"
+            );
         }
         state
     }
@@ -470,7 +473,7 @@ fn delta_psu_power_on<B: Bmc>(ps: &NvPowerSupply<B>) -> Option<bool> {
     match ps.oem_delta() {
         Ok(oem) => oem.and_then(|d| d.power()),
         Err(e) => {
-            tracing::warn!("failed to parse Delta OEM power supply data: {e:?}");
+            tracing::warn!(error = ?e, "Failed to parse Delta OEM power supply data");
             None
         }
     }
@@ -529,7 +532,10 @@ impl LiteOnSuppliesState<'_> {
         } else if off {
             ModelPowerState::Off
         } else {
-            tracing::warn!("powershelf power state is unknown: {self}");
+            tracing::warn!(
+                power_supply_states = %self,
+                "powershelf power state is unknown"
+            );
             ModelPowerState::Unknown
         }
     }

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -158,7 +158,8 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                             == Some(ErrorClass::NotFound)
                     {
                         tracing::warn!(
-                            "received 404 on system's ethernet collection fetch. Retrying. {retries_remaining} tries left"
+                            retries_remaining,
+                            "received 404 while fetching the system ethernet collection; retrying"
                         );
                         retries_remaining -= 1;
                         tokio::time::sleep(config.explore.retry_timeout).await;
@@ -196,7 +197,11 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     v.inner()
                         .parse()
                         .inspect_err(|err| {
-                            tracing::warn!("Failed to parse BaseMAC: {err} (mac: {v})");
+                            tracing::warn!(
+                                error = %err,
+                                mac_address = %v,
+                                "failed to parse BaseMAC"
+                            );
                         })
                         .ok()
                 });
@@ -354,25 +359,31 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         &self,
         hw_type: Option<hw::HwType>,
     ) -> Result<Vec<ModelEthernetInterface>, Error<B>> {
-        let mut result = self.ethernet_interfaces.iter()
+        let mut result = self
+            .ethernet_interfaces
+            .iter()
             .map(|iface| {
                 let mac_address = iface
                     .mac_address()
                     .map(|addr| {
-                        deserialize_input_mac_to_address(addr.as_str())
-                            .map_err(|e| Error::InvalidValue(format!("MAC address not valid: {addr} (err: {e})")))
+                        deserialize_input_mac_to_address(addr.as_str()).map_err(|e| {
+                            Error::InvalidValue(format!("MAC address not valid: {addr} (err: {e})"))
+                        })
                     })
                     .transpose()
                     .or_else(|err| {
                         if iface
-                            .interface_enabled().is_some_and(|is_enabled| !is_enabled)
+                            .interface_enabled()
+                            .is_some_and(|is_enabled| !is_enabled)
                         {
                             // disabled interfaces sometimes populate the MAC address with junk,
                             // ignore this error and create the interface with an empty mac address
                             // in the exploration report
                             tracing::debug!(
-                                "could not parse MAC address for a disabled interface {} (link_status: {:#?}): {err}",
-                                iface.id(), iface.link_status()
+                                interface_id = %iface.id(),
+                                link_status = ?iface.link_status(),
+                                error = %err,
+                                "could not parse MAC address for a disabled interface"
                             );
                             Ok(None)
                         } else {
@@ -395,7 +406,8 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     link_status: iface.link_status().map(|s| format!("{s:?}")),
                     uefi_device_path,
                 })
-            }).collect::<Result<Vec<_>, _>>()?;
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         if hw_type.is_some_and(|v| v == hw::HwType::Bluefield)
             && !result.iter().any(|iface| {

--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -149,61 +149,69 @@ impl<B: Bmc> ExploredManager<B> {
     }
 
     pub fn to_model(&self) -> Result<ModelManager, Error<B>> {
-        let ethernet_interfaces = self.eth_interfaces.iter().map(|iface| {
-            let mac_address = iface
-                .mac_address()
-                .map(|addr| {
-                    deserialize_input_mac_to_address(addr.as_str())
-                        .map_err(|e| Error::InvalidValue(format!("MAC address not valid: {addr} (err: {e})")))
+        let ethernet_interfaces = self
+            .eth_interfaces
+            .iter()
+            .map(|iface| {
+                let mac_address = iface
+                    .mac_address()
+                    .map(|addr| {
+                        deserialize_input_mac_to_address(addr.as_str()).map_err(|e| {
+                            Error::InvalidValue(format!("MAC address not valid: {addr} (err: {e})"))
+                        })
+                    })
+                    .transpose()
+                    .or_else(|err| {
+                        if iface
+                            .interface_enabled()
+                            .is_some_and(|is_enabled| !is_enabled)
+                        {
+                            // disabled interfaces sometimes populate the MAC address with junk,
+                            // ignore this error and create the interface with an empty mac address
+                            // in the exploration report
+                            tracing::debug!(
+                                interface_id = %iface.id(),
+                                link_status = ?iface.link_status(),
+                                error = %err,
+                                "could not parse MAC address for a disabled interface"
+                            );
+                            Ok(None)
+                        } else {
+                            Err(err)
+                        }
+                    })?;
+
+                // Warn if the manager eth0 MAC is locally-administered: a real BMC MAC is
+                // globally unique, so this signals transient pre-sync data (seen briefly
+                // after a BMC reboot) that would poison anything keyed on the BMC MAC.
+                if iface.id().inner().eq_ignore_ascii_case("eth0")
+                    && let Some(mac) = mac_address
+                    && is_locally_administered_mac(mac)
+                {
+                    tracing::warn!(
+                        manager_id = %self.manager.id().inner(),
+                        eth0_mac_address = %mac,
+                        "manager eth0 MAC is locally-administered (transient pre-sync data?)",
+                    );
+                }
+
+                let uefi_device_path = iface
+                    .uefi_device_path()
+                    .map(|v| v.into_inner())
+                    .map(UefiDevicePath::from_str)
+                    .transpose()
+                    .map_err(|err| Error::InvalidValue(format!("UefiDevicePath: {err}")))?;
+
+                Ok(ModelEthernetInterface {
+                    description: iface.description().map(|v| v.to_string()),
+                    id: Some(iface.id().to_string()),
+                    interface_enabled: iface.interface_enabled(),
+                    mac_address,
+                    link_status: iface.link_status().map(|s| format!("{s:?}")),
+                    uefi_device_path,
                 })
-                .transpose()
-                .or_else(|err| {
-                    if iface
-                        .interface_enabled().is_some_and(|is_enabled| !is_enabled)
-                    {
-                        // disabled interfaces sometimes populate the MAC address with junk,
-                        // ignore this error and create the interface with an empty mac address
-                        // in the exploration report
-                        tracing::debug!(
-                            "could not parse MAC address for a disabled interface {} (link_status: {:#?}): {err}",
-                            iface.id(), iface.link_status()
-                        );
-                        Ok(None)
-                    } else {
-                        Err(err)
-                    }
-                })?;
-
-            // Warn if the manager eth0 MAC is locally-administered: a real BMC MAC is
-            // globally unique, so this signals transient pre-sync data (seen briefly
-            // after a BMC reboot) that would poison anything keyed on the BMC MAC.
-            if iface.id().inner().eq_ignore_ascii_case("eth0")
-                && let Some(mac) = mac_address
-                && is_locally_administered_mac(mac)
-            {
-                tracing::warn!(
-                    manager_id = %self.manager.id().inner(),
-                    eth0_mac = %mac,
-                    "manager eth0 MAC is locally-administered (transient pre-sync data?)",
-                );
-            }
-
-            let uefi_device_path = iface
-                .uefi_device_path()
-                .map(|v| v.into_inner())
-                .map(UefiDevicePath::from_str)
-                .transpose()
-                .map_err(|err| Error::InvalidValue(format!("UefiDevicePath: {err}")))?;
-
-            Ok(ModelEthernetInterface {
-                description: iface.description().map(|v| v.to_string()),
-                id: Some(iface.id().to_string()),
-                interface_enabled: iface.interface_enabled(),
-                mac_address,
-                link_status: iface.link_status().map(|s| format!("{s:?}")),
-                uefi_device_path,
             })
-        }).collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(ModelManager {
             id: self.manager.id().inner().to_string(),

--- a/crates/bmc-mock/src/combined_server.rs
+++ b/crates/bmc-mock/src/combined_server.rs
@@ -60,7 +60,10 @@ impl Drop for CombinedServer {
         if let Some(join_handle) = self.join_handle.take()
             && !join_handle.is_finished()
         {
-            tracing::info!("Stopping BMC Mock at {}", self.address);
+            tracing::info!(
+                listen_address = %self.address,
+                "Stopping BMC mock",
+            );
             self.axum_handle.shutdown();
             join_handle.abort()
         }
@@ -114,7 +117,10 @@ impl CombinedServer {
                 )
             }
         };
-        tracing::info!("Listening on {}", addr);
+        tracing::info!(
+            listen_address = %addr,
+            "BMC mock listening",
+        );
 
         // Inject middleware to normalize request URIs by dropping the trailing slash
         let router = router.layer(NormalizePathLayer::trim_trailing_slash());
@@ -125,7 +131,11 @@ impl CombinedServer {
                     .serve(router.into_make_service())
                     .await
                     .inspect_err(|e| {
-                        tracing::error!("BMC mock could not listen on address {}: {}", addr, e)
+                        tracing::error!(
+                            listen_address = %addr,
+                            error = %e,
+                            "BMC mock could not listen",
+                        )
                     })?;
                 Ok(())
             })

--- a/crates/bmc-mock/src/combined_service.rs
+++ b/crates/bmc-mock/src/combined_service.rs
@@ -111,7 +111,12 @@ fn no_router_response(
     let err = format!(
         "no router configured for forwarded_host/host/authority: {forwarded_host:?}/{host:?}/{authority:?}"
     );
-    tracing::info!("{err}");
+    tracing::info!(
+        forwarded_host = ?forwarded_host,
+        host = ?host,
+        authority = ?authority,
+        "No BMC mock router is configured for request",
+    );
     Response::builder()
         .status(StatusCode::NOT_FOUND)
         .body(err.into())

--- a/crates/bmc-mock/src/injection/store.rs
+++ b/crates/bmc-mock/src/injection/store.rs
@@ -128,7 +128,7 @@ impl InjectionStore {
                         method = method_str,
                         path,
                         rule = %rule.id,
-                        status = %status,
+                        http_status = %status,
                         "injecting status",
                     );
                     status_inject = Some(status);
@@ -148,7 +148,7 @@ impl InjectionStore {
                         method = method_str,
                         path,
                         rule = %rule.id,
-                        delay_ms = delay.as_millis() as u64,
+                        delay_milliseconds = delay.as_millis() as u64,
                         "injecting latency",
                     );
                     // Combine delay if multiple rules match.

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -73,9 +73,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(ip_routers) = args.ip_router {
         for ip_router in ip_routers {
             info!(
-                "Using archive {} for {}",
-                ip_router.targz.to_string_lossy(),
-                ip_router.ip_address
+                archive_path = %ip_router.targz.to_string_lossy(),
+                ip_address = %ip_router.ip_address,
+                "Using BMC mock archive",
             );
             let r = tar_router::tar_router(
                 TarGzOption::Disk(&ip_router.targz),
@@ -87,9 +87,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let listen_addr = args.port.map(|p| SocketAddr::from(([0, 0, 0, 0], p)));
-    info!("Using cert_path: {:?}", args.cert_path);
+    info!(
+        cert_path = ?args.cert_path,
+        "Using BMC mock certificate path",
+    );
     let router = if let Some(tar_path) = args.targz {
-        info!("Using archive {} as default", tar_path.to_string_lossy());
+        info!(
+            archive_path = %tar_path.to_string_lossy(),
+            "Using default BMC mock archive",
+        );
         tar_router::tar_router(TarGzOption::Disk(&tar_path), Some(&mut tar_router_entries)).unwrap()
     } else {
         info!("Using default BMC mock");
@@ -132,7 +138,10 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
                     continue;
                 }
                 Err(err) => {
-                    tracing::error!("Error trying to run 'virsh reboot ManagedHost'. {}", err);
+                    tracing::error!(
+                        error = %err,
+                        "Failed to run virsh reboot for managed host",
+                    );
                     continue;
                 }
             };
@@ -142,11 +151,15 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
                     tracing::debug!("Rebooted qemu managed host...");
                 }
                 Some(exit_code) => {
-                    tracing::error!(
-                        "Reboot command 'virsh reboot ManagedHost' failed with exit code {exit_code}."
+                    tracing::error!(exit_code, "virsh reboot failed for managed host",);
+                    tracing::info!(
+                        stdout = %String::from_utf8_lossy(&reboot_output.stdout),
+                        "virsh reboot standard output",
                     );
-                    tracing::info!("STDOUT: {}", String::from_utf8_lossy(&reboot_output.stdout));
-                    tracing::info!("STDERR: {}", String::from_utf8_lossy(&reboot_output.stderr));
+                    tracing::info!(
+                        stderr = %String::from_utf8_lossy(&reboot_output.stderr),
+                        "virsh reboot standard error",
+                    );
                 }
                 None => {
                     tracing::error!("Reboot command killed by signal");

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -58,7 +58,12 @@ async fn process(State(mut state): State<Middleware>, request: Request<Body>) ->
     let response = state.injection.post_handle(&path, response).await;
 
     if !response.status().is_success() {
-        tracing::warn!(method = %method, path, status = %response.status());
+        tracing::warn!(
+            method = %method,
+            path,
+            http_status = %response.status(),
+            "BMC mock request returned unsuccessful response"
+        );
     }
     if !is_safe && response.status().is_success() {
         state.callbacks.state_refresh_indication();

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -93,7 +93,10 @@ async fn process(State(mut state): State<Expander>, request: Request<Body>) -> R
         .filter_map(|member| match member {
             Value::Object(object) => Some(object),
             _ => {
-                tracing::warn!("Invalid member JSON, expected Object: {:?}", member);
+                tracing::warn!(
+                    member = ?member,
+                    "Invalid member JSON, expected Object",
+                );
                 None
             }
         })
@@ -101,8 +104,8 @@ async fn process(State(mut state): State<Expander>, request: Request<Body>) -> R
             Some(Value::String(id)) => Some(id.to_owned()),
             _ => {
                 tracing::warn!(
-                    "Invalid member JSON, expected @odata.id string: {:?}",
-                    object
+                    object = ?object,
+                    "Invalid member JSON, expected @odata.id string",
                 );
                 None
             }

--- a/crates/bmc-mock/src/tar_router.rs
+++ b/crates/bmc-mock/src/tar_router.rs
@@ -140,7 +140,10 @@ async fn get_from_tar(
 
     match cache.entries.lock().unwrap().get(&path) {
         None => {
-            tracing::trace!("Not found: {path}");
+            tracing::trace!(
+                path = %path,
+                "BMC mock archive path not found",
+            );
             (StatusCode::NOT_FOUND, path).into_response()
         }
         Some(s) => (StatusCode::OK, s.clone()).into_response(),
@@ -149,7 +152,11 @@ async fn get_from_tar(
 
 // We should never get here, but axum's matchit bug means we sometimes do: https://github.com/tokio-rs/axum/issues/1986
 async fn not_found_handler(req: Request<Body>) -> (StatusCode, String) {
-    tracing::warn!("fallback: No route for {} {}", req.method(), req.uri());
+    tracing::warn!(
+        method = %req.method(),
+        uri = %req.uri(),
+        "No route for BMC mock request",
+    );
     (
         StatusCode::NOT_FOUND,
         format!("No route for {} {}", req.method(), req.uri()),

--- a/crates/bmc-mock/src/tls.rs
+++ b/crates/bmc-mock/src/tls.rs
@@ -95,7 +95,11 @@ pub fn server_config(cert_path: Option<impl AsRef<OsStr>>) -> Result<ServerConfi
         cert_file = cert_path.join("tls.crt");
         key_file = cert_path.join("tls.key");
     }
-    tracing::info!("Loading {:?} and {:?}", cert_file, key_file);
+    tracing::info!(
+        cert_file = ?cert_file,
+        key_file = ?key_file,
+        "Loading BMC mock TLS certificate and key",
+    );
     let tls_cert = std::fs::read(cert_file).map_err(Error::CertFileRead)?;
     let tls_key = std::fs::read(key_file).map_err(Error::KeyFileRead)?;
 

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -144,7 +144,7 @@ pub async fn start(
     let BmcProxyParams { config } = params;
 
     tracing::info!(
-        address = config.listen.to_string(),
+        listen_address = config.listen.to_string(),
         build_version = carbide_version::v!(build_version),
         build_date = carbide_version::v!(build_date),
         rust_version = carbide_version::v!(rust_version),
@@ -259,8 +259,8 @@ enum ConnectionFailReason {
 
 /// An inbound connection failed before it could be served -- the TCP accept
 /// errored, the TLS acceptor could not be reloaded, or the TLS handshake
-/// errored. Metric-only: the `tracing::error!` beside each emit stays the log,
-/// byte-for-byte as before; the `reason` label distinguishes which leg failed.
+/// errored. Metric-only: the `tracing::error!` beside each emit remains the log;
+/// the `reason` label distinguishes which leg failed.
 #[derive(Event)]
 #[event(
     name = "carbide_bmc_proxy_tls_connection_fail_total",
@@ -308,7 +308,10 @@ impl BmcProxy {
                     match RefreshableTlsAcceptor::new(self.state.config.tls.clone()).await {
                         Ok(acceptor) => acceptor,
                         Err(e) => {
-                            tracing::error!("Error reloading TLS certificate, will retry: {e}");
+                            tracing::error!(
+                                error = %e,
+                                "Error reloading TLS certificate, will retry",
+                            );
                             emit(TlsConnectionFailed {
                                 reason: ConnectionFailReason::TlsCertificateInvalid,
                             });
@@ -324,46 +327,52 @@ impl BmcProxy {
 
             tokio::task::Builder::new()
                 .name("http conn handler")
-                .spawn(
-                    async move {
-                        match tls_acceptor.accept(conn).await {
-                            Ok(conn) => {
-                                let conn = TokioIo::new(conn);
-                                emit(TlsConnectionSucceeded);
+                .spawn(async move {
+                    match tls_acceptor.accept(conn).await {
+                        Ok(conn) => {
+                            let conn = TokioIo::new(conn);
+                            emit(TlsConnectionSucceeded);
 
-                                let (_, session) = conn.inner().get_ref();
-                                let connection_attributes = {
-                                    let peer_address = addr;
-                                    let peer_certificates =
-                                        session.peer_certificates().unwrap_or_default().to_vec();
-                                    Arc::new(ConnectionAttributes {
-                                        peer_address,
-                                        peer_certificates,
-                                    })
-                                };
-                                let conn_attrs_extension_layer =
-                                    AddExtensionLayer::new(connection_attributes);
+                            let (_, session) = conn.inner().get_ref();
+                            let connection_attributes = {
+                                let peer_address = addr;
+                                let peer_certificates =
+                                    session.peer_certificates().unwrap_or_default().to_vec();
+                                Arc::new(ConnectionAttributes {
+                                    peer_address,
+                                    peer_certificates,
+                                })
+                            };
+                            let conn_attrs_extension_layer =
+                                AddExtensionLayer::new(connection_attributes);
 
-                                let app_with_ext = tower::ServiceBuilder::new()
-                                    .layer(conn_attrs_extension_layer)
-                                    .service(app);
+                            let app_with_ext = tower::ServiceBuilder::new()
+                                .layer(conn_attrs_extension_layer)
+                                .service(app);
 
-                                if let Err(error) = http
-                                    .serve_connection(conn, TowerToHyperService::new(app_with_ext))
-                                    .await
-                                {
-                                    tracing::debug!(%error, "error servicing tls http request: {error:?}");
-                                }
-                            }
-                            Err(error) => {
-                                tracing::error!(%error, address = %addr, "error accepting tls connection");
-                                emit(TlsConnectionFailed {
-                                    reason: ConnectionFailReason::TlsConnectionFailure,
-                                });
+                            if let Err(error) = http
+                                .serve_connection(conn, TowerToHyperService::new(app_with_ext))
+                                .await
+                            {
+                                tracing::debug!(
+                                    %error,
+                                    error_debug = ?error,
+                                    "error servicing tls http request",
+                                );
                             }
                         }
+                        Err(error) => {
+                            tracing::error!(
+                                %error,
+                                peer_address = %addr,
+                                "error accepting tls connection"
+                            );
+                            emit(TlsConnectionFailed {
+                                reason: ConnectionFailReason::TlsConnectionFailure,
+                            });
+                        }
                     }
-                )
+                })
                 // Safety: This only fails if run outside the tokio runtime
                 .expect("could not spawn task to handle HTTP connection");
         }
@@ -488,7 +497,7 @@ fn get_tls_acceptor(tls_config: &TlsConfig) -> Result<RefreshableTlsAcceptor, Bm
 pub fn cert_description_layer<AZ: Authorization>(
     auth_config: &AuthConfig,
 ) -> Result<CertDescriptionMiddleware<AZ>, BmcProxyError> {
-    tracing::info!("TrustConfig rendered from config: {:?}", auth_config.trust);
+    tracing::info!(trust_config = ?auth_config.trust, "TrustConfig rendered from config");
     let spiffe_context = SpiffeContext::try_from(auth_config.trust.clone()).map_err(|e| {
         BmcProxyError::InvalidConfiguration(format!(
             "Invalid trust config in bmc-proxy config toml file: {e}"
@@ -651,7 +660,7 @@ async fn ip_for_forwarded_target(
         .iter()
         .filter_map(|s| {
             IpAddr::from_str(s)
-                .inspect_err(|e| tracing::error!("Invalid IP address returned by API: {e}"))
+                .inspect_err(|e| tracing::error!(error = %e, "Invalid IP address returned by API"))
                 .ok()
         })
         .collect::<Vec<_>>();
@@ -666,13 +675,9 @@ async fn ip_for_forwarded_target(
         (0, 1..) => {
             if v6_ips.len() > 1 {
                 tracing::warn!(
-                    "Multiple IPv6 BMC IP's found for {} ({}), using first one",
-                    lookup_by_str,
-                    v6_ips
-                        .iter()
-                        .map(|ip| ip.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", "),
+                    lookup_by = %lookup_by_str,
+                    ip_addresses = ?v6_ips,
+                    "Multiple IPv6 BMC IP's found, using first one",
                 );
             }
             v6_ips.into_iter().next()
@@ -682,13 +687,9 @@ async fn ip_for_forwarded_target(
             // first, in case of broken dual-stack setups.
             if v4_ips.len() > 1 {
                 tracing::warn!(
-                    "Multiple IPv4 BMC IP's found for {} ({}), using first one",
-                    lookup_by_str,
-                    v4_ips
-                        .iter()
-                        .map(|ip| ip.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", "),
+                    lookup_by = %lookup_by_str,
+                    ip_addresses = ?v4_ips,
+                    "Multiple IPv4 BMC IP's found, using first one",
                 );
             }
             v4_ips.into_iter().next()
@@ -971,11 +972,11 @@ async fn get_bmc_credentials(
     credential_cache: &CredentialCache,
 ) -> Result<BmcCredentials, BmcProxyError> {
     if let Some(credentials) = credential_cache.lock().await.get(&ip).cloned() {
-        tracing::debug!(%ip, "Using cached BMC credentials");
+        tracing::debug!(bmc_ip_address = %ip, "Using cached BMC credentials");
         return Ok(credentials);
     }
 
-    tracing::debug!(%ip, "Fetching BMC credentials from Carbide API");
+    tracing::debug!(bmc_ip_address = %ip, "Fetching BMC credentials from Carbide API");
     let bmc_mac_address = api_client
         .find_mac_address_by_bmc_ip(forge::BmcIp {
             bmc_ip: ip.to_string(),
@@ -1010,7 +1011,7 @@ fn build_http_client() -> Result<reqwest::Client, BmcProxyError> {
         .pool_max_idle_per_host(4)
         .build()
         .map_err(|err| {
-            tracing::error!(%err, "build_http_client");
+            tracing::error!(error = %err, "build_http_client");
             BmcProxyError::InternalProxying(format!("Http building failed: {err}"))
         })
 }
@@ -1021,11 +1022,11 @@ async fn get_http_client(
 ) -> Result<reqwest::Client, BmcProxyError> {
     let mut client_cache = client_cache.lock().await;
     if let Some(client) = client_cache.get(&ip) {
-        tracing::debug!(%ip, "Using cached BMC HTTP client");
+        tracing::debug!(bmc_ip_address = %ip, "Using cached BMC HTTP client");
         return Ok(client.clone());
     }
 
-    tracing::debug!(%ip, "Creating cached BMC HTTP client");
+    tracing::debug!(bmc_ip_address = %ip, "Creating cached BMC HTTP client");
     let client = build_http_client()?;
     client_cache.insert(ip, client.clone());
     Ok(client)
@@ -1033,7 +1034,7 @@ async fn get_http_client(
 
 async fn evict_cached_credentials(ip: IpAddr, credential_cache: &CredentialCache) {
     if credential_cache.lock().await.remove(&ip).is_some() {
-        tracing::info!(%ip, "Evicted cached BMC credentials after upstream auth failure");
+        tracing::info!(bmc_ip_address = %ip, "Evicted cached BMC credentials after upstream auth failure");
     }
 }
 

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -37,7 +37,7 @@ pub async fn start(
     join_set: &mut JoinSet<()>,
 ) -> io::Result<()> {
     let listener = TcpListener::bind(&address).await?;
-    tracing::info!(%address, "Starting metrics listener");
+    tracing::info!(metrics_address = %address, "Starting metrics listener");
 
     join_set
         .build_task()

--- a/crates/bmc-proxy/src/setup.rs
+++ b/crates/bmc-proxy/src/setup.rs
@@ -61,7 +61,7 @@ pub fn setup_logging(debug: bool) -> SetupResult<()> {
         )
         .try_init()?;
 
-    tracing::info!("current log level: {}", LevelFilter::current());
+    tracing::info!(configured_log_level = %LevelFilter::current(), "current log level");
     Ok(())
 }
 

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -125,13 +125,13 @@ async fn register_and_map(
         .into_inner();
 
         let Some(reg_resp) = response.responses.into_iter().next() else {
-            tracing::warn!(bmc_mac = %ep.bmc_mac, "NSM returned empty response for switch");
+            tracing::warn!(bmc_mac_address = %ep.bmc_mac, "NSM returned empty response for switch");
             continue;
         };
 
         if reg_resp.status != nsm::StatusCode::Success as i32 {
             tracing::warn!(
-                bmc_mac = %ep.bmc_mac,
+                bmc_mac_address = %ep.bmc_mac,
                 error = %reg_resp.error,
                 "NSM registration failed for switch"
             );
@@ -392,7 +392,7 @@ impl NvSwitchManager for NsmSwitchBackend {
         services: Option<&[i32]>,
     ) -> Result<String, ComponentManagerError> {
         tracing::warn!(
-            bmc_mac = %endpoint.bmc_mac,
+            bmc_mac_address = %endpoint.bmc_mac,
             ?domain_name,
             ?services,
             "switch certificate configuration is not supported by NSM backend, passthrough"

--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -116,7 +116,7 @@ async fn register_with_psm(
 
     for f in &failures {
         tracing::warn!(
-            pmc_mac = %f.pmc_mac_address,
+            pmc_mac_address = %f.pmc_mac_address,
             error = %f.error,
             "PSM registration failed for power shelf"
         );

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -322,7 +322,7 @@ async fn resolve_power_shelf_identities(
     let mut map = HashMap::with_capacity(rows.len());
     for row in rows {
         let Some(rack_id) = row.rack_id else {
-            tracing::warn!(bmc_mac = %row.bmc_mac_address, "power shelf has no rack_id, skipping");
+            tracing::warn!(bmc_mac_address = %row.bmc_mac_address, "power shelf has no rack_id, skipping");
             continue;
         };
         map.insert(
@@ -359,7 +359,7 @@ async fn resolve_compute_tray_identities(
     let mut map = HashMap::with_capacity(rows.len());
     for row in rows {
         let Some(rack_id) = row.rack_id else {
-            tracing::warn!(bmc_ip = %row.bmc_ip, "compute tray has no rack_id, skipping");
+            tracing::warn!(bmc_ip_address = %row.bmc_ip, "compute tray has no rack_id, skipping");
             continue;
         };
         map.insert(
@@ -391,7 +391,7 @@ async fn resolve_switch_identities(
     let mut map = HashMap::with_capacity(rows.len());
     for row in rows {
         let Some(rack_id) = row.rack_id else {
-            tracing::warn!(bmc_mac = %row.bmc_mac_address, "switch has no rack_id, skipping");
+            tracing::warn!(bmc_mac_address = %row.bmc_mac_address, "switch has no rack_id, skipping");
             continue;
         };
         map.insert(
@@ -565,7 +565,7 @@ impl PowerShelfManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        pmc_mac = %ep.pmc_mac,
+                        pmc_mac_address = %ep.pmc_mac,
                         error = %e,
                         "RMS power control failed for power shelf"
                     );
@@ -666,7 +666,7 @@ impl PowerShelfManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        pmc_mac = %ep.pmc_mac,
+                        pmc_mac_address = %ep.pmc_mac,
                         error = %e,
                         "RMS firmware update failed for power shelf"
                     );
@@ -752,7 +752,7 @@ impl PowerShelfManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        pmc_mac = %pmc_mac,
+                        pmc_mac_address = %pmc_mac,
                         job_id = %job_id,
                         error = %e,
                         "RMS firmware job status query failed"
@@ -825,7 +825,7 @@ impl PowerShelfManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        pmc_mac = %ep.pmc_mac,
+                        pmc_mac_address = %ep.pmc_mac,
                         error = %e,
                         "RMS firmware inventory query failed for power shelf"
                     );
@@ -1104,7 +1104,7 @@ async fn query_rms_power_state(
         }
         Err(error) => {
             tracing::warn!(
-                %device_mac,
+                device_mac_address = %device_mac,
                 error = %error,
                 device_kind,
                 "RMS get power state failed"
@@ -1500,7 +1500,7 @@ impl NvSwitchManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        bmc_mac = %ep.bmc_mac,
+                        bmc_mac_address = %ep.bmc_mac,
                         error = %e,
                         "RMS power control failed for switch"
                     );
@@ -1597,14 +1597,14 @@ impl NvSwitchManager for RmsBackend {
                                 }
                             } else if job_id.is_some() {
                                 tracing::debug!(
-                                    bmc_mac = %ep.bmc_mac,
+                                    bmc_mac_address = %ep.bmc_mac,
                                     "RMS returned a firmware-object job id for a failed switch update; not tracking it"
                                 );
                             }
                         }
                         Err(e) => {
                             tracing::warn!(
-                                bmc_mac = %ep.bmc_mac,
+                                bmc_mac_address = %ep.bmc_mac,
                                 error = %e,
                                 "RMS firmware-object update failed for switch"
                             );
@@ -1659,14 +1659,14 @@ impl NvSwitchManager for RmsBackend {
                                 }
                             } else if job_id.is_some() {
                                 tracing::debug!(
-                                    bmc_mac = %ep.bmc_mac,
+                                    bmc_mac_address = %ep.bmc_mac,
                                     "RMS returned a switch system-image job id for a failed switch update; not tracking it"
                                 );
                             }
                         }
                         Err(e) => {
                             tracing::warn!(
-                                bmc_mac = %ep.bmc_mac,
+                                bmc_mac_address = %ep.bmc_mac,
                                 error = %e,
                                 "RMS switch system-image update failed for switch"
                             );
@@ -1899,7 +1899,7 @@ impl NvSwitchManager for RmsBackend {
                 }
                 Err(error) => {
                     tracing::warn!(
-                        bmc_mac = %ep.bmc_mac,
+                        bmc_mac_address = %ep.bmc_mac,
                         error = %error,
                         "RMS get slot and tray failed for switch"
                     );
@@ -2438,7 +2438,7 @@ impl ComputeTrayManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        bmc_ip = %ep.bmc_ip,
+                        bmc_ip_address = %ep.bmc_ip,
                         error = %e,
                         "RMS power control failed for compute tray"
                     );
@@ -2548,7 +2548,7 @@ impl ComputeTrayManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        bmc_ip = %ep.bmc_ip,
+                        bmc_ip_address = %ep.bmc_ip,
                         error = %e,
                         "RMS firmware update failed for compute tray"
                     );
@@ -2639,7 +2639,7 @@ impl ComputeTrayManager for RmsBackend {
                 }
                 Err(e) => {
                     tracing::warn!(
-                        bmc_ip = %bmc_ip,
+                        bmc_ip_address = %bmc_ip,
                         job_id = %job_id,
                         error = %e,
                         "RMS firmware job status query failed"

--- a/crates/dhcp-server/src/cache.rs
+++ b/crates/dhcp-server/src/cache.rs
@@ -57,14 +57,14 @@ pub fn get(
 ) -> Option<CacheEntry> {
     let key = &key(mac_address, link_address, circuit_id, remote_id, vendor_id);
     if key.len() < MIN_KEY_LEN {
-        tracing::debug!("Unexpected cache key, skipping: '{key}'");
+        tracing::debug!(key = key.as_str(), "Unexpected cache key, skipping");
         return None;
     }
     if let Some(entry) = cache.get(key) {
         if !entry.has_expired() {
             return Some(entry.clone());
         } else {
-            tracing::debug!("removed expired cached response for {mac_address:?}");
+            tracing::debug!(?mac_address, "removed expired cached response");
             let _removed = cache.pop_entry(key);
         }
     }

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -215,7 +215,7 @@ impl DhcpServerControl for DhcpServerControlService {
     ) -> Result<Response<GetDhcpTimestampsResponse>, Status> {
         let mut ts = DhcpTimestamps::new(DhcpTimestampsFilePath::Hbn);
         if let Err(e) = ts.read() {
-            tracing::warn!("Failed to read DHCP timestamps file: {e}");
+            tracing::warn!(error = %e, "Failed to read DHCP timestamps file");
         }
         let entries = ts
             .into_iter()
@@ -233,13 +233,13 @@ impl DhcpServerControl for DhcpServerControlService {
 /// Start the plain (no-TLS) gRPC control server and block until it exits.
 pub async fn run_grpc_server(addr: SocketAddr, ctrl_tx: mpsc::Sender<ControlRequest>) {
     let service = DhcpServerControlService { ctrl_tx };
-    tracing::info!("gRPC config-reload server listening on {}", addr);
+    tracing::info!(listen_address = %addr, "gRPC config-reload server listening");
 
     if let Err(e) = tonic::transport::Server::builder()
         .add_service(DhcpServerControlServer::new(service))
         .serve(addr)
         .await
     {
-        tracing::error!("gRPC server exited with error: {}", e);
+        tracing::error!(listen_address = %addr, error = %e, "gRPC server exited");
     }
 }

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -69,7 +69,7 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
     let config__ = match init(args.clone()).await {
         Ok(c) => c,
         Err(e) => {
-            tracing::error!("Failed to initialise DHCP server config: {}", e);
+            tracing::error!(error = %e, "Failed to initialise DHCP server config");
             return;
         }
     };
@@ -88,7 +88,7 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         // and pollute the logs. We could have read() skip NotFound errors, but that
         // could be misleading in other scenarios.  Let's just "init" the file.
         if let Err(e) = d.write() {
-            tracing::error!("Failed to init DHCP timestamps file: {}", e);
+            tracing::error!(error = %e, "Failed to init DHCP timestamps file");
             return;
         }
         d
@@ -116,10 +116,10 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
 
             let socket = get_socket(listen_address, interface.clone()).await;
             tracing::info!(
-                "Listening on {:?} on interface: {}, mode: {:?}",
-                listen_address,
-                interface,
-                handler
+                %listen_address,
+                interface_name = interface.as_str(),
+                mode = ?handler,
+                "DHCP server listening"
             );
 
             let mut server = Server {
@@ -140,8 +140,8 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
                 tokio::select! {
                     _ = cancel.cancelled() => {
                         tracing::info!(
-                            "DHCP server on interface {} received cancellation, shutting down",
-                            interface
+                            interface_name = interface.as_str(),
+                            "DHCP server received cancellation, shutting down"
                         );
                         break;
                     }
@@ -152,10 +152,19 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
                                 // We don't know after this read is failed, will we be able to read again
                                 // from this socket? Mostly no. In this case, recreate the socket.
                                 // We observed this fluctuation during admin to tenant network switch.
-                                tracing::error!("Socket recv failed with error: {err}");
+                                tracing::error!(
+                                    %listen_address,
+                                    interface_name = interface.as_str(),
+                                    error = %err,
+                                    "Socket receive failed"
+                                );
                                 // Try to close the existing socket.
                                 drop(server.socket);
-                                tracing::info!("Recreating the socket on {listen_address}, {interface}");
+                                tracing::info!(
+                                    %listen_address,
+                                    interface_name = interface.as_str(),
+                                    "Recreating the socket"
+                                );
                                 server.socket =
                                     Arc::new(get_socket(listen_address, interface.clone()).await);
                                 continue;
@@ -266,7 +275,7 @@ async fn handle_update_config(
         tokio::fs::write(&new_dhcp, &dhcp_yaml)
             .await
             .map_err(|e| -> Box<dyn Error> { format!("write {new_dhcp}: {e}").into() })?;
-        tracing::info!("dhcp_config changed – staged at {new_dhcp}");
+        tracing::info!(path = new_dhcp.as_str(), "dhcp_config changed – staged");
     }
 
     if let (Some(yaml), Some(path)) = (host_yaml, &args.host_config) {
@@ -276,7 +285,7 @@ async fn handle_update_config(
             tokio::fs::write(&new_host, &yaml)
                 .await
                 .map_err(|e| -> Box<dyn Error> { format!("write {new_host}: {e}").into() })?;
-            tracing::info!("host_config changed – staged at {new_host}");
+            tracing::info!(path = new_host.as_str(), "host_config changed – staged");
         }
     }
     Ok(())
@@ -382,7 +391,7 @@ async fn run_with_grpc_control(
             .map_err(|e| -> Box<dyn Error> {
                 format!("create_dir_all {}: {e}", dir.display()).into()
             })?;
-        tracing::info!("Created config directory {}", dir.display());
+        tracing::info!(path = %dir.display(), "Created config directory");
     }
 
     // Channel through which the gRPC handlers deliver control requests.
@@ -424,7 +433,13 @@ async fn run_with_grpc_control(
                     None => std::future::pending().await,
                 }
             } => {
-                tracing::error!("DHCP server exited unexpectedly: {:?}", result);
+                match result {
+                    Ok(()) => tracing::error!("DHCP server exited unexpectedly"),
+                    Err(error) => tracing::error!(
+                        error = ?error,
+                        "DHCP server exited unexpectedly"
+                    ),
+                }
                 return Ok(());
             }
 
@@ -509,9 +524,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // default HealthController state), not packet-serving readiness --
         // don't point a DHCP-serving probe at them.
         tokio::spawn(async move {
-            tracing::info!("Spawning metrics endpoint on {}", metrics_config.address);
+            tracing::info!(metrics_address = %metrics_config.address, "Spawning metrics endpoint");
             if let Err(e) = run_metrics_endpoint(&metrics_config).await {
-                tracing::error!("Metrics endpoint error: {}", e);
+                tracing::error!(error = %e, "Metrics endpoint error");
             }
         });
     }
@@ -646,7 +661,7 @@ async fn process(
         return;
     }
 
-    tracing::debug!("Received packet [{}] from {}", buf[0], addr);
+    tracing::debug!(bootp_op = buf[0], source_address = %addr, "Received DHCP packet");
 
     let packet = match packet_handler::process_packet(
         buf,
@@ -688,8 +703,9 @@ async fn process(
         dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
         if let Err(e) = dhcp_timestamps.write() {
             tracing::error!(
-                "Failed writing to {}: {e}",
-                DhcpTimestampsFilePath::HbnTmp.path_str()
+                dhcp_timestamps_path = DhcpTimestampsFilePath::HbnTmp.path_str(),
+                error = %e,
+                "Failed to write DHCP timestamps file"
             );
         }
     }

--- a/crates/dhcp-server/src/modes/controller.rs
+++ b/crates/dhcp-server/src/modes/controller.rs
@@ -73,12 +73,12 @@ impl DhcpMode for Controller {
                 &mut machine_cache,
             ) {
                 tracing::info!(
-                    "returning cached response for (mac: {}, link(or relay)_address: {}, circuit_id: {:?}, remote: {:?}, vendor: {})",
-                    discovery_request.mac_address,
-                    link_address,
-                    &discovery_request.circuit_id,
-                    &discovery_request.remote_id,
-                    &vendor_id,
+                    mac_address = %discovery_request.mac_address,
+                    %link_address,
+                    circuit_id = ?discovery_request.circuit_id,
+                    remote_id = ?discovery_request.remote_id,
+                    %vendor_id,
+                    "returning cached response"
                 );
 
                 return Ok(cache_entry.dhcp_record);

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -229,7 +229,7 @@ impl Packet {
         dst_address: SocketAddrV4,
         socket: Arc<UdpSocket>,
     ) -> Result<(), String> {
-        tracing::debug!("Sending packet to {:?}", dst_address);
+        tracing::debug!(destination_address = ?dst_address, "Sending packet");
         socket
             .send_to(&self.encoded_packet, dst_address)
             .await

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -25,7 +25,11 @@ macro_rules! socket_opr {
     ($socket:expr, $statement:expr, $retry:expr) => {
         if let Err(e) = $statement {
             drop($socket);
-            tracing::info!("Socket set option failed. Retry: {}, error: {e}", $retry);
+            tracing::info!(
+                retry = $retry,
+                error = %e,
+                "Socket set option failed"
+            );
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
             continue;
         }
@@ -94,7 +98,7 @@ pub async fn get_socket(listen_address: core::net::SocketAddr, interface: String
         ) {
             Ok(socket) => socket,
             Err(e) => {
-                tracing::info!("Socket creation failed. Retry: {retry}, error: {e}");
+                tracing::info!(retry, error = %e, "Socket creation failed");
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 continue;
             }
@@ -109,7 +113,11 @@ pub async fn get_socket(listen_address: core::net::SocketAddr, interface: String
         let mut retries_left = 10;
         while retries_left > 0 && socket.bind_device(Some(interface.as_bytes())).is_err() {
             retries_left -= 1;
-            tracing::info!("Interface {interface} not ready, retrying {retries_left} more times");
+            tracing::info!(
+                interface_name = interface.as_str(),
+                retries_left,
+                "Interface not ready, retrying"
+            );
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
         if retries_left == 0 {

--- a/crates/dns-record/src/lib.rs
+++ b/crates/dns-record/src/lib.rs
@@ -172,17 +172,18 @@ impl SoaRecord {
         } else {
             // Increment the last two digits if the date hasn't changed
             let incremented_serial = self.serial + 1;
-            debug!("DNS serial number incremented: {}", incremented_serial);
+            debug!(serial = incremented_serial, "DNS serial number incremented");
             self.serial = incremented_serial;
         }
     }
     pub fn generate_new_serial() -> u32 {
         let now = Utc::now();
         let formatted_data = now.format("%Y%m%d").to_string() + "01";
-        debug!("Serial generated for zone {}", formatted_data);
-        formatted_data
+        let serial = formatted_data
             .parse::<u32>()
-            .expect("Unable to generate new serial for zone")
+            .expect("Unable to generate new serial for zone");
+        debug!(serial, "generated serial for DNS zone");
+        serial
     }
 
     pub fn new(domain_name: &str) -> SoaRecord {

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -412,7 +412,7 @@ impl RequestHandler for DnsServer {
                         if self.negative_cache.record(cache_key, code, transient) {
                             self.metrics.negative_cache_eviction.add(1, &[]);
                         }
-                        tracing::debug!(%code, "Caching negative response");
+                        tracing::debug!(response_code = %code, "Caching negative response");
 
                         (code, vec![])
                     }
@@ -423,7 +423,7 @@ impl RequestHandler for DnsServer {
             tracing::info!(
                 response_code = ?response_code,
                 record_count = records.len(),
-                duration_ms = duration.as_millis(),
+                duration_milliseconds = duration.as_millis(),
                 "Request completed"
             );
             emit(DnsRequestCompleted {
@@ -457,10 +457,10 @@ impl DnsServer {
         let servfail_ttl = config.servfail_cache_ttl();
         if servfail_ttl.as_secs() != config.negative_cache_servfail_ttl_secs {
             warn!(
-                configured = config.negative_cache_servfail_ttl_secs,
-                clamped_secs = servfail_ttl.as_secs(),
-                min_secs = config::NEGATIVE_CACHE_SERVFAIL_TTL_MIN_SECS,
-                max_secs = config::NEGATIVE_CACHE_SERVFAIL_TTL_MAX_SECS,
+                configured_servfail_ttl_seconds = config.negative_cache_servfail_ttl_secs,
+                clamped_servfail_ttl_seconds = servfail_ttl.as_secs(),
+                minimum_servfail_ttl_seconds = config::NEGATIVE_CACHE_SERVFAIL_TTL_MIN_SECS,
+                maximum_servfail_ttl_seconds = config::NEGATIVE_CACHE_SERVFAIL_TTL_MAX_SECS,
                 "negative_cache_servfail_ttl_secs out of range; clamped"
             );
         }
@@ -507,7 +507,7 @@ impl DnsServer {
 
         tracing::debug!(
             record_count = response.records.len(),
-            duration_ms = api_duration.as_millis(),
+            duration_milliseconds = api_duration.as_millis(),
             "API lookup completed"
         );
 
@@ -544,13 +544,13 @@ impl DnsServer {
     pub async fn run(config: Config) -> Result<(), Report> {
         let listen = config.listen_address;
 
-        info!("Starting DNS server on {}", listen);
+        info!(listen_address = %listen, "Starting DNS server");
 
         let forge_client_config = config.forge_client_config();
         let api_uri = config.api_uri.to_string();
         let api_config = ApiConfig::new(api_uri.as_str(), &forge_client_config);
 
-        info!("Connecting to carbide-api at {}", api_uri);
+        info!(%api_uri, "Connecting to carbide-api");
 
         let client = Mutex::new(ForgeTlsClient::retry_build(&api_config).await?);
 
@@ -579,9 +579,9 @@ impl DnsServer {
         };
 
         tokio::spawn(async move {
-            tracing::info!("Spawning metrics endpoint on {}", metrics_config.address);
+            tracing::info!(metrics_address = %metrics_config.address, "Spawning metrics endpoint");
             if let Err(e) = run_metrics_endpoint(&metrics_config).await {
-                tracing::error!("Metrics endpoint error: {}", e);
+                tracing::error!(error = %e, "Metrics endpoint error");
             }
         });
 
@@ -612,9 +612,9 @@ impl DnsServer {
         srv.register_listener(tcp_socket, Duration::new(5, 0), 32);
 
         info!(
-            "Started DNS server on {} version {}",
-            listen,
-            carbide_version::version!()
+            listen_address = %listen,
+            version = carbide_version::version!(),
+            "Started DNS server",
         );
 
         match srv.block_until_done().await {
@@ -623,7 +623,7 @@ impl DnsServer {
             }
             Err(e) => {
                 let error_msg = format!("Carbide-dns has encountered an error: {e}");
-                error!("{}", error_msg);
+                error!(error = %e, "Carbide-dns has encountered an error");
                 return Err(eyre::eyre!("{}", error_msg));
             }
         }

--- a/crates/dns/src/main.rs
+++ b/crates/dns/src/main.rs
@@ -63,11 +63,6 @@ async fn main() -> Result<(), eyre::Report> {
         Command::Run(run_command) => {
             let config: Config = run_command.try_into()?;
 
-            tracing::info!(
-                "OpenTelemetry tracing enabled, exporting to endpoint: {}",
-                &config.otlp_endpoint.to_string()
-            );
-
             let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
                 .with_tonic()
                 .with_endpoint(config.otlp_endpoint.to_string())
@@ -95,6 +90,11 @@ async fn main() -> Result<(), eyre::Report> {
                 .with(env_filter)
                 .with(otel_layer)
                 .try_init()?;
+
+            tracing::info!(
+                endpoint = %config.otlp_endpoint,
+                "OpenTelemetry tracing enabled",
+            );
 
             DnsServer::run(config)
                 .await

--- a/crates/dpa-manager/src/card_handler/astra.rs
+++ b/crates/dpa-manager/src/card_handler/astra.rs
@@ -37,8 +37,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_provisioning idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_provisioning index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -57,7 +58,7 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
         }
 
         let new_state = DpaInterfaceControllerState::Ready;
-        tracing::info!(state = ?new_state, "Dpa Interface state transition");
+        tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
         Ok(HandlerResult {
             new_state: Some(new_state),
             txn: None,
@@ -73,8 +74,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_ready idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_ready index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -87,7 +89,7 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
         let host_use_admin_network = dpa_interface.use_admin_network();
         if !host_use_admin_network {
             let new_state = DpaInterfaceControllerState::Assigned;
-            tracing::info!(state = ?new_state, "Dpa Interface state transition");
+            tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
 
             return Ok(HandlerResult {
                 new_state: Some(new_state),
@@ -110,8 +112,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_unlocking idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_unlocking index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -122,8 +125,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
         let dpa_interface = &mh.dpa_interface_snapshots[idx];
 
         tracing::warn!(
-            "Astra DPA interface state unexpected state: {:#?}",
-            dpa_interface.id
+            dpa_interface_id = %dpa_interface.id,
+            controller_state = ?dpa_interface.controller_state.value,
+            "Astra DPA interface is in an unexpected state",
         );
 
         return Ok(HandlerResult {
@@ -141,8 +145,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_apply_firmware idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_apply_firmware index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -153,8 +158,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
         let dpa_interface = &mh.dpa_interface_snapshots[idx];
 
         tracing::warn!(
-            "Astra DPA interface state unexpected state: {:#?}",
-            dpa_interface.id
+            dpa_interface_id = %dpa_interface.id,
+            controller_state = ?dpa_interface.controller_state.value,
+            "Astra DPA interface is in an unexpected state",
         );
 
         return Ok(HandlerResult {
@@ -172,8 +178,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_apply_profile idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_apply_profile index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -183,8 +190,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
 
         let dpa_interface = &mh.dpa_interface_snapshots[idx];
         tracing::warn!(
-            "Astra DPA interface state unexpected state: {:#?}",
-            dpa_interface.id
+            dpa_interface_id = %dpa_interface.id,
+            controller_state = ?dpa_interface.controller_state.value,
+            "Astra DPA interface is in an unexpected state",
         );
         return Ok(HandlerResult {
             new_state: None,
@@ -201,8 +209,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_locking idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_locking index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -212,8 +221,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
 
         let dpa_interface = &mh.dpa_interface_snapshots[idx];
         tracing::warn!(
-            "Astra DPA interface state unexpected state: {:#?}",
-            dpa_interface.id
+            dpa_interface_id = %dpa_interface.id,
+            controller_state = ?dpa_interface.controller_state.value,
+            "Astra DPA interface is in an unexpected state",
         );
         return Ok(HandlerResult {
             new_state: None,
@@ -230,8 +240,9 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         if idx >= mh.dpa_interface_snapshots.len() {
             tracing::error!(
-                "handle_assigned idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_assigned index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -245,7 +256,7 @@ impl DpaInterfaceStateHandler for AstraInterfaceHandler {
 
         if host_use_admin_network {
             let new_state = DpaInterfaceControllerState::Ready;
-            tracing::info!(state = ?new_state, "Dpa Interface state transition");
+            tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
             return Ok(HandlerResult {
                 new_state: Some(new_state),
                 txn: None,

--- a/crates/dpa-manager/src/card_handler/svpc.rs
+++ b/crates/dpa-manager/src/card_handler/svpc.rs
@@ -50,7 +50,10 @@ impl SvpcInterfaceHandler {
     fn at_most_one<I: Iterator>(mut iter: I, ctx: &str) -> DpaManagerResult<Option<I::Item>> {
         let first = iter.next();
         if first.is_some() && iter.next().is_some() {
-            tracing::error!("{ctx}: more than one match");
+            tracing::error!(
+                context = %ctx,
+                "Multiple matches found",
+            );
             return Err(DpaManagerError::InvalidArgument(format!(
                 "{ctx}: more than one match"
             )));
@@ -232,9 +235,10 @@ impl SvpcInterfaceHandler {
             || (observed_attachment.config_version != Some(nic_version));
 
         tracing::debug!(
-            "[{}] reconcile_ready_state: need_deletion {need_deletion}, need_heartbeat {}",
-            chrono::Utc::now(),
-            !need_deletion
+            timestamp = %chrono::Utc::now(),
+            need_deletion = need_deletion,
+            heartbeat_needed = !need_deletion,
+            "Reconciled ready-state action",
         );
 
         if need_deletion {
@@ -271,8 +275,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_provisioning idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_provisioning index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -289,7 +294,7 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
         }
 
         let new_state = DpaInterfaceControllerState::Ready;
-        tracing::info!(state = ?new_state, "Dpa Interface state transition");
+        tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
         Ok(HandlerResult {
             new_state: Some(new_state),
             txn: None,
@@ -305,8 +310,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_ready idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_ready index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -317,7 +323,7 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
         let host_use_admin_network = dpa_interface.use_admin_network();
         if !host_use_admin_network {
             let new_state = DpaInterfaceControllerState::Unlocking;
-            tracing::info!(state = ?new_state, "Dpa Interface state transition");
+            tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
 
             return Ok(HandlerResult {
                 new_state: Some(new_state),
@@ -359,8 +365,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_unlocking idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_unlocking index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -370,8 +377,8 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
 
         let Some(ref cs) = dpa_interface.card_state else {
             tracing::error!(
-                "Unexpected - card_state none for dpa: {:#?}",
-                dpa_interface.id
+                dpa_interface_id = %dpa_interface.id,
+                "DPA interface has no card state",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -381,7 +388,7 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
 
         if cs.lockmode == Some(Unlocked) {
             let new_state = DpaInterfaceControllerState::ApplyFirmware;
-            tracing::info!(state = ?new_state, "Interface unlocked. Transitioning to next state");
+            tracing::info!(next_state = ?new_state, "Interface unlocked. Transitioning to next state");
             return Ok(HandlerResult {
                 new_state: Some(new_state),
                 txn: None,
@@ -404,8 +411,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_apply_firmware idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_apply_firmware index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -415,8 +423,8 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
 
         let Some(ref card_state) = dpa_interface.card_state else {
             tracing::info!(
-                "no firmware report, because card_state none for dpa: {:#?}, waiting for retry",
-                dpa_interface.id
+                dpa_interface_id = %dpa_interface.id,
+                "DPA interface has no card state; waiting to retry firmware report",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -429,7 +437,7 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
             if firmware_report.flashed && reset_ok {
                 let new_state = DpaInterfaceControllerState::ApplyProfile;
                 tracing::info!(
-                    state = ?new_state,
+                    next_state = ?new_state,
                     observed_version = firmware_report.observed_version.as_deref().unwrap_or("none"),
                     "firmware report received and successfully applied, transitioning"
                 );
@@ -462,8 +470,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_apply_profile idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_apply_profile index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -483,8 +492,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_locking idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_locking index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -494,8 +504,8 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
 
         let Some(ref cs) = dpa_interface.card_state else {
             tracing::error!(
-                "Unexpected - card_state none for dpa: {:#?}",
-                dpa_interface.id
+                dpa_interface_id = %dpa_interface.id,
+                "DPA interface has no card state",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -529,7 +539,7 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
                 .await?;
 
             let new_state = DpaInterfaceControllerState::Assigned;
-            tracing::info!(state = ?new_state, "Dpa Interface state transition");
+            tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
             return Ok(HandlerResult {
                 new_state: Some(new_state),
                 txn: Some(txn),
@@ -551,8 +561,9 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
     ) -> DpaManagerResult<HandlerResult> {
         let Some(dpa_interface) = mh.dpa_interface_snapshots.get(idx) else {
             tracing::error!(
-                "handle_assigned idx out of bounds: {idx}, len: {}",
-                mh.dpa_interface_snapshots.len()
+                index = idx,
+                dpa_interface_snapshot_count = mh.dpa_interface_snapshots.len(),
+                "handle_assigned index out of bounds",
             );
             return Ok(HandlerResult {
                 new_state: None,
@@ -564,7 +575,7 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
 
         if host_use_admin_network {
             let new_state = DpaInterfaceControllerState::Ready;
-            tracing::info!(state = ?new_state, "Dpa Interface state transition");
+            tracing::info!(next_state = ?new_state, "Dpa Interface state transition");
             return Ok(HandlerResult {
                 new_state: Some(new_state),
                 txn: None,
@@ -602,8 +613,8 @@ impl DpaInterfaceStateHandler for SvpcInterfaceHandler {
 fn apply_profile(state: &DpaInterface) -> DpaManagerResult<HandlerResult> {
     let Some(ref cs) = state.card_state else {
         tracing::info!(
-            "no profile report, because card_state none for dpa: {:#?}, waiting for retry",
-            state.id
+            dpa_interface_id = %state.id,
+            "DPA interface has no card state; waiting to retry profile report",
         );
         return Ok(HandlerResult {
             new_state: None,
@@ -613,7 +624,7 @@ fn apply_profile(state: &DpaInterface) -> DpaManagerResult<HandlerResult> {
     if cs.profile_synced == Some(true) {
         let new_state = DpaInterfaceControllerState::Locking;
         tracing::info!(
-            state = ?new_state,
+            next_state = ?new_state,
             profile = cs.profile.as_deref().unwrap_or("none"),
             "profile applied successfully, transitioning"
         );

--- a/crates/dpa-manager/src/lib.rs
+++ b/crates/dpa-manager/src/lib.rs
@@ -121,7 +121,10 @@ impl DpaMonitor {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("DpaMonitor error: {}", e);
+                    tracing::warn!(
+                        error = %e,
+                        "DPA monitor error",
+                    );
                 }
             }
 
@@ -165,7 +168,8 @@ impl DpaMonitor {
             Ok(lock) => lock,
             Err(e) => {
                 tracing::warn!(
-                    "DpaMonitor failed to acquire work lock: Another instance of carbide running? {e}"
+                    error = %e,
+                    "DpaMonitor failed to acquire work lock: Another instance of carbide running?",
                 );
                 return Ok(0);
             }
@@ -426,11 +430,11 @@ impl DpaMonitor {
                             db::AnnotatedSqlxError::new("dpa_monitor hb begin txn", e)
                         })?;
                     let res = db::dpa_interface::update_last_hb_time(state, &mut txn).await;
-                    if res.is_err() {
+                    if let Err(error) = res {
                         tracing::error!(
-                            "Error updating last_hb_time for dpa id: {} res: {:#?}",
-                            state.id,
-                            res
+                            dpa_interface_id = %state.id,
+                            error = %error,
+                            "Error updating DPA interface heartbeat time",
                         );
                     }
                     Ok(Some(txn))

--- a/crates/dpa/src/lib.rs
+++ b/crates/dpa/src/lib.rs
@@ -71,10 +71,10 @@ pub async fn send_dpa_command(
         }
         Err(e) => {
             tracing::error!(
-                "send_dpa_command -  error: {:#?} sending message: {:#?} to topic: {}",
-                e,
-                svni,
-                topic
+                error = ?e,
+                payload = ?svni,
+                %topic,
+                "failed to send DPA command"
             );
             return Err(eyre::eyre!("send_message error: {e}"));
         }

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -314,7 +314,7 @@ async fn redfish_reboot_host(
         .and_then(|sys| sys.boot_progress)
         .and_then(|bp| bp.last_state_time);
     tracing::info!(
-        host = %host_bmc_ip,
+        host_bmc_ip_address = %host_bmc_ip,
         pre_reboot_time = ?pre_reboot_time,
         "Sending ForceRestart via Redfish"
     );
@@ -349,7 +349,7 @@ async fn redfish_reboot_host(
 
                 if timestamp_changed && os_running {
                     tracing::info!(
-                        host = %host_bmc_ip,
+                        host_bmc_ip_address = %host_bmc_ip,
                         last_state_time = ?current_time,
                         "Host rebooted and OS is running"
                     );
@@ -357,9 +357,9 @@ async fn redfish_reboot_host(
                 }
 
                 tracing::debug!(
-                    host = %host_bmc_ip,
+                    host_bmc_ip_address = %host_bmc_ip,
                     last_state_time = ?current_time,
-                    last_state = ?current_state,
+                    host_state = ?current_state,
                     timestamp_changed,
                     os_running,
                     "Waiting for host reboot to complete"
@@ -367,7 +367,7 @@ async fn redfish_reboot_host(
             }
             Err(e) => {
                 tracing::debug!(
-                    host = %host_bmc_ip,
+                    host_bmc_ip_address = %host_bmc_ip,
                     error = %e,
                     "Redfish unreachable during reboot, retrying"
                 );
@@ -521,7 +521,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let password =
                 resolve_bmc_password(&repo, &cli.namespace, bmc_password.as_deref()).await?;
             redfish_reboot_host(&host_bmc_ip, &bmc_username, &password).await?;
-            tracing::info!(host = %host_bmc_ip, "Host reboot initiated via Redfish");
+            tracing::info!(host_bmc_ip_address = %host_bmc_ip, "Host reboot initiated via Redfish");
         }
     }
 
@@ -577,7 +577,7 @@ async fn monitor_until_ready(
     let _watcher = sdk
         .watcher()
         .on_dpu_event(|event| async move {
-            tracing::info!(dpu = %event.dpu_name, phase = ?event.phase, "DPU event");
+            tracing::info!(dpu_name = %event.dpu_name, phase = ?event.phase, "DPU event");
             Ok(())
         })
         .on_reboot_required({
@@ -672,7 +672,7 @@ async fn monitor_until_ready(
             }
         }
     };
-    tracing::info!(node = %node_name, host = %host_bmc_ip, "Reboot required, rebooting host via Redfish");
+    tracing::info!(node = %node_name, host_bmc_ip_address = %host_bmc_ip, "Reboot required, rebooting host via Redfish");
     redfish_reboot_host(host_bmc_ip, DEFAULT_BMC_USERNAME, bmc_password)
         .await
         .map_err(|e| format!("Redfish reboot failed: {e}"))?;
@@ -709,7 +709,7 @@ async fn run_provisioning_flow(
     let timeout = Duration::from_secs(timeout_secs);
 
     tracing::info!("=== DPF Provisioning Flow ===");
-    tracing::info!(host = %host_bmc_ip, dpu_count = dpus.len(), timeout_secs, "Starting provisioning");
+    tracing::info!(host_bmc_ip_address = %host_bmc_ip, dpu_count = dpus.len(), timeout_seconds = timeout_secs, "Starting provisioning");
 
     tracing::info!("[1/4] Initializing DPF resources...");
     let init_config = InitDpfResourcesConfig {
@@ -758,7 +758,7 @@ async fn run_provisioning_flow(
 
     tracing::info!(
         dpu_count = dpus.len(),
-        elapsed_secs = elapsed.as_secs(),
+        elapsed_seconds = elapsed.as_secs(),
         "=== Provisioning Complete ==="
     );
     Ok(())
@@ -800,7 +800,7 @@ async fn wait_for_dpu_created_after(
                 let name = dpu.metadata.name.as_deref().unwrap_or_default();
                 if dpu.spec.dpu_device_name != device_name {
                     tracing::debug!(
-                        dpu = %name,
+                        dpu_name = %name,
                         spec_device = %dpu.spec.dpu_device_name,
                         want_device = %device_name,
                         "DPU skip (device name mismatch)"
@@ -814,7 +814,7 @@ async fn wait_for_dpu_created_after(
                     .and_then(k8s_time_to_system_time)
                 else {
                     tracing::info!(
-                        dpu = %name,
+                        dpu_name = %name,
                         "DPU skip (no creation_timestamp or conversion failed)"
                     );
                     return std::future::ready(Ok::<(), DpfError>(()));
@@ -831,9 +831,9 @@ async fn wait_for_dpu_created_after(
                     .unwrap_or(0);
                 let passes = ct > cutoff;
                 tracing::info!(
-                    dpu = %name,
-                    creation_ms = ct_ms,
-                    cutoff_ms = cutoff_ms,
+                    dpu_name = %name,
+                    creation_time_milliseconds = ct_ms,
+                    cutoff_time_milliseconds = cutoff_ms,
                     passes = passes,
                     "DPU created_after check"
                 );
@@ -887,7 +887,7 @@ async fn run_reprovisioning_flow(
 
     tracing::info!(
         device_name = %device_name,
-        elapsed_secs = elapsed.as_secs(),
+        elapsed_seconds = elapsed.as_secs(),
         "=== Reprovisioning Complete ==="
     );
     Ok(())
@@ -965,7 +965,7 @@ async fn show_status(
         tracing::info!(name = %name, dpu_count, "DPU Node");
         if let Some(dpus) = &node.spec.dpus {
             for dpu in dpus {
-                tracing::info!(dpu = %dpu.name, "  DPU");
+                tracing::info!(dpu_name = %dpu.name, "  DPU");
             }
         }
     }
@@ -1005,7 +1005,7 @@ async fn show_status(
             .first()
             .map(|c| c.type_.clone())
             .unwrap_or_else(|| "Unknown".to_string());
-        tracing::info!(name = %name, serial = %serial, status = %status_str, "DPU Device");
+        tracing::info!(name = %name, serial = %serial, dpu_device_status = %status_str, "DPU Device");
     }
 
     // List DPUDeployments
@@ -1053,19 +1053,19 @@ async fn run_watcher(sdk: Arc<DpfSdk<KubeRepository>>) -> Result<(), Box<dyn std
     let watcher = sdk
         .watcher()
         .on_dpu_event(|event| async move {
-            tracing::info!(dpu = %event.dpu_name, phase = ?event.phase, "PHASE");
+            tracing::info!(dpu_name = %event.dpu_name, phase = ?event.phase, "PHASE");
             Ok(())
         })
         .on_reboot_required(|event| async move {
-            tracing::warn!(node = %event.node_name, host = %event.host_bmc_ip, "REBOOT REQUIRED");
+            tracing::warn!(node = %event.node_name, host_bmc_ip_address = %event.host_bmc_ip, "REBOOT REQUIRED");
             Ok(())
         })
         .on_dpu_ready(|event| async move {
-            tracing::info!(dpu = %event.dpu_name, device_name = %event.device_name, "READY");
+            tracing::info!(dpu_name = %event.dpu_name, device_name = %event.device_name, "READY");
             Ok(())
         })
         .on_error(|event| async move {
-            tracing::error!(dpu = %event.dpu_name, device_name = %event.device_name, node = %event.node_name, "ERROR");
+            tracing::error!(dpu_name = %event.dpu_name, device_name = %event.device_name, node = %event.node_name, "ERROR");
             Ok(())
         })
         .start()?;

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -320,14 +320,14 @@ async fn refresh_bmc_secret_if_changed<R: K8sConfigRepository>(
     match provider.get_bmc_password().await {
         Ok(new_pw) if new_pw != last_password => {
             if let Err(e) = write_bmc_secret::<R>(repo, namespace, &new_pw).await {
-                tracing::error!("Failed to refresh BMC secret: {e}");
+                tracing::error!(error = %e, "Failed to refresh BMC secret");
                 last_password
             } else {
                 new_pw
             }
         }
         Err(e) => {
-            tracing::error!("Failed to read BMC password: {e}");
+            tracing::error!(error = %e, "Failed to read BMC password");
             last_password
         }
         _ => last_password,
@@ -1546,7 +1546,7 @@ impl<R: DpuNodeRepository, L: ResourceLabeler> DpfSdk<R, L> {
         if let Err(e) =
             DpuNodeRepository::patch(&*self.repo, node_name, &self.namespace, patch).await
         {
-            tracing::warn!("Failed to remove label from DPU node {}: {}", node_name, e);
+            tracing::warn!(node_name, error = %e, "Failed to remove label from DPU node");
         }
 
         DpuNodeRepository::delete(&*self.repo, node_name, &self.namespace).await
@@ -1656,14 +1656,15 @@ impl<R: DpuDeploymentRepository + DpuRepository, L> DpfSdk<R, L> {
                     .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL));
                 let Some(owner_label) = owner_label else {
                     tracing::debug!(
-                        dpu = %cr_name,
-                        "DPU is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label; skipping"
+                        dpu_name = %cr_name,
+                        label = DPU_OWNED_BY_DEPLOYMENT_LABEL,
+                        "DPU is missing label; skipping"
                     );
                     return None;
                 };
                 let Some(deployment) = ready_deployments.get(owner_label.as_str()) else {
                     tracing::debug!(
-                        dpu = %cr_name,
+                        dpu_name = %cr_name,
                         owner = %owner_label,
                         "DPU's owning DPUDeployment is not ready or not found; skipping"
                     );
@@ -1795,12 +1796,12 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
             if let Err(e) =
                 DpuNodeRepository::patch(&*self.repo, node_name, &self.namespace, patch).await
             {
-                tracing::warn!("Failed to remove label from DPU node {}: {}", node_name, e);
+                tracing::warn!(node_name, error = %e, "Failed to remove label from DPU node");
             }
 
             if let Err(e) = DpuNodeRepository::delete(&*self.repo, node_name, &self.namespace).await
             {
-                tracing::warn!("Failed to delete DPU node {}: {}", node_name, e);
+                tracing::warn!(node_name, error = %e, "Failed to delete DPU node");
             }
 
             // dpus[].name already has the device- prefix (set by register_dpu_node)
@@ -1808,13 +1809,17 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
                 if let Err(e) =
                     DpuDeviceRepository::delete(&*self.repo, &dpu.name, &self.namespace).await
                 {
-                    tracing::warn!("Failed to delete DPU device {}: {}", dpu.name, e);
+                    tracing::warn!(
+                        dpu_device = %dpu.name,
+                        error = %e,
+                        "Failed to delete DPU device"
+                    );
                 }
             }
         } else {
             tracing::info!(
-                "DPU node {} not found, trying to delete DPU devices",
-                node_name
+                node_name,
+                "DPU node not found, trying to delete DPU devices"
             );
         }
 
@@ -1823,7 +1828,11 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
             if let Err(e) =
                 DpuDeviceRepository::delete(&*self.repo, &cr_name, &self.namespace).await
             {
-                tracing::warn!("Failed to delete DPU device {}: {}", cr_name, e);
+                tracing::warn!(
+                    dpu_device = %cr_name,
+                    error = %e,
+                    "Failed to delete DPU device"
+                );
             }
         }
 
@@ -1842,13 +1851,17 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
         let dpf_id = node_id_from_dpu_node_cr_name(node_name);
         let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
         if let Err(e) = DpuRepository::delete(&*self.repo, &cr_name, &self.namespace).await {
-            tracing::warn!("Failed to delete DPU {}: {}", cr_name, e);
+            tracing::warn!(dpu_name = %cr_name, error = %e, "Failed to delete DPU");
         }
         let device_cr_name = dpu_device_cr_name(dpu_device_name);
         if let Err(e) =
             DpuDeviceRepository::delete(&*self.repo, &device_cr_name, &self.namespace).await
         {
-            tracing::warn!("Failed to delete DPU device {}: {}", device_cr_name, e);
+            tracing::warn!(
+                dpu_device = %device_cr_name,
+                error = %e,
+                "Failed to delete DPU device"
+            );
         }
         Ok(())
     }
@@ -1869,15 +1882,19 @@ impl<R: DpuRepository + DpuNodeRepository + DpuDeviceRepository, L: ResourceLabe
         if let Err(e) =
             DpuNodeRepository::patch(&*self.repo, node_name, &self.namespace, patch).await
         {
-            tracing::warn!("Failed to remove label from DPU node {}: {}", node_name, e);
+            tracing::warn!(node_name, error = %e, "Failed to remove label from DPU node");
         }
         if let Err(e) = DpuNodeRepository::delete(&*self.repo, node_name, &self.namespace).await {
-            tracing::warn!("Failed to delete DPU node {}: {}", node_name, e);
+            tracing::warn!(node_name, error = %e, "Failed to delete DPU node");
         }
         for dpu_id in &dpu_ids {
             if let Err(e) = DpuDeviceRepository::delete(&*self.repo, dpu_id, &self.namespace).await
             {
-                tracing::warn!("Failed to delete DPU device {}: {}", dpu_id, e);
+                tracing::warn!(
+                    dpu_device = %dpu_id,
+                    error = %e,
+                    "Failed to delete DPU device"
+                );
             }
         }
         Ok(())

--- a/crates/dpf/src/watcher.rs
+++ b/crates/dpf/src/watcher.rs
@@ -369,7 +369,7 @@ where
             if matches!(status.phase, DpuStatusPhase::Rebooting) {
                 let Some(host_bmc_ip) = dpu.spec.bmc_ip.as_deref().and_then(|ip| ip.parse().ok())
                 else {
-                    tracing::warn!(dpu = %dpu_name, "Skipping reboot event with missing or invalid BMC IP");
+                    tracing::warn!(dpu_name = %dpu_name, "Skipping reboot event with missing or invalid BMC IP");
                     return Ok(());
                 };
 

--- a/crates/dpu-fmds-shared/src/machine_identity.rs
+++ b/crates/dpu-fmds-shared/src/machine_identity.rs
@@ -377,8 +377,8 @@ pub fn map_machine_identity_signing_error_to_http(status: &tonic::Status) -> (St
         Code::ResourceExhausted => (StatusCode::TOO_MANY_REQUESTS, status.message().to_string()),
         code => {
             tracing::warn!(
-                ?code,
-                message = %status.message(),
+                grpc_status_code = ?code,
+                error = %status.message(),
                 "machine-identity: upstream signing failed"
             );
             (

--- a/crates/dpu-otel-agent/src/lib.rs
+++ b/crates/dpu-otel-agent/src/lib.rs
@@ -40,7 +40,11 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
             config_path.display().to_string(),
         ),
     };
-    tracing::info!("Using configuration from {path}: {agent:?}");
+    tracing::info!(
+        config_path = path.as_str(),
+        ?agent,
+        "Using agent configuration"
+    );
 
     let forge_client_config = Arc::new(
         ForgeClientConfig::new(

--- a/crates/dpu-remediation/src/remediation.rs
+++ b/crates/dpu-remediation/src/remediation.rs
@@ -128,7 +128,10 @@ impl RemediationExecutor {
                     let status_file_str = tokio::fs::read_to_string(&status_path).await?;
                     let results = if !status_file_str.is_empty() {
                         serde_json::from_str::<HashMap<String, String>>(&status_file_str).map_err(|err| {
-                                tracing::error!("Unable to deserialize json into hashmap from status output file, error was {:#?}", err);
+                                tracing::error!(
+                                    error = ?err,
+                                    "Unable to deserialize json into hashmap from status output file",
+                                );
                             }).unwrap_or_default()
                     } else {
                         HashMap::new()
@@ -224,10 +227,7 @@ impl RemediationExecutor {
                                             tracing::debug!("Remediation successfully applied.");
                                         }
                                         Err(error) => {
-                                            tracing::error!(
-                                                "Remediation failed with error: {:#?}.",
-                                                error
-                                            );
+                                            tracing::error!(?error, "Remediation failed",);
                                         }
                                     }
                                 }
@@ -236,24 +236,26 @@ impl RemediationExecutor {
                                 }
                                 _ => {
                                     tracing::error!(
-                                        "received a response with one of id or script but not both, skipping, will retry next loop, response: {:#?}",
-                                        next_remediation
+                                        has_script = next_remediation.remediation_script.is_some(),
+                                        has_remediation_id =
+                                            next_remediation.remediation_id.is_some(),
+                                        "received a response with one of id or script but not both, skipping, will retry next loop",
                                     );
                                 }
                             }
                         }
                         Err(remediation_fetch_error) => {
                             tracing::error!(
-                                "Remediation executor unable to fetch next remediation this loop, will retry next loop, error was: {:#?}",
-                                remediation_fetch_error
+                                error = ?remediation_fetch_error,
+                                "Remediation executor unable to fetch next remediation this loop, will retry next loop",
                             );
                         }
                     }
                 }
                 Err(client_creation_error) => {
                     tracing::error!(
-                        "Remediation executor unable to create forge client this loop, will retry next loop, error was: {:#?}",
-                        client_creation_error
+                        error = ?client_creation_error,
+                        "Remediation executor unable to create forge client this loop, will retry next loop",
                     );
                 }
             }

--- a/crates/dsx-exchange-consumer/src/api_client.rs
+++ b/crates/dsx-exchange-consumer/src/api_client.rs
@@ -117,9 +117,9 @@ impl RackHealthReportSink for ConsoleRackHealthSink {
     ) -> Result<(), DsxConsumerError> {
         tracing::info!(
             rack_id = %rack_id,
-            "Inserting rack health override: {} successes and {} alerts",
-            report.successes.len(),
-            report.alerts.len()
+            success_count = report.successes.len(),
+            alert_count = report.alerts.len(),
+            "Inserting rack health override"
         );
         for alert in &report.alerts {
             tracing::warn!(rack_id = %rack_id, alert = ?alert, "Rack health alert");

--- a/crates/firmware/src/config.rs
+++ b/crates/firmware/src/config.rs
@@ -65,7 +65,11 @@ impl FirmwareConfigSnapshot {
                 }
             })
             .cloned();
-        tracing::debug!("FirmwareConfig::find: key {key} found {ret:?}");
+        tracing::debug!(
+            %key,
+            firmware = ?ret,
+            "Firmware config lookup completed",
+        );
         ret
     }
 
@@ -137,7 +141,11 @@ impl FirmwareConfig {
             // Fake configs to merge for unit tests
             for ovrd in &self.test_overrides {
                 if let Err(err) = self.merge_from_string(&mut data, ovrd.clone()) {
-                    tracing::error!("Bad override {ovrd}: {err}");
+                    tracing::error!(
+                        override_config = %ovrd,
+                        error = %err,
+                        "Failed to merge test firmware override",
+                    );
                 }
             }
         }
@@ -174,7 +182,7 @@ impl FirmwareConfig {
         firmware_directory: &PathBuf,
     ) {
         if !firmware_directory.is_dir() {
-            tracing::error!("Missing firmware directory {:?}", firmware_directory);
+            tracing::error!(?firmware_directory, "Firmware directory does not exist",);
             return;
         }
 
@@ -192,12 +200,20 @@ impl FirmwareConfig {
             let metadata = match fs::read_to_string(metadata_path.clone()) {
                 Ok(str) => str,
                 Err(e) => {
-                    tracing::error!("Could not read {metadata_path:?}: {e}");
+                    tracing::error!(
+                        ?metadata_path,
+                        error = %e,
+                        "Could not read firmware metadata",
+                    );
                     continue;
                 }
             };
             if let Err(e) = self.merge_from_string(map, metadata) {
-                tracing::error!("Failed to merge in metadata from {:?}: {e}", dir.path());
+                tracing::error!(
+                    metadata_directory = ?dir.path(),
+                    error = %e,
+                    "Failed to merge firmware metadata",
+                );
             }
         }
     }
@@ -375,7 +391,10 @@ fn vendor_model_to_key(vendor: bmc_vendor::BMCVendor, model: &str) -> String {
 
 fn subdirectories_sorted_by_modification_date(topdir: &PathBuf) -> Vec<fs::DirEntry> {
     let Ok(dirs) = topdir.read_dir() else {
-        tracing::error!("Unreadable firmware directory {:?}", topdir);
+        tracing::error!(
+            firmware_directory = ?topdir,
+            "Unreadable firmware directory",
+        );
         return vec![];
     };
 

--- a/crates/firmware/src/downloader.rs
+++ b/crates/firmware/src/downloader.rs
@@ -159,7 +159,10 @@ impl FirmwareDownloader {
         }
 
         if url.is_empty() {
-            tracing::error!("Firmware with file not present has no URL: {filename:?}");
+            tracing::error!(
+                firmware_path = ?filename,
+                "Firmware artifact is missing and has no URL",
+            );
             return false;
         }
 
@@ -273,14 +276,16 @@ fn cached_file_status(filename: &Path, sha256: &str) -> CachedFileStatus {
         Ok(()) => CachedFileStatus::Available,
         Err(err) => {
             tracing::warn!(
-                "Cached firmware artifact {} failed checksum verification: {err}",
-                filename.display()
+                filename = %filename.display(),
+                error = %err,
+                "Cached firmware artifact failed checksum verification",
             );
 
             if let Err(err) = std::fs::remove_file(filename) {
                 tracing::error!(
-                    "Failed to remove stale cached firmware artifact {}: {err}",
-                    filename.display()
+                    filename = %filename.display(),
+                    error = %err,
+                    "Failed to remove stale cached firmware artifact",
                 );
                 return CachedFileStatus::Unusable;
             }

--- a/crates/fmds/src/http_request_metrics.rs
+++ b/crates/fmds/src/http_request_metrics.rs
@@ -100,14 +100,21 @@ pub fn with_http_request_trace_layer(router: Router, metrics: Arc<HttpRequestMet
         })
         .on_request(move |request: &Request<AxumBody>, _span: &Span| {
             metrics_request.http_counter.add(1, &[]);
-            tracing::info!("started {} {}", request.method(), request.uri().path());
+            tracing::info!(
+                method = %request.method(),
+                request_path = %request.uri().path(),
+                "started request",
+            );
         })
         .on_response(
             move |_response: &Response<AxumBody>, latency: Duration, _span: &Span| {
                 metrics_response
                     .http_req_latency_histogram
                     .record(latency.as_secs_f64() * 1000.0, &[]);
-                tracing::info!("response generated in {:?}", latency);
+                tracing::info!(
+                    latency_milliseconds = latency.as_secs_f64() * 1000.0,
+                    "response generated"
+                );
             },
         );
 

--- a/crates/fmds/src/main.rs
+++ b/crates/fmds/src/main.rs
@@ -118,7 +118,7 @@ async fn main() -> eyre::Result<()> {
             additional_prefix: None,
         };
         if let Err(err) = metrics_endpoint::run_metrics_endpoint(&config).await {
-            tracing::error!("Prometheus metrics server error: {err}");
+            tracing::error!(error = %err, "Prometheus metrics server error");
         }
     });
 
@@ -139,7 +139,7 @@ async fn main() -> eyre::Result<()> {
 
         tracing::info!(%rest_address, "REST server listening");
         if let Err(err) = server.serve(router.into_make_service()).await {
-            tracing::error!("REST server error: {err}");
+            tracing::error!(error = %err, "REST server error");
         }
     });
 

--- a/crates/fmds/src/nic_init.rs
+++ b/crates/fmds/src/nic_init.rs
@@ -39,14 +39,14 @@ pub async fn assign_address(name: &str, cidr: IpNetwork) -> eyre::Result<()> {
     let index = wait_for_link(&handle, name).await?;
 
     if address_already_present(&handle, index, cidr).await? {
-        tracing::info!(interface = name, %cidr, "address already assigned; skipping add");
+        tracing::info!(interface_name = name, %cidr, "address already assigned; skipping add");
     } else {
         handle
             .address()
             .add(index, cidr.ip(), cidr.prefix())
             .execute()
             .await?;
-        tracing::info!(interface = name, %cidr, "assigned address");
+        tracing::info!(interface_name = name, %cidr, "assigned address");
     }
 
     handle
@@ -77,7 +77,7 @@ pub async fn setup_metadata_routing(interface_name: &str, cidr: IpNetwork) -> ey
             eyre::bail!("ip rule add failed: {stderr}");
         }
     }
-    tracing::info!(src = %src_ip, "policy rule: from {src_ip} lookup 100");
+    tracing::info!(source_ip_address = %src_ip, table = 100, "policy rule configured");
 
     let route = TokioCommand::new("ip")
         .args([
@@ -99,7 +99,12 @@ pub async fn setup_metadata_routing(interface_name: &str, cidr: IpNetwork) -> ey
             eyre::bail!("ip route add failed: {stderr}");
         }
     }
-    tracing::info!(gateway = %gateway, interface = interface_name, "policy route: default via {gateway} dev {interface_name} table 100");
+    tracing::info!(
+        gateway = %gateway,
+        interface_name,
+        table = 100,
+        "default policy route configured",
+    );
 
     Ok(())
 }
@@ -111,7 +116,7 @@ async fn wait_for_link(handle: &Handle, name: &str) -> eyre::Result<u32> {
             Ok(Some(link)) => return Ok(link.header.index),
             Ok(None) | Err(rtnetlink::Error::NetlinkError(_)) => {
                 tracing::debug!(
-                    interface = name,
+                    interface_name = name,
                     attempt,
                     "interface not yet present, retrying"
                 );

--- a/crates/fmds/src/phone_home.rs
+++ b/crates/fmds/src/phone_home.rs
@@ -64,9 +64,9 @@ pub async fn phone_home(state: &Arc<FmdsState>) -> Result<(), eyre::Error> {
         .ok_or_else(|| eyre!("timestamp is empty in response"))?;
 
     tracing::info!(
-        "Successfully phoned home for Machine {} at {}",
-        machine_id,
-        timestamp,
+        %machine_id,
+        %timestamp,
+        "Successfully phoned home",
     );
 
     Ok(())

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -314,7 +314,7 @@ impl ApiEndpointSource {
 
         self.prune_bmc_client_cache(&endpoints);
 
-        tracing::info!("Prepared total {} endpoints", endpoints.len());
+        tracing::info!(endpoint_count = endpoints.len(), "Prepared endpoints");
 
         Ok(endpoints)
     }
@@ -327,8 +327,8 @@ impl ApiEndpointSource {
         let removed = before - cache.len();
         if removed > 0 {
             tracing::info!(
-                removed,
-                remaining = cache.len(),
+                removed_bmc_client_count = removed,
+                remaining_bmc_client_count = cache.len(),
                 "Pruned stale BmcClient cache entries"
             );
         }
@@ -345,7 +345,10 @@ impl ApiEndpointSource {
             .await
             .map_err(HealthError::ApiInvocationError)?;
 
-        tracing::info!("Found {} machines", machine_ids.machine_ids.len(),);
+        tracing::info!(
+            machine_count = machine_ids.machine_ids.len(),
+            "Found machines"
+        );
 
         let mut endpoints = Vec::new();
 
@@ -361,8 +364,9 @@ impl ApiEndpointSource {
                 .await
                 .map_err(HealthError::ApiInvocationError)?;
             tracing::debug!(
-                "Fetched details for {} machines with chunk size of 100",
-                machines.machines.len(),
+                machine_count = machines.machines.len(),
+                requested_machine_count = ids_chunk.len(),
+                "Fetched machine details"
             );
 
             for machine in machines.machines {
@@ -411,7 +415,10 @@ impl ApiEndpointSource {
                     }
                 }
 
-                tracing::debug!(count = endpoints.len(), "Fetched switch endpoints");
+                tracing::debug!(
+                    switch_endpoint_count = endpoints.len(),
+                    "Fetched switch endpoints"
+                );
                 endpoints
             }
             Err(error) => {
@@ -442,7 +449,10 @@ impl ApiEndpointSource {
                     }
                 }
 
-                tracing::debug!(count = endpoints.len(), "Fetched power shelf endpoints");
+                tracing::debug!(
+                    power_shelf_endpoint_count = endpoints.len(),
+                    "Fetched power shelf endpoints"
+                );
                 endpoints
             }
             Err(error) => {

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -353,7 +353,7 @@ impl BmcClient {
                 };
                 tracing::warn!(
                     endpoint = ?self.addr,
-                    backoff_secs = CIRCUIT_INITIAL_BACKOFF.as_secs(),
+                    backoff_seconds = CIRCUIT_INITIAL_BACKOFF.as_secs(),
                     error = ?error,
                     "BMC connect failure; opening connection circuit to stop request flood"
                 );
@@ -368,7 +368,7 @@ impl BmcClient {
                 };
                 tracing::debug!(
                     endpoint = ?self.addr,
-                    backoff_secs = next.as_secs(),
+                    backoff_seconds = next.as_secs(),
                     "BMC still unreachable; extending connection circuit backoff"
                 );
             }

--- a/crates/health/src/collectors/discovery.rs
+++ b/crates/health/src/collectors/discovery.rs
@@ -106,7 +106,12 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             Ok(value) => Some(value),
             Err(error) => {
                 fetch_failures.fetch_add(1, Ordering::Relaxed);
-                tracing::warn!(?error, context, bmc_addr = ?self.endpoint.addr, "Discovery fetch failed");
+                tracing::warn!(
+                    ?error,
+                    context,
+                    bmc_address = ?self.endpoint.addr,
+                    "Discovery fetch failed"
+                );
                 None
             }
         }
@@ -326,7 +331,11 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             Ok(None) => Vec::new(),
             Err(error) => {
                 fetch_failures.fetch_add(1, Ordering::Relaxed);
-                tracing::warn!(?error, bmc_addr = ?self.endpoint.addr, "Failed to get chassis sensors");
+                tracing::warn!(
+                    ?error,
+                    bmc_address = ?self.endpoint.addr,
+                    "Failed to get chassis sensors"
+                );
                 Vec::new()
             }
         };

--- a/crates/health/src/collectors/entity_metrics.rs
+++ b/crates/health/src/collectors/entity_metrics.rs
@@ -391,7 +391,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
     async fn run_iteration(&mut self) -> Result<IterationResult, HealthError> {
         let Some(inventory) = self.shared.load_full() else {
             tracing::debug!(
-                bmc_addr = ?self.endpoint.addr,
+                bmc_address = ?self.endpoint.addr,
                 "No entity inventory available yet; skipping metrics iteration"
             );
             return Ok(IterationResult {
@@ -402,9 +402,9 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for MetricsCollector<B> {
         };
 
         tracing::debug!(
-            bmc_addr = ?self.endpoint.addr,
+            bmc_address = ?self.endpoint.addr,
             generation = inventory.generation,
-            inventory_age_secs = inventory.discovered_at.elapsed().as_secs(),
+            inventory_age_seconds = inventory.discovered_at.elapsed().as_secs(),
             entity_count = inventory.entities.len(),
             "Reading entity inventory snapshot for metrics iteration"
         );
@@ -528,7 +528,12 @@ impl<B: Bmc + 'static> MetricsCollector<B> {
             Ok(value) => Some(value),
             Err(error) => {
                 fetch_failures.fetch_add(1, Ordering::Relaxed);
-                tracing::warn!(?error, context, bmc_addr = ?self.endpoint.addr, "Failed to fetch metrics resource");
+                tracing::warn!(
+                    ?error,
+                    context,
+                    bmc_address = ?self.endpoint.addr,
+                    "Failed to fetch metrics resource"
+                );
                 None
             }
         }

--- a/crates/health/src/collectors/gpu_inventory.rs
+++ b/crates/health/src/collectors/gpu_inventory.rs
@@ -175,7 +175,11 @@ impl<B: Bmc + 'static> GpuInventoryCollector<B> {
     }
 
     fn emit_alert(&self, message: String) {
-        tracing::warn!(bmc = %self.endpoint.addr.mac, %message, "GPU inventory alert");
+        tracing::warn!(
+            bmc_mac_address = %self.endpoint.addr.mac,
+            reason = %message,
+            "GPU inventory alert"
+        );
         let report = HealthReport {
             source: ReportSource::GpuInventory,
             target: Some(HealthReportTarget::Machine),
@@ -306,7 +310,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for GpuInventoryCollector<B> {
         // skip this iteration rather than false-alerting on a not-yet-known count.
         let Some(actual) = self.count_gpus() else {
             tracing::debug!(
-                bmc = %self.endpoint.addr.mac,
+                bmc_mac_address = %self.endpoint.addr.mac,
                 "Entity inventory not ready yet; skipping GPU inventory iteration"
             );
             return Ok(IterationResult {
@@ -319,9 +323,9 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for GpuInventoryCollector<B> {
         let report = gpu_count_report(expected_count, actual);
         if !report.alerts.is_empty() {
             tracing::warn!(
-                bmc = %self.endpoint.addr.mac,
-                expected = expected_count,
-                actual,
+                bmc_mac_address = %self.endpoint.addr.mac,
+                expected_gpu_count = expected_count,
+                actual_gpu_count = actual,
                 "GPU count below SKU expectation"
             );
         }

--- a/crates/health/src/collectors/leak_detector.rs
+++ b/crates/health/src/collectors/leak_detector.rs
@@ -222,7 +222,7 @@ fn build_health_report(detectors: Vec<Arc<LeakDetector>>, context: &EventContext
             | None => {
                 tracing::warn!(
                     detector = %target,
-                    state = ?detector.detector_state.flatten(),
+                    leak_detector_state = ?detector.detector_state.flatten(),
                     "Leak detector is not reporting an actionable leak state"
                 );
             }

--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -202,8 +202,8 @@ impl<B: Bmc + 'static> LogsCollector<B> {
         }
 
         tracing::info!(
-            total_services = services.len(),
-            excluded_services = excluded_count,
+            service_count = services.len(),
+            excluded_service_count = excluded_count,
             "Discovered distinct log services"
         );
 
@@ -224,8 +224,8 @@ impl<B: Bmc + 'static> LogsCollector<B> {
             match self.discover_log_services().await {
                 Ok(services) => {
                     tracing::info!(
-                        "Service discovery complete. Found {} log services",
-                        services.len()
+                        service_count = services.len(),
+                        "Log service discovery complete"
                     );
 
                     let persistent_state = self.load_persistent_state().await;

--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -252,7 +252,7 @@ impl GnmiClient {
 
         tracing::debug!(
             switch_id = %self.switch_id,
-            sample_interval_nanos,
+            sample_interval_nanoseconds = sample_interval_nanos,
             "gNMI SAMPLE stream opened"
         );
 

--- a/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
@@ -119,8 +119,8 @@ impl GnmiOnChangeProcessor {
             Some(proto::subscribe_response::Response::Error(e)) => {
                 stream_metrics.stream_errors_total.inc();
                 tracing::warn!(
-                    code = e.code,
-                    message = %e.message,
+                    grpc_status_code = e.code,
+                    error = %e.message,
                     stream = %self.collector_name,
                     "nvue_gnmi ON_CHANGE: server error in stream"
                 );

--- a/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
@@ -48,8 +48,8 @@ impl GnmiSampleProcessor {
             Some(proto::subscribe_response::Response::Error(e)) => {
                 stream_metrics.stream_errors_total.inc();
                 tracing::warn!(
-                    code = e.code,
-                    message = %e.message,
+                    grpc_status_code = e.code,
+                    error = %e.message,
                     "nvue_gnmi SAMPLE: server error in stream"
                 );
                 return;

--- a/crates/health/src/collectors/sensors.rs
+++ b/crates/health/src/collectors/sensors.rs
@@ -93,7 +93,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
     async fn run_iteration(&mut self) -> Result<IterationResult, HealthError> {
         let Some(inventory) = self.shared.load_full() else {
             tracing::debug!(
-                bmc_addr = ?self.endpoint.addr,
+                bmc_address = ?self.endpoint.addr,
                 "No entity inventory available yet; skipping sensor iteration"
             );
             return Ok(IterationResult {
@@ -113,7 +113,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         let sweep = self.endpoint.bmc.collector_sweep();
         if sweep == CollectorSweep::Skip {
             tracing::debug!(
-                bmc_addr = ?self.endpoint.addr,
+                bmc_address = ?self.endpoint.addr,
                 "BMC connection circuit is open; skipping sensor iteration"
             );
             return Ok(IterationResult {
@@ -125,9 +125,9 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         let probe_only = sweep == CollectorSweep::Probe;
 
         tracing::debug!(
-            bmc_addr = ?self.endpoint.addr,
+            bmc_address = ?self.endpoint.addr,
             generation = inventory.generation,
-            inventory_age_secs = inventory.discovered_at.elapsed().as_secs(),
+            inventory_age_seconds = inventory.discovered_at.elapsed().as_secs(),
             entity_count = inventory.entities.len(),
             probe_only,
             "Reading entity inventory snapshot for sensor iteration"

--- a/crates/health/src/discovery/cleanup.rs
+++ b/crates/health/src/discovery/cleanup.rs
@@ -20,20 +20,36 @@ use std::collections::HashSet;
 
 use super::context::{CollectorKind, DiscoveryLoopContext};
 
+#[derive(Clone, Copy)]
+enum CollectorStopReason {
+    EndpointRemoved,
+    SwitchEndpointNoLongerEligible,
+}
+
+impl std::fmt::Display for CollectorStopReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::EndpointRemoved => "endpoint removed",
+            Self::SwitchEndpointNoLongerEligible => "switch endpoint is no longer eligible",
+        })
+    }
+}
+
 fn stop_collectors_for_keys(
     ctx: &mut DiscoveryLoopContext,
     kind: CollectorKind,
     removed_keys: &HashSet<Cow<'static, str>>,
-    stop_message: &'static str,
+    stop_reason: CollectorStopReason,
 ) {
     let collectors = ctx.collectors.map_mut(kind);
     for key in removed_keys {
         if let Some(collector) = collectors.remove(key) {
             tracing::info!(
                 endpoint_key = %key,
-                remaining_collectors = collectors.len(),
-                "{}",
-                stop_message
+                collector_kind = ?kind,
+                %stop_reason,
+                remaining_collector_count = collectors.len(),
+                "Stopping collector"
             );
             tokio::spawn(async move {
                 collector.stop().await;
@@ -49,7 +65,12 @@ pub(super) fn stop_removed_bmc_collectors(
     let removed_keys = ctx.collectors.removed_keys(active_endpoints);
 
     for kind in CollectorKind::ALL {
-        stop_collectors_for_keys(ctx, kind, &removed_keys, kind.stop_message());
+        stop_collectors_for_keys(
+            ctx,
+            kind,
+            &removed_keys,
+            CollectorStopReason::EndpointRemoved,
+        );
     }
 
     for key in &removed_keys {
@@ -58,14 +79,15 @@ pub(super) fn stop_removed_bmc_collectors(
 
     if !removed_keys.is_empty() {
         tracing::info!(
-            removed_count = removed_keys.len(),
-            remaining_sensors = ctx.collectors.len(CollectorKind::Sensor),
-            remaining_collectors = ctx.collectors.len(CollectorKind::Logs),
-            remaining_firmware_collectors = ctx.collectors.len(CollectorKind::Firmware),
-            remaining_leak_detector_collectors = ctx.collectors.len(CollectorKind::LeakDetector),
-            remaining_nmxt_collectors = ctx.collectors.len(CollectorKind::Nmxt),
-            remaining_nmxc_collectors = ctx.collectors.len(CollectorKind::Nmxc),
-            remaining_nvue_rest_collectors = ctx.collectors.len(CollectorKind::NvueRest),
+            removed_endpoint_count = removed_keys.len(),
+            remaining_sensor_collector_count = ctx.collectors.len(CollectorKind::Sensor),
+            remaining_log_collector_count = ctx.collectors.len(CollectorKind::Logs),
+            remaining_firmware_collector_count = ctx.collectors.len(CollectorKind::Firmware),
+            remaining_leak_detector_collector_count =
+                ctx.collectors.len(CollectorKind::LeakDetector),
+            remaining_nmxt_collector_count = ctx.collectors.len(CollectorKind::Nmxt),
+            remaining_nmxc_collector_count = ctx.collectors.len(CollectorKind::Nmxc),
+            remaining_nvue_rest_collector_count = ctx.collectors.len(CollectorKind::NvueRest),
             "Cleaned up removed endpoints"
         );
     }
@@ -92,13 +114,13 @@ pub(super) fn stop_ineligible_nmxc_collectors(
         ctx,
         CollectorKind::Nmxc,
         &ineligible_keys,
-        "Stopping NMX-C streaming collector for ineligible switch endpoint",
+        CollectorStopReason::SwitchEndpointNoLongerEligible,
     );
 
     if !ineligible_keys.is_empty() {
         tracing::info!(
-            ineligible_count = ineligible_keys.len(),
-            remaining_nmxc_collectors = ctx.collectors.len(CollectorKind::Nmxc),
+            ineligible_endpoint_count = ineligible_keys.len(),
+            remaining_nmxc_collector_count = ctx.collectors.len(CollectorKind::Nmxc),
             "Cleaned up ineligible NMX-C endpoints"
         );
     }

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -68,28 +68,6 @@ impl CollectorKind {
         CollectorKind::NvueGnmi,
         CollectorKind::GpuInventory,
     ];
-
-    pub(super) fn stop_message(self) -> &'static str {
-        match self {
-            CollectorKind::Discovery => {
-                "Stopping entity discovery collector for removed BMC endpoint"
-            }
-            CollectorKind::GpuInventory => "Stopping GPU inventory collector",
-            CollectorKind::Sensor => "Stopping sensor collector for removed BMC endpoint",
-            CollectorKind::Metrics => "Stopping entity metrics collector for removed BMC endpoint",
-            CollectorKind::Logs => "Stopping logs collector for removed BMC endpoint",
-            CollectorKind::Firmware => "Stopping firmware collector for removed BMC endpoint",
-            CollectorKind::LeakDetector => {
-                "Stopping leak detector collector for removed BMC endpoint"
-            }
-            CollectorKind::Nmxt => "Stopping NMX-T collector for removed BMC endpoint",
-            CollectorKind::Nmxc => "Stopping NMX-C streaming collector for removed switch endpoint",
-            CollectorKind::NvueRest => "Stopping NVUE REST collector for removed BMC endpoint",
-            CollectorKind::NvueGnmi => {
-                "Stopping NVUE gNMI streaming collector for removed switch endpoint"
-            }
-        }
-    }
 }
 
 pub(super) struct CollectorState {

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -117,15 +117,15 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Discovery, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_collectors = ctx.collectors.len(CollectorKind::Discovery),
+                    discovery_collector_count = ctx.collectors.len(CollectorKind::Discovery),
                     "Started entity discovery for BMC endpoint"
                 );
             }
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start entity discovery collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start entity discovery collector"
                 );
             }
         }
@@ -160,15 +160,15 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Sensor, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_collectors = ctx.collectors.len(CollectorKind::Sensor),
+                    sensor_collector_count = ctx.collectors.len(CollectorKind::Sensor),
                     "Started sensor collection for BMC endpoint"
                 );
             }
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start sensor collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start sensor collector"
                 );
             }
         }
@@ -202,15 +202,15 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Metrics, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_collectors = ctx.collectors.len(CollectorKind::Metrics),
+                    entity_metrics_collector_count = ctx.collectors.len(CollectorKind::Metrics),
                     "Started entity metrics collection for BMC endpoint"
                 );
             }
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start entity metrics collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start entity metrics collector"
                 );
             }
         }
@@ -338,7 +338,7 @@ fn spawn_generic_redfish_collectors(
                 tracing::info!(
                     endpoint_key = %key,
                     mode = ?logs_cfg.mode,
-                    total_collectors = ctx.collectors.len(CollectorKind::Logs),
+                    log_collector_count = ctx.collectors.len(CollectorKind::Logs),
                     "Started logs collection for BMC endpoint"
                 );
             }
@@ -346,8 +346,8 @@ fn spawn_generic_redfish_collectors(
                 tracing::error!(
                     ?error,
                     mode = ?logs_cfg.mode,
-                    "Could not start logs collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start logs collector"
                 );
             }
             None => {}
@@ -379,15 +379,15 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::Firmware, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_firmware_collectors = ctx.collectors.len(CollectorKind::Firmware),
+                    firmware_collector_count = ctx.collectors.len(CollectorKind::Firmware),
                     "Started firmware collection for BMC endpoint"
                 );
             }
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start firmware collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start firmware collector"
                 )
             }
         }
@@ -430,8 +430,8 @@ fn spawn_generic_redfish_collectors(
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start GPU inventory collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start GPU inventory collector"
                 );
             }
         }
@@ -464,7 +464,7 @@ fn spawn_generic_redfish_collectors(
                     .insert(CollectorKind::LeakDetector, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_leak_detector_collectors =
+                    leak_detector_collector_count =
                         ctx.collectors.len(CollectorKind::LeakDetector),
                     "Started leak detector collection for BMC endpoint"
                 );
@@ -472,8 +472,8 @@ fn spawn_generic_redfish_collectors(
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start leak detector collector for: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start leak detector collector"
                 )
             }
         }
@@ -522,15 +522,15 @@ fn spawn_switch_host_collectors(
                     .insert(CollectorKind::Nmxt, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_nmxt_collectors = ctx.collectors.len(CollectorKind::Nmxt),
+                    nmxt_collector_count = ctx.collectors.len(CollectorKind::Nmxt),
                     "Started NMX-T collection for switch host endpoint"
                 );
             }
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start NMX-T collector for switch host: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start NMX-T collector for switch host"
                 )
             }
         }
@@ -574,7 +574,7 @@ fn spawn_switch_host_collectors(
 
                     tracing::info!(
                         endpoint_key = %key,
-                        total_nmxc_collectors = ctx.collectors.len(CollectorKind::Nmxc),
+                        nmxc_collector_count = ctx.collectors.len(CollectorKind::Nmxc),
                         "Started NMX-C streaming collection for switch endpoint"
                     );
                 }
@@ -625,15 +625,15 @@ fn spawn_switch_host_collectors(
                     .insert(CollectorKind::NvueRest, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_nvue_rest_collectors = ctx.collectors.len(CollectorKind::NvueRest),
+                    nvue_rest_collector_count = ctx.collectors.len(CollectorKind::NvueRest),
                     "Started NVUE REST collection for switch host endpoint"
                 );
             }
             Err(error) => {
                 tracing::error!(
                     ?error,
-                    "Could not start NVUE REST collector for switch host: {:?}",
-                    endpoint.addr
+                    endpoint = ?endpoint.addr,
+                    "Could not start NVUE REST collector for switch host"
                 )
             }
         }
@@ -662,7 +662,7 @@ fn spawn_switch_host_collectors(
                     .insert(CollectorKind::NvueGnmi, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
-                    total_nvue_gnmi_collectors = ctx.collectors.len(CollectorKind::NvueGnmi),
+                    nvue_gnmi_collector_count = ctx.collectors.len(CollectorKind::NvueGnmi),
                     "Started NVUE gNMI streaming collection for switch endpoint"
                 );
             }

--- a/crates/health/src/endpoint/cluster.rs
+++ b/crates/health/src/endpoint/cluster.rs
@@ -255,7 +255,12 @@ fn extract_manager_devices(
         let bmc_ip: IpAddr = match bmc_ip_str.parse() {
             Ok(ip) => ip,
             Err(e) => {
-                tracing::warn!(hostname, bmc_ip = bmc_ip_str, error = %e, "Invalid BMC IP; skipping");
+                tracing::warn!(
+                    hostname,
+                    bmc_ip_address = bmc_ip_str,
+                    error = %e,
+                    "Invalid BMC IP; skipping"
+                );
                 continue;
             }
         };
@@ -317,7 +322,7 @@ impl ClusterEndpointSource {
             self.proxy_url.as_ref(),
             self.cache_size,
         );
-        tracing::info!(count = endpoints.len(), "Loaded cluster endpoints");
+        tracing::info!(endpoint_count = endpoints.len(), "Loaded cluster endpoints");
         Ok(endpoints)
     }
 }
@@ -354,7 +359,7 @@ async fn fetch_from_manager(
 
     let nodes = extract_manager_devices(&raw, username, password)?;
     tracing::info!(
-        loaded = nodes.len(),
+        loaded_node_count = nodes.len(),
         "Cluster manager device fetch complete"
     );
     Ok(nodes)
@@ -395,7 +400,7 @@ fn build_endpoints(
         let IpAddr::V4(v4) = node.bmc_ip else {
             tracing::warn!(
                 hostname = %node.hostname,
-                bmc_ip = %node.bmc_ip,
+                bmc_ip_address = %node.bmc_ip,
                 "cluster endpoint has non-IPv4 BMC address; skipping"
             );
             continue;

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -56,7 +56,11 @@ impl StaticEndpointSource {
             let mac = match MacAddress::from_str(&cfg.mac) {
                 Ok(mac) => mac,
                 Err(error) => {
-                    tracing::warn!(?error, mac = ?cfg.mac, "Invalid MAC in static endpoint config");
+                    tracing::warn!(
+                        ?error,
+                        bmc_mac_address = ?cfg.mac,
+                        "Invalid MAC in static endpoint config"
+                    );
                     continue;
                 }
             };
@@ -182,7 +186,7 @@ impl StaticEndpointSource {
                 Err(error) => {
                     tracing::warn!(
                         ?error,
-                        ?addr,
+                        bmc_address = ?addr,
                         "Failed to construct BmcClient for static endpoint"
                     );
                     continue;

--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -273,7 +273,11 @@ impl Collector for SubRegistry {
 impl Drop for CollectorRegistry {
     fn drop(&mut self) {
         if let Err(e) = self.parent.unregister(self.registry.clone()) {
-            tracing::error!(e=?e, "Could not properly drop registry for collector {}", self.prefix())
+            tracing::error!(
+                error = ?e,
+                collector_prefix = self.prefix().as_str(),
+                "Could not properly drop registry for collector"
+            )
         }
     }
 }
@@ -465,8 +469,8 @@ pub async fn run_metrics_server(
         .map_err(|e| Box::new(e) as BoxedErr)?;
 
     tracing::info!(
-        "Metrics server listening on {} (paths: /metrics, /telemetry, /livez)",
-        metrics_endpoint
+        %metrics_endpoint,
+        "Metrics server listening (paths: /metrics, /telemetry, /livez)"
     );
 
     loop {

--- a/crates/health/src/otlp/drain.rs
+++ b/crates/health/src/otlp/drain.rs
@@ -206,8 +206,8 @@ impl OtlpDrainTask {
                 Err(status) if is_retryable(&status) && attempt < MAX_RETRIES => {
                     let delay = backoff.next_delay();
                     tracing::warn!(
-                        code = ?status.code(),
-                        message = status.message(),
+                        grpc_status_code = ?status.code(),
+                        error = status.message(),
                         endpoint = %self.target.endpoint,
                         attempt,
                         retry_in = ?delay,

--- a/crates/health/src/otlp/metrics_drain.rs
+++ b/crates/health/src/otlp/metrics_drain.rs
@@ -215,8 +215,8 @@ impl OtlpMetricsDrainTask {
                 Err(status) if is_retryable(&status) && attempt < MAX_RETRIES => {
                     let delay = backoff.next_delay();
                     tracing::warn!(
-                        code = ?status.code(),
-                        message = status.message(),
+                        grpc_status_code = ?status.code(),
+                        error = status.message(),
                         endpoint = %self.target.endpoint,
                         attempt,
                         retry_in = ?delay,

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -205,7 +205,7 @@ impl SyncLogFileWriter {
             return Ok(());
         }
 
-        tracing::info!(size = self.current_size, "rotating log file");
+        tracing::info!(file_size_bytes = self.current_size, "rotating log file");
 
         // flush and drop the current file handle before renaming
         if let Some(mut file) = self.current_file.take() {

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -228,12 +228,20 @@ fn get_numa_node_from_syspath(syspath: Option<&Path>) -> Result<i32, HardwareEnu
 // discovery all the non-DPU IB devices
 pub fn discovery_ibs() -> HardwareEnumerationResult<Vec<rpc_discovery::InfinibandInterface>> {
     let device_debug_log = |device: &Device| {
-        tracing::debug!("SysPath - {:?}", device.syspath());
+        tracing::debug!(syspath = ?device.syspath(), "SysPath");
         for p in device.properties() {
-            tracing::trace!("Property - {:?} - {:?}", p.name(), p.value());
+            tracing::trace!(
+                property_name = ?p.name(),
+                property_value = ?p.value(),
+                "Property"
+            );
         }
         for a in device.attributes() {
-            tracing::trace! {"attribute - {:?} - {:?}", a.name(), a.value()}
+            tracing::trace! {
+                attribute_name = ?a.name(),
+                attribute_value = ?a.value(),
+                "attribute"
+            }
         }
     };
 
@@ -249,9 +257,9 @@ pub fn discovery_ibs() -> HardwareEnumerationResult<Vec<rpc_discovery::Infiniban
             Ok(properties_ext) => properties_ext,
             Err(e) => {
                 tracing::error!(
-                    "Failed to enumerate properties of device {:?}: {}",
-                    device.devpath(),
-                    e
+                    device_path = ?device.devpath(),
+                    error = %e,
+                    "Failed to enumerate properties of device"
                 );
                 continue;
             }
@@ -408,9 +416,13 @@ fn enumerate_hardware_inner(
 
     for device in devices {
         let sys_path = device.syspath();
-        tracing::debug!("SysPath - {:?}", sys_path);
+        tracing::debug!(syspath = ?sys_path, "SysPath");
         for p in device.properties() {
-            tracing::trace!("net device property - {:?} - {:?}", p.name(), p.value());
+            tracing::trace!(
+                property_name = ?p.name(),
+                property_value = ?p.value(),
+                "net device property"
+            );
         }
         //for a in device.attributes() {
         //    tracing::trace!("attribute - {:?} - {:?}", a.name(), a.value());
@@ -423,15 +435,15 @@ fn enumerate_hardware_inner(
                 Ok(properties_ext) => properties_ext,
                 Err(e) => {
                     tracing::error!(
-                        "Failed to enumerate properties of device {:?}: {}",
-                        device.devpath(),
-                        e
+                        device_path = ?device.devpath(),
+                        error = %e,
+                        "Failed to enumerate properties of device"
                     );
                     continue;
                 }
             };
 
-            tracing::trace!("properties: {:?}", properties_ext);
+            tracing::trace!(?properties_ext, "properties");
 
             // discovery DPU and non ib capable device
             // Note:
@@ -562,7 +574,7 @@ fn enumerate_hardware_inner(
             }
             CpuArchitecture::Unknown => {
                 tracing::error!(
-                    cpu_num,
+                    cpu_number = cpu_num,
                     arch = info.machine,
                     "CPU has unsupported architecture. Ignoring."
                 );
@@ -598,11 +610,11 @@ fn enumerate_hardware_inner(
         // skip the device if its hidden
         if convert_sysattr_to_string("hidden", &device).is_ok_and(|v| v == "1") {
             tracing::info!(
-                "Ignoring hidden device {}",
-                device
+                syspath = device
                     .syspath()
                     .and_then(|v| v.to_str())
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
+                "Ignoring hidden device"
             );
             continue;
         }
@@ -610,11 +622,11 @@ fn enumerate_hardware_inner(
         // skip the device if its removable
         if convert_sysattr_to_string("removable", &device).is_ok_and(|v| v != "0") {
             tracing::info!(
-                "Ignoring removable device {}",
-                device
+                syspath = device
                     .syspath()
                     .and_then(|v| v.to_str())
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
+                "Ignoring removable device"
             );
             continue;
         }
@@ -623,11 +635,11 @@ fn enumerate_hardware_inner(
             .is_ok_and(|v| v.contains("virtual"))
         {
             tracing::info!(
-                "Ignoring virtual device {}",
-                device
+                syspath = device
                     .syspath()
                     .and_then(|v| v.to_str())
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
+                "Ignoring virtual device"
             );
             continue;
         }
@@ -687,7 +699,7 @@ fn enumerate_hardware_inner(
     // There is only expected to be a single set, and we don't want to
     // accidentally overwrite it with other data
     if let Some(device) = devices.next() {
-        tracing::debug!("DMI device syspath: {:?}", device.syspath());
+        tracing::debug!(syspath = ?device.syspath(), "DMI device syspath");
 
         // e.g. 'DRAM'. We will use this later if smbios fails.
         backup_ram_type = device
@@ -714,9 +726,9 @@ fn enumerate_hardware_inner(
             dmi.product_name = convert_sysattr_to_string("product_name", &device)?.to_string();
             if cpu_part == BF3_CPU_PART && dmi.product_name == BF2_PRODUCT_NAME {
                 tracing::info!(
-                    "Overriding product name {} with {}",
-                    dmi.product_name,
-                    BF3_PRODUCT_NAME
+                    product_name = dmi.product_name.as_str(),
+                    new_product_name = BF3_PRODUCT_NAME,
+                    "Overriding product name"
                 );
                 dmi.product_name = BF3_PRODUCT_NAME.to_owned();
             }
@@ -747,7 +759,7 @@ fn enumerate_hardware_inner(
             )));
         }
         Err(e) => {
-            tracing::error!("Could not read TPM EK certificate: {:?}", e);
+            tracing::error!(error = ?e, "Could not read TPM EK certificate");
             None
         }
     };
@@ -756,7 +768,7 @@ fn enumerate_hardware_inner(
         "https://www.mellanox.com" | "Nvidia" => match dpu::get_dpu_info() {
             Ok(dpu_data) => Some(dpu_data),
             Err(e) => {
-                tracing::error!("Could not get DPU data: {:?}", e);
+                tracing::error!(error = ?e, "Could not get DPU data");
                 None
             }
         },
@@ -818,7 +830,9 @@ fn enumerate_hardware_inner(
         }
         Err(err) => {
             warn!(
-                "Could not discover host memory using smbios device, using {mem_info_path}: {err}"
+                memory_info_path = mem_info_path,
+                error = %err,
+                "Could not discover host memory using smbios device"
             );
             let meminfo = std::fs::read_to_string(mem_info_path).map_err(|e| {
                 HardwareEnumerationError::GenericError(format!("Err reading {mem_info_path}: {e}"))
@@ -832,19 +846,22 @@ fn enumerate_hardware_inner(
         }
     }
 
-    tracing::debug!("Discovered Disks: {:?}", disks);
+    tracing::debug!(?disks, "Discovered Disks");
     if !cpus.is_empty() {
-        tracing::debug!("Discovered CPUs[0]: {:?}", cpus[0]);
+        tracing::debug!(cpu = ?cpus[0], "Discovered CPUs[0]");
     }
-    tracing::debug!("Discovered NICS: {:?}", nics);
-    tracing::debug!("Discovered IBS: {:?}", ibs);
-    tracing::debug!("Discovered NVMES: {:?}", nvmes);
-    tracing::debug!("Discovered DMI: {:?}", dmi);
-    tracing::debug!("Discovered GPUs: {:?}", gpus);
-    tracing::debug!("Discovered Machine Architecture: {}", info.machine.as_str());
-    tracing::debug!("Discovered DPU: {:?}", dpu_vpd);
+    tracing::debug!(?nics, "Discovered NICS");
+    tracing::debug!(?ibs, "Discovered IBS");
+    tracing::debug!(?nvmes, "Discovered NVMES");
+    tracing::debug!(?dmi, "Discovered DMI");
+    tracing::debug!(?gpus, "Discovered GPUs");
+    tracing::debug!(
+        architecture = info.machine.as_str(),
+        "Discovered Machine Architecture"
+    );
+    tracing::debug!(dpu_vpd = ?dpu_vpd, "Discovered DPU");
     if let Some(cert) = tpm_ek_certificate.as_ref() {
-        tracing::debug!("TPM EK certificate (base64): {}", cert);
+        tracing::debug!(certificate = cert.as_str(), "TPM EK certificate (base64)");
     }
 
     Ok(rpc_discovery::DiscoveryInfo {
@@ -933,7 +950,7 @@ pub async fn enumerate_and_save_hardware()
     }
 
     tracing::error!(
-        last_error = %last_err,
+        error = %last_err,
         "Init container failed to generate hardware info. Try to delete the pod to recover."
     );
 

--- a/crates/host-support/src/hardware_enumeration/dpu.rs
+++ b/crates/host-support/src/hardware_enumeration/dpu.rs
@@ -98,7 +98,7 @@ pub fn get_lldp_port_info(port: &str) -> Result<String, DpuEnumerationError> {
     if cfg!(test) {
         const TEST_DATA: &str = "test/lldp_query.json";
         std::fs::read_to_string(TEST_DATA).map_err(|e| {
-            warn!("Could not read LLDP json: {e}");
+            warn!(error = %e, "Could not read LLDP json");
             DpuEnumerationError::Read(TEST_DATA, e.to_string())
         })
     } else {
@@ -107,7 +107,7 @@ pub fn get_lldp_port_info(port: &str) -> Result<String, DpuEnumerationError> {
             .args(vec!["-c", lldp_cmd.as_str()])
             .output()
             .map_err(|e| {
-                warn!("Could not discover LLDP peer for {port}, {e}");
+                warn!(port, error = %e, "Could not discover LLDP peer");
                 DpuEnumerationError::Lldp(e.to_string())
             })
     }
@@ -134,7 +134,7 @@ pub fn wait_until_all_ports_available() {
         }
     }
 
-    debug!("lldp: Ports {:?} are read successfully.", ports_read);
+    debug!(ports = ?ports_read, "lldp: Ports are read successfully.");
 }
 
 // LLDP was broken in multiple forge versions. It was fixed in HBN 2.1/ doca 2.6, as per
@@ -164,7 +164,11 @@ pub fn get_port_lldp_info(port: &str) -> Result<LldpSwitchData, DpuEnumerationEr
     let lldp_resp: LldpResponse = match serde_json::from_str(lldp_json.as_str()) {
         Ok(x) => x,
         Err(e) => {
-            warn!("Could not deserialize LLDP response {lldp_json}, {e}");
+            warn!(
+                lldp_json = lldp_json.as_str(),
+                error = %e,
+                "Could not deserialize LLDP response"
+            );
             return Err(DpuEnumerationError::Lldp(e.to_string()));
         }
     };

--- a/crates/host-support/src/hardware_enumeration/gpu.rs
+++ b/crates/host-support/src/hardware_enumeration/gpu.rs
@@ -45,7 +45,7 @@ pub fn get_nvidia_smi_data() -> HardwareEnumerationResult<Vec<RpcGpu>> {
     for result in csv_reader.deserialize() {
         match result {
             Ok(gpu) => gpus.push(gpu),
-            Err(error) => tracing::error!("Could not parse nvidia-smi output: {}", error),
+            Err(error) => tracing::error!(%error, "Could not parse nvidia-smi output"),
         }
     }
 

--- a/crates/host-support/src/hardware_enumeration/tpm.rs
+++ b/crates/host-support/src/hardware_enumeration/tpm.rs
@@ -97,14 +97,16 @@ fn get_ek_certificate_with_runner(runner: &impl CommandRunner) -> Result<Vec<u8>
         Ok(cert) => Ok(cert),
         Err(primary_error) => {
             tracing::warn!(
-                "Could not read TPM EK certificate using {TPM2_GET_EK_CERTIFICATE}: {primary_error:?}; probing known NV indices"
+                command = TPM2_GET_EK_CERTIFICATE,
+                error = ?primary_error,
+                "Could not read TPM EK certificate; probing known NV indices"
             );
             let mut certs = vec![];
             let mut nv_errors = vec![];
             for index in TPM_EK_CERT_NV_INDICES {
                 match get_ek_certificate_from_nv_index(runner, index) {
                     Ok(cert) => {
-                        tracing::info!("Read TPM EK certificate from NV index {index}");
+                        tracing::info!(index, "Read TPM EK certificate from NV index");
                         certs.extend_from_slice(&cert);
                     }
                     Err(e) => nv_errors.push(format!("{index}: {e}")),

--- a/crates/host-support/src/registration.rs
+++ b/crates/host-support/src/registration.rs
@@ -101,18 +101,15 @@ impl<'a, 'c> RegistrationClient<'a, 'c> {
     // let response = connection.your_api_endpoint(request).await?;
     //
     async fn connect(&self, purpose: &str) -> Result<ForgeClientT, RegistrationError> {
-        tracing::debug!("creating tls client connection for {purpose}");
+        tracing::debug!(purpose, "creating tls client connection");
         let client = ForgeTlsClient::new(self.config);
         match client.build(self.api_url.to_string()).await {
             Ok(connection) => {
-                tracing::debug!(
-                    "created tls client connection for {purpose}: {:?}",
-                    connection
-                );
+                tracing::debug!(purpose, ?connection, "created tls client connection");
                 Ok(connection)
             }
             Err(e) => {
-                tracing::error!("could not create tls client for {purpose}: {:?}", e);
+                tracing::error!(purpose, error = ?e, "could not create tls client");
                 Err(RegistrationError::TransportError(e.to_string()))
             }
         }
@@ -127,14 +124,14 @@ impl<'a, 'c> RegistrationClient<'a, 'c> {
         info: MachineDiscoveryInfo,
         attempt: u32,
     ) -> Result<rpc::MachineDiscoveryResult, RegistrationError> {
-        tracing::info!("Attempting to discover_machine (attempt: {})", attempt);
+        tracing::info!(attempt, "Attempting to discover_machine");
 
         // Create a new connection off of the ForgeTlsClient.
         let mut connection = self.connect("discover_machine_once").await?;
 
         // Create a new request with the provided MachineDiscoveryInfo.
         let request = tonic::Request::new(info);
-        tracing::debug!("register_machine request {:?}", request);
+        tracing::debug!(?request, "discover_machine request");
 
         // And now attempt to send the request.
         Ok(connection
@@ -142,9 +139,9 @@ impl<'a, 'c> RegistrationClient<'a, 'c> {
             .await
             .inspect_err(|err| {
                 tracing::error!(
-                    "Error attempting to discover_machine (attempt: {}): {}",
                     attempt,
-                    err.to_string()
+                    error = %err,
+                    "Error attempting to discover_machine"
                 );
             })?
             .into_inner())
@@ -180,15 +177,13 @@ impl<'a, 'c> RegistrationClient<'a, 'c> {
 
         // Create a new request with the provided AttestQuoteRequest.
         let request = tonic::Request::new(quote.clone());
-        tracing::debug!("attest_quote request {:?}", request);
+        tracing::debug!(?request, "attest_quote request");
 
         // And now attempt to send the request.
         Ok(connection
             .attest_quote(request)
             .await
-            .inspect_err(|err| {
-                tracing::error!("Error attempting to attest_quote: {}", err.to_string())
-            })?
+            .inspect_err(|err| tracing::error!(error = %err, "Error attempting to attest_quote"))?
             .into_inner())
     }
 }
@@ -207,7 +202,7 @@ fn create_client_config(
             .map_err(|e| RegistrationError::TransportError(e.to_string()))?,
         false => ForgeClientConfig::new(root_ca, None),
     };
-    tracing::debug!("{purpose} client_config {:?}", forge_client_config);
+    tracing::debug!(purpose, ?forge_client_config, "client_config");
     Ok(forge_client_config)
 }
 
@@ -243,7 +238,7 @@ pub async fn register_machine(
         discovery_reporter: discovery_reporter as i32,
         discovery_reporter_version: reporter_version,
     };
-    tracing::info!("register_machine discovery_info {:?}", info);
+    tracing::info!(machine_discovery_info = ?info, "register_machine discovery_info");
 
     let forge_client_config = create_client_config("register_machine", use_mgmt_vrf, root_ca)?;
     let response = RegistrationClient::new(forge_api, &forge_client_config, retry)
@@ -289,14 +284,7 @@ pub async fn attest_quote(
 
     let _ = write_certs(response.machine_certificate, None).await;
 
-    tracing::info!(
-        "Attestation result is {}",
-        if response.success {
-            "SUCCESS"
-        } else {
-            "FAILURE"
-        }
-    );
+    tracing::info!(success = response.success, "Attestation result");
 
     Ok(response.success)
 }
@@ -322,7 +310,7 @@ pub async fn write_certs(
             .wrap_err(format!(
                 "Failed to write new machine certificate PEM to {client_cert}"
             ))?;
-        tracing::info!("Wrote new machine certificate PEM to: {:?}", client_cert);
+        tracing::info!(%client_cert, "Wrote new machine certificate PEM");
 
         tokio::fs::write(client_key, machine_certificate.private_key.as_slice())
             .await

--- a/crates/http-connector/src/connector.rs
+++ b/crates/http-connector/src/connector.rs
@@ -205,7 +205,7 @@ impl ConnectorMetricsInner {
         self.total_successes.fetch_add(1, Ordering::SeqCst);
         GLOBAL_TOTALS.successes.fetch_add(1, Ordering::Relaxed);
         self.addr_maps.lock().unwrap().add_success_by_addr(addr);
-        trace!("connected to {addr}");
+        trace!(endpoint_address = %addr, "connected");
     }
 
     // connect_error is the "inner" function for handling a
@@ -216,7 +216,7 @@ impl ConnectorMetricsInner {
         self.total_errors.fetch_add(1, Ordering::SeqCst);
         GLOBAL_TOTALS.errors.fetch_add(1, Ordering::Relaxed);
         self.addr_maps.lock().unwrap().add_error_by_addr(addr);
-        info!("connect error for {}: {:?}", addr, e);
+        info!(endpoint_address = %addr, error = ?e, "connect error");
     }
 }
 
@@ -412,7 +412,7 @@ fn connect(
             conf = conf.with_retries(retries)
         }
         if let Err(e) = socket.set_tcp_keepalive(&conf) {
-            warn!("tcp set_keepalive error: {}", e);
+            warn!(error = %e, "tcp set_keepalive error");
         }
     }
     #[cfg(target_os = "linux")]
@@ -449,19 +449,19 @@ fn connect(
     if config.reuse_address
         && let Err(e) = socket.set_reuseaddr(true)
     {
-        warn!("tcp set_reuse_address error: {}", e);
+        warn!(error = %e, "tcp set_reuse_address error");
     }
 
     if let Some(size) = config.send_buffer_size
         && let Err(e) = socket.set_send_buffer_size(size.try_into().unwrap_or(u32::MAX))
     {
-        warn!("tcp set_buffer_size error: {}", e);
+        warn!(error = %e, "tcp set_buffer_size error");
     }
 
     if let Some(size) = config.recv_buffer_size
         && let Err(e) = socket.set_recv_buffer_size(size.try_into().unwrap_or(u32::MAX))
     {
-        warn!("tcp set_recv_buffer_size error: {}", e);
+        warn!(error = %e, "tcp set_recv_buffer_size error");
     }
 
     let connect = socket.connect(*addr);
@@ -520,7 +520,7 @@ impl<'a> ConnectingTcp<'a> {
         config: &'a Config,
         metrics: ConnectorMetrics,
     ) -> Self {
-        trace!("ConnectingTcp config: {:?}", config);
+        trace!(?config, "ConnectingTcp config");
 
         if let Some(fallback_timeout) = config.happy_eyeballs_timeout {
             let (preferred_addrs, fallback_addrs) = remote_addrs
@@ -927,10 +927,10 @@ impl tower_service::Service<Uri> for ForgeHttpConnector {
 
 fn get_host_port<'u>(config: &Config, dst: &'u Uri) -> Result<(&'u str, u16), ConnectError> {
     trace!(
-        "Http::connect; scheme={:?}, host={:?}, port={:?}",
-        dst.scheme(),
-        dst.host(),
-        dst.port(),
+        scheme = ?dst.scheme(),
+        host = ?dst.host(),
+        port = ?dst.port(),
+        "Http::connect"
     );
 
     if config.enforce_http {
@@ -1006,7 +1006,7 @@ impl ForgeHttpConnector {
             );
 
         tryhard::retry_fn(|| {
-            trace!("establishing new tcp connection for {dst}");
+            trace!(destination_address = %dst, "establishing new tcp connection");
             let c = ConnectingTcp::new(addrs.clone(), config, self.metrics.clone());
             c.connect()
         })

--- a/crates/http-connector/src/resolver.rs
+++ b/crates/http-connector/src/resolver.rs
@@ -299,7 +299,7 @@ impl<C: ConnectionProvider> Service<Name> for HickoryResolver<C> {
 
         Box::pin(async move {
             let response = resolver.lookup_ip(name.to_string()).await?;
-            trace!("response from DNS Server{:?}", response);
+            trace!(?response, "response from DNS Server");
             let addresses = response.iter();
 
             Ok(SocketAddrs {

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -21,10 +21,9 @@ pub mod ib;
 mod metrics;
 
 use std::collections::{HashMap, HashSet};
-use std::fmt::Write;
-use std::io;
 use std::sync::Arc;
 use std::time::Duration;
+use std::{fmt, io};
 
 use carbide_utils::periodic_timer::PeriodicTimer;
 use carbide_uuid::infiniband::IBPartitionId;
@@ -138,7 +137,7 @@ impl IbFabricMonitor {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("IbFabricMonitor error: {}", e);
+                    tracing::warn!(error = %e, "IB fabric monitor iteration failed");
                 }
             }
 
@@ -194,7 +193,7 @@ impl IbFabricMonitor {
                     *num_changes
                 }
                 Err(e) => {
-                    tracing::error!("IbFabricMonitor run failed due to: {:?}", e);
+                    tracing::error!(error = ?e, "IB fabric monitor run failed");
                     check_ib_fabrics_span.record("otel.status_code", "error");
                     // Writing this field will set the span status to error
                     // Therefore we only write it on errors
@@ -389,7 +388,7 @@ async fn load_single_fabric_data(
                 fabric,
                 &fabric_definition.endpoints,
                 &e,
-                "failed to build the IB fabric client",
+                FabricFailureStage::BuildClient,
             );
             return None;
         }
@@ -401,7 +400,7 @@ async fn load_single_fabric_data(
             fabric,
             &fabric_definition.endpoints,
             &e,
-            "IB fabric health check failed",
+            FabricFailureStage::HealthCheck,
         );
         // There's no point in loading other information case the fabric is down
         return Some(conn);
@@ -417,7 +416,7 @@ async fn load_single_fabric_data(
                 fabric,
                 &fabric_definition.endpoints,
                 &e,
-                "Loading port information failed",
+                FabricFailureStage::LoadPorts,
             );
             // There's no point in loading other information case the fabric is down
             return Some(conn);
@@ -434,7 +433,7 @@ async fn load_single_fabric_data(
                 fabric,
                 &fabric_definition.endpoints,
                 &e,
-                "Loading partition information failed",
+                FabricFailureStage::LoadPartitions,
             );
             // There's no point in loading other information case the fabric is down
             return Some(conn);
@@ -447,8 +446,27 @@ async fn load_single_fabric_data(
     Some(conn)
 }
 
-/// Records a failed stage of a fabric's data load: logs the failure under the
-/// stage's `message` and stores the error as the fabric's error metric.
+#[derive(Clone, Copy)]
+enum FabricFailureStage {
+    BuildClient,
+    HealthCheck,
+    LoadPorts,
+    LoadPartitions,
+}
+
+impl fmt::Display for FabricFailureStage {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::BuildClient => "build_client",
+            Self::HealthCheck => "health_check",
+            Self::LoadPorts => "load_ports",
+            Self::LoadPartitions => "load_partitions",
+        })
+    }
+}
+
+/// Records a failed stage of a fabric's data load and stores the error as the
+/// fabric's error metric.
 ///
 /// TODO: Storing the raw error string isn't efficient because we will get a
 /// lot of different dimensions. We need to have better defined errors from the
@@ -458,9 +476,15 @@ fn note_fabric_error(
     fabric: &str,
     endpoints: &[String],
     error: &IbError,
-    message: &'static str,
+    failure_stage: FabricFailureStage,
 ) {
-    tracing::error!(fabric, endpoints = endpoints.join(","), error = %error, "{message}");
+    tracing::error!(
+        fabric,
+        endpoints = endpoints.join(","),
+        %failure_stage,
+        error = %error,
+        "IB fabric operation failed",
+    );
     fabric_metrics.fabric_error = error.to_string();
 }
 
@@ -1009,7 +1033,7 @@ async fn record_machine_infiniband_status_observation(
                     tracing::debug!(
                         machine_id = %machine_id,
                         guid = %guid,
-                        state = ?port_data.state,
+                        port_state = ?port_data.state,
                         "IB port is not active"
                     );
                 }
@@ -1056,37 +1080,27 @@ async fn record_machine_infiniband_status_observation(
 
     if !result.missing_guid_pkeys.is_empty() {
         metrics.num_machines_with_missing_pkeys += 1;
-        let mut msg = "Machine is missing pkeys on UFM: ".to_string();
-        for (idx, (_fabric, guid, pkey)) in result.missing_guid_pkeys.iter().enumerate() {
-            if idx != 0 {
-                msg.push(',');
-            }
-            write!(&mut msg, "(guid: {guid}, pkey: {pkey})").unwrap();
-        }
-        tracing::warn!(machine_id = %machine_id, msg);
+        tracing::warn!(
+            machine_id = %machine_id,
+            missing_guid_pkeys = ?result.missing_guid_pkeys,
+            "Machine is missing pkeys on UFM",
+        );
     }
     if !result.unexpected_guid_pkeys.is_empty() {
         metrics.num_machines_with_unexpected_pkeys += 1;
-        let mut msg = "Machine has unexpected registered pkeys on UFM: ".to_string();
-        for (idx, (_fabric, guid, pkey)) in result.unexpected_guid_pkeys.iter().enumerate() {
-            if idx != 0 {
-                msg.push(',');
-            }
-            write!(&mut msg, "(guid: {guid}, pkey: {pkey})").unwrap();
-        }
-        tracing::warn!(machine_id = %machine_id, msg);
+        tracing::warn!(
+            machine_id = %machine_id,
+            unexpected_guid_pkeys = ?result.unexpected_guid_pkeys,
+            "Machine has unexpected registered pkeys on UFM",
+        );
     }
     if !result.unknown_guid_pkeys.is_empty() {
         metrics.num_machines_with_unknown_pkeys += 1;
-        let mut msg =
-            "Machine has registered pkeys on UFM that do not map to IB PartitionIDs: ".to_string();
-        for (idx, (_fabric, guid, pkey)) in result.unknown_guid_pkeys.iter().enumerate() {
-            if idx != 0 {
-                msg.push(',');
-            }
-            write!(&mut msg, "(guid: {guid}, pkey: {pkey})").unwrap();
-        }
-        tracing::warn!(machine_id = %machine_id, msg);
+        tracing::warn!(
+            machine_id = %machine_id,
+            unknown_guid_pkeys = ?result.unknown_guid_pkeys,
+            "Machine has registered pkeys on UFM that do not map to IB PartitionIDs",
+        );
     }
 
     let has_existing_ib_port_down_alert = mh_snapshot
@@ -1099,7 +1113,7 @@ async fn record_machine_infiniband_status_observation(
         tracing::warn!(
             machine_id = %machine_id,
             down_ports = ?result.down_port_guids,
-            total_ports = guids.len(),
+            total_port_count = guids.len(),
             "IB port(s) detected as down - setting PreventAllocations alert"
         );
         set_ib_port_down_alert(db_pool, machine_id, &result.down_port_guids, guids.len()).await?;

--- a/crates/ib-partition-controller/src/handler.rs
+++ b/crates/ib-partition-controller/src/handler.rs
@@ -59,7 +59,11 @@ impl StateHandler for IBPartitionStateHandler {
                 match state.status.as_ref().and_then(|s| s.pkey) {
                     None => {
                         let cause = "The pkey is None when deleting an IBPartition.";
-                        tracing::error!(cause);
+                        tracing::error!(
+                            ib_partition_id = %partition_id,
+                            cause = %cause,
+                            "IB partition has no pkey while deleting"
+                        );
                         let new_state = IBPartitionControllerState::Error {
                             cause: cause.to_string(),
                         };
@@ -99,10 +103,9 @@ impl StateHandler for IBPartitionStateHandler {
 
                                     if instance_count > 0 {
                                         tracing::info!(
-                                            %partition_id,
+                                            ib_partition_id = %partition_id,
                                             instance_count,
-                                            "Postponing IB partition deletion: \
-                                             {instance_count} instance(s) still reference this partition",
+                                            "Postponing IB partition deletion because instances still reference it",
                                         );
                                         return Ok(StateHandlerOutcome::wait(format!(
                                             "Waiting for {instance_count} instance(s) to release IB partition"
@@ -143,7 +146,11 @@ impl StateHandler for IBPartitionStateHandler {
             IBPartitionControllerState::Ready => match state.status.as_ref().and_then(|s| s.pkey) {
                 None => {
                     let cause = "The pkey is None when IBPartition is ready";
-                    tracing::error!(cause);
+                    tracing::error!(
+                        ib_partition_id = %partition_id,
+                        cause = %cause,
+                        "IB partition has no pkey while ready"
+                    );
 
                     Ok(StateHandlerOutcome::transition(
                         IBPartitionControllerState::Error {

--- a/crates/ipmi/src/tool.rs
+++ b/crates/ipmi/src/tool.rs
@@ -151,7 +151,7 @@ impl IPMIToolImpl {
             .args(&args)
             .attempts(self.attempts);
 
-        tracing::info!("Running command: {:?}", cmd);
+        tracing::info!(command = ?cmd, "Running IPMI command");
         let result = cmd.env("IPMITOOL_PASSWORD", password).output().await;
         count_ipmi_command(command, &result);
         result

--- a/crates/kms-provider/src/providers/transit.rs
+++ b/crates/kms-provider/src/providers/transit.rs
@@ -85,7 +85,10 @@ impl TransitKmsProvider {
                 match vaultrs::token::lookup_self(client.as_ref()).await {
                     Ok(info) => break info,
                     Err(e) => {
-                        tracing::warn!("failed to look up Transit KMS token, retrying: {e}");
+                        tracing::warn!(
+                            error = %e,
+                            "failed to look up Transit KMS token; retrying"
+                        );
                         tokio::select! {
                             _ = cancel.cancelled() => return,
                             _ = tokio::time::sleep(Duration::from_secs(30)) => {}
@@ -102,7 +105,7 @@ impl TransitKmsProvider {
             let mut next_renewal = Duration::from_secs((info.ttl as f64 * 0.9).max(30.0) as u64);
             loop {
                 tracing::debug!(
-                    sleep_secs = next_renewal.as_secs(),
+                    sleep_seconds = next_renewal.as_secs(),
                     "scheduling Transit KMS token renewal"
                 );
                 tokio::select! {
@@ -116,12 +119,12 @@ impl TransitKmsProvider {
                             (renewed.lease_duration as f64 * 0.9).max(30.0) as u64,
                         );
                         tracing::info!(
-                            new_lease_duration = renewed.lease_duration,
+                            new_lease_duration_seconds = renewed.lease_duration,
                             "renewed Transit KMS vault token"
                         );
                     }
                     Err(e) => {
-                        tracing::warn!("failed to renew Transit KMS vault token: {e}");
+                        tracing::warn!(error = %e, "failed to renew Transit KMS vault token");
                         next_renewal = Duration::from_secs(30);
                     }
                 }

--- a/crates/libmlx/src/device/discovery.rs
+++ b/crates/libmlx/src/device/discovery.rs
@@ -116,7 +116,7 @@ pub fn discover_devices() -> Result<Vec<MlxDeviceInfo>, String> {
 
     {
         let xml_content = String::from_utf8_lossy(&output.stdout);
-        warn!("mlxfwmanager XML output: {}", xml_content);
+        warn!(xml = %xml_content, "mlxfwmanager XML output");
         parse_mlxfwmanager_xml(&xml_content)
     }
 }
@@ -125,7 +125,7 @@ pub fn discover_devices() -> Result<Vec<MlxDeviceInfo>, String> {
 // The actual XML returned is still "devices", but will only
 // contain the target device.
 pub fn discover_device(device: &str) -> Result<MlxDeviceInfo, String> {
-    debug!("Running mlxfwmanager to discover device: {device}");
+    debug!(device, "Running mlxfwmanager to discover device");
 
     let output = Command::new("mlxfwmanager")
         .args(["--dev", device, "--query-format", "xml"])
@@ -148,7 +148,7 @@ pub fn discover_device(device: &str) -> Result<MlxDeviceInfo, String> {
     }
 
     let xml_content = String::from_utf8_lossy(&output.stdout);
-    debug!("mlxfwmanager XML output: {}", xml_content);
+    debug!(xml = %xml_content, "mlxfwmanager XML output");
 
     let devices = parse_mlxfwmanager_xml(&xml_content)?;
     if devices.len() > 1 {
@@ -172,20 +172,21 @@ pub fn discover_devices_with_filters(filter: DeviceFilter) -> Result<Vec<MlxDevi
         .filter(|device| {
             let matches = filter.matches(device);
             debug!(
-                "Device {} (type: {}, part: {}, fw: {}) matches filter: {}",
-                device.pci_name_pretty(),
-                device.device_type_pretty(),
-                device.part_number_pretty(),
-                device.fw_version_current_pretty(),
-                matches
+                device = device.pci_name_pretty(),
+                device_type = device.device_type_pretty(),
+                part_number = device.part_number_pretty(),
+                firmware_version = device.fw_version_current_pretty(),
+                matches,
+                "Device matches filter"
             );
             matches
         })
         .collect();
 
     debug!(
-        "Found {} devices matching filter: [{filter}]",
-        filtered_devices.len()
+        device_count = filtered_devices.len(),
+        %filter,
+        "Found devices matching filter"
     );
 
     Ok(filtered_devices)
@@ -243,7 +244,7 @@ pub fn parse_mlxfwmanager_xml(xml_content: &str) -> Result<Vec<MlxDeviceInfo>, S
         devices.push(device_info);
     }
 
-    debug!("Discovered {} MLX devices", devices.len());
+    debug!(device_count = devices.len(), "Discovered MLX devices");
     Ok(devices)
 }
 
@@ -273,8 +274,9 @@ pub fn convert_pci_name_to_address(pci_name: &str) -> Result<String, String> {
     };
 
     debug!(
-        "Converted PCI name '{}' to address '{}'",
-        pci_name, cleaned_address
+        pci_name,
+        pci_address = cleaned_address.as_str(),
+        "Converted PCI name to address"
     );
     Ok(cleaned_address)
 }

--- a/crates/libmlx/src/firmware/flasher.rs
+++ b/crates/libmlx/src/firmware/flasher.rs
@@ -152,7 +152,7 @@ impl FirmwareFlasher {
                 tracing::debug!(output = %output, "Flint output");
             }
             Err(crate::lockdown::error::MlxError::DryRun(cmd)) => {
-                tracing::debug!(cmd = %cmd, "Dry run");
+                tracing::debug!(command = %cmd, "Dry run");
             }
             Err(e) => return Err(FirmwareError::FlintError(e)),
         };
@@ -220,7 +220,7 @@ impl FirmwareFlasher {
                 Ok(output)
             }
             Err(crate::lockdown::error::MlxError::DryRun(cmd)) => {
-                tracing::debug!(cmd = %cmd, "Dry run");
+                tracing::debug!(command = %cmd, "Dry run");
                 Ok(format!("[DRY RUN] {cmd}"))
             }
             Err(e) => Err(FirmwareError::VerificationFailed(e.to_string())),
@@ -287,7 +287,7 @@ impl FirmwareFlasher {
     pub fn reset_with_level(&self, level: u8) -> FirmwareResult<String> {
         tracing::info!(
             device = %self.device_id,
-            level = %level,
+            reset_level = %level,
             "Resetting device via mlxfwreset"
         );
 
@@ -304,7 +304,7 @@ impl FirmwareFlasher {
                 Ok(output)
             }
             Err(FirmwareError::DryRun(cmd)) => {
-                tracing::debug!(cmd = %cmd, "Dry run");
+                tracing::debug!(command = %cmd, "Dry run");
                 Ok(format!("[DRY RUN] {cmd}"))
             }
             Err(e) => Err(e),
@@ -338,7 +338,7 @@ impl FirmwareFlasher {
             Some(match self.reset_with_level(options.reset_level) {
                 Ok(_) => true,
                 Err(e) => {
-                    tracing::error!(device = %self.device_id, %e, "post-flash reset failed");
+                    tracing::error!(device = %self.device_id, error = %e, "post-flash reset failed");
                     false
                 }
             })
@@ -352,7 +352,7 @@ impl FirmwareFlasher {
             Some(match self.verify_image(&profile.flash_spec).await {
                 Ok(_) => true,
                 Err(e) => {
-                    tracing::error!(device = %self.device_id, %e, "post-flash image verification failed");
+                    tracing::error!(device = %self.device_id, error = %e, "post-flash image verification failed");
                     false
                 }
             })
@@ -367,7 +367,7 @@ impl FirmwareFlasher {
                 Ok(info) => info.fw_version_current,
                 Err(e) => {
                     tracing::error!(
-                        device = %self.device_id, %e,
+                        device = %self.device_id, error = %e,
                         "failed to query device for observed firmware version"
                     );
                     None

--- a/crates/libmlx/src/firmware/reset.rs
+++ b/crates/libmlx/src/firmware/reset.rs
@@ -103,7 +103,7 @@ impl MlxFwResetRunner {
             return Err(FirmwareError::DryRun(self.build_command(&args)));
         }
 
-        tracing::debug!(cmd = %self.build_command(&args), "Executing mlxfwreset");
+        tracing::debug!(command = %self.build_command(&args), "Executing mlxfwreset");
 
         let output = Command::new(&self.mlxfwreset_path)
             .args(args)

--- a/crates/libmlx/src/firmware/source.rs
+++ b/crates/libmlx/src/firmware/source.rs
@@ -239,8 +239,8 @@ async fn resolve_http(
     file.flush().await.map_err(FirmwareError::Io)?;
 
     tracing::info!(
-        dest = %dest_path.display(),
-        bytes = bytes.len(),
+        destination_path = %dest_path.display(),
+        file_size_bytes = bytes.len(),
         "HTTP download complete"
     );
 
@@ -337,8 +337,8 @@ async fn resolve_ssh(
         .map_err(FirmwareError::Io)?;
 
     tracing::info!(
-        dest = %dest_path.display(),
-        bytes = decoded.len(),
+        destination_path = %dest_path.display(),
+        file_size_bytes = decoded.len(),
         "SSH download complete"
     );
 

--- a/crates/libnmxc/src/lib.rs
+++ b/crates/libnmxc/src/lib.rs
@@ -390,7 +390,7 @@ impl ChannelConnector for TlsChannelConnector {
                 .await?
         };
 
-        debug!("Connected to NMX-C at {}", endpoint.uri);
+        debug!(endpoint = %endpoint.uri, "Connected to NMX-C");
         Ok(channel)
     }
 

--- a/crates/libnmxm/src/lib.rs
+++ b/crates/libnmxm/src/lib.rs
@@ -356,7 +356,11 @@ impl NmxmApiClient {
                 source: e,
             })?;
         let response_body = String::from_utf8_lossy(&response_buffer).to_string();
-        debug!("RX {status_code} {}", truncate(&response_body, 1500));
+        debug!(
+            http_status = status_code.as_u16(),
+            response_body = truncate(&response_body, 1500),
+            "Received NMX-M response"
+        );
 
         if !status_code.is_success() {
             return Err(NmxmApiError::HTTPErrorCode {

--- a/crates/logfmt/benches/logfmt_layer.rs
+++ b/crates/logfmt/benches/logfmt_layer.rs
@@ -76,7 +76,7 @@ fn logfmt_subscriber() -> impl tracing::Subscriber {
 fn emit_line() {
     tracing::info!(
         machine_id = "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0",
-        state = "waiting_for_dpu_up",
+        machine_state = "waiting_for_dpu_up",
         previous_state = "dpu_reprovision",
         attempt = 3_i64,
         port = 8443_u64,

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -354,14 +354,14 @@ impl ApiClient {
             Ok(vpc_id_list) => {
                 match vpc_id_list.vpc_ids.len() {
                     0 => tracing::error!(
-                        "There are no VPC ids associated with {}. Should not have happened.",
-                        *vpc_name
+                        vpc_name = %*vpc_name,
+                        "No VPC IDs are associated with VPC name; this should not happen",
                     ),
                     1 => {}
                     _ => tracing::warn!(
-                        "There are {} VPC ids associated with {}. Should not have happened. Clean up DB and start over.",
-                        vpc_id_list.vpc_ids.len(),
-                        vpc_name
+                        vpc_id_count = vpc_id_list.vpc_ids.len(),
+                        vpc_name = %vpc_name,
+                        "Multiple VPC IDs are associated with VPC name; clean up the database and restart",
                     ),
                 }
 

--- a/crates/machine-a-tron/src/api_throttler.rs
+++ b/crates/machine-a-tron/src/api_throttler.rs
@@ -56,7 +56,10 @@ pub fn run(mut interval: Interval, api_client: ApiClient) -> ApiThrottler {
                                     chunk.iter().map(|id| **id).collect(),
                                 )
                                 .await
-                                .inspect_err(|e| tracing::error!("API failure getting machines: {e}")).unwrap_or_default();
+                                .inspect_err(|e| tracing::error!(
+                                    error = %e,
+                                    "API failure getting machines",
+                                )).unwrap_or_default();
 
                                 // Index the result by ID
                                 for m in machines {

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -92,7 +92,12 @@ impl BmcMockWrapper {
                 &self.app_context.app_config.interface,
             )
             .await
-            .inspect_err(|e| tracing::warn!("{}", e))
+            .inspect_err(|e| {
+                tracing::warn!(
+                    error = %e,
+                    "failed to add BMC mock address to interface",
+                )
+            })
             .map_err(MachineStateError::ListenAddressConfigError)?;
         }
 
@@ -138,7 +143,10 @@ impl BmcMockWrapper {
             None
         };
 
-        tracing::info!("Starting bmc mock on {:?}", address);
+        tracing::info!(
+            listen_address = ?address,
+            "Starting BMC mock",
+        );
 
         let tls_server_config = bmc_mock::tls::server_config(Some(certs_dir))?;
         let bmc_mock_router = self.bmc_mock_router.clone();

--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -44,7 +44,10 @@ pub async fn request_ip(
     api_client: ApiClient,
     request_info: DhcpRequestInfo,
 ) -> DhcpRelayResult<DhcpResponseInfo> {
-    tracing::debug!("requesting ip for mac: {}", request_info.mac_address);
+    tracing::debug!(
+        mac_address = %request_info.mac_address,
+        "Requesting IP address",
+    );
 
     let dhcp_record = api_client
         .discover_dhcp(
@@ -55,15 +58,18 @@ pub async fn request_ip(
         )
         .await
         .inspect_err(|e| {
-            tracing::warn!("discover_dhcp failed: {e}");
+            tracing::warn!(
+                error = %e,
+                "discover_dhcp failed",
+            );
         })?;
 
     tracing::info!(
-        "dhcp request for {} through relay {} got address {} (machine id {:?})",
-        request_info.mac_address,
-        request_info.relay_address,
-        dhcp_record.address,
-        dhcp_record.machine_id,
+        mac_address = %request_info.mac_address,
+        relay_address = %request_info.relay_address,
+        assigned_address = %dhcp_record.address,
+        machine_id = ?dhcp_record.machine_id,
+        "DHCP request received an address",
     );
 
     let interface_uuid = dhcp_record.machine_interface_id.ok_or_else(|| {

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -314,7 +314,10 @@ impl HostMachine {
                 }
             }
             Some(cmd) = self.bmc_control_rx.recv() => {
-                tracing::debug!("HOST set_system_power request: {cmd:?}");
+                tracing::debug!(
+                    command = ?cmd,
+                    "Received host power command",
+                );
                 match cmd {
                     BmcCommand::SetSystemPower { request, reply } => {
                         let response = self.set_system_power(request);
@@ -402,7 +405,7 @@ impl HostMachine {
     }
 
     fn set_system_power(&mut self, request: SystemPowerControl) -> SetSystemPowerResult {
-        tracing::debug!("Host set_system_power request: {request:?}");
+        tracing::debug!(?request, "Received host system-power request",);
 
         match request {
             // Force-restart does not restart DPUs
@@ -421,7 +424,8 @@ impl HostMachine {
                         _ = dpu.set_system_power(request).inspect_err(|e| {
                             tracing::error!(
                                 error = %e,
-                                "Could not send power request to DPU {dpu_index}",
+                                dpu_index,
+                                "Could not send power request to DPU",
                             )
                         });
                     }
@@ -663,8 +667,8 @@ impl HostMachineHandle {
         {
             Some(machine_id) => {
                 tracing::info!(
-                    "Attempting to delete machine with id: {} from db.",
-                    machine_id
+                    %machine_id,
+                    "Attempting to delete machine from database",
                 );
                 machine_id.to_string()
             }
@@ -672,7 +676,10 @@ impl HostMachineHandle {
                 // force_delete_machine also supports sending MAC address (which could break if there is 0 DPUs on this host)
                 match self.0.host_info.system_mac_address() {
                     Some(mac) => {
-                        tracing::info!("Attempting to delete machine with mac: {} from db.", mac);
+                        tracing::info!(
+                            mac_address = %mac,
+                            "Attempting to delete machine from database",
+                        );
                         mac.to_string()
                     }
                     None => {

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -135,7 +135,10 @@ impl MachineATron {
                         .as_mut()
                         .and_then(|m| m.remove(config_name.as_str()))
                     {
-                        tracing::info!("Recovering persisted machines for config {}", config_name);
+                        tracing::info!(
+                            config_name = %config_name,
+                            "Recovering persisted machines",
+                        );
                         persisted_machines
                             .into_iter()
                             .map(|persisted| -> eyre::Result<HostMachineHandle> {
@@ -158,7 +161,10 @@ impl MachineATron {
                             })
                             .collect::<Vec<_>>()
                     } else {
-                        tracing::info!("Constructing machines for config {}", config_name);
+                        tracing::info!(
+                            config_name = %config_name,
+                            "Constructing machines",
+                        );
                         (0..config.host_count)
                             .map(|_| {
                                 let mac_range = mac_address_pool.allocate_range_config()?;
@@ -256,7 +262,7 @@ impl MachineATron {
                     .inspect_err(|e| {
                         tracing::warn!(
                             error=?e,
-                            hw_type=%host_info.hw_type,
+                            hardware_type = %host_info.hw_type,
                             "error adding expected inventory record, likely already ingested"
                         );
                     })
@@ -264,8 +270,8 @@ impl MachineATron {
             }
         } else {
             tracing::info!(
-                "register_expected_machines=false; skipping auto-registration of {} mock host(s)",
-                machines.len()
+                machine_count = machines.len(),
+                "register_expected_machines=false; skipping auto-registration of mock host(s)",
             );
         }
 
@@ -291,7 +297,10 @@ impl MachineATron {
         {
             let host_port_str =
                 format!("{}:{}", host_str, self.app_context.app_config.bmc_mock_port);
-            tracing::info!("Configuring carbide API to use {host_port_str} as bmc_proxy",);
+            tracing::info!(
+                bmc_proxy_address = %host_port_str,
+                "Configuring carbide API to use as bmc_proxy",
+            );
             _ = self
                 .app_context
                 .api_client()
@@ -322,7 +331,10 @@ impl MachineATron {
                             subnet_handles.push(subnet);
                         }
                         Err(e) => {
-                            tracing::error!("Error creating network segment: {}", e);
+                            tracing::error!(
+                                error = %e,
+                                "Error creating network segment",
+                            );
                         }
                     }
                 }
@@ -397,7 +409,10 @@ impl MachineATron {
                             tracing::info!("allocate_instance was successful. ");
                         }
                         Err(e) => {
-                            tracing::info!("allocate_instance failed with {} ", e);
+                            tracing::info!(
+                                error = %e,
+                                "allocate_instance failed",
+                            );
                         }
                     };
                 }
@@ -408,21 +423,27 @@ impl MachineATron {
         // It rather soft deletes the VPCs by updating the deleted column of a vpc.
         if self.app_context.app_config.cleanup_on_quit {
             for vpc in vpc_handles {
-                tracing::info!("Attempting to delete VPC with id: {} from db.", vpc.vpc_id);
+                tracing::info!(
+                    vpc_id = %vpc.vpc_id,
+                    "Attempting to delete VPC from database",
+                );
                 if let Err(e) = self
                     .app_context
                     .forge_api_client
                     .delete_vpc(vpc.vpc_id)
                     .await
                 {
-                    tracing::error!("Delete VPC Api call failed with {}", e)
+                    tracing::error!(
+                        error = %e,
+                        "Delete VPC API call failed",
+                    )
                 }
             }
 
             for subnet in subnet_handles {
                 tracing::info!(
-                    "Attempting to delete network segment with id: {} from db.",
-                    subnet.segment_id
+                    network_segment_id = %subnet.segment_id,
+                    "Attempting to delete network segment from database",
                 );
                 if let Err(e) = self
                     .app_context
@@ -430,7 +451,10 @@ impl MachineATron {
                     .delete_network_segment(subnet.segment_id)
                     .await
                 {
-                    tracing::error!("Delete network segment Api call failed with {}", e)
+                    tracing::error!(
+                        error = %e,
+                        "Delete network segment API call failed",
+                    )
                 }
             }
         }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -496,7 +496,7 @@ impl MachineStateMachine {
     fn fsm_event(&mut self, event: Event) {
         let old_state = self.fsm;
         let (new_state, actions) = self.fsm.event(event);
-        tracing::info!(?old_state, ?event, ?new_state, ?actions, "machine FSM step");
+        tracing::info!(previous_state = ?old_state, ?event, next_state = ?new_state, ?actions, "machine FSM step");
         actions
             .into_iter()
             .for_each(|action| self.actions.push_back(action));
@@ -525,15 +525,16 @@ impl MachineStateMachine {
         .await
         .inspect(|_| {
             tracing::debug!(
-                "BMC DHCP Request for {} took {}ms",
-                self.machine_info.bmc_mac_address(),
-                start.elapsed().as_millis()
+                bmc_mac_address = %self.machine_info.bmc_mac_address(),
+                elapsed_milliseconds = start.elapsed().as_millis(),
+                "BMC DHCP request completed",
             );
         })
         .inspect_err(|err| {
             tracing::warn!(
-                "BMC DHCP Request failed after {}ms: {err}",
-                start.elapsed().as_millis()
+                elapsed_milliseconds = start.elapsed().as_millis(),
+                error = %err,
+                "BMC DHCP request failed",
             );
         })
     }
@@ -551,11 +552,11 @@ impl MachineStateMachine {
         let machine_dhcp_info_result = if let Some(DpuDhcpRelay::HostEnd(relay_tx)) =
             &self.dpu_dhcp_relay
         {
-            tracing::debug!(%primary_mac, "requesting machine DHCP through DPU relay");
+            tracing::debug!(primary_mac_address = %primary_mac, "requesting machine DHCP through DPU relay");
             let (reply_tx, reply_rx) = oneshot::channel();
             if relay_tx.send(reply_tx).is_err() {
                 tracing::warn!(
-                    %primary_mac,
+                    primary_mac_address = %primary_mac,
                     "DPU DHCP relay request channel is closed; retrying after relay state reconciliation"
                 );
                 return Err(MachineStateError::DpuDhcpRelayUnavailable);
@@ -566,15 +567,15 @@ impl MachineStateMachine {
                 Ok(Ok(result)) => result,
                 Ok(Err(_)) => {
                     tracing::warn!(
-                        %primary_mac,
+                        primary_mac_address = %primary_mac,
                         "DPU DHCP relay response was canceled; retrying after relay state reconciliation"
                     );
                     return Err(MachineStateError::DpuDhcpRelayUnavailable);
                 }
                 Err(_) => {
                     tracing::warn!(
-                        %primary_mac,
-                        timeout_ms = DPU_DHCP_RELAY_TIMEOUT.as_millis(),
+                        primary_mac_address = %primary_mac,
+                        timeout_milliseconds = DPU_DHCP_RELAY_TIMEOUT.as_millis(),
                         "DPU DHCP relay response timed out; retrying after relay state reconciliation"
                     );
                     return Err(MachineStateError::DpuDhcpRelayUnavailable);
@@ -587,7 +588,7 @@ impl MachineStateMachine {
                 self.config.host_inband_dhcp_relay_address,
             );
             tracing::debug!(
-                %primary_mac,
+                primary_mac_address = %primary_mac,
                 %direct_relay_address,
                 "requesting machine DHCP directly"
             );
@@ -604,16 +605,17 @@ impl MachineStateMachine {
         machine_dhcp_info_result
             .inspect(|_| {
                 tracing::debug!(
-                    %primary_mac,
-                    elapsed_ms = start.elapsed().as_millis(),
+                    primary_mac_address = %primary_mac,
+                    elapsed_milliseconds = start.elapsed().as_millis(),
                     "machine DHCP request completed"
                 );
             })
             .map_err(|err| {
                 tracing::debug!(
-                    %primary_mac,
-                    elapsed_ms = start.elapsed().as_millis(),
-                    "machine DHCP request failed: {err}"
+                    primary_mac_address = %primary_mac,
+                    elapsed_milliseconds = start.elapsed().as_millis(),
+                    error = %err,
+                    "machine DHCP request failed"
                 );
                 err.into()
             })
@@ -730,9 +732,9 @@ impl MachineStateMachine {
             return Err(MachineStateError::MachineNotFound(machine_id));
         };
         tracing::trace!(
-            "get action took {}ms; action={:?}",
-            start.elapsed().as_millis(),
-            control_response.action,
+            elapsed_milliseconds = start.elapsed().as_millis(),
+            action = ?control_response.action,
+            "forge_agent_control action received",
         );
 
         match &control_response.action {
@@ -758,9 +760,9 @@ impl MachineStateMachine {
             Some(Action::Noop(_)) => {}
             _ => {
                 tracing::warn!(
-                    "Unknown action from forge_agent_control: {:?} for OS image {}",
-                    control_response.action,
-                    os_image,
+                    action = ?control_response.action,
+                    os_image = %os_image,
+                    "Unknown forge_agent_control action for OS image",
                 );
             }
         }
@@ -901,7 +903,10 @@ impl MachineStateMachine {
             )
             .await?;
 
-        tracing::trace!("discover_machine took {}ms", start.elapsed().as_millis());
+        tracing::trace!(
+            elapsed_milliseconds = start.elapsed().as_millis(),
+            "discover_machine completed",
+        );
         Ok(machine_discovery_result)
     }
 
@@ -998,7 +1003,7 @@ impl MachineStateMachine {
             GracefulShutdown | ForceOff => self.fsm_event(Event::PowerOff),
             PushPowerButton | Nmi | Suspend | Pause | Resume => {
                 let msg = format!("Machine-a-tron mock: unsupported power request {request:?}",);
-                tracing::warn!("{msg}");
+                tracing::warn!(?request, "unsupported machine-a-tron mock power request",);
                 return Err(SetSystemPowerError::BadRequest(msg));
             }
         };
@@ -1080,7 +1085,10 @@ impl MachineStateMachine {
             .discovery_completed(*machine_id)
             .await
             .map_err(ClientApiError::InvocationError)?;
-        tracing::trace!("discovery_complete took {}ms", start.elapsed().as_millis());
+        tracing::trace!(
+            elapsed_milliseconds = start.elapsed().as_millis(),
+            "discovery_complete completed",
+        );
         Ok(())
     }
 

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -67,7 +67,10 @@ pub async fn forge_agent_control(
             if e.code() == tonic::Code::NotFound {
                 return None;
             }
-            tracing::warn!("Error getting control action: {e}");
+            tracing::warn!(
+                error = %e,
+                "Error getting control action",
+            );
             Some(ForgeAgentControlResponse::noop())
         }
     }
@@ -116,15 +119,15 @@ pub async fn send_pxe_boot_request(
             PxeResponse::Scout
         } else {
             tracing::error!(
-                "Could not determine what to do with kernel URL returned by PXE script, will treat as 'exit': {}",
-                pxe_script
+                pxe_script = %pxe_script,
+                "Could not determine what to do with kernel URL returned by PXE script, will treat as 'exit'",
             );
             PxeResponse::Exit
         }
     } else {
         tracing::error!(
-            "Could not determine what to do with PXE script (no kernel line, no exit line), will treat as 'exit': {}",
-            pxe_script
+            pxe_script = %pxe_script,
+            "Could not determine what to do with PXE script (no kernel line, no exit line), will treat as 'exit'",
         );
         PxeResponse::Exit
     };
@@ -154,14 +157,18 @@ pub async fn add_address_to_interface(
 ) -> Result<(), AddressConfigError> {
     if interface_has_address(interface, address).await? {
         tracing::info!(
-            "Skipping adding address {} to interface {}, as it is already configured.",
-            address,
-            interface
+            ip_address = %address,
+            interface_name = %interface,
+            "Skipping address addition; already configured",
         );
         return Ok(());
     }
 
-    tracing::info!("Adding address {} to interface {}", address, interface);
+    tracing::info!(
+        ip_address = %address,
+        interface_name = %interface,
+        "Adding address",
+    );
     let wrapper_cmd = find_sudo_command();
     let mut cmd = tokio::process::Command::new(wrapper_cmd);
     #[cfg(not(target_os = "macos"))]

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -104,8 +104,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         args.client_key_path,
         file_config.as_ref(),
     );
-    let proxy =
-        get_proxy_info().inspect_err(|e| tracing::error!("Failed to get proxy info: {}", e))?;
+    let proxy = get_proxy_info().inspect_err(|e| {
+        tracing::error!(
+            error = %e,
+            "Failed to get proxy info",
+        )
+    })?;
 
     let mut forge_client_config =
         ForgeClientConfig::new(forge_root_ca_path.clone(), Some(forge_client_cert));
@@ -136,8 +140,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .entries;
 
     tracing::info!(
-        "Got desired firmware versions from the server: {:?}",
-        desired_firmware_versions
+        desired_firmware_versions = ?desired_firmware_versions,
+        "Got desired firmware versions from the server",
     );
 
     let bmc_mock_port = app_config.bmc_mock_port;
@@ -184,7 +188,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
 
     let info = app_context.forge_api_client.version(false).await?;
-    tracing::info!("version: {}", info.build_version);
+    tracing::info!(
+        build_version = %info.build_version,
+        "machine-a-tron version",
+    );
 
     let mut mat = MachineATron::new(app_context.clone());
 
@@ -282,7 +289,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let mut tui = Tui::new(ui_rx, quit_rx, app_tx, tui_host_logs);
             _ = tui.run().await.inspect_err(|e| {
                 let estr = format!("Error running TUI: {e}");
-                tracing::error!(estr);
+                tracing::error!(error = %e, "TUI failed");
                 eprintln!("{estr}"); // dump it to stderr in case logs are getting redirected
             })
         }));
@@ -310,13 +317,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(tui_handle) = tui_handle {
         if let Some(tui_quit_tx) = tui_quit_tx.as_ref() {
-            _ = tui_quit_tx
-                .try_send(())
-                .inspect_err(|e| tracing::warn!("Could not send quit signal to TUI: {e}"));
+            _ = tui_quit_tx.try_send(()).inspect_err(|e| {
+                tracing::warn!(
+                    error = %e,
+                    "Could not send quit signal to TUI",
+                )
+            });
         }
         tui_handle
             .await
-            .inspect_err(|e| tracing::warn!("Error running TUI: {e}"))
+            .inspect_err(|e| {
+                tracing::warn!(
+                    error = %e,
+                    "Error running TUI",
+                )
+            })
             .ok();
     }
 

--- a/crates/machine-a-tron/src/mock_ssh_server.rs
+++ b/crates/machine-a-tron/src/mock_ssh_server.rs
@@ -119,7 +119,10 @@ impl Server {
                             tokio::spawn(async move {
                                 if config.nodelay
                                     && let Err(e) = socket.set_nodelay(true) {
-                                        tracing::warn!("set_nodelay() failed: {e:?}");
+                                        tracing::warn!(
+                                            error = ?e,
+                                            "set_nodelay failed",
+                                        );
                                     }
 
                                 let session = match run_stream(config, socket, handler).await {
@@ -283,7 +286,8 @@ impl server::Handler for MockSshHandler {
                 Ok(server::Auth::Accept)
             } else {
                 tracing::info!(
-                    "got incorrect auth_password, rejecting. user={user}, password={password}"
+                    user = %user,
+                    "Incorrect SSH password; rejecting authentication",
                 );
                 Ok(server::Auth::Reject {
                     proceed_with_methods: None,
@@ -292,7 +296,8 @@ impl server::Handler for MockSshHandler {
             }
         } else {
             tracing::info!(
-                "configured to accept any credentials, accepting user={user}, password={password}"
+                user = %user,
+                "Accepting SSH credentials because any credentials are allowed",
             );
             Ok(server::Auth::Accept)
         }
@@ -367,8 +372,8 @@ impl server::Handler for MockSshHandler {
                         (b"\x1c", PromptBehavior::Dell) => {
                             // ssh-console should have prevented this, make it a warning.
                             tracing::warn!(
-                                "Got ctrl+\\ in system console, dropping to BMC prompt {:?}",
-                                self.console_state
+                                console_state = ?self.console_state,
+                                "Got ctrl+\\ in system console, dropping to BMC prompt",
                             );
                             // ctrl+\
                             self.console_state = ConsoleState::Bmc;

--- a/crates/machine-a-tron/src/subnet.rs
+++ b/crates/machine-a-tron/src/subnet.rs
@@ -48,7 +48,10 @@ impl Subnet {
             .create_network_segment(&vpc.metadata.name, vpc.network_virtualization_type)
             .await
             .map_err(|e| {
-                tracing::error!("Error creating network segment: {}", e);
+                tracing::error!(
+                    error = %e,
+                    "Error creating network segment",
+                );
                 Status::internal("Failed to create network segment.")
             })?;
 
@@ -68,7 +71,12 @@ impl Subnet {
             _ = ui_event_tx
                 .send(UiUpdate::Subnet(details))
                 .await
-                .inspect_err(|e| tracing::warn!("Error sending TUI event: {}", e));
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "Error sending TUI event",
+                    )
+                });
         }
 
         Ok(new_subnet)

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -267,7 +267,10 @@ impl Tui {
                 .1
             }
             _ => {
-                tracing::warn!("Unexpected event: {:?}", event);
+                tracing::warn!(
+                    event = ?event,
+                    "Unexpected event",
+                );
                 false
             }
         }
@@ -459,7 +462,10 @@ impl Tui {
                         Some(Ok(event)) => {
                             list_updated = self.handle_event(event).await;
                         }
-                        Some(Err(e)) => tracing::warn!("Error: {:?}", e),
+                        Some(Err(e)) => tracing::warn!(
+                            error = ?e,
+                            "TUI error",
+                        ),
                         None => break,
                     }
                 }

--- a/crates/machine-a-tron/src/vpc.rs
+++ b/crates/machine-a-tron/src/vpc.rs
@@ -63,7 +63,12 @@ impl Vpc {
             _ = ui_event_tx
                 .send(UiUpdate::Vpc(details))
                 .await
-                .inspect_err(|e| tracing::warn!("Error sending TUI event: {}", e));
+                .inspect_err(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        "Error sending TUI event",
+                    )
+                });
         }
 
         new_vpc

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -351,7 +351,7 @@ impl DpfSdkOps {
             .watcher()
             .on_dpu_event(|event| async move {
                 tracing::debug!(
-                    dpu = %event.dpu_name,
+                    dpu_name = %event.dpu_name,
                     device_name = %event.device_name,
                     node = %event.node_name,
                     phase = ?event.phase,
@@ -366,7 +366,7 @@ impl DpfSdkOps {
                     async move {
                         tracing::info!(
                             node = %event.node_name,
-                            host = %event.host_bmc_ip,
+                            host_bmc_ip_address = %event.host_bmc_ip,
                             "DPF reboot required"
                         );
                         enqueue_host(&db_pool, &event.node_name, "reboot").await
@@ -379,7 +379,7 @@ impl DpfSdkOps {
                     let db_pool = db_pool.clone();
                     async move {
                         tracing::info!(
-                            dpu = %event.dpu_name,
+                            dpu_name = %event.dpu_name,
                             device_name = %event.device_name,
                             node = %event.node_name,
                             "DPF DPU ready"
@@ -406,7 +406,7 @@ impl DpfSdkOps {
                     let db_pool = db_pool.clone();
                     async move {
                         tracing::error!(
-                            dpu = %event.dpu_name,
+                            dpu_name = %event.dpu_name,
                             device_name = %event.device_name,
                             node = %event.node_name,
                             "DPF DPU entered error phase"
@@ -447,7 +447,7 @@ async fn enqueue_host(db_pool: &PgPool, node_name: &str, reason: &str) -> Result
     };
 
     let Some(host_machine_id) = host_machine_id else {
-        tracing::warn!(node = %node_name, %bmc_mac, reason, "Could not find host for DPF node");
+        tracing::warn!(node = %node_name, bmc_mac_address = %bmc_mac, reason, "Could not find host for DPF node");
         return Ok(());
     };
 
@@ -476,7 +476,7 @@ async fn enqueue_host(db_pool: &PgPool, node_name: &str, reason: &str) -> Result
             DpfError::InvalidState(format!("Failed to enqueue machine {}: {e}", host.id))
         })?;
 
-    tracing::info!(node = %node_name, host = %host.id, reason, "Enqueued host for DPF state handling");
+    tracing::info!(node = %node_name, machine_id = %host.id, reason, "Enqueued host for DPF state handling");
     Ok(())
 }
 
@@ -590,8 +590,9 @@ impl DpfOperations for DpfSdkOps {
         for m in mismatches {
             let Some(machine_id_str) = m.dpu_labels.get(DPU_MACHINE_ID_LABEL) else {
                 tracing::warn!(
-                    dpu = %m.dpu_cr_name,
-                    "Outdated DPU missing {DPU_MACHINE_ID_LABEL} label; skipping"
+                    dpu_name = %m.dpu_cr_name,
+                    label = DPU_MACHINE_ID_LABEL,
+                    "Outdated DPU missing label; skipping"
                 );
                 continue;
             };
@@ -599,10 +600,11 @@ impl DpfOperations for DpfSdkOps {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::warn!(
-                        dpu = %m.dpu_cr_name,
+                        dpu_name = %m.dpu_cr_name,
                         label_value = %machine_id_str,
+                        label = DPU_MACHINE_ID_LABEL,
                         error = %e,
-                        "Outdated DPU has invalid {DPU_MACHINE_ID_LABEL} label; skipping"
+                        "Outdated DPU has invalid label; skipping"
                     );
                     continue;
                 }

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -740,12 +740,11 @@ impl MachineStateHandler {
             && let Some((machine_id, details)) = get_failed_state(mh_snapshot)
         {
             tracing::error!(
-                %machine_id,
-                "ManagedHost {}/{} (failed machine: {}) is moved to Failed state with cause: {:?}",
-                mh_snapshot.host_snapshot.id,
-                get_display_ids(&mh_snapshot.dpu_snapshots),
-                machine_id,
-                details
+                machine_id = %mh_snapshot.host_snapshot.id,
+                dpu_machine_ids = %get_display_ids(&mh_snapshot.dpu_snapshots),
+                failed_machine_id = %machine_id,
+                failure_details = ?details,
+                "ManagedHost is moved to Failed state"
             );
             let next_state = match mh_state {
                 ManagedHostState::Assigned { .. } => ManagedHostState::Assigned {
@@ -981,9 +980,9 @@ impl MachineStateHandler {
                     && mh_snapshot.host_snapshot.bios_password_set_time.is_none()
                 {
                     tracing::info!(
-                        "transitioning legacy {} host {} to UefiSetupState::UnlockHost while it is in ManagedHostState::Ready so that the BIOS password can be configured",
-                        mh_snapshot.host_snapshot.bmc_vendor(),
-                        mh_snapshot.host_snapshot.id
+                        vendor = %mh_snapshot.host_snapshot.bmc_vendor(),
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "transitioning legacy host to UefiSetupState::UnlockHost while it is in ManagedHostState::Ready so that the BIOS password can be configured"
                     );
                     return Ok(StateHandlerOutcome::transition(
                         ManagedHostState::HostInit {
@@ -1483,12 +1482,11 @@ impl MachineStateHandler {
                         // Do nothing.
                         // Handle error cause and decide how to recover if possible.
                         tracing::error!(
-                            %machine_id,
-                            "ManagedHost {} is in Failed state with machine/cause {}/{}. Failed at: {}, Ignoring.",
-                            host_machine_id,
-                            machine_id,
-                            details.cause,
-                            details.failed_at,
+                            machine_id = %host_machine_id,
+                            failed_machine_id = %machine_id,
+                            failure_cause = %details.cause,
+                            failed_at = %details.failed_at,
+                            "ManagedHost is in Failed state. Ignoring.",
                         );
                         // TODO: Should this be StateHandlerError::ManualInterventionRequired ?
                         Ok(StateHandlerOutcome::do_nothing())
@@ -1779,7 +1777,11 @@ impl MachineStateHandler {
         if let Err(err) =
             handler_host_power_control(state, ctx, SystemPowerControl::ForceRestart).await
         {
-            tracing::error!(%host_machine_id, "Host reboot failed with error: {err}");
+            tracing::error!(
+                machine_id = %host_machine_id,
+                error = %err,
+                "Host reboot failed"
+            );
         }
         set_managed_host_topology_update_needed(
             ctx.pending_db_writes,
@@ -2043,7 +2045,10 @@ async fn handle_restart_verification(
                     verified: Some(true),
                     attempts: 0,
                 });
-            tracing::info!("Restart verified for host {}", mh_snapshot.host_snapshot.id);
+            tracing::info!(
+                machine_id = %mh_snapshot.host_snapshot.id,
+                "Restart verified for host"
+            );
             return Ok(None);
         }
 
@@ -2062,9 +2067,9 @@ async fn handle_restart_verification(
                 });
 
             tracing::info!(
-                "Issued force-restart for host {} after {} failed verifications",
-                mh_snapshot.host_snapshot.id,
-                verification_attempts
+                machine_id = %mh_snapshot.host_snapshot.id,
+                verification_attempt_count = verification_attempts,
+                "Issued force-restart for host after failed verifications"
             );
             return Ok(None);
         }
@@ -2148,7 +2153,7 @@ async fn handle_restart_verification(
                         verified: Some(true),
                         attempts: 0,
                     });
-                tracing::info!("Restart verified for DPU {}", dpu.id);
+                tracing::info!(machine_id = %dpu.id, "Restart verified for DPU");
             } else if verification_attempts >= MAX_VERIFICATION_ATTEMPTS {
                 dpu_redfish_client
                     .power(SystemPowerControl::ForceRestart)
@@ -2164,9 +2169,9 @@ async fn handle_restart_verification(
                     });
 
                 tracing::info!(
-                    "Issued force-restart for DPU {} after {} failed verifications",
-                    dpu.id,
-                    verification_attempts
+                    machine_id = %dpu.id,
+                    verification_attempt_count = verification_attempts,
+                    "Issued force-restart for DPU after failed verifications"
                 );
             } else {
                 ctx.pending_db_writes
@@ -2216,7 +2221,7 @@ pub async fn check_restart_in_logs(
     let logs = redfish_client.get_bmc_event_log(Some(restart_time)).await?;
 
     for log in &logs {
-        tracing::debug!("BMC log message: {}", log.message);
+        tracing::debug!(bmc_message = %log.message, "BMC log message");
     }
 
     let restart_found = logs.iter().any(|log| {
@@ -2280,7 +2285,11 @@ async fn are_dpus_up_trigger_reboot_if_needed(
                 .await
             {
                 Ok(_) => {}
-                Err(e) => tracing::warn!("could not reboot dpu {}: {e}", dpu_snapshot.id),
+                Err(e) => tracing::warn!(
+                    machine_id = %dpu_snapshot.id,
+                    error = %e,
+                    "could not reboot dpu"
+                ),
             }
             return false;
         }
@@ -2313,7 +2322,7 @@ impl StateHandler for MachineStateHandler {
             .is_empty()
             && mh_snapshot.dpu_snapshots.is_empty()
         {
-            tracing::error!("No DPU snapshot found for host {}", host_machine_id);
+            tracing::error!(machine_id = %host_machine_id, "No DPU snapshot found for host");
             return Err(StateHandlerError::GenericError(eyre!(
                 "No DPU snapshot found."
             )));
@@ -2522,9 +2531,9 @@ async fn handle_bfb_install_state(
                 .await
                 .map_err(|e| redfish_error("update_firmware_simple_update", e))?;
             tracing::info!(
-                "DPU {} OS install task {} submitted.",
-                dpu_snapshot.id,
-                task.id
+                dpu_machine_id = %dpu_snapshot.id,
+                task_id = %task.id,
+                "DPU OS install task submitted."
             );
             Ok(StateHandlerOutcome::transition(
                 next_state_resolver.next_bfb_install_state(
@@ -2545,15 +2554,20 @@ async fn handle_bfb_install_state(
                 .map_err(|e| redfish_error("get_task", e))?;
 
             tracing::info!(
-                "DPU {} OS install task {}: {:#?}",
-                dpu_snapshot.id,
-                task.id,
-                task.task_state
+                dpu_machine_id = %dpu_snapshot.id,
+                task_id = %task.id,
+                task_state = ?task.task_state,
+                "DPU OS install task"
             );
 
             match task.task_state {
                 Some(TaskState::Completed) => {
-                    tracing::info!("Install BFB on {:#?} completed", dpu_snapshot.bmc_addr());
+                    tracing::info!(
+                        dpu_machine_id = %dpu_snapshot.id,
+                        task_id = %task_id,
+                        bmc_address = ?dpu_snapshot.bmc_addr(),
+                        "Install BFB completed"
+                    );
                     let next_state = next_state_resolver.next_bfb_install_state(
                         &state.managed_state,
                         &InstallDpuOsState::Completed,
@@ -2568,7 +2582,12 @@ async fn handle_bfb_install_state(
                         dpu_snapshot.bmc_addr(),
                         task.messages.iter().map(|t| t.message.clone()).join("\n")
                     );
-                    tracing::error!(msg);
+                    tracing::error!(
+                        dpu_machine_id = %dpu_snapshot.id,
+                        %task_id,
+                        reason = %msg,
+                        "BFB install task failed",
+                    );
                     let next_state = next_state_resolver.next_bfb_install_state(
                         &state.managed_state,
                         &InstallDpuOsState::InstallationError { msg },
@@ -2593,7 +2612,13 @@ async fn handle_bfb_install_state(
                         task_state,
                         task.messages.iter().map(|t| t.message.clone()).join("\n")
                     );
-                    tracing::error!(msg);
+                    tracing::error!(
+                        dpu_machine_id = %dpu_snapshot.id,
+                        %task_id,
+                        task_state = ?task_state,
+                        reason = %msg,
+                        "BFB install task failed",
+                    );
                     let next_state = next_state_resolver.next_bfb_install_state(
                         &state.managed_state,
                         &InstallDpuOsState::InstallationError { msg },
@@ -2881,8 +2906,9 @@ async fn handle_dpu_reprovision(
             // Host is not powered-off yet. Try again.
             if power_state != libredfish::PowerState::Off {
                 tracing::error!(
-                    "Machine {} is still not power-off state. Turning off for host again.",
-                    state.host_snapshot.id
+                    machine_id = %state.host_snapshot.id,
+                    %power_state,
+                    "Host is still not powered off; forcing power off again"
                 );
                 handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
 
@@ -2958,7 +2984,7 @@ async fn handle_dpu_reprovision(
             for dsnapshot in &state.dpu_snapshots {
                 if !is_dpu_up(state, dsnapshot) {
                     let msg = format!("Waiting for DPU {} to come up", dsnapshot.id);
-                    tracing::warn!("{msg}");
+                    tracing::warn!(machine_id = %dsnapshot.id, "Waiting for DPU to come up");
 
                     let mut reboot_status = None;
                     // Only the DPU handled by this invocation should trigger its
@@ -2985,7 +3011,10 @@ async fn handle_dpu_reprovision(
                     dsnapshot,
                     state.host_snapshot.network_config.version,
                 ) {
-                    tracing::warn!("Waiting for network to be ready for DPU {}", dsnapshot.id);
+                    tracing::warn!(
+                        machine_id = %dsnapshot.id,
+                        "Waiting for network to be ready for DPU"
+                    );
 
                     // The install path already requested a DPU reboot. If this
                     // specific DPU remains unsynced, let trigger_reboot_if_needed
@@ -3240,8 +3269,8 @@ async fn handle_dpu_reprovision(
             // At this point, all of the host's DPU have finished the NIC FW Update, been power cycled, and the ARM has come up on the DPU.
             if state.host_snapshot.bmc_vendor().is_lenovo() {
                 tracing::info!(
-                    "Initiating BMC reset of lenovo machine {}",
-                    state.host_snapshot.id
+                    machine_id = %state.host_snapshot.id,
+                    "Initiating BMC reset of lenovo machine"
                 );
 
                 let redfish_client = ctx
@@ -3251,8 +3280,9 @@ async fn handle_dpu_reprovision(
 
                 if let Err(redfish_error) = redfish_client.bmc_reset().await {
                     tracing::warn!(
-                        "Failed to reboot BMC for {} through redfish, will try ipmitool: {redfish_error}",
-                        &state.host_snapshot.id
+                        machine_id = %state.host_snapshot.id,
+                        error = %redfish_error,
+                        "Failed to reboot BMC through redfish, will try ipmitool"
                     );
 
                     let bmc_mac_address = state.host_snapshot.bmc_info.mac.ok_or_else(|| {
@@ -3281,8 +3311,9 @@ async fn handle_dpu_reprovision(
                         .await
                     {
                         tracing::warn!(
-                            "Failed to reset BMC for {} through IPMI tool: {ipmitool_error}",
-                            &state.host_snapshot.id
+                            machine_id = %state.host_snapshot.id,
+                            error = %ipmitool_error,
+                            "Failed to reset BMC through IPMI tool"
                         );
 
                         return Err(StateHandlerError::GenericError(eyre!(
@@ -3583,14 +3614,22 @@ async fn check_fw_component_version(
         let inventory = match redfish_client.get_firmware(inventory_id).await {
             Ok(inventory) => inventory,
             Err(e) => {
-                tracing::error!(machine_id=%dpu_snapshot.id, "redfish command get_firmware error {}", e.to_string());
+                tracing::error!(
+                    machine_id = %dpu_snapshot.id,
+                    error = %e,
+                    "redfish command get_firmware error"
+                );
                 return Err(redfish_error("get_firmware", e));
             }
         };
 
         if inventory.version.is_none() {
             let msg = format!("Unknown {component_name:?} version");
-            tracing::error!(machine_id=%dpu_snapshot.id, msg);
+            tracing::error!(
+                machine_id = %dpu_snapshot.id,
+                component = ?component_name,
+                "Unknown firmware version",
+            );
             return Err(StateHandlerError::FirmwareUpdateError(eyre!(msg)));
         };
 
@@ -3621,20 +3660,20 @@ async fn check_fw_component_version(
             {
                 // For this case need to run host power cycle
                 tracing::info!(
-                    machine_id=%dpu_snapshot.id,
-                    "Need to launch host power cycle to update CEC FW from {} to {}",
-                    cur_version,
-                    expected_version
+                    machine_id = %dpu_snapshot.id,
+                    current_version = %cur_version,
+                    expected_version = %expected_version,
+                    "Need to launch host power cycle to update CEC FW"
                 );
                 return Ok(None);
             }
 
             tracing::debug!(
-                machine_id=%dpu_snapshot.id,
-                "{:#?} FW not yet at the expected version. Expected: {}, Current: {}",
-                component,
-                expected_version,
-                cur_version,
+                machine_id = %dpu_snapshot.id,
+                component = ?component,
+                expected_version = %expected_version,
+                current_version = %cur_version,
+                "FW not yet at the expected version",
             );
 
             // Don't return Error. In case of the error, reboot time won't be updated in db.
@@ -3647,10 +3686,10 @@ async fn check_fw_component_version(
         }
 
         tracing::info!(
-            machine_id=%dpu_snapshot.id,
-            "{:#?} FW updated successfully to {}",
-            component,
-            expected_version,
+            machine_id = %dpu_snapshot.id,
+            component = ?component,
+            expected_version = %expected_version,
+            "FW updated successfully",
         );
 
         // BMC FW version need to update in machine_topology->bmc_info
@@ -3665,8 +3704,11 @@ async fn check_fw_component_version(
                 .get_firmware("DPU_UEFI")
                 .await
                 .inspect_err(|e| {
-                    tracing::error!("redfish command get_firmware error {}", e.to_string());
-                    tracing::error!(machine_id=%dpu_snapshot.id, "redfish command get_firmware error {}", e.to_string());
+                    tracing::error!(
+                        machine_id = %dpu_snapshot.id,
+                        error = %e,
+                        "redfish command get_firmware error"
+                    );
                 })
                 .ok()
                 .and_then(|uefi| uefi.version)
@@ -3841,10 +3883,17 @@ impl DpuMachineStateHandler {
                 Ok(StateHandlerOutcome::transition(next_state))
             }
             DpuDiscoveringState::EnableRshim => {
-                let _ = dpu_redfish_client
+                dpu_redfish_client
                     .enable_rshim_bmc()
                     .await
-                    .map_err(|e| tracing::info!("failed to enable rshim on DPU {e}"));
+                    .inspect_err(|e| {
+                        tracing::info!(
+                            dpu_machine_id = %dpu_machine_id,
+                            error = %e,
+                            "failed to enable rshim on DPU"
+                        )
+                    })
+                    .ok();
 
                 let next_dpu_discovering_state =
                     DpuDiscoveringState::next_substate_based_on_bfb_support(
@@ -3854,13 +3903,14 @@ impl DpuMachineStateHandler {
                     );
 
                 tracing::info!(
-                    "DPU {dpu_machine_id} (BMC FW version: {}); next_state: {}.",
-                    dpu_snapshot
+                    dpu_machine_id = %dpu_machine_id,
+                    bmc_firmware_version = %dpu_snapshot
                         .bmc_info
                         .firmware_version
                         .clone()
                         .unwrap_or("unknown".to_string()),
-                    next_dpu_discovering_state
+                    next_state = %next_dpu_discovering_state,
+                    "DPU discovery state selected."
                 );
 
                 let next_state =
@@ -4004,8 +4054,8 @@ impl DpuMachineStateHandler {
                 }
 
                 tracing::debug!(
-                    "ManagedHostState::DPUNotReady::Init: firmware update enabled = {}",
-                    self.dpu_nic_firmware_initial_update_enabled
+                    firmware_update_enabled = self.dpu_nic_firmware_initial_update_enabled,
+                    "ManagedHostState::DPUNotReady::Init"
                 );
 
                 // All DPUs are discovered. Reboot them to proceed.
@@ -4101,7 +4151,11 @@ impl DpuMachineStateHandler {
                             "failed to create redfish client for DPU {}, potentially because we turned the host off as part of error handling in this state. err: {}",
                             dpu_snapshot.id, e
                         );
-                        tracing::warn!(msg);
+                        tracing::warn!(
+                            machine_id = %dpu_snapshot.id,
+                            error = %e,
+                            "failed to create redfish client for DPU, potentially because we turned the host off as part of error handling in this state",
+                        );
                         // If we cannot create a redfish client for the DPU, this function call will never result in an actual DPU reboot.
                         // The only side effect is turning the DPU's host back on if we turned it off earlier.
                         let reboot_status = trigger_reboot_if_needed(
@@ -4157,7 +4211,11 @@ impl DpuMachineStateHandler {
                         "redfish machine_setup failed for DPU {}, potentially due to known race condition between UEFI POST and BMC. issuing a force-restart. err: {}",
                         dpu_snapshot.id, e
                     );
-                    tracing::warn!(msg);
+                    tracing::warn!(
+                        machine_id = %dpu_snapshot.id,
+                        error = %e,
+                        "redfish machine_setup failed for DPU, potentially due to known race condition between UEFI POST and BMC; issuing a force-restart",
+                    );
                     let reboot_status = trigger_reboot_if_needed(
                         dpu_snapshot,
                         state,
@@ -4189,7 +4247,11 @@ impl DpuMachineStateHandler {
                         "Failed to run uefi_setup call failed for DPU {}: {}",
                         dpu_snapshot.id, e
                     );
-                    tracing::warn!(msg);
+                    tracing::warn!(
+                        machine_id = %dpu_snapshot.id,
+                        error = %e,
+                        "Failed to run uefi_setup for DPU",
+                    );
                     let reboot_status = trigger_reboot_if_needed(
                         dpu_snapshot,
                         state,
@@ -4263,8 +4325,8 @@ impl DpuMachineStateHandler {
                 match dpu_redfish_client.is_bios_setup(None).await {
                     Ok(true) => {
                         tracing::info!(
-                            dpu_id = %dpu_snapshot.id,
-                            "BIOS setup verified successfully for DPU"
+                            dpu_machine_id = %dpu_snapshot.id,
+                            "BIOS setup verified"
                         );
                         Ok(StateHandlerOutcome::transition(next_state))
                     }
@@ -4279,7 +4341,11 @@ impl DpuMachineStateHandler {
                             "DPU {} BIOS attributes not ready ({e}); issuing a force-restart to mitigate the known UEFI POST/BMC race",
                             dpu_snapshot.id
                         );
-                        tracing::warn!("{msg}");
+                        tracing::warn!(
+                            machine_id = %dpu_snapshot.id,
+                            error = %e,
+                            "DPU BIOS attributes not ready; issuing a force-restart to mitigate the known UEFI POST/BMC race",
+                        );
                         let reboot_status = trigger_reboot_if_needed(
                             dpu_snapshot,
                             state,
@@ -4296,7 +4362,7 @@ impl DpuMachineStateHandler {
                     }
                     Err(e) => {
                         tracing::warn!(
-                            dpu_id = %dpu_snapshot.id,
+                            dpu_machine_id = %dpu_snapshot.id,
                             error = %e,
                             "Failed to check DPU BIOS setup status, will retry"
                         );
@@ -4349,8 +4415,8 @@ impl DpuMachineStateHandler {
             }
             DpuInitState::WaitingForNetworkInstall => {
                 tracing::warn!(
-                    "Invalid State WaitingForNetworkInstall for dpu Machine {}",
-                    dpu_machine_id
+                    machine_id = %dpu_machine_id,
+                    "Invalid State WaitingForNetworkInstall for dpu Machine"
                 );
                 Err(StateHandlerError::InvalidHostState(
                     *dpu_machine_id,
@@ -4388,8 +4454,10 @@ impl DpuMachineStateHandler {
 
             if count > 0 && !has_dpu_finished_booting {
                 tracing::info!(
-                    "Waiting for DPU {} to finish booting; boot progress: {dpu_boot_progress:#?}; SetSecureBoot cycle: {count}",
-                    dpu_snapshot.id
+                    machine_id = %dpu_snapshot.id,
+                    boot_progress = ?dpu_boot_progress,
+                    attempt = count,
+                    "Waiting for DPU to finish booting; SetSecureBoot cycle"
                 )
             }
 
@@ -4511,9 +4579,9 @@ impl DpuMachineStateHandler {
                     }
                     Err(StateHandlerError::MissingData { object_id, missing }) => {
                         tracing::info!(
-                            "Missing data in secure boot status response for DPU {}: {}; rebooting DPU as a work-around",
-                            object_id,
-                            missing
+                            machine_id = %object_id,
+                            missing = %missing,
+                            "Missing data in secure boot status response for DPU; rebooting DPU as a work-around"
                         );
 
                         /***
@@ -4891,9 +4959,9 @@ pub async fn trigger_reboot_if_needed_with_location(
     if let MachineLastRebootRequestedMode::PowerOff = last_reboot_requested.mode {
         // PowerOn the host.
         tracing::info!(
-            "Machine {} is in power-off state. Turning on for host: {}",
-            target.id,
-            host.id,
+            machine_id = %target.id,
+            host_machine_id = %host.id,
+            "Machine is in power-off state. Turning on for host",
         );
 
         if wait(
@@ -4922,14 +4990,18 @@ pub async fn trigger_reboot_if_needed_with_location(
             SystemPowerControl::On
         } else {
             tracing::error!(
-                "Machine {} is still not power-off state. Turning off again for host: {}",
-                target.id,
-                host.id,
+                machine_id = %target.id,
+                host_machine_id = %host.id,
+                "Machine is still not power-off state. Turning off again for host",
             );
             SystemPowerControl::ForceOff
         };
 
-        tracing::trace!(machine_id=%target.id, "Redfish setting host power state to {action}");
+        tracing::trace!(
+            machine_id = %target.id,
+            %action,
+            "Redfish setting host power state"
+        );
         handler_host_power_control_with_location(state, ctx, action, trigger_location).await?;
         return Ok(RebootStatus {
             increase_retry_count: false,
@@ -4940,8 +5012,8 @@ pub async fn trigger_reboot_if_needed_with_location(
     // Check if reboot is prevented by health override.
     if state.aggregate_health.is_reboot_blocked_in_state_machine() {
         tracing::info!(
-            "Not trying to reboot {} since health override is set to prevent reboot.",
-            target.id,
+            machine_id = %target.id,
+            "Not trying to reboot since health override is set to prevent reboot.",
         );
         return Ok(RebootStatus {
             increase_retry_count: false,
@@ -5044,10 +5116,11 @@ pub async fn trigger_reboot_if_needed_with_location(
                 )
             };
 
-            tracing::info!(machine_id=%target.id,
-                "triggered reboot for machine in managed-host state {}: {}",
-                state.managed_state,
-                status,
+            tracing::info!(
+                machine_id = %target.id,
+                managed_host_state = %state.managed_state,
+                reboot_status = %status,
+                "Triggered reboot in managed-host state",
             );
 
             Ok(RebootStatus {
@@ -5408,7 +5481,12 @@ async fn handle_host_uefi_setup(
 
                     // For all other vendors, allow ingestion even though we couldnt set the bios password
                     // An operator will have to set the bios password manually
-                    tracing::info!(msg);
+                    tracing::info!(
+                        machine_id = %state.host_snapshot.id,
+                        bmc_vendor = %state.host_snapshot.bmc_vendor(),
+                        error = %e,
+                        "failed to set the BIOS password",
+                    );
 
                     Ok(StateHandlerOutcome::transition(
                         ManagedHostState::HostInit {
@@ -5597,12 +5675,15 @@ impl StateHandler for HostMachineStateHandler {
                     match redfish_client.lockdown_status().await {
                         Err(libredfish::RedfishError::NotSupported(_)) => {
                             tracing::info!(
-                                "BMC vendor does not support checking lockdown status for {host_machine_id}."
+                                machine_id = %host_machine_id,
+                                "BMC vendor does not support checking lockdown status."
                             );
                         }
                         Err(e) => {
                             tracing::warn!(
-                                "Error fetching lockdown status for {host_machine_id} during machine_setup check: {e}"
+                                machine_id = %host_machine_id,
+                                error = %e,
+                                "Error fetching lockdown status during machine_setup check"
                             );
                             return Ok(StateHandlerOutcome::wait(format!(
                                 "Failed to fetch lockdown status: {}",
@@ -5611,7 +5692,8 @@ impl StateHandler for HostMachineStateHandler {
                         }
                         Ok(lockdown_status) if !lockdown_status.is_fully_disabled() => {
                             tracing::info!(
-                                "Lockdown is enabled for {host_machine_id} during machine_setup, disabling now."
+                                machine_id = %host_machine_id,
+                                "Lockdown is enabled during machine_setup, disabling now."
                             );
                             let next_state = ManagedHostState::HostInit {
                                 machine_state: MachineState::WaitingForLockdown {
@@ -5788,10 +5870,9 @@ impl StateHandler for HostMachineStateHandler {
                     ) {
                         tracing::trace!(
                             machine_id = %host_machine_id,
-                            "Waiting for forge-scout to report host online. \
-                                         Host last seen {:?}, must come after DPU's {}",
-                            mh_snapshot.host_snapshot.last_discovery_time,
-                            mh_snapshot.host_snapshot.state.version.timestamp()
+                            host_last_seen = ?mh_snapshot.host_snapshot.last_discovery_time,
+                            minimum_discovery_time = %mh_snapshot.host_snapshot.state.version.timestamp(),
+                            "Waiting for forge-scout to report host online; host discovery predates the current state transition"
                         );
                         let status = trigger_reboot_if_needed(
                             &mh_snapshot.host_snapshot,
@@ -6023,7 +6104,8 @@ impl StateHandler for HostMachineStateHandler {
                                 }
                                 Err(libredfish::RedfishError::NotSupported(_)) => {
                                     tracing::info!(
-                                        "BMC vendor does not support checking lockdown status for {host_machine_id}."
+                                        machine_id = %host_machine_id,
+                                        "BMC vendor does not support checking lockdown status."
                                     );
                                     Ok(StateHandlerOutcome::transition(next_state))
                                 }
@@ -6849,7 +6931,7 @@ impl StateHandler for InstanceStateHandler {
                                 instance_id = %instance.id,
                                 machine_id = %host_machine_id,
                                 guids = ?guids,
-                                details = %details,
+                                reason = %details,
                                 "IB ports not observable during termination - IB Monitor will unbind"
                             );
 
@@ -6994,11 +7076,11 @@ impl StateHandler for InstanceStateHandler {
                         // 2. If failed during reprovision, fix the config/hw issue and
                         //    retrigger DPU reprovision.
                         tracing::warn!(
-                            "Instance id {}/machine: {} stuck in failed state. details: {:?}, failed machine: {}",
-                            instance.id,
-                            host_machine_id,
-                            details,
-                            machine_id
+                            instance_id = %instance.id,
+                            machine_id = %host_machine_id,
+                            failure_details = ?details,
+                            failed_machine_id = %machine_id,
+                            "Instance machine stuck in failed state"
                         );
                         Ok(StateHandlerOutcome::do_nothing())
                     }
@@ -7132,8 +7214,8 @@ async fn process_dpu_use_admin_network_state_change(
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<(), StateHandlerError> {
     tracing::info!(
-        "Set use_admin_network_changed flag as host {} has changed use_admin_network state and site-restart-ovs is set",
-        &mh_snapshot.host_snapshot.id
+        machine_id = %mh_snapshot.host_snapshot.id,
+        "Set use_admin_network_changed flag as host has changed use_admin_network state and site-restart-ovs is set"
     );
 
     // Determine which DPUs have tenant interface configs. A DPU matches if:
@@ -7172,7 +7254,10 @@ async fn process_dpu_use_admin_network_state_change(
         });
 
         if dpu_has_tenant_interface_config {
-            tracing::info!("Set DPU use_admin_network_changed flag for dpu {}", &dpu.id);
+            tracing::info!(
+                dpu_machine_id = %dpu.id,
+                "Set use_admin_network_changed flag"
+            );
             db::machine::set_use_admin_network_changed(txn, &dpu.id, true).await?;
         }
     }
@@ -7376,9 +7461,9 @@ async fn handle_instance_network_config_update_request(
                     .collect_vec();
 
                 tracing::info!(
-                    "Releasing network resources for instance {}: addresses: {:?}",
-                    instance.id,
-                    addresses,
+                    instance_id = %instance.id,
+                    addresses = ?addresses,
+                    "Releasing network resources",
                 );
                 db::instance_address::delete_addresses(&mut txn, &addresses).await?;
                 release_network_segments_with_vpc_prefix(&resources_to_be_released, &mut txn)
@@ -7488,15 +7573,19 @@ fn check_instance_network_synced_and_dpu_healthy(
             .iter()
             .filter(|dpu_machine_id| {
                 if let Some(device) = id_to_device_map.get(dpu_machine_id) {
-                    tracing::info!("Found device {} for dpu {}", device, dpu_machine_id);
+                    tracing::info!(
+                        %device,
+                        dpu_machine_id = %dpu_machine_id,
+                        "Found DPU device"
+                    );
                     if let Some(id_vec) = device_to_id_map.get(device)
                         && let Some(device_instance) =
                             id_vec.iter().position(|id| id == *dpu_machine_id)
                     {
                         tracing::info!(
-                            "Found device_instance {} for dpu {}",
                             device_instance,
-                            dpu_machine_id
+                            dpu_machine_id = %dpu_machine_id,
+                            "Found DPU device instance"
                         );
                         let device_locator = DeviceLocator {
                             device: device.clone(),
@@ -7517,14 +7606,14 @@ fn check_instance_network_synced_and_dpu_healthy(
 
     if instance.observations.network.len() != dpu_machine_ids.len() {
         tracing::info!(
-            "obs: {} dpus: {}",
-            instance.observations.network.len(),
-            dpu_machine_ids.len()
+            network_observation_count = instance.observations.network.len(),
+            dpu_count = dpu_machine_ids.len(),
+            "network observation count does not match DPU count"
         );
 
         let mut missing_dpus = Vec::default();
         for dpu_id in dpu_machine_ids {
-            tracing::info!("checking dpu: {}", dpu_id);
+            tracing::info!(dpu_machine_id = %dpu_id, "checking dpu");
             if !instance.observations.network.contains_key(&dpu_id) {
                 tracing::info!("missing");
                 missing_dpus.push(dpu_id);
@@ -7773,8 +7862,8 @@ async fn rack_failed_abort_host_reprovision_outcome(
     tracing::info!(
         machine_id = %machine_id,
         rack_id = %rack_id,
-        from = ?state.managed_state,
-        to = ?target_state,
+        previous_state = ?state.managed_state,
+        next_state = ?target_state,
         "Rack is in Error; aborting machine HostReprovision and returning to Ready",
     );
 
@@ -7960,8 +8049,8 @@ impl HostUpgradeState {
                 if let Some(result) = result {
                     if result.success {
                         tracing::info!(
-                            "Scout firmware upgrade succeeded for {}",
-                            state.host_snapshot.id
+                            machine_id = %state.host_snapshot.id,
+                            "Scout firmware upgrade succeeded"
                         );
                         let next_reprov_state = HostReprovisionState::ResetForNewFirmware {
                             final_version: final_version.to_string(),
@@ -7983,9 +8072,9 @@ impl HostUpgradeState {
                             result.error.clone()
                         };
                         tracing::warn!(
-                            "Scout firmware upgrade failed for {}: {}",
-                            state.host_snapshot.id,
-                            reason
+                            machine_id = %state.host_snapshot.id,
+                            reason = %reason,
+                            "Scout firmware upgrade failed"
                         );
                         Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                             HostReprovisionState::FailedFirmwareUpgrade {
@@ -7998,9 +8087,9 @@ impl HostUpgradeState {
                     }
                 } else if Utc::now() > *deadline {
                     tracing::warn!(
-                        "Scout firmware upgrade timed out for {} (deadline {})",
-                        state.host_snapshot.id,
-                        deadline,
+                        machine_id = %state.host_snapshot.id,
+                        %deadline,
+                        "Scout firmware upgrade timed out",
                     );
                     Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         HostReprovisionState::FailedFirmwareUpgrade {
@@ -8229,8 +8318,8 @@ impl HostUpgradeState {
         // For now, only gb200s need manual upgrades.
         if requires_manual_firmware_upgrade(state, &ctx.services.site_config.firmware_global) {
             tracing::info!(
-                "Machine {} (GB200) requires manual firmware upgrade, transitioning to WaitingForManualUpgrade",
-                machine_id
+                %machine_id,
+                "Machine (GB200) requires manual firmware upgrade, transitioning to WaitingForManualUpgrade"
             );
             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                 HostReprovisionState::WaitingForManualUpgrade {
@@ -8262,7 +8351,7 @@ impl HostUpgradeState {
         else {
             // find_explored_refreshed_endpoint's behavior is to return None to indicate we're waiting for an update, not to indicate there isn't anything.
 
-            tracing::debug!("Managed host {machine_id} waiting for site explorer to revisit");
+            tracing::debug!(%machine_id, "Managed host waiting for site explorer to revisit");
             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                 HostReprovisionState::CheckingFirmwareRepeatV2 {
                     firmware_type: current_firmware_type,
@@ -8376,11 +8465,12 @@ impl HostUpgradeState {
                         .await;
                 }
 
-                tracing::info!(%machine_id,
-                    "Installing {:?} (number #{}) on {}",
-                    to_install,
+                tracing::info!(
+                    %machine_id,
+                    firmware = ?to_install,
                     firmware_number,
-                    explored_endpoint.address
+                    bmc_ip_address = %explored_endpoint.address,
+                    "Installing firmware"
                 );
 
                 if !repeat && to_install.pre_update_resets {
@@ -8421,7 +8511,11 @@ impl HostUpgradeState {
                     // Note that this is different from the place where we do something similar
                     false
                 } else {
-                    tracing::warn!("Could not get lockdown status for {machine_id}: {e}",);
+                    tracing::warn!(
+                        %machine_id,
+                        error = %e,
+                        "Could not get lockdown status"
+                    );
                     return Ok(StateHandlerOutcome::do_nothing());
                 }
             }
@@ -8433,7 +8527,7 @@ impl HostUpgradeState {
                 .lockdown(libredfish::EnabledDisabled::Enabled)
                 .await
             {
-                tracing::error!("Could not set lockdown for {machine_id}: {e}");
+                tracing::error!(%machine_id, error = %e, "Could not set lockdown");
                 return Ok(StateHandlerOutcome::do_nothing());
             }
             match scenario {
@@ -8531,7 +8625,10 @@ impl HostUpgradeState {
                 Ok(cmd) => cmd,
                 Err(e) => {
                     tracing::error!(
-                        "Upgrade script {machine_id} {address} command creation failed: {e}"
+                        %machine_id,
+                        bmc_ip_address = %address,
+                        error = %e,
+                        "Upgrade script command creation failed"
                     );
                     upgrade_script_state.completed(machine_id.to_string(), false);
                     return;
@@ -8539,7 +8636,11 @@ impl HostUpgradeState {
             };
 
             let Some(stdout) = cmd.stdout.take() else {
-                tracing::error!("Upgrade script {machine_id} {address} STDOUT creation failed");
+                tracing::error!(
+                    %machine_id,
+                    bmc_ip_address = %address,
+                    "Upgrade script STDOUT creation failed"
+                );
                 let _ = cmd.kill().await;
                 let _ = cmd.wait().await;
                 upgrade_script_state.completed(machine_id.to_string(), false);
@@ -8548,7 +8649,11 @@ impl HostUpgradeState {
             let stdout = tokio::io::BufReader::new(stdout);
 
             let Some(stderr) = cmd.stderr.take() else {
-                tracing::error!("Upgrade script {machine_id} {address} STDERR creation failed");
+                tracing::error!(
+                    %machine_id,
+                    bmc_ip_address = %address,
+                    "Upgrade script STDERR creation failed"
+                );
                 let _ = cmd.kill().await;
                 let _ = cmd.wait().await;
                 upgrade_script_state.completed(machine_id.to_string(), false);
@@ -8556,37 +8661,57 @@ impl HostUpgradeState {
             };
             let stderr = tokio::io::BufReader::new(stderr);
 
-            // Take the stdout and stderr from the script and write them to a log with a searchable prefix
-            let machine_id2 = address.clone();
-            let address2 = address.clone();
+            // Record the script streams with searchable fields.
+            let stderr_machine_id = machine_id;
+            let stderr_address = address.clone();
             let thread = tokio::spawn(async move {
                 let mut lines = stderr.lines();
                 while let Some(line) = lines.next_line().await.unwrap_or(None) {
-                    tracing::info!("Upgrade script {machine_id2} {address2} STDERR {line}");
+                    tracing::info!(
+                        machine_id = %stderr_machine_id,
+                        bmc_ip_address = %stderr_address,
+                        stream = "stderr",
+                        output = %line,
+                        "Upgrade script output"
+                    );
                 }
             });
             let mut lines = stdout.lines();
             while let Some(line) = lines.next_line().await.unwrap_or(None) {
-                tracing::info!("Upgrade script {machine_id} {address} {line}");
+                tracing::info!(
+                    %machine_id,
+                    bmc_ip_address = %address,
+                    stream = "stdout",
+                    output = %line,
+                    "Upgrade script output"
+                );
             }
             let _ = tokio::join!(thread);
 
             match cmd.wait().await {
                 Err(e) => {
                     tracing::info!(
-                        "Upgrade script {machine_id} {address} FAILED: Wait failure {e}"
+                        %machine_id,
+                        bmc_ip_address = %address,
+                        error = %e,
+                        "Upgrade script FAILED: Wait failure"
                     );
                     upgrade_script_state.completed(machine_id.to_string(), false);
                 }
                 Ok(errorcode) => {
                     if errorcode.success() {
                         tracing::info!(
-                            "Upgrade script {machine_id} {address} completed successfully"
+                            %machine_id,
+                            bmc_ip_address = %address,
+                            "Upgrade script completed successfully"
                         );
                         upgrade_script_state.completed(machine_id.to_string(), true);
                     } else {
                         tracing::warn!(
-                            "Upgrade script {machine_id} {address} FAILED: Exited with {errorcode}"
+                            %machine_id,
+                            bmc_ip_address = %address,
+                            exit_status = %errorcode,
+                            "Upgrade script FAILED: Exited"
                         );
                         upgrade_script_state.completed(machine_id.to_string(), false);
                     }
@@ -8609,9 +8734,9 @@ impl HostUpgradeState {
 
         if let Some(completed_at) = state.host_snapshot.manual_firmware_upgrade_completed {
             tracing::info!(
-                "Manual firmware upgrade completed for {} at {}, proceeding to automatic upgrades",
-                machine_id,
-                completed_at
+                %machine_id,
+                %completed_at,
+                "Manual firmware upgrade completed, proceeding to automatic upgrades"
             );
 
             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
@@ -8624,8 +8749,8 @@ impl HostUpgradeState {
         }
 
         tracing::debug!(
-            "Machine {} still waiting for manual firmware upgrade to be marked complete",
-            machine_id
+            %machine_id,
+            "Machine still waiting for manual firmware upgrade to be marked complete"
         );
         Ok(StateHandlerOutcome::do_nothing())
     }
@@ -8656,7 +8781,7 @@ impl HostUpgradeState {
                 firmware_type: FirmwareComponentType::Unknown,
                 report_time: Some(Utc::now()),
                 reason: Some(format!(
-                    "The upgrade script failed.  Search the log for \"Upgrade script {}\" for script output.  Use \"forge-admin-cli mh reset-host-reprovisioning --machine {}\" to retry.",
+                    "The upgrade script failed. Search logs for the \"Upgrade script output\" message with machine_id={} to find script output. Use \"forge-admin-cli mh reset-host-reprovisioning --machine {}\" to retry.",
                     state.host_snapshot.id, state.host_snapshot.id
                 )),
             };
@@ -8772,9 +8897,9 @@ impl HostUpgradeState {
             ResolvedFirmwareArtifactSource::Remote { url, sha256 } => {
                 if !self.downloader.available(&artifact.local_path, url, sha256) {
                     tracing::debug!(
-                        "{} is being downloaded from {}, update deferred",
-                        artifact.local_path.display(),
-                        url
+                        artifact_path = %artifact.local_path.display(),
+                        %url,
+                        "firmware artifact is being downloaded, update deferred"
                     );
 
                     return Ok(StateHandlerOutcome::do_nothing());
@@ -8787,7 +8912,11 @@ impl HostUpgradeState {
                         artifact.local_path.display(),
                         snapshot.id
                     );
-                    tracing::warn!("{reason}");
+                    tracing::warn!(
+                        artifact_path = %artifact.local_path.display(),
+                        machine_id = %snapshot.id,
+                        "firmware artifact is not present and no firmware artifact URL is configured",
+                    );
                     return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         HostReprovisionState::FailedFirmwareUpgrade {
                             firmware_type: *component_type,
@@ -8802,9 +8931,9 @@ impl HostUpgradeState {
 
         let Ok(_active) = self.upload_limiter.try_acquire() else {
             tracing::debug!(
-                "Deferring installation of {:?} on {}, too many uploads already active",
-                to_install,
-                snapshot.id,
+                firmware = ?to_install,
+                machine_id = %snapshot.id,
+                "Deferring installation, too many uploads already active",
             );
             return Ok(StateHandlerOutcome::do_nothing());
         };
@@ -8824,8 +8953,9 @@ impl HostUpgradeState {
                     true
                 } else {
                     tracing::warn!(
-                        "Could not get lockdown status for {}: {e}",
-                        state.host_snapshot.id
+                        machine_id = %state.host_snapshot.id,
+                        error = %e,
+                        "Could not get lockdown status"
                     );
                     return Ok(StateHandlerOutcome::do_nothing());
                 }
@@ -8835,16 +8965,16 @@ impl HostUpgradeState {
             // Already disabled, we can go ahead
             tracing::debug!("Host fw update: No need for disabling lockdown");
         } else {
-            tracing::info!(%address, "Host fw update: Disabling lockdown");
+            tracing::info!(bmc_ip_address = %address, "Host fw update: Disabling lockdown");
             if let Err(e) = redfish_client
                 .lockdown(libredfish::EnabledDisabled::Disabled)
                 .await
             {
-                tracing::warn!("Could not set lockdown for {}: {e}", address.to_string());
+                tracing::warn!(bmc_ip_address = %address, error = %e, "Could not set lockdown");
                 return Ok(StateHandlerOutcome::do_nothing());
             }
             if fw_info.model == "Dell" {
-                tracing::info!(%address, "Host fw update: Rebooting after disabling lockdown because Dell");
+                tracing::info!(bmc_ip_address = %address, "Host fw update: Rebooting after disabling lockdown because Dell");
                 handler_host_power_control(state, ctx, SystemPowerControl::ForceRestart).await?;
                 // Wait until the next state machine iteration to let it restart
                 return Ok(StateHandlerOutcome::do_nothing());
@@ -8920,7 +9050,9 @@ impl HostUpgradeState {
         match self.async_firmware_uploader.upload_status(&machine_id) {
             None => {
                 tracing::info!(
-                    "Apparent restart before upload to {machine_id} {address} completion, returning to CheckingFirmware"
+                    %machine_id,
+                    bmc_ip_address = %address,
+                    "Apparent restart before upload completion, returning to CheckingFirmware"
                 );
                 Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                     HostReprovisionState::CheckingFirmwareRepeatV2 {
@@ -8933,7 +9065,11 @@ impl HostUpgradeState {
             Some(upload_status) => {
                 match upload_status {
                     None => {
-                        tracing::debug!("Upload to {machine_id} {address} not yet complete");
+                        tracing::debug!(
+                            %machine_id,
+                            bmc_ip_address = %address,
+                            "Upload not yet complete"
+                        );
                         Ok(StateHandlerOutcome::do_nothing())
                     }
                     Some(result) => {
@@ -8941,7 +9077,10 @@ impl HostUpgradeState {
                             UploadResult::Success { task_id } => {
                                 // We want to remove the machine ID from the hashmap, but do not do it here, because we may fail the commit.  Run it in the next state handling.  Failure case doesn't matter, it would have identical behavior.
                                 tracing::info!(
-                                    "Upload to {machine_id} {address} completed with task ID {task_id}"
+                                    %machine_id,
+                                    bmc_ip_address = %address,
+                                    %task_id,
+                                    "Upload completed"
                                 );
                                 // Upload complete and updated started, will monitor task in future iterations
                                 let reprovision_state =
@@ -9037,10 +9176,10 @@ impl HostUpgradeState {
                     | Some(TaskState::Running)
                     | Some(TaskState::Pending) => {
                         tracing::debug!(
-                            "Upgrade task for {} not yet complete, current state {:?} message {:?}",
-                            machine_id,
-                            task_info.task_state,
-                            task_info.messages,
+                            %machine_id,
+                            task_state = ?task_info.task_state,
+                            messages = ?task_info.messages,
+                            "Upgrade task not yet complete",
                         );
                         Ok(StateHandlerOutcome::do_nothing())
                     }
@@ -9082,10 +9221,11 @@ impl HostUpgradeState {
                                     .unwrap_or(false);
                                 if has_more_artifacts {
                                     tracing::debug!(
-                                        "Moving {:?} chain step {} on {} to CheckingFirmware",
-                                        selected_firmware,
+                                        %machine_id,
+                                        firmware = ?selected_firmware,
                                         firmware_number,
-                                        endpoint.address
+                                        bmc_ip_address = %endpoint.address,
+                                        "Moving firmware chain step to CheckingFirmware"
                                     );
 
                                     // There are more files to install.
@@ -9107,8 +9247,8 @@ impl HostUpgradeState {
                         }
 
                         tracing::debug!(
-                            "Saw completion of host firmware upgrade task for {}",
-                            machine_id
+                            %machine_id,
+                            "Saw completion of host firmware upgrade task"
                         );
 
                         let reprovision_state = HostReprovisionState::ResetForNewFirmware {
@@ -9138,7 +9278,11 @@ impl HostUpgradeState {
                                 .last()
                                 .map_or("".to_string(), |m| m.message.clone())
                         );
-                        tracing::warn!(msg);
+                        tracing::warn!(
+                            %machine_id,
+                            reason = %msg,
+                            "Firmware upgrade task failed",
+                        );
 
                         // We need site explorer to requery the version, just in case it actually did get done
                         let mut txn = ctx.services.db_pool.begin().await?;
@@ -9162,7 +9306,11 @@ impl HostUpgradeState {
                             "Unrecognized task state for {}: {:?}",
                             machine_id, task_info.task_state
                         );
-                        tracing::warn!(msg);
+                        tracing::warn!(
+                            %machine_id,
+                            reason = %msg,
+                            "Unrecognized firmware upgrade task state",
+                        );
 
                         let reprovision_state = HostReprovisionState::FailedFirmwareUpgrade {
                             firmware_type: *firmware_type,
@@ -9193,8 +9341,9 @@ impl HostUpgradeState {
                             && current_version == final_version
                         {
                             tracing::info!(
-                                "Marking completion of Redfish task of firmware upgrade for {} with missing task",
-                                &endpoint.address
+                                %machine_id,
+                                bmc_ip_address = %endpoint.address,
+                                "Marking completion of Redfish task of firmware upgrade with missing task"
                             );
 
                             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
@@ -9211,9 +9360,10 @@ impl HostUpgradeState {
                             && Utc::now().signed_duration_since(started_waiting)
                                 > chrono::TimeDelta::minutes(15)
                         {
-                            tracing::info!(%machine_id,
-                                "Timed out with missing Redfish task for firmware upgrade for {}, returning to CheckingFirmware",
-                                &endpoint.address
+                            tracing::info!(
+                                %machine_id,
+                                bmc_ip_address = %endpoint.address,
+                                "Timed out with missing Redfish task for firmware upgrade, returning to CheckingFirmware"
                             );
                             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                                 HostReprovisionState::CheckingFirmwareRepeatV2 {
@@ -9273,7 +9423,7 @@ impl HostUpgradeState {
         };
 
         let Some(endpoint) = find_explored_refreshed_endpoint(state, machine_id, ctx).await? else {
-            tracing::debug!("Waiting for site explorer to revisit {machine_id}");
+            tracing::debug!(%machine_id, "Waiting for site explorer to revisit");
             return Ok(StateHandlerOutcome::do_nothing());
         };
 
@@ -9282,8 +9432,9 @@ impl HostUpgradeState {
                 && *delay_until > chrono::Utc::now().timestamp()
             {
                 tracing::info!(
-                    "Waiting after {last_power_drain_operation:?} of {}",
-                    &endpoint.address
+                    last_power_drain_operation = ?last_power_drain_operation,
+                    bmc_ip_address = %endpoint.address,
+                    "Waiting after power drain operation"
                 );
                 return Ok(StateHandlerOutcome::do_nothing());
             }
@@ -9292,13 +9443,13 @@ impl HostUpgradeState {
                 None | Some(PowerDrainState::On) => {
                     // The 1000 is for unit tests; values above this will skip delays.
                     if *power_drains_needed == 0 || *power_drains_needed == 1000 {
-                        tracing::info!("Power drains for {} done", &endpoint.address);
+                        tracing::info!(bmc_ip_address = %endpoint.address, "Power drains done");
                         // This path, and only this path of the match, exits the match and lets us proceed.  All others should return after updating state.
                     } else {
                         tracing::info!(
-                            "Upgrade task has completed for {} but needs {} power drain(s), initiating one",
-                            &endpoint.address,
-                            power_drains_needed
+                            bmc_ip_address = %endpoint.address,
+                            required_power_drain_count = *power_drains_needed,
+                            "Upgrade task has completed but needs power drain(s), initiating one"
                         );
                         handler_host_power_control(state, ctx, SystemPowerControl::ForceOff)
                             .await?;
@@ -9321,7 +9472,7 @@ impl HostUpgradeState {
                     }
                 }
                 Some(PowerDrainState::Off) => {
-                    tracing::info!("Doing powercycle now for {}", &endpoint.address);
+                    tracing::info!(bmc_ip_address = %endpoint.address, "Doing powercycle now");
                     handler_host_power_control(state, ctx, SystemPowerControl::ACPowercycle)
                         .await?;
 
@@ -9341,7 +9492,7 @@ impl HostUpgradeState {
                     )));
                 }
                 Some(PowerDrainState::Powercycle) => {
-                    tracing::info!("Turning back on {}", &endpoint.address);
+                    tracing::info!(bmc_ip_address = %endpoint.address, "Turning back on");
                     handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
 
                     let delay = if *power_drains_needed < 1000 { 5 } else { 0 };
@@ -9362,8 +9513,8 @@ impl HostUpgradeState {
             };
         } else if firmware_type.is_uefi() {
             tracing::debug!(
-                "Upgrade task has completed for {} but needs reboot, initiating one",
-                &endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "Upgrade task has completed but needs reboot, initiating one"
             );
             handler_host_power_control(state, ctx, SystemPowerControl::ForceRestart).await?;
 
@@ -9378,8 +9529,8 @@ impl HostUpgradeState {
                 .is_dell()
         {
             tracing::debug!(
-                "Upgrade task has completed for {} but needs BMC reboot, initiating one",
-                &endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "Upgrade task has completed but needs BMC reboot, initiating one"
             );
             let redfish_client = ctx
                 .services
@@ -9387,7 +9538,7 @@ impl HostUpgradeState {
                 .await?;
 
             if let Err(e) = redfish_client.bmc_reset().await {
-                tracing::warn!("Failed to reboot {}: {e}", &endpoint.address);
+                tracing::warn!(bmc_ip_address = %endpoint.address, error = %e, "Failed to reboot");
                 return Ok(StateHandlerOutcome::do_nothing());
             }
         }
@@ -9405,12 +9556,20 @@ impl HostUpgradeState {
             // We previously possibly tried to use ACPowerycle here, however that requires enough time for the BMC to come back.  We use
             // the power_drains_needed setting instead for that which is already aware of how to keep track of that sort of thing.
             if let Err(e) = redfish_client.power(SystemPowerControl::ForceOff).await {
-                tracing::error!("Failed to power off {}: {e}", &endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Failed to power off"
+                );
                 return Ok(StateHandlerOutcome::do_nothing());
             }
             tokio::time::sleep(self.hgx_bmc_gpu_reboot_delay).await;
             if let Err(e) = redfish_client.power(SystemPowerControl::On).await {
-                tracing::error!("Failed to power on {}: {e}", &endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Failed to power on"
+                );
                 return Ok(StateHandlerOutcome::do_nothing());
             }
             // Okay to proceed
@@ -9461,13 +9620,13 @@ impl HostUpgradeState {
             };
 
         let Some(endpoint) = find_explored_refreshed_endpoint(state, machine_id, ctx).await? else {
-            tracing::debug!("Waiting for site explorer to revisit {machine_id}");
+            tracing::debug!(%machine_id, "Waiting for site explorer to revisit");
             return Ok(StateHandlerOutcome::do_nothing());
         };
 
         let fw_config_snapshot = self.host_firmware_config_snapshot(ctx).await?;
         let Some(fw_info) = fw_config_snapshot.find_fw_info_for_host(&endpoint) else {
-            tracing::error!("Could no longer find firmware info for {machine_id}");
+            tracing::error!(%machine_id, "Could no longer find firmware info");
             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                 HostReprovisionState::CheckingFirmwareRepeatV2 {
                     firmware_type: Some(*firmware_type),
@@ -9479,7 +9638,7 @@ impl HostUpgradeState {
 
         let current_versions = endpoint.find_all_versions(&fw_info, *firmware_type);
         if current_versions.is_empty() {
-            tracing::error!("Could no longer find current versions for {machine_id}");
+            tracing::error!(%machine_id, "Could no longer find current versions");
             return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                 HostReprovisionState::CheckingFirmwareRepeatV2 {
                     firmware_type: Some(*firmware_type),
@@ -9492,15 +9651,17 @@ impl HostUpgradeState {
         let versions_match_final_version = current_versions.iter().all(|v| *v == final_version);
         if !versions_match_final_version {
             tracing::warn!(
-                "{}: Not all firmware versions match. Expected: {final_version}, Found: {:?}",
-                endpoint.address,
-                current_versions
+                %machine_id,
+                bmc_ip_address = %endpoint.address,
+                %final_version,
+                current_versions = ?current_versions,
+                "Not all firmware versions match"
             );
         }
 
         if versions_match_final_version {
             // Done waiting, go back to overall checking of version`2s
-            tracing::debug!("Done waiting for {machine_id} to reach version");
+            tracing::debug!(%machine_id, "Done waiting to reach version");
             Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                 HostReprovisionState::CheckingFirmwareRepeatV2 {
                     firmware_type: Some(*firmware_type),
@@ -9517,7 +9678,14 @@ impl HostUpgradeState {
                     let reason = format!(
                         "Firmware version did not converge after completed update for {firmware_type}: expected {final_version}, found {current_versions:?} after {reset_retry_count} reset retries"
                     );
-                    tracing::warn!(%machine_id, "{reason}");
+                    tracing::warn!(
+                        %machine_id,
+                        firmware_type = %firmware_type,
+                        expected_version = %final_version,
+                        current_versions = ?current_versions,
+                        reset_retry_count = *reset_retry_count,
+                        "Firmware version did not converge after completed update",
+                    );
                     return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         HostReprovisionState::FailedFirmwareUpgrade {
                             firmware_type: *firmware_type,
@@ -9529,9 +9697,10 @@ impl HostUpgradeState {
                 }
 
                 tracing::info!(
-                    "Upgrade for {} {:?} has taken more than 30 minutes to report new version; resetting again.",
-                    &endpoint.address,
-                    firmware_type
+                    %machine_id,
+                    bmc_ip_address = %endpoint.address,
+                    firmware_type = ?firmware_type,
+                    "Upgrade has taken more than 30 minutes to report new version; resetting again."
                 );
                 let details = &HostReprovisionState::ResetForNewFirmware {
                     final_version: final_version.to_string(),
@@ -9547,7 +9716,11 @@ impl HostUpgradeState {
                     .await;
             }
             tracing::info!(
-                "Waiting for {machine_id} {firmware_type:?} to reach version {final_version} currently {current_versions:?}"
+                %machine_id,
+                firmware_type = ?firmware_type,
+                %final_version,
+                current_versions = ?current_versions,
+                "Waiting to reach firmware version"
             );
 
             let mut txn = ctx.services.db_pool.begin().await?;
@@ -9626,7 +9799,9 @@ impl AsyncFirmwareUploader {
             //
             // Log it so we can see what's going on in case there's problems.
             tracing::info!(
-                "Uploading conflict for {id} {address}; our upload should still be in progress."
+                machine_id = %id,
+                bmc_ip_address = %address,
+                "Uploading conflict; our upload should still be in progress."
             );
             return;
         }
@@ -9652,7 +9827,12 @@ impl AsyncFirmwareUploader {
                     hashmap.insert(id, Some(UploadResult::Success { task_id }));
                 }
                 Err(e) => {
-                    tracing::warn!("Failed uploading firmware to {id} {address}: {e}");
+                    tracing::warn!(
+                        machine_id = %id,
+                        bmc_ip_address = %address,
+                        error = %e,
+                        "Failed uploading firmware"
+                    );
                     let mut hashmap = active_uploads.lock().expect("lock poisoned");
                     hashmap.insert(id, Some(UploadResult::Failure));
                 }
@@ -9989,9 +10169,9 @@ async fn wait_for_boss_controller_job_to_scheduled(
         ),
         libredfish::JobState::Completed => {
             tracing::warn!(
-                "CreateBossVolume: job {} for {} completed before being scheduled, skipping reboot",
-                job_id,
-                mh_snapshot.host_snapshot.id,
+                %job_id,
+                machine_id = %mh_snapshot.host_snapshot.id,
+                "CreateBossVolume: job completed before being scheduled, skipping reboot",
             );
 
             waiting_for_cleanup_state(
@@ -10334,7 +10514,11 @@ async fn restart_dpu(
             .map_err(|e| {
                 // We use a Dell to mock our BMC responses in the integration tests. UefiHttp boot is not implemented
                 // for Dells, so this call is failing in our tests. Regardless, it is ok to not make this call blocking.
-                tracing::error!(%e, "Failed to configure DPU {} to boot once", machine.id);
+                tracing::error!(
+                    machine_id = %machine.id,
+                    error = %e,
+                    "Failed to configure DPU to boot once"
+                );
             });
     }
 
@@ -10342,7 +10526,7 @@ async fn restart_dpu(
         .power(SystemPowerControl::ForceRestart)
         .await
     {
-        tracing::error!(%e, "Failed to reboot a DPU");
+        tracing::error!(error = %e, "Failed to reboot a DPU");
         return Err(redfish_error("reboot dpu", e));
     }
 
@@ -10555,7 +10739,8 @@ fn handle_no_dpu_error(
     match (result, expected_dpu_count) {
         (Err(RedfishError::NoDpu), 0) => {
             tracing::info!(
-                "redfish {operation} failed with NoDpu on a zero-DPU host; treating as Ok"
+                operation,
+                "redfish operation failed with NoDpu on a zero-DPU host; treating as Ok"
             );
             Ok(None)
         }
@@ -10586,7 +10771,7 @@ async fn log_host_config(redfish_client: &dyn Redfish, mh_snapshot: &ManagedHost
         Ok(opts) => opts,
         Err(e) => {
             tracing::warn!(
-                %host_id,
+                host_machine_id = %host_id,
                 %managed_state,
                 error = %e,
                 "Failed to fetch boot options"
@@ -10650,7 +10835,7 @@ async fn log_host_config(redfish_client: &dyn Redfish, mh_snapshot: &ManagedHost
     };
 
     tracing::info!(
-        %host_id,
+        host_machine_id = %host_id,
         %managed_state,
         "Host config:\nBoot order:\n{}\n{}",
         boot_entries.join("\n"),
@@ -10839,7 +11024,11 @@ async fn handle_instance_host_platform_config(
                     }
                     Err(e) => {
                         // TODO: Dell's return a generic error if in lockdown which needs to be changed in Redfish SDK
-                        tracing::warn!("Failed to AC Powercycle host, skipping to power on: {e}");
+                        tracing::warn!(
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            error = %e,
+                            "Failed to AC Powercycle host, skipping to power on"
+                        );
                     }
                 };
             }
@@ -10854,7 +11043,7 @@ async fn handle_instance_host_platform_config(
             .map_err(|e| StateHandlerError::GenericError(eyre!("failed to power on host: {e}")))?;
 
             tracing::info!(
-                host_id = %mh_snapshot.host_snapshot.id,
+                host_machine_id = %mh_snapshot.host_snapshot.id,
                 power_on_retry_count = next_retry,
                 %power_state,
                 "waiting for host to power ON"
@@ -11166,9 +11355,9 @@ async fn set_host_boot_order(
                     // it hasn't been fixed/addressed yet, and it appears to be logged all over
                     // the place now.
                     tracing::warn!(
-                        "redfish set_boot_order_dpu_first failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
-                        mh_snapshot.host_snapshot.id,
-                        e
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        error = %e,
+                        "redfish set_boot_order_dpu_first failed, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed"
                     );
 
                     let reboot_status = if mh_snapshot.host_snapshot.last_reboot_requested.is_none()
@@ -11273,7 +11462,7 @@ async fn set_host_boot_order(
                 }
                 tracing::warn!(
                     machine_id = %mh_snapshot.host_snapshot.id,
-                    minutes_waiting,
+                    time_in_state_minutes = minutes_waiting,
                     "Re-asserted HTTP boot device still not applied after the wait window; migrating to shared BIOS repair",
                 );
                 return Ok(SetBootOrderOutcome::ConfigureBios);
@@ -11337,11 +11526,11 @@ async fn set_host_boot_order(
                         }
 
                         tracing::warn!(
-                            "SetBootOrder: job {} lookup failed for {} after {} minutes, transitioning to HandleJobFailure: {}",
-                            job_id,
-                            mh_snapshot.host_snapshot.id,
-                            minutes_since_state_change,
-                            e
+                            %job_id,
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            time_in_state_minutes = minutes_since_state_change,
+                            error = %e,
+                            "SetBootOrder: job lookup failed, transitioning to HandleJobFailure"
                         );
 
                         return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
@@ -11361,9 +11550,10 @@ async fn set_host_boot_order(
                     }
                     _ if job_state.is_error_state() => {
                         tracing::warn!(
-                            "SetBootOrder: job {} failed for {} with state {job_state:#?}, transitioning to HandleJobFailure",
-                            job_id,
-                            mh_snapshot.host_snapshot.id,
+                            %job_id,
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            job_state = ?job_state,
+                            "SetBootOrder: job failed, transitioning to HandleJobFailure",
                         );
 
                         return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
@@ -11419,9 +11609,9 @@ async fn set_host_boot_order(
 
                     // Host is powered off, reset the BMC
                     tracing::info!(
-                        "HandleJobFailure: Resetting BMC for {} after failure: {}",
-                        mh_snapshot.host_snapshot.id,
-                        failure
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        reason = %failure,
+                        "HandleJobFailure: Resetting BMC after failure"
                     );
 
                     redfish_client
@@ -11474,8 +11664,8 @@ async fn set_host_boot_order(
 
                     // Host is powered on, transition to CheckBootOrder to verify and retry
                     tracing::info!(
-                        "HandleJobFailure: BMC reset complete and host powered on for {}, transitioning to CheckBootOrder",
-                        mh_snapshot.host_snapshot.id,
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "HandleJobFailure: BMC reset complete and host powered on, transitioning to CheckBootOrder",
                     );
 
                     Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
@@ -11547,8 +11737,8 @@ async fn set_host_boot_order(
 
             if boot_order_configured {
                 tracing::info!(
-                    "Boot order verified for {} - the host has its boot order configured properly",
-                    mh_snapshot.host_snapshot.id,
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Boot order verified",
                 );
                 return Ok(SetBootOrderOutcome::Done);
             }
@@ -11558,10 +11748,10 @@ async fn set_host_boot_order(
                 mh_snapshot.host_snapshot.state.version.since_state_change();
 
             tracing::warn!(
-                "Boot order check failed for {} - the host does not have its boot order configured properly after SetBootOrder (retry_count: {}, time_in_state: {} minutes)",
-                mh_snapshot.host_snapshot.id,
+                machine_id = %mh_snapshot.host_snapshot.id,
                 retry_count,
-                time_since_state_change.num_minutes()
+                time_in_state_minutes = time_since_state_change.num_minutes(),
+                "Boot order check failed after SetBootOrder"
             );
 
             if time_since_state_change.num_minutes() < CHECK_BOOT_ORDER_TIMEOUT_MINUTES {

--- a/crates/machine-controller/src/handler/attestation.rs
+++ b/crates/machine-controller/src/handler/attestation.rs
@@ -81,8 +81,8 @@ pub async fn trigger_attestation(
         Some(product_name) => product_name,
         None => {
             tracing::info!(
-                "ServiceRoot.Product is None, not scheduling SPDM attestation for machine: {}",
-                machine_id
+                %machine_id,
+                "ServiceRoot.Product is None; not scheduling SPDM attestation"
             );
             return Ok(0);
         }
@@ -90,9 +90,9 @@ pub async fn trigger_attestation(
 
     if !is_supported_product(&product) {
         tracing::info!(
-            "ServiceRoot.Product - {} - is not supported, not scheduling SPDM attestation for machine: {}",
-            product,
-            machine_id
+            %machine_id,
+            %product,
+            "ServiceRoot.Product is not supported; not scheduling SPDM attestation"
         );
         return Ok(0);
     }
@@ -143,9 +143,9 @@ pub async fn trigger_attestation(
     txn.commit().await?;
 
     tracing::info!(
-        "SPDM attestation commenced for machine {}, scheduled {} SPDM device attestations",
-        machine_id,
-        records_inserted
+        %machine_id,
+        inserted_record_count = records_inserted,
+        "SPDM attestation commenced; scheduled SPDM device attestations"
     );
 
     Ok(records_inserted)

--- a/crates/machine-controller/src/handler/bios_config.rs
+++ b/crates/machine-controller/src/handler/bios_config.rs
@@ -104,9 +104,9 @@ pub(super) async fn configure_host_bios(
     {
         Err(e) => {
             tracing::warn!(
-                "redfish machine_setup failed for {}, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed. err: {}",
-                mh_snapshot.host_snapshot.id,
-                e
+                machine_id = %mh_snapshot.host_snapshot.id,
+                error = %e,
+                "redfish machine_setup failed, potentially due to known race condition between UEFI POST and BMC. triggering force-restart if needed"
             );
 
             // if machine_setup failed, reboot to potentially work around
@@ -178,7 +178,7 @@ pub(super) async fn advance_bios_config_job(
             if job_state.is_error_state() {
                 let failure = format!("BIOS job {} failed with state {job_state:#?}", job_id);
                 tracing::warn!(
-                    %failure,
+                    reason = %failure,
                     "transitioning to HandleBiosJobFailure (power cycle + BMC reset)"
                 );
                 return Ok(try_bios_recovery_attempt(
@@ -234,7 +234,7 @@ pub(super) async fn advance_bios_config_job(
                         job_id, minutes_since_state_change, e
                     );
                     tracing::warn!(
-                        %failure,
+                        reason = %failure,
                         "transitioning to HandleBiosJobFailure (power cycle + BMC reset)"
                     );
                     return Ok(try_bios_recovery_attempt(
@@ -254,7 +254,7 @@ pub(super) async fn advance_bios_config_job(
                         job_id
                     );
                     tracing::warn!(
-                        %failure,
+                        reason = %failure,
                         "transitioning to HandleBiosJobFailure (power cycle + BMC reset)"
                     );
                     Ok(try_bios_recovery_attempt(
@@ -290,7 +290,7 @@ pub(super) async fn advance_bios_config_job(
                         )));
                     }
                     tracing::info!(
-                        %failure,
+                        reason = %failure,
                         "HandleBiosJobFailure: resetting BMC after BIOS job failure"
                     );
                     redfish_client
@@ -358,7 +358,7 @@ fn try_bios_recovery_attempt(
         tracing::warn!(
             retry_count,
             max_retries = machine_controller_config.max_bios_config_retries,
-            %failure,
+            reason = %failure,
             "BIOS recovery budget exhausted; moving host to Failed for manual remediation"
         );
         return Ok(BiosRecoveryAttemptOutcome::Failed {

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -380,8 +380,8 @@ async fn handle_dpf_waiting_for_ready(
 
     if current_phase == carbide_dpf::DpuPhase::Error {
         tracing::error!(
-            host = %state.host_snapshot.id,
-            dpu = %dpu_snapshot.id,
+            machine_id = %state.host_snapshot.id,
+            dpu_machine_id = %dpu_snapshot.id,
             "DPU entered error phase during DPF provisioning"
         );
         let details = FailureDetails {
@@ -447,7 +447,7 @@ async fn handle_dpf_reprovisioning(
             .map_err(dpf_error)?;
     if dpf_dpudevices_and_dpunode_crs_noexist {
         tracing::info!(
-            host = %state.host_snapshot.id,
+            machine_id = %state.host_snapshot.id,
             "DPUDevice/DPUNode CRs do not exist, creating them before reprovisioning"
         );
         if let Err(err) = create_and_register_dpudevices_and_dpunode(state, dpf_sdk).await {
@@ -465,7 +465,7 @@ async fn handle_dpf_reprovisioning(
         return Ok(outcome.with_txn(txn));
     }
 
-    tracing::info!("DPF initiate reprovision of DPU {}", dpu_snapshot.id);
+    tracing::info!(machine_id = %dpu_snapshot.id, "DPF initiate reprovision of DPU");
     dpf_sdk
         .reprovision_dpu(&dpf_id(dpu_snapshot)?, &node_name)
         .await
@@ -501,7 +501,7 @@ pub async fn handle_dpf_state(
         .map_err(dpf_error)?
     {
         tracing::error!(
-            host = %state.host_snapshot.id,
+            machine_id = %state.host_snapshot.id,
             node = %node_name,
             "DPUNode has stale labels, failing for reprovisioning"
         );
@@ -532,7 +532,7 @@ pub async fn handle_dpf_state(
             handle_dpf_reprovisioning(state, dpu_snapshot, ctx, dpf_sdk).await
         }
         DpfState::Unknown => {
-            tracing::warn!(dpu_id = %dpu_snapshot.id, "unknown DPF state in DB, transitioning to provisioning");
+            tracing::warn!(dpu_machine_id = %dpu_snapshot.id, "unknown DPF state in DB, transitioning to provisioning");
             let next = set_one_dpu_dpf_state(state, &dpu_snapshot.id, DpfState::Provisioning)?;
             Ok(StateHandlerOutcome::transition(next))
         }

--- a/crates/machine-controller/src/handler/host_boot_config.rs
+++ b/crates/machine-controller/src/handler/host_boot_config.rs
@@ -445,7 +445,7 @@ async fn should_wait_for_dpus_before_host_boot_config(
                     {
                         Ok(_) => {}
                         Err(e) => tracing::warn!(
-                            dpu_id = %dpu_snapshot.id,
+                            dpu_machine_id = %dpu_snapshot.id,
                             error = %e,
                             "Could not reboot DPU while waiting to check host boot config"
                         ),

--- a/crates/machine-controller/src/handler/machine_validation.rs
+++ b/crates/machine-controller/src/handler/machine_validation.rs
@@ -127,7 +127,7 @@ async fn handle_validation_boot_config_stage(
             if !completed {
                 tracing::info!(
                     %machine_id,
-                    %validation_id,
+                    machine_validation_id = %validation_id,
                     "Machine validation boot-config failure observed after the run was already terminal"
                 );
             }
@@ -231,12 +231,12 @@ pub(crate) async fn handle_machine_validation_state(
             is_enabled,
         } => {
             tracing::trace!(
-                "context = {} id = {} completed = {} total = {}, is_enabled = {} ",
-                context,
-                id,
-                completed,
-                total,
-                is_enabled,
+                machine_validation_context = %context,
+                machine_validation_id = %id,
+                completed_validation_count = completed,
+                total_validation_count = total,
+                validation_enabled = is_enabled,
+                "machine validation progress",
             );
             if !rebooted(&mh_snapshot.host_snapshot) {
                 // Ensure the boot config is still what it should be while
@@ -305,8 +305,8 @@ pub(crate) async fn handle_machine_validation_state(
             if machine_validation_completed(&mh_snapshot.host_snapshot) {
                 if mh_snapshot.host_snapshot.failure_details.cause == FailureCause::NoError {
                     tracing::info!(
-                        "{} machine validation completed",
-                        mh_snapshot.host_snapshot.id
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "machine validation completed"
                     );
                     let machine_validation =
                         db::machine_validation::find_by_id(&mut ctx.services.db_reader, id)
@@ -330,7 +330,10 @@ pub(crate) async fn handle_machine_validation_state(
                         },
                     ));
                 } else {
-                    tracing::info!("{} machine validation failed", mh_snapshot.host_snapshot.id);
+                    tracing::info!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "machine validation failed"
+                    );
                     return Ok(StateHandlerOutcome::transition(ManagedHostState::Failed {
                         details: mh_snapshot.host_snapshot.failure_details.clone(),
                         machine_id: mh_snapshot.host_snapshot.id,

--- a/crates/machine-controller/src/handler/power.rs
+++ b/crates/machine-controller/src/handler/power.rs
@@ -62,8 +62,8 @@ pub async fn handle_power(
         }
     } else {
         tracing::warn!(
-            "Power options are not available for host: {}",
-            mh_snapshot.host_snapshot.id
+            machine_id = %mh_snapshot.host_snapshot.id,
+            "Power options are not available for host"
         );
         Ok(PowerHandlingOutcome::new(None, true, None))
     }
@@ -115,7 +115,8 @@ pub async fn handle_power_desired_on(
             }
             UsablePowerState::NotUsable(s) => {
                 tracing::warn!(
-                    "Not usable power state {s}. Since desired state is On, continuing state machine. Will check in next cycle."
+                    power_state = %s,
+                    "Not usable power state. Since desired state is On, continuing state machine. Will check in next cycle."
                 );
                 return Ok(PowerHandlingOutcome::new(
                     Some(updated_power_options),
@@ -186,7 +187,7 @@ pub async fn get_updated_power_options_desired_off(
                     "Desired state is Off and actual state is Off.".to_string()
                 };
                 if let PowerState::On = power_state {
-                    tracing::warn!(cause);
+                    tracing::warn!(reason = %cause, "Skipping host power handling");
                 }
                 return Ok(PowerHandlingOutcome::new(
                     Some(updated_power_options),
@@ -198,7 +199,7 @@ pub async fn get_updated_power_options_desired_off(
                 let cause = format!(
                     "Not usable power state {s}. Since desired state is Off, not processing any event."
                 );
-                tracing::warn!(cause);
+                tracing::warn!(reason = %cause, "Skipping host power handling");
                 return Ok(PowerHandlingOutcome::new(
                     Some(updated_power_options),
                     false,

--- a/crates/machine-controller/src/handler/sku.rs
+++ b/crates/machine-controller/src/handler/sku.rs
@@ -104,15 +104,18 @@ async fn generate_missing_sku_for_machine(
     }
     let Some(sku_id) = mh_snapshot.host_snapshot.hw_sku.as_ref() else {
         tracing::debug!(
-            "No SKU assigned to machine {}",
-            mh_snapshot.host_snapshot.id
+            machine_id = %mh_snapshot.host_snapshot.id,
+            "No SKU assigned"
         );
         return false;
     };
 
     // its unlikely we got here without a bmc mac
     let Some(bmc_mac_address) = mh_snapshot.host_snapshot.bmc_info.mac else {
-        tracing::debug!("No bmc mac for machine {}", mh_snapshot.host_snapshot.id);
+        tracing::debug!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            "No BMC MAC address configured"
+        );
         return false;
     };
 
@@ -123,7 +126,11 @@ async fn generate_missing_sku_for_machine(
         .flatten()
         .is_none_or(|em| em.data.sku_id.as_ref().is_none_or(|id| id != sku_id))
     {
-        tracing::debug!("No expected machine for bmc {}", bmc_mac_address);
+        tracing::debug!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            %bmc_mac_address,
+            "No expected machine for bmc"
+        );
         return false;
     }
 
@@ -552,7 +559,11 @@ pub(crate) async fn handle_bom_validation_state(
 
                 let diffs = diff_skus(&actual_sku, &expected_sku);
                 for diff in &diffs {
-                    tracing::error!(machine_id=%mh_snapshot.host_snapshot.id, "{}", diff);
+                    tracing::error!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        difference = %diff,
+                        "SKU validation mismatch",
+                    );
                 }
 
                 if diffs.is_empty() {

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -107,8 +107,14 @@ impl MachineValidation {
             .get_external_config(file_name.clone(), Some("container_auth".to_string()))
             .await
         {
-            Ok(()) => trace!("Fetched {} config", file_name),
-            Err(e) => trace!("Error - {}", e.to_string()),
+            Ok(()) => trace!(
+                external_config_file = %file_name,
+                "Fetched external machine validation config",
+            ),
+            Err(e) => trace!(
+                error = %e,
+                "Failed to fetch container authentication config",
+            ),
         }
         Ok(())
     }
@@ -117,7 +123,10 @@ impl MachineValidation {
         external_config_file: String,
         external_config_name: Option<String>,
     ) -> Result<(), MachineValidationError> {
-        tracing::info!("{}", external_config_file);
+        tracing::info!(
+            external_config_file = %external_config_file,
+            "Fetching external machine validation config",
+        );
 
         let name = if let Some(name) = external_config_name {
             name
@@ -172,7 +181,10 @@ impl MachineValidation {
         self,
         data: Option<rpc::forge::MachineValidationResult>,
     ) -> Result<(), MachineValidationError> {
-        tracing::info!("{}", data.clone().unwrap().name);
+        tracing::info!(
+            validation_name = %data.as_ref().expect("validation result").name,
+            "Persisting machine validation result",
+        );
         let mut client = self.create_forge_client().await?;
         let request =
             tonic::Request::new(rpc::forge::MachineValidationResultPostRequest { result: data });
@@ -228,18 +240,18 @@ impl MachineValidation {
                     .await
                 {
                     Ok(true) => {
-                        trace!(%validation_id, test_id = %test_id, "sent machine validation heartbeat")
+                        trace!(machine_validation_id = %validation_id, test_id = %test_id, "sent machine validation heartbeat")
                     }
                     Ok(false) => {
                         error!(
-                            %validation_id,
+                            machine_validation_id = %validation_id,
                             test_id = %test_id,
                             "machine validation heartbeat was rejected because run or attempt is no longer active"
                         );
                         return;
                     }
                     Err(e) => {
-                        error!(%validation_id, test_id = %test_id, error = %e, "failed to send machine validation heartbeat")
+                        error!(machine_validation_id = %validation_id, test_id = %test_id, error = %e, "failed to send machine validation heartbeat")
                     }
                 }
             }
@@ -250,7 +262,10 @@ impl MachineValidation {
         self,
         test_request: rpc::forge::MachineValidationTestsGetRequest,
     ) -> Result<Vec<rpc::forge::MachineValidationTest>, MachineValidationError> {
-        tracing::info!("{:?}", test_request);
+        tracing::info!(
+            request = ?test_request,
+            "Fetching machine validation tests",
+        );
         let mut client = self.create_forge_client().await?;
         let request = tonic::Request::new(test_request);
         let response = client
@@ -272,7 +287,7 @@ impl MachineValidation {
             "{}://{}{}{}",
             SCHME, MACHINE_VALIDATION_SERVER, MACHINE_VALIDATION_IMAGE_PATH, "list.json"
         );
-        tracing::info!(url);
+        tracing::info!(url = %url, "Fetching machine validation image list");
         MachineValidationManager::download_file(&url, IMAGE_LIST_FILE).await?;
 
         let json_file_path = Path::new("/tmp/list.json");
@@ -296,9 +311,15 @@ impl MachineValidation {
         for image_name in list.images {
             match Self::import_container(&image_name, MACHINE_VALIDATION_RUNNER_TAG).await {
                 Ok(data) => {
-                    trace!("Import successful '{}'", data)
+                    trace!(
+                        image_reference = %data,
+                        "Imported machine validation container image",
+                    )
                 }
-                Err(e) => error!("Failed to import '{}'", e.to_string()),
+                Err(e) => error!(
+                    error = %e,
+                    "Failed to import machine validation container image",
+                ),
             };
         }
         Ok(())
@@ -308,15 +329,18 @@ impl MachineValidation {
         image_name: &str,
         image_tag: &str,
     ) -> Result<String, MachineValidationError> {
-        tracing::info!(image_name);
+        tracing::info!(%image_name, "Importing machine validation image");
         let url: String = format!(
             "{SCHME}://{MACHINE_VALIDATION_SERVER}{MACHINE_VALIDATION_IMAGE_PATH}{image_name}.tar"
         );
-        tracing::info!(url);
+        tracing::info!(url = %url, "Fetching machine validation image");
         MachineValidationManager::download_file(&url, MACHINE_VALIDATION_IMAGE_FILE).await?;
 
         let command_string = format!(" ctr images import {MACHINE_VALIDATION_IMAGE_FILE}");
-        info!("Executing command '{}'", command_string);
+        info!(
+            command = %command_string,
+            "Executing machine validation command",
+        );
         TokioCmd::new("sh")
             .args(vec!["-c".to_string(), command_string])
             .timeout(DEFAULT_TIMEOUT)
@@ -329,17 +353,28 @@ impl MachineValidation {
     }
 
     pub async fn pull_container(image_name: &str) {
-        tracing::info!(image_name);
+        tracing::info!(%image_name, "Pulling machine validation image");
         let command_string = format!(" nerdctl -n default pull {image_name}");
-        tracing::info!(command_string);
+        tracing::info!(
+            command = %command_string,
+            "Executing machine validation command"
+        );
         match TokioCmd::new("sh")
             .args(vec!["-c".to_string(), command_string])
             .timeout(DEFAULT_TIMEOUT)
             .output_with_timeout()
             .await
         {
-            Ok(result) => info!("pulled: {}", result.stdout),
-            Err(e) => error!("Failed to image pull{} '{}'", image_name, e),
+            Ok(result) => info!(
+                image_name = %image_name,
+                stdout = %result.stdout,
+                "Pulled machine validation container image",
+            ),
+            Err(e) => error!(
+                image_name = %image_name,
+                error = %e,
+                "Failed to pull machine validation container image",
+            ),
         }
     }
     async fn execute_machinevalidation_command(
@@ -365,14 +400,14 @@ impl MachineValidation {
             .await
         {
             Ok(true) => trace!(
-                %validation_id,
+                machine_validation_id = %validation_id,
                 test_id = %test.test_id,
                 "sent initial machine validation heartbeat"
             ),
             Ok(false) => {
                 let now = Utc::now();
                 error!(
-                    %validation_id,
+                    machine_validation_id = %validation_id,
                     test_id = %test.test_id,
                     "initial machine validation heartbeat was rejected"
                 );
@@ -384,7 +419,7 @@ impl MachineValidation {
                 return MachineValidationExecution::without_heartbeat(mc_result);
             }
             Err(e) => error!(
-                %validation_id,
+                machine_validation_id = %validation_id,
                 test_id = %test.test_id,
                 error = %e,
                 "failed to send initial machine validation heartbeat"
@@ -401,7 +436,10 @@ impl MachineValidation {
                 .get_external_config(file_name.clone(), None)
                 .await
             {
-                Ok(()) => trace!("Fetched {} config", file_name),
+                Ok(()) => trace!(
+                    external_config_file = %file_name,
+                    "Fetched external machine validation config",
+                ),
                 Err(e) => {
                     mc_result.start_time = Some(Utc::now().into());
                     mc_result.end_time = Some(Utc::now().into());
@@ -466,7 +504,10 @@ impl MachineValidation {
                 command_string
             );
         };
-        info!("Executing command '{}'", command_string);
+        info!(
+            command = %command_string,
+            "Executing machine validation command",
+        );
 
         let _ = std::fs::remove_file("/tmp/forge_env_variables");
         match File::create("/tmp/forge_env_variables") {
@@ -559,7 +600,10 @@ impl MachineValidation {
         self,
         data: rpc::forge::MachineValidationRunRequest,
     ) -> Result<(), MachineValidationError> {
-        tracing::info!("{:?}", data.clone());
+        tracing::info!(
+            request = ?data,
+            "Updating machine validation run",
+        );
         let mut client = self.create_forge_client().await?;
         let request = tonic::Request::new(data);
         let _response = client
@@ -585,7 +629,7 @@ impl MachineValidation {
         self.clone().get_container_auth_config().await?;
         match Self::get_container_images().await {
             Ok(_) => info!("Successfully fetched container images"),
-            Err(e) => error!("{}", e.to_string()),
+            Err(e) => error!(error = %e, "Failed to fetch container images"),
         }
         if execute_tests_sequentially {
             for test in tests {
@@ -612,8 +656,15 @@ impl MachineValidation {
                     heartbeat.stop().await;
                 }
                 match persist_result {
-                    Ok(_) => info!("Successfully sent to api server - {}", test.name),
-                    Err(e) => error!("{}", e.to_string()),
+                    Ok(_) => info!(
+                        test_name = %test.name,
+                        "Sent machine validation result to API server",
+                    ),
+                    Err(e) => error!(
+                        test_name = %test.name,
+                        error = %e,
+                        "Failed to send machine validation result to API server",
+                    ),
                 }
             }
         } else {

--- a/crates/metrics-endpoint/src/lib.rs
+++ b/crates/metrics-endpoint/src/lib.rs
@@ -194,7 +194,7 @@ pub async fn run_metrics_endpoint_with_cancellation(
     let listener = TcpListener::bind(&config.address).await?;
 
     tracing::info!(
-        address = config.address.to_string(),
+        metrics_address = config.address.to_string(),
         "Starting metrics listener"
     );
 
@@ -218,7 +218,7 @@ pub async fn run_metrics_endpoint_with_listener(
         let stream = match result {
             Ok((stream, _addr)) => stream,
             Err(e) => {
-                tracing::error!("error accepting TCP connection: {e}");
+                tracing::error!(error = %e, "error accepting TCP connection");
                 continue;
             }
         };

--- a/crates/metrics-utils/src/lib.rs
+++ b/crates/metrics-utils/src/lib.rs
@@ -69,7 +69,11 @@ pub fn new_view(
             .with_unit(i.unit().to_owned())
             .build()
             .inspect_err(|e| {
-                tracing::error!("BUG: Could not build stream from view {}: {}", i.name(), e)
+                tracing::error!(
+                    view = i.name(),
+                    error = %e,
+                    "BUG: Could not build stream from view"
+                )
             })
             .ok()
     }))

--- a/crates/mqttea-example/src/main.rs
+++ b/crates/mqttea-example/src/main.rs
@@ -164,8 +164,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         client
             .on_message(|client, message: HelloWorld, topic| async move {
                 info!(
-                    "HelloWorld on {}: '{}' from device {} (timestamp: {})",
-                    topic, message.message, message.device_id, message.timestamp
+                    topic = %topic,
+                    payload = %message.message,
+                    device_id = %message.device_id,
+                    timestamp = message.timestamp,
+                    "received HelloWorld message"
                 );
                 let response_message: StringMessage =
                     format!("i got your message that said: {}", message.message).into();
@@ -179,7 +182,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     )
                     .await
                 {
-                    warn!("failed to publish response message: {:?}", publish_err);
+                    warn!(
+                        error = ?publish_err,
+                        "failed to publish response message"
+                    );
                 }
             })
             .await;
@@ -188,8 +194,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         client
             .on_message(|_client, message: CatStatus, topic| async move {
                 info!(
-                    "CatStatus on {}: {} is feeling {}",
-                    topic, message.name, message.mood,
+                    topic = %topic,
+                    cat_name = %message.name,
+                    mood = %message.mood,
+                    "received CatStatus message"
                 );
             })
             .await;
@@ -199,11 +207,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .on_message(|_client, message: RawMessage, topic| async move {
                 println!("FYI: Received message on unmapped topic: '{topic}'");
                 match String::from_utf8(message.payload.clone()) {
-                    Ok(text) => info!("RawMessage on {}: '{}'", topic, text),
+                    Ok(text) => info!(
+                        topic = %topic,
+                        payload = %text,
+                        "received raw text message"
+                    ),
                     Err(_) => info!(
-                        "RawMessage on {}: {} bytes of binary data",
-                        topic,
-                        message.payload.len()
+                        topic = %topic,
+                        payload_bytes = message.payload.len(),
+                        "received raw binary message"
                     ),
                 }
             })

--- a/crates/mqttea/src/auth/oauth2_provider.rs
+++ b/crates/mqttea/src/auth/oauth2_provider.rs
@@ -234,7 +234,7 @@ impl OAuth2TokenProvider {
         let expires_at = Instant::now() + expires_in;
 
         debug!(
-            expires_in_secs = expires_in.as_secs(),
+            expires_in_seconds = expires_in.as_secs(),
             "Successfully obtained OAuth2 access token"
         );
 
@@ -315,7 +315,7 @@ impl<'c> AsyncHttpClient<'c> for AsyncHttpClientWrapper<'_> {
             if status.is_server_error() || status.is_client_error() {
                 let body_str = std::str::from_utf8(&body).unwrap_or_default();
                 error!(
-                    body_str = %body_str,
+                    response_body = %body_str,
                     "Error response when making HTTP request for OAuth2 flow"
                 );
             }

--- a/crates/mqttea/src/client/core.rs
+++ b/crates/mqttea/src/client/core.rs
@@ -139,7 +139,7 @@ impl MqtteaClient {
             .as_ref()
             .and_then(|opts| opts.credentials_provider.clone());
 
-        info!("Created MQTT client for {}:{}", broker_host, broker_port);
+        info!(%broker_host, broker_port, "Created MQTT client");
 
         Ok(Arc::new(Self {
             client: Arc::new(client),
@@ -178,8 +178,9 @@ impl MqtteaClient {
         for (topic, qos) in subs_snapshot {
             if let Err(e) = self.client.subscribe(topic.as_str(), qos).await {
                 error!(
-                    "Failed to re-subscribe to {} after fresh session: {:?}",
-                    topic, e
+                    %topic,
+                    error = %e,
+                    "Failed to re-subscribe after fresh session",
                 );
             }
         }
@@ -273,8 +274,8 @@ impl MqtteaClient {
                                     }
                                     Err(mpsc::error::TrySendError::Full(_)) => {
                                         warn!(
-                                            "Message queue full, dropping message from topic: {}",
-                                            publish.topic
+                                            topic = %publish.topic,
+                                            "Message queue full, dropping message from topic",
                                         );
                                         queue_stats_producer.increment_dropped(payload_size);
                                         tokio::time::sleep(backoff_strategy.next_delay()).await;
@@ -292,13 +293,16 @@ impl MqtteaClient {
                             } else {
                                 queue_stats_producer.increment_unmatched_topics();
                                 if warn_on_unmatched_topic {
-                                    warn!("No registered pattern matched topic: {}", publish.topic);
+                                    warn!(
+                                        topic = %publish.topic,
+                                        "No registered pattern matched topic",
+                                    );
                                 }
                             }
                         }
                     }
                     Err(e) => {
-                        error!("MQTT event loop connection error: {:?}", e);
+                        error!(error = %e, "MQTT event loop connection error");
                         connection_state.set_connected(false);
                         queue_stats_producer.increment_event_loop_errors();
 
@@ -319,8 +323,8 @@ impl MqtteaClient {
                                 }
                                 Err(cred_err) => {
                                     error!(
-                                        "Failed to refresh credentials for reconnection: {:?}",
-                                        cred_err
+                                        error = %cred_err,
+                                        "Failed to refresh credentials for reconnection",
                                     );
                                 }
                             }
@@ -352,14 +356,19 @@ impl MqtteaClient {
                                 .decrement_pending_increment_processed(payload_size);
                         }
                         Err(e) => {
-                            error!("Handler error for {}: {}", msg.type_name, e);
+                            error!(
+                                message_type = %msg.type_name,
+                                error = %e,
+                                "Handler error",
+                            );
                             queue_stats_processor.decrement_pending_increment_failed(payload_size);
                         }
                     }
                 } else {
                     warn!(
-                        "No handler registered for message type '{}' on topic '{}'",
-                        msg.type_name, msg.topic
+                        message_type = %msg.type_name,
+                        topic = %msg.topic,
+                        "No handler registered for message type on topic",
                     );
                     queue_stats_processor.decrement_pending_increment_failed(payload_size);
                 }
@@ -450,8 +459,8 @@ impl MqtteaClient {
         let mut handlers_guard = self.handlers.write().await;
         handlers_guard.insert(std::any::type_name::<T>().to_string(), type_erased_handler);
         info!(
-            "Registered handler for message type: {}",
-            std::any::type_name::<T>()
+            message_type = std::any::type_name::<T>(),
+            "Registered handler for message type",
         );
     }
 
@@ -471,7 +480,7 @@ impl MqtteaClient {
             .await
             .map_err(MqtteaClientError::ConnectionError)?;
 
-        info!("Subscribed to topic: {} (QoS: {:?})", topic, qos);
+        info!(%topic, ?qos, "Subscribed to topic");
         Ok(())
     }
 
@@ -520,7 +529,7 @@ impl MqtteaClient {
         match self.client.publish(topic, qos, retain, payload).await {
             Ok(_) => {
                 self.publish_stats.increment_published(payload_size);
-                debug!("Published message to topic: {}", topic);
+                debug!(%topic, "Published message to topic");
                 Ok(())
             }
             Err(e) => {
@@ -709,8 +718,8 @@ impl SuperBasicBackoff {
         let delay = self.current;
         self.current = std::cmp::min(self.current * 2, self.max);
         warn!(
-            "Message event loop backoff updated: {}ms",
-            delay.as_millis()
+            delay_milliseconds = delay.as_millis(),
+            "Message event loop backoff updated"
         );
         delay
     }

--- a/crates/mqttea/src/client/messages.rs
+++ b/crates/mqttea/src/client/messages.rs
@@ -58,7 +58,7 @@ impl ReceivedMessage {
         let payload = publish.payload.to_vec();
         let payload_size = payload.len();
 
-        debug!("Looking for pattern match for topic: {}", topic);
+        debug!(%topic, "Looking for pattern match for topic");
         let registry_guard = registry.read().await;
         registry_guard
             .find_matching_type_for_topic(&topic)

--- a/crates/mqttea/src/registry/core.rs
+++ b/crates/mqttea/src/registry/core.rs
@@ -99,8 +99,9 @@ impl MqttRegistry {
 
             self.topic_patterns.push((regex, type_name.to_string()));
             debug!(
-                "Registered pattern '{}' for type '{}'",
-                regex_pattern, type_name
+                pattern = %regex_pattern,
+                message_type = %type_name,
+                "Registered MQTT topic pattern",
             );
         }
 
@@ -133,10 +134,10 @@ impl MqttRegistry {
         for (regex, type_name) in &self.topic_patterns {
             if regex.is_match(topic) {
                 debug!(
-                    "Topic '{}' matched pattern '{}' -> type '{}'",
-                    topic,
-                    regex.as_str(),
-                    type_name
+                    %topic,
+                    pattern = %regex.as_str(),
+                    message_type = %type_name,
+                    "Topic matched registered pattern",
                 );
                 return self
                     .entries
@@ -144,7 +145,7 @@ impl MqttRegistry {
                     .map(|entry| &entry.message_type_info);
             }
         }
-        debug!("Topic '{}' did not match any registered patterns", topic);
+        debug!(%topic, "Topic did not match any registered patterns");
         None
     }
 

--- a/crates/network-segment-controller/src/handler.rs
+++ b/crates/network-segment-controller/src/handler.rs
@@ -103,7 +103,7 @@ impl StateHandler for NetworkSegmentStateHandler {
         match controller_state {
             NetworkSegmentControllerState::Provisioning => {
                 let new_state = NetworkSegmentControllerState::Ready;
-                tracing::info!(%segment_id, state = ?new_state, "Network Segment state transition");
+                tracing::info!(network_segment_id = %segment_id, next_state = ?new_state, "Network Segment state transition");
                 Ok(StateHandlerOutcome::transition(new_state))
             }
             NetworkSegmentControllerState::Ready => {
@@ -116,7 +116,7 @@ impl StateHandler for NetworkSegmentStateHandler {
                             delete_at,
                         },
                     };
-                    tracing::info!(%segment_id, state = ?new_state, "Network Segment state transition");
+                    tracing::info!(network_segment_id = %segment_id, next_state = ?new_state, "Network Segment state transition");
                     Ok(StateHandlerOutcome::transition(new_state))
                 } else {
                     Ok(StateHandlerOutcome::do_nothing())
@@ -137,7 +137,7 @@ impl StateHandler for NetworkSegmentStateHandler {
                                 .unwrap_or_else(chrono::Utc::now);
                             tracing::info!(
                                 ?delete_at,
-                                %segment_id,
+                                network_segment_id = %segment_id,
                                 "Segment still has allocated IPs; waiting until the drain deadline to delete",
                             );
                             let new_state = NetworkSegmentControllerState::Deleting {
@@ -145,13 +145,13 @@ impl StateHandler for NetworkSegmentStateHandler {
                                     delete_at,
                                 },
                             };
-                            tracing::info!(%segment_id, state = ?new_state, "Network Segment state transition");
+                            tracing::info!(network_segment_id = %segment_id, next_state = ?new_state, "Network Segment state transition");
                             Ok(StateHandlerOutcome::transition(new_state).with_txn(txn))
                         } else if chrono::Utc::now() >= *delete_at {
                             let new_state = NetworkSegmentControllerState::Deleting {
                                 deletion_state: NetworkSegmentDeletionState::DBDelete,
                             };
-                            tracing::info!(%segment_id, state = ?new_state, "Network Segment state transition");
+                            tracing::info!(network_segment_id = %segment_id, next_state = ?new_state, "Network Segment state transition");
                             Ok(StateHandlerOutcome::transition(new_state).with_txn(txn))
                         } else {
                             Ok(StateHandlerOutcome::wait(format!(
@@ -171,7 +171,7 @@ impl StateHandler for NetworkSegmentStateHandler {
                                 .await?;
                         }
                         tracing::info!(
-                            %segment_id,
+                            network_segment_id = %segment_id,
                             "Network Segment getting removed from the database",
                         );
                         db::network_segment::final_delete(*segment_id, &mut txn).await?;

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -446,7 +446,7 @@ impl PartitionProcessingContext {
             tracing::info!(
                 machine_id = %machine_id,
                 gpu_guid = %gpu.guid,
-                nmx_c_id,
+                nmx_c_partition_id = nmx_c_id,
                 tray_partition = %tray_partition_nm,
                 "Enqueueing add to tray default partition"
             );
@@ -498,7 +498,10 @@ impl PartitionProcessingContext {
             }
             true
         } else {
-            tracing::error!("logical partition {} not found!!", logical_partition_id);
+            tracing::error!(
+                nvlink_logical_partition_id = %logical_partition_id,
+                "Logical partition not found",
+            );
             false
         }
     }
@@ -561,9 +564,10 @@ impl PartitionProcessingContext {
                             .collect(),
                         None => {
                             tracing::error!(
-                                "NMX-C partition not found for machine {}, GPU index {}",
-                                machine_id,
-                                device_instance
+                                machine_id = %machine_id,
+                                device_instance,
+                                nmx_c_partition_id = partition_nmx_c_id.partition_id,
+                                "NMX-C partition not found",
                             );
                             return None;
                         }
@@ -581,9 +585,10 @@ impl PartitionProcessingContext {
                         .collect(),
                     None => {
                         tracing::error!(
-                            "NMX-C partition not found for machine {}, GPU index {}",
-                            machine_id,
-                            device_instance
+                            machine_id = %machine_id,
+                            device_instance,
+                            nmx_c_partition_id = partition_nmx_c_id.partition_id,
+                            "NMX-C partition not found",
                         );
                         return None;
                     }
@@ -622,9 +627,10 @@ impl PartitionProcessingContext {
                             .collect(),
                         None => {
                             tracing::error!(
-                                "NMX-C partition not found for machine {}, GPU index {}",
-                                machine_id,
-                                device_instance
+                                machine_id = %machine_id,
+                                device_instance,
+                                nmx_c_partition_id = partition_nmx_c_id.partition_id,
+                                "NMX-C partition not found",
                             );
                             return None;
                         }
@@ -642,9 +648,10 @@ impl PartitionProcessingContext {
                         .collect(),
                     None => {
                         tracing::error!(
-                            "NMX-C partition not found for machine {}, GPU index {}",
-                            machine_id,
-                            device_instance
+                            machine_id = %machine_id,
+                            device_instance,
+                            nmx_c_partition_id = partition_nmx_c_id.partition_id,
+                            "NMX-C partition not found",
                         );
                         return None;
                     }
@@ -1060,7 +1067,10 @@ impl NvlPartitionMonitor {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!("NvlPartitionMonitor error: {}", e);
+                    tracing::warn!(
+                        error = %e,
+                        "NVLink partition monitor error",
+                    );
                 }
             }
 
@@ -1114,7 +1124,8 @@ impl NvlPartitionMonitor {
             Ok(lock) => lock,
             Err(e) => {
                 tracing::warn!(
-                    "NvlPartitionMonitor failed to acquire work lock: Another instance of carbide running? {e}"
+                    error = %e,
+                    "NvlPartitionMonitor failed to acquire work lock: Another instance of carbide running?",
                 );
                 return Ok(0);
             }
@@ -1484,7 +1495,10 @@ impl NvlPartitionMonitor {
         let nmx_c_operations = partition_processing_context.nmx_c_operations;
 
         if !nmx_c_operations.is_empty() {
-            tracing::debug!("NMX-C operations: {:?}", nmx_c_operations);
+            tracing::debug!(
+                nmx_c_operations = ?nmx_c_operations,
+                "Starting NMX-C operations",
+            );
         }
 
         // Execute any NMX-C operations and collect successful completions.
@@ -1494,8 +1508,8 @@ impl NvlPartitionMonitor {
 
         if !completed_nmx_c_operations.is_empty() {
             tracing::debug!(
-                "Completed NMX-C operations: {:?}",
-                completed_nmx_c_operations
+                completed_nmx_c_operations = ?completed_nmx_c_operations,
+                "Completed NMX-C operations",
             );
         }
 
@@ -1575,7 +1589,10 @@ impl NvlPartitionMonitor {
                 .get(&instance.machine_id)
                 .cloned()
             else {
-                tracing::warn!("No nvlink_info found for machine {}", instance.machine_id);
+                tracing::warn!(
+                    machine_id = %instance.machine_id,
+                    "No NVLink info found",
+                );
                 machine_gpu_statuses.insert(
                     instance.machine_id,
                     MachineNvLinkStatusObservation {
@@ -1634,8 +1651,8 @@ impl NvlPartitionMonitor {
                                         if db_logical_partition_id.is_none() {
                                             // How can this happen?
                                             tracing::error!(
-                                                "No logical partition ID associated with physical partition {:?}",
-                                                partition_id.to_string()
+                                                nmx_c_partition_id = partition_id,
+                                                "No logical partition ID associated with physical partition",
                                             );
                                             continue;
                                         } else if gpu_config.logical_partition_id
@@ -1668,11 +1685,11 @@ impl NvlPartitionMonitor {
                                     if is_nmx_c_default_partition(&nmxc_partition) {
                                         if instance_gpu_config.is_some() {
                                             tracing::info!(
-                                                "Removing GPU {} in machine {} and instance {} from default partition {}",
-                                                nvlink_gpu.guid,
-                                                instance.machine_id,
-                                                instance.id,
-                                                partition_id
+                                                gpu_guid = nvlink_gpu.guid,
+                                                machine_id = %instance.machine_id,
+                                                instance_id = %instance.id,
+                                                nmx_c_partition_id = partition_id,
+                                                "Removing GPU in machine and instance from default partition",
                                             );
                                             gpu_action = GpuAction::RemoveFromUnknownPartition;
                                             gpu_ctx.partition_nmx_c_id =
@@ -1685,9 +1702,9 @@ impl NvlPartitionMonitor {
                                         // Monitor does not know about this partition, so just remove the GPU. On the next iteration
                                         // the monitor will put the GPU in the correct partition (or leave it if the config says no partition)
                                         tracing::warn!(
-                                            "Removing GPU {} from unknown partition with NMX-C ID {}",
-                                            nvlink_gpu.guid,
-                                            partition_id
+                                            gpu_guid = nvlink_gpu.guid,
+                                            nmx_c_partition_id = partition_id,
+                                            "Removing GPU from unknown partition with NMX-C ID",
                                         );
                                         gpu_action = GpuAction::RemoveFromUnknownPartition;
                                         gpu_ctx.partition_nmx_c_id =
@@ -1716,7 +1733,7 @@ impl NvlPartitionMonitor {
                             tracing::warn!(
                                 machine_id = %instance.machine_id,
                                 gpu_guid = %gpu_ctx.gpu_guid,
-                                logical_partition_id = %logical_partition_id,
+                                nvlink_logical_partition_id = %logical_partition_id,
                                 "Logical partition is marked as deleted, skipping GPU action"
                             );
                             continue;
@@ -1752,7 +1769,8 @@ impl NvlPartitionMonitor {
                                         tracing::error!(
                                             gpu_guid = %gpu_ctx.gpu_guid,
                                             machine_id = %instance.machine_id,
-                                            "Failed to handle GPU addition to existing partition: {e}"
+                                            error = %e,
+                                            "Failed to handle GPU addition to existing partition",
                                         );
                                     }
                                 } else {
@@ -1763,7 +1781,8 @@ impl NvlPartitionMonitor {
                                         tracing::error!(
                                             gpu_guid = %gpu_ctx.gpu_guid,
                                             machine_id = %instance.machine_id,
-                                            "Failed to handle GPU addition to new partition: {e}"
+                                            error = %e,
+                                            "Failed to handle GPU addition to new partition",
                                         );
                                     }
                                 }
@@ -1787,7 +1806,8 @@ impl NvlPartitionMonitor {
                                     tracing::error!(
                                         gpu_guid = %gpu_ctx.gpu_guid,
                                         machine_id = %instance.machine_id,
-                                        "Failed to handle GPU removal from partition: {e}"
+                                        error = %e,
+                                        "Failed to handle GPU removal from partition",
                                     );
                                 }
                             }
@@ -1810,15 +1830,16 @@ impl NvlPartitionMonitor {
                                         tracing::error!(
                                             gpu_guid = %gpu_ctx.gpu_guid,
                                             machine_id = %instance.machine_id,
-                                            "Failed to handle GPU removal from unknown partition: {e}"
+                                            error = %e,
+                                            "Failed to handle GPU removal from unknown partition",
                                         );
                                     }
                                 } else {
                                     tracing::error!(
                                         gpu_guid = %gpu_ctx.gpu_guid,
                                         machine_id = %instance.machine_id,
-                                        "No default partition found with NMX-C ID = {}",
-                                        gpu_ctx.partition_nmx_c_id.partition_id
+                                        nmx_c_partition_id = gpu_ctx.partition_nmx_c_id.partition_id,
+                                        "NMX-C partition not found for GPU removal",
                                     );
                                     continue;
                                 }
@@ -1828,7 +1849,10 @@ impl NvlPartitionMonitor {
                     }
                 }
                 None => {
-                    tracing::warn!("No nvlink_info found for machine {}", instance.machine_id);
+                    tracing::warn!(
+                        machine_id = %instance.machine_id,
+                        "No NVLink info found",
+                    );
                 }
             }
             // Now we've generated the operations, record an observation.
@@ -1983,7 +2007,7 @@ impl NvlPartitionMonitor {
                     tracing::info!(
                         machine_id = %mh.host_snapshot.id,
                         gpu_guid = %gpu.guid,
-                        logical_partition_id = %logical_id,
+                        nvlink_logical_partition_id = %logical_id,
                         gpus_to_keep = ?gpus_to_keep,
                         "Handling GPU removal from partition for machine in admin network"
                     );
@@ -2157,7 +2181,7 @@ impl NvlPartitionMonitor {
                         match nmxc_client.create_partition(request.clone()).await {
                             Err(e) if e.is_nmx_resource_exhausted() => {
                                 tracing::info!(
-                                    %logical_partition_id,
+                                    nvlink_logical_partition_id = %logical_partition_id,
                                     partition_name = %name,
                                     create_partition_request = ?request,
                                     "NMX-C create partition returned NMX_ST_RESOURCE_EXHAUSTED; retrying with multicast_groups_limit=0"
@@ -2168,8 +2192,9 @@ impl NvlPartitionMonitor {
                                     Ok(_) => true,
                                     Err(e) => {
                                         tracing::warn!(
-                                            %logical_partition_id,
-                                            "Failed to retry create partition on NMX-C with multicast_groups_limit=0: {e}"
+                                            nvlink_logical_partition_id = %logical_partition_id,
+                                            error = %e,
+                                            "Failed to retry create partition on NMX-C with multicast_groups_limit=0",
                                         );
                                         false
                                     }
@@ -2178,9 +2203,10 @@ impl NvlPartitionMonitor {
                             Ok(_) => true,
                             Err(e) => {
                                 tracing::warn!(
-                                    %logical_partition_id,
+                                    nvlink_logical_partition_id = %logical_partition_id,
                                     create_partition_request = ?request,
-                                    "Failed to issue create partition to NMX-C, continuing with other operations: {e}"
+                                    error = %e,
+                                    "Failed to issue create partition to NMX-C, continuing with other operations",
                                 );
                                 false
                             }
@@ -2199,9 +2225,10 @@ impl NvlPartitionMonitor {
                             Ok(_) => true,
                             Err(e) => {
                                 tracing::warn!(
-                                    %logical_partition_id,
+                                    nvlink_logical_partition_id = %logical_partition_id,
                                     %nmx_c_partition_id,
-                                    "Failed to issue delete partition to NMX-C, continuing with other operations: {e}"
+                                    error = %e,
+                                    "Failed to issue delete partition to NMX-C, continuing with other operations",
                                 );
                                 false
                             }
@@ -2238,9 +2265,10 @@ impl NvlPartitionMonitor {
                         match nmxc_client.get_partition_info_list(list_req).await {
                             Err(e) => {
                                 tracing::warn!(
-                                    %logical_partition_id,
+                                    nvlink_logical_partition_id = %logical_partition_id,
                                     %nmx_c_partition_id,
-                                    "Failed to get partition info from NMX-C before update: {e}"
+                                    error = %e,
+                                    "Failed to get partition info from NMX-C before update",
                                 );
                                 false
                             }
@@ -2280,9 +2308,10 @@ impl NvlPartitionMonitor {
                                         Ok(_) => {}
                                         Err(e) => {
                                             tracing::warn!(
-                                                %logical_partition_id,
+                                                nvlink_logical_partition_id = %logical_partition_id,
                                                 %nmx_c_partition_id,
-                                                "Failed to remove GPUs from partition on NMX-C: {e}"
+                                                error = %e,
+                                                "Failed to remove GPUs from partition on NMX-C",
                                             );
                                             ok = false;
                                         }
@@ -2302,9 +2331,10 @@ impl NvlPartitionMonitor {
                                         Ok(_) => {}
                                         Err(e) => {
                                             tracing::warn!(
-                                                %logical_partition_id,
+                                                nvlink_logical_partition_id = %logical_partition_id,
                                                 %nmx_c_partition_id,
-                                                "Failed to add GPUs to partition on NMX-C: {e}"
+                                                error = %e,
+                                                "Failed to add GPUs to partition on NMX-C",
                                             );
                                             ok = false;
                                         }
@@ -2363,8 +2393,8 @@ impl NvlPartitionMonitor {
                             Some(p) => p,
                             None => {
                                 tracing::error!(
-                                    "NMX-C partition not found for name {}",
-                                    operation.name
+                                    operation_name = %operation.name,
+                                    "NMX-C partition not found",
                                 );
                                 continue;
                             }
@@ -2375,23 +2405,23 @@ impl NvlPartitionMonitor {
                             .map(|id| id.partition_id)
                         else {
                             tracing::error!(
-                                "NMX-C partition ID not found for name {}",
-                                operation.name
+                                operation_name = %operation.name,
+                                "NMX-C partition ID not found",
                             );
                             continue;
                         };
                         let Ok(nmx_c_partition_id) = i32::try_from(nmx_c_partition_id) else {
                             tracing::error!(
-                                "NMX-C partition ID does not fit in database column for name {}",
-                                operation.name
+                                operation_name = %operation.name,
+                                "NMX-C partition ID does not fit in database column",
                             );
                             continue;
                         };
 
                         if operation.name.starts_with("tray_partition_") {
                             tracing::debug!(
-                                logical_partition_id = %logical_partition_id,
-                                name = %operation.name,
+                                nvlink_logical_partition_id = %logical_partition_id,
+                                operation_name = %operation.name,
                                 "Skipping nvl_partition DB insert for tray partition"
                             );
                             continue;
@@ -2428,7 +2458,10 @@ impl NvlPartitionMonitor {
         // walk the logical partition list and check if any logical partitions need to be cleaned up
         for lp in db_nvl_logical_partitions {
             if model::nvl_logical_partition::is_marked_as_deleted(lp) {
-                tracing::info!(logical_partition_id = %lp.id, "Deleting logical partition");
+                tracing::info!(
+                    nvlink_logical_partition_id = %lp.id,
+                    "Deleting logical partition"
+                );
                 db::nvl_logical_partition::final_delete(lp.id, txn).await?;
             }
         }

--- a/crates/nvlink-manager/src/switch_cert_monitor.rs
+++ b/crates/nvlink-manager/src/switch_cert_monitor.rs
@@ -589,7 +589,10 @@ impl SwitchCertificateMonitor {
         loop {
             let tick = timer.tick();
             if let Err(e) = self.run_single_iteration(&cancel_token).await {
-                tracing::warn!("SwitchCertificateMonitor error: {}", e);
+                tracing::warn!(
+                    error = %e,
+                    "Switch certificate monitor error",
+                );
             }
 
             tokio::select! {
@@ -647,7 +650,8 @@ impl SwitchCertificateMonitor {
             Ok(lock) => lock,
             Err(e) => {
                 tracing::warn!(
-                    "SwitchCertificateMonitor failed to acquire work lock: Another instance of carbide running? {e}"
+                    error = %e,
+                    "SwitchCertificateMonitor failed to acquire work lock: Another instance of carbide running?",
                 );
                 return Ok(());
             }
@@ -864,7 +868,7 @@ impl SwitchCertificateMonitor {
                         rack_id = %target.rack_id,
                         endpoint = %target.endpoint_url,
                         job_id = %in_flight_job.job_id,
-                        state = %state,
+                        job_state = %state,
                         "RMS NMX-C switch certificate configuration job is still in progress"
                     );
                     Ok(SwitchCertApplyStatus::Pending)
@@ -1085,7 +1089,7 @@ impl SwitchCertificateMonitor {
             _ => {
                 tracing::warn!(
                     job_id = %job_id,
-                    state = %response.state,
+                    job_state = %response.state,
                     "RMS returned unknown NMX-C switch certificate job state; treating as pending"
                 );
                 Ok(RmsSwitchCertJobState::Pending(response.state))

--- a/crates/power-shelf-controller/src/configuring.rs
+++ b/crates/power-shelf-controller/src/configuring.rs
@@ -36,8 +36,8 @@ pub async fn handle_configuring(
     _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
     tracing::info!(
-        "Configuring PowerShelf {}, transitioning to Ready",
-        power_shelf_id
+        %power_shelf_id,
+        "Configuring PowerShelf; transitioning to Ready"
     );
     Ok(StateHandlerOutcome::transition(
         PowerShelfControllerState::Ready,

--- a/crates/power-shelf-controller/src/deleting.rs
+++ b/crates/power-shelf-controller/src/deleting.rs
@@ -36,7 +36,7 @@ pub async fn handle_deleting(
     _state: &mut PowerShelf,
     ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
-    tracing::info!("Deleting PowerShelf {}", power_shelf_id);
+    tracing::info!(%power_shelf_id, "Deleting PowerShelf");
     let mut txn = ctx.services.db_pool.begin().await?;
     db_power_shelf::final_delete(*power_shelf_id, &mut txn).await?;
     Ok(StateHandlerOutcome::deleted().with_txn(txn))

--- a/crates/power-shelf-controller/src/fetching_data.rs
+++ b/crates/power-shelf-controller/src/fetching_data.rs
@@ -36,8 +36,8 @@ pub async fn handle_fetching_data(
     _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
     tracing::info!(
-        "Fetching PowerShelf {} data, transitioning to Configuring",
-        power_shelf_id
+        %power_shelf_id,
+        "Fetching PowerShelf data; transitioning to Configuring"
     );
     Ok(StateHandlerOutcome::transition(
         PowerShelfControllerState::Configuring,

--- a/crates/power-shelf-controller/src/initializing.rs
+++ b/crates/power-shelf-controller/src/initializing.rs
@@ -37,8 +37,8 @@ pub async fn handle_initializing(
     _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
     tracing::info!(
-        "PowerShelf {} initializing, transitioning to FetchingData",
-        power_shelf_id
+        %power_shelf_id,
+        "PowerShelf initializing; transitioning to FetchingData"
     );
     Ok(StateHandlerOutcome::transition(
         PowerShelfControllerState::FetchingData,

--- a/crates/preingestion-manager/src/bfb_rshim_copier.rs
+++ b/crates/preingestion-manager/src/bfb_rshim_copier.rs
@@ -135,7 +135,7 @@ impl BfbRshimCopier {
                 .is_rshim_enabled(bmc_ip_address, credentials.clone())
                 .await?
             {
-                tracing::warn!("RSHIM is not enabled on {bmc_ip_address}");
+                tracing::warn!(%bmc_ip_address, "RSHIM is not enabled");
                 self.enable_rshim(bmc_ip_address, credentials.clone())
                     .await?;
 
@@ -160,7 +160,10 @@ impl BfbRshimCopier {
         let _lock = self.bfb_file_lock.lock().await;
 
         if fs::metadata(UNIFIED_PREINGESTION_BFB_PATH).await.is_err() {
-            tracing::info!("Writing {UNIFIED_PREINGESTION_BFB_PATH}");
+            tracing::info!(
+                path = UNIFIED_PREINGESTION_BFB_PATH,
+                "Writing unified preingestion BFB"
+            );
             let bf_cfg_contents = format!(
                 "BMC_USER=\"{username}\"\nBMC_PASSWORD=\"{password}\"\nBMC_REBOOT=\"yes\"\nCEC_REBOOT=\"yes\"\n"
             );
@@ -180,7 +183,7 @@ impl BfbRshimCopier {
 
             let mut buffer = vec![0; 1024 * 1024].into_boxed_slice(); // 1 MB buffer
 
-            tracing::info!("Writing BFB to {UNIFIED_PREINGESTION_BFB_PATH}");
+            tracing::info!(path = UNIFIED_PREINGESTION_BFB_PATH, "Writing BFB payload");
             loop {
                 let n = preingestion_bfb.read(&mut buffer).await.map_err(|err| {
                     BfbRshimCopyError::Other {
@@ -201,7 +204,10 @@ impl BfbRshimCopier {
                 })?;
             }
 
-            tracing::info!("Writing bf.cfg to {UNIFIED_PREINGESTION_BFB_PATH}");
+            tracing::info!(
+                path = UNIFIED_PREINGESTION_BFB_PATH,
+                "Writing bf.cfg payload"
+            );
 
             unified_bfb
                 .write_all(bf_cfg_contents.as_bytes())

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -177,7 +177,7 @@ impl PreingestionManager {
             let res = self.run_single_iteration().await;
 
             if let Err(e) = &res {
-                tracing::warn!("Preingestion manager error: {}", e);
+                tracing::warn!(error = %e, "Preingestion manager error");
             }
 
             // If we were able to go through everything (few or no uploads), or if we ran into a database error,
@@ -208,9 +208,9 @@ impl PreingestionManager {
             Err(e) => {
                 // Unable to obtain the lock, we'll sleep and try again later.  There must be another instance of carbide-api running.
                 tracing::warn!(
-                    "Unable to acquire lock for {}. Will try again on next iteration: {}",
-                    Self::ITERATION_WORK_KEY,
-                    e
+                    work_key = Self::ITERATION_WORK_KEY,
+                    error = %e,
+                    "Unable to acquire lock; will try again on next iteration"
                 );
                 return Ok(());
             }
@@ -223,15 +223,18 @@ impl PreingestionManager {
         if !items.is_empty() && items.len() < 3 {
             // Show states if a modest amount, just count otherwise
             tracing::debug!(
-                "PreingestionManager: Working on {} items {:?}",
-                items.len(),
-                items
+                item_count = items.len(),
+                items = ?items
                     .iter()
                     .map(|x| format!("({}: {:?})", x.address, x.preingestion_state))
-                    .collect::<Vec<String>>()
+                    .collect::<Vec<String>>(),
+                "Preingestion manager working on items"
             );
         } else {
-            tracing::debug!("PreingestionManager: Working on {} items", items.len())
+            tracing::debug!(
+                item_count = items.len(),
+                "Preingestion manager working on items"
+            )
         }
 
         // Limit the number of concurrent preingestion tasks.
@@ -262,11 +265,11 @@ impl PreingestionManager {
                         }
                     }
                     Err(e) => {
-                        tracing::warn!("Error handling preingestion update: {e}");
+                        tracing::warn!(error = %e, "Error handling preingestion update");
                     }
                 },
                 Err(e) => {
-                    tracing::warn!("Error handling preingestion update: {e}");
+                    tracing::warn!(error = %e, "Error handling preingestion update");
                 }
             }
         }
@@ -280,10 +283,10 @@ impl PreingestionManager {
             .max(0) as usize;
 
         tracing::debug!(
-            "Preingestion metrics: in_preingestion {} waiting {} delayed {}",
-            metrics.machines_in_preingestion,
-            metrics.waiting_for_installation,
-            metrics.delayed_uploading,
+            machines_in_preingestion = metrics.machines_in_preingestion,
+            waiting_for_installation = metrics.waiting_for_installation,
+            delayed_uploading = metrics.delayed_uploading,
+            "Preingestion metrics updated"
         );
         self.metric_holder.update_metrics(metrics);
 
@@ -300,7 +303,7 @@ async fn one_endpoint(
     endpoint: &ExploredEndpoint,
     static_info: Arc<PreingestionManagerStatic>,
 ) -> PreingestionManagerResult<EndpointResult> {
-    tracing::debug!("Preingestion on endpoint {:?}", endpoint);
+    tracing::debug!(?endpoint, "Running preingestion");
 
     // BFB-related preingestion doesn't work for a DPU running in NIC
     // mode -- the Arm OS doesn't boot, so the `in_bfb_installation_wait`
@@ -334,9 +337,9 @@ async fn one_endpoint(
         && endpoint.report.nic_mode() == Some(NicMode::Nic)
     {
         tracing::info!(
-            address = %endpoint.address,
-            %host_bmc_ip,
-            from_state = ?endpoint.preingestion_state,
+            bmc_ip_address = %endpoint.address,
+            host_bmc_ip_address = %host_bmc_ip,
+            previous_state = ?endpoint.preingestion_state,
             "DPU is in NIC mode; skipping BFB preingestion path and marking complete",
         );
         db.with_txn(|txn| {
@@ -494,7 +497,8 @@ async fn one_endpoint(
         PreingestionState::Complete => {
             // This should have been filtered out by the query that got us this list.
             tracing::warn!(
-                "Endpoint showed complete preingestion and should not have been here: {endpoint:?}"
+                ?endpoint,
+                "Endpoint showed complete preingestion and should not have been here"
             );
             false
         }
@@ -542,8 +546,8 @@ impl PreingestionManagerStatic {
         let fw_info = match self.find_fw_info_for_host(db, endpoint).await? {
             None => {
                 tracing::debug!(
-                    "check_firmware_versions_below_preingestion {}: No matching firmware info found",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "No matching firmware info found during preingestion check"
                 );
                 // No desired firmware description found for this host, nothing to do.
                 // This is the expected path for DPUs.
@@ -560,16 +564,20 @@ impl PreingestionManagerStatic {
                 && let Some(current) = endpoint.find_version(&fw_info, *fwtype)
             {
                 tracing::info!(
-                    "check_firmware_versions_below_preingestion {}: {fwtype:?} min preingestion {min_preingestion:?} current {current:?}",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    firmware_type = ?fwtype,
+                    ?min_preingestion,
+                    ?current,
+                    "Checking firmware version against preingestion minimum"
                 );
 
                 if version_compare::compare(current, min_preingestion)
                     .is_ok_and(|c| c == version_compare::Cmp::Lt)
                 {
                     tracing::info!(
-                        "check_firmware_versions_below_preingestion {}: Start upload of {fwtype:?}",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        firmware_type = ?fwtype,
+                        "Starting firmware upload during preingestion check"
                     );
                     // One or both of the versions are low enough to absolutely need upgrades first - do them both while we're at it.
                     let delayed_upgrade = self
@@ -578,16 +586,17 @@ impl PreingestionManagerStatic {
                     return Ok(delayed_upgrade);
                 } else {
                     tracing::info!(
-                        "check_firmware_versions_below_preingestion {}: {fwtype:?} is good",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        firmware_type = ?fwtype,
+                        "Firmware version satisfies preingestion minimum"
                     );
                 }
             }
         }
 
         tracing::debug!(
-            "check_firmware_versions_below_preingestion {}: Satisfied and marking complete",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            "Firmware versions satisfy preingestion requirements; marking complete"
         );
         // Good enough for now at least, proceed with ingestion.
         db.with_txn(|txn| {
@@ -609,8 +618,8 @@ impl PreingestionManagerStatic {
     ) -> PreingestionManagerResult<bool> {
         if endpoint.waiting_for_explorer_refresh {
             tracing::debug!(
-                "start_firmware_uploads_or_continue {}: Waiting for explorer refresh",
-                endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "Waiting for explorer refresh before continuing firmware uploads"
             );
             // We've updated something and are waiting for site explorer to get back around to it
             return Ok(false);
@@ -620,8 +629,8 @@ impl PreingestionManagerStatic {
         // We can't check machine IDs here as they may not be available yet, so use the global value only.
         if !self.config.autoupdate {
             tracing::debug!(
-                "start_firmware_uploads_or_continue {}: Auto updates disabled",
-                endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "Automatic firmware updates disabled"
             );
             db.with_txn(|txn| {
                 db::explored_endpoints::set_preingestion_complete(endpoint.address, txn).boxed()
@@ -634,8 +643,8 @@ impl PreingestionManagerStatic {
             None => {
                 // No desired firmware description found for this host
                 tracing::debug!(
-                    "start_firmware_uploads_or_continue {}: No firmware info found",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "No firmware info found while starting firmware uploads"
                 );
 
                 return Ok(false);
@@ -662,8 +671,8 @@ impl PreingestionManagerStatic {
         }
 
         tracing::debug!(
-            "start_firmware_uploads_or_continue {}: No further updates needed",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            "No further firmware updates needed"
         );
 
         // Nothing needed to be updated, we're complete.
@@ -688,8 +697,9 @@ impl PreingestionManagerStatic {
             match need_upgrade(endpoint, fw_info, fw_type) {
                 None => {
                     tracing::debug!(
-                        "start_upgrade_if_needed {}: Upgrade of {fw_type:?} not needed",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        firmware_type = ?fw_type,
+                        "Firmware upgrade not needed"
                     );
                     Ok((false, false))
                 }
@@ -700,9 +710,9 @@ impl PreingestionManagerStatic {
                     }
                     let Ok(_active) = self.upload_limiter.try_acquire() else {
                         tracing::debug!(
-                            "Deferring installation of {:?} on {}, too many uploads already active",
-                            to_install,
-                            endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            ?to_install,
+                            "Deferring firmware installation because too many uploads are active"
                         );
                         return Ok((true, true)); // Don't check others
                     };
@@ -712,7 +722,11 @@ impl PreingestionManagerStatic {
                         return Ok((true, false));
                     }
 
-                    tracing::info!("Installing {:?} on {}", to_install, endpoint.address);
+                    tracing::info!(
+                        bmc_ip_address = %endpoint.address,
+                        ?to_install,
+                        "Installing firmware"
+                    );
 
                     self.initiate_update(endpoint, &to_install, &fw_type, 0, db)
                         .await?;
@@ -751,7 +765,11 @@ impl PreingestionManagerStatic {
         {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
-                tracing::warn!("Redfish connection to {} failed: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Redfish connection failed"
+                );
                 return Ok(());
             }
         };
@@ -764,10 +782,10 @@ impl PreingestionManagerStatic {
                     | Some(TaskState::Running)
                     | Some(TaskState::Pending) => {
                         tracing::debug!(
-                            "Upgrade task for {} not yet complete, current state {:?} message {:?}",
-                            endpoint.address,
-                            task_info.task_state,
-                            task_info.messages,
+                            bmc_ip_address = %endpoint.address,
+                            task_state = ?task_info.task_state,
+                            task_messages = ?task_info.messages,
+                            "Firmware upgrade task not yet complete"
                         );
                     }
                     Some(TaskState::Completed) => {
@@ -793,10 +811,10 @@ impl PreingestionManagerStatic {
                                 firmware_number < selected_firmware.artifact_count()
                             }) {
                                 tracing::info!(
-                                    "Installing {:?} chain step {} on {}",
-                                    selected_firmware,
+                                    bmc_ip_address = %endpoint.address,
+                                    ?selected_firmware,
                                     firmware_number,
-                                    endpoint.address
+                                    "Installing firmware chain step"
                                 );
 
                                 if self
@@ -821,8 +839,8 @@ impl PreingestionManagerStatic {
                             }
                         }
                         tracing::info!(
-                            "Marking completion of Redfish task of firmware upgrade for {}",
-                            &endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            "Marking firmware upgrade Redfish task complete"
                         );
                         db.with_txn(|txn| {
                             db::explored_endpoints::set_preingestion_reset_for_new_firmware(
@@ -917,9 +935,9 @@ impl PreingestionManagerStatic {
                     _ => {
                         // Unexpected state
                         tracing::warn!(
-                            "Unrecognized task state for {}: {:?}",
-                            endpoint.address,
-                            task_info.task_state
+                            bmc_ip_address = %endpoint.address,
+                            task_state = ?task_info.task_state,
+                            "Unrecognized firmware upgrade task state"
                         );
                     }
                 };
@@ -934,8 +952,8 @@ impl PreingestionManagerStatic {
                             && current_version == final_version
                         {
                             tracing::debug!(
-                                "Marking completion of Redfish task of firmware upgrade for {} with missing task",
-                                &endpoint.address
+                                bmc_ip_address = %endpoint.address,
+                                "Marking missing firmware upgrade Redfish task complete"
                             );
                             db.with_txn(|txn| {
                                 db::explored_endpoints::set_preingestion_recheck_versions(
@@ -959,7 +977,11 @@ impl PreingestionManagerStatic {
                     }
                 }
                 _ => {
-                    tracing::warn!("Getting Redfish task from {} failed: {e}", endpoint.address);
+                    tracing::warn!(
+                        bmc_ip_address = %endpoint.address,
+                        error = %e,
+                        "Getting Redfish task failed"
+                    );
                 }
             },
         };
@@ -1006,7 +1028,11 @@ impl PreingestionManagerStatic {
         {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
-                tracing::error!("Redfish connection to {} failed: {e}", endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Redfish connection failed"
+                );
                 return Ok(());
             }
         };
@@ -1021,8 +1047,9 @@ impl PreingestionManagerStatic {
                 && *delay_until > chrono::Utc::now().timestamp()
             {
                 tracing::info!(
-                    "Waiting after {last_power_drain_operation:?} of {}",
-                    &endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    ?last_power_drain_operation,
+                    "Waiting after power drain operation"
                 );
                 return Ok(());
             }
@@ -1031,14 +1058,17 @@ impl PreingestionManagerStatic {
                 None | Some(PowerDrainState::On) => {
                     // The 1000 is for unit tests; values above this will skip delays.
                     if *power_drains_needed == 0 || *power_drains_needed == 1000 {
-                        tracing::info!("Power drains for {} done", &endpoint.address);
+                        tracing::info!(
+                            bmc_ip_address = %endpoint.address,
+                            "Firmware upgrade power drains complete"
+                        );
                         // This path, and only this path of the match, exits the match and lets us proceed.  All others should return after updating state.
                         need_wait = false; // We've reset multiple times already and should be reporting the new version
                     } else {
                         tracing::info!(
-                            "Upgrade task has completed for {} but needs {} power drain(s), initiating one",
-                            &endpoint.address,
-                            *power_drains_needed
+                            bmc_ip_address = %endpoint.address,
+                            required_power_drain_count = *power_drains_needed,
+                            "Firmware upgrade task complete; initiating required power drain"
                         );
                         if let Err(e) = count_power_op(
                             PowerOperation::ForceOff,
@@ -1046,7 +1076,11 @@ impl PreingestionManagerStatic {
                         )
                         .await
                         {
-                            tracing::error!("Failed to power off {}: {e}", &endpoint.address);
+                            tracing::error!(
+                                bmc_ip_address = %endpoint.address,
+                                error = %e,
+                                "Failed to power off"
+                            );
                             return Ok(());
                         }
 
@@ -1074,11 +1108,14 @@ impl PreingestionManagerStatic {
                 }
                 Some(PowerDrainState::Off) => {
                     if endpoint.report.vendor.unwrap_or_default().is_lenovo() {
-                        tracing::info!("Doing powercycle now for {}", &endpoint.address);
+                        tracing::info!(
+                            bmc_ip_address = %endpoint.address,
+                            "Starting AC power cycle"
+                        );
                         match redfish_client.get_power_state().await {
                             Ok(power_state) if power_state != PowerState::Off => {
                                 tracing::warn!(
-                                    address = %endpoint.address,
+                                    bmc_ip_address = %endpoint.address,
                                     %power_state,
                                     "ACPowercycle requires chassis to be Off, forcing off first"
                                 );
@@ -1089,8 +1126,9 @@ impl PreingestionManagerStatic {
                                 .await
                                 {
                                     tracing::error!(
-                                        "Failed to force off {}: {e}",
-                                        &endpoint.address
+                                        bmc_ip_address = %endpoint.address,
+                                        error = %e,
+                                        "Failed to force off"
                                     );
                                     return Ok(());
                                 }
@@ -1117,8 +1155,9 @@ impl PreingestionManagerStatic {
                             Ok(_) => {}
                             Err(e) => {
                                 tracing::error!(
-                                    "Failed to get power state for {}: {e}",
-                                    &endpoint.address
+                                    bmc_ip_address = %endpoint.address,
+                                    error = %e,
+                                    "Failed to get power state"
                                 );
                                 return Ok(());
                             }
@@ -1129,7 +1168,11 @@ impl PreingestionManagerStatic {
                         )
                         .await
                         {
-                            tracing::error!("Failed to power cycle {}: {e}", &endpoint.address);
+                            tracing::error!(
+                                bmc_ip_address = %endpoint.address,
+                                error = %e,
+                                "Failed to power cycle"
+                            );
                             return Ok(());
                         }
                     }
@@ -1154,14 +1197,18 @@ impl PreingestionManagerStatic {
                     return Ok(());
                 }
                 Some(PowerDrainState::Powercycle) => {
-                    tracing::info!("Turning back on {}", &endpoint.address);
+                    tracing::info!(bmc_ip_address = %endpoint.address, "Turning system back on");
                     if let Err(e) = count_power_op(
                         PowerOperation::On,
                         redfish_client.power(SystemPowerControl::On),
                     )
                     .await
                     {
-                        tracing::error!("Failed to power on {}: {e}", &endpoint.address);
+                        tracing::error!(
+                            bmc_ip_address = %endpoint.address,
+                            error = %e,
+                            "Failed to power on"
+                        );
                         return Ok(());
                     }
                     let delay = if *power_drains_needed < 1000 {
@@ -1187,8 +1234,8 @@ impl PreingestionManagerStatic {
             };
         } else if upgrade_type.is_uefi() {
             tracing::info!(
-                "Upgrade task has completed for {} but needs reboot, initiating one",
-                &endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "Firmware upgrade task complete; initiating required reboot"
             );
             if let Err(e) = count_power_op(
                 PowerOperation::ForceRestart,
@@ -1196,7 +1243,11 @@ impl PreingestionManagerStatic {
             )
             .await
             {
-                tracing::error!("Failed to reboot {}: {e}", &endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Failed to reboot"
+                );
                 return Ok(());
             }
             db.with_txn(|txn| {
@@ -1219,13 +1270,17 @@ impl PreingestionManagerStatic {
             .unwrap_or(bmc_vendor::BMCVendor::Unknown);
         if upgrade_type.is_bmc() && (bmc_vendor.is_lenovo() || bmc_vendor.is_nvidia()) {
             tracing::info!(
-                "Upgrade task has completed for {} but needs BMC reboot, initiating one",
-                &endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "Firmware upgrade task complete; initiating required BMC reboot"
             );
             if let Err(e) =
                 count_power_op(PowerOperation::BmcReset, redfish_client.bmc_reset()).await
             {
-                tracing::error!("Failed to reboot {}: {e}", &endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Failed to reboot BMC"
+                );
                 return Ok(());
             }
             db.with_txn(|txn| {
@@ -1254,7 +1309,11 @@ impl PreingestionManagerStatic {
             if let Err(e) =
                 count_power_op(poweroff_style.into(), redfish_client.power(poweroff_style)).await
             {
-                tracing::error!("Failed to power off {}: {e}", &endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Failed to power off"
+                );
                 return Ok(());
             }
             tokio::time::sleep(self.config.hgx_bmc_gpu_reboot_delay).await;
@@ -1264,7 +1323,11 @@ impl PreingestionManagerStatic {
             )
             .await
             {
-                tracing::error!("Failed to power on {}: {e}", &endpoint.address);
+                tracing::error!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Failed to power on"
+                );
                 return Ok(());
             }
             // Does not need a wait
@@ -1287,12 +1350,17 @@ impl PreingestionManagerStatic {
                 Ok(()) => {}
                 Err(e) if e.to_string().contains("is not supported") => {
                     tracing::error!(
-                        "Chassis reset is not supported by current CEC FW. Need to do host power cycle! BMC IP: {}",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        error = %e,
+                        "Chassis reset is not supported by current CEC firmware; host power cycle required"
                     );
                 }
                 Err(e) => {
-                    tracing::error!("Failed to call chassis_reset: {e}");
+                    tracing::error!(
+                        bmc_ip_address = %endpoint.address,
+                        error = %e,
+                        "Failed to call chassis reset"
+                    );
                 }
             }
         }
@@ -1329,9 +1397,9 @@ impl PreingestionManagerStatic {
                         && previous_reset_time + 30 * 60 <= Utc::now().timestamp()
                     {
                         tracing::info!(
-                            "Upgrade for {} {:?} has taken more than 30 minutes to report new version; resetting again.",
-                            &endpoint.address,
-                            upgrade_type
+                            bmc_ip_address = %endpoint.address,
+                            ?upgrade_type,
+                            "Firmware upgrade has taken more than 30 minutes to report the new version; resetting again"
                         );
                         let state = &PreingestionState::ResetForNewFirmware {
                             final_version: final_version.to_string(),
@@ -1351,23 +1419,26 @@ impl PreingestionManagerStatic {
                     })
                     .await??;
                     tracing::info!(
-                        "Upgrade {} task has completed for {} but still reports version {current_version} (expected version: {final_version})",
-                        upgrade_type,
-                        &endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        %upgrade_type,
+                        current_version,
+                        final_version,
+                        "Firmware upgrade task complete but reported version has not updated"
                     );
                     return Ok(());
                 }
                 tracing::info!(
-                    "Upgrade for {} now reports version {current_version}",
-                    &endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    current_version,
+                    "Firmware upgrade now reports the new version"
                 );
             } else {
                 // This path should only happen if something strange happened with the version definitions
                 tracing::error!(
-                    "in_upgrade_firmware_wait: Could not find current version {} {:?} {:?}",
-                    &endpoint.address,
-                    fw_info,
-                    *upgrade_type
+                    bmc_ip_address = %endpoint.address,
+                    firmware_info = ?fw_info,
+                    ?upgrade_type,
+                    "Could not find current version while waiting for firmware upgrade"
                 );
                 // Make sure we wait for the new version
                 db.with_txn(|txn| {
@@ -1379,10 +1450,10 @@ impl PreingestionManagerStatic {
         } else {
             // This path should only happen if something strange happened with the version definitions
             tracing::error!(
-                "in_upgrade_firmware_wait: Could not find fw_info {} {:?} {:?}",
-                &endpoint.address,
-                endpoint.report.vendor,
-                endpoint.report.systems
+                bmc_ip_address = %endpoint.address,
+                vendor = ?endpoint.report.vendor,
+                systems = ?endpoint.report.systems,
+                "Could not find firmware info while waiting for firmware upgrade"
             );
             // Make sure we wait for the new version
             db.with_txn(|txn| {
@@ -1420,9 +1491,8 @@ impl PreingestionManagerStatic {
                 // before its own remediation.
                 if self.is_ingested_host(db, endpoint).await {
                     tracing::info!(
-                        "{} BMC time is out of sync but the host is already ingested; \
-                         skipping time-sync remediation",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        "BMC time is out of sync but the host is already ingested; skipping time-sync remediation"
                     );
                     return self
                         .check_firmware_versions_below_preingestion(db, endpoint)
@@ -1430,8 +1500,8 @@ impl PreingestionManagerStatic {
                 }
                 // Time is not in sync, initiate reset sequence
                 tracing::warn!(
-                    "{} BMC time is out of sync, initiating reset to fix time synchronization",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "BMC time is out of sync; initiating reset to fix time synchronization"
                 );
                 self.time_sync_resets(db, endpoint, &TimeSyncResetPhase::Start, None, 0)
                     .await
@@ -1439,8 +1509,9 @@ impl PreingestionManagerStatic {
             Err(e) => {
                 if let PreingestionManagerError::Internal { message } = e {
                     tracing::error!(
-                        "{} internal error checking BMC time sync: {message}, failing preingestion",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        error = %message,
+                        "Internal error checking BMC time sync; failing preingestion"
                     );
                     db.with_txn(|txn| {
                         db::explored_endpoints::set_preingestion_failed(
@@ -1453,8 +1524,9 @@ impl PreingestionManagerStatic {
                     .await??;
                 } else {
                     tracing::warn!(
-                        "{} retryable error checking BMC time sync: {e}, will retry later",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        error = %e,
+                        "Retryable error checking BMC time sync; will retry later"
                     );
                 }
                 Ok(false)
@@ -1478,8 +1550,9 @@ impl PreingestionManagerStatic {
                     Ok(client) => client,
                     Err(e) => {
                         tracing::warn!(
-                            "Redfish connection to {} failed: {e}; will retry initial bmc reset",
-                            endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            error = %e,
+                            "Redfish connection failed; will retry initial BMC reset"
                         );
                         return Ok(false);
                     }
@@ -1490,9 +1563,11 @@ impl PreingestionManagerStatic {
                     let next = attempts + 1;
                     if next >= INITIAL_BMC_RESET_MAX_ATTEMPTS {
                         tracing::warn!(
-                            "{} initial BMC reset failed {next} times: {e}; \
-                             proceeding with preingestion without it",
-                            endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            attempt = next,
+                            max_attempts = INITIAL_BMC_RESET_MAX_ATTEMPTS,
+                            error = %e,
+                            "Initial BMC reset failed; proceeding with preingestion without it"
                         );
                         db.with_txn(|txn| {
                             db::explored_endpoints::set_preingestion_set_ntp_servers(
@@ -1507,9 +1582,11 @@ impl PreingestionManagerStatic {
                         return Ok(false);
                     }
                     tracing::warn!(
-                        "{} initial BMC reset attempt {next}/{INITIAL_BMC_RESET_MAX_ATTEMPTS} \
-                         failed: {e}; will retry",
-                        endpoint.address
+                        bmc_ip_address = %endpoint.address,
+                        attempt = next,
+                        max_attempts = INITIAL_BMC_RESET_MAX_ATTEMPTS,
+                        error = %e,
+                        "Initial BMC reset failed; will retry"
                     );
                     db.with_txn(|txn| {
                         db::explored_endpoints::set_preingestion_initial_bmc_reset(
@@ -1523,8 +1600,8 @@ impl PreingestionManagerStatic {
                     return Ok(false);
                 }
                 tracing::info!(
-                    "{} initial BMC reset initiated; polling for BMC return",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "Initial BMC reset initiated; polling for BMC return"
                 );
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_initial_bmc_reset(
@@ -1546,8 +1623,9 @@ impl PreingestionManagerStatic {
                     Ok(client) => client,
                     Err(e) => {
                         tracing::warn!(
-                            "Redfish connection to {} failed: {e}; will retry waiting for BMC",
-                            endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            error = %e,
+                            "Redfish connection failed; will retry waiting for BMC"
                         );
                         return Ok(false);
                     }
@@ -1577,8 +1655,8 @@ impl PreingestionManagerStatic {
                         })
                         .await??;
                         tracing::info!(
-                            "{} BMC came back after initial reset; awaiting fresh exploration report before continuing",
-                            endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            "BMC came back after initial reset; awaiting fresh exploration report before continuing"
                         );
                         Ok(false)
                     }
@@ -1586,8 +1664,9 @@ impl PreingestionManagerStatic {
                         // An unreachable BMC is never a reason to move on: keep
                         // waiting and continue once it comes back.
                         tracing::info!(
-                            "Waiting for {} BMC to return after initial reset: {e}",
-                            endpoint.address
+                            bmc_ip_address = %endpoint.address,
+                            error = %e,
+                            "Waiting for BMC to return after initial reset"
                         );
                         Ok(false)
                     }
@@ -1597,8 +1676,8 @@ impl PreingestionManagerStatic {
                 // Reached only once the refresh flag is cleared, i.e. site
                 // explorer re-reads the BMC post-reset.
                 tracing::info!(
-                    "{} fresh exploration report received after initial BMC reset; running NTP / time-sync / firmware checks",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "Fresh exploration report received after initial BMC reset; running NTP, time-sync, and firmware checks"
                 );
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_set_ntp_servers(
@@ -1625,8 +1704,11 @@ impl PreingestionManagerStatic {
     ) -> PreingestionManagerResult<bool> {
         if self.ntp_servers.is_empty() || attempts >= SET_NTP_SERVERS_MAX_ATTEMPTS {
             tracing::info!(
-                "{} has no NTP servers configured or max attempts reached; running initial checks",
-                endpoint.address
+                bmc_ip_address = %endpoint.address,
+                ntp_server_count = self.ntp_servers.len(),
+                attempts,
+                max_attempts = SET_NTP_SERVERS_MAX_ATTEMPTS,
+                "No NTP servers configured or maximum attempts reached; running initial checks"
             );
             return self.run_initial_checks(db, endpoint).await;
         }
@@ -1635,15 +1717,15 @@ impl PreingestionManagerStatic {
             let elapsed = Utc::now().signed_duration_since(*set_at);
             if elapsed < SET_NTP_SERVERS_CONVERGENCE_WAIT {
                 tracing::info!(
-                    "{} waiting for BMC NTP servers to converge before checking time sync",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "Waiting for BMC NTP servers to converge before checking time sync"
                 );
                 return Ok(false);
             }
 
             tracing::info!(
-                "{} BMC NTP convergence wait complete; running initial checks",
-                endpoint.address
+                bmc_ip_address = %endpoint.address,
+                "BMC NTP convergence wait complete; running initial checks"
             );
             return self.run_initial_checks(db, endpoint).await;
         }
@@ -1678,8 +1760,8 @@ impl PreingestionManagerStatic {
         }
 
         tracing::info!(
-            "{} set NTP servers; waiting for BMC time to converge",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            "Set NTP servers; waiting for BMC time to converge"
         );
         db.with_txn(|txn| {
             db::explored_endpoints::set_preingestion_set_ntp_servers(
@@ -1710,8 +1792,11 @@ impl PreingestionManagerStatic {
         let next = attempts + 1;
         if next >= SET_NTP_SERVERS_MAX_ATTEMPTS {
             tracing::warn!(
-                "{} failed to set NTP servers after {next} attempts: {error}; proceeding with initial checks",
-                endpoint.address
+                bmc_ip_address = %endpoint.address,
+                attempt = next,
+                max_attempts = SET_NTP_SERVERS_MAX_ATTEMPTS,
+                error = %error,
+                "Failed to set NTP servers; proceeding with initial checks"
             );
             db.with_txn(|txn| {
                 db::explored_endpoints::set_preingestion_set_ntp_servers(
@@ -1727,8 +1812,11 @@ impl PreingestionManagerStatic {
         }
 
         tracing::warn!(
-            "{} failed to set NTP servers attempt {next}/{SET_NTP_SERVERS_MAX_ATTEMPTS}: {error}; will retry",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            attempt = next,
+            max_attempts = SET_NTP_SERVERS_MAX_ATTEMPTS,
+            error = %error,
+            "Failed to set NTP servers; will retry"
         );
         db.with_txn(|txn| {
             db::explored_endpoints::set_preingestion_set_ntp_servers(
@@ -1759,10 +1847,18 @@ impl PreingestionManagerStatic {
             Ok(()) => {}
             Err(e) if matches!(e, RedfishError::UnnecessaryOperation) => {
                 // ignore because it is already off
-                tracing::debug!("Power off not needed on {}: {e}", endpoint.address);
+                tracing::debug!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Power off not needed"
+                );
             }
             Err(e) => {
-                tracing::warn!("Could not turn off power on {}: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Could not turn off power"
+                );
                 return false;
             }
         }
@@ -1770,16 +1866,28 @@ impl PreingestionManagerStatic {
         let status = match redfish_client.get_power_state().await {
             Ok(status) => status,
             Err(e) => {
-                tracing::warn!("Could not get power of {}: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Could not get power state"
+                );
                 return false;
             }
         };
         if status != PowerState::Off {
-            tracing::warn!("Host {} did not turn off when requested", endpoint.address);
+            tracing::warn!(
+                bmc_ip_address = %endpoint.address,
+                power_state = %status,
+                "Host did not turn off when requested"
+            );
             return false;
         }
         if let Err(e) = count_power_op(PowerOperation::BmcReset, redfish_client.bmc_reset()).await {
-            tracing::warn!("Could not reset BMC on {}: {e}", endpoint.address);
+            tracing::warn!(
+                bmc_ip_address = %endpoint.address,
+                error = %e,
+                "Could not reset BMC"
+            );
             return false;
         }
         true
@@ -1794,8 +1902,9 @@ impl PreingestionManagerStatic {
     ) -> bool {
         if let Err(e) = redfish_client.get_tasks().await {
             tracing::info!(
-                "Waiting for {} BMC reset to complete: {e}",
-                endpoint.address
+                bmc_ip_address = %endpoint.address,
+                error = %e,
+                "Waiting for BMC reset to complete"
             );
             return false;
         }
@@ -1809,10 +1918,18 @@ impl PreingestionManagerStatic {
             Ok(()) => {}
             Err(e) if matches!(e, RedfishError::UnnecessaryOperation) => {
                 // ignore because it is already on
-                tracing::debug!("Power on not needed on {}: {e}", endpoint.address);
+                tracing::debug!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Power on not needed"
+                );
             }
             Err(e) => {
-                tracing::warn!("Could not turn on power on {}: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Could not turn on power"
+                );
                 return false;
             }
         }
@@ -1820,12 +1937,20 @@ impl PreingestionManagerStatic {
         let status = match redfish_client.get_power_state().await {
             Ok(status) => status,
             Err(e) => {
-                tracing::warn!("Could not get power of {}: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Could not get power state"
+                );
                 return false;
             }
         };
         if status != PowerState::On {
-            tracing::warn!("Host {} did not turn on when requested", endpoint.address);
+            tracing::warn!(
+                bmc_ip_address = %endpoint.address,
+                power_state = %status,
+                "Host did not turn on when requested"
+            );
             return false;
         }
         true
@@ -1841,7 +1966,10 @@ impl PreingestionManagerStatic {
         if Utc::now().signed_duration_since(last_time.unwrap_or(&Utc::now()))
             < chrono::TimeDelta::minutes(20)
         {
-            tracing::trace!("Waiting for {} to complete boot sequence", endpoint.address);
+            tracing::trace!(
+                bmc_ip_address = %endpoint.address,
+                "Waiting for host to complete boot sequence"
+            );
             return false;
         }
         true
@@ -1861,7 +1989,11 @@ impl PreingestionManagerStatic {
         {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
-                tracing::warn!("Redfish connection to {} failed: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Redfish connection failed"
+                );
                 return Ok(());
             }
         };
@@ -1874,7 +2006,10 @@ impl PreingestionManagerStatic {
                 {
                     return Ok(());
                 }
-                tracing::info!("{} initial reset BMC reset intiated", endpoint.address);
+                tracing::info!(
+                    bmc_ip_address = %endpoint.address,
+                    "Initial reset BMC reset initiated"
+                );
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_initial_reset(
                         endpoint.address,
@@ -1894,8 +2029,8 @@ impl PreingestionManagerStatic {
                     return Ok(());
                 }
                 tracing::info!(
-                    "{} initial reset BMC reset complete, started host reset",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "Initial reset BMC reset complete; started host reset"
                 );
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_initial_reset(
@@ -1913,7 +2048,7 @@ impl PreingestionManagerStatic {
                     return Ok(());
                 }
                 // Now we can actually proceed with the upgrade.  Go back to checking firmware so we don't have to store all of that info.
-                tracing::info!("{} initial reset complete", endpoint.address);
+                tracing::info!(bmc_ip_address = %endpoint.address, "Initial reset complete");
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_recheck_versions(endpoint.address, txn)
                         .boxed()
@@ -1947,7 +2082,11 @@ impl PreingestionManagerStatic {
         {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
-                tracing::warn!("Redfish connection to {} failed: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Redfish connection failed"
+                );
                 return Ok(false);
             }
         };
@@ -1955,7 +2094,11 @@ impl PreingestionManagerStatic {
         match phase {
             TimeSyncResetPhase::Start => {
                 if let Err(e) = redfish_client.set_utc_timezone().await {
-                    tracing::error!("Could not set UTC timezone on {}: {e}", endpoint.address);
+                    tracing::error!(
+                        bmc_ip_address = %endpoint.address,
+                        error = %e,
+                        "Could not set UTC timezone"
+                    );
                     return Err(PreingestionManagerError::RedfishError(e));
                 }
                 if !self
@@ -1964,7 +2107,10 @@ impl PreingestionManagerStatic {
                 {
                     return Ok(false);
                 }
-                tracing::info!("{} time sync reset BMC reset initiated", endpoint.address);
+                tracing::info!(
+                    bmc_ip_address = %endpoint.address,
+                    "Time-sync reset BMC reset initiated"
+                );
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_time_sync_reset(
                         endpoint.address,
@@ -1985,8 +2131,8 @@ impl PreingestionManagerStatic {
                     return Ok(false);
                 }
                 tracing::info!(
-                    "{} time sync reset BMC reset complete, started host reset",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "Time-sync reset BMC reset complete; started host reset"
                 );
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_time_sync_reset(
@@ -2007,14 +2153,17 @@ impl PreingestionManagerStatic {
 
                 // Host has booted, now check time sync again
                 tracing::info!(
-                    "{} time sync reset complete, checking time sync",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    "Time-sync reset complete; checking time sync"
                 );
 
                 match self.check_bmc_time_sync(db, endpoint).await {
                     Ok(true) => {
                         // Time is now in sync, proceed with firmware check
-                        tracing::info!("{} BMC time is now in sync after reset", endpoint.address);
+                        tracing::info!(
+                            bmc_ip_address = %endpoint.address,
+                            "BMC time is now in sync after reset"
+                        );
                         let delayed_upgrade = self
                             .check_firmware_versions_below_preingestion(db, endpoint)
                             .await?;
@@ -2028,10 +2177,10 @@ impl PreingestionManagerStatic {
                         let attempts_done = attempt + 1;
                         if attempts_done < MAX_TIME_SYNC_RESET_ATTEMPTS {
                             tracing::warn!(
-                                "{} BMC time still out of sync after reset attempt {}/{}, retrying reset",
-                                endpoint.address,
-                                attempts_done,
-                                MAX_TIME_SYNC_RESET_ATTEMPTS
+                                bmc_ip_address = %endpoint.address,
+                                attempt = attempts_done,
+                                max_attempts = MAX_TIME_SYNC_RESET_ATTEMPTS,
+                                "BMC time still out of sync after reset; retrying reset"
                             );
                             db.with_txn(|txn| {
                                 db::explored_endpoints::set_preingestion_time_sync_reset(
@@ -2047,9 +2196,10 @@ impl PreingestionManagerStatic {
                         }
 
                         tracing::error!(
-                            "{} BMC time is still out of sync after {} reset attempts, failing preingestion",
-                            endpoint.address,
-                            attempts_done
+                            bmc_ip_address = %endpoint.address,
+                            attempt = attempts_done,
+                            max_attempts = MAX_TIME_SYNC_RESET_ATTEMPTS,
+                            "BMC time is still out of sync after reset attempts; failing preingestion"
                         );
                         db.with_txn(|txn| {
                             db::explored_endpoints::set_preingestion_failed(
@@ -2068,8 +2218,9 @@ impl PreingestionManagerStatic {
                         if let PreingestionManagerError::Internal { message } = e {
                             // Error checking time sync after reset, fail now
                             tracing::error!(
-                                "{} internal error checking BMC time sync after reset: {message}, failing preingestion",
-                                endpoint.address
+                                bmc_ip_address = %endpoint.address,
+                                error = %message,
+                                "Internal error checking BMC time sync after reset; failing preingestion"
                             );
                             db.with_txn(|txn| {
                                 db::explored_endpoints::set_preingestion_failed(
@@ -2082,8 +2233,9 @@ impl PreingestionManagerStatic {
                             .await??;
                         } else {
                             tracing::warn!(
-                                "{} retryable error checking BMC time sync after reset: {e}, will retry later",
-                                endpoint.address
+                                bmc_ip_address = %endpoint.address,
+                                error = %e,
+                                "Retryable error checking BMC time sync after reset; will retry later"
                             );
                         }
                         Ok(false)
@@ -2110,7 +2262,8 @@ impl PreingestionManagerStatic {
             let interface = db::machine_interface::find_by_ip(db, endpoint_address).await?;
             let Some(interface) = interface else {
                 tracing::warn!(
-                    "Unable to run update script for {address}: MAC address not retrievable"
+                    bmc_ip_address = address.as_str(),
+                    "Unable to run update script; MAC address not retrievable"
                 );
                 return Ok(());
             };
@@ -2126,13 +2279,16 @@ impl PreingestionManagerStatic {
                 },
                 Ok(None) => {
                     tracing::warn!(
-                        "Unable to run update script for {address}: No credentials exists"
+                        bmc_ip_address = address.as_str(),
+                        "Unable to run update script; no credentials exist"
                     );
                     return Ok(());
                 }
                 Err(e) => {
                     tracing::warn!(
-                        "Unable to run update script for {address}: Unable to retrieve credentials due to error: {e}"
+                        bmc_ip_address = address.as_str(),
+                        error = %e,
+                        "Unable to run update script; could not retrieve credentials"
                     );
                     return Ok(());
                 }
@@ -2151,14 +2307,21 @@ impl PreingestionManagerStatic {
             {
                 Ok(cmd) => cmd,
                 Err(e) => {
-                    tracing::error!("Upgrade script {address} command creation failed: {e}");
+                    tracing::error!(
+                        bmc_ip_address = address.as_str(),
+                        error = %e,
+                        "Upgrade script command creation failed"
+                    );
                     upgrade_script_state.completed(address, false);
                     return;
                 }
             };
 
             let Some(stdout) = cmd.stdout.take() else {
-                tracing::error!("Upgrade script {address} STDOUT creation failed");
+                tracing::error!(
+                    bmc_ip_address = address.as_str(),
+                    "Upgrade script stdout creation failed"
+                );
                 let _ = cmd.kill().await;
                 let _ = cmd.wait().await;
                 upgrade_script_state.completed(address, false);
@@ -2167,7 +2330,10 @@ impl PreingestionManagerStatic {
             let stdout = tokio::io::BufReader::new(stdout);
 
             let Some(stderr) = cmd.stderr.take() else {
-                tracing::error!("Upgrade script {address} STDERR creation failed");
+                tracing::error!(
+                    bmc_ip_address = address.as_str(),
+                    "Upgrade script stderr creation failed"
+                );
                 let _ = cmd.kill().await;
                 let _ = cmd.wait().await;
                 upgrade_script_state.completed(address, false);
@@ -2191,15 +2357,26 @@ impl PreingestionManagerStatic {
 
             match cmd.wait().await {
                 Err(e) => {
-                    tracing::info!("Upgrade script {address} FAILED: Wait failure {e}");
+                    tracing::info!(
+                        bmc_ip_address = address.as_str(),
+                        error = %e,
+                        "Upgrade script failed while waiting"
+                    );
                     upgrade_script_state.completed(address, false);
                 }
                 Ok(errorcode) => {
                     if errorcode.success() {
-                        tracing::info!("Upgrade script {address} completed successfully");
+                        tracing::info!(
+                            bmc_ip_address = address.as_str(),
+                            "Upgrade script completed successfully"
+                        );
                         upgrade_script_state.completed(address, true);
                     } else {
-                        tracing::warn!("Upgrade script {address} FAILED: Exited with {errorcode}");
+                        tracing::warn!(
+                            bmc_ip_address = address.as_str(),
+                            exit_status = %errorcode,
+                            "Upgrade script exited unsuccessfully"
+                        );
                         upgrade_script_state.completed(address, false);
                     }
                 }
@@ -2249,7 +2426,7 @@ impl PreingestionManagerStatic {
         db: &PgPool,
         endpoint: &ExploredEndpoint,
     ) -> PreingestionManagerResult<bool> {
-        tracing::debug!("Checking BMC time sync for {:?}", endpoint);
+        tracing::debug!(?endpoint, "Checking BMC time sync");
         let redfish_client = match self
             .redfish_client_pool
             .create_client_for_ingested_host(endpoint.address, db)
@@ -2284,18 +2461,18 @@ impl PreingestionManagerStatic {
 
         if time_diff > NTP_DRIFT_THRESHOLD_SECONDS {
             tracing::warn!(
-                "BMC time for {} is out of sync: BMC time: {}, System time: {}, Difference: {} seconds",
-                endpoint.address,
-                bmc_time,
-                system_time,
-                time_diff
+                bmc_ip_address = %endpoint.address,
+                %bmc_time,
+                %system_time,
+                difference_seconds = time_diff,
+                "BMC time is out of sync"
             );
             Ok(false)
         } else {
             tracing::debug!(
-                "BMC time for {} is in sync: difference {} seconds",
-                endpoint.address,
-                time_diff
+                bmc_ip_address = %endpoint.address,
+                difference_seconds = time_diff,
+                "BMC time is in sync"
             );
             Ok(true)
         }
@@ -2321,9 +2498,9 @@ impl PreingestionManagerStatic {
             Ok(machine_id) => machine_id.is_some(),
             Err(e) => {
                 tracing::warn!(
-                    "Could not determine if {} is an ingested host: {e}; \
-                     treating as ingested to skip time-sync remediation",
-                    endpoint.address
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "Could not determine whether endpoint is an ingested host; treating as ingested to skip time-sync remediation"
                 );
                 true
             }
@@ -2372,11 +2549,6 @@ impl PreingestionManagerStatic {
         use model::site_explorer::BfbPlatformPowercyclePhase;
 
         let address = endpoint.address;
-        let label = if post_install {
-            "post-install"
-        } else {
-            "pre-copy"
-        };
 
         match phase {
             BfbPlatformPowercyclePhase::PowerOff => {
@@ -2387,19 +2559,36 @@ impl PreingestionManagerStatic {
                 {
                     Ok(c) => c,
                     Err(e) => {
-                        tracing::error!(%address, host_ip=%host_bmc_ip, error=%e, "{label}: failed to create Redfish client for host, will retry");
+                        tracing::error!(
+                            dpu_bmc_ip_address = %address,
+                            host_bmc_ip_address = %host_bmc_ip,
+                            post_install,
+                            error = %e,
+                            "Failed to create Redfish client for host during BFB power cycle; will retry"
+                        );
                         return Ok(());
                     }
                 };
 
-                tracing::info!(%address, host_ip=%host_bmc_ip, "{label}: powering off host");
+                tracing::info!(
+                    dpu_bmc_ip_address = %address,
+                    host_bmc_ip_address = %host_bmc_ip,
+                    post_install,
+                    "Powering off host during BFB power cycle"
+                );
                 if let Err(e) = count_power_op(
                     PowerOperation::ForceOff,
                     redfish_client.power(SystemPowerControl::ForceOff),
                 )
                 .await
                 {
-                    tracing::error!(%address, host_ip=%host_bmc_ip, error=%e, "{label}: failed to power off host, will retry");
+                    tracing::error!(
+                        dpu_bmc_ip_address = %address,
+                        host_bmc_ip_address = %host_bmc_ip,
+                        post_install,
+                        error = %e,
+                        "Failed to power off host during BFB power cycle; will retry"
+                    );
                     return Ok(());
                 }
 
@@ -2423,19 +2612,36 @@ impl PreingestionManagerStatic {
                 {
                     Ok(c) => c,
                     Err(e) => {
-                        tracing::error!(%address, host_ip=%host_bmc_ip, error=%e, "{label}: failed to create Redfish client for host, will retry");
+                        tracing::error!(
+                            dpu_bmc_ip_address = %address,
+                            host_bmc_ip_address = %host_bmc_ip,
+                            post_install,
+                            error = %e,
+                            "Failed to create Redfish client for host during BFB power cycle; will retry"
+                        );
                         return Ok(());
                     }
                 };
 
-                tracing::info!(%address, host_ip=%host_bmc_ip, "{label}: powering on host");
+                tracing::info!(
+                    dpu_bmc_ip_address = %address,
+                    host_bmc_ip_address = %host_bmc_ip,
+                    post_install,
+                    "Powering on host during BFB power cycle"
+                );
                 if let Err(e) = count_power_op(
                     PowerOperation::On,
                     redfish_client.power(SystemPowerControl::On),
                 )
                 .await
                 {
-                    tracing::error!(%address, host_ip=%host_bmc_ip, error=%e, "{label}: failed to power on host, will retry");
+                    tracing::error!(
+                        dpu_bmc_ip_address = %address,
+                        host_bmc_ip_address = %host_bmc_ip,
+                        post_install,
+                        error = %e,
+                        "Failed to power on host during BFB power cycle; will retry"
+                    );
                     return Ok(());
                 }
 
@@ -2459,7 +2665,7 @@ impl PreingestionManagerStatic {
                     .await
                 {
                     Ok(()) if post_install => {
-                        tracing::info!(%address, "DPU BMC online after post-install power-cycle, completing preingestion");
+                        tracing::info!(bmc_ip_address = %address, "DPU BMC online after post-install power-cycle, completing preingestion");
                         db.with_txn(|txn| {
                             async move {
                                 db::explored_endpoints::set_preingestion_complete(address, txn)
@@ -2481,11 +2687,15 @@ impl PreingestionManagerStatic {
                         .await??;
                     }
                     Ok(()) => {
-                        tracing::info!(%address, "DPU BMC online after host power-cycle, starting BFB copy");
+                        tracing::info!(bmc_ip_address = %address, "DPU BMC online after host power-cycle, starting BFB copy");
                         self.start_bfb_copy(db, endpoint, *host_bmc_ip).await?;
                     }
                     Err(_) => {
-                        tracing::debug!(%address, "DPU BMC not yet reachable after {label} power-cycle");
+                        tracing::debug!(
+                            bmc_ip_address = %address,
+                            post_install,
+                            "DPU BMC not yet reachable after power cycle"
+                        );
                     }
                 }
             }
@@ -2503,14 +2713,14 @@ impl PreingestionManagerStatic {
         let address = endpoint.address;
 
         let Ok(permit) = self.bfb_copy_limiter.clone().try_acquire_owned() else {
-            tracing::warn!(%address, "deferring BFB copy, too many copies already active");
+            tracing::warn!(bmc_ip_address = %address, "deferring BFB copy, too many copies already active");
             return Ok(());
         };
 
         let interface = match db::machine_interface::find_by_ip(db, address).await? {
             Some(interface) => interface,
             None => {
-                tracing::error!(%address, "no machine interface found for BFB copy, marking as failed");
+                tracing::error!(bmc_ip_address = %address, "no machine interface found for BFB copy, marking as failed");
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_failed(
                         address,
@@ -2547,7 +2757,7 @@ impl PreingestionManagerStatic {
         tokio::spawn(async move {
             let _permit = permit;
 
-            tracing::info!(%address, "starting BFB copy to DPU rshim");
+            tracing::info!(bmc_ip_address = %address, "starting BFB copy to DPU rshim");
             let started = std::time::Instant::now();
 
             let result = bfb_rshim_copier
@@ -2608,7 +2818,7 @@ impl PreingestionManagerStatic {
             .resolve_or_timeout(&address, elapsed_mins > timeout_mins)
         {
             BfbResolution::Ready(BfbCopyResult::Success) => {
-                tracing::info!(%address, "BFB copy completed, waiting for installation");
+                tracing::info!(bmc_ip_address = %address, "BFB copy completed, waiting for installation");
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_bfb_installation_wait(
                         endpoint.address,
@@ -2621,7 +2831,7 @@ impl PreingestionManagerStatic {
                 Ok(())
             }
             BfbResolution::Ready(BfbCopyResult::Failed(error)) => {
-                tracing::error!(%address, error=%error, "BFB copy failed");
+                tracing::error!(bmc_ip_address = %address, error=%error, "BFB copy failed");
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_failed(
                         endpoint.address,
@@ -2664,7 +2874,7 @@ impl PreingestionManagerStatic {
                 Ok(())
             }
             BfbResolution::Untracked => {
-                tracing::warn!(%address, "detected orphaned BFB copy state, restarting copy");
+                tracing::warn!(bmc_ip_address = %address, "detected orphaned BFB copy state, restarting copy");
                 db.with_txn(|txn| {
                     db::explored_endpoints::set_preingestion_bfb_recovery_needed(
                         endpoint.address,
@@ -2679,7 +2889,7 @@ impl PreingestionManagerStatic {
                 Ok(())
             }
             BfbResolution::Pending => {
-                tracing::debug!(%address, "BFB copy still in progress");
+                tracing::debug!(bmc_ip_address = %address, "BFB copy still in progress");
                 Ok(())
             }
         }
@@ -2694,7 +2904,11 @@ impl PreingestionManagerStatic {
     ) -> Result<(), DatabaseError> {
         let elapsed_mins = Utc::now().signed_duration_since(*started_at).num_minutes();
         if elapsed_mins > BFB_INSTALLATION_TIMEOUT_MINS {
-            tracing::error!(address=%endpoint.address, elapsed_mins, "BFB installation timed out");
+            tracing::error!(
+                bmc_ip_address = %endpoint.address,
+                elapsed_minutes = elapsed_mins,
+                "BFB installation timed out"
+            );
             db.with_txn(|txn| {
                 db::explored_endpoints::set_preingestion_failed(
                     endpoint.address,
@@ -2711,12 +2925,20 @@ impl PreingestionManagerStatic {
         }
 
         if elapsed_mins < BFB_INSTALLATION_MIN_WAIT_MINS {
-            tracing::debug!(address=%endpoint.address, elapsed_mins, min_wait=BFB_INSTALLATION_MIN_WAIT_MINS, "BFB installation in progress, waiting before checking");
+            tracing::debug!(
+                bmc_ip_address = %endpoint.address,
+                elapsed_minutes = elapsed_mins,
+                minimum_wait_minutes = BFB_INSTALLATION_MIN_WAIT_MINS,
+                "BFB installation in progress, waiting before checking"
+            );
             return Ok(());
         }
 
         if self.check_dpu_console_install_complete(db, endpoint).await {
-            tracing::info!(address=%endpoint.address, "DPU installation complete, powercycling host");
+            tracing::info!(
+                bmc_ip_address = %endpoint.address,
+                "DPU installation complete, powercycling host"
+            );
             db.with_txn(|txn| {
                 db::explored_endpoints::set_preingestion_bfb_platform_powercycle(
                     endpoint.address,
@@ -2731,7 +2953,11 @@ impl PreingestionManagerStatic {
             return Ok(());
         }
 
-        tracing::debug!(address=%endpoint.address, elapsed_mins, "DPU console login not yet detected, waiting");
+        tracing::debug!(
+            bmc_ip_address = %endpoint.address,
+            elapsed_minutes = elapsed_mins,
+            "DPU console login not yet detected, waiting"
+        );
         Ok(())
     }
 
@@ -2750,14 +2976,14 @@ impl PreingestionManagerStatic {
         let bmc_addr = std::net::SocketAddr::new(address, 22);
 
         let Some(credential_reader) = &self.credential_reader else {
-            tracing::debug!(%address, "no credential reader, skipping console check");
+            tracing::debug!(bmc_ip_address = %address, "no credential reader, skipping console check");
             return false;
         };
 
         let interface = match db::machine_interface::find_by_ip(db, address).await {
             Ok(Some(iface)) => iface,
             _ => {
-                tracing::debug!(%address, "no machine interface for console check");
+                tracing::debug!(bmc_ip_address = %address, "no machine interface for console check");
                 return false;
             }
         };
@@ -2771,11 +2997,11 @@ impl PreingestionManagerStatic {
         let (username, password) = match credential_reader.get_credentials(&key).await {
             Ok(Some(Credentials::UsernamePassword { username, password })) => (username, password),
             Ok(None) => {
-                tracing::debug!(%address, "no credentials found for console check");
+                tracing::debug!(bmc_ip_address = %address, "no credentials found for console check");
                 return false;
             }
             Err(e) => {
-                tracing::warn!(%address, error=%e, "failed to retrieve credentials for console check");
+                tracing::warn!(bmc_ip_address = %address, error=%e, "failed to retrieve credentials for console check");
                 return false;
             }
         };
@@ -2784,7 +3010,7 @@ impl PreingestionManagerStatic {
         {
             Ok(found) => found,
             Err(e) => {
-                tracing::debug!(%address, error=%e, "SSH console check failed");
+                tracing::debug!(bmc_ip_address = %address, error=%e, "SSH console check failed");
                 false
             }
         }
@@ -2976,7 +3202,11 @@ impl PreingestionManagerStatic {
         ) {
             Ok(artifact) => artifact,
             Err(error) => {
-                tracing::error!("Failed to resolve firmware artifact: {error}");
+                tracing::error!(
+                    bmc_ip_address = %endpoint_clone.address,
+                    %error,
+                    "Failed to resolve firmware artifact"
+                );
                 return Ok(false);
             }
         };
@@ -2986,9 +3216,10 @@ impl PreingestionManagerStatic {
                 ResolvedFirmwareArtifactSource::Remote { url, sha256 } => {
                     if !self.downloader.available(&artifact.local_path, url, sha256) {
                         tracing::debug!(
-                            "{} is being downloaded from {}, update deferred",
-                            artifact.local_path.display(),
-                            url
+                            bmc_ip_address = %endpoint_clone.address,
+                            path = %artifact.local_path.display(),
+                            %url,
+                            "Firmware artifact is being downloaded; update deferred"
                         );
 
                         return Ok(false);
@@ -2997,8 +3228,9 @@ impl PreingestionManagerStatic {
                 ResolvedFirmwareArtifactSource::Local => {
                     if !artifact.local_path.exists() {
                         tracing::error!(
-                            "Firmware artifact {} is not present",
-                            artifact.local_path.display()
+                            bmc_ip_address = %endpoint_clone.address,
+                            path = %artifact.local_path.display(),
+                            "Firmware artifact is not present"
                         );
                         return Ok(false);
                     }
@@ -3015,16 +3247,17 @@ impl PreingestionManagerStatic {
             Ok(redfish_client) => redfish_client,
             Err(e) => {
                 tracing::debug!(
-                    "Failed to open redfish to {}: {e}",
-                    endpoint_clone.address.to_string()
+                    bmc_ip_address = %endpoint_clone.address,
+                    error = %e,
+                    "Failed to open Redfish connection"
                 );
                 return Ok(false);
             }
         };
 
         tracing::debug!(
-            "initiate_update: Started upload of firmware to {}",
-            endpoint_clone.address
+            bmc_ip_address = %endpoint_clone.address,
+            "Started firmware upload"
         );
 
         let redfish_component_type: libredfish::model::update_service::ComponentType =
@@ -3034,12 +3267,21 @@ impl PreingestionManagerStatic {
             };
 
         let task = if is_bfb_artifact(&artifact.local_path) {
-            let _ = redfish_client.enable_rshim_bmc().await.map_err(|e| {
-                tracing::error!("initiate_update: Failed to call enable_rshim_bmc: {e}")
-            });
+            redfish_client
+                .enable_rshim_bmc()
+                .await
+                .inspect_err(|e| {
+                    tracing::error!(
+                        bmc_ip_address = %endpoint_clone.address,
+                        error = %e,
+                        "Failed to enable RSHIM on BMC"
+                    )
+                })
+                .ok();
             tracing::debug!(
-                "initiate_update: Using simple_update with image URI: {}",
-                artifact.bfb_image_uri
+                bmc_ip_address = %endpoint_clone.address,
+                image_uri = artifact.bfb_image_uri.as_str(),
+                "Using simple update for firmware upload"
             );
             match redfish_client
                 .update_firmware_simple_update(
@@ -3062,8 +3304,9 @@ impl PreingestionManagerStatic {
                         outcome: Outcome::Error,
                     });
                     tracing::error!(
-                        "initiate_update: Failed to call update_firmware_simple_update {}: {e}",
-                        endpoint_clone.address
+                        bmc_ip_address = %endpoint_clone.address,
+                        error = %e,
+                        "Simple firmware update failed"
                     );
                     return Ok(false);
                 }
@@ -3091,12 +3334,18 @@ impl PreingestionManagerStatic {
                         outcome: Outcome::Error,
                     });
                     tracing::warn!(
-                        "Multipart update is not supported: {err}. Trying to use HttpPushUri"
+                        bmc_ip_address = %endpoint_clone.address,
+                        error = %err,
+                        "Multipart firmware update is not supported; trying HttpPushUri"
                     );
                     let file = match File::open(artifact.local_path.as_path()).await {
                         Ok(f) => f,
                         Err(e) => {
-                            tracing::error!("Failed to open a file: {e}");
+                            tracing::error!(
+                                bmc_ip_address = %endpoint_clone.address,
+                                error = %e,
+                                "Failed to open firmware file"
+                            );
                             return Ok(false);
                         }
                     };
@@ -3114,8 +3363,9 @@ impl PreingestionManagerStatic {
                                 outcome: Outcome::Error,
                             });
                             tracing::error!(
-                                "initiate_update: Failed uploading firmware to {}: {e}",
-                                endpoint_clone.address
+                                bmc_ip_address = %endpoint_clone.address,
+                                error = %e,
+                                "Failed to upload firmware via HttpPushUri"
                             );
                             return Ok(false);
                         }
@@ -3127,8 +3377,9 @@ impl PreingestionManagerStatic {
                         outcome: Outcome::Error,
                     });
                     tracing::warn!(
-                        "initiate_update: Failed uploading firmware to {}: {e}",
-                        endpoint_clone.address
+                        bmc_ip_address = %endpoint_clone.address,
+                        error = %e,
+                        "Failed to upload firmware via multipart update"
                     );
                     return Ok(false);
                 }
@@ -3136,8 +3387,8 @@ impl PreingestionManagerStatic {
         };
 
         tracing::debug!(
-            "initiate_update: Completed upload of firmware to {}",
-            endpoint_clone.address
+            bmc_ip_address = %endpoint_clone.address,
+            "Completed firmware upload"
         );
 
         db_pool

--- a/crates/preingestion-manager/tests/integration/host_bmc_firmware.rs
+++ b/crates/preingestion-manager/tests/integration/host_bmc_firmware.rs
@@ -389,7 +389,7 @@ async fn test_preingestion_preupdate_powercycling(
     let underlay_segment = nc.create_underlay_segment(&domain).await;
 
     let config = default_config::get();
-    tracing::debug!("{:?}", config.host_models);
+    tracing::debug!(host_models = ?config.host_models, "Using host models");
 
     let mgr = PreingestionManager::new(
         pool.clone(),
@@ -523,7 +523,10 @@ async fn test_preingestion_preupdate_powercycling(
         let endpoints = db::explored_endpoints::find_all(txn.as_mut()).await?;
         assert!(endpoints.len() == 1);
         let mut endpoint = endpoints.into_iter().next().unwrap();
-        tracing::debug!("State should be {state:?}");
+        tracing::debug!(
+            expected_power_drain_state = ?state,
+            "Checking expected preingestion state"
+        );
         match &endpoint.preingestion_state {
             PreingestionState::ResetForNewFirmware {
                 delay_until,

--- a/crates/rack-controller/src/created.rs
+++ b/crates/rack-controller/src/created.rs
@@ -93,11 +93,11 @@ pub async fn handle_created(
     }
 
     tracing::info!(
-        "Rack {} has all expected devices (compute={}, switch={}, power_shelf={}). Transitioning to Discovering.",
-        id,
+        rack_id = %id,
         compute_count,
         switch_count,
-        power_shelf_count
+        power_shelf_count,
+        "Rack has all expected devices (compute, switch, power_shelf). Transitioning to Discovering.",
     );
     Ok(StateHandlerOutcome::transition(RackState::Discovering).with_txn(txn))
 }

--- a/crates/rack-controller/src/discovering.rs
+++ b/crates/rack-controller/src/discovering.rs
@@ -107,8 +107,8 @@ pub async fn handle_discovering(
     }
 
     tracing::info!(
-        "Rack {} all devices ready, transitioning to Maintenance",
-        id
+        rack_id = %id,
+        "Rack all devices ready, transitioning to Maintenance",
     );
     Ok(StateHandlerOutcome::transition(RackState::Maintenance {
         maintenance_state: RackMaintenanceState::FirmwareUpgrade {

--- a/crates/rack-controller/src/error_state.rs
+++ b/crates/rack-controller/src/error_state.rs
@@ -48,18 +48,18 @@ pub async fn handle_error(
         };
         if scope.is_full_rack() {
             tracing::info!(
-                "Rack {} on-demand maintenance requested from Error state (full rack, activities: [{}]), transitioning to Maintenance",
-                id,
-                activities_desc,
+                rack_id = %id,
+                activity_description = %activities_desc,
+                "Rack on-demand maintenance requested from Error state (full rack, activities), transitioning to Maintenance",
             );
         } else {
             tracing::info!(
-                "Rack {} on-demand maintenance requested from Error state (partial: {} machines, {} switches, {} power shelves, activities: [{}]), transitioning to Maintenance",
-                id,
-                scope.machine_ids.len(),
-                scope.switch_ids.len(),
-                scope.power_shelf_ids.len(),
-                activities_desc,
+                rack_id = %id,
+                requested_machine_count = scope.machine_ids.len(),
+                requested_switch_count = scope.switch_ids.len(),
+                requested_power_shelf_count = scope.power_shelf_ids.len(),
+                activity_description = %activities_desc,
+                "Rack on-demand maintenance requested from Error state (partial: machines, switches, power shelves, activities), transitioning to Maintenance",
             );
         }
         let txn = ctx.services.db_pool.begin().await?;
@@ -71,14 +71,18 @@ pub async fn handle_error(
 
     if all_components_ready(id, ctx).await? {
         tracing::info!(
-            "Rack {} components all Ready, transitioning from Error back to Ready",
-            id
+            rack_id = %id,
+            "Rack components all Ready, transitioning from Error back to Ready",
         );
         let txn = ctx.services.db_pool.begin().await?;
         return Ok(StateHandlerOutcome::transition(RackState::Ready).with_txn(txn));
     }
 
-    tracing::error!("Rack {} is in error state: {}", id, cause);
+    tracing::error!(
+        rack_id = %id,
+        cause = %cause,
+        "Rack is in error state",
+    );
     Ok(StateHandlerOutcome::wait(format!(
         "rack in error state: {}",
         cause

--- a/crates/rack-controller/src/handler.rs
+++ b/crates/rack-controller/src/handler.rs
@@ -101,15 +101,19 @@ impl StateHandler for RackStateHandler {
         controller_state: &Self::ControllerState,
         ctx: &mut StateHandlerContext<Self::ContextObjects>,
     ) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
-        tracing::info!("Rack {} is in state {}", id, controller_state.to_string());
+        tracing::info!(
+            rack_id = %id,
+            rack_state = %controller_state,
+            "Rack is in state",
+        );
 
         self.record_metrics(state, ctx);
 
         if state.deleted.is_some() && !matches!(controller_state, RackState::Deleting) {
             tracing::info!(
-                "Rack {} is marked as deleted, transitioning from {} to Deleting",
-                id,
-                controller_state
+                rack_id = %id,
+                rack_state = %controller_state,
+                "Rack is marked as deleted, transitioning to Deleting",
             );
             return Ok(StateHandlerOutcome::transition(RackState::Deleting));
         }

--- a/crates/rack-controller/src/lib.rs
+++ b/crates/rack-controller/src/lib.rs
@@ -75,7 +75,10 @@ pub(crate) fn resolve_profile<'a>(
     let rack_profile_id = match rack_profile_id {
         Some(rc) => rc,
         None => {
-            tracing::info!("Rack {} has no rack_profile_id configured", id);
+            tracing::info!(
+                rack_id = %id,
+                "Rack has no rack_profile_id configured",
+            );
             return None;
         }
     };
@@ -89,9 +92,9 @@ pub(crate) fn resolve_profile<'a>(
         Some(profile) => Some(profile),
         None => {
             tracing::warn!(
-                "Rack {} has unknown rack_profile_id '{}'",
-                id,
-                rack_profile_id
+                rack_id = %id,
+                rack_profile_id = %rack_profile_id,
+                "Rack has unknown rack_profile_id",
             );
             None
         }

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -997,7 +997,7 @@ async fn rms_get_firmware_upgrade_status(
                 };
                 tracing::warn!(
                     job_id = %job_id,
-                    status = response.status,
+                    job_status = response.status,
                     error = %message,
                     "RMS returned a non-success firmware job status lookup; retrying later"
                 );
@@ -1272,7 +1272,7 @@ pub fn apply_nvos_job_status_response(
                 other => {
                     tracing::warn!(
                         job_id = %job_id,
-                        state = %other,
+                        job_state = %other,
                         "RMS returned unknown switch system image job state; keeping previous status",
                     );
                     switch.error_message =
@@ -1292,7 +1292,7 @@ pub fn apply_nvos_job_status_response(
             };
             tracing::warn!(
                 job_id = %job_id,
-                status = response.status,
+                job_status = response.status,
                 error = %message,
                 "RMS returned a non-success switch image job status lookup; retrying later",
             );
@@ -1670,8 +1670,8 @@ pub async fn handle_maintenance(
                     let next = next_state_after_firmware(scope);
                     tracing::info!(
                         rack_id = %id,
-                        completed,
-                        total,
+                        completed_device_count = completed,
+                        total_device_count = total,
                         next_state = %next,
                         "Rack firmware upgrade complete; advancing to explicitly requested next activity"
                     );
@@ -1680,8 +1680,8 @@ pub async fn handle_maintenance(
                     let next = next_state_after_nvos(scope);
                     tracing::info!(
                         rack_id = %id,
-                        completed,
-                        total,
+                        completed_device_count = completed,
+                        total_device_count = total,
                         next_state = %next,
                         "Rack firmware upgrade complete; no explicit NVOS update requested, advancing"
                     );
@@ -1931,8 +1931,8 @@ pub async fn handle_maintenance(
                         .await?;
                     } else {
                         tracing::error!(
-                            "switch {} not found in database for NVOS update",
-                            switch.mac
+                            mac_address = %switch.mac,
+                            "switch not found in database for NVOS update",
                         );
                     }
                 }
@@ -1973,8 +1973,8 @@ pub async fn handle_maintenance(
                 let next = next_state_after_nvos(scope);
                 tracing::info!(
                     rack_id = %id,
-                    completed,
-                    total,
+                    completed_switch_count = completed,
+                    total_switch_count = total,
                     next_state = %next,
                     "Rack NVOS update complete, advancing"
                 );
@@ -2132,8 +2132,8 @@ pub async fn handle_maintenance(
                     tracing::error!(
                         rack_id = %id,
                         batch_status = batch.status,
-                        successful_nodes = stats.successful_nodes,
-                        failed_nodes = stats.failed_nodes,
+                        successful_node_count = stats.successful_nodes,
+                        failed_node_count = stats.failed_nodes,
                         summary = %summary,
                         "RMS BatchSetScaleUpFabricState failed",
                     );
@@ -2148,7 +2148,7 @@ pub async fn handle_maintenance(
 
                 tracing::info!(
                     rack_id = %id,
-                    successful_nodes = stats.successful_nodes,
+                    successful_node_count = stats.successful_nodes,
                     switch_count = switch_inventory.switches.len(),
                     "ScaleUpFabric state disabled; advancing to ConfigureScaleUpFabricManager"
                 );
@@ -2319,7 +2319,7 @@ pub async fn handle_maintenance(
                     tracing::error!(
                         rack_id = %id,
                         primary_switch = %primary_switch.device.node_id,
-                        message = %message,
+                        reason = %message,
                         "RMS ConfigureScaleUpFabricManager failed for switch, advancing to WaitForFabricStatus",
                     );
                     return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
@@ -2426,20 +2426,29 @@ pub async fn handle_maintenance(
         },
         RackMaintenanceState::PowerSequence { rack_power } => match rack_power {
             RackPowerState::PoweringOn => {
-                tracing::info!("Rack {} power sequence (on) - stubbed", id);
+                tracing::info!(
+                    rack_id = %id,
+                    "Rack power sequence (on) - stubbed",
+                );
 
                 Ok(StateHandlerOutcome::transition(RackState::Maintenance {
                     maintenance_state: RackMaintenanceState::Completed,
                 }))
             }
             RackPowerState::PoweringOff => {
-                tracing::info!("Rack {} power sequence (off) - stubbed", id);
+                tracing::info!(
+                    rack_id = %id,
+                    "Rack power sequence (off) - stubbed",
+                );
                 Ok(StateHandlerOutcome::wait(
                     "power sequence (off) in progress".into(),
                 ))
             }
             RackPowerState::PowerReset => {
-                tracing::info!("Rack {} power sequence (reset) - stubbed", id);
+                tracing::info!(
+                    rack_id = %id,
+                    "Rack power sequence (reset) - stubbed",
+                );
                 Ok(StateHandlerOutcome::wait(
                     "power sequence (reset) in progress".into(),
                 ))

--- a/crates/rack-controller/src/ready.rs
+++ b/crates/rack-controller/src/ready.rs
@@ -46,8 +46,8 @@ pub async fn handle_ready(
 ) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
     if config.topology_changed {
         tracing::info!(
-            "Rack {} topology changed, transitioning from Ready to Discovering",
-            id
+            rack_id = %id,
+            "Rack topology changed, transitioning from Ready to Discovering",
         );
         state.config.topology_changed = false;
         let mut txn = ctx.services.db_pool.begin().await?;
@@ -57,8 +57,8 @@ pub async fn handle_ready(
 
     if config.reprovision_requested {
         tracing::info!(
-            "Rack {} reprovision requested, transitioning from Ready to Maintenance",
-            id
+            rack_id = %id,
+            "Rack reprovision requested, transitioning from Ready to Maintenance",
         );
         state.config.reprovision_requested = false;
         state.config.maintenance_requested = None;
@@ -85,18 +85,18 @@ pub async fn handle_ready(
         };
         if scope.is_full_rack() {
             tracing::info!(
-                "Rack {} on-demand maintenance requested (full rack, activities: [{}]), transitioning to Maintenance",
-                id,
-                activities_desc,
+                rack_id = %id,
+                activity_description = %activities_desc,
+                "Rack on-demand maintenance requested (full rack, activities), transitioning to Maintenance",
             );
         } else {
             tracing::info!(
-                "Rack {} on-demand maintenance requested (partial: {} machines, {} switches, {} power shelves, activities: [{}]), transitioning to Maintenance",
-                id,
-                scope.machine_ids.len(),
-                scope.switch_ids.len(),
-                scope.power_shelf_ids.len(),
-                activities_desc,
+                rack_id = %id,
+                requested_machine_count = scope.machine_ids.len(),
+                requested_switch_count = scope.switch_ids.len(),
+                requested_power_shelf_count = scope.power_shelf_ids.len(),
+                activity_description = %activities_desc,
+                "Rack on-demand maintenance requested (partial: machines, switches, power shelves, activities), transitioning to Maintenance",
             );
         }
         // Leave maintenance_requested set; the maintenance handler reads the
@@ -109,7 +109,11 @@ pub async fn handle_ready(
     }
 
     if let Some(cause) = detect_component_failure(id, ctx).await? {
-        tracing::warn!("Rack {} transitioning from Ready to Error: {}", id, cause);
+        tracing::warn!(
+            rack_id = %id,
+            cause = %cause,
+            "Rack transitioning from Ready to Error",
+        );
         let txn = ctx.services.db_pool.begin().await?;
         return Ok(StateHandlerOutcome::transition(RackState::Error { cause }).with_txn(txn));
     }
@@ -277,8 +281,8 @@ pub(super) async fn all_components_ready(
     let total = all_switches.len() + all_power_shelves.len() + all_machines.len();
     if total == 0 {
         tracing::debug!(
-            "Rack {} has no components registered; not promoting out of Error",
-            rack_id
+            rack_id = %rack_id,
+            "Rack has no components registered; not promoting out of Error",
         );
         return Ok(false);
     }
@@ -289,14 +293,14 @@ pub(super) async fn all_components_ready(
 
     if !all_ready {
         tracing::debug!(
-            "Rack {} components not yet all Ready: switches {}/{}, power shelves {}/{}, machines {}/{}",
-            rack_id,
-            ready_switches.len(),
-            all_switches.len(),
-            ready_power_shelves.len(),
-            all_power_shelves.len(),
-            ready_machines.len(),
-            all_machines.len(),
+            rack_id = %rack_id,
+            ready_switch_count = ready_switches.len(),
+            total_switch_count = all_switches.len(),
+            ready_power_shelf_count = ready_power_shelves.len(),
+            total_power_shelf_count = all_power_shelves.len(),
+            ready_machine_count = ready_machines.len(),
+            total_machine_count = all_machines.len(),
+            "Rack components not yet all Ready: switches, power shelves, machines",
         );
     }
 

--- a/crates/rack-controller/src/validating.rs
+++ b/crates/rack-controller/src/validating.rs
@@ -197,7 +197,11 @@ pub(super) async fn load_partition_summary(
     let machines = super::get_machines_from_rack(rack, &mut txn).await?;
     txn.commit().await?;
 
-    tracing::debug!("Rack {} has {} machines", rack_id, machines.len());
+    tracing::debug!(
+        rack_id = %rack_id,
+        machine_count = machines.len(),
+        "Rack has machines",
+    );
 
     let partitions = RvPartitions::from_machines(machines, run_id)?;
     Ok(partitions.summarize())
@@ -219,7 +223,11 @@ pub(super) async fn find_rv_run_id(
         .into_iter()
         .find_map(|m| m.metadata.labels.get(run_label).cloned());
 
-    tracing::debug!("Rack {} rv.run-id scan: {:?}", rack_id, found);
+    tracing::debug!(
+        rack_id = %rack_id,
+        found_run_id = ?found,
+        "Rack rv.run-id scan",
+    );
 
     Ok(found)
 }
@@ -320,7 +328,10 @@ pub async fn handle_validating(
     ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
     if !ctx.services.site_config.rack_validation_config.enabled {
-        tracing::info!("Rack {} validation disabled, skipping to Ready", id);
+        tracing::info!(
+            rack_id = %id,
+            "Rack validation disabled, skipping to Ready",
+        );
         return Ok(StateHandlerOutcome::transition(RackState::Ready));
     }
 
@@ -329,9 +340,9 @@ pub async fn handle_validating(
             // Stay in Pending until RVS sets rv.run-id on at least one rack machine.
             if let Some(found_run_id) = find_rv_run_id(id, state, ctx).await? {
                 tracing::info!(
-                    "Rack {} validation run started (run_id={}), entering InProgress",
-                    id,
-                    found_run_id
+                    rack_id = %id,
+                    found_run_id = %found_run_id,
+                    "Rack validation run started, entering InProgress",
                 );
                 Ok(StateHandlerOutcome::transition(RackState::Validating {
                     validating_state: RackValidationState::InProgress {
@@ -340,8 +351,8 @@ pub async fn handle_validating(
                 }))
             } else {
                 tracing::debug!(
-                    "Rack {} in Validating(Pending), waiting for RVS to set rv.run-id",
-                    id
+                    rack_id = %id,
+                    "Rack in Validating(Pending), waiting for RVS to set rv.run-id",
                 );
                 Ok(StateHandlerOutcome::do_nothing())
             }
@@ -356,32 +367,35 @@ pub async fn handle_validating(
             let summary = load_partition_summary(id, state, run_id, ctx).await?;
 
             tracing::debug!(
-                "Rack {} partition summary: total={}, pending={}, in_progress={}, validated={}, failed={}",
-                id,
-                summary.total_partitions,
-                summary.pending,
-                summary.in_progress,
-                summary.validated,
-                summary.failed
+                rack_id = %id,
+                total_partition_count = summary.total_partitions,
+                pending_partition_count = summary.pending,
+                in_progress_partition_count = summary.in_progress,
+                validated_partition_count = summary.validated,
+                failed_partition_count = summary.failed,
+                "Rack partition validation summary",
             );
 
             if let Some(next_vs) = compute_validation_transition(other, &summary) {
                 tracing::info!(
-                    "Rack {} validation transitioning from {} to {}",
-                    id,
-                    other,
-                    next_vs
+                    rack_id = %id,
+                    previous_state = %other,
+                    next_state = %next_vs,
+                    "Rack validation state transition",
                 );
                 Ok(StateHandlerOutcome::transition(RackState::Validating {
                     validating_state: next_vs,
                 }))
             } else if matches!(other, RackValidationState::Validated { .. }) {
-                tracing::info!("Rack {} fully validated, transitioning to Ready", id);
+                tracing::info!(
+                    rack_id = %id,
+                    "Rack fully validated, transitioning to Ready",
+                );
                 Ok(StateHandlerOutcome::transition(RackState::Ready))
             } else if matches!(other, RackValidationState::Failed { .. }) {
                 tracing::warn!(
-                    "Rack {} is in Validating(Failed) state, requires intervention",
-                    id
+                    rack_id = %id,
+                    "Rack is in Validating(Failed) state, requires intervention",
                 );
                 Ok(StateHandlerOutcome::do_nothing())
             } else {

--- a/crates/rpc-utils/src/managed_host_display.rs
+++ b/crates/rpc-utils/src/managed_host_display.rs
@@ -68,7 +68,7 @@ impl ManagedHostMetadata {
             .await
             .map(|response| response.into_inner())
             .map_err(|e| {
-                warn!("Failed to get site exploration report: {:?}", e);
+                warn!(error = ?e, "failed to get site exploration report");
             })
             .unwrap_or_default();
 
@@ -429,7 +429,10 @@ pub fn get_managed_host_output(source: ManagedHostMetadata) -> Vec<ManagedHostOu
                         .remove(&id)
                         .map(|dpu| (id, dpu))
                         .or_else(|| {
-                            tracing::warn!("Could not find DPU for associated_dpu_machine_id {id}");
+                            tracing::warn!(
+                                dpu_machine_id = %id,
+                                "could not find associated DPU"
+                            );
                             None
                         })
                 })
@@ -575,11 +578,11 @@ pub fn to_time<M: Display>(t: Option<Timestamp>, machine_id: Option<M>) -> Optio
             }
             Err(err) => {
                 warn!(
-                    "get_managed_host_output {}, invalid timestamp: {}",
-                    machine_id
+                    machine_id = %machine_id
                         .map(|x| x.to_string())
                         .unwrap_or_else(|| "(no machine ID)".to_string()),
-                    err
+                    error = %err,
+                    "managed host has an invalid timestamp"
                 );
                 None
             }

--- a/crates/rpc/src/errors.rs
+++ b/crates/rpc/src/errors.rs
@@ -124,7 +124,12 @@ impl From<RpcDataConversionError> for tonic::Status {
             if f.len() == 2 {
                 let handler = f[0].trim();
                 let location = f[1].trim().replace("at ", "");
-                tracing::error!("{from} location={location} handler='{handler}'");
+                tracing::error!(
+                    error = %from,
+                    error_location = %location,
+                    handler,
+                    "RPC error conversion",
+                );
                 true
             } else {
                 false
@@ -134,7 +139,7 @@ impl From<RpcDataConversionError> for tonic::Status {
         };
 
         if !printed {
-            tracing::error!("{from}");
+            tracing::error!(error = %from, "RPC error conversion");
         }
 
         Status::invalid_argument(from.to_string())

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -214,7 +214,7 @@ impl ForgeClientConfig {
                     });
 
                 if !errors.is_empty() {
-                    tracing::warn!( certs = ?errors, "Found error parsing one or more certificates");
+                    tracing::warn!(error = ?errors, "Found error parsing one or more certificates");
                 }
 
                 valid_certificates
@@ -383,9 +383,9 @@ impl<'a> ForgeTlsClient<'a> {
                     .await
                     .inspect_err(|err| {
                         tracing::error!(
-                            "error connecting client to forge api (url: {}), will retry: {}",
-                            api_config.url,
-                            format_error_chain(err)
+                            url = %api_config.url,
+                            error = %format_error_chain(err),
+                            "Failed to connect client to Forge API; retrying",
                         );
                     })
                     .map_err(|e| ForgeTlsClientError::Connection(format_error_chain(&e)))?;
@@ -397,10 +397,10 @@ impl<'a> ForgeTlsClient<'a> {
             .await
             .inspect_err(|err| {
                 tracing::error!(
-                    "error connecting client to forge api (url: {}, attempts: {}): {}",
-                    api_config.url,
-                    api_config.retry_config.retries,
-                    err
+                    url = %api_config.url,
+                    retries = api_config.retry_config.retries,
+                    error = %err,
+                    "Failed to connect client to Forge API after retries",
                 );
             });
 
@@ -688,9 +688,9 @@ impl<'a> ForgeTlsClient<'a> {
                     .await
                     .inspect_err(|err| {
                         tracing::error!(
-                            "error connecting client to forge api (url: {}), will retry: {}",
-                            api_config.url,
-                            format_error_chain(err)
+                            url = %api_config.url,
+                            error = %format_error_chain(err),
+                            "Failed to connect client to NMX-C API; retrying",
                         );
                     })
                     .map_err(|e| ForgeTlsClientError::Connection(format_error_chain(&e)))?;
@@ -702,10 +702,10 @@ impl<'a> ForgeTlsClient<'a> {
             .await
             .inspect_err(|err| {
                 tracing::error!(
-                    "error connecting client to nmx-c api (url: {}, attempts: {}): {}",
-                    api_config.url,
-                    api_config.retry_config.retries,
-                    err
+                    url = %api_config.url,
+                    retries = api_config.retry_config.retries,
+                    error = %err,
+                    "Failed to connect client to NMX-C API after retries",
                 );
             });
 

--- a/crates/rpc/src/model/dpu_remediation.rs
+++ b/crates/rpc/src/model/dpu_remediation.rs
@@ -153,7 +153,11 @@ impl RpcTryFrom<(RevokeRemediationRequest, String)> for RevokeRemediation {
                 "Request must contain a remediation id.",
             ))?;
         let revoked_by = value.1;
-        tracing::info!("Remediation: '{}' revoked by: '{}'", id, revoked_by);
+        tracing::info!(
+            remediation_id = %id,
+            revoked_by = %revoked_by,
+            "Remediation revoked",
+        );
 
         Ok(Self { id })
     }
@@ -170,7 +174,11 @@ impl RpcTryFrom<(EnableRemediationRequest, String)> for EnableRemediation {
                 "Request must contain a remediation id.",
             ))?;
         let enabled_by = value.1;
-        tracing::info!("Remediation: '{}' enabled by: '{}'", id, enabled_by);
+        tracing::info!(
+            remediation_id = %id,
+            enabled_by = %enabled_by,
+            "Remediation enabled",
+        );
 
         Ok(Self { id })
     }
@@ -187,7 +195,11 @@ impl RpcTryFrom<(DisableRemediationRequest, String)> for DisableRemediation {
                 "Request must contain a remediation id.",
             ))?;
         let disabled_by = value.1;
-        tracing::info!("Remediation: '{}' disabled by: '{}'", id, disabled_by);
+        tracing::info!(
+            remediation_id = %id,
+            disabled_by = %disabled_by,
+            "Remediation disabled",
+        );
 
         Ok(Self { id })
     }

--- a/crates/rpc/src/model/machine/mod.rs
+++ b/crates/rpc/src/model/machine/mod.rs
@@ -418,7 +418,7 @@ pub fn get_action_for_dpu_state(
                     tracing::info!(
                         dpu_machine_id = %dpu_machine_id,
                         machine_type = "DPU",
-                        %state,
+                        agent_control_state = %state,
                         "forge agent control",
                     );
                     fac::Action::noop()
@@ -440,7 +440,7 @@ pub fn get_action_for_dpu_state(
                     tracing::info!(
                         dpu_machine_id = %dpu_machine_id,
                         machine_type = "DPU",
-                        %state,
+                        agent_control_state = %state,
                         "forge agent control",
                     );
                     fac::Action::noop()
@@ -452,7 +452,7 @@ pub fn get_action_for_dpu_state(
             tracing::info!(
                 dpu_machine_id = %dpu_machine_id,
                 machine_type = "DPU",
-                %state,
+                agent_control_state = %state,
                 "forge agent control",
             );
             fac::Action::noop()

--- a/crates/rvs/src/artifact/io.rs
+++ b/crates/rvs/src/artifact/io.rs
@@ -183,7 +183,7 @@ async fn download_one(
     tokio::fs::rename(&tmp_path, path).await?;
     tracing::info!(
         path = artifact.output_path,
-        bytes,
+        file_size_bytes = bytes,
         "artifact: downloaded to cache"
     );
     Ok(())
@@ -233,7 +233,7 @@ async fn log_cache_request(
     tracing::info!(
         %method,
         path,
-        status = response.status().as_u16(),
+        http_status = response.status().as_u16(),
         "artifact: cache request"
     );
     response

--- a/crates/rvs/src/bin/carbide-rvs.rs
+++ b/crates/rvs/src/bin/carbide-rvs.rs
@@ -155,7 +155,10 @@ async fn run_validation(ctx: &RvsCtx, cancel_token: CancellationToken) -> Result
             let report = validation::validate_partition(job).await?;
             validation::submit_report(report).await?;
         }
-        tracing::info!(poll_interval_secs, "validation: cycle complete, sleeping");
+        tracing::info!(
+            poll_interval_seconds = poll_interval_secs,
+            "validation: cycle complete, sleeping"
+        );
         if cancel_token
             .run_until_cancelled(tokio::time::sleep(interval))
             .await

--- a/crates/rvs/src/rack/tray.rs
+++ b/crates/rvs/src/rack/tray.rs
@@ -46,7 +46,7 @@ impl Tray {
             nvl,
             ib,
         };
-        tracing::trace!(rack_id = %tray.rack_id, rack_state = %tray.rack_state, nvl = ?tray.nvl, ib = ?tray.ib, "Tray constructed");
+        tracing::trace!(rack_id = %tray.rack_id, rack_state = %tray.rack_state, nvlink_node = ?tray.nvl, ib_node = ?tray.ib, "Tray constructed");
         tray
     }
 }

--- a/crates/rvs/src/validation/io.rs
+++ b/crates/rvs/src/validation/io.rs
@@ -131,7 +131,10 @@ async fn wait_for_boot(
 /// Stub: counts trays in the partition as a stand-in for real validation output.
 pub async fn validate_partition(job: ValidationJob) -> Result<Report, RvsError> {
     let trays_cnt = job.trays.len() as u32;
-    tracing::info!(trays_cnt, "validation: partition validated (stub)");
+    tracing::info!(
+        tray_count = trays_cnt,
+        "validation: partition validated (stub)"
+    );
     Ok(Report { trays_cnt })
 }
 
@@ -139,7 +142,7 @@ pub async fn validate_partition(job: ValidationJob) -> Result<Report, RvsError> 
 ///
 /// Stub: prints tray count to console.
 pub async fn submit_report(report: Report) -> Result<(), RvsError> {
-    tracing::info!(trays_cnt = report.trays_cnt, "validation report");
+    tracing::info!(tray_count = report.trays_cnt, "validation report");
     Ok(())
 }
 

--- a/crates/scout/src/attestation.rs
+++ b/crates/scout/src/attestation.rs
@@ -159,10 +159,7 @@ pub(crate) fn activate_credential(
 
     let digest = ctx.activate_credential(*ak_handle, *ek_handle, cred_blob, encr_secret)?;
 
-    tracing::debug!(
-        "Activated credential with session key value of {:?} ",
-        digest.value()
-    );
+    tracing::debug!("Activated credential");
 
     ctx.flush_context(SessionHandle::from(ak_auth_session).into())?;
     ctx.flush_context(SessionHandle::from(ek_auth_session).into())?;
@@ -175,14 +172,20 @@ fn detect_pcr_hash_algo(ctx: &mut Context) -> Result<HashingAlgorithm, Box<dyn s
     let is_sha256 = match probe_sample_pcr_value(ctx, HashingAlgorithm::Sha256) {
         Ok(val) => val,
         Err(err) => {
-            tracing::error!("Error probing hash SHA256, setting to FALSE: {}", err);
+            tracing::error!(
+                error = %err,
+                "Error probing hash SHA256; setting to false",
+            );
             false
         }
     };
     let is_sha384 = match probe_sample_pcr_value(ctx, HashingAlgorithm::Sha384) {
         Ok(val) => val,
         Err(err) => {
-            tracing::error!("Error probing hash SHA384, setting to FALSE: {}", err);
+            tracing::error!(
+                error = %err,
+                "Error probing hash SHA384; setting to false",
+            );
             false
         }
     };
@@ -221,7 +224,7 @@ pub(crate) fn get_pcr_quote(
     // it used to be that PCR values would only be in SHA256, this can now
     // be in SHA384 also. We figure out which ones those are by probing them.
     let pcr_hash_algo = detect_pcr_hash_algo(ctx)?;
-    tracing::info!("Using PCR HASH {:?}", pcr_hash_algo);
+    tracing::info!(?pcr_hash_algo, "Using PCR hash");
 
     let ak_auth_session_option = ctx.start_auth_session(
         None,
@@ -279,8 +282,8 @@ pub(crate) fn get_pcr_quote(
         selection_list.clone(),
     )?;
 
-    tracing::debug!("Obtained attestation {:?}", attest);
-    tracing::debug!("Obtained signature {:?}", signature);
+    tracing::debug!(?attest, "Obtained attestation");
+    tracing::debug!(?signature, "Obtained signature");
 
     //verify_signature(ctx, &attest, &signature, &ak_handle);
 
@@ -311,7 +314,7 @@ pub(crate) fn get_pcr_quote(
         );
     }
 
-    tracing::debug!("Obtained pcr digests {:?}", digest_vec);
+    tracing::debug!(pcr_digests = ?digest_vec, "Obtained PCR digests");
 
     Ok((attest, signature, digest_vec))
 }
@@ -348,15 +351,16 @@ pub(crate) fn get_tpm_eventlog() -> Option<Vec<u8>> {
     let output = match output_res {
         Ok(output) => output,
         Err(e) => {
-            tracing::error!("Could not retrieve TPM Event Log {0}", e.to_string());
+            tracing::error!(error = %e, "Could not retrieve TPM event log");
             return None;
         }
     };
 
     if !output.status.success() {
         tracing::error!(
-            "Error retrieving TPM Event Log: {0}",
-            String::from_utf8(output.stderr).unwrap_or("<could not parse stderr log>".to_string())
+            stderr = %String::from_utf8(output.stderr)
+                .unwrap_or("<could not parse stderr log>".to_string()),
+            "Error retrieving TPM event log",
         );
         None
     } else {
@@ -368,7 +372,10 @@ pub fn get_tpm_description(ctx: &mut Context) -> Option<TpmDescription> {
     let (capabilities, _more) = match ctx.get_capability(CapabilityType::TpmProperties, 0, 80) {
         Ok(tuple) => tuple,
         Err(e) => {
-            tracing::error!("GetTpmDescription: Could not get TPM capability data: {e}");
+            tracing::error!(
+                error = %e,
+                "GetTpmDescription: Could not get TPM capability data",
+            );
             return None;
         }
     };
@@ -423,14 +430,14 @@ pub fn get_tpm_description(ctx: &mut Context) -> Option<TpmDescription> {
         }
     }
 
-    tracing::debug!("family_indicator is {0}", spec_version);
+    tracing::debug!(family_indicator = %spec_version, "Read TPM family indicator");
 
     let vendor = vendor_1.clone() + vendor_2.as_str();
-    tracing::debug!("vendor is {0}", vendor);
+    tracing::debug!(%vendor, "Read TPM vendor");
 
     let firmware_version = format!("0x{firmware_version_1:x}.0x{firmware_version_2:x}");
 
-    tracing::debug!("firmware version is {0}", firmware_version);
+    tracing::debug!(%firmware_version, "Read TPM firmware version");
 
     if firmware_version_1 == 0
         && firmware_version_2 == 0

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -192,11 +192,12 @@ async fn get_best_lba_format(nvmename: &str) -> Result<(u8, u64), CarbideClientE
     // Try 512B format first (ds=9 means 2^9 = 512 bytes)
     if let Some((idx, lbaf)) = select_best_lba_format(&namespace_params.lbafs, 9) {
         tracing::info!(
-            "Selected FLBAS {} for {} with sector_size=512 bytes (ms={}, rp={})",
-            idx,
-            nvmename,
-            lbaf.ms,
-            lbaf.rp
+            flbas_index = idx,
+            device = nvmename,
+            sector_size_bytes = 512u64,
+            metadata_size_bytes = lbaf.ms,
+            relative_performance = lbaf.rp,
+            "Selected NVMe LBA format",
         );
         return Ok((idx as u8, 512u64));
     }
@@ -204,26 +205,27 @@ async fn get_best_lba_format(nvmename: &str) -> Result<(u8, u64), CarbideClientE
     // Try 4K format (ds=12 means 2^12 = 4096 bytes)
     if let Some((idx, lbaf)) = select_best_lba_format(&namespace_params.lbafs, 12) {
         tracing::info!(
-            "Selected FLBAS {} for {} with sector_size=4096 bytes (ms={}, rp={})",
-            idx,
-            nvmename,
-            lbaf.ms,
-            lbaf.rp
+            flbas_index = idx,
+            device = nvmename,
+            sector_size_bytes = 4096u64,
+            metadata_size_bytes = lbaf.ms,
+            relative_performance = lbaf.rp,
+            "Selected NVMe LBA format",
         );
         return Ok((idx as u8, 4096u64));
     }
 
     // Fallback to FLBAS 0 - determine its actual sector size
     tracing::warn!(
-        "No 512B or 4K LBA format found for {}, falling back to FLBAS 0",
-        nvmename
+        device = nvmename,
+        "No 512B or 4K NVMe LBA format found; falling back to FLBAS 0",
     );
     if let Some(lbaf0) = namespace_params.lbafs.first() {
         let sector_size = 1u64 << lbaf0.ds;
         tracing::warn!(
-            "FLBAS 0 has sector_size={} bytes (ds={})",
-            sector_size,
-            lbaf0.ds
+            sector_size_bytes = sector_size,
+            data_size_exponent = lbaf0.ds,
+            "NVMe FLBAS 0 sector size",
         );
         Ok((0u8, sector_size))
     } else {
@@ -234,22 +236,22 @@ async fn get_best_lba_format(nvmename: &str) -> Result<(u8, u64), CarbideClientE
 }
 
 async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
-    tracing::debug!("cleaning {}", nvmename);
+    tracing::debug!(device = %nvmename, "Cleaning NVMe device");
 
     let nvme_drive_params = get_nvme_params(nvmename).await?;
 
     let namespaces_supported = nvme_drive_params.oacs & 0x8 == 0x8;
 
     tracing::debug!(
-        "nvme: device={} size={} cntlid={} oacs={} namespaces_supported={} sn={} mn={} fr={}",
-        nvmename,
-        nvme_drive_params.tnvmcap,
-        nvme_drive_params.cntlid,
-        nvme_drive_params.oacs,
+        device = %nvmename,
+        total_capacity_bytes = nvme_drive_params.tnvmcap,
+        controller_id = nvme_drive_params.cntlid,
+        optional_admin_commands = nvme_drive_params.oacs,
         namespaces_supported,
-        nvme_drive_params.sn,
-        nvme_drive_params.mn,
-        nvme_drive_params.fr
+        serial_number = %nvme_drive_params.sn,
+        model_number = %nvme_drive_params.mn,
+        firmware_revision = %nvme_drive_params.fr,
+        "Read NVMe device parameters",
     );
 
     if nvme_drive_params.mn.trim() == "M.2 NVMe 2-Bay RAID Kit" {
@@ -264,7 +266,7 @@ async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
             ))
         })?;
 
-        tracing::info!("Using Lenovo mnv_cli at {}", lenovo_mnv_cli_prog);
+        tracing::info!(program = lenovo_mnv_cli_prog, "Using Lenovo mnv_cli",);
 
         let vd_out = cmdrun::run_prog(lenovo_mnv_cli_prog, ["info", "-o", "vd", "-i", "0"]).await?;
 
@@ -322,7 +324,7 @@ async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
                 None => continue,
             };
             let nsid = caps.get(1).map_or("", |m| m.as_str());
-            tracing::debug!("namespace {}", nsid);
+            tracing::debug!(namespace_id = nsid, "Found NVMe namespace");
 
             // format with "-s2" is secure erase
             match cmdrun::run_prog(NVME_CLI_PROG, ["format", nvmename, "-s2", "-f", "-n", nsid])
@@ -332,7 +334,7 @@ async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
                 Err(e) => {
                     if namespaces_supported {
                         // format can fail if there is a wrong params for namespace. We delete it anyway.
-                        tracing::debug!("nvme format error: {}", e);
+                        tracing::debug!(error = %e, "NVMe format error");
                     } else {
                         return Err(e);
                     }
@@ -350,11 +352,11 @@ async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
             let flbas_str = flbas_index.to_string();
 
             tracing::debug!(
-                "Creating namespace on {} with flbas={}, sector_size={}, sectors={}",
-                nvmename,
+                device = %nvmename,
                 flbas_index,
-                sector_size,
-                sectors
+                sector_size_bytes = sector_size,
+                sector_count = sectors,
+                "Creating NVMe namespace",
             );
 
             let line_created_ns_id = cmdrun::run_prog(
@@ -393,7 +395,7 @@ async fn clean_this_nvme(nvmename: &String) -> Result<(), CarbideClientError> {
             .await?;
         }
     }
-    tracing::debug!("Cleanup completed for nvme device {}", nvmename);
+    tracing::debug!(device = %nvmename, "Cleanup completed for NVMe device");
     Ok(())
 }
 
@@ -542,7 +544,7 @@ async fn try_ata_secure_erase(devpath: &str) -> Result<(), CarbideClientError> {
 
     cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-set-pass", "p", devpath]).await?;
 
-    tracing::info!("Using enhanced erase for {}", devpath);
+    tracing::info!(device = devpath, "Using enhanced erase");
     cmdrun::run_prog(HDPARM_CLI_PROG, ["--security-erase-enhanced", "p", devpath]).await?;
 
     Ok(())
@@ -679,10 +681,16 @@ fn block_device_cleanup_skip_reason(devname: &str) -> Option<BlockDeviceCleanupS
 async fn clean_this_block_device(devpath: &str) -> Result<(), CarbideClientError> {
     let devname = devpath.trim_start_matches("/dev/");
     if is_sata_device(devname) {
-        tracing::info!("{} detected as SATA, using ATA Secure Erase", devpath);
+        tracing::info!(
+            device = devpath,
+            "Detected SATA device; using ATA Secure Erase",
+        );
         try_ata_secure_erase(devpath).await
     } else {
-        tracing::info!("{} detected as SAS/SCSI, using SCSI Sanitize", devpath);
+        tracing::info!(
+            device = devpath,
+            "Detected SAS/SCSI device; using SCSI Sanitize",
+        );
         try_scsi_sanitize(devpath).await
     }
 }
@@ -919,12 +927,16 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                     {
                         Ok(_) => {
                             tracing::info!(
-                                "set KEEP_IB_LINK_UP_P1=1 on IB device {} successfully.",
-                                slot
+                                device = %slot,
+                                "Set KEEP_IB_LINK_UP_P1=1 on IB device successfully",
                             );
                         }
                         Err(e) => {
-                            tracing::error!("{}", e);
+                            tracing::error!(
+                                device = %slot,
+                                error = %e,
+                                "Failed to set KEEP_IB_LINK_UP_P1=1 on IB device",
+                            );
                             return Err(e);
                         }
                     }
@@ -937,16 +949,16 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
                     {
                         Ok(_) => {
                             tracing::info!(
-                                "set KEEP_IB_LINK_UP_P2=1 on IB device {} successfully.",
-                                slot
+                                device = %slot,
+                                "Set KEEP_IB_LINK_UP_P2=1 on IB device successfully",
                             );
                         }
                         Err(e) => {
                             // P2 may not exist on single-port devices, ignore error
                             tracing::debug!(
-                                "KEEP_IB_LINK_UP_P2 not available on IB device {} (single-port): {}",
-                                slot,
-                                e
+                                device = %slot,
+                                error = %e,
+                                "KEEP_IB_LINK_UP_P2 not available on IB device (single-port)",
                             );
                         }
                     }
@@ -954,7 +966,7 @@ async fn set_ib_link_up() -> Result<(), CarbideClientError> {
             }
         }
         Err(e) => {
-            tracing::error!("{}", e);
+            tracing::error!(error = %e, "Failed to discover IB devices");
             return Err(CarbideClientError::GenericError(format!(
                 "Failed to get ibs: {e}"
             )));
@@ -976,10 +988,14 @@ async fn reset_ib_devices() -> Result<(), CarbideClientError> {
                     let slot = p.slot.unwrap();
                     match cmdrun::run_prog("mlxconfig", ["-y", "-d", &slot, "reset"]).await {
                         Ok(_) => {
-                            tracing::info!("reset IB device {} successfully.", slot);
+                            tracing::info!(device = %slot, "Reset IB device successfully");
                         }
                         Err(e) => {
-                            tracing::error!("{}", e);
+                            tracing::error!(
+                                device = %slot,
+                                error = %e,
+                                "Failed to reset IB device",
+                            );
                             return Err(e);
                         }
                     }
@@ -987,7 +1003,7 @@ async fn reset_ib_devices() -> Result<(), CarbideClientError> {
             }
         }
         Err(e) => {
-            tracing::error!("{}", e);
+            tracing::error!(error = %e, "Failed to discover IB devices");
             return Err(CarbideClientError::GenericError(format!(
                 "Failed to get ibs: {e}"
             )));
@@ -1025,7 +1041,7 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
                 });
             }
             Err(e) => {
-                tracing::error!("{}", e);
+                tracing::error!(error = %e, "NVMe cleanup failed");
                 cleanup_result.nvme = Some(rpc::machine_cleanup_info::CleanupStepResult {
                     result: rpc::machine_cleanup_info::CleanupResult::Error as _,
                     message: e.to_string(),
@@ -1042,7 +1058,7 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
                 });
             }
             Err(e) => {
-                tracing::error!("{}", e);
+                tracing::error!(error = %e, "HDD/SAS cleanup failed");
                 cleanup_result.hdd = Some(rpc::machine_cleanup_info::CleanupStepResult {
                     result: rpc::machine_cleanup_info::CleanupResult::Error as _,
                     message: e.to_string(),
@@ -1051,7 +1067,10 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
             }
         }
     } else {
-        tracing::info!("stdin == {}. Skip nvme and HDD cleanup.", stdin_link);
+        tracing::info!(
+            stdin = %stdin_link,
+            "Skipping NVMe and HDD cleanup because stdin is not /dev/null",
+        );
     }
 
     match check_memory_overwrite_efi_var() {
@@ -1062,7 +1081,7 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
             });
         }
         Err(e) => {
-            tracing::error!("{}", e);
+            tracing::error!(error = %e, "Memory overwrite check failed");
             cleanup_result.mem_overwrite = Some(rpc::machine_cleanup_info::CleanupStepResult {
                 result: rpc::machine_cleanup_info::CleanupResult::Error as _,
                 message: e.to_string(),
@@ -1099,7 +1118,7 @@ async fn do_cleanup(machine_id: &MachineId) -> CarbideClientResult<rpc::MachineC
             });
         }
         Err(e) => {
-            tracing::error!("{}", e);
+            tracing::error!(error = %e, "IB device reset failed");
             cleanup_result.ib = Some(rpc::machine_cleanup_info::CleanupStepResult {
                 result: rpc::machine_cleanup_info::CleanupResult::Error as _,
                 message: e.to_string(),

--- a/crates/scout/src/firmware_upgrade.rs
+++ b/crates/scout/src/firmware_upgrade.rs
@@ -62,9 +62,9 @@ async fn run_firmware_upgrade(
     task: &FirmwareUpgradeTask,
 ) -> Result<FirmwareUpgradeResult, Box<dyn std::error::Error>> {
     tracing::info!(
-        "[firmware_upgrade] starting for component={} version={}",
-        task.component_type,
-        task.target_version,
+        component_type = %task.component_type,
+        target_version = %task.target_version,
+        "[firmware_upgrade] starting",
     );
 
     let work_dir = tempfile::tempdir()?;
@@ -96,8 +96,8 @@ async fn run_firmware_upgrade(
         .into());
     }
     tracing::info!(
-        "[firmware_upgrade] script downloaded and verified: {:?}",
-        script_path
+        script_path = ?script_path,
+        "[firmware_upgrade] script downloaded and verified",
     );
 
     // Download file artifacts and verify checksums.
@@ -124,13 +124,16 @@ async fn run_firmware_upgrade(
             )
             .into());
         }
-        tracing::info!("[firmware_upgrade] checksum verified for {}", artifact.url);
+        tracing::info!(
+            artifact_url = %artifact.url,
+            "[firmware_upgrade] checksum verified",
+        );
         downloaded_artifacts.push(dest);
     }
 
     tracing::info!(
-        "[firmware_upgrade] files downloaded. Executing script {:?}",
-        script_path,
+        script_path = ?script_path,
+        "[firmware_upgrade] files downloaded; executing script",
     );
 
     // Execute the script with env vars for context.
@@ -204,8 +207,11 @@ async fn download_file_with_retries(
         .on_retry(|attempt, next_delay, error| {
             let delay = next_delay.unwrap_or_default();
             tracing::warn!(
-                "[firmware_upgrade] download attempt {attempt} failed for {}: {error}, retrying in {delay:?}",
-                url_owned
+                attempt,
+                url = %url_owned,
+                error = %error,
+                retry_delay_seconds = delay.as_secs_f64(),
+                "[firmware_upgrade] download attempt failed; retrying",
             );
             std::future::ready(())
         })
@@ -233,7 +239,11 @@ async fn download_file(
 
     let dest = target_dir.join(filename);
 
-    tracing::info!("[firmware_upgrade] downloading {url} -> {dest:?}");
+    tracing::info!(
+        url,
+        destination = ?dest,
+        "[firmware_upgrade] downloading",
+    );
 
     let response = client.get(url).send().await?.error_for_status()?;
     let mut stream = response.bytes_stream();

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -98,7 +98,11 @@ async fn main() -> Result<(), eyre::Report> {
 
     carbide_host_support::init_logging("nico-scout")?;
 
-    tracing::info!("Running as {}...{}", config.mode, config.version);
+    tracing::info!(
+        mode = %config.mode,
+        version_requested = config.version,
+        "Running scout",
+    );
 
     match config.mode {
         Mode::Service => run_as_service(&config).await?,
@@ -129,12 +133,12 @@ async fn initial_setup(config: &Options) -> Result<(uuid::Uuid, MachineId), eyre
     .custom_backoff(|_attempt, error: &CarbideClientError| {
         // we only want to retry if attestation has failed. In all other cases
         // just preserve the old behaviour by breaking from the retry loop
-        tracing::error!("Failed to register machine with error {}", error);
+        tracing::error!(error = %error, "Failed to register machine");
         if !error.to_string().contains("Attestation failed") {
             tracing::info!("Not retrying registration as it is not an attestation error");
             RetryPolicy::Break
         } else {
-            tracing::info!("Retrying registration again in {} seconds", retry.secs);
+            tracing::info!(retry_delay_seconds = retry.secs, "Retrying registration",);
             RetryPolicy::Delay(Duration::from_secs(retry.secs))
         }
     })
@@ -185,17 +189,26 @@ async fn run_as_service(config: &Options) -> Result<(), eyre::Report> {
     // initial_setup (and after registration is complete).
     match mlx_device::create_device_report_request(machine_id) {
         Ok(request) => match mlx_device::publish_mlx_device_report(config, request).await {
-            Ok(response) => tracing::info!("recevied PublishMlxDeviceReportResponse: {response:?}"),
-            Err(e) => tracing::warn!("failed to publish PublishMlxDeviceReportRequest: {e:?}"),
+            Ok(response) => tracing::info!(?response, "received PublishMlxDeviceReportResponse",),
+            Err(e) => tracing::warn!(
+                error = ?e,
+                "failed to publish PublishMlxDeviceReportRequest",
+            ),
         },
-        Err(e) => tracing::warn!("failed to create PublishMlxDeviceReportRequest: {e:?}"),
+        Err(e) => tracing::warn!(
+            error = ?e,
+            "failed to create PublishMlxDeviceReportRequest",
+        ),
     };
 
     let mut scout_stream_started = false;
     loop {
         if is_time_to_check_certs_expiry(next_certs_check_time) {
             next_certs_check_time = get_next_certs_check_datetime()?;
-            tracing::info!("Renewed next certs check time to {}", next_certs_check_time);
+            tracing::info!(
+                %next_certs_check_time,
+                "Renewed next certificate check time",
+            );
 
             if check_certs_validity(&client_cert)? {
                 initial_setup(config).await?;
@@ -211,8 +224,12 @@ async fn run_as_service(config: &Options) -> Result<(), eyre::Report> {
         if let Some(action) = controller_response.action {
             let action_str = action.as_str_name().to_owned();
             match handle_action(action, &machine_id, machine_interface_id, config).await {
-                Ok(_) => tracing::info!("Successfully served {}", action_str),
-                Err(e) => tracing::info!("Failed to serve {}: Err {}", action_str, e),
+                Ok(_) => tracing::info!(action = %action_str, "Successfully served action"),
+                Err(e) => tracing::info!(
+                    action = %action_str,
+                    error = %e,
+                    "Failed to serve action",
+                ),
             };
         } else {
             tracing::warn!("API response did not contain an action, skipping.");
@@ -350,7 +367,10 @@ async fn handle_action(
         fac::Action::Noop(_) => {}
         fac::Action::LogError(_) => match logerror_to_carbide(config, machine_interface_id).await {
             Ok(()) => (),
-            Err(e) => tracing::info!("Forge Scout logerror_to_carbide error: {}", e),
+            Err(e) => tracing::info!(
+                error = %e,
+                "Failed to report Scout error to Carbide",
+            ),
         },
         fac::Action::Retry(_) => {
             panic!(
@@ -424,19 +444,19 @@ async fn handle_firmware_upgrade_action(
     })?;
 
     tracing::info!(
-        "[firmware_upgrade] received upgrade task for component={} version={}",
-        task.component_type,
-        task.target_version,
+        component_type = %task.component_type,
+        target_version = %task.target_version,
+        "[firmware_upgrade] received upgrade task",
     );
 
     let result = firmware_upgrade::handle_firmware_upgrade(&http_client, &task).await;
 
     tracing::info!(
-        "[firmware_upgrade] upgrade finished: success={} component={} version={} exit_code={}",
-        result.success,
-        task.component_type,
-        task.target_version,
-        result.exit_code,
+        success = result.success,
+        component_type = %task.component_type,
+        target_version = %task.target_version,
+        exit_code = result.exit_code,
+        "[firmware_upgrade] upgrade finished",
     );
 
     report_firmware_upgrade_status(config, machine_id, task.upgrade_task_id, &result).await?;
@@ -510,8 +530,9 @@ async fn handle_mlxreport_action(
             Ok(command) => Some((device_action.pci_name.clone(), command)),
             Err(e) => {
                 tracing::error!(
-                    "handle_mlxreport_action error decoding command {e} for dev: {:#?}",
-                    device_action.pci_name
+                    error = %e,
+                    pci_name = %device_action.pci_name,
+                    "handle_mlxreport_action error decoding command",
                 );
                 None
             }
@@ -542,8 +563,9 @@ async fn handle_mlxreport_commands(
             Ok(d) => d,
             Err(s) => {
                 tracing::error!(
-                    "handle_mlxreport_action Error from discover_device::from_str {s} for dev: {:#?}",
-                    dev_pci_name
+                    error = %s,
+                    pci_name = %dev_pci_name,
+                    "handle_mlxreport_action error from discover_device::from_str",
                 );
                 continue;
             }
@@ -564,8 +586,9 @@ async fn handle_mlxreport_commands(
                 }
                 Err(e) => {
                     tracing::info!(
-                        "handle_mlxreport_action Error from lock_device: {e} for dev: {:#?}",
-                        dev_pci_name
+                        error = %e,
+                        pci_name = %dev_pci_name,
+                        "handle_mlxreport_action error from lock_device",
                     );
                 }
             },
@@ -640,8 +663,9 @@ async fn handle_mlxreport_commands(
                 }
                 Err(e) => {
                     tracing::info!(
-                        "handle_mlxreport_action Error from unlock_device: {e} for dev: {:#?}",
-                        dev_pci_name
+                        error = %e,
+                        pci_name = %dev_pci_name,
+                        "handle_mlxreport_action error from unlock_device",
                     );
                 }
             },
@@ -656,7 +680,10 @@ async fn handle_mlxreport_commands(
     match mlx_device::publish_mlx_observation_report(config, req).await {
         Ok(_resp) => (),
         Err(e) => {
-            tracing::error!("Error from publish_mlx_observation_report {e}");
+            tracing::error!(
+                error = %e,
+                "Error from publish_mlx_observation_report",
+            );
         }
     }
 }
@@ -724,9 +751,9 @@ async fn query_api(
     query_attempt: u64,
 ) -> CarbideClientResult<rpc_forge::ForgeAgentControlResponse> {
     tracing::info!(
-        "Sending ForgeAgentControlRequest (attempt:{}.{})",
         action_attempt,
         query_attempt,
+        "Sending ForgeAgentControlRequest",
     );
     let query = rpc_forge::ForgeAgentControlRequest {
         machine_id: Some(*machine_id),
@@ -741,10 +768,10 @@ async fn query_api(
         .unwrap_or_default();
 
     tracing::info!(
-        "Received ForgeAgentControlResponse (attempt:{}.{}, action:{})",
         action_attempt,
         query_attempt,
-        action_str,
+        action = %action_str,
+        "Received ForgeAgentControlResponse",
     );
     Ok(response)
 }
@@ -768,7 +795,7 @@ async fn query_api_with_retries(
         .on_retry(|_attempt, _next_delay, error: &CarbideClientError| {
             // We can't move the error, but CarbideClientError contains some results that are not clonable, so just do the format here
             let error = format!("{error}");
-            async move { tracing::info!("ForgeAgentControlRequest failed: {error}") }
+            async move { tracing::info!(error = %error, "ForgeAgentControlRequest failed") }
         });
 
     // State machine handler needs 1-2 cycles to update host_adminIP to leaf.
@@ -825,9 +852,9 @@ fn is_time_to_check_certs_expiry(next_check_time: DateTime<Utc>) -> bool {
     let diff = next_check_time - now;
     if diff < TimeDelta::minutes(2) {
         tracing::info!(
-            "Time to check certs expiry: time now is {}, certs check time is {}",
-            now,
-            next_check_time
+            %now,
+            %next_check_time,
+            "Time to check certificate expiry",
         );
         return true;
     }
@@ -876,16 +903,16 @@ fn check_certs_validity(client_cert_path: &str) -> CarbideClientResult<bool> {
         let diff = not_after_datetime - now;
         if diff < TimeDelta::days(2) {
             tracing::info!(
-                "Now timestamp is {}, NotAfter is {}, triggering certs regen",
-                now,
-                not_after_datetime
+                %now,
+                %not_after_datetime,
+                "Certificate expires soon; triggering regeneration",
             );
             Ok(true)
         } else {
             tracing::info!(
-                "Now timestamp is {}, NotAfter is {}, NOT triggering certs regen",
-                now,
-                not_after_datetime
+                %now,
+                %not_after_datetime,
+                "Certificate does not expire soon; skipping regeneration",
             );
             Ok(false)
         }

--- a/crates/scout/src/mlx_device.rs
+++ b/crates/scout/src/mlx_device.rs
@@ -67,7 +67,7 @@ pub async fn publish_mlx_device_report(
     config: &Options,
     req: PublishMlxDeviceReportRequest,
 ) -> CarbideClientResult<PublishMlxDeviceReportResponse> {
-    tracing::info!("sending PublishMlxDeviceReportRequest: {req:?}");
+    tracing::info!(request = ?req, "sending PublishMlxDeviceReportRequest");
     let request = tonic::Request::new(req);
     let mut client = client::create_forge_client(config).await?;
     let response = client
@@ -81,7 +81,10 @@ pub async fn publish_mlx_observation_report(
     config: &Options,
     req: PublishMlxObservationReportRequest,
 ) -> CarbideClientResult<PublishMlxObservationReportResponse> {
-    tracing::info!("sending PublishMlxObservationReportRequest: {req:?}");
+    tracing::info!(
+        request = ?req,
+        "sending PublishMlxObservationReportRequest",
+    );
     let request = tonic::Request::new(req);
     let mut client = client::create_forge_client(config).await?;
     let response = client
@@ -115,9 +118,9 @@ pub fn handle_profile_sync(
     request: mlx_device_pb::MlxDeviceProfileSyncRequest,
 ) -> mlx_device_pb::MlxDeviceProfileSyncResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] profile sync to device requested (device_id:{}, profile_name:{})",
-        request.device_id,
-        request.profile_name
+        device_id = %request.device_id,
+        profile_name = %request.profile_name,
+        "[scout_stream::mlx_device] profile sync to device requested",
     );
 
     let Some(serializable_profile_pb) = request.serializable_profile else {
@@ -136,7 +139,10 @@ pub fn handle_profile_sync(
     let serializable_profile: SerializableProfile = match serializable_profile_pb.try_into() {
         Ok(profile) => profile,
         Err(e) => {
-            tracing::error!("[scout_stream::mlx_device] failed to parse profile: {e}");
+            tracing::error!(
+                error = %e,
+                "[scout_stream::mlx_device] failed to parse profile",
+            );
             return mlx_device_pb::MlxDeviceProfileSyncResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_profile_sync_response::Reply::Error(
@@ -153,9 +159,9 @@ pub fn handle_profile_sync(
     match load_and_sync_profile(&request.device_id, serializable_profile) {
         Ok(sync_result) => {
             tracing::info!(
-                "[scout_stream::mlx_device] profile sync to device successful (device_id:{}, profile_name:{})",
-                request.device_id,
-                request.profile_name
+                device_id = %request.device_id,
+                profile_name = %request.profile_name,
+                "[scout_stream::mlx_device] profile sync to device successful",
             );
 
             match sync_result.try_into() {
@@ -168,7 +174,8 @@ pub fn handle_profile_sync(
                 },
                 Err(e) => {
                     tracing::error!(
-                        "[scout_stream::mlx_device] profile sync result failed to serialize: {e}"
+                        error = %e,
+                        "[scout_stream::mlx_device] profile sync result failed to serialize",
                     );
                     mlx_device_pb::MlxDeviceProfileSyncResponse {
                         reply: Some(
@@ -186,9 +193,10 @@ pub fn handle_profile_sync(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] profile sync to device failed (device_id:{}, profile_name:{}): {e}",
-                request.device_id,
-                request.profile_name
+                device_id = %request.device_id,
+                profile_name = %request.profile_name,
+                error = %e,
+                "[scout_stream::mlx_device] profile sync to device failed",
             );
             mlx_device_pb::MlxDeviceProfileSyncResponse {
                 reply: Some(
@@ -208,9 +216,9 @@ pub fn handle_profile_compare(
     request: mlx_device_pb::MlxDeviceProfileCompareRequest,
 ) -> mlx_device_pb::MlxDeviceProfileCompareResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] profile compare against device requested (device_id:{}, profile_name:{})",
-        request.device_id,
-        request.profile_name
+        device_id = %request.device_id,
+        profile_name = %request.profile_name,
+        "[scout_stream::mlx_device] profile compare against device requested",
     );
 
     let Some(serializable_profile_pb) = request.serializable_profile else {
@@ -229,7 +237,10 @@ pub fn handle_profile_compare(
     let serializable_profile: SerializableProfile = match serializable_profile_pb.try_into() {
         Ok(profile) => profile,
         Err(e) => {
-            tracing::error!("[scout_stream::mlx_device] failed to parse profile: {e}");
+            tracing::error!(
+                error = %e,
+                "[scout_stream::mlx_device] failed to parse profile",
+            );
             return mlx_device_pb::MlxDeviceProfileCompareResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_profile_compare_response::Reply::Error(
@@ -246,9 +257,9 @@ pub fn handle_profile_compare(
     match load_and_compare_profile(&request.device_id, serializable_profile) {
         Ok(comparison_result) => {
             tracing::info!(
-                "[scout_stream::mlx_device] profile compare against device successful (device_id:{}, profile_name:{})",
-                request.device_id,
-                request.profile_name
+                device_id = %request.device_id,
+                profile_name = %request.profile_name,
+                "[scout_stream::mlx_device] profile compare against device successful",
             );
 
             match comparison_result.try_into() {
@@ -261,7 +272,8 @@ pub fn handle_profile_compare(
                 },
                 Err(e) => {
                     tracing::error!(
-                        "[scout_stream::mlx_device] profile compare result failed to serialize: {e}"
+                        error = %e,
+                        "[scout_stream::mlx_device] profile compare result failed to serialize",
                     );
                     mlx_device_pb::MlxDeviceProfileCompareResponse {
                         reply: Some(
@@ -279,9 +291,10 @@ pub fn handle_profile_compare(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] profile compare against device failed (device_id:{}, profile_name:{}): {e}",
-                request.device_id,
-                request.profile_name
+                device_id = %request.device_id,
+                profile_name = %request.profile_name,
+                error = %e,
+                "[scout_stream::mlx_device] profile compare against device failed",
             );
             mlx_device_pb::MlxDeviceProfileCompareResponse {
                 reply: Some(
@@ -302,15 +315,16 @@ pub fn handle_lockdown_lock(
     request: mlx_device_pb::MlxDeviceLockdownLockRequest,
 ) -> mlx_device_pb::MlxDeviceLockdownResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] lockdown lock requested (device_id:{})",
-        request.device_id
+        device_id = %request.device_id,
+        "[scout_stream::mlx_device] lockdown lock requested",
     );
 
     let manager = match LockdownManager::new() {
         Ok(m) => m,
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] lockdown manager initialization failed: {e}"
+                error = %e,
+                "[scout_stream::mlx_device] lockdown manager initialization failed",
             );
             return mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
@@ -326,8 +340,9 @@ pub fn handle_lockdown_lock(
     match manager.lock_device(&request.device_id, &request.key) {
         Ok(status) => {
             tracing::info!(
-                "[scout_stream::mlx_device] lockdown lock successful (device_id:{}, status:{status})",
-                request.device_id
+                device_id = %request.device_id,
+                lockdown_status = %status,
+                "[scout_stream::mlx_device] lockdown lock successful",
             );
             let report = StatusReport::new(request.device_id.clone(), status);
             mlx_device_pb::MlxDeviceLockdownResponse {
@@ -338,8 +353,9 @@ pub fn handle_lockdown_lock(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] lockdown lock failed (device_id:{}): {e}",
-                request.device_id
+                device_id = %request.device_id,
+                error = %e,
+                "[scout_stream::mlx_device] lockdown lock failed",
             );
             mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
@@ -358,15 +374,16 @@ pub fn handle_lockdown_unlock(
     request: mlx_device_pb::MlxDeviceLockdownUnlockRequest,
 ) -> mlx_device_pb::MlxDeviceLockdownResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] lockdown unlock requested (device_id:{})",
-        request.device_id
+        device_id = %request.device_id,
+        "[scout_stream::mlx_device] lockdown unlock requested",
     );
 
     let manager = match LockdownManager::new() {
         Ok(m) => m,
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] lockdown manager initialization failed: {e}"
+                error = %e,
+                "[scout_stream::mlx_device] lockdown manager initialization failed",
             );
             return mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
@@ -382,8 +399,9 @@ pub fn handle_lockdown_unlock(
     match manager.unlock_device(&request.device_id, &request.key) {
         Ok(status) => {
             tracing::info!(
-                "[scout_stream::mlx_device] lockdown unlock successful (device_id:{}, status:{status})",
-                request.device_id
+                device_id = %request.device_id,
+                lockdown_status = %status,
+                "[scout_stream::mlx_device] lockdown unlock successful",
             );
             let report = StatusReport::new(request.device_id.clone(), status);
             mlx_device_pb::MlxDeviceLockdownResponse {
@@ -394,8 +412,9 @@ pub fn handle_lockdown_unlock(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] lockdown unlock failed (device_id:{}): {e}",
-                request.device_id
+                device_id = %request.device_id,
+                error = %e,
+                "[scout_stream::mlx_device] lockdown unlock failed",
             );
             mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
@@ -414,15 +433,16 @@ pub fn handle_lockdown_status(
     request: mlx_device_pb::MlxDeviceLockdownStatusRequest,
 ) -> mlx_device_pb::MlxDeviceLockdownResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] lockdown status check requested (device_id:{})",
-        request.device_id
+        device_id = %request.device_id,
+        "[scout_stream::mlx_device] lockdown status check requested",
     );
 
     let manager = match LockdownManager::new() {
         Ok(m) => m,
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] lockdown manager initialization failed: {e}"
+                error = %e,
+                "[scout_stream::mlx_device] lockdown manager initialization failed",
             );
             return mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
@@ -438,8 +458,9 @@ pub fn handle_lockdown_status(
     match manager.get_status(&request.device_id) {
         Ok(status) => {
             tracing::info!(
-                "[scout_stream::mlx_device] lockdown status check successful (device_id:{}, status: {status})",
-                request.device_id
+                device_id = %request.device_id,
+                lockdown_status = %status,
+                "[scout_stream::mlx_device] lockdown status check successful",
             );
             let report = StatusReport::new(request.device_id.clone(), status);
             mlx_device_pb::MlxDeviceLockdownResponse {
@@ -450,8 +471,9 @@ pub fn handle_lockdown_status(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] lockdown status check failed (device_id:{}): {e}",
-                request.device_id
+                device_id = %request.device_id,
+                error = %e,
+                "[scout_stream::mlx_device] lockdown status check failed",
             );
             mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
@@ -469,15 +491,15 @@ pub fn handle_info_device(
     request: mlx_device_pb::MlxDeviceInfoDeviceRequest,
 ) -> mlx_device_pb::MlxDeviceInfoDeviceResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] device info request (device_id:{})",
-        request.device_id
+        device_id = %request.device_id,
+        "[scout_stream::mlx_device] device info request",
     );
 
     match discovery::discover_device(&request.device_id) {
         Ok(device_info) => {
             tracing::info!(
-                "[scout_stream::mlx_device] device info retrieved successfully (device_id:{})",
-                request.device_id
+                device_id = %request.device_id,
+                "[scout_stream::mlx_device] device info retrieved successfully",
             );
             mlx_device_pb::MlxDeviceInfoDeviceResponse {
                 reply: Some(
@@ -489,8 +511,9 @@ pub fn handle_info_device(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] device info request failed (device_id:{}): {e}",
-                request.device_id
+                device_id = %request.device_id,
+                error = %e,
+                "[scout_stream::mlx_device] device info request failed",
             );
             mlx_device_pb::MlxDeviceInfoDeviceResponse {
                 reply: Some(
@@ -516,7 +539,8 @@ pub fn handle_info_report(
             Ok(filters) => MlxDeviceReport::new().with_filter_set(filters),
             Err(e) => {
                 tracing::error!(
-                    "[scout_stream::mlx_device] device report request failed to parse filters: {e}"
+                    error = %e,
+                    "[scout_stream::mlx_device] device report request failed to parse filters",
                 );
                 return mlx_device_pb::MlxDeviceInfoReportResponse {
                     reply: Some(
@@ -537,8 +561,8 @@ pub fn handle_info_report(
     match report.collect() {
         Ok(report) => {
             tracing::info!(
-                "[scout_stream::mlx_device] device report generated (device_count:{})",
-                report.devices.len()
+                device_count = report.devices.len(),
+                "[scout_stream::mlx_device] device report generated",
             );
             mlx_device_pb::MlxDeviceInfoReportResponse {
                 reply: Some(
@@ -549,7 +573,10 @@ pub fn handle_info_report(
             }
         }
         Err(e) => {
-            tracing::error!("[scout_stream::mlx_device] device report generation failed: {e}");
+            tracing::error!(
+                error = %e,
+                "[scout_stream::mlx_device] device report generation failed",
+            );
             mlx_device_pb::MlxDeviceInfoReportResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_info_report_response::Reply::Error(
@@ -585,16 +612,16 @@ pub fn handle_registry_show(
     request: mlx_device_pb::MlxDeviceRegistryShowRequest,
 ) -> mlx_device_pb::MlxDeviceRegistryShowResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] variable registry details requested (registry_name:{})",
-        request.registry_name
+        registry_name = %request.registry_name,
+        "[scout_stream::mlx_device] variable registry details requested",
     );
 
     match registries::get(&request.registry_name) {
         Some(registry) => {
             let registry_pb = registry.clone().into();
             tracing::info!(
-                "[scout_stream::mlx_device] variable registry details generated (registry_name:{})",
-                request.registry_name
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] variable registry details generated",
             );
             mlx_device_pb::MlxDeviceRegistryShowResponse {
                 reply: Some(
@@ -606,8 +633,8 @@ pub fn handle_registry_show(
         }
         None => {
             tracing::error!(
-                "[scout_stream::mlx_device] variable registry not found (registry_name:{})",
-                request.registry_name
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] variable registry not found",
             );
             mlx_device_pb::MlxDeviceRegistryShowResponse {
                 reply: Some(
@@ -629,19 +656,19 @@ pub fn handle_config_query(
     request: mlx_device_pb::MlxDeviceConfigQueryRequest,
 ) -> mlx_device_pb::MlxDeviceConfigQueryResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] config query requested (device_id:{}, registry_name:{}): {:?}",
-        request.device_id,
-        request.registry_name,
-        request.variables,
+        device_id = %request.device_id,
+        registry_name = %request.registry_name,
+        variables = ?request.variables,
+        "[scout_stream::mlx_device] config query requested",
     );
 
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
             tracing::warn!(
-                "[scout_stream::mlx_device] config registry not found (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config registry not found",
             );
             return mlx_device_pb::MlxDeviceConfigQueryResponse {
                 reply: Some(
@@ -672,9 +699,9 @@ pub fn handle_config_query(
     match result {
         Ok(query_result) => {
             tracing::info!(
-                "[scout_stream::mlx_device] config query against device successful (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config query against device successful",
             );
 
             match query_result.try_into() {
@@ -687,9 +714,10 @@ pub fn handle_config_query(
                 },
                 Err(e) => {
                     tracing::error!(
-                        "[scout_stream::mlx_device] config query result failed to serialize (device_id:{}, registry_name:{}): {e}",
-                        request.device_id,
-                        request.registry_name
+                        device_id = %request.device_id,
+                        registry_name = %request.registry_name,
+                        error = %e,
+                        "[scout_stream::mlx_device] config query result failed to serialize",
                     );
                     mlx_device_pb::MlxDeviceConfigQueryResponse {
                         reply: Some(
@@ -710,9 +738,10 @@ pub fn handle_config_query(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] config query against device failed (device_id:{}, registry_name:{}): {e}",
-                request.device_id,
-                request.registry_name
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                error = %e,
+                "[scout_stream::mlx_device] config query against device failed",
             );
             mlx_device_pb::MlxDeviceConfigQueryResponse {
                 reply: Some(
@@ -736,19 +765,19 @@ pub fn handle_config_set(
     request: mlx_device_pb::MlxDeviceConfigSetRequest,
 ) -> mlx_device_pb::MlxDeviceConfigSetResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] config set assignment requested (device_id:{}, registry_name:{}): {:?}",
-        request.device_id,
-        request.registry_name,
-        request.assignments
+        device_id = %request.device_id,
+        registry_name = %request.registry_name,
+        assignments = ?request.assignments,
+        "[scout_stream::mlx_device] config set assignment requested",
     );
 
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
             tracing::warn!(
-                "[scout_stream::mlx_device] config registry not found (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config registry not found",
             );
             return mlx_device_pb::MlxDeviceConfigSetResponse {
                 reply: Some(mlx_device_pb::mlx_device_config_set_response::Reply::Error(
@@ -780,9 +809,9 @@ pub fn handle_config_set(
     match runner.set(assignments) {
         Ok(_) => {
             tracing::info!(
-                "[scout_stream::mlx_device] config set on device successfully (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config set on device successfully",
             );
             mlx_device_pb::MlxDeviceConfigSetResponse {
                 reply: Some(
@@ -794,9 +823,10 @@ pub fn handle_config_set(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] config set to device failed (device_id:{}, registry_name:{}): {e}",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                error = %e,
+                "[scout_stream::mlx_device] config set to device failed",
             );
             mlx_device_pb::MlxDeviceConfigSetResponse {
                 reply: Some(mlx_device_pb::mlx_device_config_set_response::Reply::Error(
@@ -819,19 +849,19 @@ pub fn handle_config_sync(
     request: mlx_device_pb::MlxDeviceConfigSyncRequest,
 ) -> mlx_device_pb::MlxDeviceConfigSyncResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] config sync requested (device_id:{}, registry_name:{}): {:?}",
-        request.device_id,
-        request.registry_name,
-        request.assignments
+        device_id = %request.device_id,
+        registry_name = %request.registry_name,
+        assignments = ?request.assignments,
+        "[scout_stream::mlx_device] config sync requested",
     );
 
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
             tracing::warn!(
-                "[scout_stream::mlx_device] config registry not found (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config registry not found",
             );
             return mlx_device_pb::MlxDeviceConfigSyncResponse {
                 reply: Some(
@@ -863,9 +893,9 @@ pub fn handle_config_sync(
     match runner.sync(assignments) {
         Ok(sync_result) => {
             tracing::info!(
-                "[scout_stream::mlx_device] config sync to device successful (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config sync to device successful",
             );
 
             match sync_result.try_into() {
@@ -878,9 +908,10 @@ pub fn handle_config_sync(
                 },
                 Err(e) => {
                     tracing::error!(
-                        "[scout_stream::mlx_device] config sync result failed to serialize (device_id:{}, registry_name:{}): {e}",
-                        request.device_id,
-                        request.registry_name,
+                        device_id = %request.device_id,
+                        registry_name = %request.registry_name,
+                        error = %e,
+                        "[scout_stream::mlx_device] config sync result failed to serialize",
                     );
                     mlx_device_pb::MlxDeviceConfigSyncResponse {
                         reply: Some(
@@ -901,9 +932,10 @@ pub fn handle_config_sync(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] config sync to device failed (device_id:{}, registry_name:{}): {e}",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                error = %e,
+                "[scout_stream::mlx_device] config sync to device failed",
             );
             mlx_device_pb::MlxDeviceConfigSyncResponse {
                 reply: Some(
@@ -928,19 +960,19 @@ pub fn handle_config_compare(
     request: mlx_device_pb::MlxDeviceConfigCompareRequest,
 ) -> mlx_device_pb::MlxDeviceConfigCompareResponse {
     tracing::info!(
-        "[scout_stream::mlx_device] config compare requested (device_id:{}, registry_name:{}): {:?}",
-        request.device_id,
-        request.registry_name,
-        request.assignments
+        device_id = %request.device_id,
+        registry_name = %request.registry_name,
+        assignments = ?request.assignments,
+        "[scout_stream::mlx_device] config compare requested",
     );
 
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
             tracing::warn!(
-                "[scout_stream::mlx_device] config registry not found (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config registry not found",
             );
             return mlx_device_pb::MlxDeviceConfigCompareResponse {
                 reply: Some(
@@ -972,9 +1004,9 @@ pub fn handle_config_compare(
     match runner.compare(assignments) {
         Ok(comparison_result) => {
             tracing::info!(
-                "[scout_stream::mlx_device] config compare against device successful (device_id:{}, registry_name:{})",
-                request.device_id,
-                request.registry_name,
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                "[scout_stream::mlx_device] config compare against device successful",
             );
 
             match comparison_result.try_into() {
@@ -987,9 +1019,10 @@ pub fn handle_config_compare(
                 },
                 Err(e) => {
                     tracing::error!(
-                        "[scout_stream::mlx_device] config compare result failed to serialize (device_id:{}, registry_name:{}): {e}",
-                        request.device_id,
-                        request.registry_name
+                        device_id = %request.device_id,
+                        registry_name = %request.registry_name,
+                        error = %e,
+                        "[scout_stream::mlx_device] config compare result failed to serialize",
                     );
                     mlx_device_pb::MlxDeviceConfigCompareResponse {
                         reply: Some(
@@ -1010,9 +1043,10 @@ pub fn handle_config_compare(
         }
         Err(e) => {
             tracing::error!(
-                "[scout_stream::mlx_device] config compare against device failed (device_id:{}, registry_name:{}): {e}",
-                request.device_id,
-                request.registry_name
+                device_id = %request.device_id,
+                registry_name = %request.registry_name,
+                error = %e,
+                "[scout_stream::mlx_device] config compare against device failed",
             );
             mlx_device_pb::MlxDeviceConfigCompareResponse {
                 reply: Some(
@@ -1060,8 +1094,8 @@ pub async fn apply_firmware(
         psid = %profile.firmware_spec.psid,
         firmware_url = %profile.flash_spec.firmware_url,
         firmware_credential_type,
-        device_conf_url = profile.flash_spec.device_conf_url.as_deref().unwrap_or("none"),
-        device_conf_credential_type,
+        device_configuration_url = profile.flash_spec.device_conf_url.as_deref().unwrap_or("none"),
+        device_configuration_credential_type = device_conf_credential_type,
         target_version = %profile.firmware_spec.version,
         "applying firmware"
     );
@@ -1075,7 +1109,7 @@ pub async fn apply_firmware(
                 device = %device,
                 part_number = %profile.firmware_spec.part_number,
                 psid = %profile.firmware_spec.psid,
-                %e,
+                error = %e,
                 "failed to create FirmwareFlasher"
             );
             return None;
@@ -1104,7 +1138,7 @@ pub async fn apply_firmware(
                 psid = %profile.firmware_spec.psid,
                 firmware_url = %profile.flash_spec.firmware_url,
                 target_version = %profile.firmware_spec.version,
-                %e,
+                error = %e,
                 "firmware flash failed"
             );
             None
@@ -1129,7 +1163,7 @@ pub(crate) fn apply_profile(
     if let Err(e) = applier.reset_config() {
         tracing::error!(
             device = %device,
-            %e,
+            error = %e,
             "mlxconfig reset failed"
         );
         return (profile.map(|p| p.name), Some(false));
@@ -1157,7 +1191,7 @@ pub(crate) fn apply_profile(
             tracing::error!(
                 device = %device,
                 profile = %name,
-                %e,
+                error = %e,
                 "mlxconfig profile sync failed"
             );
             (Some(name), Some(false))

--- a/crates/scout/src/register.rs
+++ b/crates/scout/src/register.rs
@@ -106,7 +106,11 @@ pub async fn run(
         )
         .await?;
     let machine_id = registration_data.machine_id;
-    info!("successfully discovered machine {machine_id} for interface {machine_interface_id:?}");
+    info!(
+        %machine_id,
+        ?machine_interface_id,
+        "successfully discovered machine",
+    );
 
     // If we are not on a DPU and have some post-registration things to do,
     // we do them here.
@@ -124,9 +128,9 @@ pub async fn run(
                 "Sent AttestKeyInfo and received AttestKeyBindChallenge, starting measurements ..."
             );
             tracing::info!(
-                "cred_blob - {} bytes long, secret - {} bytes long",
-                attest_key_challenge.cred_blob.len(),
-                attest_key_challenge.encrypted_secret.len()
+                credential_blob_bytes = attest_key_challenge.cred_blob.len(),
+                encrypted_secret_bytes = attest_key_challenge.encrypted_secret.len(),
+                "Received attestation key challenge credential sizes",
             );
 
             let Some(ek_handle) = endorsement_key_handle_opt else {

--- a/crates/scout/src/stream.rs
+++ b/crates/scout/src/stream.rs
@@ -53,27 +53,32 @@ pub fn start_scout_stream(machine_id: MachineId, options: &Options) -> tokio::ta
     tokio::spawn(async move {
         loop {
             tracing::info!(
-                "scout stream starting (api:{}, machine_id:{machine_id})",
-                options.api
+                api_endpoint = %options.api,
+                %machine_id,
+                "scout stream starting",
             );
 
             match run_scout_stream_loop(machine_id, &options).await {
                 Ok(_) => {
                     tracing::info!(
-                        "scout stream closed (api:{}, machine_id:{machine_id})",
-                        options.api
+                        api_endpoint = %options.api,
+                        %machine_id,
+                        "scout stream closed",
                     );
                 }
                 Err(e) => {
                     tracing::error!(
-                        "scout stream error (api:{}, machine_id:{machine_id}): {e}",
-                        options.api
+                        api_endpoint = %options.api,
+                        %machine_id,
+                        error = %e,
+                        "scout stream error",
                     );
                 }
             }
             tracing::warn!(
-                "scout stream reconnecting (api:{}, machine_id:{machine_id}): 10s delay",
-                options.api
+                api_endpoint = %options.api,
+                %machine_id,
+                "scout stream reconnecting after 10s delay",
             );
             tokio::time::sleep(Duration::from_secs(10)).await;
         }
@@ -113,8 +118,9 @@ async fn run_scout_stream_loop(
     let mut response_stream = client.scout_stream(request_stream).await?.into_inner();
 
     tracing::info!(
-        "scout stream connection established (api:{}, machine_id:{machine_id})",
-        options.api
+        api_endpoint = %options.api,
+        %machine_id,
+        "scout stream connection established",
     );
 
     // ...and start processing streaming updates.
@@ -137,8 +143,10 @@ async fn run_scout_stream_loop(
             // And then send the response back to carbide-api.
             if let Err(e) = tx.send(payload).await {
                 tracing::error!(
-                    "scout stream failed to send response (api:{}, machine_id:{machine_id}): {e}",
-                    options.api
+                    api_endpoint = %options.api,
+                    %machine_id,
+                    error = %e,
+                    "scout stream failed to send response",
                 );
                 break;
             }
@@ -156,8 +164,8 @@ fn handle_scout_stream_api_bound_message(
     request: scout_stream_scout_bound_message::Payload,
 ) -> ScoutStreamApiBoundMessage {
     tracing::info!(
-        "[scout_stream] processing incoming request for flow_uuid: {}",
-        flow_uuid
+        %flow_uuid,
+        "[scout_stream] processing incoming request",
     );
     match request {
         scout_stream_scout_bound_message::Payload::ScoutStreamAgentPingRequest(req) => {

--- a/crates/scout/src/tpm.rs
+++ b/crates/scout/src/tpm.rs
@@ -38,24 +38,26 @@ pub(crate) fn set_tpm_max_auth_fail() -> Result<(), CarbideClientError> {
             CarbideClientError::TpmError(format!("tpm2_dictionarylockout call failed: {e}"))
         })?;
     tracing::info!(
-        "Tried setting TPM_PT_MAX_AUTH_FAIL to 256. Return code is: {0}",
-        output
+        return_code = %output
             .status
             .code()
             .map(|v| v.to_string())
-            .unwrap_or_else(|| "NO RETURN CODE PRESENT".to_string())
+            .unwrap_or_else(|| "NO RETURN CODE PRESENT".to_string()),
+        "Tried setting TPM_PT_MAX_AUTH_FAIL to 256",
     );
 
     if !output.stderr.is_empty() {
         tracing::error!(
-            "TPM_PT_MAX_AUTH_FAIL stderr is {0}",
-            String::from_utf8(output.stderr).unwrap_or_else(|_| "Invalid UTF8".to_string())
+            stderr = %String::from_utf8(output.stderr)
+                .unwrap_or_else(|_| "Invalid UTF8".to_string()),
+            "TPM_PT_MAX_AUTH_FAIL command wrote to stderr",
         );
     }
     if !output.stdout.is_empty() {
         tracing::info!(
-            "TPM_PT_MAX_AUTH_FAIL stdout is {0}",
-            String::from_utf8(output.stdout).unwrap_or_else(|_| "Invalid UTF8".to_string())
+            stdout = %String::from_utf8(output.stdout)
+                .unwrap_or_else(|_| "Invalid UTF8".to_string()),
+            "TPM_PT_MAX_AUTH_FAIL command wrote to stdout",
         );
     }
 

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -91,14 +91,15 @@ fn resolve_vault_root_ca_path(configured_path: &str) -> Result<String, eyre::Rep
         Ok(env_path) if Path::new(&env_path).exists() => Ok(env_path),
         Ok(env_path) => {
             tracing::error!(
-                "VAULT_CACERT={env_path} does not exist. Refusing to connect without TLS verification."
+                %env_path,
+                "VAULT_CACERT does not exist. Refusing to connect without TLS verification.",
             );
             Err(eyre!("Vault root CA not found"))
         }
         Err(_) => {
             tracing::error!(
-                "Vault root CA not found at {}. Refusing to connect without TLS verification.",
-                configured_path
+                configured_path,
+                "Vault root CA not found. Refusing to connect without TLS verification.",
             );
             Err(eyre!("Vault root CA not found"))
         }
@@ -340,7 +341,10 @@ async fn vault_token_refresh(
         }
     };
 
-    tracing::info!("successfully refreshed vault token, with lifetime: {vault_token_expiry_secs}");
+    tracing::info!(
+        vault_token_expiry_seconds = vault_token_expiry_secs,
+        "successfully refreshed vault token"
+    );
 
     let vault_client_settings = create_vault_client_settings(vault_token, vault_client_config)?;
     let vault_client = VaultClient::new(vault_client_settings)?;
@@ -517,15 +521,16 @@ impl VaultTask<Option<Credentials>> for GetCredentialsHelper<'_, '_> {
                     Some(404) => {
                         // Not found errors are common and of no concern
                         tracing::debug!(
-                            "Credentials not found for key ({})",
-                            self.key.to_key_str().as_ref()
+                            credential_key = %self.key.to_key_str(),
+                            "Credentials not found",
                         );
                         Ok(None)
                     }
                     _ => {
                         tracing::error!(
-                            "Error getting credentials ({}). Error: {ce:?}",
-                            self.key.to_key_str().as_ref()
+                            credential_key = %self.key.to_key_str(),
+                            error = ?ce,
+                            "Error getting credentials",
                         );
                         Err(SecretsError::GenericError(ce.into()))
                     }
@@ -601,7 +606,7 @@ impl VaultTask<()> for SetCredentialsHelper<'_, '_> {
 
         let _secret_version_metadata = vault_response.map_err(|err| {
             record_vault_client_error(&err, VaultRequestType::SetCredentials);
-            tracing::error!("Error setting credentials. Error: {err:?}");
+            tracing::error!(error = ?err, "Error setting credentials");
             err
         })?;
 
@@ -640,7 +645,7 @@ impl VaultTask<()> for DeleteCredentialsHelper<'_, '_> {
 
         let _secret_version_metadata = vault_response.map_err(|err| {
             record_vault_client_error(&err, VaultRequestType::DeleteCredentials);
-            tracing::error!("Error deleting credentials. Error: {err:?}");
+            tracing::error!(error = ?err, "Error deleting credentials");
             err
         })?;
 
@@ -834,7 +839,10 @@ impl ForgeVaultClient {
         let paths = self
             .list_secrets_for_path("", EnumerationMode::BestEffort)
             .await?;
-        tracing::info!(count = paths.len(), "listed all vault secret paths");
+        tracing::info!(
+            secret_path_count = paths.len(),
+            "listed all vault secret paths"
+        );
         Ok(paths)
     }
 
@@ -849,7 +857,7 @@ impl ForgeVaultClient {
             .await?;
         tracing::info!(
             prefix = prefix.as_str(),
-            count = paths.len(),
+            secret_path_count = paths.len(),
             "listed vault secret paths for prefix"
         );
         Ok(paths)

--- a/crates/secrets/src/local_credentials/file.rs
+++ b/crates/secrets/src/local_credentials/file.rs
@@ -83,12 +83,15 @@ impl FileCredentialsWatcher {
             move |res: notify::Result<notify::Event>| match res {
                 Ok(ref event) if event.kind.is_create() || event.kind.is_modify() => {
                     if let Err(err) = tx_clone.blocking_send(res) {
-                        tracing::warn!("failed to send static credential watch event: {err}");
+                        tracing::warn!(
+                            error = %err,
+                            "failed to send static credential watch event",
+                        );
                     }
                 }
                 Ok(_) => {}
                 Err(err) => {
-                    tracing::warn!("primary static credential watcher error: {err}");
+                    tracing::warn!(error = %err, "primary static credential watcher error");
                 }
             },
             notify::Config::default(),
@@ -102,7 +105,10 @@ impl FileCredentialsWatcher {
         let mut secondary = PollWatcher::new(
             move |res| {
                 if let Err(err) = tx.blocking_send(res) {
-                    tracing::warn!("failed to send static credential poll event: {err}");
+                    tracing::warn!(
+                        error = %err,
+                        "failed to send static credential poll event",
+                    );
                 }
             },
             notify::Config::default()
@@ -134,12 +140,18 @@ impl FileCredentialsWatcher {
                                 credentials_clone.store(Arc::new(updated));
                             }
                             Err(err) => {
-                                tracing::warn!("failed to reload credentials file: {err}");
+                                tracing::warn!(
+                                    error = %err,
+                                    "failed to reload credentials file",
+                                );
                             }
                         }
                     }
                     Err(err) => {
-                        tracing::warn!("credentials file watcher event error: {err}");
+                        tracing::warn!(
+                            error = %err,
+                            "credentials file watcher event error",
+                        );
                     }
                 }
             }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -302,12 +302,14 @@ impl BmcEndpointExplorer {
                     (Ok(report), Ok(nv_report)) => warn_report_diff(report, nv_report),
                     (Ok(_), Err(_)) => {
                         tracing::warn!(
-                            "libredfish returned success when nv-redfish error: {nvredfish:?}"
+                            nvredfish = ?nvredfish,
+                            "libredfish succeeded while nv-redfish returned an error"
                         );
                     }
                     (Err(_), Ok(_)) => {
                         tracing::warn!(
-                            "libredfish returned error: {libredfish:?}, when nv-redfish success"
+                            libredfish = ?libredfish,
+                            "libredfish returned an error while nv-redfish succeeded"
                         );
                     }
                     (Err(_), Err(_)) => (),
@@ -445,7 +447,7 @@ impl BmcEndpointExplorer {
         ) {
             tracing::info!(
                 %bmc_mac_address,
-                "Storing NVOS admin credentials in vault for switch {bmc_mac_address}"
+                "Storing NVOS admin credentials in vault"
             );
             self.credential_client
                 .set_bmc_nvos_admin_credentials(
@@ -653,7 +655,11 @@ impl EndpointExplorer for BmcEndpointExplorer {
         let vendor = match self.redfish_client.get_redfish_vendor(bmc_ip_address).await {
             Ok(vendor) => vendor,
             Err(e) => {
-                tracing::error!(%bmc_ip_address, "Failed to probe Redfish service root endpoint: {e}");
+                tracing::error!(
+                    %bmc_ip_address,
+                    error = %e,
+                    "Failed to probe Redfish service root endpoint"
+                );
 
                 // Lite-On power shelf BMCs don't expose Vendor details in the
                 // service root, so we fall back to probing the Chassis endpoint.
@@ -684,7 +690,11 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 {
                     Ok(v) => v,
                     Err(chassis_err) => {
-                        tracing::error!(%bmc_ip_address, "Failed to probe vendor from chassis: {chassis_err}");
+                        tracing::error!(
+                            %bmc_ip_address,
+                            error = %chassis_err,
+                            "Failed to probe vendor from chassis"
+                        );
                         return Err(e);
                     }
                 };
@@ -699,7 +709,11 @@ impl EndpointExplorer for BmcEndpointExplorer {
             }
         };
 
-        tracing::info!(%bmc_ip_address, "Is a {vendor} BMC that supports Redfish");
+        tracing::info!(
+            %bmc_ip_address,
+            %vendor,
+            "BMC supports Redfish"
+        );
 
         // Authenticate and set the BMC root account credentials
 
@@ -734,7 +748,10 @@ impl EndpointExplorer for BmcEndpointExplorer {
 
                         if consecutive_count > MAX_AUTH_RETRIES {
                             tracing::warn!(
-                                %bmc_ip_address, %bmc_mac_address, %details, consecutive_count,
+                                %bmc_ip_address,
+                                %bmc_mac_address,
+                                reason = %details,
+                                consecutive_unauthorized_count = consecutive_count,
                                 "BMC unauthorized error persisted - escalating to Unauthorized"
                             );
                             return Err(EndpointExplorationError::Unauthorized {
@@ -745,7 +762,10 @@ impl EndpointExplorer for BmcEndpointExplorer {
                         }
 
                         tracing::warn!(
-                            %bmc_ip_address, %bmc_mac_address, %details, consecutive_count,
+                            %bmc_ip_address,
+                            %bmc_mac_address,
+                            reason = %details,
+                            consecutive_unauthorized_count = consecutive_count,
                             "BMC unauthorized error - treating as intermittent"
                         );
                         return Err(EndpointExplorationError::IntermittentUnauthorized {
@@ -773,12 +793,18 @@ impl EndpointExplorer for BmcEndpointExplorer {
 
                 tracing::info!(
                     %bmc_ip_address,
-                    "Site explorer could not find an entry in vault at 'bmc/{bmc_mac_address}/root' - this is expected if the BMC has never been seen before.",
+                    %bmc_mac_address,
+                    "Site explorer could not find a BMC root credential entry in vault - this is expected if the BMC has never been seen before.",
                 );
 
                 let bmc_cred_data = match expected {
                     Some(v) => {
-                        tracing::info!(%bmc_ip_address, %bmc_mac_address, "Found an expected {} for this BMC mac address", v.name());
+                        tracing::info!(
+                            %bmc_ip_address,
+                            %bmc_mac_address,
+                            expected_entity = v.name(),
+                            "Found an expected entity"
+                        );
                         v.bmc_credentials_data()
                     }
                     None => {
@@ -863,13 +889,15 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     Ok(_) => {
                         tracing::trace!(
                             %bmc_ip_address, %bmc_mac_address,
-                            "NVOS admin credentials already exist in vault for switch {bmc_mac_address}"
+                            "NVOS admin credentials already exist in vault"
                         );
                     }
-                    Err(_) => {
+                    Err(e) => {
                         tracing::info!(
-                            %bmc_ip_address, %bmc_mac_address,
-                            "Site explorer could not find NVOS admin credentials in vault for switch {bmc_mac_address} - setting them up.",
+                            %bmc_ip_address,
+                            %bmc_mac_address,
+                            error = %e,
+                            "Failed to load NVOS admin credentials; attempting credential setup",
                         );
                         self.set_sitewide_switch_nvos_admin_credentials(
                             bmc_mac_address,
@@ -896,8 +924,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "Site explorer does not support resetting the BMCs that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for BMC reset",
                 );
                 Err(e)
             }
@@ -935,8 +964,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "Site explorer cannot fetch live power state for an endpoint without credentials: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for fetching live power state",
                 );
                 Err(e)
             }
@@ -959,8 +989,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "Site explorer does not support rebooting the endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for power control",
                 );
                 Err(e)
             }
@@ -979,8 +1010,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support disabling secure boot for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for disabling secure boot",
                 );
                 Err(e)
             }
@@ -1000,8 +1032,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support lockdown for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for changing lockdown state",
                 );
                 Err(e)
             }
@@ -1020,8 +1053,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support lockdown status for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for checking lockdown status",
                 );
                 Err(e)
             }
@@ -1040,8 +1074,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support enabling infinite boot for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for enabling infinite boot",
                 );
                 Err(e)
             }
@@ -1063,8 +1098,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support checking infinite boot status for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for checking infinite boot status",
                 );
                 Err(e)
             }
@@ -1087,8 +1123,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support starting machine_setup for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for machine setup",
                 );
                 Err(e)
             }
@@ -1111,8 +1148,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support configuring the boot order on host BMCs that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for configuring boot order",
                 );
                 Err(e)
             }
@@ -1132,8 +1170,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_nic_mode for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for setting NIC mode",
                 );
                 Err(e)
             }
@@ -1152,8 +1191,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support is_viking for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for checking BMC hardware type",
                 );
                 Err(e)
             }
@@ -1172,8 +1212,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support clear_nvram for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for clearing NVRAM",
                 );
                 Err(e)
             }
@@ -1198,8 +1239,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support create_bmc_user for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for creating BMC user",
                 );
                 Err(e)
             }
@@ -1222,8 +1264,9 @@ impl EndpointExplorer for BmcEndpointExplorer {
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support delete_bmc_user for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for deleting BMC user",
                 );
                 Err(e)
             }
@@ -1238,12 +1281,15 @@ impl EndpointExplorer for BmcEndpointExplorer {
     ) -> Result<(), EndpointExplorationError> {
         let bmc_mac_address = interface.mac_address;
 
-        let current_credentials =
-            self.get_bmc_root_credentials(bmc_mac_address).await.inspect_err(|_| {
+        let current_credentials = self
+            .get_bmc_root_credentials(bmc_mac_address)
+            .await
+            .inspect_err(|e| {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support set_bmc_root_password for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for setting BMC root password",
                 );
             })?;
 
@@ -1281,12 +1327,15 @@ impl EndpointExplorer for BmcEndpointExplorer {
     ) -> Result<RedfishVendor, EndpointExplorationError> {
         let bmc_mac_address = interface.mac_address;
 
-        let credentials =
-            self.get_bmc_root_credentials(bmc_mac_address).await.inspect_err(|_| {
+        let credentials = self
+            .get_bmc_root_credentials(bmc_mac_address)
+            .await
+            .inspect_err(|e| {
                 tracing::info!(
                     %bmc_ip_address,
-                    "BMC endpoint explorer does not support probe_bmc_vendor for endpoints that have not been authenticated: could not find an entry in vault at 'bmc/{}/root'.",
-                    bmc_mac_address,
+                    %bmc_mac_address,
+                    error = %e,
+                    "Failed to load BMC root credentials for probing BMC vendor",
                 );
             })?;
 
@@ -1301,98 +1350,102 @@ impl EndpointExplorer for BmcEndpointExplorer {
 fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplorationReport) {
     if report1.endpoint_type != report2.endpoint_type {
         tracing::warn!(
-            "endpoint_type are not equal: {:?} != {:?}",
-            report1.endpoint_type,
-            report2.endpoint_type
+            libredfish_endpoint_type = ?report1.endpoint_type,
+            nvredfish_endpoint_type = ?report2.endpoint_type,
+            "endpoint types are not equal"
         );
     }
 
     if report1.vendor != report2.vendor {
         tracing::warn!(
-            "vendors are not equal: {:?} != {:?}",
-            report1.vendor,
-            report2.vendor
+            libredfish_vendor = ?report1.vendor,
+            nvredfish_vendor = ?report2.vendor,
+            "vendors are not equal"
         );
     }
 
     if report1.managers != report2.managers {
         tracing::warn!(
-            "managers are not equal: {:?} != {:?}",
-            report1.managers,
-            report2.managers
+            libredfish_managers = ?report1.managers,
+            nvredfish_managers = ?report2.managers,
+            "managers are not equal"
         );
     }
 
     if report1.systems.len() != report2.systems.len() {
         tracing::warn!(
-            "reported different number of systems: {:?} != {:?}",
-            report1.systems.len(),
-            report2.systems.len(),
+            libredfish_system_count = report1.systems.len(),
+            nvredfish_system_count = report2.systems.len(),
+            "reported different number of systems",
         );
     }
 
     for (s1, s2) in report1.systems.iter().zip(report2.systems.iter()) {
         if s1.id != s2.id {
-            tracing::warn!("systems.id are not equal: {:?} != {:?}", s1.id, s2.id);
+            tracing::warn!(
+                libredfish_system_id = ?s1.id,
+                nvredfish_system_id = ?s2.id,
+                "system IDs are not equal"
+            );
         } else {
             if s1.ethernet_interfaces != s2.ethernet_interfaces {
                 tracing::warn!(
-                    "systems[{:?}].ethernet_interfaces are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.ethernet_interfaces,
-                    s2.ethernet_interfaces
+                    system_id = ?s1.id,
+                    libredfish_ethernet_interfaces = ?s1.ethernet_interfaces,
+                    nvredfish_ethernet_interfaces = ?s2.ethernet_interfaces,
+                    "system Ethernet interfaces are not equal"
                 );
             }
 
             if s1.manufacturer != s2.manufacturer {
                 tracing::warn!(
-                    "systems[{:?}].manufacturer are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.manufacturer,
-                    s2.manufacturer
+                    system_id = ?s1.id,
+                    libredfish_manufacturer = ?s1.manufacturer,
+                    nvredfish_manufacturer = ?s2.manufacturer,
+                    "system manufacturers are not equal"
                 );
             }
 
             if s1.model != s2.model {
                 tracing::warn!(
-                    "systems[{:?}].model are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.model,
-                    s2.model
+                    system_id = ?s1.id,
+                    libredfish_model = ?s1.model,
+                    nvredfish_model = ?s2.model,
+                    "system models are not equal"
                 );
             }
 
             if s1.serial_number != s2.serial_number {
                 tracing::warn!(
-                    "systems[{:?}].serial_number are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.serial_number,
-                    s2.serial_number
+                    system_id = ?s1.id,
+                    libredfish_serial_number = ?s1.serial_number,
+                    nvredfish_serial_number = ?s2.serial_number,
+                    "system serial numbers are not equal"
                 );
             }
 
             if s1.attributes != s2.attributes {
                 tracing::warn!(
-                    "systems[{:?}].attributes are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.attributes,
-                    s2.attributes
+                    system_id = ?s1.id,
+                    libredfish_attributes = ?s1.attributes,
+                    nvredfish_attributes = ?s2.attributes,
+                    "system attributes are not equal"
                 );
             }
 
             if s1.pcie_devices != s2.pcie_devices {
                 if s1.pcie_devices.len() != s2.pcie_devices.len() {
                     tracing::warn!(
-                        "systems[{:?}].pcie_devices.len() are not equal: ids1: {:?}, ids2: {:?}",
-                        s1.id,
-                        s1.pcie_devices
+                        system_id = ?s1.id,
+                        libredfish_pcie_device_ids = ?s1.pcie_devices
                             .iter()
                             .map(|v| v.id.as_ref())
                             .collect::<Vec<_>>(),
-                        s2.pcie_devices
+                        nvredfish_pcie_device_ids = ?s2.pcie_devices
                             .iter()
                             .map(|v| v.id.as_ref())
                             .collect::<Vec<_>>(),
+                        "system PCIe device counts are not equal",
                     );
                 } else {
                     let s2devices = s2
@@ -1404,18 +1457,18 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
                         if let Some(s2dev) = s2devices.get(&s1dev.id) {
                             if s1dev != *s2dev {
                                 tracing::warn!(
-                                    "systems[{:?}].pcie_devices[{:?}] devices not equal: {:?} != {:?}",
-                                    s1.id,
-                                    s1dev.id,
-                                    s1dev,
-                                    s2dev,
+                                    system_id = ?s1.id,
+                                    device_id = ?s1dev.id,
+                                    libredfish_pcie_device = ?s1dev,
+                                    nvredfish_pcie_device = ?s2dev,
+                                    "system PCIe devices are not equal",
                                 );
                             }
                         } else {
                             tracing::warn!(
-                                "systems[{:?}].pcie_devices.len() device {:?} is not found in second report",
-                                s1.id,
-                                s1dev.id
+                                system_id = ?s1.id,
+                                device_id = ?s1dev.id,
+                                "system PCIe device is missing from the second report"
                             );
                         }
                     }
@@ -1424,37 +1477,37 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
 
             if s1.base_mac != s2.base_mac {
                 tracing::warn!(
-                    "systems[{:?}].base_mac are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.base_mac,
-                    s2.base_mac
+                    system_id = ?s1.id,
+                    libredfish_base_mac_address = ?s1.base_mac,
+                    nvredfish_base_mac_address = ?s2.base_mac,
+                    "system base MAC addresses are not equal"
                 );
             }
 
             if s1.power_state != s2.power_state {
                 tracing::warn!(
-                    "systems[{:?}].power_state are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.power_state,
-                    s2.power_state
+                    system_id = ?s1.id,
+                    libredfish_power_state = ?s1.power_state,
+                    nvredfish_power_state = ?s2.power_state,
+                    "system power states are not equal"
                 );
             }
 
             if s1.sku != s2.sku {
                 tracing::warn!(
-                    "systems[{:?}].sku are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.sku,
-                    s2.sku
+                    system_id = ?s1.id,
+                    libredfish_sku = ?s1.sku,
+                    nvredfish_sku = ?s2.sku,
+                    "system SKUs are not equal"
                 );
             }
 
             if s1.boot_order != s2.boot_order {
                 tracing::warn!(
-                    "systems[{:?}].boot_order are not equal: {:?} != {:?}",
-                    s1.id,
-                    s1.boot_order,
-                    s2.boot_order
+                    system_id = ?s1.id,
+                    libredfish_boot_order = ?s1.boot_order,
+                    nvredfish_boot_order = ?s2.boot_order,
+                    "system boot orders are not equal"
                 );
             }
         }
@@ -1462,34 +1515,52 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
 
     if report1.chassis.len() != report2.chassis.len() {
         tracing::warn!(
-            "reported different number of chassis: {:?} != {:?}",
-            report1.chassis.len(),
-            report2.chassis.len(),
+            libredfish_chassis_count = report1.chassis.len(),
+            nvredfish_chassis_count = report2.chassis.len(),
+            "reported different number of chassis",
         );
     }
 
     for (c1, c2) in report1.chassis.iter().zip(report2.chassis.iter()) {
         if c1.id != c2.id {
-            tracing::warn!("chassis.id are not equal: {:?} != {:?}", c1.id, c2.id);
+            tracing::warn!(
+                libredfish_chassis_id = ?c1.id,
+                nvredfish_chassis_id = ?c2.id,
+                "chassis IDs are not equal"
+            );
         } else if c1 != c2 {
-            tracing::warn!("chassis[{:?}] are not equal: {:?} != {:?}", c1.id, c1, c2);
+            tracing::warn!(
+                chassis_id = ?c1.id,
+                libredfish_chassis = ?c1,
+                nvredfish_chassis = ?c2,
+                "chassis reports are not equal"
+            );
         }
     }
 
     if report1.service.len() != report2.service.len() {
         tracing::warn!(
-            "reported different number of service: {:?} != {:?}",
-            report1.service.len(),
-            report2.service.len(),
+            libredfish_service_count = report1.service.len(),
+            nvredfish_service_count = report2.service.len(),
+            "reported different number of service",
         );
     }
 
     for (s1, s2) in report1.service.iter().zip(report2.service.iter()) {
         if s1.id != s2.id {
-            tracing::warn!("service.id are not equal: {:?} != {:?}", s1.id, s2.id);
+            tracing::warn!(
+                libredfish_service_id = ?s1.id,
+                nvredfish_service_id = ?s2.id,
+                "service IDs are not equal"
+            );
         } else {
             if s1.inventories.len() != s2.inventories.len() {
-                tracing::warn!("service[{:?}] are not equal: {:?} != {:?}", s1.id, s1, s2);
+                tracing::warn!(
+                    service_id = ?s1.id,
+                    libredfish_service = ?s1,
+                    nvredfish_service = ?s2,
+                    "service reports are not equal"
+                );
             }
             // Stable ordering of FW by id. Dell PowerEdge R770 doesn't
             // provide stable order of FW versions.
@@ -1514,10 +1585,10 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
                             .and_then(|v| if v == "00:00:00Z" { None } else { Some(v) })
                 {
                     tracing::warn!(
-                        "service[{:?}].inventories are not equal: {:?} != {:?}",
-                        s1.id,
-                        i1,
-                        i2
+                        service_id = ?s1.id,
+                        libredfish_inventory = ?i1,
+                        nvredfish_inventory = ?i2,
+                        "service inventories are not equal"
                     );
                 }
             }
@@ -1526,15 +1597,19 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
 
     if report1.machine_setup_status.is_some() != report2.machine_setup_status.is_some() {
         tracing::warn!(
-            "forge_setup_status(es) are not equal: {:?} != {:?}",
-            report1.machine_setup_status,
-            report2.machine_setup_status,
+            libredfish_machine_setup_status = ?report1.machine_setup_status,
+            nvredfish_machine_setup_status = ?report2.machine_setup_status,
+            "machine setup statuses are not equal",
         );
     } else if let Some(r1) = &report1.machine_setup_status
         && let Some(r2) = &report2.machine_setup_status
     {
         if r1.is_done != r2.is_done {
-            tracing::warn!("forge_setup_status(es) are not equal: {r1:?} != {r2:?}",);
+            tracing::warn!(
+                libredfish_machine_setup_status = ?r1,
+                nvredfish_machine_setup_status = ?r2,
+                "machine setup statuses are not equal"
+            );
         }
 
         let mut sst1_idx = (0..r1.diffs.len()).collect::<Vec<_>>();
@@ -1543,16 +1618,20 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
         sst2_idx.sort_by_key(|i| &r2.diffs[*i].key);
         if sst1_idx.len() != sst2_idx.len() {
             tracing::warn!(
-                "machine_setup_status diffs are not equal: {:?} != {:?}",
-                r1.diffs,
-                r2.diffs
+                libredfish_machine_setup_diffs = ?r1.diffs,
+                nvredfish_machine_setup_diffs = ?r2.diffs,
+                "machine setup status differences are not equal"
             );
         } else {
             for (i1, i2) in sst1_idx.into_iter().zip(sst2_idx) {
                 let d1 = &r1.diffs[i1];
                 let d2 = &r2.diffs[i2];
                 if d1 != d2 {
-                    tracing::warn!("machine_setup_status diffs are not equal: {d1:?} != {d2:?}");
+                    tracing::warn!(
+                        libredfish_machine_setup_diff = ?d1,
+                        nvredfish_machine_setup_diff = ?d2,
+                        "machine setup status differences are not equal"
+                    );
                 }
             }
         }
@@ -1560,65 +1639,65 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
 
     if report1.secure_boot_status != report2.secure_boot_status {
         tracing::warn!(
-            "secure_boot_status(es) are not equal: {:?} != {:?}",
-            report1.secure_boot_status,
-            report2.secure_boot_status,
+            libredfish_secure_boot_status = ?report1.secure_boot_status,
+            nvredfish_secure_boot_status = ?report2.secure_boot_status,
+            "secure boot statuses are not equal",
         );
     }
 
     if report1.lockdown_status != report2.lockdown_status {
         tracing::warn!(
-            "lockdown_status(es) are not equal: {:?} != {:?}",
-            report1.lockdown_status,
-            report2.lockdown_status,
+            libredfish_lockdown_status = ?report1.lockdown_status,
+            nvredfish_lockdown_status = ?report2.lockdown_status,
+            "lockdown statuses are not equal",
         );
     }
 
     if report1.power_shelf_id != report2.power_shelf_id {
         tracing::warn!(
-            "power_shelf_id are not equal: {:?} != {:?}",
-            report1.power_shelf_id,
-            report2.power_shelf_id
+            libredfish_power_shelf_id = ?report1.power_shelf_id,
+            nvredfish_power_shelf_id = ?report2.power_shelf_id,
+            "power shelf IDs are not equal"
         )
     }
 
     if report1.switch_id != report2.switch_id {
         tracing::warn!(
-            "switch_id are not equal: {:?} != {:?}",
-            report1.switch_id,
-            report2.switch_id
+            libredfish_switch_id = ?report1.switch_id,
+            nvredfish_switch_id = ?report2.switch_id,
+            "switch IDs are not equal"
         )
     }
 
     if report1.physical_slot_number != report2.physical_slot_number {
         tracing::warn!(
-            "physical_slot_number are not equal: {:?} != {:?}",
-            report1.physical_slot_number,
-            report2.physical_slot_number
+            libredfish_physical_slot_number = ?report1.physical_slot_number,
+            nvredfish_physical_slot_number = ?report2.physical_slot_number,
+            "physical slot numbers are not equal"
         )
     }
 
     if report1.compute_tray_index != report2.compute_tray_index {
         tracing::warn!(
-            "compute_tray_index are not equal: {:?} != {:?}",
-            report1.compute_tray_index,
-            report2.compute_tray_index
+            libredfish_compute_tray_index = ?report1.compute_tray_index,
+            nvredfish_compute_tray_index = ?report2.compute_tray_index,
+            "compute tray indexes are not equal"
         )
     }
 
     if report1.topology_id != report2.topology_id {
         tracing::warn!(
-            "topology_id are not equal: {:?} != {:?}",
-            report1.topology_id,
-            report2.topology_id
+            libredfish_topology_id = ?report1.topology_id,
+            nvredfish_topology_id = ?report2.topology_id,
+            "topology IDs are not equal"
         )
     }
 
     if report1.revision_id != report2.revision_id {
         tracing::warn!(
-            "revision_id are not equal: {:?} != {:?}",
-            report1.revision_id,
-            report2.revision_id
+            libredfish_revision_id = ?report1.revision_id,
+            nvredfish_revision_id = ?report2.revision_id,
+            "revision IDs are not equal"
         )
     }
 }

--- a/crates/site-explorer/src/boot_order_tracker.rs
+++ b/crates/site-explorer/src/boot_order_tracker.rs
@@ -83,7 +83,7 @@ impl BootOrderReporter for TracingBootOrderReporter {
         let boot_orders = BootOrderDisplayProxy { systems };
 
         tracing::info!(
-            %bmc_ip,
+            bmc_ip_address = %bmc_ip,
             machine_id = ?machine_id,
             ?boot_orders,
             reason = %reason,

--- a/crates/site-explorer/src/explored_endpoint_index.rs
+++ b/crates/site-explorer/src/explored_endpoint_index.rs
@@ -201,18 +201,18 @@ impl ExploredEndpointIndexBuilder {
     pub fn with_expected_power_shelves(mut self, shelves: Vec<ExpectedPowerShelf>) -> Self {
         for shelf in shelves {
             tracing::info!(
-                "expected_power_shelf from DB: {} {}",
-                shelf.bmc_mac_address,
-                shelf.metadata.name
+                bmc_mac_address = %shelf.bmc_mac_address,
+                power_shelf_name = %shelf.metadata.name,
+                "loaded expected power shelf from database"
             );
             if let Some(iface) = self
                 .explored_underlay_interfaces
                 .get(&shelf.bmc_mac_address)
             {
                 tracing::info!(
-                    "iface mac address {} expected power shelf mac address {}",
-                    iface.mac_address,
-                    shelf.bmc_mac_address
+                    interface_mac_address = %iface.mac_address,
+                    expected_power_shelf_mac_address = %shelf.bmc_mac_address,
+                    "matched interface to expected power shelf"
                 );
                 for addr in &iface.addresses {
                     self.explored_power_shelves_addr_index
@@ -229,18 +229,18 @@ impl ExploredEndpointIndexBuilder {
         // Create a mapping of expected switches by IP address and MAC address
         for switch in switches {
             tracing::info!(
-                "expected_switch from DB: {} {}",
-                switch.bmc_mac_address,
-                switch.metadata.name
+                bmc_mac_address = %switch.bmc_mac_address,
+                switch_name = %switch.metadata.name,
+                "loaded expected switch from database"
             );
             if let Some(iface) = self
                 .explored_underlay_interfaces
                 .get(&switch.bmc_mac_address)
             {
                 tracing::info!(
-                    "iface mac address {} expected switch mac address {}",
-                    iface.mac_address,
-                    switch.bmc_mac_address
+                    interface_mac_address = %iface.mac_address,
+                    expected_switch_mac_address = %switch.bmc_mac_address,
+                    "matched interface to expected switch"
                 );
                 for addr in &iface.addresses {
                     self.explored_switches_addr_index

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -138,8 +138,8 @@ pub fn enrich_endpoint_exploration_report(
             let components_without_version = report.parse_versions(&fw_info);
             if !components_without_version.is_empty() {
                 tracing::debug!(
-                    "Can not find firmware version for component(s): {:?}",
-                    components_without_version
+                    components = ?components_without_version,
+                    "Can not find firmware version for component(s)"
                 );
             }
         } else {
@@ -147,9 +147,9 @@ pub fn enrich_endpoint_exploration_report(
             // do not keep stale data.
             report.versions = HashMap::default();
             tracing::debug!(
-                "Can not find firmware info for: vendor: {:?}; model: {:?}",
-                report.vendor,
-                report.model()
+                vendor = ?report.vendor,
+                model = ?report.model(),
+                "Can not find firmware info"
             );
         }
 
@@ -226,7 +226,7 @@ pub async fn fetch_slot_and_tray(
         }
         Err(e) => {
             tracing::warn!(
-                %e,
+                error = %e,
                 "Failed to get device info from RMS, slot_number and tray_index will be unset"
             );
             (None, None)
@@ -388,7 +388,7 @@ impl SiteExplorer {
                         .boot_order_tracker
                         .track_hosts(Instant::now(), &identified_hosts),
                     Err(e) => {
-                        tracing::warn!("SiteExplorer error: {}", e);
+                        tracing::warn!(error = %e, "SiteExplorer error");
                     }
                 }
             } else {
@@ -573,7 +573,7 @@ impl SiteExplorer {
                 explore_site_span.record("otel.status_code", "ok");
             }
             Err(e) => {
-                tracing::error!("SiteExplorer run failed due to: {:?}", e);
+                tracing::error!(error = ?e, "SiteExplorer run failed");
                 explore_site_span.record("otel.status_code", "error");
                 // Writing this field will set the span status to error
                 // Therefore we only write it on errors
@@ -890,7 +890,7 @@ impl SiteExplorer {
             create_power_shelves_res?;
         } else if !explored_power_shelves.is_empty() {
             tracing::info!(
-                num_power_shelves = explored_power_shelves.len(),
+                power_shelf_count = explored_power_shelves.len(),
                 "Identified power shelves during exploration but create_power_shelves=false; skipping PowerShelf creation. \
                  Set [site_explorer] create_power_shelves=true and declare matching expected_power_shelves records to ingest them."
             );
@@ -916,7 +916,7 @@ impl SiteExplorer {
             create_switches_res?;
         } else if !explored_switches.is_empty() {
             tracing::info!(
-                num_switches = explored_switches.len(),
+                switch_count = explored_switches.len(),
                 "Identified switches during exploration but create_switches=false; skipping Switch creation. \
                  Set [site_explorer] create_switches=true and declare matching expected_switches records to ingest them."
             );
@@ -950,7 +950,10 @@ impl SiteExplorer {
                 .await
                 .map_err(|e| DatabaseError::new("end retained boot interface sweep", e))?;
             if swept > 0 {
-                tracing::info!(swept, "Removed expired retained boot interface records");
+                tracing::info!(
+                    removed_retained_boot_interface_count = swept,
+                    "Removed expired retained boot interface records"
+                );
             }
         }
 
@@ -969,8 +972,8 @@ impl SiteExplorer {
                 expected_endpoint_index.matched_expected_power_shelf(&endpoint.address)
             else {
                 tracing::info!(
-                    "No expected power shelf found for endpoint {:#?}",
-                    endpoint.address
+                    bmc_ip_address = ?endpoint.address,
+                    "No expected power shelf found"
                 );
                 continue;
             };
@@ -989,7 +992,11 @@ impl SiteExplorer {
                 }
                 Ok(false) => {}
                 Err(error) => {
-                    tracing::error!(%error, "Failed to create power shelf {:#?}", address)
+                    tracing::error!(
+                        %error,
+                        bmc_ip_address = ?address,
+                        "Failed to create power shelf"
+                    )
                 }
             }
         }
@@ -1009,8 +1016,8 @@ impl SiteExplorer {
             .map_err(|e| DatabaseError::new("begin load create_power_shelf", e))?;
 
         tracing::info!(
-            "creating power shelf for endpoint: {} ",
-            explored_endpoint.address
+            bmc_ip_address = %explored_endpoint.address,
+            "Creating power shelf"
         );
 
         // Defense against the duplicate-power-shelves bug: if a power shelf
@@ -1023,10 +1030,10 @@ impl SiteExplorer {
                 .await?
         {
             tracing::warn!(
-                bmc_mac = %expected_shelf.bmc_mac_address,
+                bmc_mac_address = %expected_shelf.bmc_mac_address,
                 existing_power_shelf_id = %existing.id,
-                endpoint = %explored_endpoint.address,
-                "Power shelf already exists for this BMC MAC; skipping discovery",
+                bmc_ip_address = %explored_endpoint.address,
+                "Power shelf already exists; skipping discovery",
             );
             txn.rollback()
                 .await
@@ -1046,9 +1053,9 @@ impl SiteExplorer {
             for existing_ps in &existing_power_shelves {
                 if existing_ps.config.name == expected_shelf.metadata.name {
                     tracing::info!(
-                        "Power shelf with name '{}' already exists, skipping creation for endpoint {}",
-                        &expected_shelf.metadata.name,
-                        explored_endpoint.address
+                        power_shelf_name = %expected_shelf.metadata.name,
+                        bmc_ip_address = %explored_endpoint.address,
+                        "Power shelf already exists; skipping creation"
                     );
                     txn.rollback()
                         .await
@@ -1073,7 +1080,7 @@ impl SiteExplorer {
 
         if power_shelf_chassis.is_none() {
             tracing::warn!(
-                endpoint = %explored_endpoint.address,
+                bmc_ip_address = %explored_endpoint.address,
                 "No chassis reported for power shelf endpoint; falling back to defaults for id generation",
             );
         }
@@ -1096,7 +1103,7 @@ impl SiteExplorer {
         ) {
             Ok(id) => id,
             Err(e) => {
-                tracing::error!(%e, "Failed to create power shelf ID");
+                tracing::error!(error = %e, "Failed to create power shelf ID");
                 return Err(SiteExplorerError::InvalidArgument(format!(
                     "Failed to create power shelf ID: {e}"
                 )));
@@ -1147,9 +1154,9 @@ impl SiteExplorer {
             .map_err(|e| DatabaseError::new("end create_power_shelf", e))?;
 
         tracing::info!(
-            "Created power shelf {} for endpoint {}",
-            power_shelf_id,
-            explored_endpoint.address
+            %power_shelf_id,
+            bmc_ip_address = %explored_endpoint.address,
+            "Created power shelf"
         );
 
         Ok(true)
@@ -1264,8 +1271,8 @@ impl SiteExplorer {
                 let has_id = iface.id.as_deref().is_some_and(|s| !s.is_empty());
                 if has_mac != has_id {
                     tracing::info!(
-                        address = %ep.address,
-                        mac = ?iface.mac_address,
+                        bmc_ip_address = %ep.address,
+                        interface_mac_address = ?iface.mac_address,
                         interface_id = ?iface.id,
                         "site-explorer: host NIC reported with only one of (MAC, interface id) -- not recording its boot interface",
                     );
@@ -1315,7 +1322,7 @@ impl SiteExplorer {
                         &mut seen_bluefield_serials,
                     ) {
                         tracing::warn!(
-                            host_bmc_ip = %ep.address,
+                            host_bmc_ip_address = %ep.address,
                             %serial_number,
                             pcie_device_id = ?pcie_device.id,
                             "duplicate BlueField serial in host PCIe inventory; skipping duplicate record",
@@ -1444,8 +1451,8 @@ impl SiteExplorer {
                                 }
                                 DiscoveredDpu::ModeCheckFailed(err) => {
                                     tracing::warn!(
-                                        dpu = %dpu_ep.address,
-                                        dpu_sn = %dpu_sn,
+                                        bmc_ip_address = %dpu_ep.address,
+                                        dpu_serial_number = %dpu_sn,
                                         error = %err,
                                         "failed to check fallback-matched DPU mode; skipping this device this pass",
                                     );
@@ -1472,10 +1479,13 @@ impl SiteExplorer {
                     if expected_managed_dpus_total > 0 || !all_dpus_configured_properly_in_host {
                         if expected_managed_dpus_total > 0 {
                             tracing::warn!(
-                                address = %ep.address,
+                                bmc_ip_address = %ep.address,
                                 exploration_report = ?ep,
-                                "cannot identify managed host because the site explorer has only discovered {} out of the {} attached DPUs (all_dpus_configured_properly_in_host={all_dpus_configured_properly_in_host}):\n{:#?}",
-                                dpus_explored_for_host.len(), expected_managed_dpus_total, dpus_explored_for_host
+                                discovered_dpu_count = dpus_explored_for_host.len(),
+                                expected_managed_dpu_count = expected_managed_dpus_total,
+                                all_dpus_configured_properly_in_host,
+                                discovered_dpu_details = ?dpus_explored_for_host,
+                                "cannot identify managed host because the site explorer has not discovered all attached DPUs"
                             );
                         }
 
@@ -1492,8 +1502,9 @@ impl SiteExplorer {
                             );
                             if time_since_redfish_powercycle > self.config.reset_rate_limit {
                                 tracing::warn!(
-                                    "power cycling host {} to apply nic mode change for its incorrectly configured DPUs; time since last powercycle: {time_since_redfish_powercycle}",
-                                    ep.address,
+                                    bmc_ip_address = %ep.address,
+                                    %time_since_redfish_powercycle,
+                                    "power cycling host to apply nic mode change for its incorrectly configured DPUs"
                                 );
                                 metrics.increment_dpu_migration_signal(
                                     DpuMigrationSignal::ResetRequested,
@@ -1501,8 +1512,9 @@ impl SiteExplorer {
 
                                 if let Err(err) = self.redfish_powercycle(ep.address).await {
                                     tracing::warn!(
-                                        "site explorer failed to power cycle host {} to apply DPU mode changes: {err}; a manual power cycle may be required",
-                                        ep.address
+                                        bmc_ip_address = %ep.address,
+                                        error = %err,
+                                        "site explorer failed to power cycle host to apply DPU mode changes; a manual power cycle may be required"
                                     );
                                     metrics.increment_host_dpu_pairing_blocker(
                                         PairingBlockerReason::ManualPowerCycleRequired,
@@ -1550,7 +1562,7 @@ impl SiteExplorer {
                         // vector -- the operator already declared
                         // "treat as zero-DPU.")
                         tracing::warn!(
-                            address = %ep.address,
+                            bmc_ip_address = %ep.address,
                             exploration_report = ?ep,
                             ?host_dpu_mode,
                             "cannot identify managed host: site explorer sees no DPUs on this host and it isn't declared as `NoDpu`; declare `dpu_mode = \"no_dpu\"` to ingest as zero-DPU",
@@ -1591,7 +1603,7 @@ impl SiteExplorer {
                     ));
                 } else {
                     tracing::debug!(
-                        address = %ep.address,
+                        bmc_ip_address = %ep.address,
                         %mac_address,
                         "boot interface MAC has no matching Redfish interface id in the report; keeping last-known-good stored boot interface",
                     );
@@ -1619,8 +1631,10 @@ impl SiteExplorer {
                         .join(",");
 
                     tracing::error!(
-                        "Could not find mac_address {mac_address} in discovered DPU's list {all_mac}, host bmc: {}.",
-                        ep.address
+                        %mac_address,
+                        discovered_dpu_mac_addresses = %all_mac,
+                        host_bmc_ip_address = %ep.address,
+                        "MAC address not found in discovered DPU list"
                     );
                     metrics.increment_host_dpu_pairing_blocker(
                         PairingBlockerReason::BootInterfaceMacMismatch,
@@ -1766,7 +1780,7 @@ impl SiteExplorer {
             DiscoveredDpu::NeedsReconfig => exploration.all_configured = false,
             DiscoveredDpu::ModeCheckFailed(err) => {
                 tracing::warn!(
-                    dpu = %dpu_ep.address,
+                    bmc_ip_address = %dpu_ep.address,
                     error = %err,
                     "failed to check DPU mode; skipping this device",
                 );
@@ -1985,9 +1999,9 @@ impl SiteExplorer {
                     }
                     macs => {
                         tracing::warn!(
-                            bmc_mac = %expected_switch.bmc_mac_address,
-                            %nvos_ip,
-                            nvos_mac_count = macs.len(),
+                            bmc_mac_address = %expected_switch.bmc_mac_address,
+                            nvos_ip_address = %nvos_ip,
+                            nvos_mac_address_count = macs.len(),
                             "Skipping NVOS preallocation: nvos_ip_address requires exactly one nvos_mac_addresses entry"
                         );
                     }
@@ -2085,7 +2099,7 @@ impl SiteExplorer {
                 }
                 None => {
                     if endpoint.report.is_power_shelf() {
-                        tracing::info!(%address, "Retaining power shelf endpoint with no underlay interface; power shelves are sourced from their expected static IP")
+                        tracing::info!(bmc_ip_address = %address, "Retaining power shelf endpoint with no underlay interface; power shelves are sourced from their expected static IP")
                     } else {
                         delete_endpoints.push(*address)
                     }
@@ -2248,7 +2262,7 @@ impl SiteExplorer {
                             Some(guard) => guard,
                             None => {
                                 tracing::info!(
-                                    address = %endpoint.address,
+                                    bmc_ip_address = %endpoint.address,
                                     "Skipping periodic endpoint exploration; endpoint already in progress"
                                 );
                                 return Ok(None);
@@ -2424,7 +2438,7 @@ impl SiteExplorer {
                             report.last_exploration_latency = Some(exploration_duration);
                             if old_report.endpoint_type == EndpointType::Unknown {
                                 tracing::info!(
-                                    address = %address,
+                                    bmc_ip_address = %address,
                                     exploration_report = ?report,
                                     "Initial exploration of endpoint"
                                 );
@@ -2461,7 +2475,7 @@ impl SiteExplorer {
                         Ok(mut report) => {
                             report.last_exploration_latency = Some(exploration_duration);
                             tracing::info!(
-                                address = %address,
+                                bmc_ip_address = %address,
                                 exploration_report = ?report,
                                 "Initial exploration of endpoint"
                             );
@@ -2556,7 +2570,9 @@ impl SiteExplorer {
         // New endpoints haven't been explored yet, so pause_remediation defaults to false
         if endpoint.last_explored.is_some_and(|e| e.pause_remediation) {
             tracing::info!(
-                "Site explorer will not remediate error for {endpoint} because remediation is paused for this endpoint: {error}"
+                %endpoint,
+                %error,
+                "Site explorer will not remediate error because remediation is paused for this endpoint"
             );
             return;
         }
@@ -2575,8 +2591,10 @@ impl SiteExplorer {
             PreingestionState::Initial | PreingestionState::Complete
         ) {
             tracing::info!(
-                "Site explorer will not remediate error for {endpoint} because endpoint is in preingestion state {:?}: {error}",
-                endpoint.preingestion_state(),
+                %endpoint,
+                preingestion_state = ?endpoint.preingestion_state(),
+                %error,
+                "Site explorer will not remediate error because endpoint is in preingestion state",
             );
             return;
         }
@@ -2588,13 +2606,19 @@ impl SiteExplorer {
             Ok(managed_host_exists) => {
                 if managed_host_exists {
                     tracing::info!(
-                        "Site explorer will not remediate error for {endpoint} because a managed host has already been created for this endpoint: {error}"
+                        %endpoint,
+                        %error,
+                        "Site explorer will not remediate error because a managed host has already been created for this endpoint"
                     );
                     return;
                 }
             }
             Err(e) => {
-                tracing::error!(%e, "failed to retrieve whether managed host was created for endpoint: {endpoint}");
+                tracing::error!(
+                    %endpoint,
+                    error = %e,
+                    "Failed to determine whether managed host was created"
+                );
                 return;
             }
         };
@@ -2607,8 +2631,8 @@ impl SiteExplorer {
             && !matches!(power_state, PowerState::On)
         {
             tracing::warn!(
-                "Site Explorer found a host (bmc_ip_address: {}) that isnt on. Turning it on now.",
-                endpoint.address,
+                bmc_ip_address = %endpoint.address,
+                "Site Explorer found a host that isn't on. Turning it on now.",
             );
 
             match self
@@ -2617,7 +2641,10 @@ impl SiteExplorer {
             {
                 Ok(()) => return,
                 Err(err) => {
-                    tracing::error!(%err, "Site Explorer failed to power on host through Redfish");
+                    tracing::error!(
+                        error = %err,
+                        "Site Explorer failed to power on host through Redfish"
+                    );
                 }
             }
         }
@@ -2650,13 +2677,23 @@ impl SiteExplorer {
             || time_since_ipmitool_bmc_reset.num_minutes() < min_time_since_last_action_mins
         {
             tracing::info!(
-                "waiting to remediate error {error} for {endpoint}; time_since_redfish_reboot: {time_since_redfish_reboot}; time_since_redfish_bmc_reset: {time_since_redfish_bmc_reset}; time_since_ipmitool_bmc_reset: {time_since_ipmitool_bmc_reset}"
+                %endpoint,
+                %error,
+                %time_since_redfish_reboot,
+                %time_since_redfish_bmc_reset,
+                %time_since_ipmitool_bmc_reset,
+                "waiting to remediate error"
             );
             return;
         }
 
         tracing::info!(
-            "Site explorer captured an error for {endpoint}: {error};\n time_since_redfish_reboot: {time_since_redfish_reboot}; time_since_redfish_bmc_reset: {time_since_redfish_bmc_reset}; time_since_ipmitool_bmc_reset: {time_since_ipmitool_bmc_reset}'"
+            %endpoint,
+            %error,
+            %time_since_redfish_reboot,
+            %time_since_redfish_bmc_reset,
+            %time_since_ipmitool_bmc_reset,
+            "Site explorer captured an error"
         );
 
         // If the endpoint is a DPU, and the error is that the BIOS attributes are coming up as empty for this DPU,
@@ -2673,9 +2710,9 @@ impl SiteExplorer {
                 .await
                 .map_err(|err| {
                     tracing::error!(
-                        "Site Explorer failed to reboot {}: {}",
-                        endpoint.address,
-                        err
+                        bmc_ip_address = %endpoint.address,
+                        error = %err,
+                        "Site Explorer failed to reboot"
                     )
                 })
                 .is_ok()
@@ -2692,9 +2729,9 @@ impl SiteExplorer {
                 }
                 Err(e) => {
                     tracing::error!(
-                        "Site Explorer failed to clear nvram {}: {}",
-                        endpoint.address,
-                        e
+                        bmc_ip_address = %endpoint.address,
+                        error = %e,
+                        "Site Explorer failed to clear nvram"
                     )
                 }
             }
@@ -2706,9 +2743,9 @@ impl SiteExplorer {
                 .await
                 .map_err(|err| {
                     tracing::error!(
-                        "Site Explorer failed to reset BMC {} through redfish: {}",
-                        endpoint.address,
-                        err
+                        bmc_ip_address = %endpoint.address,
+                        error = %err,
+                        "Site Explorer failed to reset BMC through redfish"
                     )
                 })
                 .is_ok()
@@ -2722,9 +2759,9 @@ impl SiteExplorer {
                 .await
                 .map_err(|err| {
                     tracing::error!(
-                        "Site Explorer failed to reset BMC {} through ipmitool: {}",
-                        endpoint.address,
-                        err
+                        bmc_ip_address = %endpoint.address,
+                        error = %err,
+                        "Site Explorer failed to reset BMC through ipmitool"
                     )
                 })
                 .ok();
@@ -2734,8 +2771,8 @@ impl SiteExplorer {
 
     pub async fn ipmitool_reset_bmc(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
-            "SiteExplorer is initiating a cold BMC reset through IPMI to IP {}",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            "SiteExplorer is initiating a cold BMC reset through IPMI"
         );
 
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
@@ -2764,8 +2801,8 @@ impl SiteExplorer {
 
     pub async fn redfish_reset_bmc(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
-            "SiteExplorer is initiating a BMC reset through Redfish to IP {}",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            "SiteExplorer is initiating a BMC reset through Redfish"
         );
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
@@ -2844,15 +2881,19 @@ impl SiteExplorer {
         {
             Ok(is_viking) => is_viking,
             Err(e) => {
-                tracing::warn!("could not retrieve vendor for {}: {e}", endpoint.address);
+                tracing::warn!(
+                    bmc_ip_address = %endpoint.address,
+                    error = %e,
+                    "could not retrieve vendor"
+                );
                 false
             }
         }
     }
     pub async fn clear_nvram(&self, endpoint: &Endpoint<'_>) -> SiteExplorerResult<()> {
         tracing::info!(
-            "SiteExplorer is issuing a clean_nvram through Redfish to IP {}",
-            endpoint.address
+            bmc_ip_address = %endpoint.address,
+            "Site explorer is clearing NVRAM through Redfish"
         );
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
@@ -2898,7 +2939,11 @@ impl SiteExplorer {
         {
             Ok(managed_host_exists) => managed_host_exists,
             Err(e) => {
-                tracing::error!(%e, "failed to retrieve whether managed host was created for DPU endpoint: {dpu_endpoint}");
+                tracing::error!(
+                    %dpu_endpoint,
+                    error = %e,
+                    "Failed to determine whether managed host was created"
+                );
                 // return true by default
                 true
             }
@@ -2916,22 +2961,22 @@ impl SiteExplorer {
                 // from the redfish response. Skip the next check because the DPUs
                 // in NIC mode will not expose a pf0 interface to the host.
                 tracing::info!(
-                    "Site explorer found an uningested DPU (bmc ip: {}) in NIC mode",
-                    dpu_endpoint.address
+                    bmc_ip_address = %dpu_endpoint.address,
+                    "Site explorer found an uningested DPU in NIC mode"
                 );
                 return Ok(true);
             }
             Some(NicMode::Dpu) => {}
             None if dpu_endpoint.report.dpu_pairing_serial_number().is_some() => {
                 tracing::warn!(
-                    "Site explorer found an uningested DPU (bmc ip: {}) without a Redfish DPU/NIC mode; continuing because it has a host-pairing serial",
-                    dpu_endpoint.address
+                    bmc_ip_address = %dpu_endpoint.address,
+                    "Site explorer found an uningested DPU without a Redfish DPU/NIC mode; continuing because it has a host-pairing serial"
                 );
             }
             None => {
                 tracing::error!(
-                    "Site explorer found an uningested DPU (bmc ip: {}) without being able to determine if it is in NIC mode",
-                    dpu_endpoint.address
+                    bmc_ip_address = %dpu_endpoint.address,
+                    "Site explorer found an uningested DPU without being able to determine if it is in NIC mode"
                 );
                 metrics.increment_host_dpu_pairing_blocker(PairingBlockerReason::DpuNicModeUnknown);
                 return Ok(false);
@@ -2944,7 +2989,11 @@ impl SiteExplorer {
         match find_host_pf_mac_address(dpu_endpoint) {
             Ok(_) => Ok(true),
             Err(error) => {
-                tracing::error!(%error, "Site explorer found an uningested DPU (bmc ip: {}): failed to find the MAC address of the pf0 interface that the DPU exposes to the host", dpu_endpoint.address);
+                tracing::error!(
+                    %error,
+                    bmc_ip_address = %dpu_endpoint.address,
+                    "Site explorer found an uningested DPU: failed to find the MAC address of the pf0 interface that the DPU exposes to the host"
+                );
                 metrics.increment_host_dpu_pairing_blocker(PairingBlockerReason::DpuPf0MacMissing);
                 Ok(false)
             }
@@ -3060,7 +3109,11 @@ impl SiteExplorer {
         {
             Ok(managed_host_exists) => managed_host_exists,
             Err(e) => {
-                tracing::error!(%e, "failed to retrieve whether managed host was created for Host endpoint: {host_endpoint}");
+                tracing::error!(
+                    %host_endpoint,
+                    error = %e,
+                    "Failed to determine whether managed host was created"
+                );
                 // return true by default
                 true
             }
@@ -3075,8 +3128,8 @@ impl SiteExplorer {
         let bmc_target_addr = SocketAddr::new(host_endpoint.address, bmc_target_port);
         let Some(system) = host_endpoint.report.systems.first() else {
             tracing::warn!(
-                "Site Explorer could not find the system report for a host (bmc_ip_address: {})",
-                host_endpoint.address,
+                bmc_ip_address = %host_endpoint.address,
+                "Site Explorer could not find the system report for a host",
             );
             metrics
                 .increment_host_dpu_pairing_blocker(PairingBlockerReason::HostSystemReportMissing);
@@ -3087,8 +3140,8 @@ impl SiteExplorer {
         // then don't do it
         if host_endpoint.pause_ingestion_and_poweron {
             tracing::warn!(
-                "Host with bmc_ip_address: {} is configured to pause on ingestion",
-                host_endpoint.address
+                bmc_ip_address = %host_endpoint.address,
+                "Host is configured to pause on ingestion"
             );
             return Ok(false);
         }
@@ -3141,14 +3194,14 @@ impl SiteExplorer {
 
             if host_endpoint.pause_remediation {
                 tracing::info!(
-                    "Site Explorer found an uningested host (bmc_ip_address: {}) that is off, but remediation is paused — skipping power-on",
-                    host_endpoint.address,
+                    bmc_ip_address = %host_endpoint.address,
+                    "Site Explorer found an uningested host that is off, but remediation is paused — skipping power-on",
                 );
             } else if fresh_power_state.is_some() {
                 tracing::warn!(
-                    "Site Explorer found an uningested host (bmc_ip_address: {}) that isn't on: {:#?}",
-                    host_endpoint.address,
-                    effective_power_state
+                    bmc_ip_address = %host_endpoint.address,
+                    power_state = ?effective_power_state,
+                    "Site Explorer found an uningested host that isn't on"
                 );
 
                 if let Some(interface) = interface.as_ref() {
@@ -3161,9 +3214,9 @@ impl SiteExplorer {
                         .await
                         .map_err(|err| {
                             tracing::error!(
-                                "Site Explorer failed to turn on host (bmc_ip_address: {}) through redfish: {}",
-                                host_endpoint.address,
-                                err
+                                bmc_ip_address = %host_endpoint.address,
+                                error = %err,
+                                "Site Explorer failed to turn on host through redfish"
                             )
                         })
                         .ok();
@@ -3174,8 +3227,8 @@ impl SiteExplorer {
         if host_endpoint.report.vendor.unwrap_or_default().is_nvidia() {
             let Some(manager) = host_endpoint.report.managers.first() else {
                 tracing::warn!(
-                    "Site Explorer could not find the system report for a Nvidia host (bmc_ip_address: {})",
-                    host_endpoint.address,
+                    bmc_ip_address = %host_endpoint.address,
+                    "Site Explorer could not find the manager report for an NVIDIA host",
                 );
 
                 return Ok(false);
@@ -3198,8 +3251,10 @@ impl SiteExplorer {
                             Ok(is_cpldmb_version_at_expected) => {
                                 if !is_cpldmb_version_at_expected {
                                     tracing::warn!(
-                                        "Site Explorer found a Viking (bmc_ip_address: {}) with a CPLDMB_0 version of {current_cpldmb_0_version}, which is less than the expected version of {expected_cpldmb_0_version}. A DC Power Cycle may be needed",
-                                        host_endpoint.address,
+                                        bmc_ip_address = %host_endpoint.address,
+                                        %current_cpldmb_0_version,
+                                        %expected_cpldmb_0_version,
+                                        "Site Explorer found a Viking whose CPLDMB_0 version does not match the expected version. A DC power cycle may be needed",
                                     );
                                     metrics.increment_host_dpu_pairing_blocker(
                                         PairingBlockerReason::VikingCpldVersionIssue,
@@ -3209,8 +3264,11 @@ impl SiteExplorer {
                             }
                             Err(e) => {
                                 tracing::warn!(
-                                    "Site Explorer found a Viking (bmc_ip_address: {}) with a CPLDMB_0 version of {current_cpldmb_0_version} and could not compare it to the current CPLDMB_0 version of {expected_cpldmb_0_version}: {e:#?}",
-                                    host_endpoint.address,
+                                    bmc_ip_address = %host_endpoint.address,
+                                    %current_cpldmb_0_version,
+                                    %expected_cpldmb_0_version,
+                                    error = ?e,
+                                    "Site Explorer found a Viking with a CPLDMB_0 version and could not compare it to the current CPLDMB_0 version",
                                 );
                                 metrics.increment_host_dpu_pairing_blocker(
                                     PairingBlockerReason::VikingCpldVersionIssue,
@@ -3220,8 +3278,8 @@ impl SiteExplorer {
                         }
                     } else {
                         tracing::warn!(
-                            "Site Explorer could not find the CPLDMB_0 inventory for a Viking (bmc_ip_address: {})",
-                            host_endpoint.address,
+                            bmc_ip_address = %host_endpoint.address,
+                            "Site Explorer could not find the CPLDMB_0 inventory for a Viking",
                         );
                         metrics.increment_host_dpu_pairing_blocker(
                             PairingBlockerReason::VikingCpldVersionIssue,
@@ -3239,9 +3297,9 @@ impl SiteExplorer {
                 .is_some_and(|status| !status)
         {
             tracing::warn!(
-                "Site Explorer found an uningested Lenovo (bmc_ip_address: {}) without infinite boot enabled; System Report: {:#?}",
-                host_endpoint.address,
-                system.attributes
+                bmc_ip_address = %host_endpoint.address,
+                system_report = ?system.attributes,
+                "Site Explorer found an uningested Lenovo without infinite boot enabled"
             );
 
             let interface = self
@@ -3253,11 +3311,12 @@ impl SiteExplorer {
                 .await
                 .inspect_err(|err| {
                     tracing::error!(
-                        "Site Explorer failed to call machine_setup against Lenovo (bmc_ip_address: {}): {}",
-                        host_endpoint.address,
-                        err
+                        bmc_ip_address = %host_endpoint.address,
+                        error = %err,
+                        "Site explorer failed to run machine setup against Lenovo"
                     )
-                }).ok();
+                })
+                .ok();
 
             self.endpoint_explorer
                 .redfish_power_control(
@@ -3268,11 +3327,12 @@ impl SiteExplorer {
                 .await
                 .inspect_err(|err| {
                     tracing::error!(
-                        "Site Explorer failed to restart Lenovo (bmc_ip_address: {}) after calling machine_setup: {}",
-                        host_endpoint.address,
-                        err
+                        bmc_ip_address = %host_endpoint.address,
+                        error = %err,
+                        "Site explorer failed to restart Lenovo after running machine setup"
                     )
-                }).ok();
+                })
+                .ok();
 
             ingest_host = false;
         }
@@ -3337,7 +3397,7 @@ impl SiteExplorer {
             Some(observed) if observed == target_nic_mode => Ok(true),
             Some(observed) => {
                 tracing::warn!(
-                    address = %dpu_ep.address,
+                    bmc_ip_address = %dpu_ep.address,
                     part_number = ?dpu_part_number,
                     %observed,
                     ?target_nic_mode,
@@ -3351,9 +3411,9 @@ impl SiteExplorer {
             }
             None => {
                 tracing::warn!(
-                    "Site explorer cannot determine this DPU's mode {}: {:#?}",
-                    dpu_ep.address,
-                    dpu_ep.report
+                    bmc_ip_address = %dpu_ep.address,
+                    dpu_report = ?dpu_ep.report,
+                    "Site explorer cannot determine this DPU's mode"
                 );
                 Ok(true)
             }
@@ -3383,7 +3443,10 @@ pub async fn try_preallocate_one(
         Ok(t) => t,
         Err(error) => {
             tracing::warn!(
-                %error, %mac, %ip, kind,
+                %error,
+                mac_address = %mac,
+                ip_address = %ip,
+                kind,
                 "Site-explorer preallocation: txn_begin failed"
             );
             return;
@@ -3413,13 +3476,22 @@ pub async fn try_preallocate_one(
         Ok(()) => {
             if let Err(error) = txn.commit().await {
                 tracing::warn!(
-                    %error, %mac, %ip, kind,
+                    %error,
+                    mac_address = %mac,
+                    ip_address = %ip,
+                    kind,
                     "Site-explorer preallocation: commit failed"
                 );
             }
         }
         Err(error) => {
-            tracing::warn!(%error, %mac, %ip, kind, "Site-explorer preallocation skipped");
+            tracing::warn!(
+                %error,
+                mac_address = %mac,
+                ip_address = %ip,
+                kind,
+                "Site-explorer preallocation skipped"
+            );
         }
     }
 }
@@ -3434,18 +3506,30 @@ pub async fn try_retain_bmc(pool: &PgPool, mac: MacAddress) {
     let mut txn = match db::Transaction::begin(pool).await {
         Ok(t) => t,
         Err(error) => {
-            tracing::warn!(%error, %mac, "Site-explorer BMC retain: txn_begin failed");
+            tracing::warn!(
+                %error,
+                bmc_mac_address = %mac,
+                "Site-explorer BMC retain: txn_begin failed"
+            );
             return;
         }
     };
     match db::machine_interface::retain_bmc_address_by_mac(txn.as_pgconn(), mac).await {
         Ok(()) => {
             if let Err(error) = txn.commit().await {
-                tracing::warn!(%error, %mac, "Site-explorer BMC retain: commit failed");
+                tracing::warn!(
+                    %error,
+                    bmc_mac_address = %mac,
+                    "Site-explorer BMC retain: commit failed"
+                );
             }
         }
         Err(error) => {
-            tracing::warn!(%error, %mac, "Site-explorer BMC retain skipped");
+            tracing::warn!(
+                %error,
+                bmc_mac_address = %mac,
+                "Site-explorer BMC retain skipped"
+            );
         }
     }
 }
@@ -3701,9 +3785,9 @@ fn is_dpu_in_nic_mode(dpu_ep: &ExploredEndpoint, host_ep: &ExploredEndpoint) -> 
     let nic_mode = dpu_ep.report.nic_mode().is_some_and(|m| m == NicMode::Nic);
     if nic_mode {
         tracing::info!(
-            address = %dpu_ep.address,
-            "discovered bluefield in NIC mode attached to host {}",
-            host_ep.address
+            dpu_bmc_ip_address = %dpu_ep.address,
+            host_bmc_ip_address = %host_ep.address,
+            "discovered bluefield in NIC mode attached to host"
         );
     }
     nic_mode
@@ -3714,7 +3798,7 @@ fn get_host_pf_mac_address(dpu_ep: &ExploredEndpoint) -> Option<MacAddress> {
     match find_host_pf_mac_address(dpu_ep) {
         Ok(m) => Some(m),
         Err(error) => {
-            tracing::error!(%error, dpu_ip = %dpu_ep.address, "Failed to find base mac address for DPU");
+            tracing::error!(%error, dpu_bmc_ip_address = %dpu_ep.address, "Failed to find base mac address for DPU");
             None
         }
     }

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -108,7 +108,11 @@ impl MachineCreator {
                     }
                 }
                 Ok(false) => {}
-                Err(error) => tracing::error!(%error, "Failed to create managed host {:#?}", host),
+                Err(error) => tracing::error!(
+                    %error,
+                    host = ?host,
+                    "Failed to create managed host"
+                ),
             }
         }
 
@@ -131,7 +135,7 @@ impl MachineCreator {
     ) -> SiteExplorerResult<bool> {
         let Some(expected_machine) = expected_machine else {
             tracing::warn!(
-                host_bmc_ip = %explored_host.host_bmc_ip,
+                host_bmc_ip_address = %explored_host.host_bmc_ip,
                     "Refusing to create managed host, expected machines entry not found"
             );
             return Ok(false);
@@ -250,7 +254,12 @@ impl MachineCreator {
         if let Some(rack_id) = machine_data.and_then(|d| d.rack_id.as_ref()) {
             tracing::info!(%rack_id, %host_machine_id, "Ensuring rack exists for host machine");
             if let Some(rack) = crate::ensure_rack_exists(&mut txn, rack_id).await? {
-                tracing::info!(%rack_id, "Rack exists for host machine {host_machine_id}: {rack:#?}");
+                tracing::info!(
+                    %rack_id,
+                    %host_machine_id,
+                    rack = ?rack,
+                    "Rack exists"
+                );
                 rack_profile_id = rack.rack_profile_id;
             }
         }
@@ -338,7 +347,7 @@ impl MachineCreator {
             .await
             {
                 tracing::warn!(
-                    %e,
+                    error = %e,
                     %host_machine_id,
                     "Failed to update slot_number and tray_index for machine"
                 );
@@ -428,8 +437,8 @@ impl MachineCreator {
                 .unwrap_or_default();
             tracing::warn!(
                 %machine_id,
-                ?existing_macs,
-                predicted_host_macs=?mac_addresses,
+                existing_mac_addresses = ?existing_macs,
+                predicted_host_mac_addresses = ?mac_addresses,
                 "Predicted host already exists, with different mac addresses from this one. Potentially multiple machines with same serial number?"
             );
             return Ok(None);
@@ -622,7 +631,7 @@ impl MachineCreator {
             )
             .await?;
             tracing::info!(
-                %declared_mac, %host_machine_id,
+                declared_mac_address = %declared_mac, %host_machine_id,
                 "Adopted declared integrated boot NIC as the DpuMode host's primary",
             );
             return Ok(());
@@ -662,7 +671,7 @@ impl MachineCreator {
         )
         .await?;
         tracing::info!(
-            %declared_mac, %host_machine_id,
+            declared_mac_address = %declared_mac, %host_machine_id,
             "Minted HostInband boot-NIC prediction for DpuMode host's declared integrated primary",
         );
         Ok(())
@@ -752,8 +761,9 @@ impl MachineCreator {
                 && interface.machine_id.is_none()
             {
                 tracing::info!(
-                    "Updating machine interface {} with machine id {dpu_machine_id}.",
-                    interface.id
+                    machine_interface_id = %interface.id,
+                    machine_id = %dpu_machine_id,
+                    "Associating machine interface with machine"
                 );
                 db::machine_interface::associate_interface_with_machine(
                     &interface.id,
@@ -799,7 +809,7 @@ impl MachineCreator {
             .await
             {
                 Ok(machine) => {
-                    tracing::info!("Created DPU machine with id: {}", dpu_machine_id);
+                    tracing::info!(machine_id = %dpu_machine_id, "Created DPU machine");
                     Ok(Some(machine))
                 }
                 Err(e) => {

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -703,7 +703,7 @@ async fn fetch_manager(client: &dyn Redfish) -> Result<Manager, RedfishError> {
     {
         tracing::warn!(
             manager_id = %manager.id,
-            eth0_mac = %mac,
+            eth0_mac_address = %mac,
             "manager eth0 MAC is locally-administered (transient pre-sync data?)",
         );
     }
@@ -721,7 +721,8 @@ async fn fetch_system(client: &dyn Redfish) -> Result<ComputerSystem, EndpointEx
         Ok(interfaces) => Ok(interfaces),
         Err(e) if is_dpu => {
             tracing::warn!(
-                "Error getting system ethernet interfaces.  The error will be ignored. ({e})"
+                error = %e,
+                "Failed to get system Ethernet interfaces; ignoring the error"
             );
             Ok(Vec::default())
         }
@@ -748,14 +749,19 @@ async fn fetch_system(client: &dyn Redfish) -> Result<ComputerSystem, EndpointEx
             Ok(base_mac) => base_mac.and_then(|v| {
                 v.parse()
                     .inspect_err(|err| {
-                        tracing::warn!("Failed to parse BaseMAC: {err} (mac: {v})");
+                        tracing::warn!(
+                            error = %err,
+                            mac_address = %v,
+                            "Failed to parse BaseMAC"
+                        );
                     })
                     .ok()
             }),
             Err(error) => {
                 tracing::info!(
-                    "Could not use new method to retreive base mac address for DPU (serial number {:#?}): {error}",
-                    system.serial_number
+                    serial_number = ?system.serial_number,
+                    %error,
+                    "Could not use new method to retrieve base MAC address for DPU"
                 );
                 None
             }
@@ -878,8 +884,10 @@ async fn fetch_ethernet_interfaces(
                         // ignore this error and create the interface with an empty mac address
                         // in the exploration report
                         tracing::debug!(
-                            "could not parse MAC address for a disabled interface {iface_id} (link_status: {:#?}): {e}",
-                            iface.link_status
+                            interface_id = %iface_id,
+                            link_status = ?iface.link_status,
+                            error = %e,
+                            "could not parse MAC address for a disabled interface"
                         );
                         Ok(None)
                     } else {

--- a/crates/site-explorer/src/switch_creator.rs
+++ b/crates/site-explorer/src/switch_creator.rs
@@ -52,8 +52,8 @@ impl SwitchCreator {
                 Some(expected_switch) => expected_switch,
                 None => {
                     tracing::info!(
-                        bmc_ip = %explored_managed_switch.bmc_ip,
-                        "No expected switch found for explored switch endpoint"
+                        bmc_ip_address = %explored_managed_switch.bmc_ip,
+                        "No expected switch found"
                     );
                     continue;
                 }
@@ -78,8 +78,8 @@ impl SwitchCreator {
                 Err(error) => {
                     tracing::error!(
                         %error,
-                        "Failed to create managed switch {:#?}",
-                        explored_managed_switch.bmc_ip
+                        bmc_ip_address = %explored_managed_switch.bmc_ip,
+                        "Failed to create managed switch"
                     );
                 }
             }
@@ -138,7 +138,7 @@ impl SwitchCreator {
             db::switch::find_by_bmc_mac_address(txn, expected_switch.bmc_mac_address).await?
         {
             tracing::warn!(
-                bmc_mac = %expected_switch.bmc_mac_address,
+                bmc_mac_address = %expected_switch.bmc_mac_address,
                 existing_switch_id = %existing.id,
                 "Switch already exists for this BMC MAC; skipping discovery",
             );
@@ -163,8 +163,7 @@ impl SwitchCreator {
         if let Some(_existing_switch) = existing_switch {
             tracing::warn!(
                 %switch_id,
-                "Switch already exists, skipping. {} for switch id",
-                switch_id.to_string()
+                "Switch already exists, skipping."
             );
             return Ok(None);
         }

--- a/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
+++ b/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
@@ -149,7 +149,7 @@ impl EndpointExplorer for MockEndpointExplorer {
         _last_error: Option<&EndpointExplorationError>,
         _boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
-        tracing::info!("Endpoint {bmc_ip_address} is getting explored");
+        tracing::info!(%bmc_ip_address, "Endpoint is getting explored");
         self.explore_endpoint_calls
             .lock()
             .unwrap()

--- a/crates/site-explorer/tests/integration/power_shelf.rs
+++ b/crates/site-explorer/tests/integration/power_shelf.rs
@@ -111,9 +111,9 @@ async fn test_site_explorer_power_shelf_discovery(
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
     // Create expected power shelf entry in the database
@@ -221,9 +221,9 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
     let power_shelf = env.new_power_shelf("B8:3F:D2:90:97:B0", "192.0.1.180", "PS123456789");
 
     tracing::info!(
-        "Static ip {} assigned to power shelf mac {}",
-        power_shelf.ip,
-        power_shelf.bmc_mac_address,
+        ip_address = %power_shelf.ip,
+        mac_address = %power_shelf.bmc_mac_address,
+        "Static ip assigned to power shelf mac",
     );
     // Create expected power shelf via the RPC handler, which
     // pre-allocates a machine interface with the static IP.
@@ -471,9 +471,9 @@ async fn test_site_explorer_power_shelf_with_expected_config(
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
     // Create an expected power shelf entry
@@ -580,9 +580,9 @@ async fn test_site_explorer_power_shelf_creation_limit(
             .await?
             .into_inner();
         tracing::info!(
-            "DHCP with mac {} assigned ip {}",
-            power_shelf.bmc_mac_address,
-            response.address
+            mac_address = %power_shelf.bmc_mac_address,
+            ip_address = %response.address,
+            "DHCP assigned ip"
         );
         power_shelf.ip = response.address.clone();
     }
@@ -690,9 +690,9 @@ async fn test_site_explorer_power_shelf_disabled(
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
 
@@ -794,9 +794,9 @@ async fn test_site_explorer_power_shelf_error_handling(
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
     // Create expected power shelf entry in the database
@@ -892,9 +892,9 @@ async fn test_site_explorer_creates_power_shelf(
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
     // Create expected power shelf entry in the database
@@ -1065,9 +1065,9 @@ async fn test_power_shelf_state_history(pool: PgPool) -> Result<(), Box<dyn std:
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
     // Create expected power shelf entry in the database
@@ -1519,9 +1519,9 @@ async fn test_power_shelf_state_history_error_handling(
         .await?
         .into_inner();
     tracing::info!(
-        "DHCP with mac {} assigned ip {}",
-        power_shelf.bmc_mac_address,
-        response.address
+        mac_address = %power_shelf.bmc_mac_address,
+        ip_address = %response.address,
+        "DHCP assigned ip"
     );
     power_shelf.ip = response.address.clone();
     // Create expected power shelf entry in the database

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -79,9 +79,9 @@ impl DiscoverDhcp for FakeMachine {
             .await?
             .into_inner();
         tracing::info!(
-            "DHCP with mac {} assigned ip {}",
-            self.mac,
-            response.address
+            mac_address = %self.mac,
+            ip_address = %response.address,
+            "DHCP assigned ip"
         );
         self.ip = response.address;
         Ok(())

--- a/crates/site-explorer/tests/integration/switch.rs
+++ b/crates/site-explorer/tests/integration/switch.rs
@@ -107,7 +107,11 @@ async fn test_site_explorer_switch_discovery(
         )
         .await?
         .into_inner();
-    tracing::info!("DHCP with mac {} assigned ip {}", bmc_mac, response.address);
+    tracing::info!(
+        mac_address = %bmc_mac,
+        ip_address = %response.address,
+        "DHCP assigned ip"
+    );
     let switch_ip = response.address.clone();
 
     let mut txn = env.pool.begin().await?;

--- a/crates/spdm-controller/src/handler.rs
+++ b/crates/spdm-controller/src/handler.rs
@@ -118,7 +118,10 @@ impl StateHandler for SpdmAttestationStateHandler {
                     Ok(x) => x.version,
                     Err(libredfish::RedfishError::NotSupported(msg)) => {
                         tracing::info!(
-                            "Device attestation is not supported for device (firmware version not available): {device_id}, machine: {machine_id}, msg: {msg}"
+                            device_id = %device_id,
+                            machine_id = %machine_id,
+                            reason = %msg,
+                            "device attestation is not supported because firmware version is unavailable"
                         );
                         return Ok(StateHandlerOutcome::transition(
                             SpdmAttestationState::Passed,
@@ -238,9 +241,9 @@ impl StateHandler for SpdmAttestationStateHandler {
                     task_state => {
                         let err = task.messages.iter().map(|t| t.message.clone()).join("\n");
                         tracing::error!(
-                            "Error while triggering measurement: {}: State: {:?}",
-                            err,
-                            task_state
+                            error = %err,
+                            task_state = ?task_state,
+                            "measurement collection task entered an unexpected state"
                         );
                         if *retry_count > 4 {
                             Ok(StateHandlerOutcome::transition(

--- a/crates/ssh-console-mock-api-server/src/lib.rs
+++ b/crates/ssh-console-mock-api-server/src/lib.rs
@@ -93,7 +93,7 @@ impl MockApiServer {
         rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .inspect_err(|crypto_provider| {
-                tracing::warn!("Crypto provider already configured: {crypto_provider:?}")
+                tracing::warn!(?crypto_provider, "Crypto provider already configured")
             })
             .ok(); // if something else is already default, ignore.
 

--- a/crates/ssh-console/src/bmc/client.rs
+++ b/crates/ssh-console/src/bmc/client.rs
@@ -214,8 +214,11 @@ impl BmcClient {
                     tracing::error!(
                         %error,
                         %machine_id,
-                        "error spawning BMC connection, will retry in {}s",
-                        next_retry.checked_duration_since(Instant::now()).unwrap_or_default().as_secs()
+                        retry_delay_seconds = next_retry
+                            .checked_duration_since(Instant::now())
+                            .unwrap_or_default()
+                            .as_secs(),
+                        "error spawning BMC connection, will retry"
                     );
                     continue 'retry;
                 }
@@ -273,7 +276,11 @@ impl BmcClient {
                         if recovered_conflicting_sol_session {
                             tracing::debug!(%machine_id, "retrying immediately after IPMI SOL session recovery");
                         } else {
-                            tracing::debug!(%machine_id, "last connection lasted {}s, resetting backoff to 0s", connection_time.as_secs());
+                            tracing::debug!(
+                                %machine_id,
+                                connection_duration_seconds = connection_time.as_secs_f64(),
+                                "last connection succeeded long enough; resetting backoff"
+                            );
                         }
                         next_retry = Instant::now();
                     }
@@ -283,9 +290,12 @@ impl BmcClient {
                     tracing::warn!(
                         %machine_id,
                         error = error_string,
-                        ?connection_time,
-                        "connection to BMC closed, will retry in {}s",
-                        next_retry.checked_duration_since(Instant::now()).unwrap_or_default().as_secs(),
+                        connection_duration_seconds = connection_time.as_secs_f64(),
+                        retry_delay_seconds = next_retry
+                            .checked_duration_since(Instant::now())
+                            .unwrap_or_default()
+                            .as_secs(),
+                        "connection to BMC closed, will retry",
                     );
                 }
             }
@@ -346,7 +356,11 @@ async fn wait_until_host_is_up(
 
         if do_log {
             do_log = false;
-            tracing::info!(%machine_id, %addr, "BMC is not listening on {addr}. Will wait until the port is open before attempting to connect.")
+            tracing::info!(
+                %machine_id,
+                bmc_address = %addr,
+                "BMC is not listening; waiting for the port to open before connecting"
+            )
         }
     }
 }
@@ -490,9 +504,9 @@ fn next_retry_backoff(config: &Config, prev: Duration) -> Duration {
         Duration::from_secs_f64(rand::random_range(prev.as_secs_f64()..upper))
     };
     tracing::debug!(
-        "next_retry_backoff, increasing from {}ms to {}ms",
-        prev.as_millis(),
-        duration.as_millis()
+        previous_backoff_milliseconds = prev.as_millis(),
+        next_backoff_milliseconds = duration.as_millis(),
+        "increasing connection retry backoff"
     );
     duration
 }

--- a/crates/ssh-console/src/bmc/connection.rs
+++ b/crates/ssh-console/src/bmc/connection.rs
@@ -120,7 +120,10 @@ pub async fn lookup(
             })),
         };
         tracing::info!(
-            "Overriding bmc connection to {machine_or_instance_id} with {connection_details:?}"
+            %machine_or_instance_id,
+            bmc_address = %connection_details.addr(),
+            bmc_machine_id = %connection_details.machine_id(),
+            "Overriding BMC connection"
         );
         return Ok(connection_details);
     }
@@ -203,7 +206,9 @@ pub async fn lookup(
 
     let addr = if let Some(override_ssh_addr) = config.override_bmc_ssh_addr(port).await? {
         tracing::info!(
-            "Overriding bmc connection to {ip} with {override_ssh_addr} per configuration"
+            bmc_ip_address = %ip,
+            override_bmc_ssh_address = %override_ssh_addr,
+            "Overriding BMC connection per configuration"
         );
         override_ssh_addr
     } else {

--- a/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
@@ -663,7 +663,11 @@ impl IpmitoolMessageProxy {
                 return Ok(());
             }
             other => {
-                tracing::debug!(%machine_id, "Not handling unknown SSH frontend message in ipmitool: {other:?}");
+                tracing::debug!(
+                    %machine_id,
+                    ?other,
+                    "Not handling unknown SSH frontend message in ipmitool"
+                );
             }
         };
         Ok(())

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -104,7 +104,11 @@ pub async fn spawn(
                                 && ringbuf_contains(&output_ringbuf, bmc_prompt) {
                                     let mut ringbuf_str = String::new();
                                     output_ringbuf.read_to_string(&mut ringbuf_str).ok();
-                                    tracing::warn!(%machine_id, "BMC dropped to system prompt, exiting. output: {ringbuf_str:?}");
+                                    tracing::warn!(
+                                        %machine_id,
+                                        output = ?ringbuf_str,
+                                        "BMC dropped to system prompt, exiting"
+                                    );
                                     break;
                                 }
                         }
@@ -262,7 +266,7 @@ async fn make_authenticated_client(
         .map_err(|error| ClientCreationError::Authentication { addr: *addr, error })?
     {
         AuthResult::Success => {
-            tracing::warn!(%machine_id, %addr, %user, "auth_none succeeded, it shouldn't have!");
+            tracing::warn!(%machine_id, bmc_address = %addr, %user, "auth_none succeeded, it shouldn't have!");
             return Ok(client);
         }
         AuthResult::Failure {
@@ -302,13 +306,13 @@ async fn make_authenticated_client(
                     })? {
                     AuthResult::Success => {
                         tracing::debug!(
-                            %machine_id, %user, %addr,
+                            %machine_id, %user, bmc_address = %addr,
                             "PublicKey authentication succeeded"
                         );
                         return Ok(client);
                     }
                     AuthResult::Failure { .. } => {
-                        tracing::warn!(%machine_id, %user, %addr, "PublicKey authentication failed")
+                        tracing::warn!(%machine_id, %user, bmc_address = %addr, "PublicKey authentication failed")
                     }
                 }
             }
@@ -342,14 +346,14 @@ async fn make_authenticated_client(
                         }
                         KeyboardInteractiveAuthResponse::Success => {
                             tracing::debug!(
-                                %machine_id, %user, %addr,
+                                %machine_id, %user, bmc_address = %addr,
                                 "KeyboardInteractive authentication succeeded"
                             );
                             return Ok(client);
                         }
                         KeyboardInteractiveAuthResponse::Failure { .. } => {
                             tracing::warn!(
-                                %machine_id, %user, %addr,
+                                %machine_id, %user, bmc_address = %addr,
                                 "KeyboardInteractive authentication failed"
                             );
                             break;
@@ -369,18 +373,18 @@ async fn make_authenticated_client(
                     })? {
                     AuthResult::Success => {
                         tracing::debug!(
-                            %machine_id, %user, %addr,
+                            %machine_id, %user, bmc_address = %addr,
                             "Password authentication succeeded"
                         );
                         return Ok(client);
                     }
                     AuthResult::Failure { .. } => {
-                        tracing::warn!(%machine_id, %user, %addr, "Password authentication failed");
+                        tracing::warn!(%machine_id, %user, bmc_address = %addr, "Password authentication failed");
                     }
                 }
             }
             other => {
-                tracing::debug!(%machine_id, "Ignoring unsupported auth method {other:?}")
+                tracing::debug!(%machine_id, ?other, "Ignoring unsupported auth method")
             }
         }
     }
@@ -565,7 +569,8 @@ async fn trigger_and_await_sol_console(
                     msg => {
                         tracing::debug!(
                             %machine_id,
-                            "message from BMC while activating serial prompt: {msg:?}"
+                            bmc_message = ?msg,
+                            "message from BMC while activating serial prompt"
                         )
                     }
                 }

--- a/crates/ssh-console/src/bmc/message_proxy.rs
+++ b/crates/ssh-console/src/bmc/message_proxy.rs
@@ -44,7 +44,7 @@ pub fn spawn(
                             Ok(()) => {}
                             Err(error) => {
                                 tracing::debug!(
-                                    peer_addr,
+                                    peer_address = peer_addr,
                                     %error,
                                     "error sending message to frontend, likely disconnected"
                                 );
@@ -53,7 +53,10 @@ pub fn spawn(
                         }
                     }
                     Err(_) => {
-                        tracing::debug!(peer_addr, "client channel closed when writing message from BMC");
+                        tracing::debug!(
+                            peer_address = peer_addr,
+                            "client channel closed when writing message from BMC"
+                        );
                         break;
                     }
                 },
@@ -248,7 +251,7 @@ where
                 })?;
         }
         _ => {
-            tracing::debug!("Ignoring unknown channel message {channel_msg:?}");
+            tracing::debug!(?channel_msg, "Ignoring unknown channel message");
         }
     }
 

--- a/crates/ssh-console/src/config.rs
+++ b/crates/ssh-console/src/config.rs
@@ -392,7 +392,10 @@ role_separator = {cert_authorization_keyid_format_role_separator:?}
 
     pub fn make_forge_api_client(&self) -> ForgeApiClient {
         let carbide_uri_string = self.carbide_uri.to_string();
-        tracing::info!("carbide_uri_string: {}", carbide_uri_string);
+        tracing::info!(
+            carbide_uri = carbide_uri_string.as_str(),
+            "Configured Carbide API URI"
+        );
 
         // TODO: The API's for ClientCert/ForgeClientConfig/etc really ought to take PathBufs, not Strings.
         let client_cert = ClientCert {

--- a/crates/ssh-console/src/console_logger.rs
+++ b/crates/ssh-console/src/console_logger.rs
@@ -145,7 +145,11 @@ impl ConsoleLogger {
                     }
                     Err(broadcast::error::RecvError::Lagged(count)) => {
                         let msg = format!("console logger is lagged by {count} messages (typically bytes). Data may be missing from log");
-                        tracing::warn!(machine_id=%self.machine_id,"{msg}");
+                        tracing::warn!(
+                            machine_id = %self.machine_id,
+                            lagged_message_count = count,
+                            "console logger lagged; data may be missing from log"
+                        );
                         log_file.write_all(format!("\n--- {msg} ---\n").as_bytes()).await.ok();
                     }
                 },
@@ -197,7 +201,7 @@ impl RotatableLogFile {
                     self.file = Self::open_log_file(&self.path).await?;
                 }
                 // If we couldn't rotate, just keep writing to this file.
-                Err(error) => tracing::error!("error rotating logs: {error}"),
+                Err(error) => tracing::error!(%error, "error rotating logs"),
             }
         }
 
@@ -209,7 +213,7 @@ impl RotatableLogFile {
     }
 
     async fn rotate_logs(&mut self) -> Result<(), LogRotationError> {
-        tracing::info!("rotating logs for {}", self.path.display());
+        tracing::info!(path = %self.path.display(), "rotating logs");
         let log_path_as_str = self
             .path
             .to_str()
@@ -231,12 +235,12 @@ impl RotatableLogFile {
             };
 
             if !src_path.exists() {
-                tracing::debug!("no log file at {}", src_path.display());
+                tracing::debug!(path = %src_path.display(), "no log file found");
                 continue;
             }
 
             let dst_path = if dst_num >= self.max_rotated_files {
-                tracing::debug!("deleting oldest log file at {}", src_path.display());
+                tracing::debug!(path = %src_path.display(), "deleting oldest log file");
                 // Oldest log, more than max allowed rotated file count, delete it and continue
                 tokio::fs::remove_file(src_path.as_path())
                     .await
@@ -251,7 +255,11 @@ impl RotatableLogFile {
                     .expect("BUG: known-good log path didn't parse")
             };
 
-            tracing::debug!("renaming {} to {}", src_path.display(), dst_path.display());
+            tracing::debug!(
+                source_path = %src_path.display(),
+                destination_path = %dst_path.display(),
+                "renaming log file"
+            );
 
             tokio::fs::rename(src_path.as_path(), dst_path.as_path())
                 .await

--- a/crates/ssh-console/src/frontend.rs
+++ b/crates/ssh-console/src/frontend.rs
@@ -130,7 +130,7 @@ impl Handler {
             return Some(state);
         }
 
-        tracing::error!(peer_addr = self.peer_addr, "Request on unknown channel");
+        tracing::error!(peer_address = self.peer_addr, "Request on unknown channel");
         session.channel_failure(channel_id).ok();
         session
             .data(channel_id, "ssh-console error: Unknown channel\n")
@@ -142,7 +142,7 @@ impl Handler {
 
 impl Drop for Handler {
     fn drop(&mut self) {
-        tracing::info!(peer_addr = self.peer_addr, "end frontend connection");
+        tracing::info!(peer_address = self.peer_addr, "end frontend connection");
         // All auth failure paths set self.last_auth_failure, but auth can still succeed (they may
         // be trying multiple pubkeys, etc.) So if authenticated_user is None but last_auth_failure
         // is Some, bump the metrics.
@@ -152,14 +152,14 @@ impl Drop for Handler {
             let machine = last_auth_failure.machine_string();
             if let Some(user) = &last_auth_failure.detected_user() {
                 tracing::warn!(
-                    peer_addr = self.peer_addr,
+                    peer_address = self.peer_addr,
                     %user,
                     %machine,
                     "authentication failed",
                 );
             } else {
                 tracing::warn!(
-                    peer_addr = self.peer_addr,
+                    peer_address = self.peer_addr,
                     %machine,
                     "authentication failed",
                 );
@@ -180,7 +180,7 @@ impl russh::server::Handler for Handler {
         session: &mut Session,
     ) -> Result<bool, Self::Error> {
         use HandlerError::*;
-        tracing::trace!(peer_addr = self.peer_addr, "channel_open_session");
+        tracing::trace!(peer_address = self.peer_addr, "channel_open_session");
         let Some(machine) = &self.authenticated_machine_string else {
             return Err(MissingAuthenticatedUser {
                 method: "channel_open_session",
@@ -224,7 +224,7 @@ impl russh::server::Handler for Handler {
     }
 
     async fn auth_none(&mut self, _user: &str) -> Result<Auth, Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "auth_none");
+        tracing::trace!(peer_address = self.peer_addr, "auth_none");
         Ok(Auth::Reject {
             // Note: openssh_certificate auth is just another kind of PublicKey auth, this should
             // imply either one.
@@ -238,7 +238,7 @@ impl russh::server::Handler for Handler {
         machine_string: &str,
         certificate: &Certificate,
     ) -> Result<Auth, Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "auth_openssh_certificate");
+        tracing::trace!(peer_address = self.peer_addr, "auth_openssh_certificate");
         let Some(admin_certificate_role) = self.config.admin_certificate_role.as_ref() else {
             tracing::debug!("skipping ssh certificate auth, no admin role is configured");
             return Ok(Auth::Reject {
@@ -257,7 +257,7 @@ impl russh::server::Handler for Handler {
 
         if !is_trusted {
             tracing::warn!(
-                peer_addr = self.peer_addr,
+                peer_address = self.peer_addr,
                 machine = machine_string,
                 "openssh certificate CA certificate not trusted, rejecting authentication"
             );
@@ -277,8 +277,10 @@ impl russh::server::Handler for Handler {
             &self.config.openssh_certificate_authorization,
         ) {
             tracing::warn!(
-                peer_addr = self.peer_addr,
-                "certificate auth failed for user {machine_string}, not in role {admin_certificate_role}",
+                peer_address = self.peer_addr,
+                machine = machine_string,
+                role = admin_certificate_role.as_str(),
+                "certificate auth failed because the required role is missing",
             );
             self.last_auth_failure = Some(AuthFailureReason::Certificate {
                 user,
@@ -292,13 +294,18 @@ impl russh::server::Handler for Handler {
 
         if let Some(user) = &user {
             tracing::info!(
-                peer_addr = self.peer_addr,
-                "certificate auth succeeded for user {user} to machine {machine_string}, in role {admin_certificate_role}"
+                peer_address = self.peer_addr,
+                user = user.as_str(),
+                machine = machine_string,
+                role = admin_certificate_role.as_str(),
+                "certificate auth succeeded"
             );
         } else {
             tracing::info!(
-                peer_addr = self.peer_addr,
-                "certificate auth succeeded to machine {machine_string}, in role {admin_certificate_role}"
+                peer_address = self.peer_addr,
+                machine = machine_string,
+                role = admin_certificate_role.as_str(),
+                "certificate auth succeeded"
             );
         }
         self.authenticated_machine_string = Some(machine_string.to_owned());
@@ -311,7 +318,7 @@ impl russh::server::Handler for Handler {
         public_key: &PublicKey,
     ) -> Result<Auth, Self::Error> {
         use HandlerError::*;
-        tracing::trace!(peer_addr = self.peer_addr, "auth_publickey");
+        tracing::trace!(peer_address = self.peer_addr, "auth_publickey");
 
         // Authentication flow:
         // 1. If authorized_keys_path is set, check against file first
@@ -334,16 +341,16 @@ impl russh::server::Handler for Handler {
                 })?
         } else {
             tracing::debug!(
-                peer_addr = self.peer_addr,
-                machine_string,
-                "rejecting public key for user {machine_string}"
+                peer_address = self.peer_addr,
+                ssh_username = machine_string,
+                "rejecting public key for user"
             );
             false
         };
 
         let success = if !success && self.config.insecure {
             tracing::info!(
-                peer_addr = self.peer_addr,
+                peer_address = self.peer_addr,
                 "Overriding public-key rejection because we are in insecure (testing) mode"
             );
             true
@@ -372,7 +379,7 @@ impl russh::server::Handler for Handler {
         data: &[u8],
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "data");
+        tracing::trace!(peer_address = self.peer_addr, "data");
         if let Some(client_state) = self.get_client_state_or_report_error(session, channel) {
             client_state
                 .bmc_connection
@@ -394,7 +401,7 @@ impl russh::server::Handler for Handler {
         data: &[u8],
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "extended_data");
+        tracing::trace!(peer_address = self.peer_addr, "extended_data");
         if let Some(client_state) = self.get_client_state_or_report_error(session, channel) {
             client_state
                 .bmc_connection
@@ -422,7 +429,7 @@ impl russh::server::Handler for Handler {
         _modes: &[(Pty, u32)],
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "pty_request");
+        tracing::trace!(peer_address = self.peer_addr, "pty_request");
         session.channel_success(channel)?;
         Ok(())
     }
@@ -432,7 +439,7 @@ impl russh::server::Handler for Handler {
         channel_id: ChannelId,
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "shell_request");
+        tracing::trace!(peer_address = self.peer_addr, "shell_request");
         let peer_addr = self.peer_addr.clone();
         let Some(client_state) = self.get_client_state_or_report_error(session, channel_id) else {
             return Ok(());
@@ -444,7 +451,7 @@ impl russh::server::Handler for Handler {
         // (which makes sense.)
         let Some(channel) = client_state.client_channel.take() else {
             tracing::error!(
-                peer_addr = self.peer_addr,
+                peer_address = self.peer_addr,
                 "Channel unavailable, cannot service shell request"
             );
             session.channel_failure(channel_id).ok();
@@ -514,7 +521,7 @@ impl russh::server::Handler for Handler {
         data: &[u8],
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "exec_request");
+        tracing::trace!(peer_address = self.peer_addr, "exec_request");
         let Some(PerClientState {
             client_channel,
             bmc_connection,
@@ -526,7 +533,7 @@ impl russh::server::Handler for Handler {
         // Drop the client channel when we're done, so that it properly disconnects.
         let Some(channel) = client_channel.take() else {
             tracing::error!(
-                peer_addr = self.peer_addr,
+                peer_address = self.peer_addr,
                 "Channel unavailable, cannot service exec request"
             );
             session.channel_failure(channel_id).ok();
@@ -590,7 +597,7 @@ impl russh::server::Handler for Handler {
         pix_height: u32,
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        tracing::trace!(peer_addr = self.peer_addr, "window_change_request");
+        tracing::trace!(peer_address = self.peer_addr, "window_change_request");
         if let Some(client_state) = self.get_client_state_or_report_error(session, channel) {
             client_state
                 .bmc_connection
@@ -760,7 +767,8 @@ async fn pubkey_auth_tenant(
             Code::InvalidArgument => {
                 // InvalidArgument can happen if the user is not a valid instance ID.
                 tracing::warn!(
-                    "InvalidArgument when calling carbide-api to validate pubkey for {user}"
+                    user,
+                    "InvalidArgument when validating public key via carbide-api"
                 );
                 false
             }

--- a/crates/ssh-console/src/metrics.rs
+++ b/crates/ssh-console/src/metrics.rs
@@ -43,7 +43,10 @@ pub async fn spawn(
         .await
         .map_err(SpawnError::Listen)?;
 
-    tracing::info!("metrics listening on {}", config.metrics_address);
+    tracing::info!(
+        metrics_address = %config.metrics_address,
+        "metrics service listening"
+    );
 
     let join_handle = tokio::spawn(async move {
         loop {
@@ -55,7 +58,7 @@ pub async fn spawn(
 
                 res = listener.accept() => match res {
                     Ok((stream, addr)) => {
-                        tracing::info!("got metrics connection from {addr}");
+                        tracing::info!(peer_address = %addr, "accepted metrics connection");
                         tokio::task::spawn({
                             let metrics_state = metrics_state.clone();
                             async move {

--- a/crates/ssh-console/src/ssh_cert_parsing.rs
+++ b/crates/ssh-console/src/ssh_cert_parsing.rs
@@ -80,9 +80,8 @@ fn key_id_contains_role(key_id: &str, role: &str, key_id_format: &KeyIdFormat) -
         })
     else {
         tracing::warn!(
-            "Could not find `{}=` substring in key_id: {:?}",
-            key_id_format.role_field,
-            key_id,
+            role_field = key_id_format.role_field.as_str(),
+            "Could not find role field in key ID"
         );
         return false;
     };
@@ -108,9 +107,8 @@ fn get_user_from_key_id<'a>(key_id: &'a str, key_id_format: &KeyIdFormat) -> Opt
         })
     else {
         tracing::warn!(
-            "Could not find `{}=` substring in key_id: {:?}",
-            key_id_format.user_field,
-            key_id
+            user_field = key_id_format.user_field.as_str(),
+            "Could not find user field in key ID"
         );
         return None;
     };

--- a/crates/ssh-console/src/ssh_server.rs
+++ b/crates/ssh-console/src/ssh_server.rs
@@ -75,7 +75,7 @@ pub async fn spawn(
             addr: listen_address,
             error,
         })?;
-    tracing::info!("listening on {}", listen_address);
+    tracing::info!(%listen_address, "SSH server listening");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join_handle = tokio::spawn(server.run(listener, shutdown_rx));

--- a/crates/ssh-console/tests/util/ipmi_sim.rs
+++ b/crates/ssh-console/tests/util/ipmi_sim.rs
@@ -212,7 +212,9 @@ pub async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
     };
 
     tracing::debug!(
-        "ipmi_sim will listen on port {ipmi_sim_lanplus_port} and {ipmi_sim_serial_port}"
+        ipmi_sim_lanplus_port,
+        ipmi_sim_serial_port,
+        "ipmi_sim will listen"
     );
 
     let mock_serial_console_port = mock_serial_console.port;
@@ -290,7 +292,7 @@ sol "telnet:127.0.0.1:{mock_serial_console_port}" 115200
 pub async fn run_mock_serial_console(prompt: String) -> eyre::Result<MockSerialConsoleHandle> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let port = listener.local_addr()?.port();
-    tracing::debug!("mock serial console: listening on port {port}");
+    tracing::debug!(port, "mock serial console listening");
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
     tokio::spawn(async move {
         loop {
@@ -298,7 +300,7 @@ pub async fn run_mock_serial_console(prompt: String) -> eyre::Result<MockSerialC
                 res = listener.accept() => {
                     match res {
                         Ok((tcp_stream, addr)) => {
-                            tracing::debug!("mock serial console: got connection from {addr}");
+                            tracing::debug!(peer_address = %addr, "mock serial console accepted connection");
                             tokio::spawn({
                                 let prompt = prompt.clone();
                                 async move {

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -192,7 +192,10 @@ pub async fn run_baseline_test_environment(
             .collect(),
     );
 
-    tracing::debug!("baseline test mock hosts: {mock_hosts:?}");
+    tracing::debug!(
+        mock_host_count = mock_hosts.len(),
+        "Configured baseline test mock hosts"
+    );
 
     let api_server_handle = ssh_console_mock_api_server::MockApiServer {
         mock_hosts: mock_hosts.clone(),

--- a/crates/state-controller/src/controller.rs
+++ b/crates/state-controller/src/controller.rs
@@ -127,7 +127,7 @@ impl<IO: StateControllerIO> StateController<IO> {
                 .run_single_iteration(std::time::Duration::MAX, allow_requeue)
                 .await
             {
-                tracing::error!(%err, "State processor iteration error");
+                tracing::error!(error = %err, "State processor iteration error");
             }
             if self.processor.in_flight.is_empty() {
                 break;

--- a/crates/state-controller/src/controller/periodic_enqueuer.rs
+++ b/crates/state-controller/src/controller/periodic_enqueuer.rs
@@ -144,7 +144,7 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
                 iteration_result.skipped_iteration = true;
             }
             Err(e) => {
-                tracing::error!(controller=IO::LOG_SPAN_CONTROLLER_NAME, err=?e, "PeriodicEnqueuer iteration failed");
+                tracing::error!(controller=IO::LOG_SPAN_CONTROLLER_NAME, error=?e, "PeriodicEnqueuer iteration failed");
                 controller_span.record("otel.status_code", "error");
                 // Writing this field will set the span status to error
                 // Therefore we only write it on errors
@@ -183,7 +183,11 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
             }
         };
 
-        tracing::trace!(iteration_data = ?locked_controller_iteration.iteration_data, "Starting iteration with ID ");
+        tracing::trace!(
+            iteration_id = locked_controller_iteration.iteration_data.id.0,
+            iteration_data = ?locked_controller_iteration.iteration_data,
+            "Starting controller iteration"
+        );
         iteration_metrics.iteration_id = Some(locked_controller_iteration.iteration_data.id);
 
         self.enqueue_objects(iteration_metrics).await?;

--- a/crates/state-controller/src/controller/processor.rs
+++ b/crates/state-controller/src/controller/processor.rs
@@ -160,7 +160,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
                     }
                 }
                 Err(err) => {
-                    tracing::error!(controller=IO::LOG_SPAN_CONTROLLER_NAME, %err, "State processor iteration error")
+                    tracing::error!(controller=IO::LOG_SPAN_CONTROLLER_NAME, error = %err, "State processor iteration error")
                 }
             }
 
@@ -325,15 +325,15 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
 
         tracing::info!(
             controller = IO::LOG_SPAN_CONTROLLER_NAME,
-            tasks_in_flight = self.in_flight.len(),
-            completed_tasks = stats.num_completed_tasks,
-            dispatched_tasks = stats.num_dispatched_tasks,
-            requeued_objects = stats.num_requeued_objects,
-            errored_tasks = stats.num_errored_tasks,
-            sql_queries = db_metrics_since_last_query.num_queries,
-            sql_total_rows_affected = db_metrics_since_last_query.total_rows_affected,
-            sql_total_rows_returned = db_metrics_since_last_query.total_rows_returned,
-            sql_total_query_duration_us =
+            in_flight_task_count = self.in_flight.len(),
+            completed_task_count = stats.num_completed_tasks,
+            dispatched_task_count = stats.num_dispatched_tasks,
+            requeued_object_count = stats.num_requeued_objects,
+            errored_task_count = stats.num_errored_tasks,
+            sql_query_count = db_metrics_since_last_query.num_queries,
+            sql_affected_row_count = db_metrics_since_last_query.total_rows_affected,
+            sql_returned_row_count = db_metrics_since_last_query.total_rows_returned,
+            sql_total_query_duration_microseconds =
                 db_metrics_since_last_query.total_query_duration.as_micros(),
             "state_processor",
         );
@@ -370,7 +370,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
                 }
             }
             _ = tokio::time::sleep(max_duration) => {
-                tracing::error!(in_flight=self.in_flight.len(), "Timed out waiting for state controller object handling tasks to complete")
+                tracing::error!(in_flight_task_count = self.in_flight.len(), "Timed out waiting for state controller object handling tasks to complete")
             }
         };
 
@@ -421,8 +421,8 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
                 Err(_) => {
                     tracing::error!(
                         controller = IO::LOG_SPAN_CONTROLLER_NAME,
-                        "Can not convert queued object ID \"{}\" to IO::ObjectID format",
-                        object.object_id
+                        object_id = object.object_id.as_str(),
+                        "Can not convert queued object ID to IO::ObjectID format"
                     );
                     None
                 }
@@ -483,6 +483,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
                     }) {
                         tracing::error!(
                             object_id = %e.0.object_id,
+                            error = %e,
                             "Can't send result back to StateProcessor"
                         );
                     }
@@ -685,7 +686,7 @@ async fn process_object<IO: StateControllerIO>(
             next_state = Some(next.clone());
 
             if *next == controller_state.value {
-                tracing::warn!(state=?next, %object_id, "Transition to current state");
+                tracing::warn!(next_state = ?next, %object_id, "Transition to current state");
             }
             let new_version = controller_state.version.increment();
             if io
@@ -779,7 +780,7 @@ async fn process_object<IO: StateControllerIO>(
         }),
     };
     if let Err(e) = result {
-        tracing::warn!(%object_id, state = ?metrics.common.initial_state, error = ?e, "State handler error");
+        tracing::warn!(%object_id, initial_state = ?metrics.common.initial_state, error = ?e, "State handler error");
         metrics.common.error = Some(e);
     }
 
@@ -899,5 +900,13 @@ fn emit_object_metrics_as_log<IO: StateControllerIO>(iteration_metrics: &Iterati
         serde_json::to_string(&states_above_sla).unwrap_or_else(|_| "{}".to_string());
     let error_types = serde_json::to_string(&error_types).unwrap_or_else(|_| "{}".to_string());
 
-    tracing::info!(name: "state_controller_object_metrics", controller = IO::LOG_SPAN_CONTROLLER_NAME, %total_objects, %states, %states_above_sla, %error_types);
+    tracing::info!(
+        name: "state_controller_object_metrics",
+        controller = IO::LOG_SPAN_CONTROLLER_NAME,
+        total_object_count = total_objects,
+        %states,
+        %states_above_sla,
+        %error_types,
+        "State controller object metrics"
+    );
 }

--- a/crates/switch-controller/src/certificate.rs
+++ b/crates/switch-controller/src/certificate.rs
@@ -61,8 +61,8 @@ pub async fn start_configure_switch_certificate(
         return Ok(match mode {
             ConfigureSwitchCertificateMode::BringUp => {
                 tracing::info!(
-                    "Switch {:?}: no rack association, skipping certificate configuration",
-                    switch_id
+                    switch_id = ?switch_id,
+                    "Switch: no rack association, skipping certificate configuration",
                 );
                 StartConfigureSwitchCertificateResult::EarlyTransition(
                     StateHandlerOutcome::transition(
@@ -88,8 +88,8 @@ pub async fn start_configure_switch_certificate(
         return Ok(match mode {
             ConfigureSwitchCertificateMode::BringUp => {
                 tracing::info!(
-                    "Switch {:?}: component manager is not configured, skipping certificate configuration",
-                    switch_id
+                    switch_id = ?switch_id,
+                    "Switch: component manager is not configured, skipping certificate configuration",
                 );
                 StartConfigureSwitchCertificateResult::EarlyTransition(
                     StateHandlerOutcome::transition(
@@ -155,8 +155,8 @@ pub async fn start_configure_switch_certificate(
     tracing::info!(
         %job_id,
         ?mode,
-        "Switch {:?}: started switch certificate configuration",
-        switch_id
+        switch_id = ?switch_id,
+        "Switch: started switch certificate configuration",
     );
 
     Ok(StartConfigureSwitchCertificateResult::JobStarted(job_id))

--- a/crates/switch-controller/src/configuring.rs
+++ b/crates/switch-controller/src/configuring.rs
@@ -70,9 +70,9 @@ async fn handle_rotate_os_password(
         ctx.services.credential_manager.get_credentials(&key).await
     {
         tracing::info!(
-            "Switch {:?}: NVOS admin credentials already exist in vault for BMC MAC {}",
-            switch_id,
-            bmc_mac_address
+            switch_id = ?switch_id,
+            bmc_mac_address = %bmc_mac_address,
+            "Switch: NVOS admin credentials already exist in vault",
         );
         return Ok(StateHandlerOutcome::transition(
             SwitchControllerState::FetchInfo,
@@ -139,20 +139,18 @@ async fn handle_rotate_os_password(
             }
         };
 
-        let (username, password) = match (
-            expected_switch.nvos_username,
-            expected_switch.nvos_password,
-        ) {
-            (Some(username), Some(password)) => (username, password),
-            _ => {
-                tracing::info!(
-                    "Switch {:?}: no NVOS credentials in vault or expected switch for BMC MAC {}, skipping",
-                    switch_id,
-                    bmc_mac_address
-                );
-                return Ok(outcome);
-            }
-        };
+        let (username, password) =
+            match (expected_switch.nvos_username, expected_switch.nvos_password) {
+                (Some(username), Some(password)) => (username, password),
+                _ => {
+                    tracing::info!(
+                        switch_id = ?switch_id,
+                        bmc_mac_address = %bmc_mac_address,
+                        "Switch: no NVOS credentials in vault or expected switch; skipping",
+                    );
+                    return Ok(outcome);
+                }
+            };
 
         let credentials = Credentials::UsernamePassword { username, password };
 
@@ -169,9 +167,9 @@ async fn handle_rotate_os_password(
             })?;
 
         tracing::info!(
-            "Switch {:?}: stored NVOS admin credentials from expected switch into vault for BMC MAC {}",
-            switch_id,
-            bmc_mac_address
+            switch_id = ?switch_id,
+            bmc_mac_address = %bmc_mac_address,
+            "Switch: stored NVOS admin credentials from expected switch into vault",
         );
 
         Ok(outcome)
@@ -228,8 +226,8 @@ async fn handle_configure_certificate_wait_for_complete(
         crate::certificate::ConfigureSwitchCertificatePollOutcome::Completed => {
             tracing::info!(
                 %job_id,
-                "Switch {:?}: switch certificate configuration completed",
-                switch_id
+                switch_id = ?switch_id,
+                "Switch: switch certificate configuration completed",
             );
             Ok(StateHandlerOutcome::transition(
                 SwitchControllerState::Configuring {

--- a/crates/switch-controller/src/created.rs
+++ b/crates/switch-controller/src/created.rs
@@ -31,8 +31,8 @@ pub async fn handle_created(
     _ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
     tracing::info!(
-        "Switch {:?} created, transitioning to Initializing",
-        switch_id
+        switch_id = ?switch_id,
+        "Switch created, transitioning to Initializing",
     );
     Ok(StateHandlerOutcome::transition(
         SwitchControllerState::Initializing {

--- a/crates/switch-controller/src/deleting.rs
+++ b/crates/switch-controller/src/deleting.rs
@@ -33,7 +33,10 @@ pub async fn handle_deleting(
     _state: &mut Switch,
     ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
-    tracing::info!("Deleting Switch {}", switch_id.to_string());
+    tracing::info!(
+        %switch_id,
+        "Deleting switch",
+    );
     let mut txn = ctx.services.db_pool.begin().await?;
     db_switch::final_delete(*switch_id, &mut txn).await?;
     Ok(StateHandlerOutcome::deleted().with_txn(txn))

--- a/crates/switch-controller/src/error_state.rs
+++ b/crates/switch-controller/src/error_state.rs
@@ -34,7 +34,10 @@ pub async fn handle_error(
     state: &mut Switch,
     _ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
-    tracing::info!("Switch is in error state {}", _switch_id.to_string());
+    tracing::info!(
+        switch_id = %_switch_id,
+        "Switch is in error state",
+    );
     if state.is_marked_as_deleted() {
         return Ok(StateHandlerOutcome::transition(
             SwitchControllerState::Deleting,

--- a/crates/switch-controller/src/fetch_info.rs
+++ b/crates/switch-controller/src/fetch_info.rs
@@ -67,7 +67,7 @@ pub async fn handle_fetch_info(
                         .await
                         {
                             tracing::warn!(
-                                %e,
+                                error = %e,
                                 %switch_id,
                                 "Failed to update slot_number and tray_index for switch"
                             );

--- a/crates/switch-controller/src/initializing.rs
+++ b/crates/switch-controller/src/initializing.rs
@@ -68,9 +68,9 @@ async fn handle_wait_for_os_machine_interface(
         Some(es) => es,
         None => {
             tracing::info!(
-                "Switch {:?}: no expected switch found for BMC MAC {}, waiting",
-                switch_id,
-                bmc_mac_address
+                switch_id = %switch_id,
+                bmc_mac_address = %bmc_mac_address,
+                "No expected switch found; transitioning to error",
             );
             return Ok(StateHandlerOutcome::transition(
                 SwitchControllerState::Error {
@@ -83,10 +83,10 @@ async fn handle_wait_for_os_machine_interface(
     let nvos_mac_addresses = &expected_switch.nvos_mac_addresses;
     if nvos_mac_addresses.is_empty() {
         tracing::warn!(
-            "Switch {:?}: no NVOS MAC addresses on expected switch for serial {}, BMC MAC {}",
-            switch_id,
-            bmc_mac_address,
-            expected_switch.bmc_mac_address
+            switch_id = %switch_id,
+            bmc_mac_address = %bmc_mac_address,
+            expected_bmc_mac_address = %expected_switch.bmc_mac_address,
+            "Switch has no NVOS MAC addresses on expected switch",
         );
         return Ok(StateHandlerOutcome::transition(
             SwitchControllerState::Error {
@@ -111,10 +111,10 @@ async fn handle_wait_for_os_machine_interface(
         if let Some(existing_switch_id) = interface.switch_id {
             if existing_switch_id != *switch_id {
                 tracing::warn!(
-                    "Switch {:?}: NVOS MAC {} already associated with switch {}",
-                    switch_id,
-                    mac_address,
-                    existing_switch_id
+                    switch_id = %switch_id,
+                    nvos_mac_address = %mac_address,
+                    existing_switch_id = %existing_switch_id,
+                    "Switch: NVOS MAC already associated with switch",
                 );
                 return Ok(StateHandlerOutcome::transition(
                     SwitchControllerState::Error {
@@ -136,10 +136,10 @@ async fn handle_wait_for_os_machine_interface(
         )
         .await?;
         tracing::info!(
-            "Switch {:?}: associated NVOS interface {} (MAC {})",
-            switch_id,
-            interface.id,
-            mac_address
+            switch_id = %switch_id,
+            machine_interface_id = %interface.id,
+            nvos_mac_address = %mac_address,
+            "Switch associated NVOS interface",
         );
         associated_count += 1;
     }
@@ -147,17 +147,17 @@ async fn handle_wait_for_os_machine_interface(
     txn.commit().await?;
 
     tracing::info!(
-        "Switch {:?}: associated {} NVOS interfaces for BMC MAC {}",
-        switch_id,
-        associated_count,
-        bmc_mac_address
+        switch_id = %switch_id,
+        associated_nvos_interface_count = associated_count,
+        bmc_mac_address = %bmc_mac_address,
+        "Switch associated NVOS interfaces",
     );
     if associated_count >= 1 {
         tracing::info!(
-            "Switch {:?}: at least one NVOS interface associated ({}/{}), transitioning to Configuring",
-            switch_id,
-            associated_count,
-            total
+            switch_id = %switch_id,
+            associated_nvos_interface_count = associated_count,
+            total_nvos_interface_count = total,
+            "Switch has at least one NVOS interface associated, transitioning to Configuring",
         );
         Ok(StateHandlerOutcome::transition(
             SwitchControllerState::Configuring {
@@ -168,10 +168,10 @@ async fn handle_wait_for_os_machine_interface(
         ))
     } else {
         tracing::info!(
-            "Switch {:?}: {}/{} NVOS interfaces associated, waiting",
-            switch_id,
-            associated_count,
-            total
+            switch_id = %switch_id,
+            associated_nvos_interface_count = associated_count,
+            total_nvos_interface_count = total,
+            "Switch has no NVOS interfaces associated, waiting",
         );
         Ok(StateHandlerOutcome::wait(format!(
             "{}/{} NVOS interfaces associated, waiting",

--- a/crates/switch-controller/src/ready.rs
+++ b/crates/switch-controller/src/ready.rs
@@ -67,8 +67,8 @@ pub async fn handle_ready(
         }
 
         tracing::warn!(
-            "unknown initiator for switch reprovisioning request: {}",
-            req.initiator
+            initiator = %req.initiator,
+            "Unknown initiator for switch reprovisioning request",
         );
         return Ok(StateHandlerOutcome::transition(
             SwitchControllerState::Error {

--- a/crates/switch-controller/src/validating.rs
+++ b/crates/switch-controller/src/validating.rs
@@ -32,7 +32,10 @@ pub async fn handle_validating(
     state: &mut Switch,
     _ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
-    tracing::info!("Validating Switch {:?}", switch_id);
+    tracing::info!(
+        switch_id = ?switch_id,
+        "Validating switch",
+    );
     let validating_state = match &state.controller_state.value {
         SwitchControllerState::Validating { validating_state } => validating_state,
         _ => unreachable!("handle_validating called with non-Validating state"),

--- a/crates/vpc-prefix-controller/src/handler.rs
+++ b/crates/vpc-prefix-controller/src/handler.rs
@@ -72,14 +72,14 @@ impl StateHandler for VpcPrefixStateHandler {
                     // New prefixes are immediately considered ready once persisted.
                     VpcPrefixControllerState::Ready
                 };
-                tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                tracing::info!(%vpc_prefix_id, next_state = ?new_state, "VPC Prefix state transition");
                 Ok(StateHandlerOutcome::transition(new_state))
             }
             VpcPrefixControllerState::Ready => {
                 if state.is_marked_as_deleted() {
                     // Start the drain window after the API marks the prefix deleted.
                     let new_state = self.drain_state();
-                    tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                    tracing::info!(%vpc_prefix_id, next_state = ?new_state, "VPC Prefix state transition");
                     Ok(StateHandlerOutcome::transition(new_state))
                 } else {
                     // Ready prefixes have no periodic work until deletion is requested.
@@ -103,14 +103,14 @@ impl StateHandler for VpcPrefixStateHandler {
                             vpc_prefix = %state.id,
                             "VPC Prefix still has network prefix references",
                         );
-                        tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                        tracing::info!(%vpc_prefix_id, next_state = ?new_state, "VPC Prefix state transition");
                         Ok(StateHandlerOutcome::transition(new_state).with_txn(txn))
                     } else if chrono::Utc::now() >= *delete_at {
                         // Move to the terminal database delete state after the drain deadline.
                         let new_state = VpcPrefixControllerState::Deleting {
                             deletion_state: VpcPrefixDeletionState::DBDelete,
                         };
-                        tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                        tracing::info!(%vpc_prefix_id, next_state = ?new_state, "VPC Prefix state transition");
                         Ok(StateHandlerOutcome::transition(new_state).with_txn(txn))
                     } else {
                         // The dependency graph is drained, but the grace deadline has not passed.


### PR DESCRIPTION
## Summary

Along with making tracing events consistently structured, this starts establishing a common set of field names wherever the values make that practical -- easier searches and docs now, and a useful step toward deriving log schemas later.

- Convert roughly 1,500 direct tracing events across more than 50 crates to stable messages with semantic structured fields.
- Standardize common keys such as `error`, `machine_id`, `bmc_ip_address`, and type-derived identifiers while keeping role names where they add real context.
- Keep event messages focused on the event itself rather than narrating attached fields such as IDs or addresses.
- Document the structured-logging convention and core field vocabulary in `STYLE_GUIDE.md`, including IDs, addresses, states, counts, quantities, field formatting, and narrow presentation-oriented exceptions.
- Preserve trace levels, intentional `Display`, `Debug`, custom formatting, CLI output, child-process streams, aligned or multiline displays, and logging fixtures where the rendered text is itself the payload.

## Verification

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Earlier sweep: tests across 24 affected libraries, all 1,442 API-core library tests, and a nine-library regression matrix.
- Final standard-key follow-up: all 25 DHCP-server tests passed plus a syntax-aware residual audit of tracing keys.
- Final API-core rerun: 1,360 tests passed; 85 DB-backed tests failed together after the local Postgres server terminated template-migration connections with SQLSTATE `57P01` and stopped responding. Five tests were ignored.
- Paired local CodeRabbit and independent Claude reviews, followed by a thread-aware audit of the remaining cloud-review comments and an independent post-fix sanity pass.
- Final feedback loop: all verified findings addressed, formatter/Clippy/Carbide gates rerun, and the last local CodeRabbit review completed with no findings.

This supports https://github.com/NVIDIA/infra-controller/issues/3476

Closes #3476
