### PR TITLE
feat(helm-prereqs): automate DPF (DOCA Platform Framework) install in setup.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ ssh-console/legacy/ssh-console
 
 dev/mac-local-dev/carbide-api-config-*.toml
 crates/dpf/doca-platform
+helm-prereqs/.dpf-src/
+helm-prereqs/values/nico-core.yaml.dpf.bak
 
 /helm/Chart.lock
 

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -193,7 +193,7 @@ explicitly enabled in the TOML.
 | `[component_manager]` | Compute tray, NvLink switch, and power shelf management | RMS backends require rack profile data for node descriptors. |
 | `[vmaas_config]` | VM system integration / VM-aware traffic intercept | Requires `public_prefixes`. |
 | `[rms]` | Rack Manager Service (mTLS connectivity to external RMS) | |
-| `[dpf]` | DPU Platform Framework — Kubernetes DPU workload deployment | Requires the DPF operator deployed in-cluster. |
+| `[dpf]` | DPU Platform Framework — Kubernetes DPU workload deployment | Requires the DPF operator deployed in-cluster (`helm-prereqs/setup.sh` installs it by default; `--skip-dpf` to opt out). |
 | `rack_management_enabled` | Standalone infrastructure manager mode (GB200/GB300/VR144) | Top-level boolean, not a sub-section. |
 
 For RMS component-manager backends, NICo builds RMS node descriptors from rack
@@ -1415,7 +1415,7 @@ on or off.
 | RBAC bypass (dev only) | siteConfig | `bypass_rbac = true` | off | Disables RBAC; never set in production. |
 | Passive mode (debug only) | siteConfig | `listen_only = true` | off | RPC/web only, no background controllers. CI/dev shells only. |
 | TPM bypass (testing only) | siteConfig | `tpm_required = false` | required | Allows machine registration without TPM. Testing only. |
-| DPF (Kubernetes DPU workloads) | siteConfig | `[dpf].enabled` | off | Requires the DPF operator. |
+| DPF (Kubernetes DPU workloads) | siteConfig | `[dpf].enabled` | off | Requires the DPF operator (`setup.sh` installs and enables it by default; `--skip-dpf` to opt out). |
 | Loki sidecar (REST stack) | Helm (REST) | `nico-rest-*` log shipping | off | Optional; pairs with the same OTel collector pattern used by Core. |
 | Bundled dev Keycloak | Helm (REST) | `nico-rest-api.config.keycloak.enabled` | on | Disable for production — use external IdP. |
 

--- a/crates/dpf/README.md
+++ b/crates/dpf/README.md
@@ -35,10 +35,10 @@ This SDK provides a Rust interface for NICo to interact with the DPF operator. I
 
 ## API harness CLI
 
-The `nico-dpf-api-harness` binary exercises the DPF SDK (same surface as NICo API) against a real DPF operator for integration testing. Build with the `driver` feature:
+The `carbide-dpf-api-harness` binary exercises the DPF SDK (same surface as NICo API) against a real DPF operator for integration testing. Build with the `driver` feature:
 
 ```bash
-cargo build -p nico-dpf --features driver --bin nico-dpf-api-harness
+cargo build -p carbide-dpf --features driver --bin carbide-dpf-api-harness
 ```
 
 **Main flows:**
@@ -46,23 +46,23 @@ cargo build -p nico-dpf --features driver --bin nico-dpf-api-harness
 ```bash
 # Full provisioning flow. --dpus is device_name:dpu_bmc_ip:serial (comma-separated for multiple).
 # Optional: --services-file <PATH> for service definitions JSON.
-nico-dpf-api-harness provision --bfb-url <URL> --bmc-password <PWD> --host-bmc-ip <IP> --dpus device1:10.0.0.1:SN001
+carbide-dpf-api-harness provision --bfb-url <URL> --bmc-password <PWD> --host-bmc-ip <IP> --dpus device1:10.0.0.1:SN001
 
 # Reprovision a single DPU: delete DPU CR, watch for new DPU (creation time after delete), then same monitor flow.
 # Node name is dpu-node-<device_name>. Use --timeout for wait/monitor (default varies).
-nico-dpf-api-harness reprovision --host-bmc-ip <IP> --device-name <NAME> --timeout 600
+carbide-dpf-api-harness reprovision --host-bmc-ip <IP> --device-name <NAME> --timeout 600
 
 # Clean up all DPF resources for a host (node derived from first device name)
-nico-dpf-api-harness cleanup --host-bmc-ip <IP> --dpu-device-names name1,name2
+carbide-dpf-api-harness cleanup --host-bmc-ip <IP> --dpu-device-names name1,name2
 
 # Show current DPF resource state (optional: --host-bmc-ip to filter)
-nico-dpf-api-harness status
+carbide-dpf-api-harness status
 
 # Stream DPF events
-nico-dpf-api-harness watch
+carbide-dpf-api-harness watch
 ```
 
-Other subcommands: `get-phase`, `force-delete-dpu`, `force-delete-node`, `delete-device`, `delete-node`, `is-reboot-required`, `clear-reboot`, `release-hold`, `update-bfb`. Run `nico-dpf-api-harness --help` for the full list and options.
+Other subcommands: `get-phase`, `force-delete-dpu`, `force-delete-node`, `delete-device`, `delete-node`, `is-reboot-required`, `clear-reboot`, `release-hold`, `update-bfb`. Run `carbide-dpf-api-harness --help` for the full list and options.
 
 ## Regenerating CRDs
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -89,12 +89,15 @@ export NICO_REST_IMAGE_TAG=<nico-rest-image-tag>         # e.g. v2.0.0
 # export REGISTRY_PULL_USERNAME='$oauthtoken'            # default for NGC API-key auth
 # export REGISTRY_PULL_SECRET=<pull-secret-or-api-key>   # registry password or API key
 
-# DPF DPU provisioning is installed by default. Set these three, or pass
+# DPF DPU provisioning is installed by default. Set these two, or pass
 # --skip-dpf to setup.sh (sites with no DPUs / still on iPXE):
 export NICO_DPF_DPU_INTERFACE=<control-plane-nic>     # NIC facing the DPUs
 export NICO_DPF_DPU_CLUSTER_VIP=<free-routable-ip>    # DPU cluster control-plane VIP
-# Prompt for the BMC password so it isn't recorded in shell history:
-read -r -s -p "Site-wide BMC root password: " NICO_DPF_BMC_ROOT_PASSWORD; echo
+# Optional: if provided, setup.sh seeds the site-wide BMC root credential
+# automatically during phase 6b so DPU provisioning starts immediately.
+# If omitted, set it after deploy via nico-admin-cli (carbide-api picks it
+# up within 60 s). Prompt to keep it out of shell history:
+read -r -s -p "Site-wide BMC root password (leave blank to set later): " NICO_DPF_BMC_ROOT_PASSWORD; echo
 export NICO_DPF_BMC_ROOT_PASSWORD
 ```
 
@@ -110,7 +113,8 @@ For authenticated NGC pulls, obtain an API key at [ngc.nvidia.com](https://ngc.n
 | `NICO_CORE_IMAGE_TAG` | Unless `--skip-core` | NICo Core image tag (e.g. `v2.0.0`). |
 | `NICO_REST_IMAGE_TAG` | Unless `--skip-rest` | NICo REST image tag (e.g. `v2.0.0`). |
 | `KUBECONFIG` | No | Path to the target cluster kubeconfig. Omit when the current `kubectl` context is already correct. |
-| `NICO_DPF_DPU_INTERFACE`, `NICO_DPF_DPU_CLUSTER_VIP`, `NICO_DPF_BMC_ROOT_PASSWORD` | **Yes**, unless `--skip-dpf` | DPF DPU provisioning (default-on): the control-plane NIC facing the DPUs, a free DPU-routable VIP for the DPU cluster control plane, and the site-wide BMC root password. See [helm-prereqs → DPF](https://github.com/NVIDIA/infra-controller/blob/main/helm-prereqs/README.md#dpf). |
+| `NICO_DPF_DPU_INTERFACE`, `NICO_DPF_DPU_CLUSTER_VIP` | **Yes**, unless `--skip-dpf` | DPF DPU provisioning (default-on): the control-plane NIC facing the DPUs and a free DPU-routable VIP for the DPU cluster control plane. See [helm-prereqs → DPF](https://github.com/NVIDIA/infra-controller/blob/main/helm-prereqs/README.md#dpf). |
+| `NICO_DPF_BMC_ROOT_PASSWORD` | No | Site-wide BMC root password. When provided, setup.sh seeds the credential via nico-admin-cli in phase 6b so DPU provisioning starts immediately. When omitted, carbide-api starts without it (the startup read is best-effort) and the credential can be set at any time via `nico-admin-cli credential add-bmc --kind=site-wide-root`; carbide-api picks it up within 60 s. |
 | `NICO_SITE_UUID` | No | Stable UUID for this site. If unset, `setup.sh` tries to reuse the UUID from a prior install (site-agent ConfigMap). If that fails, it adopts an existing REST site with the same name, or mints a UUID and seeds the site record itself. |
 
 ### 3b. Set your Site Name

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -88,9 +88,17 @@ export NICO_REST_IMAGE_TAG=<nico-rest-image-tag>         # e.g. v2.0.0
 # Optional for authenticated registries:
 # export REGISTRY_PULL_USERNAME='$oauthtoken'            # default for NGC API-key auth
 # export REGISTRY_PULL_SECRET=<pull-secret-or-api-key>   # registry password or API key
+
+# DPF DPU provisioning is installed by default. Set these three, or pass
+# --skip-dpf to setup.sh (sites with no DPUs / still on iPXE):
+export NICO_DPF_DPU_INTERFACE=<control-plane-nic>     # NIC facing the DPUs
+export NICO_DPF_DPU_CLUSTER_VIP=<free-routable-ip>    # DPU cluster control-plane VIP
+# Prompt for the BMC password so it isn't recorded in shell history:
+read -r -s -p "Site-wide BMC root password: " NICO_DPF_BMC_ROOT_PASSWORD; echo
+export NICO_DPF_BMC_ROOT_PASSWORD
 ```
 
