### PR TITLE
feat(dsx-exchange-consumer): expose queue backlog and consumer lag

### DIFF
--- a/crates/dsx-exchange-consumer/src/health_updater.rs
+++ b/crates/dsx-exchange-consumer/src/health_updater.rs
@@ -30,7 +30,7 @@ use crate::ConsumerMetrics;
 use crate::api_client::{HEALTH_REPORT_SOURCE, RackHealthReportSink};
 use crate::config::CacheConfig;
 use crate::messages::{FaultValue, LeakMetadata, LeakPointType, ValueMessage};
-use crate::metrics::{MessageDeduplicated, MessageProcessed};
+use crate::metrics::{MessageAge, MessageDeduplicated, MessageProcessed};
 use crate::mqtt_consumer::MqttMessage;
 
 /// Health status updater that processes MQTT messages and updates the API.
@@ -111,6 +111,15 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
     }
 
     async fn handle_value_message(&self, topic: &str, msg: ValueMessage) {
+        // Consumer lag: how far behind the BMS event time we are when this
+        // message reaches processing. BMS-vs-consumer clock skew can make the
+        // delta negative, and `to_std()` errors on a negative duration, so
+        // clamp to zero.
+        let age = (chrono::Utc::now() - msg.timestamp)
+            .to_std()
+            .unwrap_or_default();
+        emit(MessageAge { age });
+
         let point_path = match extract_point_path(topic, &self.topic_prefix) {
             Some(path) => path,
             None => {

--- a/crates/dsx-exchange-consumer/src/lib.rs
+++ b/crates/dsx-exchange-consumer/src/lib.rs
@@ -85,10 +85,16 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
     .await
     .map_err(|e| DsxConsumerError::Secrets(e.to_string()))?;
 
-    // Connect to MQTT and get message receiver. mqttea tracks subscriptions
-    // and replays them after reconnect when the broker reports that the
-    // previous session was not resumed.
-    let rx = mqtt_consumer::connect(&config.mqtt, &meter, credential_manager.clone()).await?;
+    // Connect to MQTT and get the processing channel. mqttea tracks
+    // subscriptions and replays them after reconnect when the broker reports
+    // that the previous session was not resumed.
+    let (queue_tx, rx) =
+        mqtt_consumer::connect(&config.mqtt, &meter, credential_manager.clone()).await?;
+
+    // Expose the channel's pending depth so backpressure is visible before the
+    // drop counter starts moving. Hand the sender over by value: the gauge keeps
+    // only a weak handle, so the channel still closes when the real senders drop.
+    metrics::register_queue_pending_gauge(&meter, queue_tx);
 
     // Set up API client and create health updater
     let join_updater = if let Some(api_config) = config.carbide_api {

--- a/crates/dsx-exchange-consumer/src/metrics.rs
+++ b/crates/dsx-exchange-consumer/src/metrics.rs
@@ -23,6 +23,7 @@ use carbide_instrument::Event;
 use moka::future::Cache;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Meter};
+use tokio::sync::mpsc;
 
 pub static METRICS_PREFIX: &str = "carbide_dsx_exchange_consumer";
 
@@ -60,6 +61,37 @@ where
             observer.observe(cache.entry_count(), &[]);
         })
         .build();
+}
+
+/// Register a gauge for the number of messages queued in the processing
+/// channel, so backpressure is visible before the drop counter starts moving.
+///
+/// Takes the sender by value and keeps only a weak handle for the meter's
+/// (process) lifetime. A strong clone would pin the channel open and defeat
+/// the consumer's shutdown, which completes only when the last real sender
+/// drops and the receiver observes the close. The callback upgrades briefly to
+/// read the depth and reports nothing once the senders are gone.
+pub fn register_queue_pending_gauge<T>(meter: &Meter, tx: mpsc::Sender<T>)
+where
+    T: Send + 'static,
+{
+    let weak_tx = tx.downgrade();
+    meter
+        .u64_observable_gauge(format!("{METRICS_PREFIX}_queue_pending_messages"))
+        .with_description(
+            "Number of messages queued in the DSX exchange consumer's processing channel",
+        )
+        .with_callback(move |observer| {
+            // Upgrade only for the read; a strong handle held between scrapes
+            // would pin the channel open. Occupied slots = configured capacity
+            // minus the free slots the sender currently reports.
+            if let Some(tx) = weak_tx.upgrade() {
+                let pending = tx.max_capacity().saturating_sub(tx.capacity());
+                observer.observe(pending as u64, &[]);
+            }
+        })
+        .build();
+    // The moved-in strong sender drops here, leaving only `weak_tx`.
 }
 
 // The four message counters are `carbide-instrument` events. Each declares a
