### PR TITLE
fix: revert to version bump on clear error

### DIFF
--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -401,28 +401,17 @@ WHERE address=$4 AND version=$5";
     Ok(query_result.rows_affected() > 0)
 }
 
-/// Clears `LastExplorationError` on the endpoint's report and sets
-/// `waiting_for_explorer_refresh = true` so preingestion waits for a fresh probe.
-///
-/// Intentionally does NOT bump `version`: clearing an operator-visible error
-/// does not freshen the underlying Redfish data, so the report's age (used by
-/// the UI "Last updated" bubble and by the periodic loop's oldest-first
-/// rotation) must keep tracking the last real probe. Leaves `exploration_requested`
-/// untouched so a previously queued priority probe is not cancelled.
+/// clear_last_known_error clears the last known error in explored_endpoints for the BMC identified by IP
 pub async fn clear_last_known_error(
     address: IpAddr,
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
-    let query = "
-UPDATE explored_endpoints
-SET exploration_report = jsonb_set(exploration_report, '{LastExplorationError}', 'null'::jsonb),
-    waiting_for_explorer_refresh = true
-WHERE address = $1";
-    sqlx::query(query)
-        .bind(address)
-        .execute(txn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))?;
+    for row in find_all_by_ip(address, txn).await? {
+        let mut report = row.report;
+        report.last_exploration_error = None;
+        try_update(address, row.report_version, &report, true, txn).await?;
+    }
+
     Ok(())
 }
 

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -401,15 +401,32 @@ WHERE address=$4 AND version=$5";
     Ok(query_result.rows_affected() > 0)
 }
 
