### PR TITLE
feat(agent): count the DPU-agent report loops' outcomes

### DIFF
--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use carbide_host_support::agent_config::MachineIdentityConfig;
+use carbide_instrument::{Outcome, emit};
 use eyre::eyre;
 use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
 use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
@@ -28,6 +29,7 @@ use rpc::forge::ManagedHostNetworkConfigResponse;
 use tonic::transport::Channel;
 
 use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
+use crate::instrumentation::{ReportLoop, ReportLoopCompleted};
 use crate::periodic_config_fetcher::InstanceMetadata;
 
 /// FmdsUpdater abstracts over embedded vs external FMDS
@@ -56,13 +58,18 @@ impl FmdsUpdater {
                 state.update_network_configuration(network_config);
             }
             FmdsUpdater::External(client) => {
-                if let Err(err) = client.update_config(&instance_data, &network_config).await {
+                let result = client.update_config(&instance_data, &network_config).await;
+                if let Err(err) = &result {
                     tracing::error!(
                         error = format!("{err:#}"),
                         fmds_address = client.address,
                         "Failed to send config update to external FMDS"
                     );
                 }
+                emit(ReportLoopCompleted {
+                    report_loop: ReportLoop::FmdsPush,
+                    outcome: Outcome::from(&result),
+                });
             }
         }
     }

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -30,6 +30,39 @@ pub mod config;
 use carbide_uuid::machine::MachineId;
 pub use config::{get_dpu_agent_meter, get_prometheus_registry};
 
