### PR TITLE
chore(core): rename iPXE template Scope to Visibility to clarify and avoid confusion

### DIFF
--- a/crates/admin-cli/src/ipxe_template/show/cmd.rs
+++ b/crates/admin-cli/src/ipxe_template/show/cmd.rs
@@ -22,10 +22,10 @@ use super::args::Args;
 use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
-fn scope_display(scope: i32) -> &'static str {
-    match rpc::forge::IpxeTemplateScope::try_from(scope) {
-        Ok(rpc::forge::IpxeTemplateScope::Internal) => "internal",
-        Ok(rpc::forge::IpxeTemplateScope::Public) => "public",
+fn visibility_display(visibility: i32) -> &'static str {
+    match rpc::forge::IpxeTemplateVisibility::try_from(visibility) {
+        Ok(rpc::forge::IpxeTemplateVisibility::Internal) => "internal",
+        Ok(rpc::forge::IpxeTemplateVisibility::Public) => "public",
         _ => "unknown",
     }
 }
@@ -55,7 +55,7 @@ async fn list_all(format: OutputFormat, api_client: &ApiClient) -> Result<(), Ca
             Cell::new("ID"),
             Cell::new("Name"),
             Cell::new("Description"),
-            Cell::new("Scope"),
+            Cell::new("Visibility"),
             Cell::new("Required Params"),
             Cell::new("Required Artifacts"),
         ]));
@@ -70,7 +70,7 @@ async fn list_all(format: OutputFormat, api_client: &ApiClient) -> Result<(), Ca
                 Cell::new(&id_str),
                 Cell::new(&tmpl.name),
                 Cell::new(&tmpl.description),
-                Cell::new(scope_display(tmpl.scope)),
+                Cell::new(visibility_display(tmpl.visibility)),
                 Cell::new(&tmpl.required_params.join(", ")),
                 Cell::new(&tmpl.required_artifacts.join(", ")),
             ]));
@@ -117,7 +117,7 @@ async fn show_one(
         println!("ID:          {}", id_str);
         println!("Name:        {}", result.name);
         println!("Description: {}", result.description);
-        println!("Scope:       {}", scope_display(result.scope));
+        println!("Visibility:  {}", visibility_display(result.visibility));
 
         if !result.required_params.is_empty() {
             println!("Required params:    {}", result.required_params.join(", "));

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3455,7 +3455,7 @@ impl Forge for Api {
                 description: template.description.clone(),
                 reserved_params: template.reserved_params.clone(),
                 required_artifacts: template.required_artifacts.clone(),
-                scope: ipxe_template_scope_to_proto(template.scope).into(),
+                visibility: ipxe_template_visibility_to_proto(template.visibility).into(),
             })),
             None => Err(Status::not_found(format!(
                 "iPXE template '{}' not found",
@@ -3491,7 +3491,7 @@ impl Forge for Api {
                     description: t.description.clone(),
                     reserved_params: t.reserved_params.clone(),
                     required_artifacts: t.required_artifacts.clone(),
-                    scope: ipxe_template_scope_to_proto(t.scope).into(),
+                    visibility: ipxe_template_visibility_to_proto(t.visibility).into(),
                 })
             })
             .collect::<Result<Vec<_>, Status>>()?;
@@ -3509,14 +3509,14 @@ impl Forge for Api {
     }
 }
 
