### PR TITLE
fix(nvlink): use GPU platform chassis serial when nvlink_info is unset.

### DIFF
--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -340,6 +340,15 @@ impl HardwareInfo {
             .as_ref()
             .is_some_and(|dmi| dmi.sys_vendor == "NVIDIA" && dmi.product_name == "DGXH100")
     }
+
+    /// Chassis serial from the first GPU `platform_info`, when present and non-empty.
+    pub fn first_gpu_platform_chassis_serial(&self) -> Option<&str> {
+        self.gpus
+            .first()
+            .and_then(|gpu| gpu.platform_info.as_ref())
+            .map(|platform_info| platform_info.chassis_serial.as_str())
+            .filter(|serial| !serial.trim().is_empty())
+    }
 }
 
 /// Substrings matched against GPU `name` or DMI `product_name` to identify MNNVL-capable hardware.
@@ -952,6 +961,18 @@ mod tests {
             "no dmi data is unknown" {
                 HardwareInfo::default() => bmc_vendor::BMCVendor::Unknown,
             }
+        );
+    }
+
+    #[test]
+    fn first_gpu_platform_chassis_serial_reads_first_gpu() {
+        let mut info = HardwareInfo::default();
+        assert_eq!(info.first_gpu_platform_chassis_serial(), None);
+
+        info.gpus.push(gpu_with_platform_info("NVIDIA GB200"));
+        assert_eq!(
+            info.first_gpu_platform_chassis_serial(),
+            Some("chassis-1")
         );
     }
 

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -965,18 +965,53 @@ mod tests {
     }
 
     #[test]
-    fn first_gpu_platform_chassis_serial_reads_first_gpu() {
-        let mut info = HardwareInfo::default();
-        assert_eq!(info.first_gpu_platform_chassis_serial(), None);
+    fn first_gpu_platform_chassis_serial() {
+        value_scenarios!(
+            run = |info| info.first_gpu_platform_chassis_serial().map(str::to_string);
+            "no GPUs" {
+                HardwareInfo::default() => None,
+            }
 
-        info.gpus.push(gpu_with_platform_info("NVIDIA GB200"));
-        assert_eq!(
-            info.first_gpu_platform_chassis_serial(),
-            Some("chassis-1")
+            "GPU with missing platform_info" {
+                hardware_info_with_gpu(gpu_without_platform_info("NVIDIA GB200")) => None,
+            }
+
+            "blank chassis serial" {
+                hardware_info_with_gpu(gpu_with_platform_info("NVIDIA GB200", "")) => None,
+            }
+
+            "whitespace-only chassis serial" {
+                hardware_info_with_gpu(gpu_with_platform_info("NVIDIA GB200", "   \t  ")) => None,
+            }
+
+            "valid chassis serial" {
+                hardware_info_with_gpu(gpu_with_platform_info("NVIDIA GB200", "chassis-1"))
+                    => Some("chassis-1".to_string()),
+            }
         );
     }
 
-    fn gpu_with_platform_info(name: &str) -> Gpu {
+    fn hardware_info_with_gpu(gpu: Gpu) -> HardwareInfo {
+        let mut info = HardwareInfo::default();
+        info.gpus.push(gpu);
+        info
+    }
+
+    fn gpu_without_platform_info(name: &str) -> Gpu {
+        Gpu {
+            name: name.to_string(),
+            serial: String::new(),
+            driver_version: String::new(),
+            vbios_version: String::new(),
+            inforom_version: String::new(),
+            total_memory: String::new(),
+            frequency: String::new(),
+            pci_bus_id: String::new(),
+            platform_info: None,
+        }
+    }
+
+    fn gpu_with_platform_info(name: &str, chassis_serial: &str) -> Gpu {
         Gpu {
             name: name.to_string(),
             serial: String::new(),
@@ -987,7 +1022,7 @@ mod tests {
             frequency: String::new(),
             pci_bus_id: String::new(),
             platform_info: Some(GpuPlatformInfo {
-                chassis_serial: "chassis-1".to_string(),
+                chassis_serial: chassis_serial.to_string(),
                 slot_number: 1,
                 tray_index: 1,
                 host_id: 1,
@@ -1003,7 +1038,7 @@ mod tests {
             run = |(gpu_name, has_platform_info)| {
                 let mut info = HardwareInfo::default();
                 if has_platform_info {
-                    info.gpus.push(gpu_with_platform_info(gpu_name));
+                    info.gpus.push(gpu_with_platform_info(gpu_name, "chassis-1"));
                 } else {
                     info.gpus.push(Gpu {
                         name: gpu_name.to_string(),
@@ -1050,7 +1085,8 @@ mod tests {
                 ..Default::default()
             },
         );
-        info.gpus.push(gpu_with_platform_info("NVIDIA H100 PCIe"));
+        info.gpus
+            .push(gpu_with_platform_info("NVIDIA H100 PCIe", "chassis-1"));
         assert!(info.is_mnnvl_capable());
     }
 

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -75,6 +75,24 @@ pub const DEFAULT_NMX_M_NAME: &str = "default";
 /// to the nearest multiple of 4.
 const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 16;
 
+fn managed_host_chassis_serial(snapshot: &ManagedHostStateSnapshot) -> Option<String> {
+    snapshot
+        .host_snapshot
+        .nvlink_info
+        .as_ref()
+        .map(|info| info.chassis_serial.trim())
+        .filter(|serial| !serial.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            snapshot
+                .host_snapshot
+                .hardware_info
+                .as_ref()
+                .and_then(HardwareInfo::first_gpu_platform_chassis_serial)
+                .map(str::to_string)
+        })
+}
+
 fn rack_id_from_chassis_snapshots(
     chassis_snapshots: &[&ManagedHostStateSnapshot],
 ) -> Option<RackId> {
@@ -1118,11 +1136,8 @@ impl NvlPartitionMonitor {
         > = managed_host_snapshots.iter().fold(
             HashMap::new(),
             |mut acc, (_machine_id, snapshot)| {
-                if let Some(nvlink_info) = snapshot.host_snapshot.nvlink_info.as_ref() {
-                    let serial = nvlink_info.chassis_serial.trim();
-                    if !serial.is_empty() {
-                        acc.entry(serial.to_string()).or_default().push(snapshot);
-                    }
+                if let Some(serial) = managed_host_chassis_serial(snapshot) {
+                    acc.entry(serial).or_default().push(snapshot);
                 }
                 acc
             },

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -89,6 +89,8 @@ fn managed_host_chassis_serial(snapshot: &ManagedHostStateSnapshot) -> Option<St
                 .hardware_info
                 .as_ref()
                 .and_then(HardwareInfo::first_gpu_platform_chassis_serial)
+                .map(str::trim)
+                .filter(|serial| !serial.is_empty())
                 .map(str::to_string)
         })
 }


### PR DESCRIPTION
This should help with auto population of nvlink_info for  managed hosts that are missing that info.

Fall back to the first GPU platform_info chassis_serial from machine
topology when nvlink_info is missing or empty, so MNNVL-capable hosts
can still be grouped and have nvlink_info populated from NMX-C hello.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3481

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