-`NICO_IMAGE_REGISTRY` is used for both NICo Core (`<registry>/nvmetal-carbide`) and NICo REST (`<registry>/nico-rest-*`). Push all images to this registry before running setup.
+`NICO_IMAGE_REGISTRY` is used for both NICo Core (`<registry>/nvmetal-carbide`) and NICo REST (`<registry>/nico-rest-*`). Push all images to this registry before running setup. DPF operator/DOCA images pull anonymously from public NGC by default; to mirror or self-build them into your registry, see [helm-prereqs → DPF images and registries](https://github.com/NVIDIA/infra-controller/blob/main/helm-prereqs/README.md#dpf-images-and-registries).
 
 For authenticated NGC pulls, obtain an API key at [ngc.nvidia.com](https://ngc.nvidia.com) → **API Keys** → **Generate Personal Key**. You do not need to set `REGISTRY_PULL_SECRET` when images are public, preloaded, or an existing pull secret is configured in the values files.
 
@@ -102,6 +110,7 @@ For authenticated NGC pulls, obtain an API key at [ngc.nvidia.com](https://ngc.n
 | `NICO_CORE_IMAGE_TAG` | Unless `--skip-core` | NICo Core image tag (e.g. `v2.0.0`). |
 | `NICO_REST_IMAGE_TAG` | Unless `--skip-rest` | NICo REST image tag (e.g. `v2.0.0`). |
 | `KUBECONFIG` | No | Path to the target cluster kubeconfig. Omit when the current `kubectl` context is already correct. |
+| `NICO_DPF_DPU_INTERFACE`, `NICO_DPF_DPU_CLUSTER_VIP`, `NICO_DPF_BMC_ROOT_PASSWORD` | **Yes**, unless `--skip-dpf` | DPF DPU provisioning (default-on): the control-plane NIC facing the DPUs, a free DPU-routable VIP for the DPU cluster control plane, and the site-wide BMC root password. See [helm-prereqs → DPF](https://github.com/NVIDIA/infra-controller/blob/main/helm-prereqs/README.md#dpf). |
 | `NICO_SITE_UUID` | No | Stable UUID for this site. If unset, `setup.sh` tries to reuse the UUID from a prior install (site-agent ConfigMap). If that fails, it adopts an existing REST site with the same name, or mints a UUID and seeds the site record itself. |
 
 ### 3b. Set your Site Name
@@ -341,6 +350,7 @@ The `setup.sh` script installs all prerequisites and NICo components in sequenti
 | 3 | HashiCorp Vault (3-node HA Raft) |
 | 4 | Vault init + unseal + SSH host key |
 | 5 | external-secrets + nico-prereqs + nico-pg-cluster |
+| 5b | DPF stack for DPU provisioning (default; `--skip-dpf` to opt out) |
 | 6 | **NICo Core** (nico helm release) |
 | 7a-7g | **NICo REST** base stack (source and CA setup, PostgreSQL, Keycloak, Temporal, REST services) |
 | 7h | **NICo Flow** (Flow, PSM, and NSM), unless `--skip-flow` is used |
@@ -355,6 +365,8 @@ postgres-operator          (zalando/postgres-operator 1.10.1 - manages nico-pg-c
 cert-manager               (jetstack/cert-manager v1.17.1)
 vault                      (hashicorp/vault 0.25.0, 3-node HA Raft, TLS)
 external-secrets           (external-secrets/external-secrets 0.14.3)
+DPF stack                  (default; --skip-dpf to opt out: argo-cd, kamaji, NFD,
+                            maintenance-operator, dpf-operator — see docs/manuals/dpf.md)
 nico-prereqs               (this Helm chart - nico-system namespace)
 NICo Core                  (../helm - nico-core.yaml values)
 NICo REST                  (../helm/rest/nico-rest)
@@ -612,6 +624,12 @@ Prepare an `expected_machines.json` with the BMC MAC address, factory default cr
   ]
 }
 ```
+
+> **DPF is the per-host default.** With no `dpf_enabled` field, each host is
+> DPF-provisioned (the field defaults to `true`). Add `"dpf_enabled": false` to
+> keep a host on the deprecated iPXE path. DPF-based provisioning also requires
+> `[dpf].enabled = true` in the site config, which `setup.sh` sets by default
+> (unless `--skip-dpf`). See [DPF Setup](../manuals/dpf.md).
 
 Upload the manifest:
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -625,11 +625,9 @@ Prepare an `expected_machines.json` with the BMC MAC address, factory default cr
 }
 ```
 
-> **DPF is the per-host default.** With no `dpf_enabled` field, each host is
-> DPF-provisioned (the field defaults to `true`). Add `"dpf_enabled": false` to
-> keep a host on the deprecated iPXE path. DPF-based provisioning also requires
-> `[dpf].enabled = true` in the site config, which `setup.sh` sets by default
-> (unless `--skip-dpf`). See [DPF Setup](../manuals/dpf.md).
+<Note>
+**DPF is the per-host default.** With no `dpf_enabled` field, each host is DPF-provisioned (the field defaults to `true`). Add `"dpf_enabled": false` to keep a host on the deprecated iPXE path. DPF-based provisioning also requires `[dpf].enabled = true` in the site config, which `setup.sh` sets by default (unless `--skip-dpf`). Refer to [DPF Setup](../manuals/dpf.md).
+</Note>
 
 Upload the manifest:
 

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -37,7 +37,7 @@ The guide is organized into the following sections:
 </Note>
 ---
 
-## Automated install (default) — `setup.sh`
+## Automated install (default) with setup.sh
 
 For clusters bootstrapped with `helm-prereqs/setup.sh`, DPF installs **by
 default** — the entire DPF installation **and** carbide-api enablement below is
@@ -54,22 +54,20 @@ export NICO_DPF_METALLB_POOL=<pool>                    # optional: MetalLB pool 
 ./setup.sh                                             # DPF installs by default; add --skip-dpf to opt out
 ```
 
-What the run does, mapped to the manual sections below:
+The following table maps the sections on this page to what the run does:
 
 | Manual section | Automated by setup.sh |
-| --- | --- |
-| §1.1 namespace | Creates `dpf-operator-system`. |
-| §1.2 secrets | Creates `hbn-user-password` (generated once), `dpf-pull-secret` / `nico-pull-secret` (from `NICO_DPF_NGC_API_KEY` / `NICO_DPF_NICO_NGC_API_KEY`, defaulting to `REGISTRY_PULL_SECRET`), and the three Argo CD repository Secrets (GA repo URLs; override with `NICO_DPF_HELM_REPO_OCI/HTTPS/CARBIDE`). |
-| §1.4 cert-manager policy | Applied only when the approver-policy CRD exists. The stock helm-prereqs cert-manager does **not** run approver-policy, so this is normally skipped. |
-| prerequisites (Argo CD, Kamaji, NFD, maintenance-operator) | Installed from `helm-prereqs/helmfile.yaml` with versions/values pinned from `doca-platform deploy/helmfiles/prereqs.yaml`; cert-manager and local-path-provisioner are reused from the base install. Kamaji has a cold-start deadlock (its controller needs the `default` DataStore, whose admission webhook the controller itself serves) — setup.sh breaks it automatically. Note: upstream pins cert-manager v1.19.3 while helm-prereqs ships v1.17.1 — a known, compatible skew. |
-| §2 operator install | Clones `NVIDIA/doca-platform` at `NICO_DPF_VERSION` (default `v26.4.0`, cached under `helm-prereqs/.dpf-src/`) and installs `deploy/charts/dpf-operator`. The in-repo source chart ships an empty `controllerManager.image`, so setup.sh sets it to `nvcr.io/nvidia/doca/dpf-system:$NICO_DPF_VERSION` (override with `NICO_DPF_IMAGE_REPO`). The GA `nvidia/doca` images are **public**, so they pull anonymously by default — a registry-scoped pull secret without `nvidia/doca` entitlement makes nvcr.io 403 the pull. Set `NICO_DPF_IMAGE_PULL_SECRET` only for private DPF/DOCA registries. |
-| §3.1 RBAC | Created by the NICo Core chart (`nico-api.dpf.rbacCreate=true`, set automatically) — the Role/RoleBinding subject is the chart's actual ServiceAccount. |
-| §3.2–3.4 CRs | `DPFOperatorConfig` (API VIP/port derived from the `kubernetes` Endpoints unless `NICO_DPF_K8S_API_VIP/PORT` are set), `DPUCluster`, and the optional VIP LoadBalancer Service are applied from `helm-prereqs/operators/dpf/`. |
-| §3.5 site config + §4 enablement | **Two-phase (phase 6b).** carbide-api's DPF SDK requires the site-wide BMC root password at startup, which can only be set through a running carbide-api — so setup.sh deploys Core with `[dpf]` **off**, sets the BMC root password via `nico-admin-cli` (see below), upgrades Core to `[dpf]` **on**, then **restarts carbide-api** (the upgrade only rewrites the ConfigMap; `[dpf]` is read at startup only) so its DPF SDK initializes and creates the BFB, DPUFlavor, and DPUDeployment. |
+| -------------- | --------------------- |
+| §1.1 [Namespace](#11-create-the-dpf-operator-namespace) | Creates `dpf-operator-system`. |
+| §1.2 [Secrets](#12-image-pull-and-helm-repository-credentials) | Creates `hbn-user-password` (generated once), `dpf-pull-secret` / `nico-pull-secret` (from `NICO_DPF_NGC_API_KEY` / `NICO_DPF_NICO_NGC_API_KEY`, defaulting to `REGISTRY_PULL_SECRET`), and the three Argo CD repository Secrets (GA repo URLs; override with `NICO_DPF_HELM_REPO_OCI/HTTPS/CARBIDE`). |
+| §1.4 [Cert-manager policy](#14-cert-manager-policy-and-rbac-for-dpf) | Applied only when the approver-policy CRD exists. The stock helm-prereqs cert-manager does **not** run approver-policy, so this is normally skipped. |
+| [Prerequisites](#1-prerequisites) (Argo CD, Kamaji, NFD, maintenance-operator) | Installed from `helm-prereqs/helmfile.yaml` with versions/values pinned from `doca-platform deploy/helmfiles/prereqs.yaml`; cert-manager and local-path-provisioner are reused from the base install.<br/><br/>Kamaji has a cold-start deadlock (its controller needs the `default` DataStore, whose admission webhook the controller itself serves) — setup.sh breaks it automatically. Note: upstream pins cert-manager v1.19.3 while helm-prereqs ships v1.17.1 — a known, compatible skew. |
+| §2 [Operator install](#2-dpf-installation) | Clones `NVIDIA/doca-platform` at `NICO_DPF_VERSION` (default `v26.4.0`, cached under `helm-prereqs/.dpf-src/`) and installs `deploy/charts/dpf-operator`.<br/><br/>The in-repo source chart ships an empty `controllerManager.image`, so setup.sh sets it to `nvcr.io/nvidia/doca/dpf-system:$NICO_DPF_VERSION` (override with `NICO_DPF_IMAGE_REPO`).<br/><br/>The GA `nvidia/doca` images are **public**, so they pull anonymously by default — a registry-scoped pull secret without `nvidia/doca` entitlement makes nvcr.io 403 the pull. Set `NICO_DPF_IMAGE_PULL_SECRET` only for private DPF/DOCA registries. |
+| §3.1 [RBAC](#31-rbac-for-the-nico-orchestrator) | Created by the NICo Core chart (`nico-api.dpf.rbacCreate=true`, set automatically) — the Role/RoleBinding subject is the chart's actual ServiceAccount. |
+| §3.2–3.4 CRs  | [DPFOperatorConfig](#32-dpfoperatorconfig) (API VIP/port derived from the `kubernetes` Endpoints unless `NICO_DPF_K8S_API_VIP/PORT` are set), [DPUCluster](#33-dpucluster), and the optional [VIP LoadBalancer Service](#34-vip-loadbalancer-service-and-endpoints) are applied from `helm-prereqs/operators/dpf/`. |
+| §3.5 [Site config](#35-enable-dpf-in-the-nico-site-config) + §4 [Enablement](#4-restart-carbide-api-to-create-the-dpf-initialization-objects) | **Two-phase (phase 6b).** Carbide-api's DPF SDK requires the site-wide BMC root password at startup, which can only be set through a running carbide-api.<br/><br/>`setup.sh` deploys Core with `[dpf]` **off**, sets the BMC root password via `nico-admin-cli` (see below), upgrades Core to `[dpf]` **on**, then **restarts carbide-api**.<br/><br/>The upgrade only rewrites the ConfigMap; `[dpf]` is read at startup only. The restart ensures that the DPF SDK initializes and creates the BFB, DPUFlavor, and DPUDeployment. |
 
-Per-host enablement (§3.6) and the CLI appendix still apply unchanged. The
-sections below remain the reference for what is being installed, for manual
-installs, and for environments not using `setup.sh`.
+[Per-host enablement](#36-mark-hosts-as-dpf-managed-in-expected-machines) (§3.6) and the [CLI appendix](#appendix-nico-admin-cli-dpf-command-reference) still apply unchanged. The sections below remain the reference for what is being installed, for manual installs, and for environments not using `setup.sh`.
 
 ### BMC root precondition (why the enablement is two-phase)
 
@@ -89,11 +87,9 @@ admin client cert from the `nicoca` PKI (see
 carbide-api through its external LoadBalancer. `NICO_DPF_BMC_ROOT_PASSWORD` is
 therefore **required** unless `--skip-dpf`.
 
-> **DPU-less clusters.** The DPF operator, Kamaji `DPUCluster`, and carbide-api
-> all come up, but `DPFOperatorConfig` stays `Ready=False` until its DPU-side
-> services (multus, flannel, sriov-device-plugin, ovs-cni, sfc-controller, …)
-> schedule — which needs actual DPU nodes. On a cluster with no BlueField
-> hardware this is expected, not an error.
+<Info title="Clusters without DPUs">
+The DPF operator, Kamaji `DPUCluster`, and carbide-api all come up, but `DPFOperatorConfig` stays `Ready=False` until its DPU-side services (multus, flannel, sriov-device-plugin, ovs-cni, sfc-controller, and so on) schedule — which needs actual DPU nodes. On a cluster with no BlueField hardware this is expected, not an error.
+</Info>
 
 ---
 
@@ -174,11 +170,9 @@ kubectl -n dpf-operator-system label secret nico-pull-secret \
 DPF pulls several Helm charts via Argo CD. Apply the following Secrets so that
 Argo CD can authenticate to the NGC Helm repositories:
 
-> **Note**: the Secrets must live in the namespace where Argo CD is installed,
-> and `overrides.argoCDNamespace` in the `DPFOperatorConfig` (§3.2) must match.
-> The examples below use `argocd`; `setup.sh` (DPF default) installs Argo CD
-> into `dpf-operator-system` (same as upstream's prereqs helmfile) and creates
-> these Secrets there.
+<Note>
+Secrets must live in the namespace where Argo CD is installed, and `overrides.argoCDNamespace` in the [DPFOperatorConfig](#32-dpfoperatorconfig) must match. The examples below use `argocd`; `setup.sh` (DPF default) installs Argo CD into `dpf-operator-system` (same as upstream's prereqs helmfile) and creates these Secrets there.
+</Note>
 
 ```yaml
 ---
@@ -411,13 +405,12 @@ resources in `dpf-operator-system`. This is a **namespaced Role +
 RoleBinding** scoped to `dpf-operator-system` — cluster-admin is *not*
 required.
 
-> **Note**: On chart-based deployments this Role/RoleBinding is created by the
-> NICo Core chart itself (`nico-api.dpf.rbacCreate=true`, set automatically by
-> `setup.sh`, DPF default), with the subject bound to the chart's actual
-> ServiceAccount (`nico-api` in `nico-system` by default). Apply the manifest
-> below only on deployments that do not use the chart — and adjust the
-> RoleBinding subject to your deployment's ServiceAccount name and namespace
-> (e.g. `carbide-api` / `forge-system` on legacy carbide-named deployments).
+<Note>
+On chart-based deployments, this Role/RoleBinding is created by the
+NICo Core chart itself (`nico-api.dpf.rbacCreate=true`, set automatically by `setup.sh`, and the DPF default), with the subject bound to the chart's actual ServiceAccount (`nico-api` in `nico-system` by default).
+
+Apply the manifest below only on deployments that do not use the chart, and adjust the RoleBinding subject to your deployment's ServiceAccount name and namespace (for example, `carbide-api` / `forge-system` on legacy carbide-named deployments).
+</Note>
 
 ```yaml
 ---
@@ -977,9 +970,7 @@ provisioned via DPF only when **both** of the following are true:
 1. `[dpf].enabled = true` in the site config (section 3.5), and
 2. `dpf_enabled = true` on that host's expected-machine entry.
 
-> **Per-host default is `true`.** When `dpf_enabled` is omitted, it is stored
-> as `true` — DPF is the default provisioning path (iPXE is deprecated). Set
-> `dpf_enabled = false` explicitly to keep a host on iPXE.
+**The per-host default is `true`.** When `dpf_enabled` is omitted, it is stored as `true` — DPF is the default provisioning path (iPXE is deprecated). To keep a host on iPXE, set `dpf_enabled = false`.
 
 There are several operator paths that can set this field. They are described
 below in the order an operator typically uses them.
@@ -1063,7 +1054,7 @@ nico-admin-cli expected-machine replace-all --filename em-all.json
 ```
 
 <Warning>
-This is not a merge. Any expected-machine row that is not present in the file is **deleted**. Each entry is then re-created using the same path as `add`, so any entry whose `dpf_enabled` is omitted is re-inserted with `dpf_enabled = true` (the default). Set `dpf_enabled = false` explicitly to keep a host on iPXE.
+This is **not a merge**. Any expected-machine row that is not present in the file is **deleted**. Each entry is then re-created via the same path as `add`, so any entry whose `dpf_enabled` is omitted is re-inserted with `dpf_enabled = true` (the default). Set `dpf_enabled = false` explicitly to keep a host on iPXE.
 </Warning>
 
 #### 3.7.e. Quick reference
@@ -1165,8 +1156,8 @@ nico-admin-cli dpf disable <host-machine-id>
 ```
 
 | Argument | Required | Notes |
-|---|:---:|---|
-| `<host-machine-id>` | yes | Must be a **host** machine id; DPU ids are rejected. |
+| -------- | :------: | ----- |
+| `<host-machine-id>` | yes | Must be a **host** machine id; DPU IDs are rejected. |
 
 Sets `machines.dpf.enabled = false` on the host's runtime row. **Refused when
 the host was ingested via DPF** (`Used For Ingestion` is true, both
@@ -1249,7 +1240,7 @@ configured versions onto the cluster.
 ## Appendix: Building the NICo DPUService images and charts
 
 The mandatory DPUServices that carbide-api deploys through DPF
-(`carbide-dpu-agent`, `carbide-dhcp-server`, `carbide-fmds`,
+(`carbide-dpu-agent`, `carbide-dhcp-server`, `carbide-fmds`, and
 `carbide-otelcol`) are built from this repository under `bluefield/`. These are
 NICo's own images and belong in the **same registry you push Core/REST to** —
 build and push them there, then point `[dpf.services.*]` at them.
@@ -1269,20 +1260,20 @@ cargo make helm-package-all
 # then docker push / helm push each to <your-registry>
 ```
 
-The chart sources live in `bluefield/charts/` (`nico-dpu-agent`,
-`nico-dhcp-server`, `nico-fmds`, `nico-otelcol`); each `values.yaml` starts
+The chart sources are in `bluefield/charts/` (`nico-dpu-agent`,
+`nico-dhcp-server`, `nico-fmds`, `nico-otelcol`); each values file starts
 with the `### DPF contract ###` block that DPF/carbide-api populates at
 deploy time. Point carbide-api at your pushed images/charts via the
-`[dpf.services.<svc>]` blocks (§3.5): `helm_repo_url`, `helm_chart`,
+`[dpf.services.<svc>]` blocks ([refer to section 3.5](#35-enable-dpf-in-the-nico-site-config)): `helm_repo_url`, `helm_chart`,
 `helm_version`, `docker_repo_url`, `docker_image_tag`, and
 `docker_image_pull_secret = "nico-pull-secret"`. Unset services fall back to
 the built-in defaults (public NGC for `dts`/`doca_hbn`; private `carbide-dev`,
 needs `nico-pull-secret`, for the NICo DPUService images).
 
-The DTS (`doca-telemetry`) and `doca-hbn` services, and the DPF operator +
+The DTS (`doca-telemetry`) and `doca-hbn` services, and the DPF operator and
 operand images, are NVIDIA-published on NGC and **pull anonymously by default**
 — no build or registry needed. To mirror them into your own registry (air-gapped
-or one-registry setups), see
+or one-registry setups), refer to
 [helm-prereqs → DPF images and registries](https://github.com/NVIDIA/infra-controller/blob/main/helm-prereqs/README.md#dpf-images-and-registries)
 (`NICO_DPF_IMAGE_REPO`/`_TAG`/`_PULL_SECRET` for the operator image;
 `NICO_DPF_HELM_REPO_*` for the operand/service charts).

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -1150,8 +1150,8 @@ nico-admin-cli dpf enable <host-machine-id>
 ```
 
 | Argument | Required | Notes |
-|---|:---:|---|
-| `<host-machine-id>` | yes | Must be a **host** machine id; DPU ids are rejected. |
+| -------- | :------: | ----- |
+| `<host-machine-id>` | yes | Must be a **host** machine id; DPU IDs are rejected. |
 
 Sets `machines.dpf.enabled = true` on the given host's runtime row by calling
 the `ModifyDPFState` RPC.

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -51,6 +51,13 @@ export NICO_DPF_DPU_INTERFACE=<controller-interface>   # keepalived interface fo
 export NICO_DPF_DPU_CLUSTER_VIP=<vip>                  # VIP the DPUs use to reach their control plane
 export NICO_DPF_BMC_ROOT_PASSWORD=<bmc-password>       # site-wide BMC root (see "BMC root precondition")
 export NICO_DPF_METALLB_POOL=<pool>                    # optional: MetalLB pool advertising the VIP
+# Optional: pin NICo-owned DPF service chart versions when testing a dev/PR
+# image whose baked-in version was never published to the chart registry.
+# Point at the latest published version (e.g. most recent main build tag).
+# export NICO_DPF_DPU_AGENT_CHART_VERSION=<published-version>
+# export NICO_DPF_FMDS_CHART_VERSION=<published-version>
+# export NICO_DPF_DHCP_SERVER_CHART_VERSION=<published-version>
+# export NICO_DPF_OTEL_CHART_VERSION=<published-version>
 ./setup.sh                                             # DPF installs by default; add --skip-dpf to opt out
 ```
 

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -37,6 +37,66 @@ The guide is organized into the following sections:
 </Note>
 ---
 
+## Automated install (default) — `setup.sh`
+
+For clusters bootstrapped with `helm-prereqs/setup.sh`, DPF installs **by
+default** — the entire DPF installation **and** carbide-api enablement below is
+automated end-to-end. The DPF operator stack installs as **phase 5b** (before
+NICo Core); carbide-api DPF enablement happens as **phase 6b** (after Core).
+Pass `--skip-dpf` (or `NICO_SKIP_DPF=true`) to opt out — e.g. sites with no
+DPUs, or that still use the deprecated iPXE DPU path.
+
+```bash
+export NICO_DPF_DPU_INTERFACE=<controller-interface>   # keepalived interface for the DPU cluster VIP
+export NICO_DPF_DPU_CLUSTER_VIP=<vip>                  # VIP the DPUs use to reach their control plane
+export NICO_DPF_BMC_ROOT_PASSWORD=<bmc-password>       # site-wide BMC root (see "BMC root precondition")
+export NICO_DPF_METALLB_POOL=<pool>                    # optional: MetalLB pool advertising the VIP
+./setup.sh                                             # DPF installs by default; add --skip-dpf to opt out
+```
+
+What the run does, mapped to the manual sections below:
+
+| Manual section | Automated by setup.sh |
+| --- | --- |
+| §1.1 namespace | Creates `dpf-operator-system`. |
+| §1.2 secrets | Creates `hbn-user-password` (generated once), `dpf-pull-secret` / `nico-pull-secret` (from `NICO_DPF_NGC_API_KEY` / `NICO_DPF_NICO_NGC_API_KEY`, defaulting to `REGISTRY_PULL_SECRET`), and the three Argo CD repository Secrets (GA repo URLs; override with `NICO_DPF_HELM_REPO_OCI/HTTPS/CARBIDE`). |
+| §1.4 cert-manager policy | Applied only when the approver-policy CRD exists. The stock helm-prereqs cert-manager does **not** run approver-policy, so this is normally skipped. |
+| prerequisites (Argo CD, Kamaji, NFD, maintenance-operator) | Installed from `helm-prereqs/helmfile.yaml` with versions/values pinned from `doca-platform deploy/helmfiles/prereqs.yaml`; cert-manager and local-path-provisioner are reused from the base install. Kamaji has a cold-start deadlock (its controller needs the `default` DataStore, whose admission webhook the controller itself serves) — setup.sh breaks it automatically. Note: upstream pins cert-manager v1.19.3 while helm-prereqs ships v1.17.1 — a known, compatible skew. |
+| §2 operator install | Clones `NVIDIA/doca-platform` at `NICO_DPF_VERSION` (default `v26.4.0`, cached under `helm-prereqs/.dpf-src/`) and installs `deploy/charts/dpf-operator`. The in-repo source chart ships an empty `controllerManager.image`, so setup.sh sets it to `nvcr.io/nvidia/doca/dpf-system:$NICO_DPF_VERSION` (override with `NICO_DPF_IMAGE_REPO`). The GA `nvidia/doca` images are **public**, so they pull anonymously by default — a registry-scoped pull secret without `nvidia/doca` entitlement makes nvcr.io 403 the pull. Set `NICO_DPF_IMAGE_PULL_SECRET` only for private DPF/DOCA registries. |
+| §3.1 RBAC | Created by the NICo Core chart (`nico-api.dpf.rbacCreate=true`, set automatically) — the Role/RoleBinding subject is the chart's actual ServiceAccount. |
+| §3.2–3.4 CRs | `DPFOperatorConfig` (API VIP/port derived from the `kubernetes` Endpoints unless `NICO_DPF_K8S_API_VIP/PORT` are set), `DPUCluster`, and the optional VIP LoadBalancer Service are applied from `helm-prereqs/operators/dpf/`. |
+| §3.5 site config + §4 enablement | **Two-phase (phase 6b).** carbide-api's DPF SDK requires the site-wide BMC root password at startup, which can only be set through a running carbide-api — so setup.sh deploys Core with `[dpf]` **off**, sets the BMC root password via `nico-admin-cli` (see below), upgrades Core to `[dpf]` **on**, then **restarts carbide-api** (the upgrade only rewrites the ConfigMap; `[dpf]` is read at startup only) so its DPF SDK initializes and creates the BFB, DPUFlavor, and DPUDeployment. |
+
+Per-host enablement (§3.6) and the CLI appendix still apply unchanged. The
+sections below remain the reference for what is being installed, for manual
+installs, and for environments not using `setup.sh`.
+
+### BMC root precondition (why the enablement is two-phase)
+
+carbide-api's DPF SDK init **hard-requires** the site-wide BMC root credential
+(the shared BMC password DPF uses to reach the DPUs' host BMCs over Redfish). If
+it is not set, carbide-api fails to start with
+`Failed to initialize DPF SDK: ... Site wide BMC root credentials not set`.
+That credential can only be set through a **running** carbide-api (the
+`SetBmcRootPassword` RPC / `nico-admin-cli credential add-bmc`), so DPF cannot be
+enabled on the very first Core deploy — hence the two-phase flow.
+
+setup.sh handles this automatically (DPF is the default): it issues a short-lived
+admin client cert from the `nicoca` PKI (see
+[ingesting-hosts.md](../provisioning/ingesting-hosts.md)) and runs
+`nico-admin-cli credential add-bmc --kind=site-wide-root` from an in-cluster Job
+(the CLI ships in the NICo image at `/opt/carbide/nico-admin-cli`), reaching
+carbide-api through its external LoadBalancer. `NICO_DPF_BMC_ROOT_PASSWORD` is
+therefore **required** unless `--skip-dpf`.
+
+> **DPU-less clusters.** The DPF operator, Kamaji `DPUCluster`, and carbide-api
+> all come up, but `DPFOperatorConfig` stays `Ready=False` until its DPU-side
+> services (multus, flannel, sriov-device-plugin, ovs-cni, sfc-controller, …)
+> schedule — which needs actual DPU nodes. On a cluster with no BlueField
+> hardware this is expected, not an error.
+
+---
+
 ## 1. Prerequisites
 
 The official DPF guide lists a set of [cluster-level prerequisites](https://docs.nvidia.com/networking/display/dpf25101/helm-prerequisites) (Argo CD, cert-manager, Kamaji etc.). Follow that guide for those components.
@@ -114,6 +174,12 @@ kubectl -n dpf-operator-system label secret nico-pull-secret \
 DPF pulls several Helm charts via Argo CD. Apply the following Secrets so that
 Argo CD can authenticate to the NGC Helm repositories:
 
+> **Note**: the Secrets must live in the namespace where Argo CD is installed,
+> and `overrides.argoCDNamespace` in the `DPFOperatorConfig` (§3.2) must match.
+> The examples below use `argocd`; `setup.sh` (DPF default) installs Argo CD
+> into `dpf-operator-system` (same as upstream's prereqs helmfile) and creates
+> these Secrets there.
+
 ```yaml
 ---
 apiVersion: v1
@@ -170,11 +236,19 @@ how Argo CD discovers Helm repositories.
 
 Important: the `url` field must not end with a `/`, as any difference in the `url` (including an extra slash) will prevent Argo CD from matching the repository to the correct Secret.
 
-| Secret name | Repo URL | Type | Used by |
+The URLs below show the **staging** repos. `setup.sh` instead defaults to the
+**GA public** DOCA repos (`nvcr.io/nvidia/doca`,
+`https://helm.ngc.nvidia.com/nvidia/doca`) and the private carbide-dev repo, and
+lets you override them with `NICO_DPF_HELM_REPO_OCI` / `_HTTPS` / `_CARBIDE`.
+Whichever you use, each Secret's `url` must **exactly** match the `helm_repo_url`
+that carbide-api requests for that service (its `[dpf.services.*]` config, §3.5),
+or Argo CD cannot match the repository and the pull fails.
+
+| Secret name | Repo URL (staging example) | Type | Used by |
 | --- | --- | --- | --- |
 | `ngc-doca-oci-helm` | `nvcr.io/nvstaging/doca` | OCI helm | DPF operator chart pulls |
-| `ngc-doca-https-helm` | `https://helm.ngc.nvidia.com/nvstaging/doca` | HTTPS helm | Some DPUService charts |
-| `ngc-carbide-https-helm` | `https://helm.ngc.nvidia.com/0837451325059433/carbide-dev` | HTTPS helm | Carbide-private DPUService charts |
+| `ngc-doca-https-helm` | `https://helm.ngc.nvidia.com/nvstaging/doca` | HTTPS helm | DTS / DOCA-HBN DPUService charts |
+| `ngc-carbide-https-helm` | `https://helm.ngc.nvidia.com/0837451325059433/carbide-dev` | HTTPS helm | Carbide-private NICo DPUService charts |
 
 ### 1.3. Internet access for DPUs
 
@@ -292,21 +366,33 @@ for a NICo-integrated deployment. The example command below illustrates how to
 set them:
 
 ```bash
-REGISTRY="oci://path/to/doca"
-TAG="v26.4.0-rc.3"
+# From the NGC helm repository:
+REGISTRY="https://helm.ngc.nvidia.com/nvidia/doca"
+TAG="v26.4.0"
+helm repo add --force-update dpf-repository $REGISTRY
+helm repo update
 helm upgrade --install -n dpf-operator-system \
   --set "enableNodeFeatureRules=false" \
-  --set "imagePullSecrets[0].name=dpf-pull-secret" \
-  dpf-operator $REGISTRY/dpf-operator --version=$TAG
+  dpf-operator dpf-repository/dpf-operator --version=$TAG
+
+# Or from a clone of NVIDIA/doca-platform at the same tag (what
+# setup.sh does by default):
+helm upgrade --install -n dpf-operator-system \
+  --set "enableNodeFeatureRules=false" \
+  dpf-operator ./doca-platform/deploy/charts/dpf-operator
 ```
+
+The public `nvcr.io/nvidia/doca` operator image pulls anonymously, so no pull
+secret is set by default (matching `setup.sh`). Add
+`--set "imagePullSecrets[0].name=dpf-pull-secret"` **only** when pulling the
+operator image from a private registry or mirror — a registry-scoped secret
+without `nvidia/doca` entitlement turns a working public pull into a 403.
 
 NICo-specific notes on the parameters:
 
 - `enableNodeFeatureRules=false` — the chart's bundled `NodeFeatureRule`
   resources are disabled because nodes are labeled via NFD's own configuration
   (relying on PCI class `0200`).
-- `imagePullSecrets[0].name=dpf-pull-secret` — ties the operator's pods to the
-  pull Secret created in step 1.2.b so that staging images can be pulled.
 
 Adjust `REGISTRY` and `TAG` to the version of DPF you are deploying.
 
@@ -318,12 +404,20 @@ Once the DPF operator is running, the following objects must be applied
 **before NICo is started**. They configure the DPF operator for NICo's
 provisioning model and grant the orchestrator the access it needs.
 
-### 3.1. Cluster-wide RBAC for the NICo orchestrator
+### 3.1. RBAC for the NICo orchestrator
 
-The NICo orchestrator (the `carbide-api` ServiceAccount in NICo's default
-deployment) needs to read and write across namespaces, including
-`dpf-operator-system` and the per-DPU namespaces. Grant it `cluster-admin` via
-a `ClusterRoleBinding`:
+The NICo orchestrator's ServiceAccount needs access to the DPF custom
+resources in `dpf-operator-system`. This is a **namespaced Role +
+RoleBinding** scoped to `dpf-operator-system` — cluster-admin is *not*
+required.
+
+> **Note**: On chart-based deployments this Role/RoleBinding is created by the
+> NICo Core chart itself (`nico-api.dpf.rbacCreate=true`, set automatically by
+> `setup.sh`, DPF default), with the subject bound to the chart's actual
+> ServiceAccount (`nico-api` in `nico-system` by default). Apply the manifest
+> below only on deployments that do not use the chart — and adjust the
+> RoleBinding subject to your deployment's ServiceAccount name and namespace
+> (e.g. `carbide-api` / `forge-system` on legacy carbide-named deployments).
 
 ```yaml
 ---
@@ -335,6 +429,9 @@ metadata:
 rules:
   - apiGroups: ["provisioning.dpu.nvidia.com"]
     resources: ["bfbs"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["bluefieldsoftwares"]
     verbs: ["get", "list", "create", "patch", "delete"]
   - apiGroups: ["provisioning.dpu.nvidia.com"]
     resources: ["dpus"]
@@ -384,8 +481,11 @@ roleRef:
   name: nico-api-dpf
 subjects:
   - kind: ServiceAccount
-    name: carbide-api
-    namespace: forge-system
+    # Adjust to your deployment's API ServiceAccount. Chart-based deployments
+    # use nico-api/nico-system (and the chart creates this binding itself);
+    # legacy carbide-named deployments use carbide-api/forge-system.
+    name: nico-api
+    namespace: nico-system
 ```
 
 ### 3.2. `DPFOperatorConfig`
@@ -871,11 +971,15 @@ for the backup and recovery requirements.
 
 Whether a given host is provisioned via DPF or via iPXE is decided per host,
 in the *expected machines* list that NICo loads on startup. The relevant
-field is **`is_dpf_enabled`** on each expected-machine entry. A host is
+field is **`dpf_enabled`** on each expected-machine entry. A host is
 provisioned via DPF only when **both** of the following are true:
 
 1. `[dpf].enabled = true` in the site config (section 3.5), and
-2. `is_dpf_enabled = true` on that host's expected-machine entry.
+2. `dpf_enabled = true` on that host's expected-machine entry.
+
+> **Per-host default is `true`.** When `dpf_enabled` is omitted, it is stored
+> as `true` — DPF is the default provisioning path (iPXE is deprecated). Set
+> `dpf_enabled = false` explicitly to keep a host on iPXE.
 
 There are several operator paths that can set this field. They are described
 below in the order an operator typically uses them.
@@ -883,7 +987,7 @@ below in the order an operator typically uses them.
 #### 3.7.a. `nico-admin-cli expected-machine add` — create a new entry
 
 Adds a new expected-machine row. `--dpf-enabled` is optional; **omitting it
-stores `true`**.
+stores `true`** (DPF is the default).
 
 ```bash
 nico-admin-cli expected-machine add \
@@ -959,7 +1063,7 @@ nico-admin-cli expected-machine replace-all --filename em-all.json
 ```
 
 <Warning>
-This is not a merge. Any expected-machine row that is not present in the file is **deleted**. Each entry is then re-created using the same path as `add`, so any entry whose `dpf_enabled` is omitted is re-inserted with `dpf_enabled = true`.
+This is not a merge. Any expected-machine row that is not present in the file is **deleted**. Each entry is then re-created using the same path as `add`, so any entry whose `dpf_enabled` is omitted is re-inserted with `dpf_enabled = true` (the default). Set `dpf_enabled = false` explicitly to keep a host on iPXE.
 </Warning>
 
 #### 3.7.e. Quick reference
@@ -1054,6 +1158,24 @@ nico-admin-cli dpf enable <host-machine-id>
 Sets `machines.dpf.enabled = true` on the given host's runtime row by calling
 the `ModifyDPFState` RPC.
 
+### `dpf disable` — turn DPF off for a host
+
+```bash
+nico-admin-cli dpf disable <host-machine-id>
+```
+
+| Argument | Required | Notes |
+|---|:---:|---|
+| `<host-machine-id>` | yes | Must be a **host** machine id; DPU ids are rejected. |
+
+Sets `machines.dpf.enabled = false` on the host's runtime row. **Refused when
+the host was ingested via DPF** (`Used For Ingestion` is true, both
+client-side and server-side): disabling DPF on a DPF-ingested host would
+leave its DPF CRs (`DPUNode`, `DPUDevice`, `DPU`) orphaned and inconsistent.
+Force-delete the host first if you really need to move it off DPF (see
+`machine force-delete --allow-delete-with-orphaned-dpf-crds` for the
+site-disabled case).
+
 ### `dpf show` — inspect DPF state for one or all hosts
 
 ```bash
@@ -1116,7 +1238,51 @@ configured versions onto the cluster.
 | Goal | Command |
 | --- | --- |
 | Turn DPF on for an already-discovered host (transient) | `nico-admin-cli dpf enable <host-id>` |
+| Turn DPF off for a host (refused after DPF ingestion) | `nico-admin-cli dpf disable <host-id>` |
 | Show DPF state for one host | `nico-admin-cli dpf show <host-id>` |
 | List DPF state for all hosts | `nico-admin-cli dpf show` |
 | Snapshot DPF CRs for a host | `nico-admin-cli dpf snapshot <host-id>` |
 | Diff configured vs. deployed DPF service versions | `nico-admin-cli dpf service-version` |
+
+---
+
+## Appendix: Building the NICo DPUService images and charts
+
+The mandatory DPUServices that carbide-api deploys through DPF
+(`carbide-dpu-agent`, `carbide-dhcp-server`, `carbide-fmds`,
+`carbide-otelcol`) are built from this repository under `bluefield/`. These are
+NICo's own images and belong in the **same registry you push Core/REST to** —
+build and push them there, then point `[dpf.services.*]` at them.
+
+```bash
+cd bluefield
+export CARBIDE_IMAGE_REGISTRY=<your-registry>   # default nvcr.io/nvidia/carbide
+export DPU_AGENT_PKG_VERSION=<tag>              # the image/chart version
+
+# arm64 container images (forge-dpu-agent, forge-dhcp-server, carbide-fmds,
+# forge-dpu-otel-agent, otelcol-contrib)
+cargo make docker-build-all
+
+# Helm chart packages for the matching DPUService charts
+cargo make helm-package-all
+
+# then docker push / helm push each to <your-registry>
+```
+
+The chart sources live in `bluefield/charts/` (`nico-dpu-agent`,
+`nico-dhcp-server`, `nico-fmds`, `nico-otelcol`); each `values.yaml` starts
+with the `### DPF contract ###` block that DPF/carbide-api populates at
+deploy time. Point carbide-api at your pushed images/charts via the
+`[dpf.services.<svc>]` blocks (§3.5): `helm_repo_url`, `helm_chart`,
+`helm_version`, `docker_repo_url`, `docker_image_tag`, and
+`docker_image_pull_secret = "nico-pull-secret"`. Unset services fall back to
+the built-in defaults (public NGC for `dts`/`doca_hbn`; private `carbide-dev`,
+needs `nico-pull-secret`, for the NICo DPUService images).
+
+The DTS (`doca-telemetry`) and `doca-hbn` services, and the DPF operator +
+operand images, are NVIDIA-published on NGC and **pull anonymously by default**
+— no build or registry needed. To mirror them into your own registry (air-gapped
+or one-registry setups), see
+[helm-prereqs → DPF images and registries](https://github.com/NVIDIA/infra-controller/blob/main/helm-prereqs/README.md#dpf-images-and-registries)
+(`NICO_DPF_IMAGE_REPO`/`_TAG`/`_PULL_SECRET` for the operator image;
+`NICO_DPF_HELM_REPO_*` for the operand/service charts).

--- a/helm-prereqs/.helmignore
+++ b/helm-prereqs/.helmignore
@@ -1,0 +1,13 @@
+# Patterns to ignore when loading/packaging the nico-prereqs chart (chart: ".").
+# Keep non-chart artifacts out of helm — notably the DPF source clone, which
+# setup.sh --install-dpf caches at .dpf-src/ and whose large .git pack files
+# otherwise exceed helm's per-file size limit.
+.dpf-src/
+.git/
+.gitignore
+*.bak
+values/*.dpf.bak
+# Common editor/VCS noise
+*.swp
+*.tmp
+.DS_Store

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -7,9 +7,20 @@ export NICO_IMAGE_REGISTRY=<nico-image-registry>      # unless using --skip-core
 export NICO_CORE_IMAGE_TAG=<nico-core-image-tag>      # unless using --skip-core
 export NICO_REST_IMAGE_TAG=<nico-rest-image-tag>      # unless using --skip-rest
 # export REGISTRY_PULL_SECRET=<registry-pull-secret> # optional; authenticated registries only
+
+# DPF DPU provisioning installs by DEFAULT — set these three, or pass --skip-dpf:
+export NICO_DPF_DPU_INTERFACE=<control-plane-nic>     # NIC facing the DPUs
+export NICO_DPF_DPU_CLUSTER_VIP=<free-routable-ip>    # DPU cluster control-plane VIP
+export NICO_DPF_BMC_ROOT_PASSWORD=<bmc-root-password> # site-wide BMC root password
+
 ./setup.sh        # interactive - prompts before deploying Core and REST
-./setup.sh -y     # non-interactive - deploys everything
+./setup.sh -y     # non-interactive - deploys everything (DPF included)
+./setup.sh -y --skip-dpf   # ... without DPF (no DPUs, or still on iPXE)
 ```
+
+> DPF (DOCA Platform Framework) DPU provisioning is on by default; the three
+> `NICO_DPF_*` vars above are required unless you pass `--skip-dpf`. See
+> [DPF](#dpf) and [DPF images and registries](#dpf-images-and-registries).
 
 ## Documentation
 
@@ -46,6 +57,7 @@ helm-prereqs/
 │   └── metallb-config.yaml     # MetalLB IP pools, BGP peers, and advertisements
 ├── templates/                  # nico-prereqs Helm chart templates (PKI, ESO, PostgreSQL)
 ├── operators/                  # Raw manifests and operator values (local-path, MetalLB, cert-manager, Vault, ESO)
+│   └── dpf/                    # DPF manifests/templates (DPF installs by default; --skip-dpf to opt out)
 ├── keycloak/                   # Dev Keycloak deployment and token helper scripts
 └── observability/              # Optional monitoring stack (Loki, Tempo, OTEL, Prometheus, Grafana)
 ```
@@ -85,8 +97,16 @@ config it edits.
    `carbide-ntp.forge`, etc. See *DPU compatibility DNS* below.
 7. **Export the runtime env vars** (registry, image tags, optional pull
    secret) — see *Environment variables* below.
+8. **DPF (DPU provisioning) — on by default.** Unless you pass `--skip-dpf`,
+   export `NICO_DPF_DPU_INTERFACE` (the control-plane NIC facing the DPUs),
+   `NICO_DPF_DPU_CLUSTER_VIP` (a free, DPU-routable IP), and
+   `NICO_DPF_BMC_ROOT_PASSWORD` (the site-wide BMC root password). DPF images
+   pull anonymously from public NGC by default — set the `NICO_DPF_IMAGE_*`
+   vars only for your own/mirrored registry. See *DPF* below. Sites with no
+   DPUs (or still on iPXE) run `./setup.sh -y --skip-dpf` and can ignore these.
 
-Once the above is done, run `./setup.sh -y`.
+Once the above is done, run `./setup.sh -y` (DPF installs by default; add
+`--skip-dpf` to opt out).
 
 ## Configuration reference
 
@@ -108,6 +128,20 @@ The tables below summarize the keys that must be set per site.
 | `NICO_MANAGE_DEFAULT_STORAGE_CLASS` | No | Whether `setup.sh` marks `local-path` as the default StorageClass. Defaults to `true`. Set to `false` when the cluster already has an operator-managed default StorageClass. |
 | `NICO_STORAGE_CLASS` | No | StorageClass used by Vault data/audit PVCs. Defaults to `local-path-persistent`. |
 | `PREFLIGHT_CHECK_IMAGE` | No | Image used for preflight per-node checks. Defaults to `busybox:1.36`; set to a local mirror for air-gapped clusters. |
+| `NICO_SKIP_DPF` | No | Skip the DPF (DOCA Platform Framework) DPU provisioning stack, which installs **by default**. Same as `--skip-dpf`. Defaults to `false`. |
+| `NICO_DPF_VERSION` | No | `NVIDIA/doca-platform` tag that setup.sh clones and installs. Defaults to `v26.4.0`. |
+| `NICO_DPF_SRC_DIR` | No | Cache directory for the doca-platform clone. Defaults to `helm-prereqs/.dpf-src`. |
+| `NICO_DPF_NGC_API_KEY` | No | NGC API key for `dpf-pull-secret` and the Argo CD helm repository secrets. Defaults to `REGISTRY_PULL_SECRET`. |
+| `NICO_DPF_NICO_NGC_API_KEY` | No | NGC API key with access to the NICo DPUService images (`nico-pull-secret`). Defaults to `NICO_DPF_NGC_API_KEY`. |
+| `NICO_DPF_K8S_API_VIP` / `NICO_DPF_K8S_API_PORT` | No | Host-cluster API server address/port that DPUs must reach. Defaults are derived from the `kubernetes` Endpoints — override when the derived address is not routable from the DPUs. |
+| `NICO_DPF_DPU_INTERFACE` | Unless `--skip-dpf` | Controller interface on which keepalived advertises the DPU cluster VIP. |
+| `NICO_DPF_DPU_CLUSTER_VIP` | Unless `--skip-dpf` | Floating IP the DPUs use to reach their (Kamaji) control plane. |
+| `NICO_DPF_BMC_ROOT_PASSWORD` | Unless `--skip-dpf` | Site-wide BMC root password. carbide-api's DPF SDK requires it at startup; setup.sh sets it via `nico-admin-cli` between the DPF-off and DPF-on Core deploys. |
+| `NICO_DPF_METALLB_POOL` | No | MetalLB address pool used to advertise the DPU cluster VIP. When unset, the VIP LoadBalancer Service is skipped — the VIP must then be routable from the DPUs by other means. |
+| `NICO_DPF_IMAGE_REPO` | No | DPF operator image repository. Defaults to the public `nvcr.io/nvidia/doca/dpf-system`. Point at your own registry (mirror or self-built) to match where you push Core/REST images. See [DPF images and registries](#dpf-images-and-registries). |
+| `NICO_DPF_IMAGE_TAG` | No | DPF operator image tag. Defaults to `NICO_DPF_VERSION`. Set separately when your self-built image uses a different tag than the chart version. |
+| `NICO_DPF_IMAGE_PULL_SECRET` | No | Pull secret for the DPF operator/DOCA images. Unset by default — the GA `nvidia/doca` images are public and pull anonymously. Set only for a private DPF/DOCA registry or mirror. |
+| `NICO_DPF_HELM_REPO_OCI` / `_HTTPS` / `_CARBIDE` | No | Argo CD helm repository URLs DPF pulls operand/service charts from. `_OCI`/`_HTTPS` default to the public `nvidia/doca` repos; `_CARBIDE` defaults to the **private** `0837451325059433/carbide-dev` (the NICo DPUService charts). Must match the `[dpf.services.*].helm_repo_url` carbide-api requests — override in lockstep when mirroring. |
 
 ### `values.yaml`
 
@@ -190,6 +224,7 @@ It supports these common deployment modes:
 | `--skip-core --skip-rest` | Infrastructure-only run; image tags, image registry, and REST repo are not required. |
 | `--core-values <file>` | Use site-specific Core values instead of `helm-prereqs/values/nico-core.yaml`. |
 | `--metallb-config <path>` | Use a site-specific MetalLB manifest file or kustomize directory. |
+| `--skip-dpf` | Skip the DPF (DOCA Platform Framework) DPU provisioning stack, which installs **by default**. Use for sites with no DPUs or that still use the deprecated iPXE DPU path. See [DPF](#dpf). |
 | `--site-overlay <dir>` | Apply a site kustomize overlay after Core deploys. |
 | `--with-observability` | Also install the local monitoring stack (metrics + logs + traces) after Core. Runs in every mode, including `--skip-rest`. Can also be run standalone at any time: `observability/install-observability.sh`. See [observability/README.md](observability/README.md). |
 | `--debug` | Enable bash tracing. This can print secrets, so avoid it in shared logs. |
@@ -221,6 +256,12 @@ postgres-operator          (zalando/postgres-operator 1.10.1 - manages nico-pg-c
 cert-manager               (jetstack/cert-manager v1.17.1)
 vault                      (hashicorp/vault 0.25.0, 3-node HA Raft, TLS)
 external-secrets           (external-secrets/external-secrets 0.14.3)
+DPF stack (default — --skip-dpf to opt out, all in dpf-operator-system)
+  ├── argo-cd               (argo/argo-cd 9.4.1)
+  ├── kamaji                (ghcr.io/nvidia/charts/kamaji 1.2.0 - DPU cluster control planes)
+  ├── maintenance-operator  (ghcr.io/mellanox/maintenance-operator-chart 0.3.0)
+  ├── node-feature-discovery (nfd/node-feature-discovery 0.18.3)
+  └── dpf-operator          (NVIDIA/doca-platform clone at NICO_DPF_VERSION)
 nico-prereqs               (this Helm chart - nico-system namespace)
 NICo Core                  (../helm - nico-core.yaml values)
   ├── nico-api              (Deployment - gRPC/REST API, requires PostgreSQL + Vault)
@@ -247,6 +288,137 @@ Observability (opt-in)     (observability/ - only with --with-observability; als
   ├── otel-agent            (opentelemetry-collector 0.106.0 - pod logs -> Loki, spans -> Tempo)
   └── otel-collector-gateway (optional, WITH_DPU=true - DPU OTLP/mTLS receiver)
 ```
+
+## DPF
+
+DPF-based DPU provisioning installs **by default**. Pass `--skip-dpf` (or
+`NICO_SKIP_DPF=true`) to opt out — e.g. sites with no DPUs, or that still use
+the deprecated iPXE DPU path. setup.sh installs the
+[DOCA Platform Framework](../docs/manuals/dpf.md) stack as phase 5b (between the
+base infrastructure and NICo Core) and enables it in carbide-api as phase 6b:
+
+1. **Prerequisite operators** — Argo CD, Kamaji, maintenance-operator, and
+   node-feature-discovery, pinned from `NVIDIA/doca-platform`
+   `deploy/helmfiles/prereqs.yaml` at the same tag as `NICO_DPF_VERSION`
+   (cert-manager and local-path-provisioner are reused from the base install).
+   Kamaji's cold-start deadlock is broken automatically.
+2. **Secrets** — `dpf-pull-secret` / `nico-pull-secret` (nvcr.io, from
+   `NICO_DPF_NGC_API_KEY` / `NICO_DPF_NICO_NGC_API_KEY`), a generated
+   `hbn-user-password`, and the Argo CD helm repository secrets.
+3. **DPF operator** — cloned from `NVIDIA/doca-platform` at `NICO_DPF_VERSION`
+   (cached in `.dpf-src/`) and installed from `deploy/charts/dpf-operator`.
+   The image (`NICO_DPF_IMAGE_REPO`, default `nvcr.io/nvidia/doca/dpf-system`)
+   is set explicitly and pulls anonymously (the GA `nvidia/doca` images are
+   public); set `NICO_DPF_IMAGE_PULL_SECRET` only for a private registry.
+4. **Operator CRs** — `DPFOperatorConfig`, `DPUCluster` (keepalived VIP from
+   `NICO_DPF_DPU_INTERFACE` / `NICO_DPF_DPU_CLUSTER_VIP`), and, when
+   `NICO_DPF_METALLB_POOL` is set, the VIP LoadBalancer Service that makes the
+   DPU cluster VIP routable.
+5. **carbide-api enablement (phase 6b)** — DPF SDK init requires the site-wide
+   BMC root password, which can only be set through a running carbide-api. So
+   Core is deployed with `[dpf]` off, `NICO_DPF_BMC_ROOT_PASSWORD` is set via an
+   in-cluster `nico-admin-cli` Job, then Core is upgraded to `[dpf]` on and
+   carbide-api is restarted so it initializes DPF and creates the BFB,
+   DPUFlavor, and DPUDeployment. The `nico-api-dpf` Role is created via
+   `nico-api.dpf.rbacCreate=true`.
+
+Requirements (unless `--skip-dpf`): `git` + `envsubst` on the machine running
+setup, an NGC API key, `NICO_DPF_DPU_INTERFACE` / `NICO_DPF_DPU_CLUSTER_VIP` for
+the DPU cluster VIP, and `NICO_DPF_BMC_ROOT_PASSWORD`. Per-host enablement is
+controlled by `dpf_enabled` on expected machines
+(defaults to true). See [docs/manuals/dpf.md](../docs/manuals/dpf.md) for the
+full background, BF4 opt-in, proxy configuration, and troubleshooting.
+
+Teardown is part of `clean.sh` (step 1b); `health-check.sh` gains a DPF
+section automatically when the stack is present.
+
+### DPF images and registries
+
+A DPF-enabled site pulls from three image/chart sources with different defaults:
+
+- The **DPF operator image** and the **public DOCA services** (`dts`,
+  `doca-hbn`, plus the DPF operand charts) default to **public NVIDIA NGC
+  (`nvidia/doca`)** and pull **anonymously** — no registry, key, or mirror.
+- The **NICo DPUService images** (`dpu-agent`, `dhcp-server`, `fmds`,
+  `otelcol`) default to the **private `carbide-dev` registry**
+  (`nvcr.io/0837451325059433/carbide-dev`) and **require credentials** —
+  `nico-pull-secret`, created by setup.sh from `NICO_DPF_NICO_NGC_API_KEY` (an
+  NGC key with carbide access). Sites without that access **must build and push
+  these to their own registry** (below).
+
+For air-gapped sites, or to keep everything in the one registry you already push
+Core/REST to (`NICO_IMAGE_REGISTRY`), mirror or build each source into your
+registry and point setup.sh at it.
+
+| Source | What it is | Default | Point at your registry |
+|---|---|---|---|
+| **DPF operator image** | `dpf-system` — the operator setup.sh installs | `nvcr.io/nvidia/doca/dpf-system:$NICO_DPF_VERSION`, **public, anonymous** | `NICO_DPF_IMAGE_REPO` + `NICO_DPF_IMAGE_TAG` + `NICO_DPF_IMAGE_PULL_SECRET` |
+| **DOCA operand/service charts** | Charts the operator deploys onto DPUs (DTS, DOCA-HBN, multus, flannel, sriov, ovs-cni, …) via Argo CD | Public NGC `nvidia/doca` helm repo, anonymous | `NICO_DPF_HELM_REPO_OCI` / `_HTTPS` / `_CARBIDE` (the Argo CD repo URLs) |
+| **NICo DPUService images** | NICo's own DPU-side services (`dpu-agent`, `dhcp-server`, `fmds`, `otelcol`) built from `bluefield/` | **Private** `nvcr.io/0837451325059433/carbide-dev`, needs `nico-pull-secret` | Build/push to your registry (below), then set `[dpf.services.*]` in the site config |
+
+**1. DPF operator image (self-built or mirrored).** The public GA image is
+public and pulls anonymously — the default needs nothing. To use your own
+registry:
+
+```bash
+# mirror the public image into your registry (or build it from the
+# NVIDIA/doca-platform source and push — see that repo's Makefile)
+docker pull  nvcr.io/nvidia/doca/dpf-system:v26.4.0
+docker tag   nvcr.io/nvidia/doca/dpf-system:v26.4.0  <your-registry>/dpf-system:v26.4.0
+docker push  <your-registry>/dpf-system:v26.4.0
+
+export NICO_DPF_IMAGE_REPO=<your-registry>/dpf-system
+export NICO_DPF_IMAGE_TAG=v26.4.0                 # or your own build tag
+export NICO_DPF_IMAGE_PULL_SECRET=imagepullsecret # the pull secret setup.sh
+                                                  # already creates in dpf-operator-system
+```
+
+Set `NICO_DPF_IMAGE_PULL_SECRET` **only** for a private registry — attaching a
+registry-scoped secret to the public `nvidia/doca` pull makes nvcr.io return
+403 (the credential can't be entitled to `nvidia/doca`), and kubelet does not
+fall back to anonymous.
+
+**2. NICo DPUService images (built from this repo).** These are NICo's own
+DPU-side services and belong in the same registry as Core/REST. Build and push
+them with the `bluefield/` cargo-make targets, overriding the registry/tag:
+
+```bash
+cd bluefield
+export CARBIDE_IMAGE_REGISTRY=<your-registry>     # default nvcr.io/nvidia/carbide
+export DPU_AGENT_PKG_VERSION=<tag>                # the image tag
+cargo make docker-build-all      # builds forge-dpu-agent, forge-dhcp-server,
+                                  # carbide-fmds, forge-dpu-otel-agent, otelcol-contrib (arm64)
+cargo make helm-package-all       # packages the matching DPUService charts
+# then docker push / helm push each to <your-registry>
+```
+
+Then point carbide-api at them by adding `[dpf.services.<svc>]` blocks to the
+site config (`nicoApiSiteConfig` TOML) with `helm_repo_url`, `helm_chart`,
+`helm_version`, `docker_repo_url`, and `docker_image_tag` for each of `dts`,
+`doca_hbn`, `dpu_agent`, `dhcp_server`, `fmds`, `otel`. Unset entries fall back
+to the built-in defaults (public NGC for `dts`/`doca_hbn`; private `carbide-dev`,
+needs `nico-pull-secret`, for `dpu_agent`/`dhcp_server`/`fmds`/`otel`). See
+[docs/manuals/dpf.md](../docs/manuals/dpf.md) §3.5 for the full `[dpf.services]`
+schema. `docker_image_pull_secret = "nico-pull-secret"` (created by setup.sh
+from `NICO_DPF_NICO_NGC_API_KEY`) authenticates pulls of the private NICo
+images.
+
+**3. DOCA / NICo service charts (mirrored).** The operator pulls its
+operand/service helm charts through Argo CD using the three Argo CD repository
+Secrets. Their URLs must match the `helm_repo_url` carbide-api requests per
+`[dpf.services.*]` (defaults in `crates/api-core/src/dpf_services.rs`). To pull
+from your mirror instead, override the repo URLs **and** the matching
+`[dpf.services.*].helm_repo_url`:
+`NICO_DPF_HELM_REPO_OCI` (default `nvcr.io/nvidia/doca`),
+`NICO_DPF_HELM_REPO_HTTPS` (default `https://helm.ngc.nvidia.com/nvidia/doca`),
+`NICO_DPF_HELM_REPO_CARBIDE` (default the private
+`https://helm.ngc.nvidia.com/0837451325059433/carbide-dev`, where the NICo
+DPUService charts live).
+
+> **Version.** `NICO_DPF_VERSION` (default `v26.4.0`) is the single DPF version
+> knob — it selects the doca-platform chart/CRDs to install and is the default
+> for `NICO_DPF_IMAGE_TAG`. Keep your mirrored/self-built artifacts on the same
+> version, or set `NICO_DPF_IMAGE_TAG` explicitly when they diverge.
 
 ## DPU compatibility DNS (`.forge` zone) — REQUIRED for DPU bring-up
 

--- a/helm-prereqs/clean.sh
+++ b/helm-prereqs/clean.sh
@@ -20,11 +20,13 @@
 # Destroys in reverse order:
 #   0. NCX stack           (nico-rest helm, temporal, keycloak, ncx postgres)
 #   1. nico core        (separate helm release, if installed)
+#   1b. DPF stack          (DPF CRs, dpf-operator helm release — if installed)
 #   2. helmfile releases   (nico-prereqs, external-secrets, vault, cert-manager,
-#                           postgres-operator)
+#                           postgres-operator, DPF prereqs when installed)
 #   3. cluster-scoped hook resources (ClusterIssuers, ClusterSecretStore, etc.)
 #   4. vault init secrets  (vault-cluster-keys, vaultunsealkeys, vaultroottoken)
-#   5. namespaces          (nico-system, cert-manager, vault, external-secrets, postgres)
+#   5. namespaces          (nico-system, cert-manager, vault, external-secrets,
+#                           postgres, dpf-operator-system)
 #   6. local-path-persistent PVs owned by this stack (Retain policy — not deleted with namespace)
 #   7. local-path-provisioner + StorageClass (applied via kubectl, not helm-managed)
 # =============================================================================
@@ -79,8 +81,82 @@ echo "=== [1/8] Uninstalling nico core ==="
 helm uninstall nico -n nico-system 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
+# 1b. DPF stack (setup.sh, DPF default), skipped fast when never installed.
+#     Order matters: DPF CRs must be deleted while the operator, Kamaji, and
+#     Argo CD controllers are still running so their finalizers can complete.
+#     The four prereq releases (argo-cd, kamaji, maintenance-operator, NFD)
+#     ride the helmfile destroy in step 2.
+# ---------------------------------------------------------------------------
+if kubectl get namespace dpf-operator-system &>/dev/null; then
+    echo "=== [1b] Removing DPF stack ==="
+
+    # DPU-facing CRs first (service chain, then provisioning objects), while
+    # the controllers can still finalize them.
+    kubectl delete dpudeployments,dpuservicechains,dpuservices,dpusets \
+        --all -n dpf-operator-system --timeout=120s 2>/dev/null || true
+    kubectl delete dpuserviceinterfaces,dpuservicetemplates,dpuserviceconfigurations,dpuservicenads \
+        --all -n dpf-operator-system --timeout=120s 2>/dev/null || true
+    kubectl delete dpus,dpudevices,dpunodes,dpunodemaintenances \
+        --all -n dpf-operator-system --timeout=180s 2>/dev/null || true
+    kubectl delete bfbs,bluefieldsoftwares,dpuflavors \
+        --all -n dpf-operator-system --timeout=120s 2>/dev/null || true
+    kubectl delete dpfoperatorconfig --all -n dpf-operator-system \
+        --timeout=120s 2>/dev/null || true
+    # DPUCluster last among CRs — deleting it tears down the Kamaji
+    # TenantControlPlane behind the DPU cluster.
+    kubectl delete dpucluster --all -n dpf-operator-system \
+        --timeout=180s 2>/dev/null || true
+    kubectl delete tenantcontrolplane --all -A --timeout=180s 2>/dev/null || true
+    # Kamaji `default` DataStore: carries helm.sh/resource-policy:keep (so
+    # helmfile destroy won't remove it) and a kamaji finalizer. Delete it here,
+    # while the kamaji controller is still alive to finalize it — otherwise its
+    # finalizer blocks the datastores CRD deletion and namespace termination.
+    kubectl delete datastores.kamaji.clastix.io --all -A \
+        --timeout=120s 2>/dev/null || true
+    # Argo CD Applications carry resources-finalizer.argocd.argoproj.io, which
+    # cascades a delete onto the (now-gone) DPU cluster and cannot complete on a
+    # DPU-less / VIP-unroutable cluster. Delete best-effort; stragglers get their
+    # finalizers stripped below before argo-cd itself is destroyed.
+    kubectl delete applications.argoproj.io --all -A \
+        --timeout=60s 2>/dev/null || true
+
+    # Best-effort finalizer strip for anything stuck after the bounded waits.
+    # Cover every DPF CR kind here — plus the kamaji DataStore and the Argo CD
+    # Applications/AppProjects — because `kubectl delete crd` (step 2) blocks
+    # until all instances finalize, so any kind left finalizer-stuck would hang
+    # the whole teardown. Applications must be stripped before argo-cd is
+    # destroyed (below), or nothing can ever clear their cascade finalizer.
+    for _kind in dpudeployments dpuservices dpuservicechains dpuserviceinterfaces \
+                 dpuservicetemplates dpuserviceconfigurations dpuservicenads \
+                 dpus dpudevices dpunodes dpunodemaintenances dpusets \
+                 bfbs bluefieldsoftwares dpuflavors \
+                 dpfoperatorconfigs dpuclusters tenantcontrolplanes \
+                 datastores.kamaji.clastix.io \
+                 applications.argoproj.io appprojects.argoproj.io; do
+        # Discover with the namespace so the patch targets the resource's ACTUAL
+        # namespace (a bare `-o name` + hard-coded `-n dpf-operator-system` would
+        # silently miss anything outside it). Cluster-scoped kinds (e.g.
+        # datastores) report an empty namespace and are patched without -n.
+        # Read the whole line and split on the tab manually — `read` with
+        # IFS=tab would strip the leading tab of a cluster-scoped resource's
+        # empty namespace and drop it (the DataStore is exactly such a resource).
+        while IFS= read -r _line; do
+            _ns="${_line%%$'\t'*}"; _name="${_line#*$'\t'}"
+            [[ -z "${_name}" ]] && continue
+            echo "WARNING: force-removing finalizers on stuck ${_kind}/${_name}${_ns:+ (ns ${_ns})}"
+            kubectl patch "${_kind}/${_name}" ${_ns:+-n "${_ns}"} --type merge \
+                -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+        done < <(kubectl get "${_kind}" -A \
+            -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+    done
+
+    helm uninstall dpf-operator -n dpf-operator-system 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
 # 2. All helmfile releases in reverse dependency order:
-#    nico-prereqs → external-secrets → vault → cert-manager → metallb
+#    nico-prereqs → node-feature-discovery → maintenance-operator → kamaji →
+#    argo-cd → external-secrets → vault → cert-manager → metallb
 # ---------------------------------------------------------------------------
 echo "=== [2/8] Destroying helmfile releases ==="
 
@@ -165,6 +241,28 @@ kubectl get clusterrole,clusterrolebinding -o name \
     | grep nico-rest \
     | xargs kubectl delete --ignore-not-found 2>/dev/null || true
 
+# DPF stack CRDs and cluster-scoped leftovers (DPF is installed by default).
+# Helm does not delete CRDs on uninstall; the prereq operators (argo-cd,
+# kamaji, maintenance-operator, NFD) also leave their CRDs and cluster RBAC.
+# NOTE: match only Argo *CD* CRDs (applications/appprojects/applicationsets),
+# not the whole argoproj.io group — a cluster running Argo Workflows would
+# otherwise have its workflows.argoproj.io CRDs (and live objects) deleted.
+# --timeout bounds the delete: `kubectl delete crd` blocks on CR finalizers
+# (the strip loop in step 1b handles those, but bound it anyway).
+echo "Removing DPF, Argo CD, Kamaji, NFD, and maintenance-operator CRDs..."
+kubectl get crd -o name \
+    | grep -E '\.dpu\.nvidia\.com|(applications|appprojects|applicationsets)\.argoproj\.io|kamaji\.clastix\.io|nfd\.k8s-sigs\.io|maintenance\.nvidia\.com' \
+    | xargs -r kubectl delete --ignore-not-found --timeout=120s 2>/dev/null || true
+kubectl get clusterrole,clusterrolebinding -o name \
+    | grep -E "dpf-operator|argo-cd|argocd|kamaji|maintenance-operator|node-feature-discovery" \
+    | xargs kubectl delete --ignore-not-found 2>/dev/null || true
+# CertificateRequestPolicy + RBAC (only present on approver-policy clusters)
+kubectl delete certificaterequestpolicy dpf-approval-policy \
+    --ignore-not-found 2>/dev/null || true
+kubectl delete "clusterrole/cert-manager-policy:dpf-approval-policy" \
+    "clusterrolebinding/cert-manager-policy:dpf-approval-policy" \
+    --ignore-not-found 2>/dev/null || true
+
 # ---------------------------------------------------------------------------
 # 3. Cluster-scoped resources created by helm hooks.
 #    These survive helm/helmfile uninstall because hook-delete-policy is
@@ -205,12 +303,12 @@ kubectl delete secret vault-cluster-keys vaultunsealkeys vaultroottoken \
 #    conflict with setup.sh's helmfile install into the external-secrets ns.
 # ---------------------------------------------------------------------------
 echo "=== [5/8] Deleting namespaces ==="
-kubectl delete ns nico-system cert-manager vault external-secrets postgres metallb-system \
+kubectl delete ns nico-system cert-manager vault external-secrets postgres metallb-system dpf-operator-system \
     --wait=false --ignore-not-found 2>/dev/null || true
 
 echo "Waiting for namespaces to terminate..."
 kubectl wait --for=delete \
-    ns/nico-system ns/cert-manager ns/vault ns/external-secrets ns/postgres ns/metallb-system \
+    ns/nico-system ns/cert-manager ns/vault ns/external-secrets ns/postgres ns/metallb-system ns/dpf-operator-system \
     --timeout=180s 2>/dev/null || true
 
 echo "Purging default namespace (ESO and other non-kubespray resources)..."
@@ -245,7 +343,7 @@ echo "=== [6/8] Removing Released PersistentVolumes owned by this stack ==="
 kubectl get pv -o json 2>/dev/null \
     | jq -r '.items[] | select(
         .spec.storageClassName == "local-path-persistent" and
-        (.spec.claimRef.namespace // "" | test("^(nico-system|cert-manager|vault|external-secrets|postgres|metallb-system|nico-rest|temporal|loki|tempo|monitoring|otel)$"))
+        (.spec.claimRef.namespace // "" | test("^(nico-system|cert-manager|vault|external-secrets|postgres|metallb-system|dpf-operator-system|nico-rest|temporal|loki|tempo|monitoring|otel)$"))
       ) | .metadata.name' \
     | xargs -r kubectl delete pv --ignore-not-found 2>/dev/null || true
 

--- a/helm-prereqs/clean.sh
+++ b/helm-prereqs/clean.sh
@@ -96,7 +96,13 @@ if kubectl get namespace dpf-operator-system &>/dev/null; then
         --all -n dpf-operator-system --timeout=120s 2>/dev/null || true
     kubectl delete dpuserviceinterfaces,dpuservicetemplates,dpuserviceconfigurations,dpuservicenads \
         --all -n dpf-operator-system --timeout=120s 2>/dev/null || true
-    kubectl delete dpus,dpudevices,dpunodes,dpunodemaintenances \
+    # NOTE: if DPUs are mid-provisioning (OSInstall / ConfigureFirmware state)
+    # this deletion will interrupt them and may leave them in an inconsistent
+    # state. Confirm no active provisioning before running clean.sh on a live
+    # site. `dpu` and `dpunodemaintenances` are omitted here: they carry owner
+    # references to DpuNode and are garbage-collected automatically when
+    # DpuNode is deleted.
+    kubectl delete dpudevices,dpunodes \
         --all -n dpf-operator-system --timeout=180s 2>/dev/null || true
     kubectl delete bfbs,bluefieldsoftwares,dpuflavors \
         --all -n dpf-operator-system --timeout=120s 2>/dev/null || true

--- a/helm-prereqs/health-check.sh
+++ b/helm-prereqs/health-check.sh
@@ -242,6 +242,62 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# 1b. DPF (installed by default; --skip-dpf to opt out)
+# NOTE: 'kubectl get deployment <name> -A' is invalid (by-name lookups cannot
+# cross namespaces); use a field selector for the namespace autodetect.
+# --------------------------------------------------------------------------
+if [[ -z "${DPF_NS:-}" ]]; then
+  DPF_NS=$(kubectl get deployment -A \
+    --field-selector metadata.name=dpf-operator-controller-manager \
+    -o jsonpath='{.items[0].metadata.namespace}' 2>/dev/null || true)
+fi
+
+section "DPF"
+if [[ -n "${DPF_NS:-}" ]]; then
+  _check_deployment "${DPF_NS}" dpf-operator-controller-manager
+  _check_deployment "${DPF_NS}" kamaji
+  _check_deployment "${DPF_NS}" maintenance-operator
+  _check_deployment "${DPF_NS}" node-feature-discovery-master
+  _check_deployment "${DPF_NS}" argo-cd-argocd-repo-server
+  _check_statefulset "${DPF_NS}" argo-cd-argocd-application-controller
+  _check_secret_exists "${DPF_NS}" hbn-user-password
+  # dpf-pull-secret is optional: setup.sh only creates it when an NGC key is
+  # set, and the operator pulls the public nvidia/doca images anonymously.
+  if kc get secret -n "${DPF_NS}" dpf-pull-secret &>/dev/null; then
+    pass "secret/dpf-pull-secret: exists"
+  else
+    skip "secret/dpf-pull-secret: not set (public images pull anonymously)"
+  fi
+  _dpf_cluster_phase=$(kc get dpucluster carbide-dpf-cluster -n "${DPF_NS}" \
+    -o jsonpath='{.status.phase}' || true)
+  if [[ "${_dpf_cluster_phase}" == "Ready" ]]; then
+    pass "dpucluster/carbide-dpf-cluster: Ready"
+  else
+    fail "dpucluster/carbide-dpf-cluster: phase=${_dpf_cluster_phase:-unknown}"
+  fi
+  # DPFOperatorConfig only reaches Ready once its DPU-side services schedule,
+  # which needs actual DPU (BlueField) nodes. On a DPU-less cluster it stays
+  # Ready=False by design — warn, don't fail (see docs/manuals/dpf.md).
+  _dpf_config_ready=$(kc get dpfoperatorconfig dpfoperatorconfig -n "${DPF_NS}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' || true)
+  _dpf_count=$(kc get dpus.provisioning.dpu.nvidia.com -A \
+    -o name 2>/dev/null | wc -l | tr -d '[:space:]')
+  if [[ "${_dpf_config_ready}" == "True" ]]; then
+    pass "dpfoperatorconfig/dpfoperatorconfig: Ready"
+  elif [[ "${_dpf_count:-0}" == "0" ]]; then
+    warn "dpfoperatorconfig/dpfoperatorconfig: Ready=${_dpf_config_ready:-unknown} (no DPUs — DPU-side services can't schedule; expected)"
+  else
+    fail "dpfoperatorconfig/dpfoperatorconfig: Ready=${_dpf_config_ready:-unknown}"
+  fi
+elif kc get namespace dpf-operator-system &>/dev/null; then
+  # The operator deployment is absent but its namespace lingers — a partial or
+  # failed DPF install, not a clean opt-out. Fail rather than silently skip.
+  fail "dpf-operator-controller-manager: not found, but namespace dpf-operator-system exists (partial/failed DPF install)"
+else
+  skip "not installed (--skip-dpf was used)"
+fi
+
+# --------------------------------------------------------------------------
 # 2. Vault
 # --------------------------------------------------------------------------
 section "Vault"

--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -35,6 +35,10 @@ repositories:
     url: https://opensource.zalando.com/postgres-operator/charts/postgres-operator
   - name: metallb
     url: https://metallb.github.io/metallb
+  - name: argo
+    url: https://argoproj.github.io/argo-helm
+  - name: nfd
+    url: https://kubernetes-sigs.github.io/node-feature-discovery/charts
 
 releases:
   # ---------------------------------------------------------------------------
@@ -118,6 +122,84 @@ releases:
     timeout: 600
     values:
       - operators/values/external-secrets.yaml
+
+  # ---------------------------------------------------------------------------
+  # DPF prerequisites — Argo CD, Kamaji, maintenance-operator, NFD.
+  # Installed by setup.sh phase 5b unless --skip-dpf (per-release
+  # sync; nothing here installs on a normal run). Versions and values are
+  # pinned from NVIDIA/doca-platform deploy/helmfiles/prereqs.yaml at the tag
+  # matching NICO_DPF_VERSION (v26.4.0) — bump together.
+  # All four install into dpf-operator-system, same as upstream.
+  # NOTE: upstream pins cert-manager v1.19.3; we reuse our v1.17.1 release
+  # above (compatible with DPF's Issuer/Certificate v1 usage — known skew).
+  # ---------------------------------------------------------------------------
+  - name: argo-cd
+    namespace: dpf-operator-system
+    createNamespace: true
+    chart: argo/argo-cd
+    version: "9.4.1"
+    labels:
+      group: dpf-prereqs
+    wait: true
+    timeout: 600
+    values:
+      - operators/values/argo-cd.yaml
+
+  - name: kamaji
+    namespace: dpf-operator-system
+    createNamespace: true
+    chart: oci://ghcr.io/nvidia/charts/kamaji
+    version: "1.2.0"
+    labels:
+      group: dpf-prereqs
+    wait: true
+    timeout: 600
+    values:
+      - operators/values/kamaji.yaml
+    hooks:
+      # Upstream applies chart CRDs before sync (deploy/helmfiles/apply-crds.sh)
+      # because helm only installs crds/ on first install, never on upgrade.
+      - events: ["preSync"]
+        command: "bash"
+        args:
+          - -c
+          - |
+            helm show crds oci://ghcr.io/nvidia/charts/kamaji --version 1.2.0 \
+              | kubectl apply --server-side --field-manager=helmfile --force-conflicts -f - \
+              || echo "WARNING: CRD apply for kamaji failed; continuing" >&2
+
+  - name: maintenance-operator
+    namespace: dpf-operator-system
+    createNamespace: true
+    chart: oci://ghcr.io/mellanox/maintenance-operator-chart
+    version: "0.3.0"
+    labels:
+      group: dpf-prereqs
+    wait: true
+    timeout: 600
+    values:
+      - operators/values/maintenance-operator.yaml
+    hooks:
+      - events: ["preSync"]
+        command: "bash"
+        args:
+          - -c
+          - |
+            helm show crds oci://ghcr.io/mellanox/maintenance-operator-chart --version 0.3.0 \
+              | kubectl apply --server-side --field-manager=helmfile --force-conflicts -f - \
+              || echo "WARNING: CRD apply for maintenance-operator failed; continuing" >&2
+
+  - name: node-feature-discovery
+    namespace: dpf-operator-system
+    createNamespace: true
+    chart: nfd/node-feature-discovery
+    version: "0.18.3"
+    labels:
+      group: dpf-prereqs
+    wait: true
+    timeout: 600
+    values:
+      - operators/values/node-feature-discovery.yaml
 
   # ---------------------------------------------------------------------------
   # nico-prereqs — local Helm chart (this directory)

--- a/helm-prereqs/operators/dpf/cert-manager-policy.yaml
+++ b/helm-prereqs/operators/dpf/cert-manager-policy.yaml
@@ -1,0 +1,70 @@
+# =============================================================================
+# operators/dpf/cert-manager-policy.yaml — DPF CertificateRequestPolicy + RBAC
+#
+# Only required on clusters that run cert-manager approver-policy (CRD
+# policy.cert-manager.io/CertificateRequestPolicy). On such clusters no CSR is
+# approved unless a policy whitelists it, and every DPF CSR hangs Pending
+# without this. setup.sh applies this file only when the CRD exists — the
+# stock helm-prereqs cert-manager does NOT install approver-policy (its
+# built-in approver auto-approves; see operators/values/cert-manager.yaml).
+#
+# Wildcards are intentional per docs/manuals/dpf.md §1.4; tighten in
+# production with guidance from the DPF team.
+# =============================================================================
+---
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  name: dpf-approval-policy
+spec:
+  selector:
+    namespace:
+      matchNames: [dpf-operator-system]
+    issuerRef:
+      name: '*'
+      kind: '*'
+      group: '*'
+  allowed:
+    commonName:
+      value: '*'
+    dnsNames:
+      values: ['*']
+    ipAddresses:
+      values: ['*']
+    uris:
+      values: ['*']
+    emailAddresses:
+      values: ['*']
+    isCA: true
+    usages:
+      - server auth
+      - client auth
+      - digital signature
+      - key encipherment
+      # isCA: true certs get cert-manager's auto-added CA usages; whitelist them
+      # too or approver-policy denies the CA CSR (usages must be a subset).
+      - cert sign
+      - crl sign
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-policy:dpf-approval-policy
+rules:
+  - apiGroups: [policy.cert-manager.io]
+    resources: [certificaterequestpolicies]
+    verbs: [use]
+    resourceNames: [dpf-approval-policy]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-policy:dpf-approval-policy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-policy:dpf-approval-policy
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager

--- a/helm-prereqs/operators/dpf/dpfoperatorconfig.yaml.tmpl
+++ b/helm-prereqs/operators/dpf/dpfoperatorconfig.yaml.tmpl
@@ -1,0 +1,49 @@
+# =============================================================================
+# operators/dpf/dpfoperatorconfig.yaml.tmpl — DPFOperatorConfig for NICo
+#
+# Rendered by setup.sh with:
+#   envsubst '${NICO_DPF_K8S_API_VIP} ${NICO_DPF_K8S_API_PORT}'
+# Only the two whitelisted variables are substituted.
+#
+# NICo-specific choices (docs/manuals/dpf.md §3.2):
+#   - dpuDetector disabled: NICo feeds DPUs in explicitly, no auto-discovery.
+#   - installViaRedfish + skipDPUNodeDiscovery: provisioning driven through the
+#     host BMC, DPUNodes registered by carbide-api rather than detected.
+#   - argoCDNamespace matches the helm-prereqs Argo CD install
+#     (dpf-operator-system, same as upstream deploy/helmfiles/prereqs.yaml).
+# =============================================================================
+---
+apiVersion: operator.dpu.nvidia.com/v1alpha1
+kind: DPFOperatorConfig
+metadata:
+  name: dpfoperatorconfig
+  namespace: dpf-operator-system
+spec:
+  # NOTE: newer DPF releases make spec.deploymentMode a required field (with CEL
+  # rules: zero-trust requires installViaRedfish; host-trusted forbids it). It
+  # does not exist in v26.4.0 (the NICO_DPF_VERSION default), so it is omitted
+  # here. When bumping NICO_DPF_VERSION to a release that requires it, add e.g.
+  #   deploymentMode: zero-trust
+  # or the apply will be rejected with "spec.deploymentMode: Required value".
+  dpuDetector:
+    disable: true
+  provisioningController:
+    osInstallTimeout: "60m"
+    installInterface:
+      installViaRedfish:
+        skipDPUNodeDiscovery: true
+  overrides:
+    # Host-cluster API server VIP/port that DPUs must be able to reach.
+    kubernetesAPIServerVIP: "${NICO_DPF_K8S_API_VIP}"
+    # Must render as an integer — do not quote.
+    kubernetesAPIServerPort: ${NICO_DPF_K8S_API_PORT}
+    argoCDNamespace: dpf-operator-system
+  kamajiClusterManager:
+    disable: false
+  networking:
+    highSpeedMTU: 9000
+  # No imagePullSecrets: the GA nvidia/doca operand images are public and pull
+  # anonymously. A registry-scoped secret without nvidia/doca entitlement would
+  # make nvcr.io 403 the pull. For a private DPF/DOCA registry/mirror, add:
+  #   imagePullSecrets:
+  #     - <your-doca-pull-secret>

--- a/helm-prereqs/operators/dpf/dpu-cluster-vip-service.yaml.tmpl
+++ b/helm-prereqs/operators/dpf/dpu-cluster-vip-service.yaml.tmpl
@@ -1,0 +1,41 @@
+# =============================================================================
+# operators/dpf/dpu-cluster-vip-service.yaml.tmpl — MetalLB advertisement for
+# the DPU cluster VIP
+#
+# Rendered by setup.sh with:
+#   envsubst '${NICO_DPF_METALLB_POOL} ${NICO_DPF_DPU_CLUSTER_VIP}'
+# Applied only when NICO_DPF_METALLB_POOL is set; skip it in environments
+# where the VIP is already routable from the DPUs.
+#
+# Deliberately unusual (docs/manuals/dpf.md §3.4): the selector-less Service
+# reserves and advertises the VIP via MetalLB, while the same-named Endpoints
+# object points at a dummy RFC 5737 address so nothing is actually routed —
+# keepalived (from the DPUCluster CR) terminates the traffic.
+# =============================================================================
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dpu-cluster-vip-loadbalancer
+  namespace: dpf-operator-system
+  annotations:
+    metallb.io/address-pool: '${NICO_DPF_METALLB_POOL}'
+spec:
+  allocateLoadBalancerNodePorts: true
+  loadBalancerIP: "${NICO_DPF_DPU_CLUSTER_VIP}"
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: dpu-cluster-vip-loadbalancer
+  namespace: dpf-operator-system
+subsets:
+- addresses:
+  - ip: 192.0.2.10     # dummy/test IP (RFC 5737) — keepalived owns the VIP
+  ports:
+  - port: 80

--- a/helm-prereqs/operators/dpf/dpucluster.yaml.tmpl
+++ b/helm-prereqs/operators/dpf/dpucluster.yaml.tmpl
@@ -28,7 +28,8 @@ spec:
       vip: "${NICO_DPF_DPU_CLUSTER_VIP}"
       virtualRouterID: 126
       nodeSelector:
-        # Some environments label control-plane nodes with value "true" —
-        # verify with:
+        # kubeadm labels control-plane nodes with an empty value, but some
+        # environments use "true" — set NICO_DPF_CP_LABEL_VALUE to match.
+        # Verify with:
         #   kubectl get node <n> -o jsonpath='{.metadata.labels.node-role\.kubernetes\.io/control-plane}'
-        node-role.kubernetes.io/control-plane: ""
+        node-role.kubernetes.io/control-plane: "${NICO_DPF_CP_LABEL_VALUE}"

--- a/helm-prereqs/operators/dpf/dpucluster.yaml.tmpl
+++ b/helm-prereqs/operators/dpf/dpucluster.yaml.tmpl
@@ -1,0 +1,34 @@
+# =============================================================================
+# operators/dpf/dpucluster.yaml.tmpl — Kamaji-backed DPU cluster control plane
+#
+# Rendered by setup.sh with:
+#   envsubst '${NICO_DPF_DPU_INTERFACE} ${NICO_DPF_DPU_CLUSTER_VIP}'
+# Only the two whitelisted variables are substituted.
+#
+# The DPU cluster runs as a Kamaji TenantControlPlane inside the host cluster;
+# DPU nodes join it through the keepalived VIP below. The VIP must be routable
+# from the DPUs (see the optional MetalLB Service in
+# dpu-cluster-vip-service.yaml.tmpl). virtualRouterID must be unique per host
+# if other keepalived instances run there (docs/manuals/dpf.md §3.3).
+# =============================================================================
+---
+apiVersion: provisioning.dpu.nvidia.com/v1alpha1
+kind: DPUCluster
+metadata:
+  name: carbide-dpf-cluster
+  namespace: dpf-operator-system
+spec:
+  type: kamaji
+  maxNodes: 1000
+  clusterEndpoint:
+    keepalived:
+      # Controller interface where the Kamaji cluster IP is configured.
+      interface: "${NICO_DPF_DPU_INTERFACE}"
+      # External IP used by the Kamaji cluster; must be reachable from DPUs.
+      vip: "${NICO_DPF_DPU_CLUSTER_VIP}"
+      virtualRouterID: 126
+      nodeSelector:
+        # Some environments label control-plane nodes with value "true" —
+        # verify with:
+        #   kubectl get node <n> -o jsonpath='{.metadata.labels.node-role\.kubernetes\.io/control-plane}'
+        node-role.kubernetes.io/control-plane: ""

--- a/helm-prereqs/operators/values/argo-cd.yaml
+++ b/helm-prereqs/operators/values/argo-cd.yaml
@@ -1,0 +1,43 @@
+# =============================================================================
+# operators/values/argo-cd.yaml — Argo CD static values
+#
+# DPF prerequisite (installed by default; skip with --skip-dpf).
+# Copied from NVIDIA/doca-platform deploy/helmfiles/values at tag v26.4.0 —
+# keep in sync with NICO_DPF_VERSION when bumping DPF.
+#
+# Chart: argo/argo-cd 9.4.1
+# =============================================================================
+
+## Disable the ApplicationSet controller.
+applicationSet:
+  replicas: 0
+dex:
+  enabled: false
+notifications:
+  enabled: false
+global:
+  podLabels:
+    ovn.dpu.nvidia.com/skip-injection: ""
+  affinity:
+    nodeAffinity:
+      # -- Default node affinity rules. Either: `none`, `soft` or `hard`
+      type: hard
+      # -- Default match expressions for node affinity
+      matchExpressions:
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: Exists
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+redis:
+  image:
+    repository: mirror.gcr.io/redis
+configs:
+  params:
+    # Argo CD can be deployed to a different namespace.
+    # Setting namespaces to dpf-operator-system ensures Argo CD reconciles applications in that namespace.
+    application.namespaces: dpf-operator-system

--- a/helm-prereqs/operators/values/kamaji.yaml
+++ b/helm-prereqs/operators/values/kamaji.yaml
@@ -1,0 +1,89 @@
+# =============================================================================
+# operators/values/kamaji.yaml — Kamaji static values
+#
+# DPF prerequisite (installed by default; skip with --skip-dpf).
+# Copied from NVIDIA/doca-platform deploy/helmfiles/values at tag v26.4.0 —
+# keep in sync with NICO_DPF_VERSION when bumping DPF.
+#
+# Chart: oci://ghcr.io/nvidia/charts/kamaji 1.2.0
+# =============================================================================
+
+# Kamaji configuration
+# Number of Kamaji controller replicas for High Availability. The chart key is
+# `replicaCount` (templates/controller.yaml renders `replicas: .Values.replicaCount`,
+# default 1) — a top-level `replicas:` is silently ignored, so HA needs this key.
+# The controller runs --leader-elect, so 2 replicas give active/standby failover;
+# there is no pod anti-affinity, so this never blocks scheduling on a small cluster.
+replicaCount: 2
+resources: null
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "node-role.kubernetes.io/master"
+              operator: Exists
+        - matchExpressions:
+            - key: "node-role.kubernetes.io/control-plane"
+              operator: Exists
+tolerations:
+  - key: node-role.kubernetes.io/master
+    operator: Exists
+    effect: NoSchedule
+  - key: node-role.kubernetes.io/control-plane
+    operator: Exists
+    effect: NoSchedule
+kamaji-etcd:
+  persistentVolumeClaim:
+    storageClassName: local-path
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: Exists
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+  jobs:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: "node-role.kubernetes.io/master"
+                  operator: Exists
+            - matchExpressions:
+                - key: "node-role.kubernetes.io/control-plane"
+                  operator: Exists
+    tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+  datastore:
+    enabled: true
+    annotations:
+      helm.sh/resource-policy: keep
+    name: default
+image:
+  repository: ghcr.io/nvidia/kamaji
+  tag: v1.34.0-25.9.3
+  pullPolicy: Always
+# NOTE: this key is currently a no-op in kamaji-etcd 1.2.0 — its cert-preinstall
+# job (charts/kamaji-etcd/templates/etcd_job_preinstall_1.yaml) hardcodes the
+# image as `cfssl/cfssl:latest` and reads no `cfssl.image` value. Kept (matching
+# upstream) to carry the intended pin for a future chart that wires it up.
+cfssl:
+  image:
+    tag: v1.6.5

--- a/helm-prereqs/operators/values/maintenance-operator.yaml
+++ b/helm-prereqs/operators/values/maintenance-operator.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# operators/values/maintenance-operator.yaml — NVIDIA maintenance-operator static values
+#
+# DPF prerequisite (installed by default; skip with --skip-dpf).
+# Copied from NVIDIA/doca-platform deploy/helmfiles/values at tag v26.4.0 —
+# keep in sync with NICO_DPF_VERSION when bumping DPF.
+#
+# Chart: oci://ghcr.io/mellanox/maintenance-operator-chart 0.3.0
+# =============================================================================
+
+# Maintenance Operator Chart configuration
+operatorConfig:
+  deploy: true
+  maxParallelOperations: 60%
+operator:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: Exists
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule

--- a/helm-prereqs/operators/values/node-feature-discovery.yaml
+++ b/helm-prereqs/operators/values/node-feature-discovery.yaml
@@ -1,0 +1,65 @@
+# =============================================================================
+# operators/values/node-feature-discovery.yaml — Node Feature Discovery static values
+#
+# DPF prerequisite (installed by default; skip with --skip-dpf).
+# Copied from NVIDIA/doca-platform deploy/helmfiles/values at tag v26.4.0 —
+# keep in sync with NICO_DPF_VERSION when bumping DPF.
+#
+# Chart: nfd/node-feature-discovery 0.18.3
+# =============================================================================
+
+# Node Feature Discovery configuration
+master:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: Exists
+  tolerations:
+  # Note: beginning with v0.18.3 the master toleration was dropped from the chart's default values.yaml.
+  - key: "node-role.kubernetes.io/master"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+worker:
+  enable: true
+  hostNetwork: true
+  tolerations:
+    - key: node.kubernetes.io/not-ready
+      operator: Exists
+  config:
+    sources:
+      pci:
+        deviceClassWhitelist:
+          - "0200"
+        deviceLabelFields:
+          - "class"
+          - "vendor"
+          - "device"
+gc:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: Exists
+          - matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: Exists
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -83,11 +83,16 @@ _SOURCED=false
 # setup.sh has consumed its own args, so this block is a no-op there.
 # ---------------------------------------------------------------------------
 if ! ${_SOURCED}; then
+    # DPF is on by default; derive INSTALL_DPF from env, then let flags override.
+    INSTALL_DPF="${INSTALL_DPF:-${NICO_INSTALL_DPF:-true}}"
+    [[ "${NICO_SKIP_DPF:-false}" == "true" ]] && INSTALL_DPF=false
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --skip-core)      SKIP_CORE=true ;;
             --skip-rest)      SKIP_REST=true ;;
             --skip-flow)      SKIP_FLOW=true ;;
+            --skip-dpf)       INSTALL_DPF=false ;;
+            --install-dpf)    INSTALL_DPF=true ;;
             -y|--yes)         AUTO_YES=true ;;
             --core-values)    CORE_VALUES="$2"; shift ;;
             --metallb-config) METALLB_CONFIG="$2"; shift ;;
@@ -464,6 +469,57 @@ if [[ -n "${KUBECONFIG:-}" && ! -f "${KUBECONFIG}" ]]; then
     ERRORS+=("KUBECONFIG='${KUBECONFIG}' does not exist — check the path to your cluster kubeconfig")
 fi
 
+# DPF requirements. DPF installs by default; these apply unless --skip-dpf
+# (NICO_SKIP_DPF=true / NICO_INSTALL_DPF=false), which clears INSTALL_DPF.
+if [[ "${INSTALL_DPF:-true}" == "true" ]]; then
+    command -v git &>/dev/null || \
+        ERRORS+=("DPF requires 'git' to clone doca-platform — install it, or pass --skip-dpf")
+    command -v envsubst &>/dev/null || \
+        ERRORS+=("DPF requires 'envsubst' (gettext) to render DPF manifests — install it, or pass --skip-dpf")
+    [[ -z "${NICO_DPF_DPU_INTERFACE:-}" ]] && \
+        ERRORS+=("NICO_DPF_DPU_INTERFACE is not set    (controller interface for the DPU cluster keepalived VIP; required unless --skip-dpf)")
+    [[ -z "${NICO_DPF_DPU_CLUSTER_VIP:-}" ]] && \
+        ERRORS+=("NICO_DPF_DPU_CLUSTER_VIP is not set    (VIP the DPUs use to reach their control plane; required unless --skip-dpf)")
+    [[ -z "${NICO_DPF_BMC_ROOT_PASSWORD:-}" ]] && \
+        ERRORS+=("NICO_DPF_BMC_ROOT_PASSWORD is not set    (site-wide BMC root password; DPF SDK init requires it — required unless --skip-dpf)")
+    if [[ -z "${NICO_DPF_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" ]]; then
+        WARNINGS+=("NICO_DPF_NGC_API_KEY / REGISTRY_PULL_SECRET not set — the DPF operator + public DOCA images still pull anonymously, but the Argo repo secrets are skipped, so the private NICo DPUService charts (carbide) won't authenticate unless you mirror/build them into your own registry")
+    fi
+    if [[ "${NICO_MANAGE_DEFAULT_STORAGE_CLASS:-true}" == "false" ]]; then
+        WARNINGS+=("DPF (default) with NICO_MANAGE_DEFAULT_STORAGE_CLASS=false — Kamaji's etcd PVCs use the local-path StorageClass; ensure a usable StorageClass exists")
+    fi
+    # Validate the site config actually enables [dpf] *before* setup.sh installs
+    # the whole DPF prereq stack. Without this, a --core-values file with a
+    # missing/commented [dpf] block passes preflight and aborts only in phase 6,
+    # after argo-cd, kamaji, NFD, the operator and its CRs are already installed,
+    # leaving a half-provisioned cluster. This mirrors the setup.sh two-phase
+    # guard, but it is a pure function of the static file so it can run up front.
+    if [[ "${SKIP_CORE:-false}" != "true" && -f "${_CORE_VALUES_CFG}" ]]; then
+        # Reproduce setup.sh's DPF-ON rendering: the default file ships the [dpf]
+        # block '#dpf# '-commented (uncomment it); a --core-values file is
+        # expected to carry a live [dpf] block already.
+        if [[ -n "${CORE_VALUES:-}" ]]; then
+            _dpf_on_src="$(cat "${_CORE_VALUES_CFG}")"
+        else
+            _dpf_on_src="$(sed -E 's/^([[:space:]]*)#dpf# ?/\1/' "${_CORE_VALUES_CFG}")"
+        fi
+        _dpf_enabled_val="$(printf '%s\n' "${_dpf_on_src}" | awk '
+            /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { indpf = ($0 ~ /^[[:space:]]*\[dpf\][[:space:]]*$/) ? 1 : 0 }
+            indpf==1 && /^[[:space:]]*enabled[[:space:]]*=/ {
+                # Anchor to the FIRST "=" so a trailing comment (e.g. "# default=true")
+                # is not misread as the value — matches setup.sh _dpf_site_enabled.
+                v=$0; sub(/^[^=]*=[[:space:]]*/,"",v); sub(/[[:space:]].*/,"",v); print v; exit
+            }')"
+        if [[ "${_dpf_enabled_val}" != "true" ]]; then
+            if [[ -n "${CORE_VALUES:-}" ]]; then
+                ERRORS+=("${_CORE_VALUES_LABEL}: DPF is enabled (the default) but the site config has no '[dpf]' table with 'enabled = true' on its own line — add one (enabled = true, docker_image_pull_secret = \"nico-pull-secret\"; see docs/manuals/dpf.md §3.5), or pass --skip-dpf")
+            else
+                ERRORS+=("${_CORE_VALUES_LABEL}: the default [dpf] block (normally '#dpf# '-commented) is missing or malformed — restore helm-prereqs/values/nico-core.yaml, or pass --skip-dpf")
+            fi
+        fi
+    fi
+fi
+
 # ---------------------------------------------------------------------------
 # 2. Required tools
 # ---------------------------------------------------------------------------
@@ -615,6 +671,15 @@ _ip_in_block() {
         return 2
     fi
 }
+
+# DPF DPU-cluster keepalived VIP must be a valid IPv4. It is NOT a MetalLB pool
+# VIP (keepalived advertises it on the control-plane interface), so it is only
+# format-checked here — consistent with how every other VIP is validated. The
+# empty case is already an error above (near the DPF required-var block).
+if [[ "${INSTALL_DPF:-true}" == "true" && -n "${NICO_DPF_DPU_CLUSTER_VIP:-}" ]] \
+   && ! _is_ipv4 "${NICO_DPF_DPU_CLUSTER_VIP}"; then
+    ERRORS+=("NICO_DPF_DPU_CLUSTER_VIP='${NICO_DPF_DPU_CLUSTER_VIP}' is not a valid IPv4 address")
+fi
 
 if [[ "${SKIP_CORE:-false}" != "true" && -f "${_CORE_VALUES_CFG}" ]]; then
     # Collect the MetalLB pool blocks (CIDRs + ranges) from the rendered config.

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -481,7 +481,7 @@ if [[ "${INSTALL_DPF:-true}" == "true" ]]; then
     [[ -z "${NICO_DPF_DPU_CLUSTER_VIP:-}" ]] && \
         ERRORS+=("NICO_DPF_DPU_CLUSTER_VIP is not set    (VIP the DPUs use to reach their control plane; required unless --skip-dpf)")
     [[ -z "${NICO_DPF_BMC_ROOT_PASSWORD:-}" ]] && \
-        ERRORS+=("NICO_DPF_BMC_ROOT_PASSWORD is not set    (site-wide BMC root password; DPF SDK init requires it — required unless --skip-dpf)")
+        WARNINGS+=("NICO_DPF_BMC_ROOT_PASSWORD is not set  (site-wide BMC root password; setup.sh will skip automated credential seeding — set it manually via nico-admin-cli after deploy before DPU provisioning will work)")
     if [[ -z "${NICO_DPF_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}" ]]; then
         WARNINGS+=("NICO_DPF_NGC_API_KEY / REGISTRY_PULL_SECRET not set — the DPF operator + public DOCA images still pull anonymously, but the Argo repo secrets are skipped, so the private NICo DPUService charts (carbide) won't authenticate unless you mirror/build them into your own registry")
     fi

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -208,9 +208,13 @@ NICO_DPF_NICO_NGC_API_KEY="${NICO_DPF_NICO_NGC_API_KEY:-${NICO_DPF_NGC_API_KEY}}
 # to the chart version (NICO_DPF_VERSION) but can differ for a self-built image.
 NICO_DPF_IMAGE_REPO="${NICO_DPF_IMAGE_REPO:-nvcr.io/nvidia/doca/dpf-system}"
 NICO_DPF_IMAGE_TAG="${NICO_DPF_IMAGE_TAG:-${NICO_DPF_VERSION}}"
-# Site-wide BMC root password. DPF SDK init hard-requires it, and it can only be
-# set through a running carbide-api (with DPF off). setup.sh deploys Core with
-# DPF disabled, sets this via nico-admin-cli, then enables DPF and restarts.
+# Site-wide BMC root password. Optional: when provided, setup.sh calls
+# nico-admin-cli (phase 6b) to store the credential via the API so DPU
+# provisioning starts immediately. When omitted, carbide-api starts cleanly
+# without it (fixed in #4167 — the DPF SDK init is now best-effort when a
+# 60 s refresh interval is configured) and the operator must set the credential
+# manually via `nico-admin-cli credential add-bmc --kind=site-wide-root`
+# before DPU provisioning will work.
 NICO_DPF_BMC_ROOT_PASSWORD="${NICO_DPF_BMC_ROOT_PASSWORD:-}"
 # Optional chart-version overrides for NICo-owned DPF services. Useful when
 # testing a dev/PR image whose baked-in version was never published to the
@@ -828,11 +832,13 @@ if "${INSTALL_DPF}"; then
         sleep 10
     done
 
-    # 5b.8 [dpf] is NOT enabled in the Core config here. carbide-api's DPF SDK
-    #      init hard-requires the site-wide BMC root password, which can only be
-    #      set through a running carbide-api. So the enablement is deferred:
-    #      phase 6 deploys Core with DPF OFF, sets the BMC root password via
-    #      nico-admin-cli, then enables [dpf] and restarts carbide-api.
+    # 5b.8 [dpf] is NOT enabled in the Core config here. The two-phase approach
+    #      (Core DPF-off first, then DPF-on after phase 6b) lets setup.sh call
+    #      nico-admin-cli to set the BMC root credential while carbide-api is
+    #      already up. carbide-api can start with DPF enabled even when the
+    #      credential is absent (#4167), but setting it before enabling DPF
+    #      ensures DPU provisioning begins immediately without waiting for the
+    #      first 60 s refresh tick.
     echo "DPF stack installed (carbide-api DPF enablement happens after Core in phase 6)"
 else
     echo "Skipping DPF (--skip-dpf / NICO_SKIP_DPF=true). DPUs, if any, use the deprecated iPXE path."
@@ -1007,10 +1013,13 @@ else
     _CORE_VALUES_ARG="${CORE_VALUES:-helm-prereqs/values/nico-core.yaml}"
 
     if "${INSTALL_DPF}"; then
-        # Two-phase DPF enablement. carbide-api's DPF SDK init hard-requires the
-        # site-wide BMC root password, which can only be set through a running
-        # carbide-api — so Core is deployed with DPF OFF first, then re-deployed
-        # with DPF ON after the password is set (phase 6b below). Build both.
+        # Two-phase DPF enablement: Core is deployed with DPF OFF first so that
+        # carbide-api is running when setup.sh tries to set the site-wide BMC
+        # root credential via nico-admin-cli (phase 6b). If the credential is
+        # not provided here the password step is skipped and DPF-on is still
+        # deployed — carbide-api tolerates a missing credential at startup
+        # (#4167) and writes the K8s Secret on the next refresh tick once the
+        # operator sets the credential manually. Build both value files.
         _DPF_ON_VALUES="$(mktemp -t nico-core-dpf-on.XXXXXX)"
         _DPF_OFF_VALUES="$(mktemp -t nico-core-dpf-off.XXXXXX)"
         if [[ -n "${CORE_VALUES}" ]]; then
@@ -1185,19 +1194,29 @@ else
         #     carbide-api so it initializes the DPF SDK.
         # -------------------------------------------------------------------
         if "${INSTALL_DPF}" && "${_dpf_already_on:-false}"; then
-            # Skip the destructive DPF-off down-cycle, but still (re-)apply the
-            # site-wide BMC root credential so a rerun with a rotated/corrected
-            # NICO_DPF_BMC_ROOT_PASSWORD is reconciled — preflight requires it, so
-            # it must not be silently ignored on an already-enabled site.
+            # Skip the destructive DPF-off down-cycle. If a BMC root password
+            # was supplied (e.g. a rotation), reconcile it via nico-admin-cli;
+            # otherwise carbide-api's 60 s refresh task will pick it up from
+            # Vault automatically — no action needed here.
             _SETUP_PHASE="[6b] DPF already enabled — refreshing BMC-root credential"
             echo "=== [6b] DPF already enabled — refreshing BMC-root credential ==="
             kubectl rollout status deployment/nico-api -n nico-system --timeout=300s
-            _dpf_set_bmc_root
+            if [[ -n "${NICO_DPF_BMC_ROOT_PASSWORD}" ]]; then
+                _dpf_set_bmc_root
+            else
+                echo "NICO_DPF_BMC_ROOT_PASSWORD not set — skipping BMC-root reconcile (carbide-api refresh task handles rotation automatically)."
+            fi
         elif "${INSTALL_DPF}"; then
             _SETUP_PHASE="[6b] DPF enablement"
             echo "=== [6b] Enabling DPF in carbide-api ==="
             kubectl rollout status deployment/nico-api -n nico-system --timeout=300s
-            _dpf_set_bmc_root
+            if [[ -n "${NICO_DPF_BMC_ROOT_PASSWORD}" ]]; then
+                _dpf_set_bmc_root
+            else
+                echo "NICO_DPF_BMC_ROOT_PASSWORD not set — skipping BMC-root credential setup."
+                echo "Set the site-wide BMC root via: nico-admin-cli credential add-bmc --kind=site-wide-root --password='<password>'"
+                echo "carbide-api will pick it up within 60 s of it being set."
+            fi
             echo "Upgrading NICo Core to enable [dpf]..."
             (cd "${SCRIPT_DIR}/.." && helm upgrade --install nico ./helm \
                 --namespace nico-system -f "${_DPF_ON_VALUES}" \

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -77,6 +77,11 @@
 #                          REQUIRED when DPF install is enabled.
 #   NICO_DPF_METALLB_POOL  MetalLB address pool that advertises the DPU cluster
 #                          VIP. Optional — skip when the VIP is already routable.
+#   NICO_DPF_CP_LABEL_VALUE
+#                          Value of the node-role.kubernetes.io/control-plane
+#                          label on this cluster's control-plane nodes.
+#                          Default: "" (the kubeadm convention); set to "true"
+#                          on distributions that label with a value.
 #   NICO_DPF_BMC_ROOT_PASSWORD
 #                          Site-wide BMC root password. REQUIRED unless --skip-dpf.
 #                          setup.sh deploys Core with DPF off, sets this via
@@ -218,6 +223,11 @@ _on_failure() {
     # skipped _dpf_set_bmc_root's own cleanup — the plaintext site-wide BMC
     # password must never linger in the cluster after setup exits.
     if [[ "${INSTALL_DPF:-false}" == "true" ]]; then
+        # Stop the credential Job first: a still-running pod holds the BMC
+        # password in its environment, so it must be gone before (not after)
+        # its source Secrets are removed.
+        kubectl delete job dpf-set-bmc-root -n nico-system \
+            --ignore-not-found --wait=true --timeout=60s >/dev/null 2>&1 || true
         kubectl delete secret dpf-bmc-root-pw dpf-admincli-cert -n nico-system \
             --ignore-not-found >/dev/null 2>&1 || true
     fi
@@ -686,7 +696,7 @@ if "${INSTALL_DPF}"; then
     if ! kubectl get secret hbn-user-password -n dpf-operator-system &>/dev/null; then
         kubectl create secret generic hbn-user-password \
             --namespace dpf-operator-system \
-            --from-literal=password="$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 10)"
+            --from-file=password=<(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 10)
     fi
     kubectl label secret hbn-user-password -n dpf-operator-system \
         dpu.nvidia.com/image-pull-secret="" --overwrite
@@ -770,9 +780,10 @@ if "${INSTALL_DPF}"; then
     fi
     export NICO_DPF_K8S_API_VIP NICO_DPF_K8S_API_PORT
     export NICO_DPF_DPU_INTERFACE NICO_DPF_DPU_CLUSTER_VIP
+    export NICO_DPF_CP_LABEL_VALUE="${NICO_DPF_CP_LABEL_VALUE:-}"
     envsubst '${NICO_DPF_K8S_API_VIP} ${NICO_DPF_K8S_API_PORT}' \
         < operators/dpf/dpfoperatorconfig.yaml.tmpl | kubectl apply -f -
-    envsubst '${NICO_DPF_DPU_INTERFACE} ${NICO_DPF_DPU_CLUSTER_VIP}' \
+    envsubst '${NICO_DPF_DPU_INTERFACE} ${NICO_DPF_DPU_CLUSTER_VIP} ${NICO_DPF_CP_LABEL_VALUE}' \
         < operators/dpf/dpucluster.yaml.tmpl | kubectl apply -f -
     if [[ -n "${NICO_DPF_METALLB_POOL:-}" ]]; then
         export NICO_DPF_METALLB_POOL

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -48,6 +48,39 @@
 #   CERT_MANAGER_NS        cert-manager namespace. Default: cert-manager
 #   PREFLIGHT_CHECK_IMAGE  Image for preflight per-node checks.
 #                          Default: busybox:1.36
+#   NICO_SKIP_DPF          Skip the DPF (DOCA Platform Framework) DPU provisioning
+#                          stack, which installs by DEFAULT. Default: false.
+#                          Same as --skip-dpf. (NICO_INSTALL_DPF=false honored too.)
+#   NICO_DPF_VERSION       doca-platform tag to clone/install. Default: v26.4.0
+#   NICO_DPF_SRC_DIR       Where the doca-platform clone is cached.
+#                          Default: helm-prereqs/.dpf-src
+#   NICO_DPF_IMAGE_REPO    DPF operator image repository. Default the public NGC
+#                          image nvcr.io/nvidia/doca/dpf-system. Point at your own
+#                          registry (mirror or self-built) to match Core/REST.
+#   NICO_DPF_IMAGE_TAG     DPF operator image tag. Default: NICO_DPF_VERSION.
+#   NICO_DPF_IMAGE_PULL_SECRET
+#                          Pull secret for the DPF/DOCA images. Unset by default —
+#                          the GA nvidia/doca images are public and pull
+#                          anonymously. Set for a private registry/mirror.
+#   NICO_DPF_NGC_API_KEY   NGC API key for dpf-pull-secret + Argo helm repos.
+#                          Default: $REGISTRY_PULL_SECRET
+#   NICO_DPF_NICO_NGC_API_KEY
+#                          NGC API key with access to NICo DPUService images
+#                          (nico-pull-secret). Default: $NICO_DPF_NGC_API_KEY
+#   NICO_DPF_K8S_API_VIP   Host-cluster API server IP reachable from DPUs.
+#                          Default: derived from the kubernetes Endpoints.
+#   NICO_DPF_K8S_API_PORT  Host-cluster API server port. Default: derived.
+#   NICO_DPF_DPU_INTERFACE Controller interface for the Kamaji keepalived VIP.
+#                          REQUIRED when DPF install is enabled.
+#   NICO_DPF_DPU_CLUSTER_VIP
+#                          VIP the DPUs use to reach their control plane.
+#                          REQUIRED when DPF install is enabled.
+#   NICO_DPF_METALLB_POOL  MetalLB address pool that advertises the DPU cluster
+#                          VIP. Optional — skip when the VIP is already routable.
+#   NICO_DPF_BMC_ROOT_PASSWORD
+#                          Site-wide BMC root password. REQUIRED unless --skip-dpf.
+#                          setup.sh deploys Core with DPF off, sets this via
+#                          nico-admin-cli, then enables DPF and restarts carbide-api.
 #
 # Usage:
 #   export KUBECONFIG=/path/to/kubeconfig
@@ -66,6 +99,7 @@
 #   ./setup.sh --core-values /path/to/values.yaml      # use site-specific values for Phase 6
 #   ./setup.sh --metallb-config /path/to/metallb.yaml  # use site-specific MetalLB config (file or kustomize dir)
 #   ./setup.sh --site-overlay /path/to/kustomize-dir   # kubectl apply -k after Phase 6 (NTP services, etc.)
+#   ./setup.sh --skip-dpf               # skip DPF DPU provisioning (installed by default otherwise)
 #   ./setup.sh --with-observability     # also install the local monitoring stack (Loki, Tempo,
 #                                       #   OTEL collector, Prometheus, Grafana) after Core —
 #                                       #   see helm-prereqs/observability/README.md; can also be
@@ -87,6 +121,11 @@ AUTO_YES=false
 SKIP_CORE=false
 SKIP_REST=false
 SKIP_FLOW=false
+# DPF (DOCA Platform Framework) DPU provisioning installs by DEFAULT. Opt out
+# with --skip-dpf or NICO_SKIP_DPF=true (e.g. sites with no DPUs, or that still
+# use the deprecated iPXE DPU path). NICO_INSTALL_DPF=false is honored too.
+INSTALL_DPF="${NICO_INSTALL_DPF:-true}"
+[[ "${NICO_SKIP_DPF:-false}" == "true" ]] && INSTALL_DPF=false
 WITH_OBSERVABILITY="${WITH_OBSERVABILITY:-false}"
 CORE_VALUES=""
 METALLB_CONFIG=""
@@ -97,6 +136,8 @@ while [[ $# -gt 0 ]]; do
         --skip-core)    SKIP_CORE=true ;;
         --skip-rest)    SKIP_REST=true ;;
         --skip-flow)    SKIP_FLOW=true ;;
+        --install-dpf)  INSTALL_DPF=true ;;   # explicit; DPF is the default
+        --skip-dpf)     INSTALL_DPF=false ;;
         --with-observability) WITH_OBSERVABILITY=true ;;
         --debug)        set -x         ;;
         --core-values)
@@ -114,7 +155,7 @@ while [[ $# -gt 0 ]]; do
             SITE_OVERLAY="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
             [[ ! -d "${SITE_OVERLAY}" ]] && { echo "Error: --site-overlay directory not found: $2"; exit 1; }
             shift ;;
-        *) echo "Usage: $0 [-y] [--skip-core] [--skip-rest] [--skip-flow] [--with-observability] [--core-values <file>] [--metallb-config <file-or-dir>] [--site-overlay <dir>] [--debug]"; exit 1 ;;
+        *) echo "Usage: $0 [-y] [--skip-core] [--skip-rest] [--skip-flow] [--skip-dpf] [--with-observability] [--core-values <file>] [--metallb-config <file-or-dir>] [--site-overlay <dir>] [--debug]"; exit 1 ;;
     esac
     shift
 done
@@ -124,7 +165,14 @@ done
 # (in-tree rest-api/) and NICO_REST_HELM_DIR (in-tree helm/rest/). Exits 1 if
 # user declines to continue.
 # ---------------------------------------------------------------------------
-export AUTO_YES SKIP_CORE SKIP_REST SKIP_FLOW
+export AUTO_YES SKIP_CORE SKIP_REST SKIP_FLOW INSTALL_DPF
+# Validate INSTALL_DPF BEFORE sourcing preflight — preflight gates its DPF
+# checks on INSTALL_DPF==true, so a garbage NICO_INSTALL_DPF would otherwise
+# silently skip those checks before erroring here.
+case "${INSTALL_DPF}" in
+    true|false) ;;
+    *) echo "Error: NICO_INSTALL_DPF must be true or false (got '${INSTALL_DPF}')"; exit 1 ;;
+esac
 # shellcheck source=preflight.sh
 source "${SCRIPT_DIR}/preflight.sh"
 
@@ -132,16 +180,53 @@ VAULT_NS="${VAULT_NS:-vault}"
 CERT_MANAGER_NS="${CERT_MANAGER_NS:-cert-manager}"
 NICO_MANAGE_DEFAULT_STORAGE_CLASS="${NICO_MANAGE_DEFAULT_STORAGE_CLASS:-true}"
 NICO_STORAGE_CLASS="${NICO_STORAGE_CLASS:-local-path-persistent}"
+NICO_DPF_VERSION="${NICO_DPF_VERSION:-v26.4.0}"
+NICO_DPF_SRC_DIR="${NICO_DPF_SRC_DIR:-${SCRIPT_DIR}/.dpf-src}"
+NICO_DPF_NGC_API_KEY="${NICO_DPF_NGC_API_KEY:-${REGISTRY_PULL_SECRET:-}}"
+NICO_DPF_NICO_NGC_API_KEY="${NICO_DPF_NICO_NGC_API_KEY:-${NICO_DPF_NGC_API_KEY}}"
+# DPF operator image. Defaults to the public NGC image (anonymous pull). To use
+# your own registry (mirror or self-built, e.g. matching NICO_IMAGE_REGISTRY),
+# set NICO_DPF_IMAGE_REPO/_TAG and NICO_DPF_IMAGE_PULL_SECRET. The tag defaults
+# to the chart version (NICO_DPF_VERSION) but can differ for a self-built image.
+NICO_DPF_IMAGE_REPO="${NICO_DPF_IMAGE_REPO:-nvcr.io/nvidia/doca/dpf-system}"
+NICO_DPF_IMAGE_TAG="${NICO_DPF_IMAGE_TAG:-${NICO_DPF_VERSION}}"
+# Site-wide BMC root password. DPF SDK init hard-requires it, and it can only be
+# set through a running carbide-api (with DPF off). setup.sh deploys Core with
+# DPF disabled, sets this via nico-admin-cli, then enables DPF and restarts.
+NICO_DPF_BMC_ROOT_PASSWORD="${NICO_DPF_BMC_ROOT_PASSWORD:-}"
 
 # ---------------------------------------------------------------------------
 # Failure handler — offer to run clean.sh if setup exits with an error.
 # Registered AFTER preflight so preflight aborts don't trigger it.
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="initializing"
+# Set true only while Kamaji's DataStore webhook is relaxed to Ignore during the
+# cold-start deadlock break, so the EXIT trap can restore Fail if we abort in
+# between and never leave admission validation fail-open.
+_KAMAJI_WH_RELAXED=false
 
 _on_failure() {
     local _rc=$?
     local _cmd="${BASH_COMMAND}"
+    # Always remove the DPF two-phase rendered-values tempfiles (they hold the
+    # full site config) and the freshly issued admin client key/cert, regardless
+    # of success or failure. Runs on every EXIT, so the private key is wiped even
+    # when errexit aborts _dpf_set_bmc_root before its own explicit cleanup.
+    rm -f "${_DPF_ON_VALUES:-}" "${_DPF_OFF_VALUES:-}" 2>/dev/null || true
+    rm -rf "${_DPF_CERT_JSON:-}" "${_DPF_CERT_DIR:-}" 2>/dev/null || true
+    # Drop the ephemeral BMC-root + admin-cert Secrets if a mid-run errexit
+    # skipped _dpf_set_bmc_root's own cleanup — the plaintext site-wide BMC
+    # password must never linger in the cluster after setup exits.
+    if [[ "${INSTALL_DPF:-false}" == "true" ]]; then
+        kubectl delete secret dpf-bmc-root-pw dpf-admincli-cert -n nico-system \
+            --ignore-not-found >/dev/null 2>&1 || true
+    fi
+    # Restore Kamaji's DataStore webhook to Fail if a mid-run errexit left it
+    # relaxed to Ignore during the deadlock break — never exit fail-open.
+    if [[ "${_KAMAJI_WH_RELAXED:-false}" == "true" ]]; then
+        _kamaji_patch_failurepolicy Fail 2>/dev/null || true
+        _KAMAJI_WH_RELAXED=false
+    fi
     [[ ${_rc} -eq 0 ]] && return              # clean exit — nothing to do
     [[ "${_SETUP_PHASE}" == "complete" ]] && return  # finished successfully
 
@@ -462,6 +547,405 @@ until ROLE_ID_B64="$(kubectl get secret nico-vault-approle-tokens \
 done
 echo "Vault AppRole credentials ready"
 
+# ---------------------------------------------------------------------------
+# 5b. DPF (DOCA Platform Framework) — optional DPU provisioning stack.
+#     Needs StorageClass (1), MetalLB (1c), cert-manager (2). Must complete
+#     BEFORE NICo Core (6): carbide-api reads [dpf] config at startup only and
+#     expects the dpu.nvidia.com CRDs, the operator, DPFOperatorConfig, and
+#     DPUCluster to already exist; the core chart's nico-api-dpf Role also
+#     targets the dpf-operator-system namespace created here.
+#     See docs/manuals/dpf.md for the full background.
+# ---------------------------------------------------------------------------
+if "${INSTALL_DPF}"; then
+    _SETUP_PHASE="[5b] DPF operator stack"
+    echo "=== [5b] DPF (DOCA Platform Framework) ${NICO_DPF_VERSION} ==="
+
+    # 5b.1 Prerequisite operators (Argo CD, Kamaji, maintenance-operator, NFD),
+    #      pinned from doca-platform deploy/helmfiles/prereqs.yaml. All land in
+    #      dpf-operator-system, same as upstream.
+    helmfile sync -l name=argo-cd
+
+    # Kamaji has a cold-start deadlock: its controller requires the 'default'
+    # DataStore at boot (--datastore=default), but that DataStore's admission
+    # webhook (vdatastore.kb.io, failurePolicy=Fail) is served by the
+    # not-yet-running controller — so the DataStore can never be created and
+    # the controller crashloops. Break the cycle: attempt the install (creates
+    # etcd + controller + webhook, DataStore rejected), relax the datastore
+    # webhook to Ignore, create the DataStore out-of-band so the controller can
+    # boot, restore the webhook to Fail, then re-sync to reconcile the release.
+    if ! helmfile sync -l name=kamaji; then
+        echo "kamaji first sync failed (expected DataStore webhook deadlock) — breaking the cycle..."
+        _kamaji_wh=kamaji-validating-webhook-configuration
+        _kamaji_patch_failurepolicy() {  # $1 = Ignore|Fail
+            local _idx
+            # `|| true`: if the webhook config is absent (kamaji aborted before Helm
+            # created it), pipefail+errexit would otherwise kill setup here, before
+            # the empty-_idx tolerance guard below can handle it.
+            _idx=$(kubectl get validatingwebhookconfiguration "${_kamaji_wh}" -o json 2>/dev/null \
+                | jq -r '.webhooks | to_entries[] | select(.value.name=="vdatastore.kb.io") | .key' || true)
+            [[ -z "${_idx}" ]] && return 0
+            kubectl patch validatingwebhookconfiguration "${_kamaji_wh}" --type=json \
+                -p="[{\"op\":\"replace\",\"path\":\"/webhooks/${_idx}/failurePolicy\",\"value\":\"$1\"}]"
+        }
+        _kamaji_patch_failurepolicy Ignore
+        _KAMAJI_WH_RELAXED=true
+        # Create the controller's bootstrap dependencies out-of-band: the
+        # cert-manager Issuer + Certificate (so the webhook-server cert issues
+        # and the controller container can mount it) and the default DataStore
+        # (so the controller doesn't crashloop). The failed first sync aborts
+        # at the DataStore CR and may not have created the Issuer (helm's CR
+        # apply order is nondeterministic), so we can't rely on its partial
+        # state — create all three explicitly, matching the chart.
+        echo "Creating the Kamaji Issuer, webhook Certificate, and default DataStore out-of-band..."
+        helm template kamaji oci://ghcr.io/nvidia/charts/kamaji --version 1.2.0 \
+            -n dpf-operator-system -f operators/values/kamaji.yaml \
+            --show-only templates/certmanager_issuer.yaml \
+            --show-only templates/certmanager_certificate.yaml \
+            --show-only charts/kamaji-etcd/templates/etcd_datastore.yaml | kubectl apply -f -
+        echo "Waiting for the kamaji controller to come up (cert issued + DataStore present)..."
+        kubectl rollout status deployment/kamaji -n dpf-operator-system --timeout=300s
+        # Restore failurePolicy to Fail *before* the reconcile sync. helm's
+        # server-side apply only conflicts when it would change a field another
+        # manager owns to a different value — setting Fail (what the chart
+        # renders) to the already-Fail value is co-ownership, not a conflict.
+        _kamaji_patch_failurepolicy Fail
+        _KAMAJI_WH_RELAXED=false
+        # Reconcile the release to deployed now that the controller backs the
+        # webhook and the DataStore exists.
+        helmfile sync -l name=kamaji
+    fi
+
+    helmfile sync -l name=maintenance-operator
+    helmfile sync -l name=node-feature-discovery
+    echo "Waiting for DPF prerequisite controllers..."
+    kubectl rollout status deployment -n dpf-operator-system \
+        -l app.kubernetes.io/name=argocd-repo-server --timeout=300s
+    kubectl rollout status statefulset -n dpf-operator-system \
+        -l app.kubernetes.io/name=argocd-application-controller --timeout=300s
+
+    # 5b.2 Pull + repo secrets. Idempotent (apply of a dry-run render).
+    #      The dpu.nvidia.com/image-pull-secret label makes DPF propagate the
+    #      Secret into DPUService image-pull secrets on the DPU cluster.
+    if [[ -n "${NICO_DPF_NGC_API_KEY}" ]]; then
+        echo "Creating DPF pull and Argo CD repository secrets..."
+        # Build the docker-registry secrets off-argv: a kubectl `--docker-password`
+        # argument is world-readable via ps / /proc on the host running setup.sh.
+        # Feed the token through the builtin printf + a process-substitution file
+        # so the NGC key never appears in an exec argument. Same resulting
+        # kubernetes.io/dockerconfigjson secret as `kubectl create secret
+        # docker-registry` would produce.
+        _dpf_docker_secret() {  # secret-name, registry-server, token
+            local _n="$1" _srv="$2" _tok="$3" _auth
+            _auth="$(printf '%s' "\$oauthtoken:${_tok}" | base64 | tr -d '\n')"
+            kubectl create secret generic "${_n}" \
+                --namespace dpf-operator-system \
+                --type=kubernetes.io/dockerconfigjson \
+                --from-file=.dockerconfigjson=<(printf \
+                    '{"auths":{"%s":{"username":"$oauthtoken","password":"%s","auth":"%s"}}}' \
+                    "${_srv}" "${_tok}" "${_auth}") \
+                --dry-run=client -o yaml | kubectl apply -f -
+        }
+        _dpf_docker_secret dpf-pull-secret  nvcr.io "${NICO_DPF_NGC_API_KEY}"
+        _dpf_docker_secret nico-pull-secret nvcr.io "${NICO_DPF_NICO_NGC_API_KEY}"
+        kubectl label secret dpf-pull-secret nico-pull-secret \
+            -n dpf-operator-system dpu.nvidia.com/image-pull-secret="" --overwrite
+        # Argo CD helm repository secrets (argocd.argoproj.io/secret-type label
+        # is how Argo CD discovers them). URLs must not end with '/'.
+        _dpf_argo_repo_secret() {  # name, repo-name, url, extra literals...
+            local _name="$1" _repo="$2" _url="$3"; shift 3
+            kubectl create secret generic "${_name}" \
+                --namespace dpf-operator-system \
+                --from-literal=name="${_repo}" \
+                --from-literal=url="${_url}" \
+                --from-literal=type=helm \
+                --from-literal=username='$oauthtoken' \
+                --from-file=password=<(printf '%s' "${NICO_DPF_NGC_API_KEY}") \
+                "$@" \
+                --dry-run=client -o yaml | kubectl apply -f -
+            kubectl label secret "${_name}" -n dpf-operator-system \
+                argocd.argoproj.io/secret-type=repository --overwrite
+        }
+        # These repo-secret URLs must EXACTLY match the helm_repo_url carbide-api
+        # requests when deploying each DPUService (its [dpf.services.*] defaults,
+        # crates/api-core/src/dpf_services.rs), or Argo CD can't match the repo
+        # and the private chart pull fails. Override in lockstep with
+        # [dpf.services.*] when you mirror the charts.
+        _dpf_argo_repo_secret ngc-doca-oci-helm nvidia-doca-oci \
+            "${NICO_DPF_HELM_REPO_OCI:-nvcr.io/nvidia/doca}" \
+            --from-literal=enableOCI=true
+        _dpf_argo_repo_secret ngc-doca-https-helm nvidia-doca-https \
+            "${NICO_DPF_HELM_REPO_HTTPS:-https://helm.ngc.nvidia.com/nvidia/doca}"
+        _dpf_argo_repo_secret ngc-carbide-https-helm nvidia-carbide-https \
+            "${NICO_DPF_HELM_REPO_CARBIDE:-https://helm.ngc.nvidia.com/0837451325059433/carbide-dev}"
+    else
+        echo "NICO_DPF_NGC_API_KEY / REGISTRY_PULL_SECRET not set — skipping DPF pull"
+        echo "and Argo CD repository secrets (air-gapped or pre-loaded registry)."
+    fi
+    # hbn-user-password: random local FRR credential for the HBN DPUService;
+    # generate only when absent so re-runs don't rotate it.
+    if ! kubectl get secret hbn-user-password -n dpf-operator-system &>/dev/null; then
+        kubectl create secret generic hbn-user-password \
+            --namespace dpf-operator-system \
+            --from-literal=password="$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 10)"
+    fi
+    kubectl label secret hbn-user-password -n dpf-operator-system \
+        dpu.nvidia.com/image-pull-secret="" --overwrite
+
+    # 5b.3 cert-manager approver policy. Only needed (and only appliable) when
+    #      the cluster runs approver-policy; our stock cert-manager does not
+    #      (built-in approver auto-approves — operators/values/cert-manager.yaml).
+    if kubectl get crd certificaterequestpolicies.policy.cert-manager.io &>/dev/null; then
+        echo "approver-policy detected — applying DPF CertificateRequestPolicy..."
+        kubectl apply -f operators/dpf/cert-manager-policy.yaml
+    else
+        echo "approver-policy not installed — built-in cert-manager approver auto-approves; skipping CertificateRequestPolicy."
+    fi
+
+    # 5b.4 Clone doca-platform at the pinned tag (cached, shallow, idempotent).
+    if [[ -d "${NICO_DPF_SRC_DIR}/.git" ]]; then
+        echo "Reusing doca-platform clone at ${NICO_DPF_SRC_DIR} (tag ${NICO_DPF_VERSION})..."
+        git -C "${NICO_DPF_SRC_DIR}" fetch --depth 1 origin \
+            "refs/tags/${NICO_DPF_VERSION}:refs/tags/${NICO_DPF_VERSION}" 2>/dev/null || true
+        git -C "${NICO_DPF_SRC_DIR}" checkout -q -f "refs/tags/${NICO_DPF_VERSION}"
+    else
+        # A leftover non-git or partially-cloned directory (e.g. a clone killed
+        # mid-run, or disk-full) would make `git clone` fail with "destination
+        # path already exists and is not empty" on every retry — remove it first
+        # so a re-run always recovers. Guard the rm -rf against a dangerous
+        # NICO_DPF_SRC_DIR override (empty / root / $HOME) before deleting.
+        case "${NICO_DPF_SRC_DIR}" in
+            ""|"/"|"${HOME}"|"${HOME}/")
+                echo "ERROR: refusing to remove NICO_DPF_SRC_DIR='${NICO_DPF_SRC_DIR}' — set it to a dedicated clone dir."
+                exit 1 ;;
+        esac
+        if [[ -e "${NICO_DPF_SRC_DIR}" ]]; then
+            echo "ERROR: '${NICO_DPF_SRC_DIR}' exists but is not a doca-platform Git clone."
+            echo "  Remove it explicitly and re-run (refusing to auto-delete a non-clone path)."
+            exit 1
+        fi
+        echo "Cloning doca-platform ${NICO_DPF_VERSION}..."
+        git clone --depth 1 --branch "${NICO_DPF_VERSION}" \
+            https://github.com/NVIDIA/doca-platform.git "${NICO_DPF_SRC_DIR}"
+    fi
+
+    # 5b.5 DPF operator chart from the clone. NICo overrides (docs/manuals/dpf.md
+    #      §2): NodeFeatureRules off because NFD labels nodes via its own config
+    #      (PCI class 0200). The in-repo source chart ships EMPTY
+    #      controllerManager.image (CI stamps it when publishing to NGC), so we
+    #      set it explicitly — matching the published nvidia/doca chart. Repo is
+    #      overridable; the tag tracks NICO_DPF_VERSION.
+    #      Image pull secret: the GA nvidia/doca images are PUBLIC, so by default
+    #      the operator pulls them anonymously. Attaching a registry-scoped
+    #      secret that lacks nvidia/doca entitlement makes nvcr.io 403 the pull
+    #      (kubelet does not fall back to anonymous). Set NICO_DPF_IMAGE_PULL_SECRET
+    #      only when the DPF/DOCA images live in a private registry/mirror.
+    _dpf_op_pull_args=()
+    if [[ -n "${NICO_DPF_IMAGE_PULL_SECRET:-}" ]]; then
+        _dpf_op_pull_args+=(--set "imagePullSecrets[0].name=${NICO_DPF_IMAGE_PULL_SECRET}")
+    fi
+    helm upgrade --install dpf-operator \
+        "${NICO_DPF_SRC_DIR}/deploy/charts/dpf-operator" \
+        --namespace dpf-operator-system \
+        --set "enableNodeFeatureRules=false" \
+        ${_dpf_op_pull_args[@]+"${_dpf_op_pull_args[@]}"} \
+        --set "controllerManager.image.repository=${NICO_DPF_IMAGE_REPO}" \
+        --set "controllerManager.image.tag=${NICO_DPF_IMAGE_TAG}" \
+        --wait --timeout 600s
+    kubectl wait --for=condition=Available deployment/dpf-operator-controller-manager \
+        -n dpf-operator-system --timeout=300s
+    echo "DPF operator ready"
+
+    # 5b.6 Operator-level CRs. carbide-api only reads/patches these — they must
+    #      be created here (its SDK creates BFB/DPUFlavor/DPUDeployment itself
+    #      at startup, but never DPFOperatorConfig or DPUCluster).
+    if [[ -z "${NICO_DPF_K8S_API_VIP:-}" ]]; then
+        NICO_DPF_K8S_API_VIP="$(kubectl get endpoints kubernetes -n default \
+            -o jsonpath='{.subsets[0].addresses[0].ip}')"
+        echo "NICO_DPF_K8S_API_VIP not set — derived ${NICO_DPF_K8S_API_VIP} from the kubernetes Endpoints."
+        echo "  NOTE: this must be reachable FROM THE DPUs; override if the derived address is not."
+    fi
+    if [[ -z "${NICO_DPF_K8S_API_PORT:-}" ]]; then
+        NICO_DPF_K8S_API_PORT="$(kubectl get endpoints kubernetes -n default \
+            -o jsonpath='{.subsets[0].ports[0].port}')"
+    fi
+    export NICO_DPF_K8S_API_VIP NICO_DPF_K8S_API_PORT
+    export NICO_DPF_DPU_INTERFACE NICO_DPF_DPU_CLUSTER_VIP
+    envsubst '${NICO_DPF_K8S_API_VIP} ${NICO_DPF_K8S_API_PORT}' \
+        < operators/dpf/dpfoperatorconfig.yaml.tmpl | kubectl apply -f -
+    envsubst '${NICO_DPF_DPU_INTERFACE} ${NICO_DPF_DPU_CLUSTER_VIP}' \
+        < operators/dpf/dpucluster.yaml.tmpl | kubectl apply -f -
+    if [[ -n "${NICO_DPF_METALLB_POOL:-}" ]]; then
+        export NICO_DPF_METALLB_POOL
+        envsubst '${NICO_DPF_METALLB_POOL} ${NICO_DPF_DPU_CLUSTER_VIP}' \
+            < operators/dpf/dpu-cluster-vip-service.yaml.tmpl | kubectl apply -f -
+    else
+        echo "NICO_DPF_METALLB_POOL not set — skipping the DPU cluster VIP LoadBalancer Service."
+        echo "  Ensure ${NICO_DPF_DPU_CLUSTER_VIP} is routable from the DPUs by other means."
+    fi
+
+    # 5b.7 Readiness — WARN only. Kamaji TenantControlPlane bring-up can take
+    #      minutes and depends on VIP routability that this script can't verify.
+    echo "Waiting up to 300s for the DPU cluster control plane (non-fatal)..."
+    _dpf_deadline=$(( $(date +%s) + 300 ))
+    until [[ "$(kubectl get dpucluster carbide-dpf-cluster -n dpf-operator-system \
+                -o jsonpath='{.status.phase}' 2>/dev/null)" == "Ready" ]]; do
+        if (( $(date +%s) >= _dpf_deadline )); then
+            echo "WARNING: DPUCluster carbide-dpf-cluster is not Ready yet. Continuing —"
+            echo "  check it later with: kubectl get dpucluster,tenantcontrolplane -n dpf-operator-system"
+            break
+        fi
+        sleep 10
+    done
+
+    # 5b.8 [dpf] is NOT enabled in the Core config here. carbide-api's DPF SDK
+    #      init hard-requires the site-wide BMC root password, which can only be
+    #      set through a running carbide-api. So the enablement is deferred:
+    #      phase 6 deploys Core with DPF OFF, sets the BMC root password via
+    #      nico-admin-cli, then enables [dpf] and restarts carbide-api.
+    echo "DPF stack installed (carbide-api DPF enablement happens after Core in phase 6)"
+else
+    echo "Skipping DPF (--skip-dpf / NICO_SKIP_DPF=true). DPUs, if any, use the deprecated iPXE path."
+fi
+
+# ---------------------------------------------------------------------------
+# Set the site-wide BMC root password via nico-admin-cli. Used by phase 6b.
+# Issues a short-lived admin client cert from the nicoca PKI (per
+# docs/provisioning/ingesting-hosts.md), then runs the CLI (bundled in the
+# NICo image at /opt/carbide/nico-admin-cli) as an in-cluster Job that reaches
+# carbide-api through its external LoadBalancer, verifying TLS with the
+# issued CA and authenticating with the client cert.
+# ---------------------------------------------------------------------------
+_dpf_set_bmc_root() {
+    local _hostname _lbip _vault_token
+    # `|| true` so a no-match grep (nothing to resolve) doesn't trip `set -e`
+    # via pipefail before the guard below can report a clean error.
+    # Strip an inline YAML "# comment" before quotes/space so a value left with
+    # the shipped trailing comment (hostname: "api.foo" # REQUIRED: ...) doesn't
+    # bleed the comment text into the hostname (which would break API_URL and the
+    # Job hostAliases). Matches preflight's _strip_comments.
+    _hostname="$( { grep -E '^[[:space:]]+hostname:' "${_CORE_VALUES_FILE}" | head -1 \
+        | sed -E "s/.*hostname:[[:space:]]*//; s/[[:space:]]+#.*$//; s/[\"']//g" | tr -d '[:space:]'; } || true)"
+    _lbip="$(kubectl get svc nico-api-external -n nico-system \
+        -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+    if [[ -z "${_hostname}" || -z "${_lbip}" ]]; then
+        echo "ERROR: could not resolve nico-api hostname (${_hostname:-?}) or LB IP (${_lbip:-?})"
+        return 1
+    fi
+    echo "Setting site-wide BMC root password (api ${_hostname} -> ${_lbip})..."
+
+    # 1. Issue a short-lived admin client cert from the nicoca PKI.
+    _vault_token="$(kubectl -n "${VAULT_NS}" get secret vaultroottoken \
+        -o jsonpath='{.data.token}' | base64 -d)"
+    # Script-global (not local) so the EXIT trap wipes the private key if we
+    # fail before the explicit cleanup below — errexit skips the rest of the fn.
+    _DPF_CERT_JSON="$(mktemp)"; _DPF_CERT_DIR="$(mktemp -d)"
+    # Feed the Vault ROOT token via stdin, never as an exec argument: kubectl
+    # encodes argv into the API-server audit log (requestURI) and it surfaces in
+    # vault-0's process list, exposing the full-privilege root token. `read`
+    # pulls it from stdin inside the pod; the CN (not secret) rides in as $1.
+    printf '%s\n' "${_vault_token}" | kubectl -n "${VAULT_NS}" exec -i vault-0 -- \
+        sh -c 'read -r VAULT_TOKEN; export VAULT_TOKEN VAULT_SKIP_VERIFY=true
+               vault write -format=json nicoca/issue/nico-cluster \
+                 common_name="$1" ttl=1h' _ "${_hostname}" > "${_DPF_CERT_JSON}"
+    jq -r '.data.certificate' "${_DPF_CERT_JSON}" > "${_DPF_CERT_DIR}/client.crt"
+    jq -r '.data.private_key' "${_DPF_CERT_JSON}" > "${_DPF_CERT_DIR}/client.key"
+    jq -r '.data.issuing_ca'  "${_DPF_CERT_JSON}" > "${_DPF_CERT_DIR}/ca.crt"
+    kubectl create secret generic dpf-admincli-cert -n nico-system \
+        --from-file=client.crt="${_DPF_CERT_DIR}/client.crt" \
+        --from-file=client.key="${_DPF_CERT_DIR}/client.key" \
+        --from-file=ca.crt="${_DPF_CERT_DIR}/ca.crt" \
+        --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create secret generic dpf-bmc-root-pw -n nico-system \
+        --from-file=password=<(printf '%s' "${NICO_DPF_BMC_ROOT_PASSWORD}") \
+        --dry-run=client -o yaml | kubectl apply -f -
+    rm -rf "${_DPF_CERT_JSON}" "${_DPF_CERT_DIR}"; _DPF_CERT_JSON=""; _DPF_CERT_DIR=""
+
+    # 2. Run nico-admin-cli as a Job against carbide-api's external endpoint.
+    kubectl delete job dpf-set-bmc-root -n nico-system --ignore-not-found >/dev/null 2>&1
+    kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dpf-set-bmc-root
+  namespace: nico-system
+spec:
+  backoffLimit: 3
+  # Hard-bound the Job so a stuck/retrying pod can't keep the BMC password in
+  # its environment past the poll deadline below.
+  activeDeadlineSeconds: 180
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      imagePullSecrets:
+        - name: imagepullsecret
+      hostAliases:
+        - ip: "${_lbip}"
+          hostnames: ["${_hostname}"]
+      volumes:
+        - name: cert
+          secret:
+            secretName: dpf-admincli-cert
+      containers:
+        - name: admincli
+          image: "${NICO_IMAGE_REGISTRY}/nvmetal-carbide:${NICO_CORE_IMAGE_TAG}"
+          command: ["/opt/carbide/nico-admin-cli"]
+          args:
+            - credential
+            - add-bmc
+            - --kind=site-wide-root
+            - --username=admin
+            - --password=\$(BMC_ROOT_PASSWORD)
+          env:
+            - name: API_URL
+              value: "https://${_hostname}:443"
+            - name: ROOT_CA_PATH
+              value: /certs/ca.crt
+            - name: CLIENT_CERT_PATH
+              value: /certs/client.crt
+            - name: CLIENT_KEY_PATH
+              value: /certs/client.key
+            - name: BMC_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dpf-bmc-root-pw
+                  key: password
+          volumeMounts:
+            - name: cert
+              mountPath: /certs
+              readOnly: true
+EOF
+    # Poll for either terminal state so a failed Job (bad password, cert
+    # rejected) is caught immediately instead of burning the full timeout.
+    echo "Waiting for the BMC-root Job to complete..."
+    local _job_ok=false _deadline _s _f
+    _deadline=$(( $(date +%s) + 180 ))
+    while (( $(date +%s) < _deadline )); do
+        _s="$(kubectl get job dpf-set-bmc-root -n nico-system \
+            -o jsonpath='{.status.succeeded}' 2>/dev/null || true)"
+        _f="$(kubectl get job dpf-set-bmc-root -n nico-system \
+            -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)"
+        [[ "${_s}" == "1" ]] && { _job_ok=true; break; }
+        [[ "${_f}" == "True" ]] && break
+        sleep 3
+    done
+    if [[ "${_job_ok}" != "true" ]]; then
+        echo "ERROR: nico-admin-cli BMC-root Job did not complete. Recent logs:"
+        kubectl logs job/dpf-set-bmc-root -n nico-system --tail=40 2>/dev/null || true
+        # Delete (and wait for) the Job so no pod keeps the BMC password in its
+        # environment before we remove the Secrets below.
+        kubectl delete job dpf-set-bmc-root -n nico-system \
+            --ignore-not-found --wait=true >/dev/null 2>&1 || true
+    fi
+    # Always remove the plaintext BMC password + client-cert secrets — on the
+    # failure path too, so the site-wide BMC password never lingers in the
+    # cluster after a failed enablement.
+    kubectl delete secret dpf-bmc-root-pw dpf-admincli-cert -n nico-system \
+        --ignore-not-found >/dev/null 2>&1
+    [[ "${_job_ok}" == "true" ]] || return 1
+    echo "Site-wide BMC root password set."
+}
+
 if ! "${SKIP_CORE}"; then
     # Create imagepullsecret in nico-system so the API migrate hook can pull its
     # image. The hook runs before chart resources are created, so this must exist
@@ -491,6 +975,93 @@ else
     _CORE_VALUES_FILE="${CORE_VALUES:-${SCRIPT_DIR}/values/nico-core.yaml}"
     _CORE_VALUES_ARG="${CORE_VALUES:-helm-prereqs/values/nico-core.yaml}"
 
+    if "${INSTALL_DPF}"; then
+        # Two-phase DPF enablement. carbide-api's DPF SDK init hard-requires the
+        # site-wide BMC root password, which can only be set through a running
+        # carbide-api — so Core is deployed with DPF OFF first, then re-deployed
+        # with DPF ON after the password is set (phase 6b below). Build both.
+        _DPF_ON_VALUES="$(mktemp -t nico-core-dpf-on.XXXXXX)"
+        _DPF_OFF_VALUES="$(mktemp -t nico-core-dpf-off.XXXXXX)"
+        if [[ -n "${CORE_VALUES}" ]]; then
+            # --core-values is expected to carry a [dpf] block with enabled=true.
+            cp "${_CORE_VALUES_FILE}" "${_DPF_ON_VALUES}"
+        else
+            # default file: the [dpf] block ships '#dpf# '-commented; uncomment it.
+            sed -E 's/^([[:space:]]*)#dpf# ?/\1/' "${_CORE_VALUES_FILE}" > "${_DPF_ON_VALUES}"
+        fi
+        # DPF-OFF = DPF-ON with the [dpf] section's own `enabled` forced to false.
+        # Only the direct [dpf] key is targeted: entering any other top-level
+        # [section] clears the in-block state so we never flip a later
+        # section's `enabled` when [dpf] has no inline `enabled =` of its own.
+        awk '
+            /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { indpf = ($0 ~ /^[[:space:]]*\[dpf\][[:space:]]*$/) ? 1 : 0 }
+            indpf==1 && /^[[:space:]]*enabled[[:space:]]*=/ { sub(/=[[:space:]]*true/, "= false"); indpf=0 }
+            { print }
+        ' "${_DPF_ON_VALUES}" > "${_DPF_OFF_VALUES}"
+
+        # Guard against a silent no-op: if the ON values don't actually enable
+        # [dpf] (e.g. --core-values with no/commented [dpf] block, or an inline
+        # [dpf] table the toggle can't read), the two-phase flow would deploy
+        # Core, "enable" nothing, restart, and falsely report success while
+        # carbide-api runs DPF-off. Fail early with an actionable message.
+        _dpf_site_enabled() {   # prints the [dpf] section's `enabled` value, or "absent"
+            awk '
+                /^[[:space:]]*\[[^]]+\][[:space:]]*$/ { indpf = ($0 ~ /^[[:space:]]*\[dpf\][[:space:]]*$/) ? 1 : 0 }
+                indpf==1 && /^[[:space:]]*enabled[[:space:]]*=/ {
+                    # Anchor to the FIRST "=" (the key/value separator); a greedy
+                    # ".*=" would read a trailing comment like "# default=true".
+                    v=$0; sub(/^[^=]*=[[:space:]]*/,"",v); sub(/[[:space:]].*/,"",v); print v; found=1; exit
+                }
+                END { if (!found) print "absent" }
+            ' "$1"
+        }
+        if [[ "$(_dpf_site_enabled "${_DPF_ON_VALUES}")" != "true" ]]; then
+            echo "Error: DPF is enabled (the default), but the site config has no '[dpf]' table with"
+            echo "  'enabled = true' on its own line."
+            if [[ -n "${CORE_VALUES}" ]]; then
+                echo "  Add a [dpf] block (enabled = true, docker_image_pull_secret = \"nico-pull-secret\")"
+                echo "  to ${CORE_VALUES}, or pass --skip-dpf. See docs/manuals/dpf.md §3.5."
+            else
+                echo "  The default values/nico-core.yaml [dpf] block appears to have been removed."
+            fi
+            exit 1
+        fi
+        if [[ "$(_dpf_site_enabled "${_DPF_OFF_VALUES}")" == "true" ]]; then
+            echo "Error: could not disable [dpf] for the first-phase (DPF-off) Core deploy."
+            echo "  Write [dpf] as a standard table header with 'enabled = true' on its own line."
+            exit 1
+        fi
+
+        # Idempotent re-run: if the LIVE site config already has DPF enabled (a
+        # prior run reached phase 6b), carbide-api is already up with the site-wide
+        # BMC root set. Re-running the DPF-OFF phase would rewrite the ConfigMap to
+        # enabled=false and — if phase 6b then failed — leave the site DPF-disabled
+        # on the next pod restart ([dpf] is read only at startup). So detect that
+        # state and deploy DPF-ON directly, skipping the down-cycle and BMC step.
+        # The live ConfigMap's [dpf].enabled=true is only ever persisted by phase
+        # 6b's DPF-ON upgrade, which runs strictly AFTER _dpf_set_bmc_root sets the
+        # site-wide BMC root — so enabled=true alone implies BMC is set. Detect it
+        # from the ConfigMap ONLY: gating on live pod health would false-negative
+        # during a healthy in-progress rollout and wrongly re-run the destructive
+        # down-cycle this check exists to prevent. (A fresh install has no such
+        # ConfigMap; a prior run that failed before phase 6b left it enabled=false.)
+        _dpf_already_on=false
+        _live_site_toml="$(kubectl get configmap nico-api-site-config-files -n nico-system \
+            -o jsonpath='{.data.nico-api-site-config\.toml}' 2>/dev/null || true)"
+        if [[ -n "${_live_site_toml}" ]] \
+           && [[ "$(_dpf_site_enabled <(printf '%s\n' "${_live_site_toml}"))" == "true" ]]; then
+            _dpf_already_on=true
+        fi
+        if "${_dpf_already_on}"; then
+            echo "DPF already enabled in the live site config — skipping the DPF-off down-cycle;"
+            echo "the BMC-root credential is refreshed in phase 6b (idempotent re-run)."
+            _CORE_VALUES_ARG="${_DPF_ON_VALUES}"
+        else
+            # Deploy the DPF-OFF version in this phase; phase 6b upgrades to DPF-ON.
+            _CORE_VALUES_ARG="${_DPF_OFF_VALUES}"
+        fi
+    fi
+
     NICO_CORE_CMD=(
         helm upgrade --install nico ./helm
         --namespace nico-system
@@ -499,6 +1070,11 @@ else
         --set-string "global.image.tag=${NICO_CORE_IMAGE_TAG}"
         --timeout 600s --wait
     )
