### PR TITLE
feat(bmc-mock): add optional IPMI and SOL simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1501,6 +1501,7 @@ where
         api_refresh_interval: Duration::from_millis(500),
         mock_bmc_ssh_server: false,
         mock_bmc_ssh_port: None,
+        enable_ipmi_simulation: false,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
     };

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -53,6 +53,7 @@ rustls-pemfile = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 tar = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -58,6 +58,9 @@ pub struct Args {
         help = "An ip_address and .tar.gz file pair (comma separated).\nThe file is an archive of redfish data when the request is forwarded to a specific IP address.\nRepeat for different machines"
     )]
     pub ip_router: Option<Vec<IpRouterPair>>,
+
+    #[clap(long, help = "Start an IPMI/SOL simulator for the generated BMC mock")]
+    pub enable_ipmi_simulation: bool,
 }
 
 pub fn parse_args() -> Args {

--- a/crates/bmc-mock/src/ipmi_sim.rs
+++ b/crates/bmc-mock/src/ipmi_sim.rs
@@ -1,0 +1,493 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::io::ErrorKind;
+use std::net::{IpAddr, SocketAddr, TcpListener, UdpSocket};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener as TokioTcpListener, TcpStream};
+use tokio::task::JoinHandle;
+
+use crate::BmcState;
+use crate::redfish::account_service::PasswordUpdater;
+use crate::redfish::manager::ManagerState;
+
+const START_ATTEMPTS: usize = 5;
+const READY_TIMEOUT: Duration = Duration::from_secs(5);
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const PASSWORD_UPDATE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone)]
+pub struct IpmiSimConfig {
+    pub bind_ip: IpAddr,
+    pub stable_id: String,
+    pub console_prompt: String,
+}
+
+pub struct IpmiSimHandle {
+    child: tokio::process::Child,
+    _temp_dir: TempDir,
+    _console: MockConsole,
+    manager: Arc<ManagerState>,
+    _password_updater: Arc<dyn PasswordUpdater>,
+    pub ipmi_sim_lan_port: u16,
+}
+
+impl std::fmt::Debug for IpmiSimHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IpmiSimHandle")
+            .field("ipmi_sim_lan_port", &self.ipmi_sim_lan_port)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for IpmiSimHandle {
+    fn drop(&mut self) {
+        self.child.start_kill().ok();
+        self.manager.set_ipmi_endpoint(None);
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("the BMC mock has no administrative account")]
+    MissingAdministrativeAccount,
+    #[error("the IPMI simulator {0} contains unsupported characters")]
+    UnsupportedCredentialCharacters(&'static str),
+    #[error("failed to prepare IPMI simulator: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("ipmi_sim exited during startup with status {0}")]
+    EarlyExit(std::process::ExitStatus),
+    #[error("ipmi_sim did not claim its ports within {READY_TIMEOUT:?}")]
+    ReadinessTimeout,
+    #[error("ipmi_sim failed to start after {START_ATTEMPTS} attempts: {0}")]
+    AttemptsExhausted(Box<Error>),
+}
+
+struct Reservations {
+    ipmi_sim_lan_socket: UdpSocket,
+    ipmi_sim_serial_listener: TcpListener,
+}
+
+impl Reservations {
+    fn new(bind_ip: IpAddr) -> Result<Self, std::io::Error> {
+        Ok(Self {
+            ipmi_sim_lan_socket: UdpSocket::bind(SocketAddr::new(bind_ip, 0))?,
+            ipmi_sim_serial_listener: TcpListener::bind((
+                IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
+                0,
+            ))?,
+        })
+    }
+
+    fn ipmi_sim_lan_port(&self) -> Result<u16, std::io::Error> {
+        Ok(self.ipmi_sim_lan_socket.local_addr()?.port())
+    }
+
+    fn ipmi_sim_serial_port(&self) -> Result<u16, std::io::Error> {
+        Ok(self.ipmi_sim_serial_listener.local_addr()?.port())
+    }
+}
+
+pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHandle, Error> {
+    let (username, password) = state
+        .account_service_state
+        .administrator_credentials()
+        .ok_or(Error::MissingAdministrativeAccount)?;
+    validate_credential("username", &username)?;
+    validate_credential("password", &password)?;
+    let temp_dir = tempfile::Builder::new()
+        .prefix("bmc-mock-ipmi-")
+        .tempdir()?;
+    std::fs::set_permissions(temp_dir.path(), std::fs::Permissions::from_mode(0o700))?;
+
+    let console = MockConsole::start(config.console_prompt.clone()).await?;
+    let mut last_error = None;
+
+    for attempt in 1..=START_ATTEMPTS {
+        let reservations = Reservations::new(config.bind_ip)?;
+        let ipmi_sim_lan_port = reservations.ipmi_sim_lan_port()?;
+        let ipmi_sim_serial_port = reservations.ipmi_sim_serial_port()?;
+        let state_dir = temp_dir.path().join(format!("state-{attempt}"));
+        std::fs::create_dir(&state_dir)?;
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700))?;
+        write_config(
+            temp_dir.path(),
+            &config,
+            &username,
+            &password,
+            ipmi_sim_lan_port,
+            ipmi_sim_serial_port,
+            console.bmc_mock_console_port,
+        )?;
+
+        drop(reservations);
+        let mut child = tokio::process::Command::new("ipmi_sim")
+            .current_dir(temp_dir.path())
+            .arg("-c")
+            .arg(temp_dir.path().join("lan.conf"))
+            .arg("-f")
+            .arg(temp_dir.path().join("cmd.conf"))
+            .arg("-s")
+            .arg(state_dir)
+            .arg("--nostdio")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        match wait_until_ready(
+            &mut child,
+            config.bind_ip,
+            ipmi_sim_lan_port,
+            ipmi_sim_serial_port,
+        )
+        .await
+        {
+            Ok(()) => {
+                let connect_ip = if config.bind_ip.is_unspecified() {
+                    IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+                } else {
+                    config.bind_ip
+                };
+                let password_updater: Arc<dyn PasswordUpdater> = Arc::new(IpmiPasswordUpdater {
+                    connect_ip,
+                    ipmi_sim_lan_port,
+                });
+                state
+                    .account_service_state
+                    .set_password_updater(&password_updater);
+                state.manager.set_ipmi_endpoint(Some(ipmi_sim_lan_port));
+                return Ok(IpmiSimHandle {
+                    child,
+                    _temp_dir: temp_dir,
+                    _console: console,
+                    manager: state.manager.clone(),
+                    _password_updater: password_updater,
+                    ipmi_sim_lan_port,
+                });
+            }
+            Err(error) => {
+                child.kill().await.ok();
+                last_error = Some(error);
+                tracing::warn!(
+                    attempt,
+                    ipmi_sim_lan_port,
+                    ipmi_sim_serial_port,
+                    "ipmi_sim startup failed; retrying"
+                );
+            }
+        }
+    }
+
+    Err(Error::AttemptsExhausted(Box::new(
+        last_error.expect("at least one startup attempt ran"),
+    )))
+}
+
+struct IpmiPasswordUpdater {
+    connect_ip: IpAddr,
+    ipmi_sim_lan_port: u16,
+}
+
+impl PasswordUpdater for IpmiPasswordUpdater {
+    fn update_password<'a>(
+        &'a self,
+        username: &'a str,
+        current_password: &'a str,
+        new_password: &'a str,
+    ) -> futures::future::BoxFuture<'a, Result<(), String>> {
+        Box::pin(async move {
+            let connect_ip = self.connect_ip.to_string();
+            let ipmi_sim_lan_port = self.ipmi_sim_lan_port.to_string();
+            let mut command = [
+                "-I",
+                "lanplus",
+                "-H",
+                connect_ip.as_str(),
+                "-p",
+                ipmi_sim_lan_port.as_str(),
+                "-U",
+                username,
+                "-E",
+                "-C",
+                "3",
+                "user",
+                "set",
+                "password",
+                "3",
+                new_password,
+                "20",
+            ]
+            .into_iter()
+            .fold(
+                tokio::process::Command::new("ipmitool"),
+                |mut command, argument| {
+                    command.arg(argument);
+                    command
+                },
+            );
+            command
+                .env("IPMI_PASSWORD", current_password)
+                .kill_on_drop(true);
+            let output = tokio::time::timeout(PASSWORD_UPDATE_TIMEOUT, command.output())
+                .await
+                .map_err(|_| format!("ipmitool timed out after {PASSWORD_UPDATE_TIMEOUT:?}"))?
+                .map_err(|error| format!("failed to execute ipmitool: {error}"))?;
+            if output.status.success() {
+                Ok(())
+            } else {
+                Err(format!(
+                    "ipmitool exited with {}: {}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ))
+            }
+        })
+    }
+}
+
+fn validate_credential(field: &'static str, value: &str) -> Result<(), Error> {
+    if value
+        .chars()
+        .any(|character| character == '"' || character == '\\' || character.is_control())
+    {
+        return Err(Error::UnsupportedCredentialCharacters(field));
+    }
+    Ok(())
+}
+
+fn write_config(
+    base: &Path,
+    config: &IpmiSimConfig,
+    username: &str,
+    password: &str,
+    ipmi_sim_lan_port: u16,
+    ipmi_sim_serial_port: u16,
+    bmc_mock_console_port: u16,
+) -> Result<(), std::io::Error> {
+    let lan_config = format!(
+        r#"name "ManagedHostBmc"
+set_working_mc 0x20
+
+startlan 1
+  addr {} {ipmi_sim_lan_port}
+  priv_limit admin
+  allowed_auths_admin none md2 md5 straight none
+  guid {}
+endlan
+
+user 1 true "" "" user 10 none md2 md5 straight none
+user 2 true "admin" "admin" admin 10 none md2 md5 straight none
+user 3 true "{username}" "{password}" admin 10 none md2 md5 straight none
+
+chassis_control "./chassis-control.sh 0x20"
+serial 15 127.0.0.1 {ipmi_sim_serial_port} codec VM ipmb 0x20
+sol "telnet:127.0.0.1:{bmc_mock_console_port}" 115200
+"#,
+        config.bind_ip,
+        stable_guid(&config.stable_id),
+    );
+
+    write_private_file(&base.join("lan.conf"), lan_config.as_bytes(), 0o600)?;
+    write_private_file(
+        &base.join("cmd.conf"),
+        include_bytes!("../../../dev/ipmi/cmd.conf"),
+        0o600,
+    )?;
+    write_private_file(
+        &base.join("chassis-control.sh"),
+        include_bytes!("../../../dev/ipmi/ipmi_sim_chassiscontrol.sh"),
+        0o700,
+    )?;
+    Ok(())
+}
+
+fn write_private_file(path: &Path, contents: &[u8], mode: u32) -> Result<(), std::io::Error> {
+    std::fs::write(path, contents)?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+}
+
+fn stable_guid(stable_id: &str) -> String {
+    let mut bytes = [0_u8; 16];
+    for (index, value) in stable_id.bytes().enumerate() {
+        let slot = index % bytes.len();
+        bytes[slot] = bytes[slot]
+            .wrapping_mul(31)
+            .wrapping_add(value)
+            .wrapping_add(index as u8);
+    }
+    bytes.iter().map(|value| format!("{value:02x}")).collect()
+}
+
+async fn wait_until_ready(
+    child: &mut tokio::process::Child,
+    bind_ip: IpAddr,
+    ipmi_sim_lan_port: u16,
+    ipmi_sim_serial_port: u16,
+) -> Result<(), Error> {
+    let deadline = Instant::now() + READY_TIMEOUT;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Err(Error::EarlyExit(status));
+        }
+
+        if udp_port_is_claimed(bind_ip, ipmi_sim_lan_port)?
+            && tcp_port_is_claimed(ipmi_sim_serial_port)?
+        {
+            tokio::time::sleep(READY_POLL_INTERVAL).await;
+            if let Some(status) = child.try_wait()? {
+                return Err(Error::EarlyExit(status));
+            }
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(Error::ReadinessTimeout);
+        }
+        tokio::time::sleep(READY_POLL_INTERVAL).await;
+    }
+}
+
+fn udp_port_is_claimed(bind_ip: IpAddr, port: u16) -> Result<bool, std::io::Error> {
+    port_is_claimed(UdpSocket::bind(SocketAddr::new(bind_ip, port)))
+}
+
+fn tcp_port_is_claimed(port: u16) -> Result<bool, std::io::Error> {
+    port_is_claimed(TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port)))
+}
+
+fn port_is_claimed<T>(result: Result<T, std::io::Error>) -> Result<bool, std::io::Error> {
+    match result {
+        Ok(_) => Ok(false),
+        Err(error) if error.kind() == ErrorKind::AddrInUse => Ok(true),
+        Err(error) => Err(error),
+    }
+}
+
+struct MockConsole {
+    bmc_mock_console_port: u16,
+    task: JoinHandle<()>,
+}
+
+impl Drop for MockConsole {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl MockConsole {
+    async fn start(prompt: String) -> Result<Self, std::io::Error> {
+        let listener = TokioTcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).await?;
+        let bmc_mock_console_port = listener.local_addr()?.port();
+        let task = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let prompt = prompt.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = serve_console(stream, &prompt).await {
+                        tracing::debug!(%error, "mock SOL console connection closed with error");
+                    }
+                });
+            }
+        });
+        Ok(Self {
+            bmc_mock_console_port,
+            task,
+        })
+    }
+}
+
+async fn serve_console(mut stream: TcpStream, prompt: &str) -> Result<(), std::io::Error> {
+    let mut input = Vec::new();
+    let mut buffer = [0_u8; 32];
+    loop {
+        let length = stream.read(&mut buffer).await?;
+        if length == 0 {
+            return Ok(());
+        }
+        input.extend_from_slice(&buffer[..length]);
+        stream.write_all(&buffer[..length]).await?;
+        if input.ends_with(b"\n") || input.ends_with(b"\r") {
+            input.clear();
+            stream.write_all(format!("\r\n{prompt}").as_bytes()).await?;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Error, MockConsole, stable_guid, validate_credential};
+
+    #[test]
+    fn stable_guid_is_stable_and_has_ipmi_length() {
+        assert_eq!(stable_guid("machine-1"), stable_guid("machine-1"));
+        assert_ne!(stable_guid("machine-1"), stable_guid("machine-2"));
+        assert_eq!(stable_guid("machine-1").len(), 32);
+    }
+
+    #[test]
+    fn credential_validation_rejects_ipmi_sim_syntax_characters() {
+        for value in [
+            "double\"quote",
+            "back\\slash",
+            "line\nfeed",
+            "carriage\rreturn",
+            "nul\0byte",
+        ] {
+            assert!(matches!(
+                validate_credential("password", value),
+                Err(Error::UnsupportedCredentialCharacters("password"))
+            ));
+        }
+    }
+
+    #[test]
+    fn credential_validation_accepts_plain_credentials() {
+        assert!(validate_credential("username", "root-admin").is_ok());
+        assert!(validate_credential("password", "Welcome123! @$%^&*()").is_ok());
+    }
+
+    #[tokio::test]
+    async fn dropping_mock_console_releases_listener() {
+        let console = MockConsole::start("prompt".to_string()).await.unwrap();
+        let port = console.bmc_mock_console_port;
+
+        drop(console);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                match std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port)) {
+                    Ok(_) => break,
+                    Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+                        tokio::task::yield_now().await;
+                    }
+                    Err(error) => panic!("failed to probe console listener: {error}"),
+                }
+            }
+        })
+        .await
+        .expect("mock console listener was not released");
+    }
+}

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 pub mod ipmi;
+pub mod ipmi_sim;
 
 mod auth_router;
 mod bmc_state;

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -943,6 +943,18 @@ impl HostMachineInfo {
 }
 
 impl MachineInfo {
+    pub fn supports_ipmi_console(&self) -> bool {
+        matches!(
+            self,
+            MachineInfo::Host(host)
+                if matches!(
+                    host.bmc_vendor(),
+                    redfish::oem::BmcVendor::Supermicro
+                        | redfish::oem::BmcVendor::Nvidia(_)
+                )
+        )
+    }
+
     pub fn oem_state(&self) -> redfish::oem::State {
         match self {
             MachineInfo::Host(host) => host.oem_state(),

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -29,8 +29,9 @@ use bmc_mock::mac_address_pool::{
     RangesConfig as MacAddressRangesConfig,
 };
 use bmc_mock::{
-    BmcCommand, Callbacks, DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo,
-    ListenerOrAddress, MachineInfo, MockPowerState, SetSystemPowerError, SystemPowerControl,
+    BmcCommand, BmcState, Callbacks, DpuMachineInfo, DpuSettings, HostHardwareType,
+    HostMachineInfo, ListenerOrAddress, MachineInfo, MockPowerState, SetSystemPowerError,
+    SystemPowerControl,
 };
 use mac_address::MacAddress;
 use tar_router::TarGzOption;
@@ -70,6 +71,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut tar_router_entries = HashMap::default();
 
     let args = command_line::parse_args();
+    if args.enable_ipmi_simulation && (args.targz.is_some() || args.ip_router.is_some()) {
+        return Err(
+            "--enable-ipmi-simulation cannot be combined with archive-backed routers".into(),
+        );
+    }
     if let Some(ip_routers) = args.ip_router {
         for ip_router in ip_routers {
             info!(
@@ -87,19 +93,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let listen_addr = args.port.map(|p| SocketAddr::from(([0, 0, 0, 0], p)));
-    info!(
-        cert_path = ?args.cert_path,
-        "Using BMC mock certificate path",
-    );
-    let router = if let Some(tar_path) = args.targz {
-        info!(
-            archive_path = %tar_path.to_string_lossy(),
-            "Using default BMC mock archive",
-        );
-        tar_router::tar_router(TarGzOption::Disk(&tar_path), Some(&mut tar_router_entries)).unwrap()
+    info!(cert_path = ?args.cert_path, "Using BMC mock certificate path");
+    let (router, generated_state) = if let Some(tar_path) = args.targz {
+        info!(archive_path = %tar_path.to_string_lossy(), "Using default BMC mock archive");
+        (
+            tar_router::tar_router(TarGzOption::Disk(&tar_path), Some(&mut tar_router_entries))
+                .unwrap(),
+            None,
+        )
     } else {
         info!("Using default BMC mock");
-        default_host_mock()
+        let (router, state) = default_host_mock();
+        (router, Some(state))
+    };
+
+    let _ipmi_sim_handle = if args.enable_ipmi_simulation {
+        let state = generated_state
+            .as_ref()
+            .expect("archive-backed routers were rejected above");
+        Some(
+            bmc_mock::ipmi_sim::start(
+                state,
+                bmc_mock::ipmi_sim::IpmiSimConfig {
+                    bind_ip: "0.0.0.0".parse().unwrap(),
+                    stable_id: "standalone-bmc-mock".to_string(),
+                    console_prompt: "root@bmc-mock # ".to_string(),
+                },
+            )
+            .await?,
+        )
+    } else {
+        None
     };
 
     routers_by_ip.insert("".to_owned(), router);
@@ -170,7 +194,7 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
     command_tx
 }
 
-fn default_host_mock() -> Router {
+fn default_host_mock() -> (Router, BmcState) {
     let command_channel = spawn_qemu_reboot_handler();
     let callbacks = Arc::new(ChannelCallbacks::new(command_channel));
     let mut pool = MacAddressPool::new(MacAddressConfig {
@@ -197,7 +221,7 @@ fn default_host_mock() -> Router {
         &mut pool,
         mac_range,
     ));
-    bmc_mock::machine_router(&machine_info, callbacks, String::default(), false).0
+    bmc_mock::machine_router(&machine_info, callbacks, String::default(), false)
 }
 
 #[derive(Debug)]

--- a/crates/bmc-mock/src/redfish/account_service.rs
+++ b/crates/bmc-mock/src/redfish/account_service.rs
@@ -17,13 +17,14 @@
 
 use std::borrow::Cow;
 use std::fmt::Display;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, Weak};
 
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::Response;
 use axum::routing::get;
 use axum::{Json, Router};
+use futures::future::BoxFuture;
 use serde_json::json;
 
 use crate::bmc_state::BmcState;
@@ -56,17 +57,33 @@ const ACCOUNTS_COLLECTION_RESOURCE: redfish::Collection<'static> = redfish::Coll
     odata_type: Cow::Borrowed("#ManagerAccountCollection.ManagerAccountCollection"),
     name: Cow::Borrowed("Accounts Collection"),
 };
+const ADMINISTRATOR_ROLE_ID: &str = "Administrator";
 
 #[derive(Debug)]
 pub struct AccountServiceState {
     accounts: Mutex<Vec<Account>>,
+    password_updater: Mutex<Option<Weak<dyn PasswordUpdater>>>,
+}
+
+pub(crate) trait PasswordUpdater: Send + Sync {
+    fn update_password<'a>(
+        &'a self,
+        username: &'a str,
+        current_password: &'a str,
+        new_password: &'a str,
+    ) -> BoxFuture<'a, Result<(), String>>;
 }
 
 impl AccountServiceState {
     pub fn new(factory_default_account: Account) -> Self {
         Self {
             accounts: Mutex::new(vec![factory_default_account]),
+            password_updater: Mutex::new(None),
         }
+    }
+
+    pub(crate) fn set_password_updater(&self, updater: &Arc<dyn PasswordUpdater>) {
+        *self.password_updater.lock().expect("mutex poisoned") = Some(Arc::downgrade(updater));
     }
 
     pub fn accounts(&self) -> Vec<Account> {
@@ -80,6 +97,15 @@ impl AccountServiceState {
             .iter()
             .find(|account| account.id == account_id)
             .cloned()
+    }
+
+    pub(crate) fn administrator_credentials(&self) -> Option<(String, String)> {
+        self.accounts
+            .lock()
+            .expect("mutex poisoned")
+            .iter()
+            .find(|account| account.role_id == ADMINISTRATOR_ROLE_ID)
+            .map(|account| (account.username.clone(), account.password.clone()))
     }
 
     pub fn is_authorized(&self, username: &str, password: &str) -> bool {
@@ -98,13 +124,35 @@ impl AccountServiceState {
             .any(|account| account.matches_factory_default_password(username, password))
     }
 
-    pub fn update_password(&self, account_id: &str, password: impl Into<String>) -> bool {
-        let mut accounts = self.accounts.lock().expect("mutex poisoned");
-        let Some(account) = accounts.iter_mut().find(|account| account.id == account_id) else {
-            return false;
+    pub async fn update_password(
+        &self,
+        account_id: &str,
+        password: impl Into<String>,
+    ) -> Result<bool, String> {
+        let password = password.into();
+        let account = self.find(account_id);
+        let Some(account) = account else {
+            return Ok(false);
         };
-        account.password = password.into();
-        true
+        let updater = self
+            .password_updater
+            .lock()
+            .expect("mutex poisoned")
+            .as_ref()
+            .and_then(Weak::upgrade);
+        if let Some(updater) = updater {
+            updater
+                .update_password(&account.username, &account.password, &password)
+                .await?;
+        }
+
+        let mut accounts = self.accounts.lock().expect("mutex poisoned");
+        let account = accounts
+            .iter_mut()
+            .find(|candidate| candidate.id == account_id)
+            .expect("account existed before password synchronization");
+        account.password = password;
+        Ok(true)
     }
 
     /// Rotates every account on its factory default password to `new_password`
@@ -140,7 +188,7 @@ impl Account {
             username: username.into(),
             password: password.clone(),
             factory_default_password: password,
-            role_id: "Administrator".into(),
+            role_id: ADMINISTRATOR_ROLE_ID.into(),
         }
     }
 
@@ -219,13 +267,18 @@ pub async fn patch_account(
         return json!("Password must be a string").into_response(StatusCode::BAD_REQUEST);
     };
 
-    if state
+    match state
         .account_service_state
         .update_password(&account_id, password)
+        .await
     {
-        http::ok_no_content()
-    } else {
-        http::not_found()
+        Ok(true) => http::ok_no_content(),
+        Ok(false) => http::not_found(),
+        Err(error) => {
+            tracing::error!(%error, %account_id, "failed to synchronize BMC account password");
+            json!("Failed to synchronize BMC account password")
+                .into_response(StatusCode::INTERNAL_SERVER_ERROR)
+        }
     }
 }
 
@@ -238,4 +291,58 @@ pub async fn get_account(
         .find(&account_id)
         .map(|account| account.to_json().into_ok_response())
         .unwrap_or_else(http::not_found)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::future::BoxFuture;
+
+    use super::{Account, AccountServiceState, PasswordUpdater};
+
+    struct TestPasswordUpdater {
+        result: Result<(), String>,
+    }
+
+    impl PasswordUpdater for TestPasswordUpdater {
+        fn update_password<'a>(
+            &'a self,
+            _username: &'a str,
+            _current_password: &'a str,
+            _new_password: &'a str,
+        ) -> BoxFuture<'a, Result<(), String>> {
+            let result = self.result.clone();
+            Box::pin(async move { result })
+        }
+    }
+
+    fn state_with_updater(
+        result: Result<(), String>,
+    ) -> (AccountServiceState, Arc<dyn PasswordUpdater>) {
+        let state = AccountServiceState::new(Account::administrator("1", "root", "old-password"));
+        let updater: Arc<dyn PasswordUpdater> = Arc::new(TestPasswordUpdater { result });
+        state.set_password_updater(&updater);
+        (state, updater)
+    }
+
+    #[tokio::test]
+    async fn update_password_commits_after_ipmi_update_succeeds() {
+        let (state, _updater) = state_with_updater(Ok(()));
+
+        assert_eq!(state.update_password("1", "new-password").await, Ok(true));
+        assert!(state.is_authorized("root", "new-password"));
+    }
+
+    #[tokio::test]
+    async fn update_password_preserves_redfish_password_when_ipmi_update_fails() {
+        let (state, _updater) = state_with_updater(Err("IPMI update failed".to_string()));
+
+        assert_eq!(
+            state.update_password("1", "new-password").await,
+            Err("IPMI update failed".to_string())
+        );
+        assert!(state.is_authorized("root", "old-password"));
+        assert!(!state.is_authorized("root", "new-password"));
+    }
 }

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -269,11 +269,18 @@ impl ManagerState {
     pub fn find(&self, manager_id: &str) -> Option<&SingleManagerState> {
         self.managers.iter().find(|c| c.id == manager_id)
     }
+
+    pub fn set_ipmi_endpoint(&self, port: Option<u16>) {
+        for manager in &self.managers {
+            manager.set_ipmi_endpoint(port);
+        }
+    }
 }
 
 pub struct SingleManagerState {
     id: &'static str,
     ipmi_enabled: Arc<atomic::AtomicBool>,
+    ipmi_port: Mutex<Option<u16>>,
     ntp: Mutex<NtpState>,
     config: SingleConfig,
     // PATCHes applied to the manager resource (e.g. HPE lockdown flips
@@ -325,6 +332,7 @@ impl SingleManagerState {
             id: config.id,
             config: config.clone(),
             ipmi_enabled: Arc::new(false.into()),
+            ipmi_port: Mutex::new(None),
             ntp: Mutex::new(NtpState::default()),
             overrides: Arc::new(Mutex::new(json!({}))),
             host_interface_overrides: Mutex::new(HashMap::new()),
@@ -335,9 +343,18 @@ impl SingleManagerState {
         let resource = redfish::manager_network_protocol::manager_resource(self.id);
         let ntp = self.ntp.lock().expect("mutex poisoned");
         redfish::manager_network_protocol::builder(&resource)
-            .ipmi_enabled(self.ipmi_enabled.load(atomic::Ordering::Relaxed))
+            .ipmi(
+                self.ipmi_enabled.load(atomic::Ordering::Relaxed),
+                *self.ipmi_port.lock().expect("mutex poisoned"),
+            )
             .ntp(ntp.protocol_enabled, &ntp.servers)
             .build()
+    }
+
+    fn set_ipmi_endpoint(&self, port: Option<u16>) {
+        *self.ipmi_port.lock().expect("mutex poisoned") = port;
+        self.ipmi_enabled
+            .store(port.is_some(), atomic::Ordering::Relaxed);
     }
 
     fn patch_network_protocol(&self, patch_request: serde_json::Value) {

--- a/crates/bmc-mock/src/redfish/manager_network_protocol.rs
+++ b/crates/bmc-mock/src/redfish/manager_network_protocol.rs
@@ -52,8 +52,12 @@ impl Builder for ManagerNetworkProtocolBuilder {
 }
 
 impl ManagerNetworkProtocolBuilder {
-    pub fn ipmi_enabled(self, value: bool) -> Self {
-        self.apply_patch(json!({"IPMI": { "ProtocolEnabled": value }}))
+    pub fn ipmi(self, enabled: bool, port: Option<u16>) -> Self {
+        let value = self.apply_patch(json!({"IPMI": { "ProtocolEnabled": enabled }}));
+        match port {
+            Some(port) => value.apply_patch(json!({"IPMI": { "Port": port }})),
+            None => value,
+        }
     }
 
     pub fn ntp(self, protocol_enabled: bool, servers: &[impl AsRef<str>]) -> Self {

--- a/crates/machine-a-tron/config/mac.toml
+++ b/crates/machine-a-tron/config/mac.toml
@@ -65,6 +65,11 @@ pxe_server_port = "8080"
 #
 bmc_mock_port = 2000
 
+# Set to true to start an independent IPMI/SOL simulator for each IPMI-capable
+# host BMC. This requires ipmi_sim and ipmitool to be available in PATH.
+#
+enable_ipmi_simulation = false
+
 # If set, host/DPU BMC mocks start with the factory default password rotated
 # to this value. Leave unset to keep the factory default.
 #

--- a/crates/machine-a-tron/config/mat.toml
+++ b/crates/machine-a-tron/config/mat.toml
@@ -58,6 +58,11 @@ pxe_server_port = "8080"
 #
 bmc_mock_port = 2000
 
+# Set to true to start an independent IPMI/SOL simulator for each IPMI-capable
+# host BMC. This requires ipmi_sim and ipmitool to be available in PATH.
+#
+enable_ipmi_simulation = false
+
 # If set, host/DPU BMC mocks start with the factory default password rotated
 # to this value. Leave unset to keep the factory default.
 #

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
+use bmc_mock::ipmi_sim::{IpmiSimConfig, IpmiSimHandle};
 use bmc_mock::{
     BmcState, Callbacks, CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo,
 };
@@ -41,6 +42,8 @@ pub struct BmcMockWrapper {
     bmc_mock_router: Router,
     bmc_mock_state: BmcState,
     hostname: Arc<dyn HostnameQuerying>,
+    supports_ipmi_console: bool,
+    stable_id: String,
 }
 
 impl BmcMockWrapper {
@@ -63,9 +66,13 @@ impl BmcMockWrapper {
             bmc_mock_router,
             bmc_mock_state,
             hostname,
+            supports_ipmi_console: machine_info.supports_ipmi_console(),
+            stable_id: host_id.to_string(),
         }
     }
 
+    /// Starts the per-machine Redfish server and any enabled SSH and IPMI simulators.
+    /// When requested, the BMC address is first added as an alias on the configured interface.
     pub async fn start(
         &mut self,
         address: SocketAddr,
@@ -142,6 +149,7 @@ impl BmcMockWrapper {
         } else {
             None
         };
+        let ipmi_sim_handle = self.start_ipmi_sim(address.ip()).await?;
 
         tracing::info!(
             listen_address = ?address,
@@ -151,7 +159,7 @@ impl BmcMockWrapper {
         let tls_server_config = bmc_mock::tls::server_config(Some(certs_dir))?;
         let bmc_mock_router = self.bmc_mock_router.clone();
         Ok(BmcMockWrapperHandle {
-            _bmc_mock: CombinedServer::run(
+            _bmc_mock: Some(CombinedServer::run(
                 "bmc-mock",
                 Arc::new(RwLock::new(HashMap::from([(
                     "".to_string(),
@@ -159,9 +167,48 @@ impl BmcMockWrapper {
                 )]))),
                 Some(ListenerOrAddress::Address(address)),
                 tls_server_config,
-            ),
+            )),
             ssh_handle,
+            _ipmi_sim_handle: ipmi_sim_handle,
         })
+    }
+
+    /// Starts only the optional IPMI simulator when Redfish is served by a shared BMC mock.
+    /// Returns `None` when IPMI simulation is disabled or the machine does not support IPMI SOL.
+    pub async fn start_ipmi_only(
+        &self,
+        bind_ip: std::net::IpAddr,
+    ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
+        Ok(self
+            .start_ipmi_sim(bind_ip)
+            .await?
+            .map(|ipmi_sim_handle| BmcMockWrapperHandle {
+                _bmc_mock: None,
+                ssh_handle: None,
+                _ipmi_sim_handle: Some(ipmi_sim_handle),
+            }))
+    }
+
+    async fn start_ipmi_sim(
+        &self,
+        bind_ip: std::net::IpAddr,
+    ) -> Result<Option<IpmiSimHandle>, MachineStateError> {
+        if !self.app_context.app_config.enable_ipmi_simulation || !self.supports_ipmi_console {
+            return Ok(None);
+        }
+
+        let console_prompt = format!("root@{} # ", self.hostname.get_hostname());
+        bmc_mock::ipmi_sim::start(
+            &self.bmc_mock_state,
+            IpmiSimConfig {
+                bind_ip,
+                stable_id: self.stable_id.clone(),
+                console_prompt,
+            },
+        )
+        .await
+        .map(Some)
+        .map_err(MachineStateError::IpmiSim)
     }
 
     pub fn router(&self) -> &Router {
@@ -175,8 +222,9 @@ impl BmcMockWrapper {
 
 #[derive(Debug)]
 pub struct BmcMockWrapperHandle {
-    pub _bmc_mock: CombinedServer,
+    pub _bmc_mock: Option<CombinedServer>,
     pub ssh_handle: Option<MockSshServerHandle>,
+    _ipmi_sim_handle: Option<IpmiSimHandle>,
 }
 
 /// BmcMockRegistry is shared state that MachineATron's mock hosts can use to register their BMC

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -221,6 +221,10 @@ pub struct MachineATronConfig {
     #[serde(default = "default_false")]
     pub mock_bmc_ssh_server: bool,
 
+    /// Opt in to an independent IPMI/SOL simulator for each IPMI-capable host BMC.
+    #[serde(default = "default_false")]
+    pub enable_ipmi_simulation: bool,
+
     /// Set this to configure the port to use when mocking a BMC SSH server. If unset and
     /// use_single_bmc_mock is true, it will pick a random port. If unset and use_single_bmc_mock
     /// is false, it will use port 2222 for each IP alias. (Port 22 is problematic because it
@@ -602,6 +606,11 @@ scout_run_interval = "5s"
         let round_tripped = toml::from_str::<MachineATronConfig>(&serialized)
             .expect("Could not deserialize serialized config");
         assert_eq!(round_tripped, cfg);
+    }
+
+    #[test]
+    fn ipmi_simulation_is_disabled_by_default() {
+        assert!(!rack_config().enable_ipmi_simulation);
     }
 
     #[test]

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -1072,7 +1072,10 @@ impl MachineStateMachine {
                     .write()
                     .await
                     .insert(ip_address.to_string(), bmc_mock.router().clone());
-                None
+                bmc_mock
+                    .start_ipmi_only(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED))
+                    .await?
+                    .map(Arc::new)
             }
         };
         Ok((maybe_bmc_mock_handle, bmc_mock.state().clone()))
@@ -1175,6 +1178,8 @@ pub enum MachineStateError {
     PxeError(#[from] PxeError),
     #[error("BMC mock TLS error: {0}")]
     BmcMockTls(#[from] bmc_mock::tls::Error),
+    #[error("failed to start IPMI simulator: {0}")]
+    IpmiSim(#[from] bmc_mock::ipmi_sim::Error),
     #[error("Mock SSH server error: {0}")]
     MockSshServer(String),
     #[error("{0}")]

--- a/crates/ssh-console/tests/util/ipmi_sim.rs
+++ b/crates/ssh-console/tests/util/ipmi_sim.rs
@@ -14,37 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::net::{IpAddr, Ipv4Addr};
 use std::os::fd::{AsRawFd, OwnedFd};
-use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
-use std::process::Stdio;
 use std::time::Duration;
 
-use api_test_helper::utils::REPO_ROOT;
 use eyre::Context;
-use lazy_static::lazy_static;
 use nix::errno::Errno;
 use nix::fcntl::{FcntlArg, OFlag, fcntl};
 use nix::pty::openpty;
 use nix::unistd;
-use temp_dir::TempDir;
 use tokio::io::unix::AsyncFd;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::oneshot;
 
-use crate::util::log_stdout_and_stderr;
-
-lazy_static! {
-    static ref IPMI_SCRIPTS_DIR: PathBuf = REPO_ROOT.join("dev/ipmi").canonicalize().unwrap();
-}
-
-pub struct IpmiSimHandle {
-    _ipmi_sim: tokio::process::Child,
-    _temp_dir: TempDir,
-    _mock_serial_console: MockSerialConsoleHandle,
-    pub port: u16,
-}
+pub type IpmiSimHandle = bmc_mock::ipmi_sim::IpmiSimHandle;
 
 pub struct ActiveSolSession {
     _ipmitool: tokio::process::Child,
@@ -194,175 +175,18 @@ fn set_nonblocking(fd: &OwnedFd) -> nix::Result<()> {
 /// use. Accepts a `prompt` parameter which will be echoed back when the clients send data (for
 /// tests to assert that it's the expected host.)
 pub async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
-    // Run a simple echo server to pretend it's a serial console. ipmi_sim talks to this through
-    // telnet to emulate a serial connection.
-    let mock_serial_console = run_mock_serial_console(prompt).await?;
-
-    let temp_dir = TempDir::new()?;
-
-    // Allocate 2 ports for ipmi_sim: One for lanplus communication, and another for serial
-    // communications
-    let ipmi_sim_lanplus_port = {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-        listener.local_addr()?.port()
-    };
-    let ipmi_sim_serial_port = {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-        listener.local_addr()?.port()
-    };
-
-    tracing::debug!(
-        ipmi_sim_lanplus_port,
-        ipmi_sim_serial_port,
-        "ipmi_sim will listen"
-    );
-
-    let mock_serial_console_port = mock_serial_console.port;
-
-    let ipmi_state_dir = temp_dir.path().join("ipmi_state");
-    let lan_conf = temp_dir.path().join("lan.conf");
-    let cmd_conf = temp_dir.path().join("cmd.conf");
-    let chassis_control = temp_dir.path().join("ipmi_sim_chassiscontrol.sh");
-
-    // Build config to talk to our mock console for `sol activate` commands
-    std::fs::create_dir(&ipmi_state_dir)?;
-    std::fs::write(
-        &lan_conf,
-        format!(
-            r#"
-name "ManagedHostBmC"
-set_working_mc 0x20
-
-startlan 1
-  addr 0.0.0.0 {ipmi_sim_lanplus_port}
-  priv_limit admin
-  allowed_auths_admin none md2 md5 straight none
-  guid 61120bdcc43211edb674ef2f47d8b462
-endlan
-
-user 1 true  ""      ""      user     10       none md2 md5 straight none
-user 2 true  "admin" "admin" admin    10       none md2 md5 straight none
-user 3 true  "root" "password" admin    10       none md2 md5 straight none
-
-# Note: chassis_control is unused right now, but it's in the dev/ipmi directory and can be used to
-# simulate power control commands.
-chassis_control "./ipmi_sim_chassiscontrol.sh 0x20"
-serial 15 0.0.0.0 {ipmi_sim_serial_port} codec VM ipmb 0x20
-sol "telnet:127.0.0.1:{mock_serial_console_port}" 115200
-    "#
-        ),
-    )?;
-
-    std::fs::write(&cmd_conf, include_bytes!("../../../../dev/ipmi/cmd.conf"))?;
-
-    std::fs::write(
-        &chassis_control,
-        include_bytes!("../../../../dev/ipmi/ipmi_sim_chassiscontrol.sh"),
-    )?;
-    std::fs::set_permissions(&chassis_control, PermissionsExt::from_mode(0o755))?;
-
-    // Then run ipmi_sim
-    tracing::info!("Launching ipmi_sim");
-    let mut process = tokio::process::Command::new("ipmi_sim")
-        .current_dir(temp_dir.path())
-        .arg("-c")
-        .arg(lan_conf.as_path())
-        .arg("-f")
-        .arg(cmd_conf.as_path())
-        .arg("-s")
-        .arg(ipmi_state_dir.as_path())
-        .stdin(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .kill_on_drop(true)
-        .spawn()
-        .context("failed to spawn ipmi_sim")?;
-    log_stdout_and_stderr(&mut process, "ipmi_sim");
-
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
-    Ok(IpmiSimHandle {
-        _ipmi_sim: process,
-        _temp_dir: temp_dir,
-        _mock_serial_console: mock_serial_console,
-        port: ipmi_sim_lanplus_port,
-    })
-}
-
-pub async fn run_mock_serial_console(prompt: String) -> eyre::Result<MockSerialConsoleHandle> {
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
-    let port = listener.local_addr()?.port();
-    tracing::debug!(port, "mock serial console listening");
-    let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
-    tokio::spawn(async move {
-        loop {
-            tokio::select! {
-                res = listener.accept() => {
-                    match res {
-                        Ok((tcp_stream, addr)) => {
-                            tracing::debug!(peer_address = %addr, "mock serial console accepted connection");
-                            tokio::spawn({
-                                let prompt = prompt.clone();
-                                async move {
-                                    match handle_mock_console_client(tcp_stream, prompt.clone()).await {
-                                        Ok(()) => {}
-                                        Err(error) => {
-                                            tracing::error!(?error, "mock serial console: error handling client in mock_serial_console");
-                                        }
-                                    }
-                                }
-                            });
-                        }
-                        Err(error) => {
-                            tracing::error!(?error, "mock serial console: error accepting connection");
-                            break;
-                        }
-                    }
-                }
-                _ = &mut shutdown_rx => {
-                    tracing::debug!("mock serial console: shutting down");
-                    break;
-                }
-            }
-        }
-    });
-    Ok(MockSerialConsoleHandle {
-        _shutdown_tx: shutdown_tx,
-        port,
-    })
-}
-
-pub struct MockSerialConsoleHandle {
-    _shutdown_tx: oneshot::Sender<()>,
-    pub port: u16,
-}
-
-async fn handle_mock_console_client(mut tcp_stream: TcpStream, prompt: String) -> eyre::Result<()> {
-    let mut input = Vec::new();
-    let mut read_buf = [0u8; 32];
-    loop {
-        match tcp_stream.read(&mut read_buf).await {
-            Ok(len) => {
-                if len == 0 {
-                    tracing::debug!("eof from mock console client");
-                    break;
-                }
-                input.extend_from_slice(&read_buf[..len]);
-                tcp_stream.write_all(&read_buf[..len]).await?;
-                if input.ends_with(b"\n") || input.ends_with(b"\r") {
-                    input.clear();
-                    tcp_stream
-                        .write_all(format!("\r\n{prompt}").as_bytes())
-                        .await?;
-                }
-            }
-            Err(error) => {
-                return Err(eyre::format_err!(
-                    "error reading from mock console client: {error:?}"
-                ));
-            }
-        }
-    }
-
-    Ok(())
+    let bmc = bmc_mock::test_support::generic_supermicro_bmc().await;
+    bmc.state
+        .account_service_state
+        .change_factory_default_password("password");
+    bmc_mock::ipmi_sim::start(
+        &bmc.state,
+        bmc_mock::ipmi_sim::IpmiSimConfig {
+            bind_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            stable_id: prompt.clone(),
+            console_prompt: prompt,
+        },
+    )
+    .await
+    .map_err(Into::into)
 }

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -27,7 +27,6 @@ use futures::future::join_all;
 use futures_util::future::BoxFuture;
 use machine_a_tron::{MockSshServerHandle, PromptBehavior};
 use ssh_console_mock_api_server::{MockApiServerHandle, MockHost};
-use tokio::io::{AsyncBufReadExt, BufReader};
 use uuid::Uuid;
 
 use crate::util::ipmi_sim::IpmiSimHandle;
@@ -79,31 +78,6 @@ pub mod fixtures {
             .canonicalize()
             .unwrap();
     }
-}
-
-pub fn log_stdout_and_stderr(process: &mut tokio::process::Child, prefix: &str) {
-    let stdout = process.stdout.take().unwrap();
-    let stderr = process.stderr.take().unwrap();
-    let prefix = prefix.to_string();
-
-    tokio::spawn(async move {
-        let stdout_reader = BufReader::new(stdout);
-        let stderr_reader = BufReader::new(stderr);
-        let mut stdout_lines = stdout_reader.lines();
-        let mut stderr_lines = stderr_reader.lines();
-        loop {
-            tokio::select! {
-                Ok(Some(line)) = stdout_lines.next_line() => {
-                    tracing::info!("[{prefix} STDOUT] {line}")
-                }
-                Ok(Some(line)) = stderr_lines.next_line() => {
-                    // stderr can be logged as info, because in practice ssh-console logs everything to stderr.
-                    tracing::info!("[{prefix} STDERR] {line}")
-                }
-                else => break,
-            }
-        }
-    });
 }
 
 /// Runs a baseline test environment for comparing results for leagacy ssh-console and (soon) new
@@ -184,7 +158,7 @@ pub async fn run_baseline_test_environment(
                 },
                 ipmi_port: match &bmc_handle {
                     MockBmcHandle::Ssh(_) => None,
-                    MockBmcHandle::Ipmi(i) => Some(i.port),
+                    MockBmcHandle::Ipmi(i) => Some(i.ipmi_sim_lan_port),
                 },
                 bmc_user: "root".to_string(),
                 bmc_password: "password".to_string(),


### PR DESCRIPTION
Machine-a-tron currently simulates BMC management through Redfish and optional SSH, but it cannot exercise workflows that depend on IPMI or Serial over LAN. This leaves the SSH console integration path dependent on separately managed simulator infrastructure and prevents local environments from representing an IPMI-capable BMC as one coherent mock.

This PR is the first step toward full IPMI support in machine-a-tron. It establishes the simulator lifecycle and integration foundation; broader IPMI command and behavior coverage will follow separately.

## What changed

- Integrates ipmi_sim into bmc-mock.
- Allows machine-a-tron to start an independent IPMI/SOL simulator for each supported host BMC.
- Supports both per-machine BMC mocks and deployments using a shared Redfish BMC-mock instance.
- Dynamically allocates IPMI LAN, serial, and mock console ports.
- Advertises the simulated IPMI endpoint through Redfish.
- Synchronizes Redfish password changes with the corresponding IPMI user.
- Adds an IPMI-backed mock SOL console for SSH-console integration testing.
- Makes IPMI simulation opt-in because ipmi_sim and ipmitool are external runtime dependencies.
- Validates credentials before writing ipmi_sim configuration.
- Cleans up simulator processes, listener tasks, temporary files, and advertised endpoints when handles are dropped.
- Updates local test dependencies and SSH-console integration coverage.

## Related issues

Part of #3378 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

