### PR TITLE
refactor(fmds): serve /metrics through the shared metrics-endpoint crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "hyper-util",
  "ipnetwork",
  "logfmt",
+ "metrics-endpoint",
  "netlink-packet-route 0.19.0",
  "nonzero_ext",
  "opentelemetry 0.32.0",

--- a/crates/fmds/Cargo.toml
+++ b/crates/fmds/Cargo.toml
@@ -39,6 +39,7 @@ carbide-tls = { path = "../tls" }
 carbide-uuid = { path = "../uuid" }
 carbide-version = { path = "../version" }
 logfmt = { path = "../logfmt" }
+metrics-endpoint = { path = "../metrics-endpoint" }
 
 arc-swap = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/fmds/src/http_request_metrics.rs
+++ b/crates/fmds/src/http_request_metrics.rs
@@ -19,19 +19,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
-use axum::extract::State;
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
-use axum::routing::get;
 use eyre::WrapErr;
-use http_body_util::Full;
-use hyper::body::Bytes;
 use hyper::{Request, Response};
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider};
 use opentelemetry_prometheus::ExporterBuilder;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_semantic_conventions::resource::{SERVICE_NAME, SERVICE_NAMESPACE};
-use prometheus::{Encoder, Registry, TextEncoder};
+use prometheus::Registry;
 use tonic::service::AxumBody;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
@@ -89,31 +84,6 @@ pub fn init() -> eyre::Result<(Registry, HttpRequestMetrics)> {
     opentelemetry::global::set_meter_provider(meter_provider);
 
     Ok((prometheus_registry, http_metrics))
-}
-
-pub fn metrics_router(registry: Registry) -> Router {
-    Router::new()
-        .route("/", get(export_metrics))
-        .with_state(registry)
-}
-
-#[axum::debug_handler]
-async fn export_metrics(State(registry): State<Registry>) -> Response<Full<Bytes>> {
-    tokio::task::spawn_blocking(move || {
-        let mut buffer = vec![];
-        let encoder = TextEncoder::new();
-        let metric_families = registry.gather();
-        encoder.encode(&metric_families, &mut buffer).unwrap();
-
-        Response::builder()
-            .status(200)
-            .header(CONTENT_TYPE, encoder.format_type())
-            .header(CONTENT_LENGTH, buffer.len())
-            .body(buffer.into())
-            .unwrap()
-    })
-    .await
-    .unwrap()
 }
 
 /// Same HTTP instrumentation as forge-dpu-agent `WithTracingLayer` (request count + latency + tracing logs).

--- a/crates/fmds/src/main.rs
+++ b/crates/fmds/src/main.rs
@@ -111,13 +111,13 @@ async fn main() -> eyre::Result<()> {
     let metrics_address = options.metrics_address;
     let registry_for_metrics = prometheus_registry.clone();
     tokio::spawn(async move {
-        let router = axum::Router::new().nest(
-            "/metrics",
-            http_request_metrics::metrics_router(registry_for_metrics),
-        );
-        let server = axum_server::Server::bind(metrics_address);
-        tracing::info!(%metrics_address, "Prometheus /metrics listening");
-        if let Err(err) = server.serve(router.into_make_service()).await {
+        let config = metrics_endpoint::MetricsEndpointConfig {
+            address: metrics_address,
+            registry: registry_for_metrics,
+            health_controller: None,
+            additional_prefix: None,
+        };
+        if let Err(err) = metrics_endpoint::run_metrics_endpoint(&config).await {
             tracing::error!("Prometheus metrics server error: {err}");
         }
     });


### PR DESCRIPTION
fmds served `/metrics` from its own axum router -- a `nest("/metrics", ...)` over a hand-written `export_metrics` handler. That duplicates the shared `metrics-endpoint` crate the rest of the fleet uses, so this hands fmds's existing Prometheus registry to `metrics_endpoint::run_metrics_endpoint` and deletes the bespoke router.

- The metrics server now builds a `MetricsEndpointConfig` over the registry `http_request_metrics::init()` produces and serves it, keeping the same bind address and task structure.
- `metrics_router` and `export_metrics` are gone, along with their now-unused axum and encoder imports; `init()` (the meter setup) is untouched.

The endpoint serves the same registry through the same `TextEncoder`, so `/metrics` stays byte-identical; it also answers `/health`, `/ready`, and `/` on the same port, matching the other migrated services.

This supports #3180