+    if "${INSTALL_DPF}"; then
+        # Create the nico-api-dpf Role/RoleBinding in dpf-operator-system so
+        # carbide-api can manage DPF CRs (chart template dpf-rbac.yaml).
+        NICO_CORE_CMD+=(--set "nico-api.dpf.rbacCreate=true")
+    fi
     _NICO_CORE_CMD_DISPLAY=""
     for _arg in "${NICO_CORE_CMD[@]}"; do
         printf -v _quoted_arg '%q' "${_arg}"
@@ -556,6 +1132,52 @@ else
         _SETUP_PHASE="[6/6] NICo Core"
         echo "=== [6/6] NICo Core ==="
         (cd "${SCRIPT_DIR}/.." && "${NICO_CORE_CMD[@]}")
+
+        # -------------------------------------------------------------------
+        # 6b. DPF enablement in carbide-api. Core is up with DPF OFF; now set
+        #     the site-wide BMC root password (required by the DPF SDK) via
+        #     nico-admin-cli, then upgrade Core to DPF ON, which rolls
+        #     carbide-api so it initializes the DPF SDK.
+        # -------------------------------------------------------------------
+        if "${INSTALL_DPF}" && "${_dpf_already_on:-false}"; then
+            # Skip the destructive DPF-off down-cycle, but still (re-)apply the
+            # site-wide BMC root credential so a rerun with a rotated/corrected
+            # NICO_DPF_BMC_ROOT_PASSWORD is reconciled — preflight requires it, so
+            # it must not be silently ignored on an already-enabled site.
+            _SETUP_PHASE="[6b] DPF already enabled — refreshing BMC-root credential"
+            echo "=== [6b] DPF already enabled — refreshing BMC-root credential ==="
+            kubectl rollout status deployment/nico-api -n nico-system --timeout=300s
+            _dpf_set_bmc_root
+        elif "${INSTALL_DPF}"; then
+            _SETUP_PHASE="[6b] DPF enablement"
+            echo "=== [6b] Enabling DPF in carbide-api ==="
+            kubectl rollout status deployment/nico-api -n nico-system --timeout=300s
+            _dpf_set_bmc_root
+            echo "Upgrading NICo Core to enable [dpf]..."
+            (cd "${SCRIPT_DIR}/.." && helm upgrade --install nico ./helm \
+                --namespace nico-system -f "${_DPF_ON_VALUES}" \
+                --set-string "global.image.repository=${NICO_IMAGE_REGISTRY}/nvmetal-carbide" \
+                --set-string "global.image.tag=${NICO_CORE_IMAGE_TAG}" \
+                --set "nico-api.dpf.rbacCreate=true" \
+                --timeout 600s --wait)
+            # The helm upgrade only rewrites the site-config ConfigMap; the
+            # nico-api pod template is unchanged, so it does NOT roll on its own
+            # and carbide-api keeps its in-memory DPF-off config ([dpf] is read
+            # at startup only). Force a restart so it re-reads [dpf].enabled=true
+            # and creates the DPF init objects (BFB, DPUFlavor, DPUDeployment).
+            echo "Restarting carbide-api so it reads the DPF-enabled config..."
+            kubectl rollout restart deployment/nico-api -n nico-system
+            kubectl rollout status deployment/nico-api -n nico-system --timeout=300s
+            echo "DPF enabled in carbide-api"
+        fi
+    elif "${INSTALL_DPF}"; then
+        # The DPF path deploys from a mktemp values file that the EXIT trap
+        # deletes, and enablement is a two-phase flow (deploy DPF-off, set the
+        # site-wide BMC root password, re-deploy DPF-on) that can't be reduced to
+        # a single command — so point back at setup.sh rather than print a stale
+        # helm command the operator can't actually run.
+        echo "Skipped. Re-run setup.sh to deploy NICo Core (DPF enablement is a two-phase"
+        echo "flow driven by this script), or pass --skip-dpf to deploy without DPF."
     else
         echo "Skipped. To deploy manually, run from $(dirname "${SCRIPT_DIR}"):"
         echo "  ${_NICO_CORE_CMD_DISPLAY}"

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -86,6 +86,19 @@
 #                          Site-wide BMC root password. REQUIRED unless --skip-dpf.
 #                          setup.sh deploys Core with DPF off, sets this via
 #                          nico-admin-cli, then enables DPF and restarts carbide-api.
