### PR TITLE
refactor(agent): serve /metrics through the shared metrics-endpoint crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,6 +1091,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mac_address",
+ "metrics-endpoint",
  "mockall",
  "netlink-packet-route 0.19.0",
  "nix 0.31.3",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -51,6 +51,7 @@ carbide-health-report = { path = "../health-report" }
 carbide-rpc = { path = "../rpc" }
 carbide-rpc-utils = { path = "../rpc-utils" }
 carbide-utils = { path = "../utils" }
+metrics-endpoint = { path = "../metrics-endpoint" }
 nvue-client = { path = "../nvue-client" }
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -19,15 +19,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use axum::Router;
-use axum::extract::State;
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
-use axum::routing::get;
-use http_body_util::Full;
-use hyper::body::Bytes;
 use hyper::{Request, Response};
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
-use prometheus::{Encoder, TextEncoder};
 use tonic::service::AxumBody;
 use tower::ServiceBuilder;
 use tracing::Span;
@@ -260,30 +254,6 @@ impl NetworkMonitorMetricsState {
     }
 }
 
-pub fn get_metrics_router(registry: prometheus::Registry) -> Router {
-    Router::new()
-        .route("/", get(export_metrics))
-        .with_state(registry)
-}
-
-#[axum::debug_handler]
-async fn export_metrics(State(registry): State<prometheus::Registry>) -> Response<Full<Bytes>> {
-    tokio::task::spawn_blocking(move || {
-        let mut buffer = vec![];
-        let encoder = TextEncoder::new();
-        let metric_families = registry.gather();
-        encoder.encode(&metric_families, &mut buffer).unwrap();
-
-        Response::builder()
-            .status(200)
-            .header(CONTENT_TYPE, encoder.format_type())
-            .header(CONTENT_LENGTH, buffer.len())
-            .body(buffer.into())
-            .unwrap()
-    })
-    .await
-    .unwrap()
-}
 pub trait WithTracingLayer {
     fn with_tracing_layer(self, metrics: Arc<AgentMetricsState>) -> Router;
 }

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -55,7 +55,7 @@ use crate::ethernet_virtualization::{
 use crate::fmds_client::FmdsUpdater;
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
-use crate::instrumentation::{create_metrics, get_dpu_agent_meter};
+use crate::instrumentation::{create_metrics, get_dpu_agent_meter, get_prometheus_registry};
 use crate::machine_inventory_updater::MachineInventoryUpdaterConfig;
 use crate::network_monitor::{self, NetworkPingerType};
 use crate::util::get_host_boot_timestamp;
@@ -129,13 +129,37 @@ pub async fn setup_and_run(
     let agent_meter = get_dpu_agent_meter();
     let metrics = create_metrics(agent_meter);
 
-    if let Err(e) = crate::metadata_service::spawn_prometheus_metrics_server(
-        agent_config.telemetry.metrics_address.clone(),
-    ) {
-        tracing::warn!(
-            error = format!("{e:#}"),
-            "Failed to start Prometheus /metrics endpoint"
-        );
+    match agent_config
+        .telemetry
+        .metrics_address
+        .parse::<std::net::SocketAddr>()
+    {
+        Ok(metrics_address) => {
+            tracing::info!(
+                metrics_address = %metrics_address,
+                "Starting Prometheus /metrics endpoint"
+            );
+            let metrics_config = metrics_endpoint::MetricsEndpointConfig {
+                address: metrics_address,
+                registry: get_prometheus_registry(),
+                health_controller: None,
+                additional_prefix: None,
+            };
+            tokio::task::spawn(async move {
+                if let Err(e) = metrics_endpoint::run_metrics_endpoint(&metrics_config).await {
+                    tracing::error!(
+                        error = format!("{e:#}"),
+                        "Prometheus /metrics endpoint exited with error"
+                    );
+                }
+            });
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = format!("{e:#}"),
+                "Failed to start Prometheus /metrics endpoint"
+            );
+        }
     }
 
     // And now set up our FMDS updater, which will either be our original

--- a/crates/agent/src/metadata_service.rs
+++ b/crates/agent/src/metadata_service.rs
@@ -20,25 +20,7 @@ use std::sync::Arc;
 use axum::Router;
 
 use crate::instance_metadata_endpoint::{InstanceMetadataRouterStateImpl, get_fmds_router};
-use crate::instrumentation::{
-    AgentMetricsState, WithTracingLayer, get_metrics_router, get_prometheus_registry,
-};
-
-/// Exposes Prometheus metrics on `[telemetry] metrics-address` (default `0.0.0.0:8888`),
-/// matching the `/metrics` route served alongside embedded FMDS on DPU OS.
-pub fn spawn_prometheus_metrics_server(
-    metrics_address: String,
-) -> Result<(), Box<dyn std::error::Error>> {
-    tracing::info!(
-        metrics_address = %metrics_address,
-        "Starting Prometheus /metrics endpoint"
-    );
-    let prometheus_registry = get_prometheus_registry();
-    start_server(
-        metrics_address,
-        Router::new().nest("/metrics", get_metrics_router(prometheus_registry)),
-    )
-}
+use crate::instrumentation::{AgentMetricsState, WithTracingLayer};
 
 pub fn spawn_metadata_service(
     metadata_service_address: String,


### PR DESCRIPTION
The agent stood up its own axum server for `/metrics` -- a `spawn_prometheus_metrics_server` wrapper plus a `get_metrics_router`/`export_metrics` pair that hand-encoded the registry. That is exactly what the shared `metrics-endpoint` crate already does for the rest of the fleet, so this hands the agent's existing Prometheus registry to `metrics_endpoint::run_metrics_endpoint` and deletes the bespoke server.

- The metrics listener now builds a `MetricsEndpointConfig` over `get_prometheus_registry()` and serves it, keeping the same bind address and the same fire-and-forget task.
- `spawn_prometheus_metrics_server`, `get_metrics_router`, and `export_metrics` are gone, along with their now-unused axum and encoder imports.
- The meter setup -- the `InstrumentationSingleton` and its custom network and retry views -- is untouched, so the exposed series are unchanged.

The endpoint serves the same registry through the same `TextEncoder`, so `/metrics` stays byte-identical; it also answers `/health`, `/ready`, and `/` on the same port, matching the other migrated services.

> The previous server offloaded the encode to `spawn_blocking`; the shared endpoint encodes inline, as it does for every other consumer. That's the shared crate's established behavior, not a regression here -- moving the encode off the async worker for all consumers is tracked in #3524.

This supports #3180