### PR TITLE
fix: align deb package version stamping with carbide-api's VERSION ov…

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -232,11 +232,15 @@ SCCACHE_HOST="${SCCACHE_DIR:-$HOME/.sccache}"
 mkdir -p "$SCCACHE_HOST"
 HOST_UID=$(id -u)
 HOST_GID=$(id -g)
-PKG_VERSION=$(git -C "${REPO_ROOT}" describe --tags --first-parent --always --long 2>/dev/null | sed 's/^v//')
-case "${PKG_VERSION}" in
-  [0-9]*) ;;
-  *) PKG_VERSION="0.0.0-${PKG_VERSION}" ;;
-esac
+if [ -n "$VERSION" ]; then
+  PKG_VERSION=$(echo "$VERSION" | sed 's/^v//')
+else
+  PKG_VERSION=$(git -C "${REPO_ROOT}" describe --tags --first-parent --always --long 2>/dev/null | sed 's/^v//')
+  case "${PKG_VERSION}" in
+    [0-9]*) ;;
+    *) PKG_VERSION="0.0.0-${PKG_VERSION}" ;;
+  esac
+fi
 docker run --rm \
   --privileged \
   -v "${REPO_ROOT}":/code \
@@ -247,6 +251,7 @@ docker run --rm \
   -e SCCACHE_DIR=/sccache \
   -e SA_ENABLEMENT=1 \
   -e PKG_VERSION="${PKG_VERSION}" \
+  -e VERSION="${VERSION}" \
   -e HOST_UID="${HOST_UID}" \
   -e HOST_GID="${HOST_GID}" \
   carbide-pxe-builder \

--- a/bluefield/Makefile.toml
+++ b/bluefield/Makefile.toml
@@ -21,7 +21,7 @@ REPO_ROOT = { script = [
 ] }
 # e.g. 2024.05.24-rc1-0-0-g786e94757
 DPU_AGENT_PKG_VERSION = { script = [
-  "v=$(git describe --tags --first-parent --always --long | sed 's/^v//'); case \"$v\" in [0-9]*) echo \"$v\" ;; *) echo \"0.0.0-$v\" ;; esac",
+  "if [ -n \"$VERSION\" ]; then echo \"$VERSION\" | sed 's/^v//'; else v=$(git describe --tags --first-parent --always --long | sed 's/^v//'); case \"$v\" in [0-9]*) echo \"$v\" ;; *) echo \"0.0.0-$v\" ;; esac; fi",
 ] }
 
 [tasks.cleanup-local-pkg-files]

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -19,8 +19,8 @@ REPO_ROOT = { script = [
   "dirname $(cargo locate-project --message-format plain --workspace)",
 ] }
 PKG_VERSION = { script = [
-  "v=$(git describe --tags --first-parent --always --long | sed 's/^v//'); case \"$v\" in [0-9]*) echo \"$v\" ;; *) echo \"0.0.0-$v\" ;; esac",
-] }
+  "if [ -n \"$VERSION\" ]; then echo \"$VERSION\" | sed 's/^v//'; else v=$(git describe --tags --first-parent --always --long | sed 's/^v//'); case \"$v\" in [0-9]*) echo \"$v\" ;; *) echo \"0.0.0-$v\" ;; esac; fi",
+], condition = { env_not_set = ["PKG_VERSION"] } }
 FORGE_CA_PATH = { value = "${REPO_ROOT}/dev/forge_prodroot.pem" }
 
 # BlueField Bundle (BFB) Version


### PR DESCRIPTION
…erride (#3508)

Addresses #3490.

## Problem

On a release built from an exact git tag, `carbide-api`'s `build_version` honors a `VERSION` env override
(`crates/version/src/lib.rs`), falling back to `git describe --long` only if unset. The `forge-dpu` and `forge-scout` deb package versions (`bluefield/Makefile.toml`, `pxe/Makefile.toml`, root `Makefile.toml`) never checked `VERSION` at
all - they always used `git describe --long`, which appends a `-<commits>-g<hash>` suffix even on an exact tag.

Since the DPU agent's upgrade path pins the `apt` install to exactly `carbide-api`'s `build_version`, this mismatch means `apt-get install forge-dpu=2.0.0-rc.4` gets attempted against a repo that only contains `2.0.0-rc.4-0-gcb7fa2b49`. `apt` does exact version matching, so the install fails and the DPU agent never converges to the release version on any clean-tag release - it's stuck retry-looping forever under the `UpDown` policy.

## Fix

All three version-stamping scripts now check `VERSION` first, falling back to the existing `git describe`-based logic only when unset - mirroring `crates/version/src/lib.rs`'s own pattern exactly. CI already exports `VERSION` for these build steps
(`.github/workflows/build-boot-artifacts.yml`), so no CI wiring changes are needed - this is purely a Makefile logic fix.

## Testing

Verified directly through `cargo-make` itself (not just in isolated shell), for all three files

- With `VERSION=v2.0.0-rc.4` set: all three now resolve to `2.0.0-rc.4`, exactly matching `carbide-api`'s `build_version`.
- Without `VERSION` set: all three fall back to the original `git describe`-based value, completely unchanged - no impact on
  normal dev/PR builds.

This directly resolves the version mismatch that breaks DPU agent self-upgrade described in the issue.

---------

<!--
Description: Describe what this PR does, focusing on *why* you are making this
change. What problem is it solving? What motivated making this change? Assume
the audience has no other context: Don't assume people are already aware of
your feature roadmap. If a linked GitHub issue contains the necessary context,
repeat enough of it here to help people understand it at a glance, then link to
it below. PR descriptions are not just for code review, they're also for
helping people understand why a given change happened after it merges. Please
keep both audiences in mind for your PR description.

NOTE: Delete all commented sections like this one before submitting your PR.
-->

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!--
If checked, describe the breaking changes and migration steps. Breaking changes
are not generally permitted, please discuss on a GitHub discussion or with the
development team if you believe you need to break a backward compatibility
guarantee
-->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