+#   NICO_DPF_DPU_AGENT_CHART_VERSION
+#                          Helm chart version for nico-dpu-agent. Defaults to the
+#                          version baked into the carbide-api binary at build time
+#                          (CARBIDE_BUILD_HELM_VERSION). Set this when testing a
+#                          dev/PR image whose chart version was never published to
+#                          the registry — point it at the latest published version
+#                          (e.g. the most recent main build tag).
+#   NICO_DPF_FMDS_CHART_VERSION
+#                          Same override for the nico-fmds chart.
+#   NICO_DPF_DHCP_SERVER_CHART_VERSION
+#                          Same override for the nico-dhcp-server chart.
+#   NICO_DPF_OTEL_CHART_VERSION
+#                          Same override for the nico-otelcol chart.
 #
 # Usage:
 #   export KUBECONFIG=/path/to/kubeconfig
@@ -199,6 +212,13 @@ NICO_DPF_IMAGE_TAG="${NICO_DPF_IMAGE_TAG:-${NICO_DPF_VERSION}}"
 # set through a running carbide-api (with DPF off). setup.sh deploys Core with
 # DPF disabled, sets this via nico-admin-cli, then enables DPF and restarts.
 NICO_DPF_BMC_ROOT_PASSWORD="${NICO_DPF_BMC_ROOT_PASSWORD:-}"