-/// clear_last_known_error clears the last known error in explored_endpoints for the BMC identified by IP
+/// Clears the last known error in `explored_endpoints` for the BMC identified by IP.
+///
+/// Lock the endpoint while reading its report so a concurrent exploration
+/// update either commits first and is preserved, or loses its optimistic update
+/// after this clear commits.
 pub async fn clear_last_known_error(
     address: IpAddr,
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
-    for row in find_all_by_ip(address, txn).await? {
-        let mut report = row.report;
-        report.last_exploration_error = None;
-        try_update(address, row.report_version, &report, true, txn).await?;
+    let query = "SELECT * FROM explored_endpoints WHERE address = $1 FOR UPDATE";
+    let Some(row) = sqlx::query_as::<_, DbExploredEndpoint>(query)
+        .bind(address)
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?
+    else {
+        return Ok(());
+    };
+
+    let mut report = row.report;
+    report.last_exploration_error = None;
+    if !try_update(address, row.report_version, &report, true, txn).await? {
+        return Err(DatabaseError::ConcurrentModificationError(
+            "ExploredEndpoint",
+            row.report_version.version_string(),
+        ));
     }
 
     Ok(())

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bmc_explorer::test_support::generate_managed_host_reports;
 use bmc_mock::HostHardwareType;
@@ -2092,8 +2093,10 @@ async fn test_site_explorer_clear_last_known_error(
     let env = Env::new(pool).await;
     let ip_address = "192.168.1.1";
     let bmc_ip: IpAddr = IpAddr::from_str(ip_address)?;
-    let last_error = Some(EndpointExplorationError::Unreachable {
-        details: Some("test_unreachable_detail".to_string()),
+    let last_error = Some(EndpointExplorationError::Unauthorized {
+        details: "Not authorized".to_string(),
+        response_body: None,
+        response_code: Some(401),
     });
 
     let mut dpu_report1: EndpointExplorationReport = DpuConfig {
@@ -2111,8 +2114,9 @@ async fn test_site_explorer_clear_last_known_error(
     let nodes = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
     txn.commit().await?;
     assert_eq!(nodes.len(), 1);
-    let node = nodes.first();
-    assert_eq!(node.unwrap().report.last_exploration_error, last_error);
+    let node = nodes.first().unwrap();
+    assert_eq!(node.report.last_exploration_error, last_error);
+    let old_version = node.report_version;
 
     env.api()
         .clear_site_exploration_error(Request::new(rpc::forge::ClearSiteExplorationErrorRequest {
@@ -2126,8 +2130,33 @@ async fn test_site_explorer_clear_last_known_error(
     let nodes = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
     txn.commit().await?;
     assert_eq!(nodes.len(), 1);
-    let node = nodes.first();
-    assert_eq!(node.unwrap().report.last_exploration_error, None);
+    let node = nodes.first().unwrap();
+    assert_eq!(node.report.last_exploration_error, None);
+    assert_eq!(
+        node.report_version.version_nr(),
+        old_version.version_nr() + 1
+    );
+
+    let mut txn = db::Transaction::begin(&env.pool).await?;
+    let stale_write_applied = db::explored_endpoints::try_update_last_exploration_error(
+        bmc_ip,
+        old_version,
+        &EndpointExplorationError::AvoidLockout,
+        Duration::from_secs(1),
+        &mut txn,
+    )
+    .await?;
+    txn.commit().await?;
+    assert!(
+        !stale_write_applied,
+        "a stale exploration result must not overwrite a cleared error"
+    );
+
+    let mut txn = env.pool.begin().await?;
+    let nodes = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes.first().unwrap().report.last_exploration_error, None);
 
     Ok(())
 }

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -2086,6 +2086,9 @@ async fn test_site_explorer_reexplore(pool: PgPool) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
+// This regression intentionally keeps the exploration transaction open while
+// awaiting the competing clear, so it can verify both row-lock orderings.
+#[allow(txn_held_across_await)]
 #[sqlx_test]
 async fn test_site_explorer_clear_last_known_error(
     pool: PgPool,
@@ -2157,6 +2160,47 @@ async fn test_site_explorer_clear_last_known_error(
     txn.commit().await?;
     assert_eq!(nodes.len(), 1);
     assert_eq!(nodes.first().unwrap().report.last_exploration_error, None);
+
+    // Exercise the inverse race: an exploration write acquires the row lock
+    // first. The clear must wait for that write to commit, then clear the error
+    // from the freshly persisted report.
+    let version_before_race = nodes.first().unwrap().report_version;
+    let mut exploration_txn = db::Transaction::begin(&env.pool).await?;
+    let exploration_write_applied = db::explored_endpoints::try_update_last_exploration_error(
+        bmc_ip,
+        version_before_race,
+        &EndpointExplorationError::AvoidLockout,
+        Duration::from_secs(2),
+        &mut exploration_txn,
+    )
+    .await?;
+    assert!(exploration_write_applied);
+
+    let mut clear_txn = db::Transaction::begin(&env.pool).await?;
+    {
+        let clear = db::explored_endpoints::clear_last_known_error(bmc_ip, &mut clear_txn);
+        tokio::pin!(clear);
+        tokio::select! {
+            result = &mut clear => {
+                panic!("clear unexpectedly completed while the exploration write held the row lock: {result:?}");
+            }
+            () = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+
+        exploration_txn.commit().await?;
+        clear.await?;
+    }
+    clear_txn.commit().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let nodes = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(
+        nodes.first().unwrap().report.last_exploration_error,
+        None,
+        "the clear must retry after the exploration write wins the race"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Fix races between clearing a site exploration error and an in-flight exploration update. Clearing now locks the endpoint row and increments its version, ensuring the error remains cleared regardless of which operation commits first. Adds regression coverage for both race orderings.

This PR unblocks VR testing. A follow-up PR will separate error clearing from exploration-report freshness. It will clear only `LastExplorationError`, set `waiting_for_explorer_refresh`, preserve `exploration_requested`, and avoid incrementing the endpoint version so the UI’s “Last updated” value and oldest-first exploration scheduling continue to reflect the last real probe.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3553

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

