### PR TITLE
fix(flow): Allow migration signature recovery

### DIFF
--- a/rest-api/flow/cmd/db_migrate.go
+++ b/rest-api/flow/cmd/db_migrate.go
@@ -16,6 +16,10 @@ import (
 
 var (
 	rollBack string
+	// ignoreSignatureChanges is a hidden, temporary recovery option. It accepts
+	// changed signatures for installed migrations by updating their table rows
+	// without re-running their SQL.
+	ignoreSignatureChanges bool
 
 	// migrateCmd is the subcommand that runs database migrations.
 	migrateCmd = &cobra.Command{
@@ -32,6 +36,8 @@ func init() {
 	dbCmd.AddCommand(migrateCmd)
 
 	migrateCmd.Flags().StringVarP(&rollBack, "rollback", "r", "", "Roll back the schema to the way it was at the specified time.  This is the application time, not from the ID.  Format 2006-01-02T15:04:05")
+	migrateCmd.Flags().BoolVar(&ignoreSignatureChanges, "ignore-signature-changes", false, "Accept changed signatures for installed migrations without re-applying them")
+	_ = migrateCmd.Flags().MarkHidden("ignore-signature-changes")
 }
 
 // doMigration connects to the database and runs pending migrations. If the
@@ -60,7 +66,8 @@ func doMigration() {
 			log.Fatal().Msgf("Failed to roll back migrations: %v", err)
 		}
 	} else {
-		if err := migrations.MigrateWithDB(ctx, session.DB); err != nil {
+		options := migrations.MigrateOptions{IgnoreSignatureChanges: ignoreSignatureChanges}
+		if err := migrations.MigrateWithDB(ctx, session.DB, options); err != nil {
 			log.Fatal().Msgf("Failed to run migrations: %v", err)
 		}
 	}

--- a/rest-api/flow/internal/common/utils/utils.go
+++ b/rest-api/flow/internal/common/utils/utils.go
@@ -24,7 +24,7 @@ func UnitTestDB(ctx context.Context, t *testing.T, dbConf cdb.Config) (*cdb.Sess
 		return nil, err
 	}
 
-	err = migrations.MigrateWithDB(ctx, session.DB)
+	err = migrations.MigrateWithDB(ctx, session.DB, migrations.MigrateOptions{})
 
 	return session, err
 }

--- a/rest-api/flow/internal/db/migrations/main.go
+++ b/rest-api/flow/internal/db/migrations/main.go
@@ -8,6 +8,7 @@ import (
 	"crypto/md5"
 	"embed"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -103,12 +104,25 @@ func parseMigrationFilename(path string, is_up bool) (id string, name string, ok
 }
 
 func stringHash(contents []byte) string {
-	hash := md5.Sum([]byte(contents))
+	hash := md5.Sum(contents)
 	return hex.EncodeToString(hash[:])
 }
 
 func hashMatch(contents []byte, oldHash string) bool {
 	return stringHash(contents) == oldHash
+}
+
+func checkMigrationSignature(contents []byte, oldHash string, options MigrateOptions) (shouldUpdateSignature bool, err error) {
+	if hashMatch(contents, oldHash) {
+		return false, nil
+	}
+	if options.IgnoreSignatureChanges {
+		return true, nil
+	}
+	if strings.Contains(string(contents), "Allow hash changing") {
+		return false, nil
+	}
+	return false, errors.New("signature does not match")
 }
 
 // applyMigration will apply an individual migration to the database
@@ -153,23 +167,33 @@ func alternatePresent(path string) bool {
 	return false
 }
 
-// MigrateWithDB ensures that the database contains all currently known migrations.
-// Accepts a *bun.DB directly.
-func MigrateWithDB(ctx context.Context, db *bun.DB) error {
-	return migrateInternalWithDB(ctx, db, nil)
+// MigrateOptions controls optional forward-migration behavior.
+type MigrateOptions struct {
+	// IgnoreSignatureChanges accepts changed contents for migrations that are
+	// already installed. The migration SQL is not run again; only the stored
+	// hash is updated.
+	IgnoreSignatureChanges bool
+}
+
+// MigrateWithDB ensures that the database contains all currently known
+// migrations using the supplied options.
+func MigrateWithDB(ctx context.Context, db *bun.DB, options MigrateOptions) error {
+	return migrateInternalWithDB(ctx, db, nil, options)
 }
 
 // RollbackWithDB will roll back migrations that have been applied since the given time.
 // Accepts a *bun.DB directly.
 func RollbackWithDB(ctx context.Context, db *bun.DB, rollbackTime time.Time) error {
-	return migrateInternalWithDB(ctx, db, &rollbackTime)
+	return migrateInternalWithDB(ctx, db, &rollbackTime, MigrateOptions{})
 }
 
-// pendingMigration holds information about a migration that needs to be applied
-type pendingMigration struct {
+// migration holds information needed to apply a migration or update its
+// recorded signature.
+type migration struct {
 	id   string
 	name string
 	path string
+	hash string
 }
 
 // readMigrationContents reads the contents of a migration file
@@ -183,7 +207,7 @@ func readMigrationContents(path string) ([]byte, error) {
 }
 
 // migrateInternalWithDB migrates either up or down using a *bun.DB
-func migrateInternalWithDB(ctx context.Context, db *bun.DB, rollbackTime *time.Time) (errFinal error) {
+func migrateInternalWithDB(ctx context.Context, db *bun.DB, rollbackTime *time.Time, options MigrateOptions) (errFinal error) {
 	return db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error { //nolint:exhaustruct,varnamelen,wrapcheck // default options; tx is idiomatic; thin wrapper
 		// Lock the migration table manually in case we are running multiple instances that may try to upgrade simultaneously
 		if err := lockOrCreateMigrationTable(ctx, &tx); err != nil {
@@ -197,7 +221,8 @@ func migrateInternalWithDB(ctx context.Context, db *bun.DB, rollbackTime *time.T
 		}
 
 		isRollback := rollbackTime != nil
-		var pending []pendingMigration
+		var pending []migration
+		var changedSignatures []migration
 
 		// Collect all migrations that need to be applied
 		if err := fs.WalkDir(sqlMigrations, ".", func(path string, d fs.DirEntry, err error) error {
@@ -209,10 +234,10 @@ func migrateInternalWithDB(ctx context.Context, db *bun.DB, rollbackTime *time.T
 				return fmt.Errorf("Migration file %s does not have a matching down/up migration", path)
 			}
 
-			migration, alreadyApplied := appliedMigrations[id]
+			installedMigration, alreadyApplied := appliedMigrations[id]
 			if isRollback {
 				// For rollback: only include migrations that were applied after rollbackTime
-				if !alreadyApplied || !rollbackTime.Before(migration.applied) {
+				if !alreadyApplied || !rollbackTime.Before(installedMigration.applied) {
 					return nil
 				}
 			} else {
@@ -223,17 +248,38 @@ func migrateInternalWithDB(ctx context.Context, db *bun.DB, rollbackTime *time.T
 					if err != nil {
 						return err
 					}
-					if !hashMatch(contents, migration.hash) && !strings.Contains(string(contents), "Allow hash changing") {
+
+					shouldUpdateSignature, err := checkMigrationSignature(contents, installedMigration.hash, options)
+					if err != nil {
 						return fmt.Errorf("Hash for migration %s (%s) does not match already applied migration.  Something inappropriately altered the migration.  Aborting.", name, id)
 					}
+
+					if shouldUpdateSignature {
+						changedSignatures = append(
+							changedSignatures,
+							migration{
+								id:   id,
+								name: name,
+								hash: stringHash(contents),
+							},
+						)
+					}
+
 					return nil
 				}
 			}
 
-			pending = append(pending, pendingMigration{id: id, name: name, path: path})
+			pending = append(pending, migration{id: id, name: name, path: path})
 			return nil
 		}); err != nil {
 			return err
+		}
+
+		for _, migration := range changedSignatures {
+			log.Warn().Msgf("Accepting changed signature for installed migration %s (%s) without re-applying it", migration.name, migration.id)
+			if _, err := tx.ExecContext(ctx, "UPDATE migrations SET hash = ?0 WHERE id = ?1", migration.hash, migration.id); err != nil {
+				return fmt.Errorf("updating signature for installed migration %s (%s): %w", migration.name, migration.id, err)
+			}
 		}
 
 		// Sort migrations in the appropriate order
@@ -260,7 +306,7 @@ func migrateInternalWithDB(ctx context.Context, db *bun.DB, rollbackTime *time.T
 			}
 		}
 
-		if len(pending) == 0 {
+		if len(pending) == 0 && len(changedSignatures) == 0 {
 			log.Info().Msg("Database schema up to date, no migrations applied")
 		}
 

--- a/rest-api/flow/internal/service/service.go
+++ b/rest-api/flow/internal/service/service.go
@@ -35,6 +35,17 @@ import (
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/proto/v1"
 )
 
+// ignoreMigrationSignatureChangesEnvVar enables the temporary migration
+// recovery workaround during service startup. When set to "true", changed
+// signatures are stored without re-running installed migration SQL.
+const ignoreMigrationSignatureChangesEnvVar = "FLOW_DB_MIGRATION_IGNORE_SIGNATURE_CHANGES"
+
+func migrationOptionsFromEnv() migrations.MigrateOptions {
+	return migrations.MigrateOptions{
+		IgnoreSignatureChanges: os.Getenv(ignoreMigrationSignatureChangesEnvVar) == "true",
+	}
+}
+
 // Service is the top-level Flow service. It owns the gRPC server, database
 // session, inventory manager, and task manager and coordinates their lifecycles.
 type Service struct {
@@ -66,8 +77,14 @@ func New(ctx context.Context, c Config) (*Service, error) {
 		return nil, fmt.Errorf("failed to create database connection: %w", err)
 	}
 
-	// Run migrations
-	if err := migrations.MigrateWithDB(ctx, session.DB); err != nil {
+	// Run migrations. The signature override is an operational escape hatch for
+	// recovering from changed migration files; strict verification remains the
+	// default.
+	migrationOptions := migrationOptionsFromEnv()
+	if migrationOptions.IgnoreSignatureChanges {
+		log.Warn().Msgf("Migration signature changes will be accepted because %s=true", ignoreMigrationSignatureChangesEnvVar)
+	}
+	if err := migrations.MigrateWithDB(ctx, session.DB, migrationOptions); err != nil {
 		session.Close()
 
 		return nil, fmt.Errorf("failed to run migrations: %w", err)


### PR DESCRIPTION
- Flow normally aborts startup when an installed migration file no longer matches the hash recorded in the migrations table. A migration-file changed shipped with an affected build can therefore prevent the service from starting even when the changes may not affect the DB schemas, such as the copy-right changes in the migration files.

<!-- Describe what this PR does -->
- Add an explicit recovery mode that accepts mismatched installed migrations by updating only their recorded hashes in the same locked transaction. Installed migration SQL is never re-applied, while migrations that have not yet run continue through the normal application path.

- Expose the recovery mode through a hidden db migrate flag and a service startup environment variable. These controls are intentionally hidden and undocumented because they are temporary operational escape hatches for the known issue, not part of the supported migration workflow. Strict signature verification remains the default.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

