### PR TITLE
fix(site-explorer): don't cache incomplete service root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,6 +2748,9 @@ version = "0.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "axum",
+ "axum-server",
+ "bmc-mock",
  "bmc-vendor",
  "carbide-api-model",
  "carbide-instrument",
@@ -2759,6 +2762,7 @@ dependencies = [
  "mac_address",
  "nv-redfish",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "state-controller",

--- a/crates/redfish/Cargo.toml
+++ b/crates/redfish/Cargo.toml
@@ -45,4 +45,9 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+axum = { workspace = true }
+axum-server = { workspace = true, features = ["tls-rustls"] }
+bmc-mock = { path = "../bmc-mock" }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
+nv-redfish = { workspace = true, features = ["chassis"] }
+rustls = { workspace = true }

--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -64,6 +64,18 @@ impl NvRedfishClientPool {
         bmc_address: SocketAddr,
         credentials: Credentials,
     ) -> Result<Arc<ServiceRoot>, Error> {
+        self.service_root_with_cache_predicate(bmc_address, credentials, |_| true)
+            .await
+    }
+
+    /// Same as [`Self::service_root`], but a freshly fetched root is cached
+    /// only when `should_cache` returns true for it.
+    pub async fn service_root_with_cache_predicate(
+        &self,
+        bmc_address: SocketAddr,
+        credentials: Credentials,
+        should_cache: impl FnOnce(&ServiceRoot) -> bool,
+    ) -> Result<Arc<ServiceRoot>, Error> {
         let Credentials::UsernamePassword { username, password } = credentials;
         let bmc_credentials = BmcCredentials::new(username, password);
 
@@ -95,7 +107,9 @@ impl NvRedfishClientPool {
                 service_root
             };
             let service_root = Arc::new(service_root);
-            self.update_cache(bmc_address, bmc_credentials, service_root.clone());
+            if should_cache(&service_root) {
+                self.update_cache(bmc_address, bmc_credentials, service_root.clone());
+            }
             Ok(service_root)
         }
     }

