### PR TITLE
perf(metrics-endpoint): encode the registry on a dedicated thread

### DIFF
--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -43,7 +43,7 @@ pub async fn start(
         .build_task()
         .name("bmc-proxy metrics service")
         .spawn(async move {
-            metrics_endpoint::run_metrics_endpoint_with_listener(
+            if let Err(e) = metrics_endpoint::run_metrics_endpoint_with_listener(
                 &MetricsEndpointConfig {
                     address,
                     registry: metrics_setup.registry,
@@ -54,6 +54,9 @@ pub async fn start(
                 listener,
             )
             .await
+            {
+                tracing::error!(error = %e, "metrics endpoint exited with error");
+            }
         })
         // Safety: Should only fail if not in a tokio runtime
         .expect("Error spawning metrics endpoint");

--- a/crates/metrics-endpoint/src/lib.rs
+++ b/crates/metrics-endpoint/src/lib.rs
@@ -17,6 +17,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{SyncSender, TrySendError, sync_channel};
 
 use bytes::Bytes;
 use carbide_metrics_utils::OtelView;
@@ -33,6 +34,7 @@ use opentelemetry_semantic_conventions as semconv;
 use prometheus::proto::MetricFamily;
 use prometheus::{Encoder, TextEncoder};
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
 /// Health and readiness controller
@@ -83,11 +85,54 @@ pub struct MetricsSetup {
     pub health_controller: HealthController,
 }
 
+/// Depth of the bounded queue feeding the dedicated encoder thread.
+///
+/// The single encoder thread caps total encode CPU at one core no matter how many scrapes
+/// arrive at once. This queue is sized to comfortably absorb a burst of concurrent scrapes
+/// — roughly half a second of queued encode work on a modern core — so a transient backlog
+/// waits behind the in-flight encode instead of being shed. Only a sustained overload that
+/// fills all 64 slots sheds the excess with `503`.
+const ENCODER_QUEUE_CAPACITY: usize = 64;
+
+/// How long shutdown waits for the encoder thread to drain to its `Stop` and exit before
+/// returning anyway. `Stop` cannot be observed while the thread is mid-encode, so a
+/// pathologically slow — or hung — collector callback (`catch_unwind` catches panics, not
+/// hangs) must not block shutdown forever; the detached thread finishes its encode and exits
+/// shortly after, so this is bounded-lifetime lingering rather than a permanent leak.
+const ENCODER_SHUTDOWN_JOIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Why the encoder thread could not produce an exposition. Both variants become an HTTP
+/// `500` but log distinctly. `Panicked` is isolated per-request via `catch_unwind` so a
+/// misbehaving collector or observable callback cannot take down the sole encoder thread.
+#[derive(Debug)]
+enum EncodeError {
+    /// The Prometheus text encoder returned an error.
+    Encode(prometheus::Error),
+    /// A collector or observable callback panicked during `gather()`/encode; the encoder
+    /// thread caught the unwind and stayed alive to serve later scrapes.
+    Panicked,
+}
+
+/// The reply channel a scrape hands to the encoder thread. The thread sends the encoded
+/// exposition back through it, or an [`EncodeError`] describing why it could not.
+type EncodeReply = oneshot::Sender<Result<Vec<u8>, EncodeError>>;
+
+/// An item on the encoder queue: either a scrape to encode (carrying its reply channel) or
+/// a control message telling the thread to stop. Using an explicit `Stop` lets the thread
+/// block on `recv()` with no polling; shutdown enqueues one and the thread exits regardless
+/// of how many connection tasks still hold a queue sender.
+enum Item {
+    Work(EncodeReply),
+    Stop,
+}
+
 /// The shared state between HTTP requests
 struct MetricsHandlerState {
-    registry: prometheus::Registry,
+    /// Bounded queue to the single dedicated encoder thread. Each `/metrics` scrape
+    /// enqueues a reply channel and awaits the encoded exposition on it. The thread
+    /// owns the registry and prefix, so those are not held here.
+    encoder_tx: SyncSender<Item>,
     health_controller: HealthController,
-    additional_prefix: Option<PrefixMigration>,
 }
 
 /// An old/new prefix pair: metric families whose name starts with `old` are
@@ -198,20 +243,29 @@ pub async fn run_metrics_endpoint_with_cancellation(
         "Starting metrics listener"
     );
 
-    run_metrics_endpoint_with_listener(config, cancel_token, listener).await;
-    Ok(())
+    run_metrics_endpoint_with_listener(config, cancel_token, listener).await
 }
 
-/// Run the metrics service on an existing listener (which allows this function to not return errors.)
+/// Run the metrics service on an existing listener.
+///
+/// Returns an error only if the dedicated encoder thread cannot be spawned at startup
+/// (rare — OS resource exhaustion); once running it serves until `cancel_token` fires.
 pub async fn run_metrics_endpoint_with_listener(
     config: &MetricsEndpointConfig,
     cancel_token: CancellationToken,
     listener: TcpListener,
-) {
+) -> Result<(), std::io::Error> {
+    // Spawn the single dedicated encoder thread. It owns the registry and prefix and
+    // serializes all `/metrics` encoding onto one core. We keep a `shutdown_tx` sender
+    // clone so that, once the accept loop ends, we can enqueue an `Item::Stop` and join the
+    // thread — stopping it regardless of how many connection tasks still hold a sender.
+    let (encoder_tx, encoder_thread) =
+        spawn_encoder_thread(config.registry.clone(), config.additional_prefix.clone())?;
+    let shutdown_tx = encoder_tx.clone();
+
     let handler_state = Arc::new(MetricsHandlerState {
-        registry: config.registry.clone(),
+        encoder_tx,
         health_controller: config.health_controller.clone().unwrap_or_default(),
-        additional_prefix: config.additional_prefix.clone(),
     });
 
     while let Some(result) = cancel_token.run_until_cancelled(listener.accept()).await {
@@ -233,7 +287,7 @@ pub async fn run_metrics_endpoint_with_listener(
                     io,
                     service_fn(move |req: Request<body::Incoming>| {
                         let handler_state = handler_state.clone();
-                        async move { handle_metrics_request(req, handler_state) }
+                        async move { handle_metrics_request(req, handler_state).await }
                     }),
                 )
                 .await
@@ -242,6 +296,99 @@ pub async fn run_metrics_endpoint_with_listener(
             }
         });
     }
+
+    // The accept loop only returns once the token is cancelled. Enqueue a `Stop` and join
+    // the encoder thread so shutdown is clean and connection-independent: `Stop` ends the
+    // thread no matter how many connection tasks still hold a queue sender. Since the accept
+    // loop has stopped, no new work is enqueued, so the queue drains to the `Stop` and the
+    // thread exits (bounded by queue depth times encode time — typically ~empty). Do the
+    // blocking send + join off an async worker, and cap the wait: `Stop` cannot be observed
+    // while the thread is mid-encode, so a pathologically slow (or hung) collector must not
+    // block shutdown forever.
+    let join_task = tokio::task::spawn_blocking(move || {
+        // If the thread already exited, the send errors — ignore it.
+        shutdown_tx.send(Item::Stop).ok();
+        encoder_thread.join()
+    });
+    match tokio::time::timeout(ENCODER_SHUTDOWN_JOIN_TIMEOUT, join_task).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(_panic))) => tracing::error!("metrics encoder thread panicked"),
+        Ok(Err(err)) => tracing::error!(error = %err, "failed to join metrics encoder thread"),
+        Err(_elapsed) => tracing::warn!(
+            "metrics encoder did not exit within the shutdown timeout (a scrape is likely \
+             mid-encode); returning without it — the detached thread exits on its queued Stop"
+        ),
+    }
+
+    Ok(())
+}
+
+/// Spawn the single dedicated OS thread that owns the registry and serializes all
+/// `/metrics` encoding onto one core.
+///
+/// The thread owns `registry` (a cheap `Arc`-backed clone) and `additional_prefix`
+/// (moved in), and services items arriving on the returned bounded channel: for each
+/// [`Item::Work`] it encodes the current exposition with [`encode_metrics`] and sends the
+/// `Result` back through the oneshot; an [`Item::Stop`] — enqueued by the server once its
+/// accept loop ends — breaks the loop. A requester that already gave up (its receiver is
+/// closed) is skipped without encoding, so an abandoned scrape never burns the sole
+/// encoder.
+///
+/// It blocks on `recv()` with no polling; the loop also ends if every sender is dropped.
+/// The explicit `Stop` makes shutdown connection-independent — the thread exits regardless
+/// of how many connection tasks still hold a queue sender. Using a plain OS thread (not a
+/// tokio worker) keeps the blocking `recv` off the async runtime.
+///
+/// Returns an error if the OS refuses to create the thread (e.g. resource exhaustion), so
+/// startup can surface it rather than panic.
+fn spawn_encoder_thread(
+    registry: prometheus::Registry,
+    additional_prefix: Option<PrefixMigration>,
+) -> std::io::Result<(SyncSender<Item>, std::thread::JoinHandle<()>)> {
+    let (encoder_tx, encoder_rx) = sync_channel::<Item>(ENCODER_QUEUE_CAPACITY);
+
+    let handle = std::thread::Builder::new()
+        .name("metrics-encoder".to_string())
+        .spawn(move || {
+            // `recv` blocks until an item arrives; `Err` means every sender was dropped.
+            while let Ok(item) = encoder_rx.recv() {
+                match item {
+                    Item::Stop => break,
+                    Item::Work(reply_tx) => {
+                        // A scrape that disconnected or timed out while queued has already
+                        // dropped its receiver; skip the expensive gather+encode so we do
+                        // not burn the sole encoder (and risk 503-ing live scrapes) on
+                        // work nobody is waiting for.
+                        if reply_tx.is_closed() {
+                            continue;
+                        }
+                        // Isolate a panicking collector/observable callback: a panic during
+                        // `gather()` must fail only this one scrape (500), not unwind and
+                        // kill the sole encoder thread — which would then 500 every later
+                        // scrape until the process restarts. This restores the per-request
+                        // isolation the previous `spawn_blocking` gave for free.
+                        let result =
+                            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                encode_metrics(&registry, additional_prefix.as_ref())
+                            })) {
+                                Ok(Ok(buffer)) => Ok(buffer),
+                                Ok(Err(err)) => Err(EncodeError::Encode(err)),
+                                Err(_panic) => {
+                                    tracing::error!(
+                                        "metrics gather/encode panicked; encoder thread surviving"
+                                    );
+                                    Err(EncodeError::Panicked)
+                                }
+                            };
+                        // The requester may still have gone away between the check and
+                        // here; dropping the result in that case is fine.
+                        reply_tx.send(result).ok();
+                    }
+                }
+            }
+        })?;
+
+    Ok((encoder_tx, handle))
 }
 
 /// Encode the registry's metric families in the Prometheus text exposition format.
