### PR TITLE
fix(machine-a-tron): route NIC-mode DHCP through HostInband

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -119,7 +119,8 @@ async fn test_integration() -> eyre::Result<()> {
     // HostInband segments must live in a Flat VPC -- those VPC types are
     // mutually bound. Create one for the HostInband fixture.
     let flat_vpc = vpc::create_flat(carbide_api_addrs, tenant_org_id).await?;
-    subnet::create(carbide_api_addrs, &flat_vpc, &domain_id, 11, true).await?;
+    let host_inband_segment_id =
+        subnet::create(carbide_api_addrs, &flat_vpc, &domain_id, 11, true).await?;
 
     // Create FNN VPC + VPC prefixes (IPv4 + IPv6) for dual-stack L3 linknet testing.
     let fnn_vpc = vpc::create_fnn(carbide_api_addrs, tenant_org_id).await?;
@@ -192,32 +193,47 @@ async fn test_integration() -> eyre::Result<()> {
             HostHardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
-            // Relay IP in host-inband net
-            Ipv4Addr::new(10, 10, 11, 2),
+            &flat_vpc,
         )
         .boxed(),
-        test_machine_a_tron_singledpu_nic_mode(
+        test_machine_a_tron_nic_mode(
             HostHardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
-            // Relay IP in host-inband  net
-            Ipv4Addr::new(10, 10, 11, 2),
+            &flat_vpc,
+            &host_inband_segment_id,
         )
         .boxed(),
-        test_machine_a_tron_singledpu_nic_mode(
+        test_machine_a_tron_nic_mode(
             HostHardwareType::HpeProliantDl380aGen11,
             &test_env,
             &bmc_address_registry,
-            // Relay IP in host-inband net
-            Ipv4Addr::new(10, 10, 11, 2),
+            &flat_vpc,
+            &host_inband_segment_id,
+        )
+        .boxed(),
+        test_machine_a_tron_nic_mode(
+            HostHardwareType::WiwynnGB200Nvl,
+            &test_env,
+            &bmc_address_registry,
+            &flat_vpc,
+            &host_inband_segment_id,
+        )
+        .boxed(),
+        test_machine_a_tron_nic_mode(
+            HostHardwareType::SupermicroGb300Nvl,
+            &test_env,
+            &bmc_address_registry,
+            &flat_vpc,
+            &host_inband_segment_id,
         )
         .boxed(),
         test_machine_a_tron_dpu_to_nic_mode_reregistration(
             HostHardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
-            // Relay IP in host-inband net
-            Ipv4Addr::new(10, 10, 11, 2),
+            // Relay IP in admin net
+            Ipv4Addr::new(172, 20, 0, 2),
         )
         .boxed(),
         test_machine_a_tron_dual_stack(
@@ -543,7 +559,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
                 let instance_id = instance::create(
                     &carbide_api_addrs,
                     &host_machine_id,
-                    Some(&segment_id),
+                    &segment_id,
                     Some("test"),
                     true,
                     true,
@@ -663,7 +679,7 @@ async fn test_machine_a_tron_multidpu(
                 let instance_id = instance::create(
                     carbide_api_addrs,
                     &machine_id,
-                    Some(&segment_id),
+                    &segment_id,
                     None,
                     false,
                     false,
@@ -786,7 +802,7 @@ async fn test_machine_a_tron_zerodpu(
     hw_type: HostHardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    flat_vpc_id: &str,
 ) -> eyre::Result<()> {
     run_machine_a_tron_test(
         hw_type,
@@ -796,9 +812,10 @@ async fn test_machine_a_tron_zerodpu(
         None,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        Ipv4Addr::new(172, 20, 0, 2),
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
+            let flat_vpc_id = flat_vpc_id.to_string();
             async move {
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
@@ -808,24 +825,17 @@ async fn test_machine_a_tron_zerodpu(
                     .expect("Machine ID should be set if host is ready");
                 tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
 
-                // Zero-DPU tenants pass `auto: true` with empty interfaces; the
-                // allocator resolves the host's HostInband segment(s) from the
-                // machine snapshot (which is also covered in unit tests as
-                // `test_zero_dpu_instance_allocation_auto`).
-                let instance_id = instance::create(
+                let instance_id = instance::create_with_auto_host_inband_networking(
                     carbide_api_addrs,
                     &machine_id,
-                    None,
-                    None,
-                    false,
-                    false,
-                    &[],
+                    &flat_vpc_id,
                 )
                 .await?;
 
                 machine_handle
                     .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(90))
                     .await?;
+                assert_auto_instance_network(carbide_api_addrs, &instance_id, &flat_vpc_id).await?;
                 tracing::info!(
                     "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
                 );
@@ -843,11 +853,12 @@ async fn test_machine_a_tron_zerodpu(
     .await
 }
 
-async fn test_machine_a_tron_singledpu_nic_mode(
+async fn test_machine_a_tron_nic_mode(
     hw_type: HostHardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
-    admin_dhcp_relay_address: Ipv4Addr,
+    flat_vpc_id: &str,
+    host_inband_segment_id: &str,
 ) -> eyre::Result<()> {
     run_machine_a_tron_test(
         hw_type,
@@ -857,9 +868,18 @@ async fn test_machine_a_tron_singledpu_nic_mode(
         None,
         test_env,
         bmc_mock_registry,
-        admin_dhcp_relay_address,
+        Ipv4Addr::new(172, 20, 0, 2),
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
+            let flat_vpc_id = flat_vpc_id.to_string();
+            let host_inband_segment_id = host_inband_segment_id.to_string();
+            let expected_host_mac = machine_handle
+                .host_info()
+                .dpus
+                .first()
+                .expect("NIC-mode host should contain at least one DPU NIC")
+                .host_mac_address
+                .to_string();
             async move {
                 machine_handle
                     .wait_until_machine_up_with_api_state("Ready", Duration::from_secs(90))
@@ -869,25 +889,25 @@ async fn test_machine_a_tron_singledpu_nic_mode(
                     .expect("Machine ID should be set if host is ready");
                 tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
 
-                // For a DPU in NIC-mode, the DPU is treated as a plain NIC, meaning
-                // allocation goes through HostInband the same way the zero-DPU path
-                // allocation does; the request carries `auto: true` with empty
-                // interfaces, and Carbide resolves from the host's HostInband
-                // segment(s).
-                let instance_id = instance::create(
+                assert_nic_mode_host(
                     carbide_api_addrs,
                     &machine_id,
-                    None,
-                    None,
-                    false,
-                    false,
-                    &[],
+                    &expected_host_mac,
+                    &host_inband_segment_id,
+                )
+                .await?;
+
+                let instance_id = instance::create_with_auto_host_inband_networking(
+                    carbide_api_addrs,
+                    &machine_id,
+                    &flat_vpc_id,
                 )
                 .await?;
 
                 machine_handle
                     .wait_until_machine_up_with_api_state("Assigned/Ready", Duration::from_secs(90))
                     .await?;
+                assert_auto_instance_network(carbide_api_addrs, &instance_id, &flat_vpc_id).await?;
                 tracing::info!(
                     "Machine {machine_id} has made it to Assigned/Ready, releasing instance"
                 );
@@ -903,6 +923,97 @@ async fn test_machine_a_tron_singledpu_nic_mode(
         },
     )
     .await
+}
+
+async fn assert_nic_mode_host(
+    carbide_api_addrs: &[SocketAddr],
+    machine_id: &carbide_uuid::machine::MachineId,
+    expected_host_mac: &str,
+    host_inband_segment_id: &str,
+) -> eyre::Result<()> {
+    let machine = machine::get_json_by_id(carbide_api_addrs, machine_id).await?;
+    let associated_dpus = machine["associatedDpuMachineIds"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    eyre::ensure!(
+        associated_dpus.is_empty(),
+        "NIC-mode host {machine_id} still has associated DPUs: {associated_dpus:?}"
+    );
+
+    let interfaces = machine["interfaces"]
+        .as_array()
+        .ok_or_else(|| eyre::eyre!("NIC-mode host {machine_id} has no interfaces"))?;
+    eyre::ensure!(
+        interfaces
+            .iter()
+            .all(|interface| interface["attachedDpuMachineId"].is_null()),
+        "NIC-mode host {machine_id} still has a DPU-backed interface: {interfaces:?}"
+    );
+
+    let has_expected_primary_host_inband_interface = interfaces.iter().any(|interface| {
+        interface["macAddress"]
+            .as_str()
+            .is_some_and(|mac| mac.eq_ignore_ascii_case(expected_host_mac))
+            && interface["primaryInterface"] == true
+            && interface["segmentId"]["value"] == host_inband_segment_id
+            && interface["interfaceType"] != "INTERFACE_TYPE_BMC"
+    });
+    eyre::ensure!(
+        has_expected_primary_host_inband_interface,
+        "NIC-mode host {machine_id} did not promote DPU host-facing PF {expected_host_mac} as its primary HostInband interface"
+    );
+    Ok(())
+}
+
+async fn assert_auto_instance_network(
+    carbide_api_addrs: &[SocketAddr],
+    instance_id: &str,
+    flat_vpc_id: &str,
+) -> eyre::Result<()> {
+    let instance = instance::get_instance_json_by_id(carbide_api_addrs, instance_id).await?;
+    let network = &instance["config"]["network"];
+    eyre::ensure!(
+        network["auto"] == true,
+        "instance {instance_id} did not retain auto networking: {network}"
+    );
+    eyre::ensure!(
+        network["interfaces"].as_array().is_some_and(Vec::is_empty),
+        "instance {instance_id} exposed resolved interfaces in its external config: {network}"
+    );
+    eyre::ensure!(
+        network["autoConfig"]["vpcId"]["value"] == flat_vpc_id,
+        "instance {instance_id} did not retain Flat VPC {flat_vpc_id}: {network}"
+    );
+
+    let status_interfaces = instance["status"]["network"]["interfaces"]
+        .as_array()
+        .ok_or_else(|| eyre::eyre!("instance {instance_id} has no network status interfaces"))?;
+    eyre::ensure!(
+        !status_interfaces.is_empty()
+            && status_interfaces.iter().all(|interface| {
+                interface["vpcId"]["value"] == flat_vpc_id
+                    && interface["macAddress"]
+                        .as_str()
+                        .is_some_and(|mac| !mac.is_empty())
+                    && interface["addresses"]
+                        .as_array()
+                        .is_some_and(|values| !values.is_empty())
+                    && interface["gateways"]
+                        .as_array()
+                        .is_some_and(|values| !values.is_empty())
+                    && interface["prefixes"]
+                        .as_array()
+                        .is_some_and(|values| !values.is_empty())
+            }),
+        "instance {instance_id} status does not contain resolved Flat VPC networking: {status_interfaces:?}"
+    );
+    eyre::ensure!(
+        instance["status"]["network"]["configsSynced"] == "SYNCED",
+        "instance {instance_id} network status is not synced: {}",
+        instance["status"]["network"]
+    );
+    Ok(())
 }
 
 /// DPU-mode -> NIC-mode flip + zero-DPU re-ingestion (machine-a-tron harness,
@@ -1223,7 +1334,7 @@ async fn test_machine_a_tron_dual_stack_l2(
                 let instance_id = instance::create(
                     carbide_api_addrs,
                     &machine_id,
-                    Some(&segment_id),
+                    &segment_id,
                     None,
                     false,
                     false,
@@ -1315,6 +1426,9 @@ where
                     .unwrap()
                     .to_string(),
                 admin_dhcp_relay_address,
+                // Keep this distinct from the Admin relay so NIC-mode tests
+                // fail if machine-a-tron sends host DHCP through Admin.
+                host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
                 oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
                 vpc_count: 0,
                 subnets_per_vpc: 0,

--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -25,17 +25,66 @@ use super::machine::wait_for_state;
 pub async fn create(
     addrs: &[SocketAddr],
     host_machine_id: &MachineId,
-    segment_id: Option<&str>,
+    segment_id: &str,
     hostname: Option<&str>,
     phone_home_enable: bool,
     wait_until_ready: bool,
     keyset_ids: &[&str],
 ) -> eyre::Result<String> {
     tracing::info!(
-        "Creating instance with machine: {host_machine_id}, with network segment: {}",
-        segment_id.unwrap_or("<none>")
+        "Creating instance with machine: {host_machine_id}, with network segment: {segment_id}"
     );
 
+    let network = serde_json::json!({
+        "interfaces": [{
+            "function_type": "PHYSICAL",
+            "network_segment_id": {"value": segment_id}
+        }]
+    });
+
+    create_with_network(
+        addrs,
+        host_machine_id,
+        network,
+        hostname,
+        phone_home_enable,
+        wait_until_ready,
+        keyset_ids,
+    )
+    .await
+}
+
+/// Creates an instance whose HostInband interfaces are resolved automatically
+/// within the requested Flat VPC.
+pub async fn create_with_auto_host_inband_networking(
+    addrs: &[SocketAddr],
+    host_machine_id: &MachineId,
+    flat_vpc_id: &str,
+) -> eyre::Result<String> {
+    tracing::info!(
+        "Creating automatically-networked instance with machine: {host_machine_id}, with Flat VPC: {flat_vpc_id}"
+    );
+
+    let network = serde_json::json!({
+        "interfaces": [],
+        "auto": true,
+        "auto_config": {
+            "vpc_id": {"value": flat_vpc_id}
+        }
+    });
+
+    create_with_network(addrs, host_machine_id, network, None, false, false, &[]).await
+}
+
+async fn create_with_network(
+    addrs: &[SocketAddr],
+    host_machine_id: &MachineId,
+    network: serde_json::Value,
+    hostname: Option<&str>,
+    phone_home_enable: bool,
+    wait_until_ready: bool,
+    keyset_ids: &[&str],
+) -> eyre::Result<String> {
     let mut tenant = serde_json::json!({
         "tenant_organization_id": "tenant_organization",
         "tenantKeysetIds": keyset_ids,
@@ -56,31 +105,11 @@ pub async fn create(
         "user_data": "hello",
     });
 
-    let instance_config = match segment_id {
-        Some(segment_id) => serde_json::json!({
-            "tenant": tenant,
-            "network": {
-                "interfaces": [{
-                    "function_type": "PHYSICAL",
-                    "network_segment_id": {"value": segment_id}
-                }]
-            },
-            "os": os,
-        }),
-        // segment_id is None, i.e. this is the zero-DPU path.
-        // The allocator requires `auto: true` and an empty `interfaces`
-        // list, and will resolve the host's HostInband segments into
-        // the stored config (status reflects the resolved per-interface
-        // details).
-        None => serde_json::json!({
-            "tenant": tenant,
-            "network": {
-                "interfaces": [],
-                "auto": true,
-            },
-            "os": os,
-        }),
-    };
+    let instance_config = serde_json::json!({
+        "tenant": tenant,
+        "network": network,
+        "os": os,
+    });
 
     let data = serde_json::json!({
         "machine_id": {"id": host_machine_id},
@@ -269,6 +298,22 @@ pub async fn get_instance_json_by_machine_id(
     let data = serde_json::json!({ "id": machine_id });
     let response = grpcurl(addrs, "FindInstanceByMachineID", Some(&data)).await?;
     Ok(serde_json::from_str(&response)?)
+}
+
+pub async fn get_instance_json_by_id(
+    addrs: &[SocketAddr],
+    instance_id: &str,
+) -> eyre::Result<serde_json::Value> {
+    let data = serde_json::json!({
+        "instance_ids": [{"value": instance_id}]
+    });
+    let response = grpcurl(addrs, "FindInstancesByIds", Some(&data)).await?;
+    let response: serde_json::Value = serde_json::from_str(&response)?;
+    response["instances"]
+        .as_array()
+        .and_then(|instances| instances.first())
+        .cloned()
+        .ok_or_else(|| eyre::eyre!("instance {instance_id} was not returned by FindInstancesByIds"))
 }
 
 /// Waits for an instance to reach a certain state

--- a/crates/api-test-helper/src/machine.rs
+++ b/crates/api-test-helper/src/machine.rs
@@ -24,6 +24,22 @@ use crate::grpcurl::grpcurl;
 
 const MAX_RETRY: usize = 30; // Equal to 30s wait time
 
+pub async fn get_json_by_id(
+    addrs: &[SocketAddr],
+    machine_id: &MachineId,
+) -> eyre::Result<serde_json::Value> {
+    let data = serde_json::json!({
+        "machine_ids": [{"id": machine_id}],
+    });
+    let response = grpcurl(addrs, "FindMachinesByIds", Some(&data)).await?;
+    let response: serde_json::Value = serde_json::from_str(&response)?;
+    response["machines"]
+        .as_array()
+        .and_then(|machines| machines.first())
+        .cloned()
+        .ok_or_else(|| eyre::eyre!("machine {machine_id} was not returned by FindMachinesByIds"))
+}
+
 /// Waits for a Machine to reach a certain target state
 /// If the Machine does not reach the state within 30s, the function will fail.
 pub async fn wait_for_state(

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -159,20 +159,6 @@ impl SupermicroGB300Nvl<'_> {
         )
         .collect::<Vec<_>>();
 
-        let eth_interfaces = [&self.embedded_1g_nic.ethernet_nic()]
-            .iter()
-            .enumerate()
-            .map(|(index, nic)| {
-                redfish::ethernet_interface::builder(&redfish::ethernet_interface::system_resource(
-                    system_id,
-                    &format!("EthernetInterface{index}"),
-                ))
-                .mac_address(nic.mac_address)
-                .interface_enabled(false)
-                .build()
-            })
-            .collect();
-
         redfish::computer_system::Config {
             systems: vec![
                 redfish::computer_system::SingleSystemConfig {
@@ -200,7 +186,7 @@ impl SupermicroGB300Nvl<'_> {
                     boot_options: Some(boot_options),
                     boot_order_mode: redfish::computer_system::BootOrderMode::OrderedCollection,
                     chassis: vec!["Chassis_0".into()],
-                    eth_interfaces: Some(eth_interfaces),
+                    eth_interfaces: None,
                     id: system_id.into(),
                     log_services: None,
                     // SMC GB300: Supermicro host system reporting product "GB NVL".

--- a/crates/machine-a-tron/config/mac.toml
+++ b/crates/machine-a-tron/config/mac.toml
@@ -85,6 +85,8 @@ host_reboot_delay = 10 # in units of seconds
 # only used for filling in gateway/relay fields in the DHCP request object
 # (which carbide uses to determine what network the request came from.)
 admin_dhcp_relay_address = "192.168.252.1"
+# Direct host DHCP for zero-DPU hosts and DPUs operating as plain NICs.
+host_inband_dhcp_relay_address = "192.168.253.1"
 oob_dhcp_relay_address = "192.168.2.1"
 # oob_dhcp_relay_address = "192.168.2.1"
 # admin_dhcp_relay_address = "192.164.0.1"

--- a/crates/machine-a-tron/config/mat.toml
+++ b/crates/machine-a-tron/config/mat.toml
@@ -85,6 +85,8 @@ host_reboot_delay = 20 # in units of seconds
 # (which carbide uses to determine what network the request came from.)
 oob_dhcp_relay_address = "192.168.2.1"
 admin_dhcp_relay_address = "192.164.0.1"
+# Direct host DHCP for zero-DPU hosts and DPUs operating as plain NICs.
+host_inband_dhcp_relay_address = "192.165.0.1"
 
 # Configures the location of some JSON templates machine-a-tron uses as a basis
 # for mocking certain data. There is no reason to change this from the default.

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -26,9 +26,9 @@ use mac_address::MacAddress;
 use rpc::forge::instance_operating_system_config::Variant;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, ExpectedPowerShelf, ExpectedRack, ExpectedRackRequest,
-    ExpectedSwitch, InlineIpxe, InstanceOperatingSystemConfig, MachinesByIdsRequest,
-    SetDynamicConfigRequest, VpcVirtualizationType,
+    ConfigSetting, ExpectedHostNic, ExpectedMachine, ExpectedPowerShelf, ExpectedRack,
+    ExpectedRackRequest, ExpectedSwitch, InlineIpxe, InstanceOperatingSystemConfig,
+    MachinesByIdsRequest, SetDynamicConfigRequest, VpcVirtualizationType,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
 
@@ -501,6 +501,7 @@ impl ApiClient {
         chassis_serial_number: String,
         rack_id: Option<RackId>,
         dpu_mode: Option<rpc::forge::DpuMode>,
+        host_nics: Vec<ExpectedHostNic>,
     ) -> ClientApiResult<()> {
         self.0
             .add_expected_machine(ExpectedMachine {
@@ -512,7 +513,7 @@ impl ApiClient {
                 metadata: None,
                 sku_id: None,
                 id: None,
-                host_nics: vec![],
+                host_nics,
                 rack_id,
                 default_pause_ingestion_and_poweron: None,
                 #[allow(deprecated)]

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -89,6 +89,10 @@ pub struct MachineConfig {
     pub template_dir: String,
     pub oob_dhcp_relay_address: Ipv4Addr,
     pub admin_dhcp_relay_address: Ipv4Addr,
+    /// Relay address used when a host DHCPs directly through a plain NIC rather than a managed DPU.
+    /// If omitted, direct host DHCP falls back to `admin_dhcp_relay_address` for compatibility.
+    #[serde(default)]
+    pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
 
     #[serde(
         default = "default_run_interval_working",
@@ -126,6 +130,13 @@ pub struct MachineConfig {
 
     #[serde(default)]
     pub dpu_agent_version: Option<String>,
+}
+
+impl MachineConfig {
+    pub(crate) fn missing_host_inband_relay_for_direct_host_dhcp(&self) -> bool {
+        self.host_inband_dhcp_relay_address.is_none()
+            && (self.dpu_per_host_count == 0 || self.dpus_in_nic_mode)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -541,7 +552,7 @@ where
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
@@ -571,6 +582,7 @@ dpu_reboot_delay = 1 # in units of seconds
 host_reboot_delay = 1 # in units of seconds
 vpc_count = 0
 admin_dhcp_relay_address = "192.168.176.1"
+host_inband_dhcp_relay_address = "192.168.177.1"
 oob_dhcp_relay_address = "192.168.192.1"
 subnets_per_vpc = 0
 run_interval_working = "100ms"
@@ -590,6 +602,21 @@ scout_run_interval = "5s"
         let round_tripped = toml::from_str::<MachineATronConfig>(&serialized)
             .expect("Could not deserialize serialized config");
         assert_eq!(round_tripped, cfg);
+    }
+
+    #[test]
+    fn host_inband_dhcp_relay_is_optional() {
+        let mut serialized =
+            toml::Value::try_from(rack_config()).expect("Could not serialize config");
+        serialized["machines"]["config"]
+            .as_table_mut()
+            .expect("machine config should be a TOML table")
+            .remove("host_inband_dhcp_relay_address");
+
+        let cfg: MachineATronConfig = serialized
+            .try_into()
+            .expect("legacy config without host_inband_dhcp_relay_address should deserialize");
+        assert_eq!(cfg.machines["config"].host_inband_dhcp_relay_address, None);
     }
 
     #[test]
@@ -648,6 +675,44 @@ scout_run_interval = "5s"
                 },
             ],
             |config| config.validate().map_err(drop),
+        );
+    }
+
+    #[test]
+    fn missing_host_inband_relay_warning_selection() {
+        let host_inband = Ipv4Addr::new(192, 168, 177, 1);
+
+        check_values(
+            [
+                Check {
+                    scenario: "zero-DPU host without HostInband",
+                    input: (0, false, None),
+                    expect: true,
+                },
+                Check {
+                    scenario: "NIC-mode host without HostInband",
+                    input: (1, true, None),
+                    expect: true,
+                },
+                Check {
+                    scenario: "managed-DPU host without HostInband",
+                    input: (1, false, None),
+                    expect: false,
+                },
+                Check {
+                    scenario: "zero-DPU host with HostInband",
+                    input: (0, false, Some(host_inband)),
+                    expect: false,
+                },
+            ],
+            |(dpu_per_host_count, dpus_in_nic_mode, host_inband_dhcp_relay_address)| {
+                let mut config = rack_config();
+                let machine = Arc::make_mut(config.machines.get_mut("config").unwrap());
+                machine.dpu_per_host_count = dpu_per_host_count;
+                machine.dpus_in_nic_mode = dpus_in_nic_mode;
+                machine.host_inband_dhcp_relay_address = host_inband_dhcp_relay_address;
+                machine.missing_host_inband_relay_for_direct_host_dhcp()
+            },
         );
     }
 }

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -17,10 +17,10 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use bmc_mock::HostHardwareType;
 use bmc_mock::mac_address_pool::PoolConfig as MacAddressPoolConfig;
+use bmc_mock::{HostHardwareType, HostMachineInfo};
 use futures::future::try_join_all;
-use rpc::forge::{DpuMode, VpcVirtualizationType};
+use rpc::forge::{DpuMode, ExpectedHostNic, NetworkSegmentType, VpcVirtualizationType};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -42,6 +42,35 @@ pub struct MachineATron {
     app_context: Arc<MachineATronContext>,
 }
 
+fn expected_host_nics(
+    host_info: &HostMachineInfo,
+    dpu_mode: Option<DpuMode>,
+) -> Vec<ExpectedHostNic> {
+    let mac_addresses = match dpu_mode {
+        Some(DpuMode::NicMode) => host_info
+            .dpus
+            .iter()
+            .map(|dpu| dpu.host_mac_address)
+            .collect::<Vec<_>>(),
+        Some(DpuMode::NoDpu) => host_info.non_dpu_mac_address.into_iter().collect(),
+        _ => Vec::new(),
+    };
+
+    mac_addresses
+        .into_iter()
+        .enumerate()
+        .map(|(index, mac_address)| ExpectedHostNic {
+            mac_address: mac_address.to_string(),
+            nic_type: None,
+            fixed_ip: None,
+            fixed_mask: None,
+            fixed_gateway: None,
+            primary: Some(index == 0),
+            network_segment_type: Some(NetworkSegmentType::HostInband as i32),
+        })
+        .collect()
+}
+
 impl MachineATron {
     pub fn new(app_context: Arc<MachineATronContext>) -> Self {
         Self { app_context }
@@ -49,6 +78,18 @@ impl MachineATron {
 
     pub async fn make_machines(&self, paused: bool) -> eyre::Result<Vec<HostMachineHandle>> {
         self.app_context.app_config.validate()?;
+
+        for (machine_group, machine) in &self.app_context.app_config.machines {
+            if machine.missing_host_inband_relay_for_direct_host_dhcp() {
+                tracing::warn!(
+                    machine_group,
+                    dpu_per_host_count = machine.dpu_per_host_count,
+                    dpus_in_nic_mode = machine.dpus_in_nic_mode,
+                    admin_dhcp_relay_address = %machine.admin_dhcp_relay_address,
+                    "host_inband_dhcp_relay_address is not configured for a zero-DPU or NIC-mode host; direct host DHCP will fall back to admin_dhcp_relay_address"
+                );
+            }
+        }
 
         let mut persisted_machines = self
             .app_context
@@ -197,6 +238,7 @@ impl MachineATron {
                         } else {
                             None
                         };
+                        let host_nics = expected_host_nics(host_info, dpu_mode);
                         self.app_context
                             .api_client()
                             .add_expected_machine(
@@ -204,6 +246,7 @@ impl MachineATron {
                                 host_info.serial.clone(),
                                 rack_id,
                                 dpu_mode,
+                                host_nics,
                             )
                             .await
                     }
@@ -428,5 +471,91 @@ fn parse_network_virtualization_type(s: Option<&str>) -> Option<VpcVirtualizatio
             None
         }
         None => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bmc_mock::{DpuMachineInfo, DpuSettings};
+    use carbide_test_support::{Check, check_values};
+    use mac_address::MacAddress;
+
+    use super::*;
+
+    fn mac(value: &str) -> MacAddress {
+        MacAddress::from_str(value).unwrap()
+    }
+
+    fn host_info(dpu_host_macs: &[MacAddress], non_dpu_mac: Option<MacAddress>) -> HostMachineInfo {
+        HostMachineInfo {
+            hw_type: HostHardwareType::WiwynnGB200Nvl,
+            bmc_mac_address: mac("02:00:00:00:00:f0"),
+            serial: "test-host".to_string(),
+            dpus: dpu_host_macs
+                .iter()
+                .enumerate()
+                .map(|(index, host_mac_address)| DpuMachineInfo {
+                    hw_type: HostHardwareType::WiwynnGB200Nvl,
+                    bmc_mac_address: mac(&format!("02:00:00:00:10:{index:02x}")),
+                    host_mac_address: *host_mac_address,
+                    oob_mac_address: mac(&format!("02:00:00:00:20:{index:02x}")),
+                    serial: format!("test-dpu-{index}"),
+                    settings: DpuSettings::default(),
+                })
+                .collect(),
+            non_dpu_mac_address: non_dpu_mac,
+            nvos_mac_addresses: Vec::new(),
+            switch_serial_number: None,
+            hw_mac_addr_pool: MacAddressPoolConfig::new(mac("0a:00:00:00:00:00"), 24).unwrap(),
+            delta_psu_power: None,
+        }
+    }
+
+    fn expected_nic(mac_address: MacAddress, primary: bool) -> ExpectedHostNic {
+        ExpectedHostNic {
+            mac_address: mac_address.to_string(),
+            nic_type: None,
+            fixed_ip: None,
+            fixed_mask: None,
+            fixed_gateway: None,
+            primary: Some(primary),
+            network_segment_type: Some(NetworkSegmentType::HostInband as i32),
+        }
+    }
+
+    #[test]
+    fn expected_host_nic_derivation() {
+        let first_dpu_mac = mac("02:00:00:00:00:01");
+        let second_dpu_mac = mac("02:00:00:00:00:02");
+        let integrated_mac = mac("02:00:00:00:00:03");
+
+        check_values(
+            [
+                Check {
+                    scenario: "NIC-mode host declares every host-facing DPU PF",
+                    input: (
+                        host_info(&[first_dpu_mac, second_dpu_mac], None),
+                        Some(DpuMode::NicMode),
+                    ),
+                    expect: vec![
+                        expected_nic(first_dpu_mac, true),
+                        expected_nic(second_dpu_mac, false),
+                    ],
+                },
+                Check {
+                    scenario: "zero-DPU host declares its integrated NIC",
+                    input: (host_info(&[], Some(integrated_mac)), Some(DpuMode::NoDpu)),
+                    expect: vec![expected_nic(integrated_mac, true)],
+                },
+                Check {
+                    scenario: "managed-DPU host relies on automatic DPU discovery",
+                    input: (host_info(&[first_dpu_mac], None), None),
+                    expect: Vec::new(),
+                },
+            ],
+            |(host_info, dpu_mode)| expected_host_nics(&host_info, dpu_mode),
+        );
     }
 }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -50,6 +50,18 @@ use crate::{PersistedDpuMachine, PersistedHostMachine, dhcp_wrapper};
 
 pub type DpuDhcpRelayHandle = oneshot::Sender<()>;
 
+fn direct_dhcp_relay_address(
+    is_host: bool,
+    admin_relay_address: Ipv4Addr,
+    host_inband_relay_address: Option<Ipv4Addr>,
+) -> Ipv4Addr {
+    if is_host {
+        host_inband_relay_address.unwrap_or(admin_relay_address)
+    } else {
+        admin_relay_address
+    }
+}
+
 /// MachineStateMachine (yo dawg) models the state machine of a machine endpoint
 ///
 /// This code is in common between DPUs and Hosts.(ie. anything that has a BMC, boots via DHCP, can
@@ -531,54 +543,59 @@ impl MachineStateMachine {
             return Err(MachineStateError::NoMachineMacAddress);
         };
 
-        tracing::debug!("Sending Admin DHCP Request for {}", primary_mac);
         let start = Instant::now();
-        // Bound the relay wait so a vanished DPU (one mid-flip to NIC mode, its
-        // relay server gone) can't block the host actor indefinitely.
-        const DPU_DHCP_RELAY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+        // Bound the relay wait so an unavailable DPU cannot block the host actor
+        // indefinitely. Returning to the actor lets it confirm a NIC-mode flip
+        // before detaching the relay, or retry the managed relay otherwise.
+        const DPU_DHCP_RELAY_TIMEOUT: Duration = Duration::from_secs(10);
         let machine_dhcp_info_result = if let Some(DpuDhcpRelay::HostEnd(relay_tx)) =
             &self.dpu_dhcp_relay
         {
-            // Relay this host's data-plane DHCP through its managed DPU, but fall
-            // back to a direct request on the host's own MAC if the relay does not
-            // answer promptly -- e.g. the DPU just flipped to NIC mode, so its relay
-            // server is gone. The same MAC is used either way, so a retained boot
-            // interface still matches on re-ingestion.
+            tracing::debug!(%primary_mac, "requesting machine DHCP through DPU relay");
             let (reply_tx, reply_rx) = oneshot::channel();
-            let relayed = match relay_tx.send(reply_tx) {
-                Ok(()) => match tokio::time::timeout(DPU_DHCP_RELAY_TIMEOUT, reply_rx).await {
-                    // The relay answered -- use its result (success OR a real
-                    // DHCP/API error). Only fall back to a direct request when the
-                    // relay is genuinely gone: send failed, channel canceled, or
-                    // timed out.
-                    Ok(Ok(result)) => Some(result),
-                    Ok(Err(_)) | Err(_) => None,
-                },
-                Err(_) => None,
-            };
-            match relayed {
-                Some(result) => result,
-                None => {
+            if relay_tx.send(reply_tx).is_err() {
+                tracing::warn!(
+                    %primary_mac,
+                    "DPU DHCP relay request channel is closed; retrying after relay state reconciliation"
+                );
+                return Err(MachineStateError::DpuDhcpRelayUnavailable);
+            }
+            match tokio::time::timeout(DPU_DHCP_RELAY_TIMEOUT, reply_rx).await {
+                // The relay answered. Preserve either its successful response or
+                // the actual DHCP/API error it returned.
+                Ok(Ok(result)) => result,
+                Ok(Err(_)) => {
                     tracing::warn!(
-                        "DPU DHCP relay did not answer for {primary_mac}; falling back to a direct request (the DPU likely flipped to NIC mode)"
+                        %primary_mac,
+                        "DPU DHCP relay response was canceled; retrying after relay state reconciliation"
                     );
-                    dhcp_wrapper::request_ip(
-                        self.app_context.api_client(),
-                        DhcpRequestInfo {
-                            mac_address: primary_mac,
-                            relay_address: self.config.admin_dhcp_relay_address,
-                            template_dir: self.config.template_dir.clone(),
-                        },
-                    )
-                    .await
+                    return Err(MachineStateError::DpuDhcpRelayUnavailable);
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        %primary_mac,
+                        timeout_ms = DPU_DHCP_RELAY_TIMEOUT.as_millis(),
+                        "DPU DHCP relay response timed out; retrying after relay state reconciliation"
+                    );
+                    return Err(MachineStateError::DpuDhcpRelayUnavailable);
                 }
             }
         } else {
+            let direct_relay_address = direct_dhcp_relay_address(
+                matches!(&self.machine_info, MachineInfo::Host(_)),
+                self.config.admin_dhcp_relay_address,
+                self.config.host_inband_dhcp_relay_address,
+            );
+            tracing::debug!(
+                %primary_mac,
+                %direct_relay_address,
+                "requesting machine DHCP directly"
+            );
             dhcp_wrapper::request_ip(
                 self.app_context.api_client(),
                 DhcpRequestInfo {
                     mac_address: primary_mac,
-                    relay_address: self.config.admin_dhcp_relay_address,
+                    relay_address: direct_relay_address,
                     template_dir: self.config.template_dir.clone(),
                 },
             )
@@ -587,16 +604,16 @@ impl MachineStateMachine {
         machine_dhcp_info_result
             .inspect(|_| {
                 tracing::debug!(
-                    "Admin DHCP Request for {} took {}ms",
-                    primary_mac,
-                    start.elapsed().as_millis()
+                    %primary_mac,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "machine DHCP request completed"
                 );
             })
             .map_err(|err| {
                 tracing::debug!(
-                    "Admin DHCP Request for {} failed after {}ms: {err}",
-                    primary_mac,
-                    start.elapsed().as_millis()
+                    %primary_mac,
+                    elapsed_ms = start.elapsed().as_millis(),
+                    "machine DHCP request failed: {err}"
                 );
                 err.into()
             })
@@ -1144,6 +1161,8 @@ pub enum MachineStateError {
     ClientApi(#[from] ClientApiError),
     #[error("Failed to get DHCP address: {0:?}")]
     DhcpError(#[from] DhcpRelayError),
+    #[error("DPU DHCP relay is unavailable")]
+    DpuDhcpRelayUnavailable,
     #[error("Failed to get PXE response: {0}")]
     PxeError(#[from] PxeError),
     #[error("BMC mock TLS error: {0}")]
@@ -1166,4 +1185,38 @@ pub enum AddressConfigError {
     Io(#[from] std::io::Error),
     #[error("Error running ip command: {0:?}, output: {1:?}")]
     CommandFailure(Box<tokio::process::Command>, std::process::Output),
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[test]
+    fn direct_dhcp_relay_selection() {
+        let admin = Ipv4Addr::new(172, 21, 0, 1);
+        let host_inband = Ipv4Addr::new(172, 22, 0, 1);
+
+        check_values(
+            [
+                Check {
+                    scenario: "NIC-mode or zero-DPU host",
+                    input: (true, Some(host_inband)),
+                    expect: host_inband,
+                },
+                Check {
+                    scenario: "legacy host without HostInband configuration",
+                    input: (true, None),
+                    expect: admin,
+                },
+                Check {
+                    scenario: "DPU ignores HostInband configuration",
+                    input: (false, Some(host_inband)),
+                    expect: admin,
+                },
+            ],
+            |(is_host, host_inband)| direct_dhcp_relay_address(is_host, admin, host_inband),
+        );
+    }
 }

--- a/dev/docker-env/mat.toml
+++ b/dev/docker-env/mat.toml
@@ -72,6 +72,8 @@ subnets_per_vpc = 2
 # (which carbide uses to determine what network the request came from.)
 oob_dhcp_relay_address = "172.21.0.1"
 admin_dhcp_relay_address = "172.20.0.1"
+# Direct host DHCP for zero-DPU hosts and DPUs operating as plain NICs.
+host_inband_dhcp_relay_address = "172.22.0.1"
 
 # Configures the location of some JSON templates machine-a-tron uses as a basis
 # for mocking certain data. There is no reason to change this from the default.


### PR DESCRIPTION
Declare NIC-mode and zero-DPU host interfaces as HostInband and route their direct DHCP requests through the configured HostInband relay. Preserve Admin fallback compatibility and switch managed hosts only after confirming a DPU-to-NIC transition.

Add integration coverage for GB200 & SMC GB300 with its DPU operating in NIC mode, including automatic Flat-VPC instance networking.

## Related issues

Closes: #3457 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

