### PR TITLE
fix(flow): key inventory linking and drift on BMC MAC, not serial number

### DIFF
--- a/rest-api/flow/internal/db/model/component.go
+++ b/rest-api/flow/internal/db/model/component.go
@@ -93,6 +93,9 @@ func GetAllComponents(ctx context.Context, idb bun.IDB) (ret []Component, err er
 }
 
 // GetComponentsByType returns all components of a specific type with their associated BMCs
+// GetComponentsByType returns all components of the given type, with each
+// component's BMCs relation preloaded (callers rely on this for BMC-MAC-based
+// linking).
 func GetComponentsByType(ctx context.Context, idb bun.IDB, componentType devicetypes.ComponentType) (ret []Component, err error) {
 	err = idb.NewSelect().Model(&ret).Where("type = ?", devicetypes.ComponentTypeToString(componentType)).Relation("BMCs").Scan(ctx)
 	return ret, err
@@ -278,14 +281,6 @@ func (cd *Component) SerialInfo() deviceinfo.SerialInfo {
 // InvalidType returns true if the component type is unknown.
 func (cd *Component) InvalidType() bool {
 	return !devicetypes.IsValidComponentTypeString(cd.Type)
-}
-
-func (cd *Component) SetComponentIDBySerial(ctx context.Context, idb bun.IDB) error {
-	if cd.ComponentID == nil {
-		return errors.New("component ID not set")
-	}
-	_, err := idb.NewUpdate().Model(cd).Set("external_id = ?", *cd.ComponentID).Where("serial_number = ?", cd.SerialNumber).Exec(ctx)
-	return err
 }
 
 func (cd *Component) SetPowerStateByComponentID(ctx context.Context, idb bun.IDB) error {

--- a/rest-api/flow/internal/db/model/component.go
+++ b/rest-api/flow/internal/db/model/component.go
@@ -92,7 +92,6 @@ func GetAllComponents(ctx context.Context, idb bun.IDB) (ret []Component, err er
 	return ret, err
 }
 
-// GetComponentsByType returns all components of a specific type with their associated BMCs
 // GetComponentsByType returns all components of the given type, with each
 // component's BMCs relation preloaded (callers rely on this for BMC-MAC-based
 // linking).

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
@@ -6,7 +6,6 @@ package inventorysync
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/uptrace/bun"
@@ -17,10 +16,6 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
-
-// driftFieldSerialNumber is the canonical drift field name used by both the
-// machine and inventory paths when chassis serial mismatches show up.
-const driftFieldSerialNumber = "serial_number"
 
 // runActualSync runs every per-type actual-vs-expected drift detector,
 // concatenates their drifts, and logs a per-type "received from Core"
@@ -125,8 +120,9 @@ func persistComponentOperationStatuses(
 
 // applyInventoryToComponents extracts firmware_version and power_state from
 // GetComponentInventoryResponse and direct-writes them to the matching
-// components. Serial numbers are compared (not overwritten) and returned as
-// drift records. componentsByID maps the component_id echoed back in each
+// components. It does not emit drift: correlation and drift are keyed on BMC
+// MAC (handled by each type's linked-RPC sync), and serial number is no longer
+// compared. componentsByID maps the component_id echoed back in each
 // ComponentResult to the DB component. Shared by the switch and power-shelf
 // syncs; the machine sync uses pre-fetched MachineDetail directly instead of
 // going through GetComponentInventory.
@@ -135,10 +131,7 @@ func applyInventoryToComponents(
 	pool *cdb.Session,
 	resp *corev1.GetComponentInventoryResponse,
 	componentsByID map[string]*model.Component,
-) []model.ComponentDrift {
-	now := time.Now()
-	var drifts []model.ComponentDrift
-
+) {
 	for _, entry := range resp.GetEntries() {
 		result := entry.GetResult()
 		if result == nil {
@@ -172,25 +165,6 @@ func applyInventoryToComponents(
 			}
 		}
 
-		// Compare serial_number from first Chassis entry (drift, not overwrite)
-		if chassisList := report.GetChassis(); len(chassisList) > 0 {
-			if sn := chassisList[0].GetSerialNumber(); sn != "" && comp.SerialNumber != sn {
-				compID := comp.ID
-				extID := result.GetComponentId()
-				drifts = append(drifts, model.ComponentDrift{
-					ComponentID: &compID,
-					ExternalID:  &extID,
-					DriftType:   model.DriftTypeMismatch,
-					Diffs: []model.FieldDiff{{
-						FieldName:     driftFieldSerialNumber,
-						ExpectedValue: comp.SerialNumber,
-						ActualValue:   sn,
-					}},
-					CheckedAt: now,
-				})
-			}
-		}
-
 		// Extract power_state from first ComputerSystem entry
 		if systems := report.GetSystems(); len(systems) > 0 {
 			ps := computerSystemPowerStateToNICo(systems[0].GetPowerState())
@@ -206,8 +180,6 @@ func applyInventoryToComponents(
 			}
 		}
 	}
-
-	return drifts
 }
 
 func computerSystemPowerStateToNICo(

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
 func isMachineComponentType(t string) bool {
@@ -246,8 +247,15 @@ func syncMachineIDs(
 	components []model.Component,
 ) {
 	// Index discovered machines by normalized BMC MAC → Core MachineId.
+	// Restrict to HOST machines: a compute component owns both a host BMC and
+	// a DPU BMC, and Core exposes the DPU as its own MachineDetail whose BmcMac
+	// is that DPU BMC. Including DPUs here would let a compute component's DPU
+	// BMC resolve to the DPU's machine id instead of the host's.
 	machineIDByBmcMac := make(map[string]string)
 	for _, cur := range allDetails {
+		if cur.MachineType != corev1.MachineType_HOST.String() {
+			continue
+		}
 		if cur.BmcMac != "" && cur.MachineID != "" {
 			machineIDByBmcMac[utils.NormalizeMAC(cur.BmcMac)] = cur.MachineID
 		}
@@ -255,21 +263,36 @@ func syncMachineIDs(
 
 	var toUpdate []model.Component
 	for _, comp := range components {
-		if len(comp.BMCs) != 1 {
-			log.Error().Msgf("Compute component %s has %d BMCs, expected exactly 1; skipping", comp.SerialNumber, len(comp.BMCs))
+		if len(comp.BMCs) == 0 {
+			log.Error().
+				Str("component_id", comp.ID.String()).
+				Str("rack_id", comp.RackID.String()).
+				Msg("Compute component has no BMCs; skipping")
 			continue
 		}
-		bmcMacAddr, err := net.ParseMAC(comp.BMCs[0].MacAddress)
-		if err != nil {
-			log.Error().Msgf("Compute component %s has invalid BMC MAC address %s; skipping", comp.SerialNumber, comp.BMCs[0].MacAddress)
-			continue
-		}
-		if machineID, ok := machineIDByBmcMac[bmcMacAddr.String()]; ok {
+		// A compute component can legitimately expose several BMCs (e.g. host
+		// and DPU). Core advertises only one of them as MachineDetail.BmcMac,
+		// so try each BMC and link on the first that resolves to a machine.
+		for _, bmc := range comp.BMCs {
+			bmcMacAddr, err := net.ParseMAC(bmc.MacAddress)
+			if err != nil {
+				log.Error().
+					Str("component_id", comp.ID.String()).
+					Str("rack_id", comp.RackID.String()).
+					Str("bmc_mac_address", bmc.MacAddress).
+					Msg("Compute component has invalid BMC MAC address; skipping")
+				continue
+			}
+			machineID, ok := machineIDByBmcMac[bmcMacAddr.String()]
+			if !ok {
+				continue
+			}
 			if comp.ComponentID == nil || *comp.ComponentID != machineID {
 				componentID := machineID
 				comp.ComponentID = &componentID
 				toUpdate = append(toUpdate, comp)
 			}
+			break
 		}
 	}
 

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
@@ -6,12 +6,14 @@ package inventorysync
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/uptrace/bun"
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -27,20 +29,22 @@ func isMachineComponentType(t string) bool {
 // ---------------------------------------------------------------------------
 //
 // NICo API calls (3 round-trips):
-//   - GetMachines (FindMachineIds + FindMachinesByIds): serial matching,
-//     firmware_version direct-write, and drift comparison data
+//   - GetMachines (FindMachineIds + FindMachinesByIds): BMC-MAC linking,
+//     firmware_version and controller_state direct-write, plus
+//     missing_in_expected detection
 //   - GetPowerStates: power_state direct-write
 //   - GetMachinePositionInfo: position validation fields for drift comparison
 //
 // Flow:
-//  1. DB: get all machine components
-//  2. NICo GetMachines: fetch all machine details (reused for steps 3, 5, and drift)
-//  3. Match by serial → direct-write external_id
+//  1. DB: get all compute components (with BMCs)
+//  2. NICo GetMachines: fetch all machine details (linking, firmware, state, missing_in_expected)
+//  3. Link by BMC MAC (from step 2 data) → direct-write external_id
 //  4. NICo GetPowerStates: direct-write power_state
 //  5. Direct-write firmware_version (from step 2 data)
 //  6. NICo GetMachinePositionInfo: compare validation fields, return drifts
 //
-// Validation fields (compared for drift): slot_id, tray_index, host_id, serial_number
+// Correlation/identity key: BMC MAC address (serial number is not used).
+// Validation fields (compared for drift): slot_id, tray_index, host_id
 // Direct-write fields (written to DB, not compared): external_id, power_state, firmware_version
 func syncMachines(
 	ctx context.Context,
@@ -49,25 +53,21 @@ func syncMachines(
 ) (received int, drifts []model.ComponentDrift, rpcOK bool) {
 	log.Debug().Msg("Syncing machines...")
 
-	// Step 1: Get all machine components from DB
-	allComponents, err := model.GetAllComponents(ctx, pool.DB)
+	// Step 1: Get all compute components (with BMCs) from DB
+	components, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeCompute)
 	if err != nil {
-		log.Error().Msgf("Unable to retrieve components from db: %v", err)
+		log.Error().Msgf("Unable to retrieve compute components from db: %v", err)
 		return 0, nil, false
-	}
-
-	var components []model.Component
-	for _, c := range allComponents {
-		if isMachineComponentType(c.Type) {
-			components = append(components, c)
-		}
 	}
 
 	if len(components) == 0 {
 		return 0, nil, true
 	}
 
-	// Step 2: Fetch all machine details from NICo
+	// Step 2: Fetch all machine details from NICo. This is the single source
+	// for BMC-MAC linking, firmware_version, controller_state, and
+	// missing_in_expected detection — a failure here means we can't trust this
+	// cycle, so preserve prior state rather than writing a partial view.
 	allMachineDetails, err := nicoClient.GetMachines(ctx)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve machine details from NICo: %v", err)
@@ -80,11 +80,11 @@ func syncMachines(
 		detailByID[d.MachineID] = d
 	}
 
-	// Step 3: Direct-write external_id by serial matching
+	// Step 3: Direct-write external_id by BMC MAC matching
 	syncMachineIDs(ctx, pool, allMachineDetails, components)
 
 	// Re-read components to pick up any external_id updates
-	allComponents, err = model.GetAllComponents(ctx, pool.DB)
+	allComponents, err := model.GetAllComponents(ctx, pool.DB)
 	if err != nil {
 		log.Error().Msgf("Unable to re-read components from db after machine ID update: %v", err)
 		return received, nil, false
@@ -150,7 +150,7 @@ func syncMachines(
 		}
 
 		externalID := *comp.ComponentID
-		detail, foundDetail := detailByID[externalID]
+		_, foundDetail := detailByID[externalID]
 		position, foundPosition := positionByID[externalID]
 
 		if !foundDetail {
@@ -169,7 +169,7 @@ func syncMachines(
 		if foundPosition {
 			posPtr = &position
 		}
-		fieldDiffs := compareMachineFieldsForDrift(comp, detail, posPtr)
+		fieldDiffs := compareMachineFieldsForDrift(comp, posPtr)
 		if len(fieldDiffs) > 0 {
 			compID := comp.ID
 			drifts = append(drifts, model.ComponentDrift{
@@ -234,29 +234,41 @@ func buildDriftsForUnmatchedComponents(
 	return drifts
 }
 
-// syncMachineIDs matches components by serial number against pre-fetched NICo
-// machine details and direct-writes the external_id.
+// syncMachineIDs matches components by BMC MAC address against pre-fetched NICo
+// machine details and direct-writes the external_id. BMC MAC is the stable
+// identity Core populates on the discovered machine (Machine.bmc_info.mac,
+// surfaced as MachineDetail.BmcMac), so linking no longer depends on serial
+// number.
 func syncMachineIDs(
 	ctx context.Context,
 	pool *cdb.Session,
 	allDetails []nicoapi.MachineDetail,
 	components []model.Component,
 ) {
-	containersBySerial := make(map[string]model.Component)
-	for _, cur := range components {
-		containersBySerial[cur.SerialNumber] = cur
+	// Index discovered machines by normalized BMC MAC → Core MachineId.
+	machineIDByBmcMac := make(map[string]string)
+	for _, cur := range allDetails {
+		if cur.BmcMac != "" && cur.MachineID != "" {
+			machineIDByBmcMac[utils.NormalizeMAC(cur.BmcMac)] = cur.MachineID
+		}
 	}
 
 	var toUpdate []model.Component
-	for _, cur := range allDetails {
-		if cur.ChassisSerial == nil {
+	for _, comp := range components {
+		if len(comp.BMCs) != 1 {
+			log.Error().Msgf("Compute component %s has %d BMCs, expected exactly 1; skipping", comp.SerialNumber, len(comp.BMCs))
 			continue
 		}
-		if container, ok := containersBySerial[*cur.ChassisSerial]; ok {
-			if container.ComponentID == nil || *container.ComponentID != cur.MachineID {
-				componentID := cur.MachineID
-				container.ComponentID = &componentID
-				toUpdate = append(toUpdate, container)
+		bmcMacAddr, err := net.ParseMAC(comp.BMCs[0].MacAddress)
+		if err != nil {
+			log.Error().Msgf("Compute component %s has invalid BMC MAC address %s; skipping", comp.SerialNumber, comp.BMCs[0].MacAddress)
+			continue
+		}
+		if machineID, ok := machineIDByBmcMac[bmcMacAddr.String()]; ok {
+			if comp.ComponentID == nil || *comp.ComponentID != machineID {
+				componentID := machineID
+				comp.ComponentID = &componentID
+				toUpdate = append(toUpdate, comp)
 			}
 		}
 	}
@@ -264,13 +276,13 @@ func syncMachineIDs(
 	if len(toUpdate) > 0 {
 		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			for _, cur := range toUpdate {
-				if err := cur.SetComponentIDBySerial(ctx, tx); err != nil {
+				if err := cur.Patch(ctx, tx); err != nil {
 					return fmt.Errorf("Unable to update machine ID: %w", err)
 				}
 			}
 			return nil
 		}); err != nil {
-			log.Error().Msgf("Unable to update components with serial: %v", err)
+			log.Error().Msgf("Unable to update components with BMC MAC: %v", err)
 			return
 		}
 
@@ -367,10 +379,11 @@ func syncMachineStatuses(
 }
 
 // compareMachineFieldsForDrift compares validation fields between expected (DB) and actual (NICo).
-// Validation fields: slot_id, tray_index, host_id, serial_number.
+// Validation fields: slot_id, tray_index, host_id. Serial number is not compared:
+// correlation and drift are keyed on BMC MAC, and a hardware swap surfaces as a
+// BMC-MAC presence change (missing_in_actual / missing_in_expected).
 func compareMachineFieldsForDrift(
 	expected *model.Component,
-	actual nicoapi.MachineDetail,
 	position *nicoapi.MachinePosition,
 ) []model.FieldDiff {
 	var diffs []model.FieldDiff
@@ -419,15 +432,6 @@ func compareMachineFieldsForDrift(
 				ActualValue:   "<missing>",
 			})
 		}
-	}
-
-	// Compare serial_number (chassis_serial)
-	if actual.ChassisSerial != nil && expected.SerialNumber != *actual.ChassisSerial {
-		diffs = append(diffs, model.FieldDiff{
-			FieldName:     driftFieldSerialNumber,
-			ExpectedValue: expected.SerialNumber,
-			ActualValue:   *actual.ChassisSerial,
-		})
 	}
 
 	return diffs

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
@@ -24,21 +24,17 @@ func TestCompareMachineFieldsForDrift_NoMismatch(t *testing.T) {
 		TrayIndex:       1,
 		HostID:          5,
 	}
-	actual := nicoapi.MachineDetail{
-		ChassisSerial:   ptr("SN001"),
-		FirmwareVersion: "1.0.0",
-	}
 	position := nicoapi.MachinePosition{
 		PhysicalSlotNum:  ptr(int32(2)),
 		ComputeTrayIndex: ptr(int32(1)),
 		TopologyID:       ptr(int32(5)),
 	}
 
-	diffs := compareMachineFieldsForDrift(expected, actual, &position)
+	diffs := compareMachineFieldsForDrift(expected, &position)
 	assert.Empty(t, diffs)
 }
 
-func TestCompareMachineFieldsForDrift_AllFieldsMismatch(t *testing.T) {
+func TestCompareMachineFieldsForDrift_AllPositionalFieldsMismatch(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
 		FirmwareVersion: "1.0.0",
@@ -46,18 +42,14 @@ func TestCompareMachineFieldsForDrift_AllFieldsMismatch(t *testing.T) {
 		TrayIndex:       1,
 		HostID:          5,
 	}
-	actual := nicoapi.MachineDetail{
-		ChassisSerial:   ptr("SN999"),
-		FirmwareVersion: "2.0.0",
-	}
 	position := nicoapi.MachinePosition{
 		PhysicalSlotNum:  ptr(int32(10)),
 		ComputeTrayIndex: ptr(int32(3)),
 		TopologyID:       ptr(int32(7)),
 	}
 
-	diffs := compareMachineFieldsForDrift(expected, actual, &position)
-	assert.Len(t, diffs, 4)
+	diffs := compareMachineFieldsForDrift(expected, &position)
+	assert.Len(t, diffs, 3)
 
 	diffByField := make(map[string]model.FieldDiff)
 	for _, d := range diffs {
@@ -73,9 +65,8 @@ func TestCompareMachineFieldsForDrift_AllFieldsMismatch(t *testing.T) {
 	assert.Equal(t, "5", diffByField["host_id"].ExpectedValue)
 	assert.Equal(t, "7", diffByField["host_id"].ActualValue)
 
-	assert.Equal(t, "SN001", diffByField["serial_number"].ExpectedValue)
-	assert.Equal(t, "SN999", diffByField["serial_number"].ActualValue)
-
+	// Serial number is no longer a drift signal (correlation is by BMC MAC).
+	assert.NotContains(t, diffByField, "serial_number")
 	assert.NotContains(t, diffByField, "firmware_version")
 }
 
@@ -87,28 +78,22 @@ func TestCompareMachineFieldsForDrift_NilPositionFieldsSkipped(t *testing.T) {
 		TrayIndex:       1,
 		HostID:          5,
 	}
-	actual := nicoapi.MachineDetail{
-		ChassisSerial:   ptr("SN001"),
-		FirmwareVersion: "1.0.0",
-	}
 	// Position found but all fields nil — should not produce diffs
 	position := nicoapi.MachinePosition{}
 
-	diffs := compareMachineFieldsForDrift(expected, actual, &position)
+	diffs := compareMachineFieldsForDrift(expected, &position)
 	assert.Empty(t, diffs)
 }
 
-func TestCompareMachineFieldsForDrift_NilChassisSerialSkipped(t *testing.T) {
+func TestCompareMachineFieldsForDrift_SerialNeverCompared(t *testing.T) {
+	// Even when serial numbers differ, no drift is produced: serial is not a
+	// correlation/drift signal anymore.
 	expected := &model.Component{
 		SerialNumber: "SN001",
 	}
-	// Nil ChassisSerial from NICo — should not flag as mismatch
-	actual := nicoapi.MachineDetail{
-		ChassisSerial: nil,
-	}
 	position := nicoapi.MachinePosition{}
 
-	diffs := compareMachineFieldsForDrift(expected, actual, &position)
+	diffs := compareMachineFieldsForDrift(expected, &position)
 	assert.Empty(t, diffs)
 }
 
@@ -120,17 +105,13 @@ func TestCompareMachineFieldsForDrift_PartialMismatch(t *testing.T) {
 		TrayIndex:       1,
 		HostID:          5,
 	}
-	actual := nicoapi.MachineDetail{
-		ChassisSerial:   ptr("SN001"), // match
-		FirmwareVersion: "2.0.0",      // mismatch
-	}
 	position := nicoapi.MachinePosition{
 		PhysicalSlotNum:  ptr(int32(2)), // match
 		ComputeTrayIndex: ptr(int32(1)), // match
 		TopologyID:       ptr(int32(9)), // mismatch
 	}
 
-	diffs := compareMachineFieldsForDrift(expected, actual, &position)
+	diffs := compareMachineFieldsForDrift(expected, &position)
 	assert.Len(t, diffs, 1)
 
 	diffByField := make(map[string]model.FieldDiff)
@@ -145,19 +126,6 @@ func TestCompareMachineFieldsForDrift_PartialMismatch(t *testing.T) {
 	assert.NotContains(t, diffByField, "serial_number")
 }
 
-func TestCompareMachineFieldsForDrift_FirmwareVersionNotCompared(t *testing.T) {
-	expected := &model.Component{
-		FirmwareVersion: "", // empty in DB
-	}
-	actual := nicoapi.MachineDetail{
-		FirmwareVersion: "2.0.0", // NICo has value — should NOT produce drift (firmware_version is direct-write)
-	}
-	position := nicoapi.MachinePosition{}
-
-	diffs := compareMachineFieldsForDrift(expected, actual, &position)
-	assert.Empty(t, diffs)
-}
-
 func TestCompareMachineFieldsForDrift_MissingPositionReportsDrift(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
@@ -166,13 +134,9 @@ func TestCompareMachineFieldsForDrift_MissingPositionReportsDrift(t *testing.T) 
 		TrayIndex:       1,
 		HostID:          5,
 	}
-	actual := nicoapi.MachineDetail{
-		ChassisSerial:   ptr("SN001"),
-		FirmwareVersion: "1.0.0",
-	}
 
 	// nil position means no entry in positionByID — should flag non-zero expected fields
-	diffs := compareMachineFieldsForDrift(expected, actual, nil)
+	diffs := compareMachineFieldsForDrift(expected, nil)
 	assert.Len(t, diffs, 3)
 
 	diffByField := make(map[string]model.FieldDiff)
@@ -197,11 +161,8 @@ func TestCompareMachineFieldsForDrift_MissingPositionZeroExpectedNoDrift(t *test
 		TrayIndex:    0,
 		HostID:       0,
 	}
-	actual := nicoapi.MachineDetail{
-		ChassisSerial: ptr("SN001"),
-	}
 
 	// nil position with zero-value expected fields — no position drift
-	diffs := compareMachineFieldsForDrift(expected, actual, nil)
+	diffs := compareMachineFieldsForDrift(expected, nil)
 	assert.Empty(t, diffs)
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_powershelf.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_powershelf.go
@@ -108,12 +108,11 @@ func syncPowershelvesNICo(
 		componentsByShelfID[leps.PowerShelfID] = ps
 	}
 
-	// Fetch inventory from Core for all matched power shelves. A failure here
-	// leaves the serial-mismatch drifts incomplete, so flag the type
-	// not-OK: the caller then preserves the existing drift table this cycle
-	// rather than overwriting it with a partial view.
-	now := time.Now()
-	inventoryOK := true
+	// Fetch inventory from Core for all matched power shelves. Inventory only
+	// feeds the firmware_version / power_state direct-writes now — drift is
+	// keyed on PMC MAC via the linked RPC above — so a failure here is
+	// best-effort and just leaves those fields stale this cycle; it does not
+	// make the drift table partial.
 	if len(shelfIDs) > 0 {
 		invResp, err := nicoClient.GetComponentInventory(ctx, &corev1.GetComponentInventoryRequest{
 			Target: &corev1.GetComponentInventoryRequest_PowerShelfIds{
@@ -122,15 +121,15 @@ func syncPowershelvesNICo(
 		})
 		if err != nil {
 			log.Error().Msgf("Unable to retrieve powershelf inventory from NICo: %v", err)
-			inventoryOK = false
 		} else {
-			drifts = append(drifts, applyInventoryToComponents(ctx, pool, invResp, componentsByShelfID)...)
+			applyInventoryToComponents(ctx, pool, invResp, componentsByShelfID)
 		}
 	}
 
 	syncPowershelfStatuses(ctx, pool, nicoClient, componentsByShelfID)
 
 	// Build drifts for components that don't have a Core PowerShelfId yet
+	now := time.Now()
 	for _, ps := range expectedByPmcMac {
 		if ps.ComponentID == nil || *ps.ComponentID == "" {
 			compID := ps.ID
@@ -145,7 +144,7 @@ func syncPowershelvesNICo(
 	}
 
 	log.Info().Msgf("Powershelf NICo sync: %d drift(s) out of %d expected", len(drifts), len(expectedPowershelves))
-	return received, drifts, inventoryOK
+	return received, drifts, true
 }
 
 // syncPowershelfStatuses is the power-shelf equivalent of syncSwitchStatuses.

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_switch.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_switch.go
@@ -113,12 +113,11 @@ func syncNVSwitchesNICo(
 		componentsBySwitchID[les.SwitchID] = sw
 	}
 
-	// Fetch inventory from Core for all matched switches. A failure here
-	// leaves the serial-mismatch drifts incomplete, so flag the type
-	// not-OK: the caller then preserves the existing drift table this cycle
-	// rather than overwriting it with a partial view.
-	now := time.Now()
-	inventoryOK := true
+	// Fetch inventory from Core for all matched switches. Inventory only feeds
+	// the firmware_version / power_state direct-writes now — drift is keyed on
+	// BMC MAC via the linked RPC above — so a failure here is best-effort and
+	// just leaves those fields stale this cycle; it does not make the drift
+	// table partial.
 	if len(switchIDs) > 0 {
 		invResp, err := nicoClient.GetComponentInventory(ctx, &corev1.GetComponentInventoryRequest{
 			Target: &corev1.GetComponentInventoryRequest_SwitchIds{
@@ -127,9 +126,8 @@ func syncNVSwitchesNICo(
 		})
 		if err != nil {
 			log.Error().Msgf("Unable to retrieve switch inventory from NICo: %v", err)
-			inventoryOK = false
 		} else {
-			drifts = append(drifts, applyInventoryToComponents(ctx, pool, invResp, componentsBySwitchID)...)
+			applyInventoryToComponents(ctx, pool, invResp, componentsBySwitchID)
 		}
 	}
 
@@ -138,6 +136,7 @@ func syncNVSwitchesNICo(
 	syncSwitchNvosIPs(ctx, pool, nicoClient, componentsBySwitchID)
 
 	// Build drifts for components that don't have a Core SwitchId yet
+	now := time.Now()
 	for _, sw := range expectedByBmcMac {
 		if sw.ComponentID == nil || *sw.ComponentID == "" {
 			compID := sw.ID
@@ -152,7 +151,7 @@ func syncNVSwitchesNICo(
 	}
 
 	log.Info().Msgf("NVSwitch NICo sync: %d drift(s) out of %d expected", len(drifts), len(expectedSwitches))
-	return received, drifts, inventoryOK
+	return received, drifts, true
 }
 
 // syncSwitchStatuses fetches controller_state for the matched switches and

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
 // createTestBMC inserts a single BMC row for the given component so BMC-MAC
@@ -49,10 +51,11 @@ func TestInventory(t *testing.T) {
 	// chassis serial for correlation.
 	mac2 := "aa:bb:cc:dd:ee:02"
 	mac4 := "aa:bb:cc:dd:ee:04"
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id1"})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id2", BmcMac: mac2})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id3"})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id4"})
+	hostType := corev1.MachineType_HOST.String()
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id1", MachineType: hostType})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id2", BmcMac: mac2, MachineType: hostType})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id3", MachineType: hostType})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id4", MachineType: hostType})
 	grpcMock.AddPowerState("id2", nicoapi.PowerStateOn)
 
 	// serial2's BMC MAC (mac2) matches machine id2; serial4's BMC MAC (mac4)
@@ -130,8 +133,8 @@ func TestSyncFirmwareVersion(t *testing.T) {
 	// the machine's BmcMac).
 	mac1 := "aa:bb:cc:dd:ff:01"
 	mac2 := "aa:bb:cc:dd:ff:02"
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id1", BmcMac: mac1, FirmwareVersion: "2.0.0"})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id2", BmcMac: mac2, FirmwareVersion: "3.1.0"})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id1", BmcMac: mac1, FirmwareVersion: "2.0.0", MachineType: corev1.MachineType_HOST.String()})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id2", BmcMac: mac2, FirmwareVersion: "3.1.0", MachineType: corev1.MachineType_HOST.String()})
 	grpcMock.AddPowerState("fw-id1", nicoapi.PowerStateOn)
 
 	rack := model.Rack{
@@ -166,4 +169,60 @@ func TestSyncFirmwareVersion(t *testing.T) {
 	err = pool.DB.NewSelect().Model(&updated2).Where("id = ?", c2.ID).Scan(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, "3.1.0", updated2.FirmwareVersion)
+}
+
+// TestSyncMachineIDs_DpuBmcNotLinked verifies that a compute component owning
+// both a host BMC and a DPU BMC links to the HOST machine id, never the DPU's.
+// Core exposes the DPU as its own MachineDetail whose BmcMac is the DPU BMC, so
+// without the host-only filter the component could resolve to the DPU machine.
+func TestSyncMachineIDs_DpuBmcNotLinked(t *testing.T) {
+	ctx := context.Background()
+
+	if os.Getenv("DB_PORT") == "" {
+		log.Warn().Msgf("Not running unit test due to no DB environment specified")
+		t.SkipNow()
+	}
+
+	dbConf, err := cdb.ConfigFromEnv()
+	assert.Nil(t, err)
+	pool, err := utils.UnitTestDB(ctx, t, dbConf)
+	assert.Nil(t, err)
+
+	hostMac := "aa:bb:cc:dd:0a:01"
+	dpuMac := "aa:bb:cc:dd:0a:02"
+
+	// The DPU machine is listed first so that, without the host-only filter,
+	// map-build order alone would not save us; the guard is the type filter.
+	allDetails := []nicoapi.MachineDetail{
+		{MachineID: "dpu-machine", BmcMac: dpuMac, MachineType: corev1.MachineType_DPU.String()},
+		{MachineID: "host-machine", BmcMac: hostMac, MachineType: corev1.MachineType_HOST.String()},
+	}
+
+	rack := model.Rack{
+		Name:         "test-rack-dpu",
+		Manufacturer: "TestMfg",
+		SerialNumber: "rack-serial-dpu",
+	}
+	err = rack.Create(ctx, pool.DB)
+	assert.Nil(t, err)
+
+	comp := model.Component{SerialNumber: "dpu-host-serial", Manufacturer: "TestMfg", RackID: rack.ID}
+	err = comp.Create(ctx, pool.DB)
+	assert.Nil(t, err)
+	// Two BMCs on the same compute component: host and DPU.
+	createTestBMC(ctx, t, pool, comp.ID, hostMac)
+	dpuBMC := model.BMC{MacAddress: dpuMac, ComponentID: comp.ID, Type: "DPU"}
+	_, err = pool.DB.NewInsert().Model(&dpuBMC).Exec(ctx)
+	assert.Nil(t, err)
+
+	components, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeCompute)
+	assert.Nil(t, err)
+
+	syncMachineIDs(ctx, pool, allDetails, components)
+
+	var updated model.Component
+	err = pool.DB.NewSelect().Model(&updated).Where("id = ?", comp.ID).Scan(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, updated.ComponentID)
+	assert.Equal(t, "host-machine", *updated.ComponentID)
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 
@@ -17,6 +18,15 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 )
+
+// createTestBMC inserts a single BMC row for the given component so BMC-MAC
+// linking has a MAC to correlate on.
+func createTestBMC(ctx context.Context, t *testing.T, pool *cdb.Session, componentID uuid.UUID, mac string) {
+	t.Helper()
+	bmc := model.BMC{MacAddress: mac, ComponentID: componentID, Type: "Host"}
+	_, err := pool.DB.NewInsert().Model(&bmc).Exec(ctx)
+	assert.Nil(t, err)
+}
 
 // TestInventory is the main test for the inventory package
 func TestInventory(t *testing.T) {
@@ -34,15 +44,19 @@ func TestInventory(t *testing.T) {
 
 	grpcMock := nicoapi.NewMockClient()
 
-	// Create a basic faked GRPC environment
-	serial1 := "serial1"
-	serial2 := "serial2"
-	serial3 := "serial3"
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id1", ChassisSerial: &serial1})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id2", ChassisSerial: &serial2})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id3", ChassisSerial: &serial3})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id4", ChassisSerial: nil})
+	// Create a basic faked GRPC environment. Linking is keyed on BMC MAC now
+	// (matched against the machine's BmcMac), so machines no longer carry a
+	// chassis serial for correlation.
+	mac2 := "aa:bb:cc:dd:ee:02"
+	mac4 := "aa:bb:cc:dd:ee:04"
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id1"})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id2", BmcMac: mac2})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id3"})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "id4"})
 	grpcMock.AddPowerState("id2", nicoapi.PowerStateOn)
+
+	// serial2's BMC MAC (mac2) matches machine id2; serial4's BMC MAC (mac4)
+	// matches no machine, so it stays unmatched (missing_in_actual).
 
 	// Create a rack (required for components due to NOT NULL constraint)
 	rack := model.Rack{
@@ -57,9 +71,11 @@ func TestInventory(t *testing.T) {
 	c := model.Component{SerialNumber: "serial2", Manufacturer: "TestMfg", RackID: rack.ID}
 	err = c.Create(ctx, pool.DB)
 	assert.Nil(t, err)
+	createTestBMC(ctx, t, pool, c.ID, mac2)
 	c = model.Component{SerialNumber: "serial4", Manufacturer: "TestMfg2", RackID: rack.ID}
 	err = c.Create(ctx, pool.DB)
 	assert.Nil(t, err)
+	createTestBMC(ctx, t, pool, c.ID, mac4)
 
 	// expectedSyncEnabled=false: this test exercises actual-sync only. The
 	// mock carries no expected machines, so running the mirror would treat
@@ -110,10 +126,12 @@ func TestSyncFirmwareVersion(t *testing.T) {
 
 	grpcMock := nicoapi.NewMockClient()
 
-	serial1 := "fw-serial-1"
-	serial2 := "fw-serial-2"
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id1", ChassisSerial: &serial1, FirmwareVersion: "2.0.0"})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id2", ChassisSerial: &serial2, FirmwareVersion: "3.1.0"})
+	// Link both components to their Core machines by BMC MAC (matched against
+	// the machine's BmcMac).
+	mac1 := "aa:bb:cc:dd:ff:01"
+	mac2 := "aa:bb:cc:dd:ff:02"
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id1", BmcMac: mac1, FirmwareVersion: "2.0.0"})
+	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id2", BmcMac: mac2, FirmwareVersion: "3.1.0"})
 	grpcMock.AddPowerState("fw-id1", nicoapi.PowerStateOn)
 
 	rack := model.Rack{
@@ -127,10 +145,12 @@ func TestSyncFirmwareVersion(t *testing.T) {
 	c1 := model.Component{SerialNumber: "fw-serial-1", Manufacturer: "TestMfg", RackID: rack.ID, FirmwareVersion: "1.0.0"}
 	err = c1.Create(ctx, pool.DB)
 	assert.Nil(t, err)
+	createTestBMC(ctx, t, pool, c1.ID, mac1)
 
 	c2 := model.Component{SerialNumber: "fw-serial-2", Manufacturer: "TestMfg", RackID: rack.ID, FirmwareVersion: "1.0.0"}
 	err = c2.Create(ctx, pool.DB)
 	assert.Nil(t, err)
+	createTestBMC(ctx, t, pool, c2.ID, mac2)
 
 	// expectedSyncEnabled=false: actual-sync only. See TestInventory for why
 	// the mirror must stay off here (empty expected-mock would soft-delete


### PR DESCRIPTION
Flow overloaded ExpectedMachine.chassis_serial_number as both inventory serial and the linking/drift key. On Lenovo GB300 the DMI and Redfish serials are disjoint, breaking compute linking and raising false drift. 

We have found the BMC MAC to be a stable identifier for machines. Link compute components to Core machines by BMC MAC (from GetMachines' BmcMac) instead of serial, and drop serial as a drift signal across compute, NVSwitch, and PowerShelf. 


## Related issues

https://github.com/NVIDIA/infra-controller/issues/3327

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