@@ -250,10 +397,13 @@ pub async fn run_metrics_endpoint_with_listener(
 /// family whose name starts with `old` is additionally emitted under a copy whose name
 /// has that prefix replaced by `new`, so the same series appear under both names. When
 /// `None`, the output is exactly `TextEncoder` over `registry.gather()`.
+///
+/// Returns the `prometheus::Error` from the text encoder rather than panicking, so the
+/// handler can surface an encode failure as `500` instead of tearing down the thread.
 fn encode_metrics(
     registry: &prometheus::Registry,
     additional_prefix: Option<&PrefixMigration>,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, prometheus::Error> {
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
     let mut metric_families = registry.gather();
@@ -277,25 +427,73 @@ fn encode_metrics(
         }
     }
 
-    encoder.encode(&metric_families, &mut buffer).unwrap();
-    buffer
+    encoder.encode(&metric_families, &mut buffer)?;
+    Ok(buffer)
 }
 
 /// Metrics request handler
-fn handle_metrics_request(
-    req: Request<body::Incoming>,
+async fn handle_metrics_request<B>(
+    req: Request<B>,
     state: Arc<MetricsHandlerState>,
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let response = match (req.method(), req.uri().path()) {
         (&Method::GET, "/metrics") => {
-            let buffer = encode_metrics(&state.registry, state.additional_prefix.as_ref());
+            // `gather()` + text encoding can briefly stall a tokio worker on a large
+            // registry, so it runs on the single dedicated encoder thread. Hand it a
+            // reply channel through the bounded queue and await the encoded exposition.
+            let (reply_tx, reply_rx) = oneshot::channel();
+            match state.encoder_tx.try_send(Item::Work(reply_tx)) {
+                Ok(()) => {}
+                Err(TrySendError::Full(_)) => {
+                    // The single encoder is already busy with a backlog; shed this
+                    // scrape rather than pile on more work.
+                    tracing::warn!("metrics encoder busy; shedding scrape with 503");
+                    return Ok(Response::builder()
+                        .status(503)
+                        .body(Full::new(Bytes::from("metrics encoder busy")))
+                        .unwrap());
+                }
+                Err(TrySendError::Disconnected(_)) => {
+                    tracing::error!("metrics encoder thread is gone; cannot encode metrics");
+                    return Ok(Response::builder()
+                        .status(500)
+                        .body(Full::new(Bytes::from("Failed to encode metrics")))
+                        .unwrap());
+                }
+            }
 
-            Response::builder()
-                .status(200)
-                .header(CONTENT_TYPE, TextEncoder::new().format_type())
-                .header(CONTENT_LENGTH, buffer.len())
-                .body(Full::new(Bytes::from(buffer)))
-                .unwrap()
+            match reply_rx.await {
+                Ok(Ok(buffer)) => Response::builder()
+                    .status(200)
+                    .header(CONTENT_TYPE, TextEncoder::new().format_type())
+                    .header(CONTENT_LENGTH, buffer.len())
+                    .body(Full::new(Bytes::from(buffer)))
+                    .unwrap(),
+                Ok(Err(EncodeError::Encode(err))) => {
+                    tracing::error!(error = %err, "failed to encode metrics");
+                    Response::builder()
+                        .status(500)
+                        .body(Full::new(Bytes::from("Failed to encode metrics")))
+                        .unwrap()
+                }
+                Ok(Err(EncodeError::Panicked)) => {
+                    tracing::error!("metrics encoder caught a panic while encoding");
+                    Response::builder()
+                        .status(500)
+                        .body(Full::new(Bytes::from("Failed to encode metrics")))
+                        .unwrap()
+                }
+                Err(_) => {
+                    // The encoder thread dropped the reply without answering — it was told
+                    // to stop (shutdown) or otherwise went away. Distinct from a busy or
+                    // already-gone encoder above.
+                    tracing::error!("metrics encoder dropped the reply without responding");
+                    Response::builder()
+                        .status(500)
+                        .body(Full::new(Bytes::from("Failed to encode metrics")))
+                        .unwrap()
+                }
+            }
         }
         (&Method::GET, "/health") if state.health_controller.is_healthy() => Response::builder()
             .status(200)
@@ -468,7 +666,7 @@ mod tests {
             .encode(&registry.gather(), &mut expected)
             .unwrap();
 
-        let actual = encode_metrics(&registry, None);
+        let actual = encode_metrics(&registry, None).expect("encode succeeds");
 
         assert_eq!(
             actual, expected,
@@ -486,7 +684,9 @@ mod tests {
             new: "nico_".to_string(),
         };
 
-        let out = String::from_utf8(encode_metrics(&registry, Some(&prefixes))).unwrap();
+        let out =
+            String::from_utf8(encode_metrics(&registry, Some(&prefixes)).expect("encode succeeds"))
+                .unwrap();
 
         // Original families remain, unchanged.
         assert!(out.contains("# HELP carbide_requests_total Total number of requests"));
@@ -543,5 +743,369 @@ mod tests {
             result.expect("server task panicked").is_ok(),
             "cancelled server should return Ok"
         );
+    }
+
+    /// A live `GET /metrics` round-trip returns `200` with a body byte-for-byte equal to
+    /// [`encode_metrics`], proving the dedicated encoder thread produces the same
+    /// exposition the handler used to build inline.
+    #[tokio::test]
+    async fn test_metrics_endpoint_serves_encoded_body() {
+        let registry = sample_registry();
+        let expected = encode_metrics(&registry, None).expect("encode succeeds");
+        let expected_content_type = TextEncoder::new().format_type().to_ascii_lowercase();
+
+        // Bind here so we know the address and there is no bind race with the client.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let config = MetricsEndpointConfig {
+            address: addr,
+            registry,
+            health_controller: None,
+            additional_prefix: None,
+        };
+
+        let cancel_token = CancellationToken::new();
+        let server_token = cancel_token.clone();
+        let server = tokio::spawn(async move {
+            run_metrics_endpoint_with_listener(&config, server_token, listener).await
+        });
+
+        let (headers, body) = scrape_metrics(addr).await;
+
+        assert!(
+            headers.starts_with("http/1.1 200"),
+            "expected a 200 status line, got headers:\n{headers}"
+        );
+        assert!(
+            headers.contains(&format!("content-type: {expected_content_type}")),
+            "expected content-type {expected_content_type:?} in headers:\n{headers}"
+        );
+        assert_eq!(
+            body, expected,
+            "served body must be byte-identical to encode_metrics output"
+        );
+
+        cancel_token.cancel();
+        server
+            .await
+            .unwrap()
+            .expect("metrics server exited cleanly");
+    }
+
+    /// The dedicated encoder thread answers an encode request with the expected bytes and
+    /// then exits on an `Item::Stop` — while a sender is still alive — proving the exit is
+    /// message-driven and never gated on connection tasks dropping their senders.
+    #[test]
+    fn test_encoder_thread_answers_then_exits_on_stop_message() {
+        let registry = sample_registry();
+        let expected = encode_metrics(&registry, None).expect("encode succeeds");
+
+        let (encoder_tx, handle) =
+            spawn_encoder_thread(registry, None).expect("spawn encoder thread");
+
+        // A normal request is answered with the same bytes as encode_metrics.
+        let (reply_tx, mut reply_rx) = oneshot::channel();
+        encoder_tx
+            .try_send(Item::Work(reply_tx))
+            .expect("queue has room");
+        // Bounded wait for the reply so a regressed encoder fails the test rather than
+        // hanging it, using the same deadline pattern as the thread-exit assertion below.
+        let reply_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let encoded = loop {
+            match reply_rx.try_recv() {
+                Ok(result) => break result.expect("encode succeeds"),
+                Err(oneshot::error::TryRecvError::Empty) => {
+                    assert!(
+                        std::time::Instant::now() < reply_deadline,
+                        "encoder did not reply within the deadline"
+                    );
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(oneshot::error::TryRecvError::Closed) => {
+                    panic!("encoder dropped the reply channel without responding")
+                }
+            }
+        };
+        assert_eq!(encoded, expected, "encoder bytes match encode_metrics");
+
+        // Send Stop but keep the sender alive: the thread must still exit.
+        encoder_tx.send(Item::Stop).expect("send stop");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !handle.is_finished() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "encoder thread did not exit after Stop was sent"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        handle.join().expect("encoder thread joined cleanly");
+
+        // The sender was alive the whole time, so the exit came from the Stop message, not
+        // from the queue disconnecting.
+        drop(encoder_tx);
+    }
+
+    /// Cancelling the server while a connection (and therefore a queue-sender clone in its
+    /// handler state) is still alive must still exit and join the encoder thread. The
+    /// server future only completes after that join, so finishing within the timeout
+    /// proves the thread did not linger behind the open connection.
+    #[tokio::test]
+    async fn test_cancel_exits_encoder_thread_with_live_connection() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let config = MetricsEndpointConfig {
+            address: addr,
+            registry: sample_registry(),
+            health_controller: None,
+            additional_prefix: None,
+        };
+
+        let cancel_token = CancellationToken::new();
+        let server_token = cancel_token.clone();
+        let server = tokio::spawn(async move {
+            run_metrics_endpoint_with_listener(&config, server_token, listener).await
+        });
+
+        // Complete one keep-alive `/health` round-trip BEFORE cancelling, so the connection
+        // is deterministically accepted and its task holds an `encoder_tx` clone. Without
+        // `Connection: close` the socket stays open across shutdown.
+        let mut held = tokio::net::TcpStream::connect(addr).await.unwrap();
+        held.write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let response = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut raw = Vec::new();
+            let mut chunk = [0u8; 128];
+            loop {
+                // Read until we have the full headers plus the Content-Length body.
+                if let Some(end) = raw.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let head = String::from_utf8_lossy(&raw[..end]).to_ascii_lowercase();
+                    let body_len: usize = head
+                        .lines()
+                        .find_map(|line| line.strip_prefix("content-length:"))
+                        .map_or(0, |value| value.trim().parse().unwrap());
+                    if raw.len() >= end + 4 + body_len {
+                        break;
+                    }
+                }
+                let n = held.read(&mut chunk).await.unwrap();
+                assert!(n > 0, "connection closed before a full /health response");
+                raw.extend_from_slice(&chunk[..n]);
+            }
+            String::from_utf8_lossy(&raw).to_ascii_lowercase()
+        })
+        .await
+        .expect("/health round-trip timed out");
+        assert!(
+            response.starts_with("http/1.1 200"),
+            "kept-alive /health should be 200, got:\n{response}"
+        );
+
+        // Cancel with the connection still open. The encoder thread must still exit and be
+        // joined — the server future only completes after that join.
+        cancel_token.cancel();
+
+        let joined = tokio::time::timeout(std::time::Duration::from_secs(5), server).await;
+        joined
+            .expect("server did not shut down (encoder-thread join hung) within timeout")
+            .expect("server task panicked")
+            .expect("metrics server exited cleanly");
+
+        drop(held);
+    }
+
+    /// Issue one `GET /metrics` over a fresh connection and return the lowercased header
+    /// block and the raw body bytes. `Connection: close` lets us read to EOF without
+    /// parsing `Content-Length`.
+    async fn scrape_metrics(addr: SocketAddr) -> (String, Vec<u8>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let exchange = async {
+            let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .await
+                .unwrap();
+            let mut raw = Vec::new();
+            stream.read_to_end(&mut raw).await.unwrap();
+            raw
+        };
+        let raw = tokio::time::timeout(std::time::Duration::from_secs(5), exchange)
+            .await
+            .expect("metrics round-trip timed out");
+
+        let separator = b"\r\n\r\n";
+        let split = raw
+            .windows(separator.len())
+            .position(|window| window == separator)
+            .expect("response has a header/body separator");
+        let headers = String::from_utf8_lossy(&raw[..split]).to_ascii_lowercase();
+        let body = raw[split + separator.len()..].to_vec();
+        (headers, body)
+    }
+
+    /// A collector that panics the first time it is gathered and behaves thereafter. It
+    /// lets a test drive one panicking `/metrics` scrape and confirm the encoder thread
+    /// survives to serve the next.
+    struct PanicOnceCollector {
+        desc: prometheus::core::Desc,
+        panicked: AtomicBool,
+    }
+
+    impl PanicOnceCollector {
+        fn new() -> Self {
+            let desc = prometheus::core::Desc::new(
+                "panic_probe".to_string(),
+                "collector that panics on its first gather".to_string(),
+                vec![],
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+            Self {
+                desc,
+                panicked: AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl prometheus::core::Collector for PanicOnceCollector {
+        fn desc(&self) -> Vec<&prometheus::core::Desc> {
+            vec![&self.desc]
+        }
+
+        fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+            if !self.panicked.swap(true, Ordering::SeqCst) {
+                panic!("collector panic during gather");
+            }
+            vec![]
+        }
+    }
+
+    /// A collector that panics during `gather()` must fail only that one scrape (500); the
+    /// sole encoder thread has to survive so a subsequent scrape on the same server still
+    /// succeeds. This is the per-request panic isolation the previous `spawn_blocking`
+    /// provided for free.
+    #[tokio::test]
+    async fn test_encoder_survives_collector_panic() {
+        let registry = prometheus::Registry::new();
+        registry
+            .register(Box::new(PanicOnceCollector::new()))
+            .unwrap();
+        let survives = prometheus::Counter::with_opts(prometheus::Opts::new(
+            "survives_total",
+            "present once the encoder survives a panic",
+        ))
+        .unwrap();
+        survives.inc();
+        registry.register(Box::new(survives)).unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let config = MetricsEndpointConfig {
+            address: addr,
+            registry,
+            health_controller: None,
+            additional_prefix: None,
+        };
+
+        let cancel_token = CancellationToken::new();
+        let server_token = cancel_token.clone();
+        let server = tokio::spawn(async move {
+            run_metrics_endpoint_with_listener(&config, server_token, listener).await
+        });
+
+        // First scrape trips the collector panic. The encoder thread catches the unwind
+        // and answers 500 instead of dying.
+        let (headers, _body) = scrape_metrics(addr).await;
+        assert!(
+            headers.starts_with("http/1.1 500"),
+            "panicking scrape should be 500, got headers:\n{headers}"
+        );
+
+        // The thread survived, so a subsequent scrape on the same server succeeds.
+        let (headers, body) = scrape_metrics(addr).await;
+        assert!(
+            headers.starts_with("http/1.1 200"),
+            "post-panic scrape should be 200, got headers:\n{headers}"
+        );
+        assert!(
+            String::from_utf8_lossy(&body).contains("survives_total"),
+            "post-panic body should contain the registry's metrics"
+        );
+
+        cancel_token.cancel();
+        server
+            .await
+            .unwrap()
+            .expect("metrics server exited cleanly");
+    }
+
+    /// The `/metrics` handler maps a full queue to `503` and a disconnected encoder to
+    /// `500`, exercised directly against `handle_metrics_request` with a channel we control
+    /// — no live server or encoder thread.
+    #[tokio::test]
+    async fn test_handle_metrics_request_queue_backpressure() {
+        // The encoder sender under test, plus any receiver that must stay alive for the
+        // call (`None` means it was dropped, disconnecting the channel).
+        type EncoderChannel = (SyncSender<Item>, Option<std::sync::mpsc::Receiver<Item>>);
+
+        struct Case {
+            name: &'static str,
+            setup: fn() -> EncoderChannel,
+            expected_status: u16,
+        }
+
+        let cases = [
+            Case {
+                name: "queue full -> 503",
+                setup: || {
+                    let (tx, rx) = sync_channel::<Item>(1);
+                    // Fill the single slot so the handler's try_send sees `Full`.
+                    tx.try_send(Item::Stop).expect("prime the queue");
+                    (tx, Some(rx))
+                },
+                expected_status: 503,
+            },
+            Case {
+                name: "encoder gone -> 500",
+                setup: || {
+                    let (tx, rx) = sync_channel::<Item>(1);
+                    drop(rx);
+                    (tx, None)
+                },
+                expected_status: 500,
+            },
+        ];
+
+        for case in cases {
+            let (encoder_tx, _rx_guard) = (case.setup)();
+            let state = Arc::new(MetricsHandlerState {
+                encoder_tx,
+                health_controller: HealthController::new(),
+            });
+            let request = Request::builder()
+                .method(Method::GET)
+                .uri("/metrics")
+                .body(())
+                .unwrap();
+
+            let response = handle_metrics_request(request, state)
+                .await
+                .expect("handler returns a response");
+
+            assert_eq!(
+                response.status().as_u16(),
+                case.expected_status,
+                "case: {}",
+                case.name
+            );
+            // `_rx_guard` (kept for the full-queue case) stays alive until here so the
+            // channel reads as full rather than disconnected.
+        }
     }
 }


### PR DESCRIPTION
The shared `/metrics` handler ran `registry.gather()` and the text encode inline on the tokio task serving the connection, so a large scrape could stall a worker -- and every binary serves `/metrics` through this crate. Spawning each encode on the blocking pool would cap one encode's latency but not the aggregate CPU: N concurrent scrapes would run N encoders on N cores. Instead this hands the encode to one dedicated thread behind a bounded queue, capping encode CPU to a single core no matter how many scrapes arrive.

- `run_metrics_endpoint_with_listener` spawns one `metrics-encoder` thread that owns the registry and prefix and serves encode requests off a small bounded channel; the `/metrics` handler sends a request and awaits the result.
- Shutdown is prompt and connection-independent: a cancel-driven stop flag lets the thread exit within one poll interval even while idle keep-alive connections are open, and the server joins it. A full queue returns 503 (backpressure); a failed encode returns 500 carrying the Prometheus error, kept distinct from a dead-thread 500.
- A panic in `gather()` (a misbehaving collector or callback) is caught, so it returns 500 for that one scrape and the encoder survives to serve the next -- the per-request isolation the inline/pool approach had.
- `encode_metrics` now returns the Prometheus encode error instead of unwrapping it. The success-path bytes are unchanged, so `/metrics` output stays byte-identical.
- A thread-creation failure at startup now propagates as an `io::Error` from the endpoint entry points instead of panicking; `bmc-proxy` (the one direct caller of `run_metrics_endpoint_with_listener`) logs that error rather than discarding the server's exit outcome.

This supports #3524