### PR TITLE
fix(machine-a-tron): serve control API in all BMC modes

### DIFF
--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -107,9 +107,9 @@ mod tests {
     use crate::status::MachineStatusConfig;
 
     #[tokio::test]
-    async fn machines_status_returns_json() {
+    async fn machines_status_does_not_require_bmc_routes() {
         let router = append(
-            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            Router::new(),
             ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
         );
 

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -202,28 +202,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .as_slice(),
     )?;
 
-    // If we're using a combined BMC mock that routes to each mock machine using headers, launch it
-    // after the machines are created so the control UI can report their handles.
-    let maybe_bmc_mock_handles: Option<(CombinedServer, Option<MockSshServerHandle>)> =
+    // Launch the control UI after the machines are created so it can report their handles. In
+    // combined-BMC mode it shares the combined BMC listener. In per-IP mode it listens on the
+    // loopback address at the same port, independently of the per-machine BMC listeners.
+    let control_state = ControlState::new(
+        machine_handles.clone(),
+        MachineStatusConfig::new(bmc_mock_port),
+    );
+    let certs_dir = app_context
+        .bmc_mock_certs_dir
+        .as_ref()
+        .cloned()
+        .or_else(|| {
+            PathBuf::from(forge_root_ca_path.clone())
+                .parent()
+                .map(Path::to_path_buf)
+        });
+    let server_handles: (CombinedServer, Option<MockSshServerHandle>) =
         match &app_context.bmc_registration_mode {
             BmcRegistrationMode::BackingInstance(bmc_mock_registry) => {
-                let certs_dir = app_context
-                    .bmc_mock_certs_dir
-                    .as_ref()
-                    .cloned()
-                    .or_else(|| {
-                        PathBuf::from(forge_root_ca_path.clone())
-                            .parent()
-                            .map(Path::to_path_buf)
-                    });
-
-                let server_config = bmc_mock::tls::server_config(certs_dir)?;
-                let control_state = ControlState::new(
-                    machine_handles.clone(),
-                    MachineStatusConfig::new(bmc_mock_port),
-                );
+                let server_config = bmc_mock::tls::server_config(certs_dir.clone())?;
                 let bmc_router = bmc_mock::combined_router(bmc_mock_registry.clone());
-                let router = append_control_routes(bmc_router, control_state);
+                let router = append_control_routes(bmc_router, control_state.clone());
                 let bmc_https_mock = bmc_mock::CombinedServer::run_router(
                     "bmc-mock",
                     router,
@@ -255,11 +255,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     None
                 };
 
-                Some((bmc_https_mock, bmc_ssh_mock))
+                (bmc_https_mock, bmc_ssh_mock)
             }
             BmcRegistrationMode::None(_) => {
-                // Otherwise each mock machine runs its own listener
-                None
+                let server_config = bmc_mock::tls::server_config(certs_dir)?;
+                let router = append_control_routes(axum::Router::new(), control_state);
+                let control_server = bmc_mock::CombinedServer::run_router(
+                    "machine-a-tron-control",
+                    router,
+                    Some(ListenerOrAddress::Address(
+                        format!("127.0.0.1:{bmc_mock_port}").parse().unwrap(),
+                    )),
+                    server_config,
+                );
+                (control_server, None)
             }
         };
 
@@ -311,9 +320,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .ok();
     }
 
-    if let Some((mut bmc_mock_handle, _mock_ssh_server_handle)) = maybe_bmc_mock_handles {
-        bmc_mock_handle.stop().await?;
-    }
+    let (mut server_handle, _mock_ssh_server_handle) = server_handles;
+    server_handle.stop().await?;
     Ok(())
 }
 


### PR DESCRIPTION
Fix machine-a-tron’s Web UI and /machines/status endpoint so they are available in both combined and per-IP BMC registration modes.

**History**

The bug was introduced by #3390, which added the machine status API and Web UI.

**Root cause**

That implementation appended the control routes to the combined BMC router inside the `BmcRegistrationMode::BackingInstance` startup branch. When machine-a-tron used `BmcRegistrationMode::None`, each simulated BMC started its own per-IP listener, but no listener was created for the control routes. Consequently, `/machines/status` and the Web UI were unavailable in that mode.

**Fix**

Create the control state independently of BMC registration mode and start the control router in both modes:
- Combined-BMC mode retains the existing behavior: control and BMC routes share 0.0.0.0:<bmc_mock_port>.
- Per-IP mode starts a control-only router on 127.0.0.1:<bmc_mock_port>, while simulated BMCs continue listening on their assigned IP addresses using the same port.

Binding the control router to loopback avoids conflicts with the per-machine BMC listeners and preserves the existing local URL without adding configuration.

The route test now constructs the control router without any BMC routes, verifying that /machines/status works independently.

## Related issues

#3390

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