-fn ipxe_template_scope_to_proto(
-    scope: carbide_ipxe_renderer::IpxeTemplateScope,
-) -> ::rpc::forge::IpxeTemplateScope {
-    use ::rpc::forge::IpxeTemplateScope as ProtoScope;
-    use carbide_ipxe_renderer::IpxeTemplateScope as RendererScope;
-    match scope {
-        RendererScope::Internal => ProtoScope::Internal,
-        RendererScope::Public => ProtoScope::Public,
+fn ipxe_template_visibility_to_proto(
+    visibility: carbide_ipxe_renderer::IpxeTemplateVisibility,
+) -> ::rpc::forge::IpxeTemplateVisibility {
+    use ::rpc::forge::IpxeTemplateVisibility as ProtoVisibility;
+    use carbide_ipxe_renderer::IpxeTemplateVisibility as RendererVisibility;
+    match visibility {
+        RendererVisibility::Internal => ProtoVisibility::Internal,
+        RendererVisibility::Public => ProtoVisibility::Public,
     }
 }
 

--- a/crates/api-web/src/ipxe_template.rs
+++ b/crates/api-web/src/ipxe_template.rs
@@ -28,9 +28,9 @@ use rpc::forge::forge_server::Forge;
 
 use super::Base;
 
-fn ipxe_template_scope_fmt(scope: &i32) -> Cow<'static, str> {
-    rpc::forge::IpxeTemplateScope::try_from(*scope)
-        .map(|scope| Cow::Owned(format!("{scope:?}")))
+fn ipxe_template_visibility_fmt(visibility: &i32) -> Cow<'static, str> {
+    rpc::forge::IpxeTemplateVisibility::try_from(*visibility)
+        .map(|visibility| Cow::Owned(format!("{visibility:?}")))
         .unwrap_or(Cow::Borrowed("Unknown"))
 }
 
@@ -38,11 +38,11 @@ mod filters {
     pub use super::super::filters::option_fmt;
 
     #[askama::filter_fn]
-    pub fn ipxe_template_scope_fmt(
-        scope: &i32,
+    pub fn ipxe_template_visibility_fmt(
+        visibility: &i32,
         _env: &dyn askama::Values,
     ) -> askama::Result<super::Cow<'static, str>> {
-        Ok(super::ipxe_template_scope_fmt(scope))
+        Ok(super::ipxe_template_visibility_fmt(visibility))
     }
 }
 

--- a/crates/api-web/templates/ipxe_template_detail.html
+++ b/crates/api-web/templates/ipxe_template_detail.html
@@ -8,7 +8,7 @@
 <table class="detailsview">
 	<tr><th>Name</th><td>{{ tmpl.name }}</td></tr>
 	<tr><th>Description</th><td>{{ tmpl.description }}</td></tr>
-	<tr><th>Scope</th><td>{{ tmpl.scope|ipxe_template_scope_fmt }}</td></tr>
+	<tr><th>Visibility</th><td>{{ tmpl.visibility|ipxe_template_visibility_fmt }}</td></tr>
 </table>
 
 {% if !tmpl.required_params.is_empty() %}

--- a/crates/api-web/templates/ipxe_template_show.html
+++ b/crates/api-web/templates/ipxe_template_show.html
@@ -10,7 +10,7 @@
 	<thead>
 		<th>Name</th>
 		<th>Description</th>
-		<th>Scope</th>
+		<th>Visibility</th>
 		<th>Required Params</th>
 		<th>Required Artifacts</th>
 	</thead>
@@ -19,7 +19,7 @@
 		<tr>
 			<td><a href="/admin/ipxe-template/{{ tmpl.id|option_fmt }}">{{ tmpl.name }}</a></td>
 			<td>{{ tmpl.description }}</td>
-			<td>{{ tmpl.scope|ipxe_template_scope_fmt }}</td>
+			<td>{{ tmpl.visibility|ipxe_template_visibility_fmt }}</td>
 			<td>{{ tmpl.required_params.len() }}</td>
 			<td>{{ tmpl.required_artifacts.len() }}</td>
 		</tr>

--- a/crates/ipxe-renderer/src/lib.rs
+++ b/crates/ipxe-renderer/src/lib.rs
@@ -63,10 +63,10 @@ pub struct IpxeTemplateArtifact {
     pub cached_url: Option<String>,
 }
 
-/// Scope for iPXE script templates.
+/// Visibility for iPXE script templates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum IpxeTemplateScope {
+pub enum IpxeTemplateVisibility {
     /// NICo Core usage only.
     #[default]
     Internal,
@@ -87,8 +87,8 @@ pub struct IpxeTemplate {
     pub required_params: Vec<String>,
     #[serde(default)]
     pub required_artifacts: Vec<String>,
-    #[serde(default)]
-    pub scope: IpxeTemplateScope,
+    #[serde(default, alias = "scope")]
+    pub visibility: IpxeTemplateVisibility,
 }
 
 /// Template collection loaded from YAML

--- a/crates/ipxe-renderer/templates.yaml
+++ b/crates/ipxe-renderer/templates.yaml
@@ -5,7 +5,7 @@ templates:
   - id: ddbf83c0-a753-5fde-96c1-6b74e9c9db10
     name: raw-ipxe
     description: Allows for raw iPXE scripting but provides base_url, console and arch variables
-    scope: public
+    visibility: public
     required_params:
       - ipxe
     reserved_params:
@@ -34,7 +34,7 @@ templates:
   - id: ea756ddd-add3-5e42-a202-44bfc2d5aac2
     name: qcow-image
     description: Generic multi-platform template iPXE script for qcow images
-    scope: public
+    visibility: public
     required_params:
       - image_url
     reserved_params:
@@ -64,7 +64,7 @@ templates:
   - id: 5c7cfa88-6003-5ac0-b4c0-201eb5b28153
     name: kernel-only
     description: Boot kernel/EFI without initrd (ESXi, etc.)
-    scope: public
+    visibility: public
     required_params:
       - kernel_params
     required_artifacts:
@@ -83,7 +83,7 @@ templates:
   - id: c4b1d4f6-69ba-5f55-90cd-ab2acd002475
     name: kernel-initrd
     description: Generic kernel + initrd boot (Ubuntu autoinstall, NKE, BCM scout, etc.)
-    scope: public
+    visibility: public
     required_params:
       - kernel_params
     required_artifacts:
@@ -104,7 +104,7 @@ templates:
   - id: a7850943-e3cd-5e9a-93ca-9e12f52939cc
     name: ubuntu-autoinstall
     description: Template for Ubuntu autoinstall
-    scope: public
+    visibility: public
     required_artifacts:
       - install_iso
       - kernel
@@ -122,7 +122,7 @@ templates:
   - id: ecaf197e-d60e-50f8-a598-c844afccc24d
     name: dgx-os
     description: Template for DGX OS autoinstall
-    scope: public
+    visibility: public
     required_params:
       - force_platform
     required_artifacts:
@@ -267,7 +267,7 @@ templates:
   - id: 9f1b388e-cf6d-52a2-a20a-19eeeaca2f47
     name: openshift-coreos
     description: OpenShift/Assisted Installer - CoreOS live boot with initrd before kernel
-    scope: public
+    visibility: public
     required_artifacts:
       - initrd
       - kernel
@@ -285,7 +285,7 @@ templates:
   - id: 7be5f99b-9719-53cb-9733-7d674c02e887
     name: chain-efi
     description: Chain to arbitrary EFI binary (firmware update, custom loader, etc.)
-    scope: public
+    visibility: public
     required_params:
       - efi_url
     reserved_params:
@@ -302,7 +302,7 @@ templates:
   - id: d38ae593-8f92-5869-9605-e6d8b2359e7d
     name: loader-rootfs
     description: Chain loader.efi with newrootfs (custom root filesystem)
-    scope: public
+    visibility: public
     required_params:
       - loader_url
       - newrootfs_url
@@ -327,6 +327,6 @@ templates:
   - id: c816a939-0993-5ebf-82dd-5227ad215703
     name: carbide-menu-static-ipxe
     description: NICo Menu
-    scope: public
+    visibility: public
     # Populated from pxe/ipxe/local/embed.ipxe by DefaultIpxeScriptRenderer::new.
     template: ""

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2785,8 +2785,8 @@ message IpxeTemplateArtifact {
   optional string cached_url = 7;           // Local cached URL, set by carbide-core on successful download. If present overrides 'url' at boot time.
 }
 
-// Scope for iPXE script templates.
-enum IpxeTemplateScope {
+// Visibility for iPXE script templates.
+enum IpxeTemplateVisibility {
   INTERNAL = 0;  // Carbide-core usage only
   PUBLIC = 1;    // Usable by tenant
 }
@@ -2799,8 +2799,10 @@ message IpxeTemplate {
   string description = 4;
   repeated string reserved_params = 5;  // Reserved for carbide-core to provide at render time
   repeated string required_artifacts = 6;  // Error if these artifacts are not provided or empty
-  IpxeTemplateScope scope = 7;  // INTERNAL = carbide-core only, PUBLIC = tenant-usable
+  reserved 7;  // formerly `IpxeTemplateScope scope`; renamed to `visibility` and moved to 9
+  reserved "scope";  // old field name; do not reuse
   common.IpxeTemplateId id = 8;  // Stable UUID, hardcoded in templates.yaml; consistent across all sites
+  IpxeTemplateVisibility visibility = 9;  // INTERNAL = carbide-core only, PUBLIC = tenant-usable
 }
 
 // Tenant related configuration that is set once the instance is allocated

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -913,50 +913,50 @@ func (IpxeTemplateArtifactCacheStrategy) EnumDescriptor() ([]byte, []int) {
 	return file_nico_nico_proto_rawDescGZIP(), []int{14}
 }
 
-// Scope for iPXE script templates.
-type IpxeTemplateScope int32
+// Visibility for iPXE script templates.
+type IpxeTemplateVisibility int32
 
 const (
-	IpxeTemplateScope_INTERNAL IpxeTemplateScope = 0 // NICo-core usage only
-	IpxeTemplateScope_PUBLIC   IpxeTemplateScope = 1 // Usable by tenant
+	IpxeTemplateVisibility_INTERNAL IpxeTemplateVisibility = 0 // NICo-core usage only
+	IpxeTemplateVisibility_PUBLIC   IpxeTemplateVisibility = 1 // Usable by tenant
 )
 
-// Enum value maps for IpxeTemplateScope.
+// Enum value maps for IpxeTemplateVisibility.
 var (
-	IpxeTemplateScope_name = map[int32]string{
+	IpxeTemplateVisibility_name = map[int32]string{
 		0: "INTERNAL",
 		1: "PUBLIC",
 	}
-	IpxeTemplateScope_value = map[string]int32{
+	IpxeTemplateVisibility_value = map[string]int32{
 		"INTERNAL": 0,
 		"PUBLIC":   1,
 	}
 )
 
-func (x IpxeTemplateScope) Enum() *IpxeTemplateScope {
-	p := new(IpxeTemplateScope)
+func (x IpxeTemplateVisibility) Enum() *IpxeTemplateVisibility {
+	p := new(IpxeTemplateVisibility)
 	*p = x
 	return p
 }
 
-func (x IpxeTemplateScope) String() string {
+func (x IpxeTemplateVisibility) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (IpxeTemplateScope) Descriptor() protoreflect.EnumDescriptor {
+func (IpxeTemplateVisibility) Descriptor() protoreflect.EnumDescriptor {
 	return file_nico_nico_proto_enumTypes[15].Descriptor()
 }
 
-func (IpxeTemplateScope) Type() protoreflect.EnumType {
+func (IpxeTemplateVisibility) Type() protoreflect.EnumType {
 	return &file_nico_nico_proto_enumTypes[15]
 }
 
-func (x IpxeTemplateScope) Number() protoreflect.EnumNumber {
+func (x IpxeTemplateVisibility) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use IpxeTemplateScope.Descriptor instead.
-func (IpxeTemplateScope) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use IpxeTemplateVisibility.Descriptor instead.
+func (IpxeTemplateVisibility) EnumDescriptor() ([]byte, []int) {
 	return file_nico_nico_proto_rawDescGZIP(), []int{15}
 }
 
@@ -16519,8 +16519,8 @@ type IpxeTemplate struct {
 	Description       string                 `protobuf:"bytes,4,opt,name=description,proto3" json:"description,omitempty"`
 	ReservedParams    []string               `protobuf:"bytes,5,rep,name=reserved_params,json=reservedParams,proto3" json:"reserved_params,omitempty"`          // Reserved for nico-core to provide at render time
 	RequiredArtifacts []string               `protobuf:"bytes,6,rep,name=required_artifacts,json=requiredArtifacts,proto3" json:"required_artifacts,omitempty"` // Error if these artifacts are not provided or empty
-	Scope             IpxeTemplateScope      `protobuf:"varint,7,opt,name=scope,proto3,enum=forge.IpxeTemplateScope" json:"scope,omitempty"`                    // INTERNAL = nico-core only, PUBLIC = tenant-usable
 	Id                *IpxeTemplateId        `protobuf:"bytes,8,opt,name=id,proto3" json:"id,omitempty"`                                                        // Stable UUID, hardcoded in templates.yaml; consistent across all sites
+	Visibility        IpxeTemplateVisibility `protobuf:"varint,9,opt,name=visibility,proto3,enum=forge.IpxeTemplateVisibility" json:"visibility,omitempty"`     // INTERNAL = nico-core only, PUBLIC = tenant-usable
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -16597,18 +16597,18 @@ func (x *IpxeTemplate) GetRequiredArtifacts() []string {
 	return nil
 }
 
-func (x *IpxeTemplate) GetScope() IpxeTemplateScope {
-	if x != nil {
-		return x.Scope
-	}
-	return IpxeTemplateScope_INTERNAL
-}
-
 func (x *IpxeTemplate) GetId() *IpxeTemplateId {
 	if x != nil {
 		return x.Id
 	}
 	return nil
+}
+
+func (x *IpxeTemplate) GetVisibility() IpxeTemplateVisibility {
+	if x != nil {
+		return x.Visibility
+	}
+	return IpxeTemplateVisibility_INTERNAL
 }
 
 // Tenant related configuration that is set once the instance is allocated
@@ -61528,16 +61528,18 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\n" +
 	"_auth_typeB\r\n" +
 	"\v_auth_tokenB\r\n" +
-	"\v_cached_url\"\xb9\x02\n" +
+	"\v_cached_url\"\xd5\x02\n" +
 	"\fIpxeTemplate\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
 	"\btemplate\x18\x02 \x01(\tR\btemplate\x12'\n" +
 	"\x0frequired_params\x18\x03 \x03(\tR\x0erequiredParams\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12'\n" +
 	"\x0freserved_params\x18\x05 \x03(\tR\x0ereservedParams\x12-\n" +
-	"\x12required_artifacts\x18\x06 \x03(\tR\x11requiredArtifacts\x12.\n" +
-	"\x05scope\x18\a \x01(\x0e2\x18.forge.IpxeTemplateScopeR\x05scope\x12&\n" +
-	"\x02id\x18\b \x01(\v2\x16.common.IpxeTemplateIdR\x02id\"\xb4\x01\n" +
+	"\x12required_artifacts\x18\x06 \x03(\tR\x11requiredArtifacts\x12&\n" +
+	"\x02id\x18\b \x01(\v2\x16.common.IpxeTemplateIdR\x02id\x12=\n" +
+	"\n" +
+	"visibility\x18\t \x01(\x0e2\x1d.forge.IpxeTemplateVisibilityR\n" +
+	"visibilityJ\x04\b\a\x10\bR\x05scope\"\xb4\x01\n" +
 	"\fTenantConfig\x124\n" +
 	"\x16tenant_organization_id\x18\x01 \x01(\tR\x14tenantOrganizationId\x12\x1f\n" +
 	"\bhostname\x18\x0f \x01(\tH\x00R\bhostname\x88\x01\x01\x12(\n" +
@@ -65498,8 +65500,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\n" +
 	"LOCAL_ONLY\x10\x01\x12\x0f\n" +
 	"\vCACHED_ONLY\x10\x02\x12\x0f\n" +
-	"\vREMOTE_ONLY\x10\x03*-\n" +
-	"\x11IpxeTemplateScope\x12\f\n" +
+	"\vREMOTE_ONLY\x10\x03*2\n" +
+	"\x16IpxeTemplateVisibility\x12\f\n" +
 	"\bINTERNAL\x10\x00\x12\n" +
 	"\n" +
 	"\x06PUBLIC\x10\x01*7\n" +
@@ -66347,7 +66349,7 @@ var file_nico_nico_proto_goTypes = []any{
 	(NetworkSegmentType)(0),                                                   // 12: forge.NetworkSegmentType
 	(NetworkSegmentFlag)(0),                                                   // 13: forge.NetworkSegmentFlag
 	(IpxeTemplateArtifactCacheStrategy)(0),                                    // 14: forge.IpxeTemplateArtifactCacheStrategy
-	(IpxeTemplateScope)(0),                                                    // 15: forge.IpxeTemplateScope
+	(IpxeTemplateVisibility)(0),                                               // 15: forge.IpxeTemplateVisibility
 	(SpxAttachmentType)(0),                                                    // 16: forge.SpxAttachmentType
 	(IssueCategory)(0),                                                        // 17: forge.IssueCategory
 	(AssignStaticAddressStatus)(0),                                            // 18: forge.AssignStaticAddressStatus
@@ -67786,8 +67788,8 @@ var file_nico_nico_proto_depIdxs = []int32{
 	264,  // 250: forge.BatchInstanceAllocationRequest.instance_requests:type_name -> forge.InstanceAllocationRequest
 	293,  // 251: forge.BatchInstanceAllocationResponse.instances:type_name -> forge.Instance
 	14,   // 252: forge.IpxeTemplateArtifact.cache_strategy:type_name -> forge.IpxeTemplateArtifactCacheStrategy
-	15,   // 253: forge.IpxeTemplate.scope:type_name -> forge.IpxeTemplateScope
-	1003, // 254: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
+	1003, // 253: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
+	15,   // 254: forge.IpxeTemplate.visibility:type_name -> forge.IpxeTemplateVisibility
 	272,  // 255: forge.InstanceOperatingSystemConfig.ipxe:type_name -> forge.InlineIpxe
 	996,  // 256: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
 	1004, // 257: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -2784,8 +2784,8 @@ message IpxeTemplateArtifact {
   optional string cached_url = 7;           // Local cached URL, set by nico-core on successful download. If present overrides 'url' at boot time.
 }
 
-// Scope for iPXE script templates.
-enum IpxeTemplateScope {
+// Visibility for iPXE script templates.
+enum IpxeTemplateVisibility {
   INTERNAL = 0;  // NICo-core usage only
   PUBLIC = 1;    // Usable by tenant
 }
@@ -2798,8 +2798,10 @@ message IpxeTemplate {
   string description = 4;
   repeated string reserved_params = 5;  // Reserved for nico-core to provide at render time
   repeated string required_artifacts = 6;  // Error if these artifacts are not provided or empty
-  IpxeTemplateScope scope = 7;  // INTERNAL = nico-core only, PUBLIC = tenant-usable
+  reserved 7;  // formerly `IpxeTemplateScope scope`; renamed to `visibility` and moved to 9
+  reserved "scope";  // old field name; do not reuse
   common.IpxeTemplateId id = 8;  // Stable UUID, hardcoded in templates.yaml; consistent across all sites
+  IpxeTemplateVisibility visibility = 9;  // INTERNAL = nico-core only, PUBLIC = tenant-usable
 }
 
 // Tenant related configuration that is set once the instance is allocated


### PR DESCRIPTION
Rename the iPXE template "scope" concept to "visibility" across NICo Core so the naming matches its meaning (INTERNAL = core-only, PUBLIC = tenant-usable), avoid confusion with scope in Operating Systems and lines up with the rest-api side.

## Type of Change
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Manual testing performed