@@ -118,6 +150,24 @@ pub struct MessageDropped;
     describe = "Number of messages skipped due to deduplication"
 )]
 pub struct MessageDeduplicated;
+
+/// How far behind the BMS event time we are when a value message reaches
+/// processing: end-to-end consumer lag (MQTT transit plus time spent queued).
+///
+/// Metric-only histogram. The `_seconds` suffix declares the unit, and the
+/// framework records the `Duration` observation in seconds.
+#[derive(Event)]
+#[event(
+    name = "carbide_dsx_exchange_consumer_message_age_seconds",
+    component = "nico-dsx-exchange-consumer",
+    log = off,
+    metric = histogram,
+    describe = "Age of consumed BMS value messages at processing time (consumer lag), in seconds"
+)]
+pub struct MessageAge {
+    #[observation]
+    pub age: std::time::Duration,
+}
 
 /// Consumer metrics that remain hand-rolled OpenTelemetry counters.
 ///

--- a/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
+++ b/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
@@ -44,17 +44,18 @@ pub enum MqttMessage {
     },
 }
 
-/// Connect to MQTT and return a receiver for incoming messages.
+/// Connect to MQTT and return the processing channel's sender and receiver.
 ///
 /// Sets up the MQTT client, registers message handlers and the client's
 /// queue/publish/connection metrics on the meter, subscribes to topics,
-/// and connects. Returns a receiver that yields messages with
+/// and connects. Returns a sender handle (for the caller to observe the
+/// channel's pending depth) alongside the receiver that yields messages with
 /// drop-on-overflow.
 pub async fn connect(
     config: &MqttConfig,
     meter: &opentelemetry::metrics::Meter,
     credential_reader: Arc<dyn CredentialReader>,
-) -> Result<mpsc::Receiver<MqttMessage>, DsxConsumerError> {
+) -> Result<(mpsc::Sender<MqttMessage>, mpsc::Receiver<MqttMessage>), DsxConsumerError> {
     let (tx, rx) = mpsc::channel(config.queue_capacity);
 
     // QoS 0 is the recommended setting for DSX Exchange integrations.
@@ -109,14 +110,17 @@ pub async fn connect(
 
     // Register handler for value messages
     client
-        .on_message::<ValueMessage, _, _>(move |_client, value, topic| {
-            emit(MessageReceived);
-            let msg = MqttMessage::Value { topic, value };
-            if tx.try_send(msg).is_err() {
-                emit(MessageDropped);
-                tracing::warn!("Message queue full, dropping value message");
+        .on_message::<ValueMessage, _, _>({
+            let tx = tx.clone();
+            move |_client, value, topic| {
+                emit(MessageReceived);
+                let msg = MqttMessage::Value { topic, value };
+                if tx.try_send(msg).is_err() {
+                    emit(MessageDropped);
+                    tracing::warn!("Message queue full, dropping value message");
+                }
+                std::future::ready(())
             }
-            std::future::ready(())
         })
         .await;
 
@@ -137,7 +141,7 @@ pub async fn connect(
 
     tracing::info!("MQTT consumer connected");
 
-    Ok(rx)
+    Ok((tx, rx))
 }
 
 async fn build_credentials_provider(


### PR DESCRIPTION
The DSX exchange consumer bridges a BMS MQTT feed onto an internal channel, but its only visibility into flow was a drop counter — by the time drops appear the backlog is already saturated, and there was no signal for how far behind real time the consumer had fallen. Two metrics make the pressure and the lag observable before they turn into drops.

- `carbide_dsx_exchange_consumer_queue_pending_messages` is an observable gauge over the channel's occupancy (`max_capacity − capacity`), sampled on scrape. It's a raw OTel gauge because the framework's `Event` derive only models counters and histograms.
- `carbide_dsx_exchange_consumer_message_age_seconds` is a histogram of each value message's age at handling time, taken from the BMS-supplied event timestamp. Clock skew can make that negative, so the age is clamped to zero.

To register the gauge, `mqtt_consumer::connect` now hands back the sending half of the channel alongside the receiver. The gauge holds only a **weak** sender and `run_service` relinquishes its strong handle, so the channel still closes — and the consumer still shuts down — when the real handler senders drop. The existing connection-state gauge is untouched, and the consumer's `/metrics` is binary-local, so there is no catalogue change.

Supports #3178.