+# Optional chart-version overrides for NICo-owned DPF services. Useful when
+# testing a dev/PR image whose baked-in version was never published to the
+# chart registry — point at the latest published version instead.
+NICO_DPF_DPU_AGENT_CHART_VERSION="${NICO_DPF_DPU_AGENT_CHART_VERSION:-}"
+NICO_DPF_FMDS_CHART_VERSION="${NICO_DPF_FMDS_CHART_VERSION:-}"
+NICO_DPF_DHCP_SERVER_CHART_VERSION="${NICO_DPF_DHCP_SERVER_CHART_VERSION:-}"
+NICO_DPF_OTEL_CHART_VERSION="${NICO_DPF_OTEL_CHART_VERSION:-}"
 
 # ---------------------------------------------------------------------------
 # Failure handler — offer to run clean.sh if setup exits with an error.
@@ -1009,6 +1029,20 @@ else
             indpf==1 && /^[[:space:]]*enabled[[:space:]]*=/ { sub(/=[[:space:]]*true/, "= false"); indpf=0 }
             { print }
         ' "${_DPF_ON_VALUES}" > "${_DPF_OFF_VALUES}"
+
+        # Inject per-service chart-version overrides into both value files.
+        # These let operators (and QA) pin NICo-owned DPF service charts to a
+        # published version when testing a dev/PR image whose baked-in version
+        # does not exist in the registry.
+        _dpf_inject_service_overrides() {
+            local file="$1"
+            [[ -n "${NICO_DPF_DPU_AGENT_CHART_VERSION}" ]] && printf '\n[dpf.services.dpu_agent]\nhelm_version = "%s"\n' "${NICO_DPF_DPU_AGENT_CHART_VERSION}" >> "${file}"
+            [[ -n "${NICO_DPF_FMDS_CHART_VERSION}" ]]      && printf '\n[dpf.services.fmds]\nhelm_version = "%s"\n'      "${NICO_DPF_FMDS_CHART_VERSION}"      >> "${file}"
+            [[ -n "${NICO_DPF_DHCP_SERVER_CHART_VERSION}" ]] && printf '\n[dpf.services.dhcp_server]\nhelm_version = "%s"\n' "${NICO_DPF_DHCP_SERVER_CHART_VERSION}" >> "${file}"
+            [[ -n "${NICO_DPF_OTEL_CHART_VERSION}" ]]      && printf '\n[dpf.services.otel]\nhelm_version = "%s"\n'      "${NICO_DPF_OTEL_CHART_VERSION}"      >> "${file}"
+        }
+        _dpf_inject_service_overrides "${_DPF_ON_VALUES}"
+        _dpf_inject_service_overrides "${_DPF_OFF_VALUES}"
 
         # Guard against a silent no-op: if the ON values don't actually enable
         # [dpf] (e.g. --core-values with no/commented [dpf] block, or an inline

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -334,6 +334,29 @@ nico-api:
         { start = "51008", end = "51011" },
       ]
 
