### PR TITLE
chore(rest-api): Use new structured gRPC fields for VPC status/config

### DIFF
--- a/rest-api/api/pkg/api/handler/vpc.go
+++ b/rest-api/api/pkg/api/handler/vpc.go
@@ -16,7 +16,6 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
-	wutil "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 	"github.com/labstack/echo/v4"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -435,9 +434,7 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 	statusDetails := []cdbm.StatusDetail{*ssd}
 
 	// Make a best-effort attempt to return a response with the allocated VNI.
-	if controllerVpc.GetStatus() != nil {
-		activeVni := wutil.GetUint32PtrToIntPtr(controllerVpc.GetStatus().Vni)
-
+	if activeVni := cdbm.VpcProtoAllocatedVNI(controllerVpc); activeVni != nil {
 		uvpcInput := cdbm.VpcUpdateInput{
 			VpcID:     vpc.ID,
 			ActiveVni: activeVni,

--- a/rest-api/api/pkg/api/handler/vpc.go
+++ b/rest-api/api/pkg/api/handler/vpc.go
@@ -434,7 +434,10 @@ func (cvh CreateVPCHandler) Handle(c echo.Context) error {
 	statusDetails := []cdbm.StatusDetail{*ssd}
 
 	// Make a best-effort attempt to return a response with the allocated VNI.
-	if activeVni := cdbm.VpcProtoAllocatedVNI(controllerVpc); activeVni != nil {
+	controllerVpcModel := &cdbm.Vpc{}
+	controllerVpcModel.FromProto(controllerVpc)
+	activeVni := controllerVpcModel.ActiveVni
+	if activeVni != nil {
 		uvpcInput := cdbm.VpcUpdateInput{
 			VpcID:     vpc.ID,
 			ActiveVni: activeVni,

--- a/rest-api/api/pkg/api/model/vpc.go
+++ b/rest-api/api/pkg/api/model/vpc.go
@@ -180,16 +180,17 @@ func (ascr APIVpcCreateRequest) ToProto(vpc *cdbm.Vpc) *corev1.VpcCreationReques
 		routingProfile = vpc.RoutingProfile
 	}
 	vpcProto := vpc.ToProto()
+	config := vpcProto.GetConfig()
 	return &corev1.VpcCreationRequest{
 		Id:                              vpcProto.Id,
 		Name:                            vpcProto.Name,
-		TenantOrganizationId:            vpcProto.TenantOrganizationId,
-		NetworkVirtualizationType:       vpcProto.NetworkVirtualizationType,
+		TenantOrganizationId:            config.TenantOrganizationId,
+		NetworkVirtualizationType:       config.NetworkVirtualizationType,
 		RoutingProfileType:              routingProfile,
-		NetworkSecurityGroupId:          vpcProto.NetworkSecurityGroupId,
+		NetworkSecurityGroupId:          config.NetworkSecurityGroupId,
 		Vni:                             vni,
 		Metadata:                        vpcProto.Metadata,
-		DefaultNvlinkLogicalPartitionId: vpcProto.DefaultNvlinkLogicalPartitionId,
+		DefaultNvlinkLogicalPartitionId: config.DefaultNvlinkLogicalPartitionId,
 	}
 }
 
@@ -245,10 +246,11 @@ func (asur APIVpcUpdateRequest) Validate() error {
 // from the validated DB value.
 func (asur APIVpcUpdateRequest) ToProto(vpc *cdbm.Vpc) *corev1.VpcUpdateRequest {
 	vpcProto := vpc.ToProto()
+	config := vpcProto.GetConfig()
 	return &corev1.VpcUpdateRequest{
 		Id:                              vpcProto.Id,
-		NetworkSecurityGroupId:          vpcProto.NetworkSecurityGroupId,
-		DefaultNvlinkLogicalPartitionId: vpcProto.DefaultNvlinkLogicalPartitionId,
+		NetworkSecurityGroupId:          config.NetworkSecurityGroupId,
+		DefaultNvlinkLogicalPartitionId: config.DefaultNvlinkLogicalPartitionId,
 		Metadata:                        vpcProto.Metadata,
 	}
 }

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -164,96 +164,6 @@ func (vpc *Vpc) GetSiteID() *uuid.UUID {
 	return &vpc.ID
 }
 
-// toMetadataProto builds a workflow Metadata proto from the VPC's Name,
-// Description, and Labels. Description defaults to the empty string when
-// the receiver's pointer is nil; this matches the existing handler
-// behaviour.
-func (vpc *Vpc) toMetadataProto() *corev1.Metadata {
-	md := &corev1.Metadata{
-		Name:        vpc.Name,
-		Description: "",
-	}
-	if vpc.Description != nil {
-		md.Description = *vpc.Description
-	}
-	if vpc.Labels != nil {
-		md.Labels = vpc.Labels.ToProto()
-	}
-	return md
-}
-
-func vpcStringToProtoVirtualizationType(virtType *string) *corev1.VpcVirtualizationType {
-	if virtType == nil {
-		return nil
-	}
-	nwvt := corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER
-	switch *virtType {
-	case corev1.VpcVirtualizationType_FNN.String():
-		nwvt = corev1.VpcVirtualizationType_FNN
-	case corev1.VpcVirtualizationType_FLAT.String():
-		nwvt = corev1.VpcVirtualizationType_FLAT
-	}
-	return &nwvt
-}
-
-func vpcProtoVirtualizationTypeToString(virtType corev1.VpcVirtualizationType) string {
-	switch virtType {
-	case corev1.VpcVirtualizationType_FNN:
-		return VpcFNN
-	case corev1.VpcVirtualizationType_FLAT:
-		return VpcFlat
-	default:
-		return VpcEthernetVirtualizer
-	}
-}
-
-// VpcProtoAllocatedVNI returns the active VNI reported by a site agent
-// via `status.vni`. The allocated VNI is carried in status, not config,
-// so it is read separately from the desired VNI (`config.vni`). Returns
-// nil when status (or its VNI) is absent.
-func VpcProtoAllocatedVNI(proto *corev1.Vpc) *int {
-	status := proto.GetStatus()
-	if status == nil {
-		return nil
-	}
-	return cutil.Uint32PtrToIntPtr(status.Vni)
-}
-
-// VpcProtoNetworkVirtualizationType returns the network virtualization
-// type as its DB string form from a site-reported Vpc proto, reading
-// from the structured `config`. Returns nil when config (or the field)
-// is absent.
-func VpcProtoNetworkVirtualizationType(proto *corev1.Vpc) *string {
-	cfg := proto.GetConfig()
-	if cfg == nil || cfg.NetworkVirtualizationType == nil {
-		return nil
-	}
-	s := vpcProtoVirtualizationTypeToString(*cfg.NetworkVirtualizationType)
-	return &s
-}
-
-// VpcProtoRoutingProfile returns the routing profile from the structured
-// `config` of a site-reported Vpc proto, or nil when config (or the
-// field) is absent.
-func VpcProtoRoutingProfile(proto *corev1.Vpc) *string {
-	cfg := proto.GetConfig()
-	if cfg == nil {
-		return nil
-	}
-	return cfg.RoutingProfileType
-}
-
-// VpcProtoNetworkSecurityGroupID returns the NSG ID from the structured
-// `config` of a site-reported Vpc proto, or nil when config (or the
-// field) is absent.
-func VpcProtoNetworkSecurityGroupID(proto *corev1.Vpc) *string {
-	cfg := proto.GetConfig()
-	if cfg == nil {
-		return nil
-	}
-	return cfg.NetworkSecurityGroupId
-}
-
 // ToProto converts this VPC into its workflow proto representation.
 // Used as the canonical entity-to-proto conversion; request-shape
 // protos (create / update) are produced by `ToProto` methods on the
@@ -264,9 +174,31 @@ func VpcProtoNetworkSecurityGroupID(proto *corev1.Vpc) *string {
 // are no longer populated: site agents at or after commit a2e3f88b read
 // exclusively from `config`/`status`.
 func (vpc *Vpc) ToProto() *corev1.Vpc {
+	metadata := &corev1.Metadata{
+		Name:        vpc.Name,
+		Description: "",
+	}
+	if vpc.Description != nil {
+		metadata.Description = *vpc.Description
+	}
+	if vpc.Labels != nil {
+		metadata.Labels = vpc.Labels.ToProto()
+	}
+
 	var nvllpProto *corev1.NVLinkLogicalPartitionId
 	if vpc.NVLinkLogicalPartitionID != nil {
 		nvllpProto = &corev1.NVLinkLogicalPartitionId{Value: vpc.NVLinkLogicalPartitionID.String()}
+	}
+	var networkVirtualizationType *corev1.VpcVirtualizationType
+	if vpc.NetworkVirtualizationType != nil {
+		nwvt := corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER
+		switch *vpc.NetworkVirtualizationType {
+		case corev1.VpcVirtualizationType_FNN.String():
+			nwvt = corev1.VpcVirtualizationType_FNN
+		case corev1.VpcVirtualizationType_FLAT.String():
+			nwvt = corev1.VpcVirtualizationType_FLAT
+		}
+		networkVirtualizationType = &nwvt
 	}
 
 	config := &corev1.VpcConfig{
@@ -275,13 +207,13 @@ func (vpc *Vpc) ToProto() *corev1.Vpc {
 		DefaultNvlinkLogicalPartitionId: nvllpProto,
 		Vni:                             cutil.IntPtrToUint32Ptr(vpc.Vni),
 		RoutingProfileType:              vpc.RoutingProfile,
-		NetworkVirtualizationType:       vpcStringToProtoVirtualizationType(vpc.NetworkVirtualizationType),
+		NetworkVirtualizationType:       networkVirtualizationType,
 	}
 
 	proto := &corev1.Vpc{
 		Id:       &corev1.VpcId{Value: vpc.GetSiteID().String()},
 		Name:     vpc.Name,
-		Metadata: vpc.toMetadataProto(),
+		Metadata: metadata,
 		Config:   config,
 	}
 
@@ -294,11 +226,9 @@ func (vpc *Vpc) ToProto() *corev1.Vpc {
 }
 
 // FromProto populates this VPC from its workflow proto representation.
-// A nil proto is a no-op. This is the inverse of `ToProto` and exists
-// for convention symmetry — currently no code path on the cloud side
-// reconstructs a full VPC entity from a `corev1.Vpc` (the site is the
-// destination, not the source), but the method is provided so future
-// reconciliation flows have a single canonical entry point.
+// A nil proto is a no-op. This is the inverse of `ToProto` and is the
+// canonical entry point for cloud-side callers that consume structured
+// config and status reported by a site.
 //
 // Field-level contract:
 //   - `vpc.ID` is preserved on a missing or unparseable `proto.Id`,
@@ -307,8 +237,7 @@ func (vpc *Vpc) ToProto() *corev1.Vpc {
 //     back to the legacy top-level `proto.Name` when metadata omits it.
 //   - Desired-configuration fields (Org, NSG, NVLink, virtualization
 //     type, routing profile, requested VNI) are read from the structured
-//     `config`. The allocated VNI comes from `status` (via
-//     `VpcProtoAllocatedVNI`), not `config`.
+//     `config`. The allocated VNI comes from `status`, not `config`.
 //   - Optional pointer fields (NetworkSecurityGroupID,
 //     NVLinkLogicalPartitionID) are cleared when the proto omits them
 //     OR when the proto value is invalid (e.g. an unparseable UUID).
@@ -337,7 +266,11 @@ func (vpc *Vpc) FromProto(proto *corev1.Vpc) {
 	vpc.NetworkSecurityGroupID = cfg.NetworkSecurityGroupId
 	vpc.RoutingProfile = cfg.RoutingProfileType
 	vpc.Vni = cutil.Uint32PtrToIntPtr(cfg.Vni)
-	vpc.ActiveVni = VpcProtoAllocatedVNI(proto)
+	vpc.ActiveVni = nil
+	status := proto.GetStatus()
+	if status != nil {
+		vpc.ActiveVni = cutil.Uint32PtrToIntPtr(status.Vni)
+	}
 
 	vpc.NVLinkLogicalPartitionID = nil
 	if cfg.DefaultNvlinkLogicalPartitionId != nil {
@@ -348,7 +281,13 @@ func (vpc *Vpc) FromProto(proto *corev1.Vpc) {
 
 	vpc.NetworkVirtualizationType = nil
 	if cfg.NetworkVirtualizationType != nil {
-		s := vpcProtoVirtualizationTypeToString(*cfg.NetworkVirtualizationType)
+		s := VpcEthernetVirtualizer
+		switch *cfg.NetworkVirtualizationType {
+		case corev1.VpcVirtualizationType_FNN:
+			s = VpcFNN
+		case corev1.VpcVirtualizationType_FLAT:
+			s = VpcFlat
+		}
 		vpc.NetworkVirtualizationType = &s
 	}
 

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"time"
 
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
@@ -181,37 +182,114 @@ func (vpc *Vpc) toMetadataProto() *corev1.Metadata {
 	return md
 }
 
+func vpcStringToProtoVirtualizationType(virtType *string) *corev1.VpcVirtualizationType {
+	if virtType == nil {
+		return nil
+	}
+	nwvt := corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER
+	switch *virtType {
+	case corev1.VpcVirtualizationType_FNN.String():
+		nwvt = corev1.VpcVirtualizationType_FNN
+	case corev1.VpcVirtualizationType_FLAT.String():
+		nwvt = corev1.VpcVirtualizationType_FLAT
+	}
+	return &nwvt
+}
+
+func vpcProtoVirtualizationTypeToString(virtType corev1.VpcVirtualizationType) string {
+	switch virtType {
+	case corev1.VpcVirtualizationType_FNN:
+		return VpcFNN
+	case corev1.VpcVirtualizationType_FLAT:
+		return VpcFlat
+	default:
+		return VpcEthernetVirtualizer
+	}
+}
+
+// VpcProtoAllocatedVNI returns the active VNI reported by a site agent
+// via `status.vni`. The allocated VNI is carried in status, not config,
+// so it is read separately from the desired VNI (`config.vni`). Returns
+// nil when status (or its VNI) is absent.
+func VpcProtoAllocatedVNI(proto *corev1.Vpc) *int {
+	status := proto.GetStatus()
+	if status == nil {
+		return nil
+	}
+	return cutil.Uint32PtrToIntPtr(status.Vni)
+}
+
+// VpcProtoNetworkVirtualizationType returns the network virtualization
+// type as its DB string form from a site-reported Vpc proto, reading
+// from the structured `config`. Returns nil when config (or the field)
+// is absent.
+func VpcProtoNetworkVirtualizationType(proto *corev1.Vpc) *string {
+	cfg := proto.GetConfig()
+	if cfg == nil || cfg.NetworkVirtualizationType == nil {
+		return nil
+	}
+	s := vpcProtoVirtualizationTypeToString(*cfg.NetworkVirtualizationType)
+	return &s
+}
+
+// VpcProtoRoutingProfile returns the routing profile from the structured
+// `config` of a site-reported Vpc proto, or nil when config (or the
+// field) is absent.
+func VpcProtoRoutingProfile(proto *corev1.Vpc) *string {
+	cfg := proto.GetConfig()
+	if cfg == nil {
+		return nil
+	}
+	return cfg.RoutingProfileType
+}
+
+// VpcProtoNetworkSecurityGroupID returns the NSG ID from the structured
+// `config` of a site-reported Vpc proto, or nil when config (or the
+// field) is absent.
+func VpcProtoNetworkSecurityGroupID(proto *corev1.Vpc) *string {
+	cfg := proto.GetConfig()
+	if cfg == nil {
+		return nil
+	}
+	return cfg.NetworkSecurityGroupId
+}
+
 // ToProto converts this VPC into its workflow proto representation.
 // Used as the canonical entity-to-proto conversion; request-shape
 // protos (create / update) are produced by `ToProto` methods on the
 // corresponding API request types in api/pkg/api/model/vpc.go.
 //
-// `NetworkVirtualizationType` is mapped from the DB column's string
-// value to the workflow enum (defaulting to `ETHERNET_VIRTUALIZER`
-// when the string is set but unrecognized, matching the pre-refactor
-// handler behaviour). It is omitted from the proto when the DB
-// column is nil.
+// Desired configuration is emitted via the structured `config` field
+// and the allocated VNI via `status`. The deprecated flat mirror fields
+// are no longer populated: site agents at or after commit a2e3f88b read
+// exclusively from `config`/`status`.
 func (vpc *Vpc) ToProto() *corev1.Vpc {
-	proto := &corev1.Vpc{
-		Id:                     &corev1.VpcId{Value: vpc.GetSiteID().String()},
-		Name:                   vpc.Name,
-		TenantOrganizationId:   vpc.Org,
-		NetworkSecurityGroupId: vpc.NetworkSecurityGroupID,
-		Metadata:               vpc.toMetadataProto(),
-	}
+	var nvllpProto *corev1.NVLinkLogicalPartitionId
 	if vpc.NVLinkLogicalPartitionID != nil {
-		proto.DefaultNvlinkLogicalPartitionId = &corev1.NVLinkLogicalPartitionId{Value: vpc.NVLinkLogicalPartitionID.String()}
+		nvllpProto = &corev1.NVLinkLogicalPartitionId{Value: vpc.NVLinkLogicalPartitionID.String()}
 	}
-	if vpc.NetworkVirtualizationType != nil {
-		nwvt := corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER
-		switch *vpc.NetworkVirtualizationType {
-		case corev1.VpcVirtualizationType_FNN.String():
-			nwvt = corev1.VpcVirtualizationType_FNN
-		case corev1.VpcVirtualizationType_FLAT.String():
-			nwvt = corev1.VpcVirtualizationType_FLAT
-		}
-		proto.NetworkVirtualizationType = &nwvt
+
+	config := &corev1.VpcConfig{
+		TenantOrganizationId:            vpc.Org,
+		NetworkSecurityGroupId:          vpc.NetworkSecurityGroupID,
+		DefaultNvlinkLogicalPartitionId: nvllpProto,
+		Vni:                             cutil.IntPtrToUint32Ptr(vpc.Vni),
+		RoutingProfileType:              vpc.RoutingProfile,
+		NetworkVirtualizationType:       vpcStringToProtoVirtualizationType(vpc.NetworkVirtualizationType),
 	}
+
+	proto := &corev1.Vpc{
+		Id:       &corev1.VpcId{Value: vpc.GetSiteID().String()},
+		Name:     vpc.Name,
+		Metadata: vpc.toMetadataProto(),
+		Config:   config,
+	}
+
+	allocatedVni := cutil.IntPtrToUint32Ptr(vpc.ActiveVni)
+	if allocatedVni != nil {
+		proto.Status = &corev1.VpcStatus{Vni: allocatedVni}
+	}
+
 	return proto
 }
 
@@ -226,8 +304,11 @@ func (vpc *Vpc) ToProto() *corev1.Vpc {
 //   - `vpc.ID` is preserved on a missing or unparseable `proto.Id`,
 //     because callers pre-validate the UUID before calling.
 //   - `Name` is sourced from `proto.Metadata.Name` when set, falling
-//     back to the (deprecated) top-level `proto.Name` so the method
-//     keeps working through the deprecation window.
+//     back to the legacy top-level `proto.Name` when metadata omits it.
+//   - Desired-configuration fields (Org, NSG, NVLink, virtualization
+//     type, routing profile, requested VNI) are read from the structured
+//     `config`. The allocated VNI comes from `status` (via
+//     `VpcProtoAllocatedVNI`), not `config`.
 //   - Optional pointer fields (NetworkSecurityGroupID,
 //     NVLinkLogicalPartitionID) are cleared when the proto omits them
 //     OR when the proto value is invalid (e.g. an unparseable UUID).
@@ -246,26 +327,39 @@ func (vpc *Vpc) FromProto(proto *corev1.Vpc) {
 	if proto.Metadata != nil && proto.Metadata.Name != "" {
 		vpc.Name = proto.Metadata.Name
 	}
-	vpc.Org = proto.TenantOrganizationId
-	vpc.NetworkSecurityGroupID = proto.NetworkSecurityGroupId
-	if proto.DefaultNvlinkLogicalPartitionId != nil {
-		if id, err := uuid.Parse(proto.DefaultNvlinkLogicalPartitionId.Value); err == nil {
-			vpc.NVLinkLogicalPartitionID = &id
-		} else {
-			vpc.NVLinkLogicalPartitionID = nil
-		}
-	} else {
-		vpc.NVLinkLogicalPartitionID = nil
+
+	cfg := proto.GetConfig()
+	if cfg == nil {
+		cfg = &corev1.VpcConfig{}
 	}
+
+	vpc.Org = cfg.TenantOrganizationId
+	vpc.NetworkSecurityGroupID = cfg.NetworkSecurityGroupId
+	vpc.RoutingProfile = cfg.RoutingProfileType
+	vpc.Vni = cutil.Uint32PtrToIntPtr(cfg.Vni)
+	vpc.ActiveVni = VpcProtoAllocatedVNI(proto)
+
+	vpc.NVLinkLogicalPartitionID = nil
+	if cfg.DefaultNvlinkLogicalPartitionId != nil {
+		if id, err := uuid.Parse(cfg.DefaultNvlinkLogicalPartitionId.Value); err == nil {
+			vpc.NVLinkLogicalPartitionID = &id
+		}
+	}
+
+	vpc.NetworkVirtualizationType = nil
+	if cfg.NetworkVirtualizationType != nil {
+		s := vpcProtoVirtualizationTypeToString(*cfg.NetworkVirtualizationType)
+		vpc.NetworkVirtualizationType = &s
+	}
+
+	vpc.Description = nil
 	if proto.Metadata != nil {
-		vpc.Description = nil
 		if proto.Metadata.Description != "" {
 			desc := proto.Metadata.Description
 			vpc.Description = &desc
 		}
 		vpc.Labels.FromProto(proto.Metadata.GetLabels())
 	} else {
-		vpc.Description = nil
 		vpc.Labels = nil
 	}
 }

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -1503,24 +1503,29 @@ func TestVpc_ToProto(t *testing.T) {
 	nsg := "nsg-1"
 	nvllpID := uuid.New()
 
-	t.Run("populates id, org, metadata, NSG, and NVLink partition", func(t *testing.T) {
+	t.Run("emits config and status without deprecated flat mirrors", func(t *testing.T) {
+		fnn := VpcFNN
+		routingProfile := "INTERNAL"
+		requestedVni := 4242
+		activeVni := 9999
 		v := &Vpc{
-			ID:                       id,
-			Org:                      "org-1",
-			Name:                     "vpc-a",
-			Description:              &desc,
-			NetworkSecurityGroupID:   &nsg,
-			NVLinkLogicalPartitionID: &nvllpID,
-			Labels:                   map[string]string{"env": "prod"},
+			ID:                        id,
+			Org:                       "org-1",
+			Name:                      "vpc-a",
+			Description:               &desc,
+			NetworkSecurityGroupID:    &nsg,
+			NVLinkLogicalPartitionID:  &nvllpID,
+			NetworkVirtualizationType: &fnn,
+			RoutingProfile:            &routingProfile,
+			Vni:                       &requestedVni,
+			ActiveVni:                 &activeVni,
+			Labels:                    map[string]string{"env": "prod"},
 		}
 		got := v.ToProto()
 		require.NotNil(t, got)
 		require.NotNil(t, got.Id)
 		assert.Equal(t, id.String(), got.Id.Value)
 		assert.Equal(t, "vpc-a", got.Name)
-		assert.Equal(t, "org-1", got.TenantOrganizationId)
-		require.NotNil(t, got.NetworkSecurityGroupId)
-		assert.Equal(t, "nsg-1", *got.NetworkSecurityGroupId)
 		require.NotNil(t, got.Metadata)
 		assert.Equal(t, "vpc-a", got.Metadata.Name)
 		assert.Equal(t, "primary", got.Metadata.Description)
@@ -1528,8 +1533,33 @@ func TestVpc_ToProto(t *testing.T) {
 		assert.Equal(t, "env", got.Metadata.Labels[0].Key)
 		require.NotNil(t, got.Metadata.Labels[0].Value)
 		assert.Equal(t, "prod", *got.Metadata.Labels[0].Value)
-		require.NotNil(t, got.DefaultNvlinkLogicalPartitionId)
-		assert.Equal(t, nvllpID.String(), got.DefaultNvlinkLogicalPartitionId.Value)
+
+		// Desired configuration is emitted via the structured `config`.
+		require.NotNil(t, got.Config)
+		assert.Equal(t, "org-1", got.Config.TenantOrganizationId)
+		require.NotNil(t, got.Config.NetworkSecurityGroupId)
+		assert.Equal(t, "nsg-1", *got.Config.NetworkSecurityGroupId)
+		require.NotNil(t, got.Config.DefaultNvlinkLogicalPartitionId)
+		assert.Equal(t, nvllpID.String(), got.Config.DefaultNvlinkLogicalPartitionId.Value)
+		require.NotNil(t, got.Config.NetworkVirtualizationType)
+		assert.Equal(t, corev1.VpcVirtualizationType_FNN, *got.Config.NetworkVirtualizationType)
+		require.NotNil(t, got.Config.Vni)
+		assert.Equal(t, uint32(requestedVni), *got.Config.Vni)
+		require.NotNil(t, got.Config.RoutingProfileType)
+		assert.Equal(t, routingProfile, *got.Config.RoutingProfileType)
+
+		// The allocated VNI is emitted via `status`.
+		require.NotNil(t, got.Status)
+		require.NotNil(t, got.Status.Vni)
+		assert.Equal(t, uint32(activeVni), *got.Status.Vni)
+
+		// Deprecated flat mirrors are no longer populated.
+		assert.Empty(t, got.TenantOrganizationId)
+		assert.Nil(t, got.NetworkVirtualizationType)
+		assert.Nil(t, got.Vni)
+		assert.Nil(t, got.DeprecatedVni)
+		assert.Nil(t, got.RoutingProfileType)
+		assert.Nil(t, got.NetworkSecurityGroupId)
 	})
 
 	t.Run("nil description and labels yield zero-value metadata", func(t *testing.T) {
@@ -1538,8 +1568,9 @@ func TestVpc_ToProto(t *testing.T) {
 		require.NotNil(t, got.Metadata)
 		assert.Equal(t, "", got.Metadata.Description)
 		assert.Nil(t, got.Metadata.Labels)
-		assert.Nil(t, got.NetworkSecurityGroupId)
-		assert.Nil(t, got.DefaultNvlinkLogicalPartitionId)
+		require.NotNil(t, got.Config)
+		assert.Nil(t, got.Config.NetworkSecurityGroupId)
+		assert.Nil(t, got.Config.DefaultNvlinkLogicalPartitionId)
 	})
 
 	t.Run("uses ControllerVpcID for the proto Id when set", func(t *testing.T) {
@@ -1554,30 +1585,34 @@ func TestVpc_ToProto(t *testing.T) {
 		empty := ""
 		v := &Vpc{ID: id, Name: "vpc-a", NetworkSecurityGroupID: &empty}
 		got := v.ToProto()
-		require.NotNil(t, got.NetworkSecurityGroupId)
-		assert.Equal(t, "", *got.NetworkSecurityGroupId)
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.NetworkSecurityGroupId)
+		assert.Equal(t, "", *got.Config.NetworkSecurityGroupId)
 	})
 
 	t.Run("maps NetworkVirtualizationType FNN string to the FNN enum", func(t *testing.T) {
 		fnn := VpcFNN
 		v := &Vpc{ID: id, Name: "vpc-a", NetworkVirtualizationType: &fnn}
 		got := v.ToProto()
-		require.NotNil(t, got.NetworkVirtualizationType)
-		assert.Equal(t, corev1.VpcVirtualizationType_FNN, *got.NetworkVirtualizationType)
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.NetworkVirtualizationType)
+		assert.Equal(t, corev1.VpcVirtualizationType_FNN, *got.Config.NetworkVirtualizationType)
 	})
 
 	t.Run("maps NetworkVirtualizationType ethernet string to ETHERNET_VIRTUALIZER", func(t *testing.T) {
 		eth := VpcEthernetVirtualizer
 		v := &Vpc{ID: id, Name: "vpc-a", NetworkVirtualizationType: &eth}
 		got := v.ToProto()
-		require.NotNil(t, got.NetworkVirtualizationType)
-		assert.Equal(t, corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER, *got.NetworkVirtualizationType)
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.NetworkVirtualizationType)
+		assert.Equal(t, corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER, *got.Config.NetworkVirtualizationType)
 	})
 
 	t.Run("omits NetworkVirtualizationType when the entity has none", func(t *testing.T) {
 		v := &Vpc{ID: id, Name: "vpc-a"}
 		got := v.ToProto()
-		assert.Nil(t, got.NetworkVirtualizationType)
+		require.NotNil(t, got.Config)
+		assert.Nil(t, got.Config.NetworkVirtualizationType)
 	})
 }
 
@@ -1605,13 +1640,24 @@ func TestVpc_FromProto(t *testing.T) {
 	})
 
 	t.Run("populates fields from proto", func(t *testing.T) {
+		fnnEnum := corev1.VpcVirtualizationType_FNN
+		requestedVni := uint32(12001)
+		activeVni := uint32(12002)
+		routingProfile := "INTERNAL"
+
 		v := &Vpc{}
 		v.FromProto(&corev1.Vpc{
-			Id:                              &corev1.VpcId{Value: id.String()},
-			Name:                            "vpc-a",
-			TenantOrganizationId:            "org-1",
-			NetworkSecurityGroupId:          &nsg,
-			DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{Value: nvllpID.String()},
+			Id:   &corev1.VpcId{Value: id.String()},
+			Name: "vpc-a",
+			Config: &corev1.VpcConfig{
+				TenantOrganizationId:            "org-1",
+				NetworkSecurityGroupId:          &nsg,
+				NetworkVirtualizationType:       &fnnEnum,
+				Vni:                             &requestedVni,
+				RoutingProfileType:              &routingProfile,
+				DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{Value: nvllpID.String()},
+			},
+			Status: &corev1.VpcStatus{Vni: &activeVni},
 			Metadata: &corev1.Metadata{
 				Name:        "vpc-a",
 				Description: "primary",
@@ -1625,6 +1671,14 @@ func TestVpc_FromProto(t *testing.T) {
 		assert.Equal(t, "org-1", v.Org)
 		require.NotNil(t, v.NetworkSecurityGroupID)
 		assert.Equal(t, "nsg-1", *v.NetworkSecurityGroupID)
+		require.NotNil(t, v.NetworkVirtualizationType)
+		assert.Equal(t, VpcFNN, *v.NetworkVirtualizationType)
+		require.NotNil(t, v.Vni)
+		assert.Equal(t, int(requestedVni), *v.Vni)
+		require.NotNil(t, v.ActiveVni)
+		assert.Equal(t, int(activeVni), *v.ActiveVni)
+		require.NotNil(t, v.RoutingProfile)
+		assert.Equal(t, routingProfile, *v.RoutingProfile)
 		require.NotNil(t, v.NVLinkLogicalPartitionID)
 		assert.Equal(t, nvllpID, *v.NVLinkLogicalPartitionID)
 		require.NotNil(t, v.Description)
@@ -1632,21 +1686,58 @@ func TestVpc_FromProto(t *testing.T) {
 		assert.Equal(t, Labels{"env": "prod"}, v.Labels)
 	})
 
-	t.Run("missing optional fields are explicitly cleared", func(t *testing.T) {
-		stale := "stale"
+	t.Run("clears stale fields and ignores deprecated flat fields", func(t *testing.T) {
+		// A fully populated receiver plus a proto carrying only the
+		// deprecated flat mirrors (no `config`/`status`) proves two
+		// properties at once: every optional field is reset to its zero
+		// value (clean reset, not a partial merge) and none of the flat
+		// values leak into the entity.
 		staleNvllp := uuid.New()
+		staleNSG := "stale-nsg"
+		staleVirt := VpcFNN
+		staleRouting := "INTERNAL"
+		staleRequested := 7000
+		staleActive := 7001
+		staleDesc := "stale"
+
+		flatNvllp := uuid.New()
+		flatNSG := "nsg-flat"
+		flatVirt := corev1.VpcVirtualizationType_FNN
+		flatRequestedVni := uint32(15001)
+		flatAllocatedVni := uint32(15002)
+		flatRouting := "EXTERNAL"
+
 		v := &Vpc{
-			ID:                       id,
-			Description:              &stale,
-			NetworkSecurityGroupID:   &stale,
-			NVLinkLogicalPartitionID: &staleNvllp,
-			Labels:                   map[string]string{"old": "val"},
+			ID:                        id,
+			Org:                       "stale-org",
+			Description:               &staleDesc,
+			NetworkSecurityGroupID:    &staleNSG,
+			NetworkVirtualizationType: &staleVirt,
+			RoutingProfile:            &staleRouting,
+			Vni:                       &staleRequested,
+			ActiveVni:                 &staleActive,
+			NVLinkLogicalPartitionID:  &staleNvllp,
+			Labels:                    map[string]string{"old": "val"},
 		}
 		v.FromProto(&corev1.Vpc{
-			Id:   &corev1.VpcId{Value: id.String()},
-			Name: "vpc-a",
+			Id:                              &corev1.VpcId{Value: id.String()},
+			TenantOrganizationId:            "org-flat",
+			NetworkSecurityGroupId:          &flatNSG,
+			NetworkVirtualizationType:       &flatVirt,
+			Vni:                             &flatRequestedVni,
+			DeprecatedVni:                   &flatAllocatedVni,
+			RoutingProfileType:              &flatRouting,
+			DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{Value: flatNvllp.String()},
+			Metadata:                        &corev1.Metadata{Name: "reset"},
 		})
+
+		assert.Equal(t, "reset", v.Name)
+		assert.Empty(t, v.Org)
 		assert.Nil(t, v.NetworkSecurityGroupID)
+		assert.Nil(t, v.NetworkVirtualizationType)
+		assert.Nil(t, v.RoutingProfile)
+		assert.Nil(t, v.Vni)
+		assert.Nil(t, v.ActiveVni)
 		assert.Nil(t, v.NVLinkLogicalPartitionID)
 		assert.Nil(t, v.Description)
 		assert.Nil(t, v.Labels)
@@ -1656,9 +1747,11 @@ func TestVpc_FromProto(t *testing.T) {
 		staleNvllp := uuid.New()
 		v := &Vpc{ID: id, NVLinkLogicalPartitionID: &staleNvllp}
 		v.FromProto(&corev1.Vpc{
-			Id:                              &corev1.VpcId{Value: id.String()},
-			Name:                            "vpc-a",
-			DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{Value: "not-a-uuid"},
+			Id:   &corev1.VpcId{Value: id.String()},
+			Name: "vpc-a",
+			Config: &corev1.VpcConfig{
+				DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{Value: "not-a-uuid"},
+			},
 		})
 		assert.Nil(t, v.NVLinkLogicalPartitionID)
 	})
@@ -1681,5 +1774,153 @@ func TestVpc_FromProto(t *testing.T) {
 			Metadata: &corev1.Metadata{Name: ""},
 		})
 		assert.Equal(t, "top-level-fallback", v.Name)
+	})
+}
+
+// TestVpcProtoCompatHelpers covers the exported accessor helpers used by
+// the site-sync activity: they read exclusively from the structured
+// `config`/`status` and return nil for a nil proto, an absent config, or
+// an absent status (the deprecated flat fields are never consulted).
+func TestVpcProtoCompatHelpers(t *testing.T) {
+	fnnEnum := corev1.VpcVirtualizationType_FNN
+	routingProfile := "EXTERNAL"
+	nsg := "nsg-flat"
+
+	t.Run("reads structured config, ignoring deprecated flat fields", func(t *testing.T) {
+		proto := &corev1.Vpc{
+			Config: &corev1.VpcConfig{
+				NetworkVirtualizationType: &fnnEnum,
+				RoutingProfileType:        &routingProfile,
+				NetworkSecurityGroupId:    &nsg,
+			},
+			// Deprecated flat mirrors are present but must be ignored.
+			NetworkVirtualizationType: cutil.GetPtr(corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER),
+			RoutingProfileType:        cutil.GetPtr("INTERNAL"),
+			NetworkSecurityGroupId:    cutil.GetPtr("nsg-deprecated"),
+		}
+
+		virtType := VpcProtoNetworkVirtualizationType(proto)
+		require.NotNil(t, virtType)
+		assert.Equal(t, VpcFNN, *virtType)
+		assert.Equal(t, routingProfile, *VpcProtoRoutingProfile(proto))
+		assert.Equal(t, nsg, *VpcProtoNetworkSecurityGroupID(proto))
+	})
+
+	t.Run("allocated VNI reads status.vni", func(t *testing.T) {
+		statusVni := uint32(100)
+		proto := &corev1.Vpc{Status: &corev1.VpcStatus{Vni: &statusVni}}
+		got := VpcProtoAllocatedVNI(proto)
+		require.NotNil(t, got)
+		assert.Equal(t, 100, *got)
+	})
+
+	t.Run("allocated VNI is nil when status is absent (deprecated_vni ignored)", func(t *testing.T) {
+		deprecatedVni := uint32(200)
+		proto := &corev1.Vpc{DeprecatedVni: &deprecatedVni}
+		assert.Nil(t, VpcProtoAllocatedVNI(proto))
+	})
+
+	t.Run("nil proto yields nil", func(t *testing.T) {
+		assert.Nil(t, VpcProtoAllocatedVNI(nil))
+		assert.Nil(t, VpcProtoNetworkVirtualizationType(nil))
+		assert.Nil(t, VpcProtoRoutingProfile(nil))
+		assert.Nil(t, VpcProtoNetworkSecurityGroupID(nil))
+	})
+
+	t.Run("config absent yields nil (deprecated flat fields ignored)", func(t *testing.T) {
+		proto := &corev1.Vpc{
+			NetworkVirtualizationType: &fnnEnum,
+			RoutingProfileType:        &routingProfile,
+			NetworkSecurityGroupId:    &nsg,
+		}
+		assert.Nil(t, VpcProtoNetworkVirtualizationType(proto))
+		assert.Nil(t, VpcProtoRoutingProfile(proto))
+		assert.Nil(t, VpcProtoNetworkSecurityGroupID(proto))
+	})
+}
+
+// TestVpc_ToProtoFromProto_RoundTrip verifies the entity survives a
+// ToProto -> FromProto round trip. ID round-trips cleanly only when
+// ControllerVpcID is unset (ToProto sources proto.Id from GetSiteID).
+func TestVpc_ToProtoFromProto_RoundTrip(t *testing.T) {
+	id := uuid.New()
+	nvllpID := uuid.New()
+	fnn := VpcFNN
+	nsg := "nsg-rt"
+	routing := "INTERNAL"
+	requested := 20001
+	active := 20002
+
+	orig := &Vpc{
+		ID:                        id,
+		Org:                       "org-rt",
+		Name:                      "vpc-rt",
+		NetworkVirtualizationType: &fnn,
+		NetworkSecurityGroupID:    &nsg,
+		RoutingProfile:            &routing,
+		Vni:                       &requested,
+		ActiveVni:                 &active,
+		NVLinkLogicalPartitionID:  &nvllpID,
+	}
+
+	got := &Vpc{}
+	got.FromProto(orig.ToProto())
+
+	assert.Equal(t, orig.ID, got.ID)
+	assert.Equal(t, orig.Name, got.Name)
+	assert.Equal(t, orig.Org, got.Org)
+	assert.Equal(t, orig.NetworkVirtualizationType, got.NetworkVirtualizationType)
+	assert.Equal(t, orig.NetworkSecurityGroupID, got.NetworkSecurityGroupID)
+	assert.Equal(t, orig.RoutingProfile, got.RoutingProfile)
+	assert.Equal(t, orig.Vni, got.Vni)
+	assert.Equal(t, orig.ActiveVni, got.ActiveVni)
+	assert.Equal(t, orig.NVLinkLogicalPartitionID, got.NVLinkLogicalPartitionID)
+}
+
+// TestVpcVirtualizationTypeConversions exercises both directions of the
+// VPC virtualization-type mapping, including the documented default
+// (unrecognized string -> ETHERNET_VIRTUALIZER) and nil handling.
+func TestVpcVirtualizationTypeConversions(t *testing.T) {
+	t.Run("string to proto", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   *string
+			want *corev1.VpcVirtualizationType
+		}{
+			{"nil yields nil", nil, nil},
+			{"FNN", cutil.GetPtr(VpcFNN), cutil.GetPtr(corev1.VpcVirtualizationType_FNN)},
+			{"FLAT", cutil.GetPtr(VpcFlat), cutil.GetPtr(corev1.VpcVirtualizationType_FLAT)},
+			{"ETHERNET_VIRTUALIZER", cutil.GetPtr(VpcEthernetVirtualizer), cutil.GetPtr(corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER)},
+			{"unrecognized defaults to ETHERNET_VIRTUALIZER", cutil.GetPtr("bogus"), cutil.GetPtr(corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := vpcStringToProtoVirtualizationType(tc.in)
+				if tc.want == nil {
+					assert.Nil(t, got)
+					return
+				}
+				require.NotNil(t, got)
+				assert.Equal(t, *tc.want, *got)
+			})
+		}
+	})
+
+	t.Run("proto to string", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   corev1.VpcVirtualizationType
+			want string
+		}{
+			{"FNN", corev1.VpcVirtualizationType_FNN, VpcFNN},
+			{"FLAT", corev1.VpcVirtualizationType_FLAT, VpcFlat},
+			{"ETHERNET_VIRTUALIZER", corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER, VpcEthernetVirtualizer},
+			{"unhandled enum defaults to ETHERNET_VIRTUALIZER", corev1.VpcVirtualizationType_FNN_CLASSIC, VpcEthernetVirtualizer},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Equal(t, tc.want, vpcProtoVirtualizationTypeToString(tc.in))
+			})
+		}
 	})
 }

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -1599,6 +1599,15 @@ func TestVpc_ToProto(t *testing.T) {
 		assert.Equal(t, corev1.VpcVirtualizationType_FNN, *got.Config.NetworkVirtualizationType)
 	})
 
+	t.Run("maps NetworkVirtualizationType FLAT string to the FLAT enum", func(t *testing.T) {
+		flat := VpcFlat
+		v := &Vpc{ID: id, Name: "vpc-a", NetworkVirtualizationType: &flat}
+		got := v.ToProto()
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.NetworkVirtualizationType)
+		assert.Equal(t, corev1.VpcVirtualizationType_FLAT, *got.Config.NetworkVirtualizationType)
+	})
+
 	t.Run("maps NetworkVirtualizationType ethernet string to ETHERNET_VIRTUALIZER", func(t *testing.T) {
 		eth := VpcEthernetVirtualizer
 		v := &Vpc{ID: id, Name: "vpc-a", NetworkVirtualizationType: &eth}
@@ -1613,6 +1622,15 @@ func TestVpc_ToProto(t *testing.T) {
 		got := v.ToProto()
 		require.NotNil(t, got.Config)
 		assert.Nil(t, got.Config.NetworkVirtualizationType)
+	})
+
+	t.Run("defaults an unrecognized NetworkVirtualizationType to ETHERNET_VIRTUALIZER", func(t *testing.T) {
+		unknown := "unknown"
+		v := &Vpc{ID: id, Name: "vpc-a", NetworkVirtualizationType: &unknown}
+		got := v.ToProto()
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.NetworkVirtualizationType)
+		assert.Equal(t, corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER, *got.Config.NetworkVirtualizationType)
 	})
 }
 
@@ -1684,6 +1702,25 @@ func TestVpc_FromProto(t *testing.T) {
 		require.NotNil(t, v.Description)
 		assert.Equal(t, "primary", *v.Description)
 		assert.Equal(t, Labels{"env": "prod"}, v.Labels)
+	})
+
+	t.Run("maps proto network virtualization types", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   corev1.VpcVirtualizationType
+			want string
+		}{
+			{name: "FLAT", in: corev1.VpcVirtualizationType_FLAT, want: VpcFlat},
+			{name: "unhandled defaults to ETHERNET_VIRTUALIZER", in: corev1.VpcVirtualizationType_FNN_CLASSIC, want: VpcEthernetVirtualizer},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				v := &Vpc{}
+				v.FromProto(&corev1.Vpc{Config: &corev1.VpcConfig{NetworkVirtualizationType: &tc.in}})
+				require.NotNil(t, v.NetworkVirtualizationType)
+				assert.Equal(t, tc.want, *v.NetworkVirtualizationType)
+			})
+		}
 	})
 
 	t.Run("clears stale fields and ignores deprecated flat fields", func(t *testing.T) {
@@ -1777,68 +1814,6 @@ func TestVpc_FromProto(t *testing.T) {
 	})
 }
 
-// TestVpcProtoCompatHelpers covers the exported accessor helpers used by
-// the site-sync activity: they read exclusively from the structured
-// `config`/`status` and return nil for a nil proto, an absent config, or
-// an absent status (the deprecated flat fields are never consulted).
-func TestVpcProtoCompatHelpers(t *testing.T) {
-	fnnEnum := corev1.VpcVirtualizationType_FNN
-	routingProfile := "EXTERNAL"
-	nsg := "nsg-flat"
-
-	t.Run("reads structured config, ignoring deprecated flat fields", func(t *testing.T) {
-		proto := &corev1.Vpc{
-			Config: &corev1.VpcConfig{
-				NetworkVirtualizationType: &fnnEnum,
-				RoutingProfileType:        &routingProfile,
-				NetworkSecurityGroupId:    &nsg,
-			},
-			// Deprecated flat mirrors are present but must be ignored.
-			NetworkVirtualizationType: cutil.GetPtr(corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER),
-			RoutingProfileType:        cutil.GetPtr("INTERNAL"),
-			NetworkSecurityGroupId:    cutil.GetPtr("nsg-deprecated"),
-		}
-
-		virtType := VpcProtoNetworkVirtualizationType(proto)
-		require.NotNil(t, virtType)
-		assert.Equal(t, VpcFNN, *virtType)
-		assert.Equal(t, routingProfile, *VpcProtoRoutingProfile(proto))
-		assert.Equal(t, nsg, *VpcProtoNetworkSecurityGroupID(proto))
-	})
-
-	t.Run("allocated VNI reads status.vni", func(t *testing.T) {
-		statusVni := uint32(100)
-		proto := &corev1.Vpc{Status: &corev1.VpcStatus{Vni: &statusVni}}
-		got := VpcProtoAllocatedVNI(proto)
-		require.NotNil(t, got)
-		assert.Equal(t, 100, *got)
-	})
-
-	t.Run("allocated VNI is nil when status is absent (deprecated_vni ignored)", func(t *testing.T) {
-		deprecatedVni := uint32(200)
-		proto := &corev1.Vpc{DeprecatedVni: &deprecatedVni}
-		assert.Nil(t, VpcProtoAllocatedVNI(proto))
-	})
-
-	t.Run("nil proto yields nil", func(t *testing.T) {
-		assert.Nil(t, VpcProtoAllocatedVNI(nil))
-		assert.Nil(t, VpcProtoNetworkVirtualizationType(nil))
-		assert.Nil(t, VpcProtoRoutingProfile(nil))
-		assert.Nil(t, VpcProtoNetworkSecurityGroupID(nil))
-	})
-
-	t.Run("config absent yields nil (deprecated flat fields ignored)", func(t *testing.T) {
-		proto := &corev1.Vpc{
-			NetworkVirtualizationType: &fnnEnum,
-			RoutingProfileType:        &routingProfile,
-			NetworkSecurityGroupId:    &nsg,
-		}
-		assert.Nil(t, VpcProtoNetworkVirtualizationType(proto))
-		assert.Nil(t, VpcProtoRoutingProfile(proto))
-		assert.Nil(t, VpcProtoNetworkSecurityGroupID(proto))
-	})
-}
-
 // TestVpc_ToProtoFromProto_RoundTrip verifies the entity survives a
 // ToProto -> FromProto round trip. ID round-trips cleanly only when
 // ControllerVpcID is unset (ToProto sources proto.Id from GetSiteID).
@@ -1875,52 +1850,4 @@ func TestVpc_ToProtoFromProto_RoundTrip(t *testing.T) {
 	assert.Equal(t, orig.Vni, got.Vni)
 	assert.Equal(t, orig.ActiveVni, got.ActiveVni)
 	assert.Equal(t, orig.NVLinkLogicalPartitionID, got.NVLinkLogicalPartitionID)
-}
-
-// TestVpcVirtualizationTypeConversions exercises both directions of the
-// VPC virtualization-type mapping, including the documented default
-// (unrecognized string -> ETHERNET_VIRTUALIZER) and nil handling.
-func TestVpcVirtualizationTypeConversions(t *testing.T) {
-	t.Run("string to proto", func(t *testing.T) {
-		cases := []struct {
-			name string
-			in   *string
-			want *corev1.VpcVirtualizationType
-		}{
-			{"nil yields nil", nil, nil},
-			{"FNN", cutil.GetPtr(VpcFNN), cutil.GetPtr(corev1.VpcVirtualizationType_FNN)},
-			{"FLAT", cutil.GetPtr(VpcFlat), cutil.GetPtr(corev1.VpcVirtualizationType_FLAT)},
-			{"ETHERNET_VIRTUALIZER", cutil.GetPtr(VpcEthernetVirtualizer), cutil.GetPtr(corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER)},
-			{"unrecognized defaults to ETHERNET_VIRTUALIZER", cutil.GetPtr("bogus"), cutil.GetPtr(corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER)},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				got := vpcStringToProtoVirtualizationType(tc.in)
-				if tc.want == nil {
-					assert.Nil(t, got)
-					return
-				}
-				require.NotNil(t, got)
-				assert.Equal(t, *tc.want, *got)
-			})
-		}
-	})
-
-	t.Run("proto to string", func(t *testing.T) {
-		cases := []struct {
-			name string
-			in   corev1.VpcVirtualizationType
-			want string
-		}{
-			{"FNN", corev1.VpcVirtualizationType_FNN, VpcFNN},
-			{"FLAT", corev1.VpcVirtualizationType_FLAT, VpcFlat},
-			{"ETHERNET_VIRTUALIZER", corev1.VpcVirtualizationType_ETHERNET_VIRTUALIZER, VpcEthernetVirtualizer},
-			{"unhandled enum defaults to ETHERNET_VIRTUALIZER", corev1.VpcVirtualizationType_FNN_CLASSIC, VpcEthernetVirtualizer},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				assert.Equal(t, tc.want, vpcProtoVirtualizationTypeToString(tc.in))
-			})
-		}
-	})
 }

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -162,21 +162,21 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 		// Initialized Network virtualization type
 		var networkVirtualizationType *string
 		// If the VPC in the DB has Network Virtualization Type, but Site reported different one then update it
-		if controllerVpc.NetworkVirtualizationType != nil &&
+		reportedVirtType := cdbm.VpcProtoNetworkVirtualizationType(controllerVpc)
+		if reportedVirtType != nil &&
 			(vpc.NetworkVirtualizationType == nil || (vpc.NetworkVirtualizationType != nil &&
-				controllerVpc.NetworkVirtualizationType.String() != *vpc.NetworkVirtualizationType)) {
-			networkVirtualizationType = cwutil.GetPtr(controllerVpc.NetworkVirtualizationType.String())
+				*reportedVirtType != *vpc.NetworkVirtualizationType)) {
+			networkVirtualizationType = reportedVirtType
 		}
 
-		var controllerActiveVni *int
-		if controllerVpc.Status != nil {
-			controllerActiveVni = util.GetUint32PtrToIntPtr(controllerVpc.Status.Vni)
-		}
+		controllerActiveVni := cdbm.VpcProtoAllocatedVNI(controllerVpc)
+		reportedRoutingProfile := cdbm.VpcProtoRoutingProfile(controllerVpc)
+		reportedNSGID := cdbm.VpcProtoNetworkSecurityGroupID(controllerVpc)
 
 		needsUpdate := isMissingOnSite != nil ||
 			controllerVpcID != nil ||
 			networkVirtualizationType != nil ||
-			!util.PtrsEqual(vpc.RoutingProfile, controllerVpc.RoutingProfileType) ||
+			!util.PtrsEqual(vpc.RoutingProfile, reportedRoutingProfile) ||
 			!vpc.NetworkSecurityGroupPropagationDetails.Equal(sitePropagationStatus) ||
 			// Changing VNI isn't allowed after creation, and it should never go back to nil - that would be a bug.
 			// We should assume status _could start_ as null and then update to the active VPC VNI.
@@ -198,7 +198,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 				}
 			}
 
