### PR TITLE
fix(ci): bump dsx-github-actions security scan pins to v1.16.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1848,7 +1848,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@739847ddf00fda38916504ef84e1f504eac3158f
+      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           post-pr-comment: 'true'
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Grype vulnerability scan
         if: ${{ inputs.scan && inputs.load && !inputs.push && steps.build.outcome == 'success' }}
         continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
+        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           image: ${{ inputs.image_name }}:${{ inputs.image_tag }}
           fail-on: critical

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -446,6 +446,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@739847ddf00fda38916504ef84e1f504eac3158f
+      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           post-pr-comment: 'true'

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Grype vulnerability scan
         if: matrix.arch == 'amd64'
         continue-on-error: true
-        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@739847ddf00fda38916504ef84e1f504eac3158f
+        uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:
           image: ${{ steps.docker-tags.outputs.arch_tag }}
           fail-on: critical


### PR DESCRIPTION
## Summary
- Bump `security-container-scan` and `security-container-scan-aggregate` from `739847ddf` (v1.16.0) to `aa4e470` (v1.16.2)
- Consumes [NVIDIA/dsx-github-actions#52](https://github.com/NVIDIA/dsx-github-actions/pull/52), which pins `anchore/sbom-action` by SHA for GHE allowlist compliance
- Fixes instant CI failures: `The action anchore/sbom-action@v0 is not allowed`

## Files
- `.github/workflows/docker-build.yml`
- `.github/workflows/ci.yaml`
- `.github/workflows/rest-build-push-service.yml`
- `.github/workflows/rest-build-push-docker.yml`

## Test plan
- [ ] Container build jobs pass GHE workflow validation (no instant sbom-action allowlist error)
- [ ] `build-release-container-*` / REST docker build jobs complete successfully
- [ ] Note: `trufflesecurity/trufflehog@aade3bff...` is a separate allowlist issue if secret-scan jobs still fail