### PR TITLE
feat(fmds): count config-ingest and phone-home outcomes

### DIFF
--- a/crates/fmds/src/grpc_server.rs
+++ b/crates/fmds/src/grpc_server.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::{DynamicLog, Event, LogAt, Outcome, emit};
 use rpc::fmds::fmds_config_service_server::FmdsConfigService;
 use rpc::fmds::{UpdateConfigRequest, UpdateConfigResponse};
 use tonic::{Request, Response, Status};
@@ -33,9 +34,57 @@ impl FmdsGrpcServer {
     }
 }
 
+/// One inbound gRPC config-update ingest ran to completion. The event owns the
+/// failure log line -- every ingest is counted, only the failures write the
+/// WARN line (the success path keeps its own "Received config update" INFO log).
+#[derive(Event)]
+#[event(
+    name = "carbide_fmds_config_updates_total",
+    component = "fmds",
+    log = dynamic,
+    metric = counter,
+    message = "Failed to ingest config update",
+    describe = "Number of FMDS gRPC config-update ingests, by outcome"
+)]
+struct ConfigUpdateIngested {
+    #[label]
+    outcome: Outcome,
+    /// The rejection's error text; empty on success (the line only renders on
+    /// failure).
+    #[context]
+    error: String,
+}
+
+impl DynamicLog for ConfigUpdateIngested {
+    fn log_at(&self) -> LogAt {
+        match self.outcome {
+            Outcome::Error => LogAt::Level(tracing::Level::WARN),
+            Outcome::Ok => LogAt::Off,
+        }
+    }
+}
+
 #[tonic::async_trait]
 impl FmdsConfigService for FmdsGrpcServer {
     async fn update_config(
+        &self,
+        request: Request<UpdateConfigRequest>,
+    ) -> Result<Response<UpdateConfigResponse>, Status> {
+        let result = self.apply_config_update(request);
+        emit(ConfigUpdateIngested {
+            outcome: Outcome::from(&result),
+            error: result
+                .as_ref()
+                .err()
+                .map(|status| status.to_string())
+                .unwrap_or_default(),
+        });
+        result
+    }
+}
+
+impl FmdsGrpcServer {
+    fn apply_config_update(
         &self,
         request: Request<UpdateConfigRequest>,
     ) -> Result<Response<UpdateConfigResponse>, Status> {

--- a/crates/fmds/src/phone_home.rs
+++ b/crates/fmds/src/phone_home.rs
@@ -17,17 +17,102 @@
 
 use std::sync::Arc;
 
+use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt, emit};
 use eyre::eyre;
 use forge_dpu_agent_utils::utils::create_forge_client;
 use rpc::forge::InstancePhoneHomeLastContactRequest;
 
 use crate::state::FmdsState;
 
+/// The terminal outcome of a phone-home operation. `RateLimited` (the outbound
+/// governor rejected the attempt) and `InstanceNotFound` (no instance for this
+/// machine yet) are the two failures the per-RPC RED instrumentation cannot
+/// see: the first never reaches an RPC, the second is a successful lookup that
+/// returned nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum PhoneHomeOutcome {
+    Ok,
+    RateLimited,
+    InstanceNotFound,
+    Error,
+}
+
+/// One phone-home operation ran to completion. The event owns the failure log
+/// line -- every attempt is counted, only the failures write the WARN line
+/// (the success path keeps its own "Successfully phoned home" INFO log).
+#[derive(Event)]
+#[event(
+    name = "carbide_fmds_phone_home_total",
+    component = "fmds",
+    log = dynamic,
+    metric = counter,
+    message = "Phone home failed",
+    describe = "Number of FMDS tenant phone-home operations, by outcome"
+)]
+struct PhoneHomeCompleted {
+    #[label]
+    outcome: PhoneHomeOutcome,
+    /// The failure's error chain; empty on success.
+    #[context]
+    error: String,
+}
+
+impl DynamicLog for PhoneHomeCompleted {
+    fn log_at(&self) -> LogAt {
+        match self.outcome {
+            PhoneHomeOutcome::Ok => LogAt::Off,
+            PhoneHomeOutcome::RateLimited
+            | PhoneHomeOutcome::InstanceNotFound
+            | PhoneHomeOutcome::Error => LogAt::Level(tracing::Level::WARN),
+        }
+    }
+}
+
+/// A phone-home failure tagged with the bounded outcome for the metric label,
+/// carrying the eyre report for the log line and the caller. Any failure that
+/// is not specifically rate-limited or instance-not-found maps to `Error`.
+struct PhoneHomeError {
+    outcome: PhoneHomeOutcome,
+    source: eyre::Error,
+}
+
+impl From<eyre::Error> for PhoneHomeError {
+    fn from(source: eyre::Error) -> Self {
+        Self {
+            outcome: PhoneHomeOutcome::Error,
+            source,
+        }
+    }
+}
+
+impl From<tonic::Status> for PhoneHomeError {
+    fn from(status: tonic::Status) -> Self {
+        Self {
+            outcome: PhoneHomeOutcome::Error,
+            source: status.into(),
+        }
+    }
+}
+
 pub async fn phone_home(state: &Arc<FmdsState>) -> Result<(), eyre::Error> {
-    match state.outbound_governor.clone().check() {
-        Ok(_) => {}
-        Err(e) => return Err(eyre!("rate limit exceeded for phone_home; {}\n", e)),
+    let result = attempt_phone_home(state).await;
+    let (outcome, error) = match &result {
+        Ok(()) => (PhoneHomeOutcome::Ok, String::new()),
+        Err(err) => (err.outcome, format!("{:#}", err.source)),
     };
+    emit(PhoneHomeCompleted { outcome, error });
+    result.map_err(|err| err.source)
+}
+
+async fn attempt_phone_home(state: &Arc<FmdsState>) -> Result<(), PhoneHomeError> {
+    state
+        .outbound_governor
+        .clone()
+        .check()
+        .map_err(|e| PhoneHomeError {
+            outcome: PhoneHomeOutcome::RateLimited,
+            source: eyre!("rate limit exceeded for phone_home; {}\n", e),
+        })?;
 
     let forge_client_config = state
         .forge_client_config
@@ -50,7 +135,10 @@ pub async fn phone_home(state: &Arc<FmdsState>) -> Result<(), eyre::Error> {
         .instances
         .first()
         .cloned()
-        .ok_or_else(|| eyre!("no instance found for machine {}", machine_id))?;
+        .ok_or_else(|| PhoneHomeError {
+            outcome: PhoneHomeOutcome::InstanceNotFound,
+            source: eyre!("no instance found for machine {}", machine_id),
+        })?;
 
     let instance_id = instance.id;
 


### PR DESCRIPTION
FMDS's two inbound entry points had no outcome signal — the gRPC `update_config` ingest and the `phone_home` handler each logged and returned, so a spike in rejected config pushes or rate-limited phone-homes was invisible to metrics. Both are server-side, so the framework's client-side RED wrapper doesn't reach them.

- `carbide_fmds_config_updates_total{outcome}` counts each `update_config` by outcome; the handler body moves into a small `apply_config_update` so the counter is emitted once.
- `carbide_fmds_phone_home_total{outcome}` counts phone-home attempts across `Ok`, `RateLimited`, `InstanceNotFound`, and `Error`, via an extracted `attempt_phone_home` returning a tagged `PhoneHomeError { outcome, source }` — mirroring the firmware download path.
- Both events are `log = dynamic`: failures log WARN, successes stay silent, and every existing log line is kept.

The outbound RPCs those handlers make are already RED-counted by codegen and are left alone. FMDS's `/metrics` is binary-local, so there is no catalogue change.

Supports #3178.