-			if vpc.RoutingProfile != nil && controllerVpc.RoutingProfileType == nil {
+			if vpc.RoutingProfile != nil && reportedRoutingProfile == nil {
 				vpc, err = vpcDAO.Clear(ctx, nil, cdbm.VpcClearInput{
 					VpcID:          vpc.ID,
 					RoutingProfile: true,
@@ -210,7 +210,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			}
 
 			// Save controller VPC ID
-			_, serr := vpcDAO.Update(ctx, nil, cdbm.VpcUpdateInput{VpcID: vpc.ID, NetworkSecurityGroupID: controllerVpc.NetworkSecurityGroupId, NetworkSecurityGroupPropagationDetails: sitePropagationStatus, NetworkVirtualizationType: networkVirtualizationType, RoutingProfile: controllerVpc.RoutingProfileType, ControllerVpcID: controllerVpcID, IsMissingOnSite: isMissingOnSite, ActiveVni: controllerActiveVni})
+			_, serr := vpcDAO.Update(ctx, nil, cdbm.VpcUpdateInput{VpcID: vpc.ID, NetworkSecurityGroupID: reportedNSGID, NetworkSecurityGroupPropagationDetails: sitePropagationStatus, NetworkVirtualizationType: networkVirtualizationType, RoutingProfile: reportedRoutingProfile, ControllerVpcID: controllerVpcID, IsMissingOnSite: isMissingOnSite, ActiveVni: controllerActiveVni})
 			if serr != nil {
 				slogger.Error().Err(serr).Msg("failed to update missing on Site flag/controller VPC ID in DB")
 				continue

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -163,9 +163,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 		var networkVirtualizationType *string
 		// If the VPC in the DB has Network Virtualization Type, but Site reported different one then update it
 		reportedVirtType := cdbm.VpcProtoNetworkVirtualizationType(controllerVpc)
-		if reportedVirtType != nil &&
-			(vpc.NetworkVirtualizationType == nil || (vpc.NetworkVirtualizationType != nil &&
-				*reportedVirtType != *vpc.NetworkVirtualizationType)) {
+		if reportedVirtType != nil && !util.PtrsEqual(vpc.NetworkVirtualizationType, reportedVirtType) {
 			networkVirtualizationType = reportedVirtType
 		}
 

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -159,17 +159,20 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			controllerVpcID = &ctrlID
 		}
 
+		reportedVpc := &cdbm.Vpc{}
+		reportedVpc.FromProto(controllerVpc)
+
 		// Initialized Network virtualization type
 		var networkVirtualizationType *string
 		// If the VPC in the DB has Network Virtualization Type, but Site reported different one then update it
-		reportedVirtType := cdbm.VpcProtoNetworkVirtualizationType(controllerVpc)
+		reportedVirtType := reportedVpc.NetworkVirtualizationType
 		if reportedVirtType != nil && !util.PtrsEqual(vpc.NetworkVirtualizationType, reportedVirtType) {
 			networkVirtualizationType = reportedVirtType
 		}
 
-		controllerActiveVni := cdbm.VpcProtoAllocatedVNI(controllerVpc)
-		reportedRoutingProfile := cdbm.VpcProtoRoutingProfile(controllerVpc)
-		reportedNSGID := cdbm.VpcProtoNetworkSecurityGroupID(controllerVpc)
+		controllerActiveVni := reportedVpc.ActiveVni
+		reportedRoutingProfile := reportedVpc.RoutingProfile
+		reportedNSGID := reportedVpc.NetworkSecurityGroupID
 
 		needsUpdate := isMissingOnSite != nil ||
 			controllerVpcID != nil ||

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -423,10 +423,12 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 					},
 					Vpcs: []*corev1.Vpc{
 						{
-							Id:                        &corev1.VpcId{Value: vpc1.ID.String()},
-							Name:                      vpc1.ID.String(),
-							NetworkVirtualizationType: &nwvt,
-							RoutingProfileType:        cutil.GetPtr("INTERNAL"),
+							Id:   &corev1.VpcId{Value: vpc1.ID.String()},
+							Name: vpc1.ID.String(),
+							Config: &corev1.VpcConfig{
+								NetworkVirtualizationType: &nwvt,
+								RoutingProfileType:        cutil.GetPtr("INTERNAL"),
+							},
 						},
 						{
 							Id:   &corev1.VpcId{Value: vpc2.ControllerVpcID.String()},
@@ -453,14 +455,18 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 							Name: vpc10.ID.String(),
 						},
 						{
-							Id:                        &corev1.VpcId{Value: vpc12.ControllerVpcID.String()},
-							Name:                      vpc12.ID.String(),
-							NetworkVirtualizationType: &evt,
+							Id:   &corev1.VpcId{Value: vpc12.ControllerVpcID.String()},
+							Name: vpc12.ID.String(),
+							Config: &corev1.VpcConfig{
+								NetworkVirtualizationType: &evt,
+							},
 						},
 						{
-							Id:                        &corev1.VpcId{Value: vpc13.ControllerVpcID.String()},
-							Name:                      vpc13.ID.String(),
-							NetworkVirtualizationType: &evt,
+							Id:   &corev1.VpcId{Value: vpc13.ControllerVpcID.String()},
+							Name: vpc13.ID.String(),
+							Config: &corev1.VpcConfig{
+								NetworkVirtualizationType: &evt,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Recent changes to Core (https://github.com/NVIDIA/infra-controller/pull/2613) reworked the VPC proto to better conform to convention by sending config and status information as structs rather than a bunch of flat fields. This PR transitions the REST API to use these new structured fields and ignore the now deprecated flat fields.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2793

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [ x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This work is a prerequisite for https://github.com/NVIDIA/infra-controller/issues/2794. That work to fully remove the flat fields must wait for another release (2.2). That way we don't have to risk trouble during release deployment if the Core is temporarily a minor ahead of the REST, as we know the REST API will not be relying on the flat fields.