### PR TITLE
Add BIOS reset command to admin cli

### DIFF
--- a/crates/admin-cli/src/redfish/args.rs
+++ b/crates/admin-cli/src/redfish/args.rs
@@ -231,7 +231,9 @@ Clear the UEFI password (supply the current one):
     ClearNvram,
     /// Set BIOS options
     SetBios(SetBios),
-    /// Reset BIOS settings to factory defaults
+    /// Reset BIOS settings to factory defaults. Returns once the BMC accepts
+    /// the reset request. A system restart is required for the settings to
+    /// take effect.
     #[command(after_long_help = "\
 EXAMPLES:
 
@@ -539,7 +541,11 @@ pub struct MachineSetupStatusArgs {
 
 #[derive(Parser, Debug, PartialEq, Clone)]
 pub struct ResetBiosArgs {
-    #[clap(short, long, help = "Restart the system to apply the BIOS reset")]
+    #[clap(
+        short,
+        long,
+        help = "Perform a forced restart after the BMC accepts the BIOS reset request"
+    )]
     pub reboot: bool,
 }
 

--- a/crates/admin-cli/src/redfish/args.rs
+++ b/crates/admin-cli/src/redfish/args.rs
@@ -231,6 +231,19 @@ Clear the UEFI password (supply the current one):
     ClearNvram,
     /// Set BIOS options
     SetBios(SetBios),
+    /// Reset BIOS settings to factory defaults
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Reset BIOS settings to factory defaults:
+    $ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword reset-bios
+
+Reset BIOS settings and restart the system to apply the change:
+    $ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    reset-bios --reboot
+
+")]
+    ResetBios(ResetBiosArgs),
     /// Get DPU mode
     GetNicMode,
     /// Is infinite boot enable
@@ -522,6 +535,12 @@ Check what machine-setup steps remain:
 pub struct MachineSetupStatusArgs {
     #[clap(long, help = "boot_interface_mac")]
     pub boot_interface_mac: Option<String>,
+}
+
+#[derive(Parser, Debug, PartialEq, Clone)]
+pub struct ResetBiosArgs {
+    #[clap(short, long, help = "Restart the system to apply the BIOS reset")]
+    pub reboot: bool,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]

--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -476,6 +476,14 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
             redfish.set_bios(attrmap).await?;
             println!("success");
         }
+        ResetBios(args) => {
+            redfish.reset_bios().await?;
+            if args.reboot {
+                redfish.power(SystemPowerControl::ForceRestart).await?;
+            } else {
+                println!("BIOS changes require a system restart to take effect.");
+            }
+        }
         GetNicMode => {
             let is_dpu_in_nic_mode = redfish.get_nic_mode().await?;
             println!("{is_dpu_in_nic_mode:#?}");

--- a/crates/admin-cli/src/redfish/tests.rs
+++ b/crates/admin-cli/src/redfish/tests.rs
@@ -173,6 +173,33 @@ fn parse_create_bmc_user() {
     );
 }
 
+#[test]
+fn parse_reset_bios() {
+    scenarios!(
+        run = |argv| {
+            RedfishAction::try_parse_from(argv.iter().copied())
+                .map(|a| match a.command {
+                    Cmd::ResetBios(args) => args.reboot,
+                    _ => panic!("expected ResetBios variant"),
+                })
+                .map_err(drop)
+        };
+        "without reboot" {
+            &["redfish", "--address", "192.0.2.10", "reset-bios"][..] => Yields(false),
+        }
+
+        "with reboot" {
+            &[
+                "redfish",
+                "--address",
+                "192.0.2.10",
+                "reset-bios",
+                "--reboot",
+            ][..] => Yields(true),
+        }
+    );
+}
+
 // `dpu firmware status` parses through the nested DpuOperations / FwCommand
 // subcommands to the Dpu Firmware Status variant.
 #[test]

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
@@ -1,0 +1,53 @@
+# `nico-admin-cli redfish reset-bios`
+
+_[Hardware commands](../../hardware.md) › [redfish](./redfish.md) › **reset-bios**_
+
+## NAME
+
+nico-admin-cli-redfish-reset-bios - Reset BIOS settings to factory
+defaults
+
+## SYNOPSIS
+
+**nico-admin-cli redfish reset-bios** \[**-r**\|**--reboot**\]
+\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Reset BIOS settings to factory defaults
+
+## OPTIONS
+
+**-r**, **--reboot**  
+Restart the system to apply the BIOS reset
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword reset-bios
+nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword reset-bios --reboot
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
@@ -10,16 +10,18 @@ defaults
 ## SYNOPSIS
 
 **nico-admin-cli redfish reset-bios** \[**-r**\|**--reboot**\]
-\[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
+\[**--extended**\] \[**--sort-by** *\<SORT_BY\>*\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION
 
-Reset BIOS settings to factory defaults
+Reset BIOS settings to factory defaults. Returns once the BMC accepts
+the reset request. A system restart is required for the settings to take
+effect.
 
 ## OPTIONS
 
 **-r**, **--reboot**  
-Restart the system to apply the BIOS reset
+Perform a forced restart after the BMC accepts the BIOS reset request
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish-reset-bios.md
@@ -26,7 +26,7 @@ Perform a forced restart after the BMC accepts the BIOS reset request
 **--extended**  
 Extended result output.
 
-This used by measured boot, where basic output contains just what you
+This is used by measured boot, where basic output contains just what you
 probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 

--- a/docs/manuals/nico-admin-cli/commands/redfish/redfish.md
+++ b/docs/manuals/nico-admin-cli/commands/redfish/redfish.md
@@ -117,6 +117,7 @@ nico-admin-cli redfish --address 192.0.2.10 --username admin --password mypasswo
 | [`get-base-mac-address`](./redfish-get-base-mac-address.md) | Get Base Mac Address (DPU only) |
 | [`clear-nvram`](./redfish-clear-nvram.md) | Clear Nvram (Viking only) |
 | [`set-bios`](./redfish-set-bios.md) | Set BIOS options |
+| [`reset-bios`](./redfish-reset-bios.md) | Reset BIOS settings to factory defaults |
 | [`get-nic-mode`](./redfish-get-nic-mode.md) | Get DPU mode |
 | [`is-infinite-boot-enabled`](./redfish-is-infinite-boot-enabled.md) | Is infinite boot enable |
 | [`enable-infinite-boot`](./redfish-enable-infinite-boot.md) | Enable infinite boot |


### PR DESCRIPTION
Adds a direct `nico-admin-cli redfish reset-bios` command for restoring BIOS settings to factory defaults. This allows operators to reset BIOS before a machine has been ingested by NICo, when no machine ID is available, without manually constructing Redfish requests.

The command targets a BMC using its address and credentials. By default, it exits once the BMC accepts the BIOS-reset request and informs the operator that a restart is required. Passing `--reboot` submits a force restart after the BIOS-reset request succeeds.

The command uses libredfish’s vendor-specific `reset_bios()` implementation. NVIDIA GBx00 and GH200 support depends on the linked libredfish PR and a subsequent NICo dependency update.

## Related issues
- GBx00 and GH200 support depends on: https://github.com/NVIDIA/libredfish/pull/103
- https://github.com/NVIDIA/infra-controller/issues/3661

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This PR will not support GBx00 or GH200 until the related libredfish PR is merged and NICo’s libredfish dependency is updated to a tag containing it.