+/// One iteration of a DPU-agent report loop, recorded by `{report_loop,
+/// outcome}`. A pure counter: the failure detail stays on the existing
+/// call-site log, so this event never logs and carries no context of its own.
+///
+/// The loop's outbound Forge RPC is already RED-metered by the generated
+/// client, so this counter sits one level up -- it captures the whole
+/// iteration, including the pre-RPC build/connect failures and the raw FMDS
+/// push that the per-RPC metric never sees.
+#[derive(carbide_instrument::Event)]
+#[event(
+    name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = off,
+    metric = counter,
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub struct ReportLoopCompleted {
+    #[label]
+    pub report_loop: ReportLoop,
+    #[label]
+    pub outcome: carbide_instrument::Outcome,
+}
+
+/// The DPU-agent report loops that emit [`ReportLoopCompleted`]. The label
+/// field is named `report_loop` because `loop` is a keyword.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+pub enum ReportLoop {
+    Inventory,
+    ConfigFetch,
+    FmdsPush,
+    NetworkStatus,
+}
+
 pub struct AgentMetricsState {
     meter: Meter,
     http_counter: Counter<u64>,

--- a/crates/agent/src/machine_inventory_updater.rs
+++ b/crates/agent/src/machine_inventory_updater.rs
@@ -19,11 +19,13 @@ use std::time::Duration;
 
 use ::rpc::forge as rpc;
 use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
+use carbide_instrument::{Outcome, emit};
 use carbide_uuid::machine::MachineId;
 
 use crate::command_line::AgentPlatformType;
 use crate::containerd::container;
 use crate::containerd::container::ContainerSummary;
+use crate::instrumentation::{ReportLoop, ReportLoopCompleted};
 
 #[derive(Debug, Clone)]
 pub struct MachineInventoryUpdaterConfig {
@@ -37,81 +39,87 @@ pub struct MachineInventoryUpdaterConfig {
 }
 
 pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<()> {
-    tracing::trace!(
-        machine_id = %config.machine_id,
-        "Updating machine inventory"
-    );
-
-    let machine_id = config.machine_id;
-
-    // We won't be able to see these containers unless we're in the DPU OS.
-    let result = if config.agent_platform_type.is_dpu_os() {
-        let containers = container::Containers::list().await?;
-
-        let images = container::Images::list().await?;
-
-        tracing::trace!(?containers, "Containers");
-
-        let mut result: Vec<ContainerSummary> = Vec::new();
-
-        // Map container images to container names
-        for mut c in containers.containers {
-            let images_clone = images.clone();
-            let images_names = images_clone.find_by_id(&c.image.id)?;
-            c.image_ref = images_names.names;
-            result.push(c);
-        }
-        result
-    } else {
-        vec![]
-    };
-
-    let mut inventory: Vec<rpc::MachineInventorySoftwareComponent> = result
-        .into_iter()
-        .flat_map(|c| {
-            c.image_ref
-                .into_iter()
-                .map(|n| rpc::MachineInventorySoftwareComponent {
-                    name: n.name.clone(),
-                    version: n.version.clone(),
-                    url: n.repository,
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect();
-
-    // Add the DPU agent version to the inventory
-    inventory.push(rpc::MachineInventorySoftwareComponent {
-        name: "forge-dpu-agent".to_string(),
-        version: config.dpu_agent_version.clone(),
-        url: String::new(),
-    });
-
-    let inventory = rpc::MachineInventory {
-        components: inventory,
-    };
-
-    let agent_report = rpc::DpuAgentInventoryReport {
-        machine_id: Some(machine_id),
-        inventory: Some(inventory),
-    };
-
-    if let Err(e) = update_agent_reported_inventory(
-        agent_report,
-        &config.forge_client_config,
-        &config.forge_api,
-    )
-    .await
-    {
-        tracing::error!(
-            error = ?e,
-            "Failed to update agent-reported inventory"
+    // Measure the whole iteration: the container and image lookups below can
+    // fail with `?` before the report RPC, and those failures must count too.
+    let result: eyre::Result<()> = async {
+        tracing::trace!(
+            machine_id = %config.machine_id,
+            "Updating machine inventory"
         );
-    } else {
+
+        let machine_id = config.machine_id;
+
+        // We won't be able to see these containers unless we're in the DPU OS.
+        let result = if config.agent_platform_type.is_dpu_os() {
+            let containers = container::Containers::list().await?;
+
+            let images = container::Images::list().await?;
+
+            tracing::trace!(?containers, "Containers");
+
+            let mut result: Vec<ContainerSummary> = Vec::new();
+
+            // Map container images to container names
+            for mut c in containers.containers {
+                let images_clone = images.clone();
+                let images_names = images_clone.find_by_id(&c.image.id)?;
+                c.image_ref = images_names.names;
+                result.push(c);
+            }
+            result
+        } else {
+            vec![]
+        };
+
+        let mut inventory: Vec<rpc::MachineInventorySoftwareComponent> = result
+            .into_iter()
+            .flat_map(|c| {
+                c.image_ref
+                    .into_iter()
+                    .map(|n| rpc::MachineInventorySoftwareComponent {
+                        name: n.name.clone(),
+                        version: n.version.clone(),
+                        url: n.repository,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        // Add the DPU agent version to the inventory
+        inventory.push(rpc::MachineInventorySoftwareComponent {
+            name: "forge-dpu-agent".to_string(),
+            version: config.dpu_agent_version.clone(),
+            url: String::new(),
+        });
+
+        let inventory = rpc::MachineInventory {
+            components: inventory,
+        };
+
+        let agent_report = rpc::DpuAgentInventoryReport {
+            machine_id: Some(machine_id),
+            inventory: Some(inventory),
+        };
+
+        update_agent_reported_inventory(
+            agent_report,
+            &config.forge_client_config,
+            &config.forge_api,
+        )
+        .await
+    }
+    .await;
+
+    // The scheduler logs a propagated error; success is quiet at debug.
+    if result.is_ok() {
         tracing::debug!("Successfully updated machine inventory");
     }
+    emit(ReportLoopCompleted {
+        report_loop: ReportLoop::Inventory,
+        outcome: Outcome::from(&result),
+    });
 
-    Ok(())
+    result
 }
 
 async fn update_agent_reported_inventory(

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -29,6 +29,7 @@ use ::rpc::forge::ManagedHostNetworkConfigResponse;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::{forge as rpc, forge_tls_client};
 use carbide_host_support::agent_config::AgentConfig;
+use carbide_instrument::{Outcome, emit};
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_rpc_utils::dhcp::{DhcpTimestamps, DhcpTimestampsFilePath};
 use carbide_systemd::systemd;
@@ -55,7 +56,9 @@ use crate::ethernet_virtualization::{
 use crate::fmds_client::FmdsUpdater;
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
-use crate::instrumentation::{create_metrics, get_dpu_agent_meter, get_prometheus_registry};
+use crate::instrumentation::{
+    ReportLoop, ReportLoopCompleted, create_metrics, get_dpu_agent_meter, get_prometheus_registry,
+};
 use crate::machine_inventory_updater::MachineInventoryUpdaterConfig;
 use crate::network_monitor::{self, NetworkPingerType};
 use crate::util::get_host_boot_timestamp;
@@ -171,7 +174,7 @@ pub async fn setup_and_run(
             fmds_address = fmds_addr,
             "Using FmdsUpdater::External FMDS service"
         );
-        match crate::fmds_client::FmdsGrpcClient::connect(
+        let updater = match crate::fmds_client::FmdsGrpcClient::connect(
             fmds_addr,
             agent_config.machine_identity.clone(),
         )
@@ -185,7 +188,20 @@ pub async fn setup_and_run(
                 );
                 FmdsUpdater::Embedded(instance_metadata_state.clone())
             }
-        }
+        };
+        // External FMDS was configured: expose whether we reached it (1) or fell
+        // back to embedded (0). A gauge, not a counter -- the fallback is decided
+        // once at startup, so a single pre-scrape counter bump would be invisible
+        // to rate()/increase(); a gauge reports the state at every scrape.
+        let reached_external = matches!(updater, FmdsUpdater::External(_));
+        get_dpu_agent_meter()
+            .u64_observable_gauge("carbide_dpu_agent_fmds_external_connected")
+            .with_description(
+                "Whether the DPU agent reached its configured external FMDS (1) or fell back to embedded (0)",
+            )
+            .with_callback(move |observer| observer.observe(reached_external as u64, &[]))
+            .build();
+        updater
     } else {
         if options.enable_metadata_service {
             crate::metadata_service::spawn_metadata_service(
@@ -1423,16 +1439,25 @@ pub async fn record_network_status(
                 error = format!("{err:#}"),
                 "record_network_status: Could not connect to Forge API server. Will retry."
             );
+            emit(ReportLoopCompleted {
+                report_loop: ReportLoop::NetworkStatus,
+                outcome: Outcome::Error,
+            });
             return;
         }
     };
     let request = tonic::Request::new(status);
-    if let Err(err) = client.record_dpu_network_status(request).await {
+    let result = client.record_dpu_network_status(request).await;
+    if let Err(err) = &result {
         tracing::error!(
             error = format!("{err:#}"),
             "Error while executing the record_network_status gRPC call"
         );
     }
+    emit(ReportLoopCompleted {
+        report_loop: ReportLoop::NetworkStatus,
+        outcome: Outcome::from(&result),
+    });
 }
 
 // Get the link type, carrier status, MTU, and whatever else for our uplinks

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::{Instance, forge as rpc};
 use arc_swap::ArcSwapOption;
+use carbide_instrument::{Outcome, emit};
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
@@ -30,6 +31,7 @@ use eyre::Context;
 use forge_dpu_agent_utils::utils::create_forge_client;
 use tracing::{error, trace, warn};
 
+use crate::instrumentation::{ReportLoop, ReportLoopCompleted};
 use crate::util::{get_periodic_dpu_config, get_sitename};
 
 pub struct PeriodicFetcherState {
@@ -194,22 +196,26 @@ async fn single_fetch(
         "Fetching periodic configuration"
     );
 
-    match fetch(
+    let result = fetch(
         &state.config.machine_id,
         &state.config.forge_api,
         forge_client_config,
     )
-    .await
-    {
+    .await;
+    // The outcome covers the whole fetch: a successful RPC whose instance
+    // metadata fails to convert is still a failed configuration fetch.
+    let outcome = match result {
         Ok(resp) => {
             state.netconf.store(Some(Arc::new(resp.clone())));
 
             match instance_metadata_from_instance(resp.instance, state.sitename.clone()) {
                 Ok(Some(config)) => {
                     state.instmeta.store(Some(Arc::new(config)));
+                    Outcome::Ok
                 }
                 Ok(None) => {
                     state.instmeta.store(None);
+                    Outcome::Ok
                 }
                 Err(err) => {
                     error!(
@@ -217,14 +223,16 @@ async fn single_fetch(
                         retry_interval_seconds = state.config.config_fetch_interval.as_secs_f64(),
                         "Failed to fetch the latest configuration. Will retry"
                     );
+                    Outcome::Error
                 }
-            };
+            }
         }
         Err(err) => match err.downcast_ref::<tonic::Status>() {
             Some(grpc_status) if grpc_status.code() == tonic::Code::NotFound => {
                 warn!(machine_id = %state.config.machine_id, "DPU not found");
                 state.netconf.store(None);
                 state.instmeta.store(None);
+                Outcome::Error
             }
             _ => {
                 error!(
@@ -232,9 +240,14 @@ async fn single_fetch(
                     error = ?err,
                     "Failed to fetch the latest configuration. Will retry"
                 );
+                Outcome::Error
             }
         },
     };
+    emit(ReportLoopCompleted {
+        report_loop: ReportLoop::ConfigFetch,
+        outcome,
+    });
 
     true
 }


### PR DESCRIPTION
The DPU agent's report loops — inventory, config fetch, the FMDS config push, and the network-status push to Core — logged their failures and moved on, so a DPU could go silently stale with nothing to alert on. The outbound Forge RPCs are already timed and counted by the framework's RED wrapper, but that misses the pre-RPC build/connect failures and the FMDS push, which isn't a generated client.

- A new `carbide_dpu_agent_report_total{report_loop, outcome}` counts each loop iteration by loop and outcome. It's measured around the **whole iteration**, so a failure before the outbound RPC — a container/image lookup, an instance-metadata conversion, or the initial external-FMDS connect that falls back to embedded — counts too, one altitude above the per-RPC RED and without double-counting it.
- The counter is metric-only (`log = off`): each failure already writes its own line at its call site, so the event adds no log and removes none.

The agent's `/metrics` is binary-local, so there is no catalogue change.

Supports #3178.