--- a/crates/redfish/tests/service_root_cache_poisoning.rs
+++ b/crates/redfish/tests/service_root_cache_poisoning.rs
@@ -1,0 +1,179 @@
+// Covers `NvRedfishClientPool::service_root_with_cache_predicate`: a fetched
+// ServiceRoot is cached only when the caller's predicate accepts it.
+//
+// Some BMCs transiently serve a service root with
+// navigation properties missing while resetting or booting. The pool cache has
+// no TTL, so caching such a root would poison every later exploration until
+// process restart. The mock BMC here serves a `Chassis`-less root first
+// (rejected by the predicate, not cached), then a full root (re-fetched,
+// accepted, and served from cache afterwards).
+
+use std::net::{SocketAddr, TcpListener};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arc_swap::ArcSwap;
+use axum::Router;
+use axum::extract::State;
+use axum::http::header;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum_server::tls_rustls::RustlsConfig;
+use carbide_redfish::nv_redfish::NvRedfishClientPool;
+use carbide_secrets::credentials::Credentials;
+
+// A full, healthy AMI service root including the `Chassis` navigation property.
+const FULL_ROOT: &str = r##"{
+  "@odata.id": "/redfish/v1/",
+  "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "RedfishVersion": "1.15.1",
+  "Vendor": "AMI",
+  "Product": "AMI Redfish Server",
+  "UUID": "6acb216c-bfde-11d3-02c0-146dd4e0ff10",
+  "Chassis": { "@odata.id": "/redfish/v1/Chassis" },
+  "Systems": { "@odata.id": "/redfish/v1/Systems" },
+  "Managers": { "@odata.id": "/redfish/v1/Managers" },
+  "UpdateService": { "@odata.id": "/redfish/v1/UpdateService" },
+  "SessionService": { "@odata.id": "/redfish/v1/SessionService" },
+  "Links": { "Sessions": { "@odata.id": "/redfish/v1/SessionService/Sessions" } },
+  "ProtocolFeaturesSupported": {
+    "ExpandQuery": { "ExpandAll": true, "Levels": true, "Links": true, "MaxLevels": 5, "NoLinks": true },
+    "FilterQuery": true,
+    "SelectQuery": true
+  }
+}"##;
+
+// The same root as served transiently during a BMC reset/boot: every nav
+// property is the same EXCEPT `Chassis`, which the BMC omits.
+const STRIPPED_ROOT: &str = r##"{
+  "@odata.id": "/redfish/v1/",
+  "@odata.type": "#ServiceRoot.v1_13_0.ServiceRoot",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "RedfishVersion": "1.15.1",
+  "Vendor": "AMI",
+  "Product": "AMI Redfish Server",
+  "UUID": "6acb216c-bfde-11d3-02c0-146dd4e0ff10",
+  "Systems": { "@odata.id": "/redfish/v1/Systems" },
+  "Managers": { "@odata.id": "/redfish/v1/Managers" },
+  "UpdateService": { "@odata.id": "/redfish/v1/UpdateService" },
+  "SessionService": { "@odata.id": "/redfish/v1/SessionService" },
+  "Links": { "Sessions": { "@odata.id": "/redfish/v1/SessionService/Sessions" } },
+  "ProtocolFeaturesSupported": {
+    "ExpandQuery": { "ExpandAll": true, "Levels": true, "Links": true, "MaxLevels": 5, "NoLinks": true },
+    "FilterQuery": true,
+    "SelectQuery": true
+  }
+}"##;
+
+const CHASSIS_COLLECTION: &str = r##"{
+  "@odata.id": "/redfish/v1/Chassis",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "Name": "Chassis Collection",
+  "Members@odata.count": 0,
+  "Members": []
+}"##;
+
+#[derive(Clone)]
+struct AppState {
+    root_hits: Arc<AtomicUsize>,
+}
+
+async fn service_root(State(state): State<AppState>) -> impl IntoResponse {
+    // First request -> stripped (BMC mid-reset); subsequent -> full (recovered).
+    let n = state.root_hits.fetch_add(1, Ordering::SeqCst);
+    let body = if n == 0 { STRIPPED_ROOT } else { FULL_ROOT };
+    ([(header::CONTENT_TYPE, "application/json")], body)
+}
+
+async fn chassis_collection() -> impl IntoResponse {
+    (
+        [(header::CONTENT_TYPE, "application/json")],
+        CHASSIS_COLLECTION,
+    )
+}
+
+#[tokio::test]
+async fn poisoned_service_root_cache_recovers_after_bmc_heals() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let root_hits = Arc::new(AtomicUsize::new(0));
+    let app = Router::new()
+        .route("/redfish/v1", get(service_root))
+        .route("/redfish/v1/", get(service_root))
+        .route("/redfish/v1/Chassis", get(chassis_collection))
+        .with_state(AppState {
+            root_hits: root_hits.clone(),
+        });
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+
+    let tls = bmc_mock::tls::server_config(None::<&str>).unwrap();
+    let config = RustlsConfig::from_config(Arc::new(tls));
+    tokio::spawn(async move {
+        axum_server::from_tcp_rustls(listener, config)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    let pool = NvRedfishClientPool::new(Arc::new(ArcSwap::new(Arc::new(None))));
+    let creds = || Credentials::UsernamePassword {
+        username: "root".to_string(),
+        password: "placeholder".to_string(),
+    };
+
+    // Cache predicate as used by site-explorer's exploration path: only roots
+    // exposing `Chassis` and `Managers` are worth caching.
+    let root_has_chassis = |root: &carbide_redfish::nv_redfish::ServiceRoot| {
+        root.root.chassis.is_some() && root.root.managers.is_some()
+    };
+
+    // 1st exploration: the BMC transiently serves a Chassis-less root, which
+    // must NOT be cached.
+    let first = pool
+        .service_root_with_cache_predicate(addr, creds(), root_has_chassis)
+        .await
+        .unwrap();
+    assert!(
+        first.chassis_links().await.unwrap().is_none(),
+        "precondition: the first root must be the stripped (Chassis-less) one",
+    );
+    assert_eq!(root_hits.load(Ordering::SeqCst), 1);
+
+    // The BMC has recovered and now serves a complete root. Since the stripped
+    // root was rejected by the cache predicate, the pool must re-fetch and
+    // observe the recovered root.
+    let second = pool
+        .service_root_with_cache_predicate(addr, creds(), root_has_chassis)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        2,
+        "BUG: pool never re-fetched the service root; it served the cached \
+         Chassis-less root from the BMC's reset window",
+    );
+    assert!(
+        second.chassis_links().await.unwrap().is_some(),
+        "BUG: pool returned a Chassis-less ServiceRoot even though the BMC has \
+         recovered -- this is what surfaces as 'BMC has not provided chassis collection'",
+    );
+
+    // The recovered root passed the predicate, so it IS cached now: a third
+    // call must be served from cache with no extra fetch.
+    let third = pool
+        .service_root_with_cache_predicate(addr, creds(), root_has_chassis)
+        .await
+        .unwrap();
+    assert_eq!(root_hits.load(Ordering::SeqCst), 2);
+    assert!(third.chassis_links().await.unwrap().is_some());
+}

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -337,7 +337,18 @@ impl RedfishClient {
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let service_root = self
             .nv_redfish_client_pool
-            .service_root(bmc_ip_address, credentials)
+            .service_root_with_cache_predicate(bmc_ip_address, credentials, |root| {
+                let complete = root.root.chassis.is_some() && root.root.managers.is_some();
+                if !complete {
+                    tracing::warn!(
+                        %bmc_ip_address,
+                        chassis = root.root.chassis.is_some(),
+                        managers = root.root.managers.is_some(),
+                        "BMC served a service root without required navigation not caching it"
+                    );
+                }
+                complete
+            })
             .await
             .map_err(|err| EndpointExplorationError::Other {
                 details: format!("Cannot Redfish service root: {err}"),


### PR DESCRIPTION
## Bug
The pool caches the parsed ServiceRoot in memory with no TTL and no eviction.
Some BMCs return a stripped root during reset/boot, and site-explorer caches it permanently.

Every later exploration reuses it, so `root.chassis()` keeps returning `Ok(None)` and exploration fails with "BMC has not provided chassis collection"

## Workaround
Clearing the last exploration error doesn't help since it doesn't clean the internal cache.
The only workaround to get rid of this error is restarting nico-api.

<img width="3390" height="363" alt="image" src="https://github.com/user-attachments/assets/199f9b8d-6888-4218-8051-af38f11d2471" />

## Fix
- Add a `service_root_with_cache_predicate` method that lets the caller decide whether a freshly fetched root is worth caching
- Site-explorer caches a ServiceRoot only if `Chassis` and `Managers` are present

This is not necessarily the best way to fix it, but of the options considered (TTL on the cache entries, caching only the HTTP client and re-fetching the root on every call, explicit cache invalidation from the clear-error API), it's the least invasive: (expected) no behavior change for any other pool consumer.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!-- If checked, describe the breaking changes and migration steps -->
<!-- Breaking changes are not generally permitted, please discuss on a GitHub discussion or with the development team if you believe you need to break a backward compatibility guarantee -->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

