### PR TITLE
docs: fix vpc-peering delete examples

### DIFF
--- a/docs/manuals/vpc/vpc_peering_management.md
+++ b/docs/manuals/vpc/vpc_peering_management.md
@@ -70,12 +70,12 @@ The output will display:
 To delete an existing VPC peering connection:
 
 ```bash
-nico-admin-cli vpc-peering delete <PEERING_CONNECTION_ID>
+nico-admin-cli vpc-peering delete --id <PEERING_CONNECTION_ID>
 ```
 
 **Example:**
 ```bash
-nico-admin-cli vpc-peering delete 123e4567-e89b-12d3-a456-426614174000
+nico-admin-cli vpc-peering delete --id 123e4567-e89b-12d3-a456-426614174000
 ```
 
 **Notes:**


### PR DESCRIPTION
Update the VPC peering management manual to use the required `--id`
option in the delete command synopsis and example.

## Related issues

Fixes #3153

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

`git diff --check` passed. `rumdl` was not available locally.