### PR TITLE
fix(dhcp): resync hostname on static assign/remove-address (#3383)

### DIFF
--- a/crates/api-core/src/dhcp/expire.rs
+++ b/crates/api-core/src/dhcp/expire.rs
@@ -83,6 +83,7 @@ pub async fn expire_dhcp_lease(
                 model::allocation_type::AllocationType::Dhcp,
             )
             .await?
+            .is_some()
         }
     };
 

--- a/crates/api-core/src/dhcp/expire.rs
+++ b/crates/api-core/src/dhcp/expire.rs
@@ -66,24 +66,33 @@ pub async fn expire_dhcp_lease(
     // pair. Otherwise, just call the address-only variant, which would
     // be something we would see from an admin-cli call used for deleting
     // a specific IP allocation.
-    let deleted = match mac_address {
+    // Determine which interfaces need a hostname resync after the delete. The
+    // mac-scoped variant targets a single (ip, mac) row, so resync the interface
+    // looked up above; the address-only variant can match multiple rows, so
+    // resync every owner it reports rather than dropping all but one.
+    let (deleted, resync_targets) = match mac_address {
         Some(mac) => {
-            db::machine_interface_address::delete_by_address_and_mac(
+            let deleted = db::machine_interface_address::delete_by_address_and_mac(
                 &mut txn,
                 ip_address,
                 mac,
                 model::allocation_type::AllocationType::Dhcp,
             )
-            .await?
+            .await?;
+            let targets = match (deleted, &interface) {
+                (true, Some(iface)) => vec![iface.id],
+                _ => Vec::new(),
+            };
+            (deleted, targets)
         }
         None => {
-            !db::machine_interface_address::delete_by_address(
+            let owners = db::machine_interface_address::delete_by_address(
                 &mut txn,
                 ip_address,
                 model::allocation_type::AllocationType::Dhcp,
             )
-            .await?
-            .is_empty()
+            .await?;
+            (!owners.is_empty(), owners)
         }
     };
 
@@ -91,8 +100,8 @@ pub async fn expire_dhcp_lease(
     // consistent: the IP style re-derives (and re-derives again from the next
     // allocated IP on rediscovery); the other styles keep their names and only
     // drop out of DNS while addressless.
-    if deleted && let Some(iface) = interface {
-        db::machine_interface::sync_hostname_after_address_change(&mut txn, iface.id).await?;
+    for iface_id in &resync_targets {
+        db::machine_interface::sync_hostname_after_address_change(&mut txn, *iface_id).await?;
     }
 
     txn.commit().await?;

--- a/crates/api-core/src/dhcp/expire.rs
+++ b/crates/api-core/src/dhcp/expire.rs
@@ -57,44 +57,32 @@ pub async fn expire_dhcp_lease(
 
     let mut txn = api.txn_begin().await?;
 
-    // Look up the interface that owns this IP before deleting so we can clear
-    // its hostname afterward. The JOIN in find_by_ip requires the address row
-    // to still exist, so we must do this before the delete.
-    let interface = db::machine_interface::find_by_ip(&mut txn, ip_address).await?;
-
-    // When the caller provides the MAC, scope the delete to the (ip, mac)
-    // pair. Otherwise, just call the address-only variant, which would
-    // be something we would see from an admin-cli call used for deleting
-    // a specific IP allocation.
-    // Determine which interfaces need a hostname resync after the delete. The
-    // mac-scoped variant targets a single (ip, mac) row, so resync the interface
-    // looked up above; the address-only variant can match multiple rows, so
-    // resync every owner it reports rather than dropping all but one.
-    let (deleted, resync_targets) = match mac_address {
+    // When the caller provides the MAC, scope the delete to the (ip, mac) pair.
+    // Otherwise use the address-only variant, which is what an admin-cli call
+    // deleting a specific IP allocation would hit. Either way, both variants
+    // return the interfaces whose rows were actually deleted, so we resync those
+    // authoritative owners rather than a separately looked-up interface (which
+    // could differ if ownership changed or multiple rows share the address).
+    let resync_targets = match mac_address {
         Some(mac) => {
-            let deleted = db::machine_interface_address::delete_by_address_and_mac(
+            db::machine_interface_address::delete_by_address_and_mac(
                 &mut txn,
                 ip_address,
                 mac,
                 model::allocation_type::AllocationType::Dhcp,
             )
-            .await?;
-            let targets = match (deleted, &interface) {
-                (true, Some(iface)) => vec![iface.id],
-                _ => Vec::new(),
-            };
-            (deleted, targets)
+            .await?
         }
         None => {
-            let owners = db::machine_interface_address::delete_by_address(
+            db::machine_interface_address::delete_by_address(
                 &mut txn,
                 ip_address,
                 model::allocation_type::AllocationType::Dhcp,
             )
-            .await?;
-            (!owners.is_empty(), owners)
+            .await?
         }
     };
+    let deleted = !resync_targets.is_empty();
 
     // Sync the hostname to the remaining address state so DNS stays
     // consistent: the IP style re-derives (and re-derives again from the next

--- a/crates/api-core/src/dhcp/expire.rs
+++ b/crates/api-core/src/dhcp/expire.rs
@@ -77,13 +77,13 @@ pub async fn expire_dhcp_lease(
             .await?
         }
         None => {
-            db::machine_interface_address::delete_by_address(
+            !db::machine_interface_address::delete_by_address(
                 &mut txn,
                 ip_address,
                 model::allocation_type::AllocationType::Dhcp,
             )
             .await?
-            .is_some()
+            .is_empty()
         }
     };
 

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -151,6 +151,17 @@ pub async fn assign_static_address(
         );
     }
 
+    // Keep the interface's IP-derived hostname/domain consistent with the new
+    // address, matching every other assignment path. Skipping this leaves a
+    // stale hostname that encodes a now-freed IP and collides with the
+    // fqdn_must_be_unique constraint when the allocator reuses that IP.
+    db::machine_interface::sync_hostname_after_address_assignment(
+        &mut txn,
+        interface_id,
+        target_segment.config.subdomain_id,
+    )
+    .await?;
+
     txn.commit().await?;
 
     let status: rpc::AssignStaticAddressStatus = result.into();
@@ -180,6 +191,14 @@ pub async fn remove_static_address(
         AllocationType::Static,
     )
     .await?;
+
+    // Re-derive the interface's hostname/domain now that the address is gone,
+    // matching the DHCP lease-expiry path. Without this the interface keeps a
+    // hostname pinned to the removed IP.
+    if deleted {
+        db::machine_interface::sync_hostname_after_address_change(&mut txn, interface_id).await?;
+    }
+
     txn.commit().await?;
 
     let status = if deleted {

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -185,23 +185,24 @@ pub async fn remove_static_address(
     let ip_address: std::net::IpAddr = req.ip_address.parse()?;
 
     let mut txn = api.txn_begin().await?;
-    let deleted = db::machine_interface_address::delete_by_address(
+    let removed_owner = db::machine_interface_address::delete_by_address(
         &mut txn,
         ip_address,
         AllocationType::Static,
     )
     .await?;
 
-    // Re-derive the interface's hostname/domain now that the address is gone,
-    // matching the DHCP lease-expiry path. Without this the interface keeps a
-    // hostname pinned to the removed IP.
-    if deleted {
-        db::machine_interface::sync_hostname_after_address_change(&mut txn, interface_id).await?;
+    // Re-derive the hostname/domain of the interface that actually owned the
+    // removed address, matching the DHCP lease-expiry path. delete_by_address
+    // deletes by IP, so the owner may differ from the request's interface_id;
+    // resyncing the wrong one would leave the real owner with a stale hostname.
+    if let Some(owner_id) = removed_owner {
+        db::machine_interface::sync_hostname_after_address_change(&mut txn, owner_id).await?;
     }
 
     txn.commit().await?;
 
-    let status = if deleted {
+    let status = if removed_owner.is_some() {
         tracing::info!(machine_interface_id = %interface_id, %ip_address, "Removed static address");
         rpc::RemoveStaticAddressStatus::Removed
     } else {

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -185,24 +185,29 @@ pub async fn remove_static_address(
     let ip_address: std::net::IpAddr = req.ip_address.parse()?;
 
     let mut txn = api.txn_begin().await?;
-    let removed_owners = db::machine_interface_address::delete_by_address(
+    // Scope the delete to the caller's interface so remove-address only ever
+    // removes that interface's own address, matching the command's contract
+    // ("remove the address from a machine interface"). A mismatched interface_id
+    // deletes nothing and returns NotFound rather than removing another
+    // interface's row that happens to hold the same IP.
+    let deleted = db::machine_interface_address::delete_by_interface_and_address(
         &mut txn,
+        interface_id,
         ip_address,
         AllocationType::Static,
     )
     .await?;
 
-    // Re-derive the hostname/domain of every interface that actually owned a
-    // removed address, matching the DHCP lease-expiry path. delete_by_address
-    // deletes by IP, so the owner may differ from the request's interface_id;
-    // resyncing the wrong one would leave the real owner with a stale hostname.
-    for owner_id in &removed_owners {
-        db::machine_interface::sync_hostname_after_address_change(&mut txn, *owner_id).await?;
+    // Re-derive the interface's hostname/domain now that its address is gone,
+    // matching the DHCP lease-expiry path. Without this the interface keeps a
+    // hostname pinned to the removed IP.
+    if deleted {
+        db::machine_interface::sync_hostname_after_address_change(&mut txn, interface_id).await?;
     }
 
     txn.commit().await?;
 
-    let status = if !removed_owners.is_empty() {
+    let status = if deleted {
         tracing::info!(machine_interface_id = %interface_id, %ip_address, "Removed static address");
         rpc::RemoveStaticAddressStatus::Removed
     } else {

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -185,24 +185,24 @@ pub async fn remove_static_address(
     let ip_address: std::net::IpAddr = req.ip_address.parse()?;
 
     let mut txn = api.txn_begin().await?;
-    let removed_owner = db::machine_interface_address::delete_by_address(
+    let removed_owners = db::machine_interface_address::delete_by_address(
         &mut txn,
         ip_address,
         AllocationType::Static,
     )
     .await?;
 
-    // Re-derive the hostname/domain of the interface that actually owned the
+    // Re-derive the hostname/domain of every interface that actually owned a
     // removed address, matching the DHCP lease-expiry path. delete_by_address
     // deletes by IP, so the owner may differ from the request's interface_id;
     // resyncing the wrong one would leave the real owner with a stale hostname.
-    if let Some(owner_id) = removed_owner {
-        db::machine_interface::sync_hostname_after_address_change(&mut txn, owner_id).await?;
+    for owner_id in &removed_owners {
+        db::machine_interface::sync_hostname_after_address_change(&mut txn, *owner_id).await?;
     }
 
     txn.commit().await?;
 
-    let status = if removed_owner.is_some() {
+    let status = if !removed_owners.is_empty() {
         tracing::info!(machine_interface_id = %interface_id, %ip_address, "Removed static address");
         rpc::RemoveStaticAddressStatus::Removed
     } else {

--- a/crates/api-core/tests/integration/dhcp_lease_expiration.rs
+++ b/crates/api-core/tests/integration/dhcp_lease_expiration.rs
@@ -537,3 +537,70 @@ async fn test_expire_with_mismatched_mac_is_no_op(
 
     Ok(())
 }
+
+/// Regression for #3383 (review follow-up): the MAC-scoped expiry path must
+/// resync the interface that actually owned the deleted (ip, mac) row — derived
+/// from the delete itself — and leave other interfaces on the segment untouched.
+#[sqlx_test]
+async fn test_mac_scoped_expiry_resyncs_only_the_owner(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (env, admin_segment) = init(pool).await;
+    let owner_mac = "aa:bb:cc:dd:ee:20";
+    let other_mac = "aa:bb:cc:dd:ee:21";
+
+    // Two interfaces, each with its own DHCP address and IP-derived hostname.
+    let owner = env
+        .api()
+        .discover_dhcp(
+            DhcpDiscovery::builder(owner_mac, admin_segment.relay_address).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let owner_ip = owner.address.clone();
+    let owner_id = owner.machine_interface_id.unwrap();
+
+    let other = env
+        .api()
+        .discover_dhcp(
+            DhcpDiscovery::builder(other_mac, admin_segment.relay_address).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let other_id = other.machine_interface_id.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let other_hostname_before = db::machine_interface::find_one(&mut *txn, other_id)
+        .await?
+        .hostname;
+    txn.commit().await?;
+
+    // Expire the owner's lease scoped by (ip, mac).
+    let expire_response = env
+        .api()
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: owner_ip,
+            mac_address: Some(owner_mac.to_string()),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(expire_response.status(), ExpireDhcpLeaseStatus::Released);
+
+    // The owner is resynced to the dormant placeholder; the other interface is
+    // left exactly as it was.
+    let mut txn = env.db_txn().await;
+    let owner_after = db::machine_interface::find_one(&mut *txn, owner_id).await?;
+    let other_after = db::machine_interface::find_one(&mut *txn, other_id).await?;
+    txn.commit().await?;
+    assert!(
+        owner_after.hostname.to_lowercase().starts_with("noip"),
+        "the (ip, mac) owner should be resynced to dormant, got: {}",
+        owner_after.hostname,
+    );
+    assert_eq!(
+        other_after.hostname, other_hostname_before,
+        "an unrelated interface must not be resynced"
+    );
+
+    Ok(())
+}

--- a/crates/api-core/tests/integration/static_address_management.rs
+++ b/crates/api-core/tests/integration/static_address_management.rs
@@ -452,6 +452,82 @@ async fn test_assign_remove_then_dhcp_reallocates(
     Ok(())
 }
 
+/// Regression for #3383: assign-address and remove-address must keep the
+/// interface's IP-derived hostname consistent with its address, like every
+/// other allocation path. A stale hostname encoding a now-freed IP collides
+/// with the fqdn_must_be_unique constraint and wedges DHCP allocation on the
+/// whole segment.
+#[sqlx_test]
+async fn test_assign_and_remove_resync_hostname(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let StaticAddressTestEnv {
+        env, admin_segment, ..
+    } = init(pool).await;
+    let mac = MacAddress::from_str("aa:bb:cc:dd:ee:17").unwrap();
+    let mac_str = mac.to_string();
+
+    // Let the interface get a DHCP address; its hostname is derived from it.
+    let discover_resp = env
+        .api()
+        .discover_dhcp(
+            DhcpDiscovery::builder(&mac_str, admin_segment.relay_address).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let dhcp_ip = discover_resp.address.clone();
+    let interface_id = discover_resp.machine_interface_id.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let iface = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert_eq!(
+        iface.hostname,
+        dhcp_ip.replace('.', "-"),
+        "hostname should be derived from the DHCP address"
+    );
+    txn.commit().await?;
+
+    // Move it to a different static IP (same family, so it replaces the DHCP
+    // one). The hostname must follow the new address, not stay pinned to the
+    // now-freed DHCP IP.
+    let static_ip = "192.0.2.217";
+    env.api()
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(interface_id),
+            ip_address: static_ip.to_string(),
+        }))
+        .await?;
+
+    let mut txn = env.db_txn().await;
+    let iface_after_assign = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert_eq!(
+        iface_after_assign.hostname,
+        static_ip.replace('.', "-"),
+        "hostname should resync to the newly assigned static address"
+    );
+    txn.commit().await?;
+
+    // Remove the static address; with no addresses left the hostname must reset
+    // to the dormant placeholder rather than keep encoding the freed IP.
+    env.api()
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(interface_id),
+            ip_address: static_ip.to_string(),
+        }))
+        .await?;
+
+    let mut txn = env.db_txn().await;
+    let iface_after_remove = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert!(
+        iface_after_remove.hostname.to_lowercase().starts_with("noip"),
+        "hostname should reset to dormant format after removal, got: {}",
+        iface_after_remove.hostname,
+    );
+    txn.commit().await?;
+
+    Ok(())
+}
+
 /// When assigning a static IP that's within a managed segment's prefix,
 /// the interface's segment_id should be updated to that segment.
 #[sqlx_test]

--- a/crates/api-core/tests/integration/static_address_management.rs
+++ b/crates/api-core/tests/integration/static_address_management.rs
@@ -519,9 +519,78 @@ async fn test_assign_and_remove_resync_hostname(
     let mut txn = env.db_txn().await;
     let iface_after_remove = db::machine_interface::find_one(&mut *txn, interface_id).await?;
     assert!(
-        iface_after_remove.hostname.to_lowercase().starts_with("noip"),
+        iface_after_remove
+            .hostname
+            .to_lowercase()
+            .starts_with("noip"),
         "hostname should reset to dormant format after removal, got: {}",
         iface_after_remove.hostname,
+    );
+    txn.commit().await?;
+
+    Ok(())
+}
+
+/// Regression for #3383 (review follow-up): remove-address deletes by IP, so the
+/// interface that owned the removed address may differ from the caller-supplied
+/// interface_id. The resync must target the actual owner, otherwise the real
+/// owner keeps a hostname pinned to the freed IP.
+#[sqlx_test]
+async fn test_remove_resyncs_the_address_owner_not_the_request_id(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let StaticAddressTestEnv {
+        env, admin_segment, ..
+    } = init(pool).await;
+
+    // Owner interface: give it a static address so its hostname is IP-derived.
+    let owner_mac = MacAddress::from_str("aa:bb:cc:dd:ee:18").unwrap().to_string();
+    let owner = env
+        .api()
+        .discover_dhcp(
+            DhcpDiscovery::builder(&owner_mac, admin_segment.relay_address).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let owner_id = owner.machine_interface_id.unwrap();
+    let owned_ip = "192.0.2.218";
+    env.api()
+        .assign_static_address(Request::new(AssignStaticAddressRequest {
+            interface_id: Some(owner_id),
+            ip_address: owned_ip.to_string(),
+        }))
+        .await?;
+
+    // A second, unrelated interface whose id we will (incorrectly) pass to
+    // remove-address.
+    let other_mac = MacAddress::from_str("aa:bb:cc:dd:ee:19").unwrap().to_string();
+    let other = env
+        .api()
+        .discover_dhcp(
+            DhcpDiscovery::builder(&other_mac, admin_segment.relay_address).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let other_id = other.machine_interface_id.unwrap();
+
+    // Remove the owner's IP but pass the *other* interface's id.
+    let resp = env
+        .api()
+        .remove_static_address(Request::new(RemoveStaticAddressRequest {
+            interface_id: Some(other_id),
+            ip_address: owned_ip.to_string(),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(resp.status(), RemoveStaticAddressStatus::Removed);
+
+    // The owner (which actually lost the address) must be resynced to dormant.
+    let mut txn = env.db_txn().await;
+    let owner_after = db::machine_interface::find_one(&mut *txn, owner_id).await?;
+    assert!(
+        owner_after.hostname.to_lowercase().starts_with("noip"),
+        "the address owner should be resynced to dormant, got: {}",
+        owner_after.hostname,
     );
     txn.commit().await?;
 

--- a/crates/api-core/tests/integration/static_address_management.rs
+++ b/crates/api-core/tests/integration/static_address_management.rs
@@ -531,12 +531,11 @@ async fn test_assign_and_remove_resync_hostname(
     Ok(())
 }
 
-/// Regression for #3383 (review follow-up): remove-address deletes by IP, so the
-/// interface that owned the removed address may differ from the caller-supplied
-/// interface_id. The resync must target the actual owner, otherwise the real
-/// owner keeps a hostname pinned to the freed IP.
+/// Regression for #3383 (review follow-up): remove-address is scoped to the
+/// caller's interface. Passing an interface_id that does not own the IP must not
+/// remove another interface's address — it returns NotFound and changes nothing.
 #[sqlx_test]
-async fn test_remove_resyncs_the_address_owner_not_the_request_id(
+async fn test_remove_with_mismatched_interface_id_is_rejected(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let StaticAddressTestEnv {
@@ -563,6 +562,12 @@ async fn test_remove_resyncs_the_address_owner_not_the_request_id(
         }))
         .await?;
 
+    let mut txn = env.db_txn().await;
+    let owner_hostname_before = db::machine_interface::find_one(&mut *txn, owner_id)
+        .await?
+        .hostname;
+    txn.commit().await?;
+
     // A second, unrelated interface whose id we will (incorrectly) pass to
     // remove-address.
     let other_mac = MacAddress::from_str("aa:bb:cc:dd:ee:19")
@@ -586,17 +591,27 @@ async fn test_remove_resyncs_the_address_owner_not_the_request_id(
         }))
         .await?
         .into_inner();
-    assert_eq!(resp.status(), RemoveStaticAddressStatus::Removed);
+    assert_eq!(resp.status(), RemoveStaticAddressStatus::NotFound);
 
-    // The owner (which actually lost the address) must be resynced to dormant.
+    // The owner still holds its address and keeps its IP-derived hostname; the
+    // mismatched interface was not touched.
+    let addrs = env
+        .api()
+        .find_interface_addresses(Request::new(FindInterfaceAddressesRequest {
+            interface_id: Some(owner_id),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(addrs.addresses.len(), 1);
+    assert_eq!(addrs.addresses[0].address, owned_ip);
+
     let mut txn = env.db_txn().await;
     let owner_after = db::machine_interface::find_one(&mut *txn, owner_id).await?;
-    assert!(
-        owner_after.hostname.to_lowercase().starts_with("noip"),
-        "the address owner should be resynced to dormant, got: {}",
-        owner_after.hostname,
-    );
     txn.commit().await?;
+    assert_eq!(
+        owner_after.hostname, owner_hostname_before,
+        "the owner's hostname must be unchanged after a mismatched remove"
+    );
 
     Ok(())
 }

--- a/crates/api-core/tests/integration/static_address_management.rs
+++ b/crates/api-core/tests/integration/static_address_management.rs
@@ -544,7 +544,9 @@ async fn test_remove_resyncs_the_address_owner_not_the_request_id(
     } = init(pool).await;
 
     // Owner interface: give it a static address so its hostname is IP-derived.
-    let owner_mac = MacAddress::from_str("aa:bb:cc:dd:ee:18").unwrap().to_string();
+    let owner_mac = MacAddress::from_str("aa:bb:cc:dd:ee:18")
+        .unwrap()
+        .to_string();
     let owner = env
         .api()
         .discover_dhcp(
@@ -563,7 +565,9 @@ async fn test_remove_resyncs_the_address_owner_not_the_request_id(
 
     // A second, unrelated interface whose id we will (incorrectly) pass to
     // remove-address.
-    let other_mac = MacAddress::from_str("aa:bb:cc:dd:ee:19").unwrap().to_string();
+    let other_mac = MacAddress::from_str("aa:bb:cc:dd:ee:19")
+        .unwrap()
+        .to_string();
     let other = env
         .api()
         .discover_dhcp(

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -303,7 +303,7 @@ async fn test_retain_bmc_address_pins_dhcp_and_survives_expiry(
         crate::machine_interface_address::find_for_interface(txn.as_pgconn(), interface_id).await?;
     txn.commit().await?;
     assert!(
-        !deleted,
+        deleted.is_none(),
         "DHCP-scoped expiry delete should not match a Static address"
     );
     assert_eq!(

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -303,7 +303,7 @@ async fn test_retain_bmc_address_pins_dhcp_and_survives_expiry(
         crate::machine_interface_address::find_for_interface(txn.as_pgconn(), interface_id).await?;
     txn.commit().await?;
     assert!(
-        deleted.is_none(),
+        deleted.is_empty(),
         "DHCP-scoped expiry delete should not match a Static address"
     );
     assert_eq!(

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -150,6 +150,27 @@ pub async fn delete_by_interface_family(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Delete a specific address from a specific interface. Returns true if a
+/// matching row was deleted. Scoping by `interface_id` ensures an operator
+/// remove-address call only removes the caller's own address, never another
+/// interface's row that happens to hold the same IP.
+pub async fn delete_by_interface_and_address(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    address: IpAddr,
+    allocation_type: AllocationType,
+) -> Result<bool, DatabaseError> {
+    let query = "DELETE FROM machine_interface_addresses WHERE interface_id = $1 AND address = $2::inet AND allocation_type = $3";
+    sqlx::query(query)
+        .bind(interface_id)
+        .bind(address)
+        .bind(allocation_type)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 /// Insert a new address for an interface with the given allocation type.
 pub async fn insert(
     txn: &mut PgConnection,

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -203,21 +203,22 @@ pub async fn assign_static(
     Ok(result)
 }
 
-/// Delete an address allocation of the given type. Returns true if a
-/// matching allocation was found and deleted, false otherwise.
+/// Delete an address allocation of the given type. Returns the interface that
+/// owned the deleted address, or `None` if no matching allocation was found, so
+/// callers can resync that interface's hostname rather than guessing the owner.
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,
     allocation_type: AllocationType,
-) -> Result<bool, DatabaseError> {
+) -> Result<Option<MachineInterfaceId>, DatabaseError> {
     let query =
-        "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2";
-    sqlx::query(query)
+        "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2 RETURNING interface_id";
+    sqlx::query_scalar(query)
         .bind(address)
         .bind(allocation_type)
-        .execute(txn)
+        .fetch_all(txn)
         .await
-        .map(|r| r.rows_affected() > 0)
+        .map(|owners| owners.into_iter().next())
         .map_err(|e| DatabaseError::query(query, e))
 }
 

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -213,8 +213,7 @@ pub async fn delete_by_address(
     address: IpAddr,
     allocation_type: AllocationType,
 ) -> Result<Vec<MachineInterfaceId>, DatabaseError> {
-    let query =
-        "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2 RETURNING interface_id";
+    let query = "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2 RETURNING interface_id";
     sqlx::query_scalar(query)
         .bind(address)
         .bind(allocation_type)

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -225,26 +225,28 @@ pub async fn delete_by_address(
 /// Delete an address allocation for a given (ip, mac) pair, which
 /// of course only actually deletes when the pair matches.
 ///
-/// Returns true if a matching allocation was found and deleted.
+/// Returns the interfaces that owned the deleted allocations (normally one,
+/// empty if the pair matched nothing) so callers can resync each one's hostname
+/// against the authoritative deleted rows rather than a separate lookup.
 pub async fn delete_by_address_and_mac(
     txn: &mut PgConnection,
     address: IpAddr,
     mac_address: mac_address::MacAddress,
     allocation_type: AllocationType,
-) -> Result<bool, DatabaseError> {
+) -> Result<Vec<MachineInterfaceId>, DatabaseError> {
     let query = "DELETE FROM machine_interface_addresses mia
         USING machine_interfaces mi
         WHERE mia.interface_id = mi.id
           AND mia.address = $1::inet
           AND mia.allocation_type = $2
-          AND mi.mac_address = $3::macaddr";
-    sqlx::query(query)
+          AND mi.mac_address = $3::macaddr
+        RETURNING mia.interface_id";
+    sqlx::query_scalar(query)
         .bind(address)
         .bind(allocation_type)
         .bind(mac_address)
-        .execute(txn)
+        .fetch_all(txn)
         .await
-        .map(|r| r.rows_affected() > 0)
         .map_err(|e| DatabaseError::query(query, e))
 }
 

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -203,14 +203,16 @@ pub async fn assign_static(
     Ok(result)
 }
 
-/// Delete an address allocation of the given type. Returns the interface that
-/// owned the deleted address, or `None` if no matching allocation was found, so
-/// callers can resync that interface's hostname rather than guessing the owner.
+/// Delete an address allocation of the given type. Returns the interfaces that
+/// owned the deleted addresses (normally one, empty if nothing matched) so
+/// callers can resync each one's hostname rather than guessing the owner. The
+/// delete removes every matching row, so all owners are returned — not just the
+/// first — since `(address, allocation_type)` is not unique on its own.
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,
     allocation_type: AllocationType,
-) -> Result<Option<MachineInterfaceId>, DatabaseError> {
+) -> Result<Vec<MachineInterfaceId>, DatabaseError> {
     let query =
         "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2 RETURNING interface_id";
     sqlx::query_scalar(query)
@@ -218,7 +220,6 @@ pub async fn delete_by_address(
         .bind(allocation_type)
         .fetch_all(txn)
         .await
-        .map(|owners| owners.into_iter().next())
         .map_err(|e| DatabaseError::query(query, e))
 }
 


### PR DESCRIPTION
## Problem

`carbide-admin-cli machine-interfaces assign-address` and `remove-address` mutate an interface's address but skip the hostname-resync step that every other allocation path runs. With the default IP-derived naming strategy, this leaves the interface's `hostname` pinned to an IP it no longer holds — e.g. the interface is moved to `7.243.174.25` but stays named `7-243-174-20`.

That single stale row then wedges **all** new DHCP allocation on the segment:

1. The fast-path allocator deterministically reuses the lowest free IP (the one just freed).
2. It re-derives the same IP-based hostname, and the insert collides with the `fqdn_must_be_unique (domain_id, hostname)` constraint.
3. The collision is treated as a transient race and retried — but candidate selection is deterministic, so all 128 retries pick the same IP and fail.
4. Every DHCP `DISCOVER` on the segment queues behind that IP and is dropped.

Observed on `ytl-dev1`: after a repave, no host BMC or DPU BMC could get an address and site-explorer couldn't discover attached DPUs, until the stale interface was deleted.

Fixes #3383.

## Fix

- **`assign_static_address`** now calls `sync_hostname_after_address_assignment` after assigning, mirroring the static-preallocation path.
- **`remove_static_address`** is now scoped to the caller's interface: it deletes via `delete_by_interface_and_address(interface_id, address, Static)` and resyncs that interface's hostname. A mismatched `interface_id` — one that doesn't own the IP — deletes nothing and returns `NotFound`, rather than removing another interface's row that happens to hold the same IP. This matches the command's contract ("remove the address from a machine interface").
- **`expire_dhcp_lease`** resyncs every interface whose row was actually deleted. Because expiry deletes by IP (or IP+MAC) and the owning interface can differ from any caller-supplied id:
  - `delete_by_address` and `delete_by_address_and_mac` now return the affected `interface_id`s via `RETURNING` (a `Vec`, since `(address, allocation_type)` is not unique on its own).
  - The separate `find_by_ip` lookup in `expire_dhcp_lease` is dropped — the delete's returned owners are authoritative, so the lookup (which could diverge if ownership changed) is no longer needed.

The DB-layer primitives deliberately leave hostname sync to their callers; these handlers were the only callers that skipped it.

## Testing

- `test_assign_and_remove_resync_hostname` — hostname follows the new static IP on assign, and resets to the dormant `noip-…` placeholder on remove.
- `test_remove_with_mismatched_interface_id_is_rejected` — removing an address while passing an `interface_id` that doesn't own it returns `NotFound` and changes nothing; the real owner keeps both its address and its IP-derived hostname.
- `test_mac_scoped_expiry_resyncs_only_the_owner` — `(ip, mac)`-scoped lease expiry resyncs the deleted row's owner and leaves unrelated interfaces untouched.
- Full `static_address_management` (18 tests) and `dhcp_lease_expiration` suites pass, no regressions.

Run on Linux (the crate pulls in `tss-esapi-sys`, which doesn't build on macOS):

```
DATABASE_URL="postgresql://…@…:5432/postgres" \
cargo test -p carbide-api-core --test integration static_address_management
```

## Notes / follow-ups (out of scope)

- The allocator's deterministic retry-on-`fqdn_must_be_unique` means one inconsistent row could still block allocation of unrelated IPs. This PR removes the cause; hardening the allocator against any stale row is a separate change.
- The misleading `num_free_ips: 0` diagnostic on a mostly-empty prefix is filed separately.