+      # -----------------------------------------------------------------------
+      # DPF — DPU provisioning via the DOCA Platform Framework.
+      # setup.sh uncomments this block automatically when installing DPF (the default; the
+      # '#dpf# ' prefixes are its marker). To enable manually: install the DPF
+      # stack (docs/manuals/dpf.md), remove every '#dpf# ' prefix, and restart
+      # carbide-api — [dpf] is read at startup only.
+      # docker_image_pull_secret is created by setup.sh phase 5b.
+      # -----------------------------------------------------------------------
+      #dpf# [dpf]
+      #dpf# enabled = true
+      #dpf# docker_image_pull_secret = "nico-pull-secret"
+
+      # BF3 deployment defaults, shown for reference — these match the built-in
+      # defaults and only need uncommenting to override (e.g. a different BFB).
+      # BF4 is opt-in via an additional [dpf.deployments.bf4_generic] table;
+      # see docs/manuals/dpf.md §3.5.
+      #
+      # [dpf.deployments.bf3]
+      # bfb_url         = "https://content.mellanox.com/BlueField/BFBs/Ubuntu24.04/bf-bundle-3.2.2-125_26.02_ubuntu-24.04_64k_prod.bfb"
+      # flavor_name     = "carbide-dpu-flavor"
+      # deployment_name = "nico-deployment-v2"
+      # node_label_key  = "carbide.nvidia.com/controlled.node.v2"
+
 ## ---------------------------------------------------------------------------
 ## Service VIP assignments - MetalLB loadBalancerIPs
 ##

--- a/helm/charts/nico-api/templates/dpf-rbac.yaml
+++ b/helm/charts/nico-api/templates/dpf-rbac.yaml
@@ -1,0 +1,74 @@
+# Access for the API to manage DPF (DOCA Platform Framework) custom resources
+# in the DPF operator namespace. Enabled with --set nico-api.dpf.rbacCreate=true
+# (setup.sh does this by default; --skip-dpf to opt out). Requires the DPF operator namespace to
+# exist at install time — it is created by setup.sh phase 5b before NICo Core.
+# Rule set follows docs/manuals/dpf.md §3.1 plus bluefieldsoftwares, which the
+# DPF SDK creates for BF4 deployments.
+{{- if .Values.dpf.rbacCreate }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "nico-api.name" . }}-dpf
+  namespace: {{ .Values.dpf.operatorNamespace | default "dpf-operator-system" }}
+  labels:
+    {{- include "nico-api.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["bfbs"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["bluefieldsoftwares"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpus"]
+    verbs: ["get", "list", "watch", "patch", "delete"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpudevices"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpunodes"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpunodemaintenances"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpuflavors"]
+    verbs: ["get", "create"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpusets"]
+    verbs: ["get"]
+  - apiGroups: ["provisioning.dpu.nvidia.com"]
+    resources: ["dpuclusters"]
+    verbs: ["get", "list"]
+  - apiGroups: ["svc.dpu.nvidia.com"]
+    resources: ["dpudeployments"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["svc.dpu.nvidia.com"]
+    resources: ["dpuservices", "dpuservicechains"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["svc.dpu.nvidia.com"]
+    resources: ["dpuserviceinterfaces", "dpuservicetemplates", "dpuserviceconfigurations", "dpuservicenads"]
+    verbs: ["get", "list", "create", "patch", "delete"]
+  - apiGroups: ["operator.dpu.nvidia.com"]
+    resources: ["dpfoperatorconfigs"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "nico-api.name" . }}-dpf
+  namespace: {{ .Values.dpf.operatorNamespace | default "dpf-operator-system" }}
+  labels:
+    {{- include "nico-api.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "nico-api.name" . }}-dpf
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "nico-api.name" . }}
+    namespace: {{ include "nico-api.namespace" . }}
+{{- end }}

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -321,6 +321,23 @@ siteConfig:
   enabled: true
   nicoApiSiteConfig: ""  # Must include [pools.lo-ip], [pools.vlan-id], [pools.vni], [pools.vpc-vni]
 
+## DPF (DOCA Platform Framework) integration.
+## rbacCreate: create a Role/RoleBinding in the DPF operator namespace so the
+## API can manage DPF CRs (templates/dpf-rbac.yaml). Enabled by setup.sh (DPF is
+## the default); pair with a [dpf] block in siteConfig.nicoApiSiteConfig
+## (docs/manuals/dpf.md §3.5).
+## HARD PRECONDITION: operatorNamespace must already exist when rbacCreate=true,
+## or `helm install` fails with "namespaces ... not found" and rolls back the
+## whole release. setup.sh sets rbacCreate=true only after phase 5b creates the
+## namespace. Leave it false unless the DPF operator stack is installed.
+## This value must MATCH the namespace the DPF operator + prereqs run in — the
+## prereq stack hardcodes dpf-operator-system, so changing it here alone would
+## put the Role/RoleBinding in a different namespace than the operator it grants
+## carbide-api access to, silently breaking DPF CR management.
+dpf:
+  rbacCreate: false
+  operatorNamespace: dpf-operator-system
+
 ## NICo Web UI hostname (always created as ConfigMap)
 hostname: "nico.local"
 


### PR DESCRIPTION
## Related issues
Closes #2897 — docs: Document standalone NICo control plane setup with DPF provisioning.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [x] **This PR contains breaking changes**

DPF now installs by default, so existing `setup.sh` runs will fail preflight unless they either set the DPF env vars (`NICO_DPF_DPU_INTERFACE`, `NICO_DPF_DPU_CLUSTER_VIP`, `NICO_DPF_BMC_ROOT_PASSWORD`) or add `--skip-dpf` to keep the previous behavior.

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Clean teardown + full reinstall on a dev cluster (DPF default-on): all pods healthy, `dpucluster: Ready=True`, kamaji HA 2/2, `[dpf] enabled = true`.

## Additional Notes
DPF v26.4.0 via setup.sh; `--skip-dpf` opts out. Known upstream (kamaji cold-start deadlock, BYO-ArgoCD, clone-unusable operator chart) and NICo-internal (BMC two-phase, SDK doesn't create its CRs, no config-checksum restart) items are worked around here and catalogued for separate issues — none block this PR.
