### PR TITLE
fix(redfish): expire stale service root cache entries

### DIFF
--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -15,9 +15,11 @@
  * limitations under the License.
  */
 
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use carbide_secrets::credentials::Credentials;
@@ -35,16 +37,75 @@ pub type RedfishBmc = HttpBmc<RedfishReqwestClient>;
 pub type ServiceRoot = NvServiceRoot<RedfishBmc>;
 pub type Error = NvError<RedfishBmc>;
 
+/// Service roots are refreshed hourly so long-running processes eventually
+/// observe BMC replacements, upgrades, and configuration changes.
+const DEFAULT_SERVICE_ROOT_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+
 pub fn new_pool(proxy_address: Arc<ArcSwap<Option<HostPortPair>>>) -> Arc<NvRedfishClientPool> {
     NvRedfishClientPool::new(proxy_address).into()
 }
 
 pub struct NvRedfishClientPool {
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
-    cache: Arc<Mutex<HashMap<PoolKey, Arc<ServiceRoot>>>>,
+    cache: Arc<Mutex<ServiceRootCache>>,
+    cache_ttl: Duration,
 }
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Default)]
+struct ServiceRootCache {
+    roots: HashMap<PoolKey, CachedServiceRoot>,
+    expirations: BinaryHeap<Reverse<CacheExpiration>>,
+    next_generation: u64,
+}
+
+impl ServiceRootCache {
+    fn allocate_generation(&mut self) -> u64 {
+        if self.next_generation == u64::MAX {
+            self.roots.clear();
+            self.expirations.clear();
+            self.next_generation = 0;
+        }
+
+        let generation = self.next_generation;
+        self.next_generation += 1;
+        generation
+    }
+}
+
+struct CachedServiceRoot {
+    root: Arc<ServiceRoot>,
+    generation: u64,
+}
+
+struct CacheExpiration {
+    expires_at: Instant,
+    generation: u64,
+    key: PoolKey,
+}
+
+impl PartialEq for CacheExpiration {
+    fn eq(&self, other: &Self) -> bool {
+        self.expires_at == other.expires_at && self.generation == other.generation
+    }
+}
+
+impl Eq for CacheExpiration {}
+
+impl PartialOrd for CacheExpiration {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CacheExpiration {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.expires_at
+            .cmp(&other.expires_at)
+            .then_with(|| self.generation.cmp(&other.generation))
+    }
+}
+
+#[derive(Clone, Hash, PartialEq, Eq)]
 struct PoolKey {
     proxy_address: Arc<Option<HostPortPair>>,
     bmc_address: SocketAddr,
@@ -53,9 +114,21 @@ struct PoolKey {
 
 impl NvRedfishClientPool {
     pub fn new(proxy_address: Arc<ArcSwap<Option<HostPortPair>>>) -> Self {
+        Self::with_cache_ttl(proxy_address, DEFAULT_SERVICE_ROOT_CACHE_TTL)
+    }
+
+    /// Creates a client pool with an explicit service-root cache lifetime.
+    ///
+    /// This is primarily useful for tests that need deterministic expiration
+    /// without sleeping.
+    pub fn with_cache_ttl(
+        proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
+        cache_ttl: Duration,
+    ) -> Self {
         Self {
             proxy_address,
             cache: Default::default(),
+            cache_ttl,
         }
     }
 
@@ -76,6 +149,8 @@ impl NvRedfishClientPool {
         credentials: Credentials,
         should_cache: impl FnOnce(&ServiceRoot) -> bool,
     ) -> Result<Arc<ServiceRoot>, Error> {
+        self.remove_expired(Instant::now());
+
         let Credentials::UsernamePassword { username, password } = credentials;
         let bmc_credentials = BmcCredentials::new(username, password);
 
@@ -127,9 +202,10 @@ impl NvRedfishClientPool {
         };
         self.cache
             .lock()
-            .expect("nv-redish client cache mutex poisoned")
+            .expect("nv-redfish client cache mutex poisoned")
+            .roots
             .get(&key)
-            .cloned()
+            .map(|entry| entry.root.clone())
     }
 
     fn update_cache(
@@ -147,8 +223,41 @@ impl NvRedfishClientPool {
         let mut cache = self
             .cache
             .lock()
-            .expect("nv-redish client cache mutex poisoned");
-        cache.insert(key, root);
+            .expect("nv-redfish client cache mutex poisoned");
+        let expires_at = Instant::now() + self.cache_ttl;
+        let generation = cache.allocate_generation();
+        cache
+            .roots
+            .insert(key.clone(), CachedServiceRoot { root, generation });
+        cache.expirations.push(Reverse(CacheExpiration {
+            expires_at,
+            generation,
+            key,
+        }));
+    }
+
+    fn remove_expired(&self, now: Instant) {
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("nv-redfish client cache mutex poisoned");
+
+        while cache
+            .expirations
+            .peek()
+            .is_some_and(|expiration| expiration.0.expires_at <= now)
+        {
+            let Some(Reverse(expiration)) = cache.expirations.pop() else {
+                break;
+            };
+            if cache
+                .roots
+                .get(&expiration.key)
+                .is_some_and(|entry| entry.generation == expiration.generation)
+            {
+                cache.roots.remove(&expiration.key);
+            }
+        }
     }
 
     pub fn create_bmc(
@@ -195,5 +304,33 @@ impl NvRedfishClientPool {
             CacheSettings::with_capacity(10),
             headers,
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_overflow_clears_expirations_and_restarts_from_zero() {
+        let key = PoolKey {
+            proxy_address: Arc::new(None),
+            bmc_address: "127.0.0.1:443".parse().unwrap(),
+            credentials: BmcCredentials::new("root".to_string(), "password".to_string()),
+        };
+        let mut cache = ServiceRootCache {
+            expirations: BinaryHeap::from([Reverse(CacheExpiration {
+                expires_at: Instant::now(),
+                generation: u64::MAX - 1,
+                key,
+            })]),
+            next_generation: u64::MAX,
+            ..Default::default()
+        };
+
+        assert_eq!(cache.allocate_generation(), 0);
+        assert!(cache.roots.is_empty());
+        assert!(cache.expirations.is_empty());
+        assert_eq!(cache.next_generation, 1);
     }
 }

--- a/crates/redfish/tests/service_root_cache_poisoning.rs
+++ b/crates/redfish/tests/service_root_cache_poisoning.rs
@@ -2,15 +2,16 @@
 // ServiceRoot is cached only when the caller's predicate accepts it.
 //
 // Some BMCs transiently serve a service root with
-// navigation properties missing while resetting or booting. The pool cache has
-// no TTL, so caching such a root would poison every later exploration until
-// process restart. The mock BMC here serves a `Chassis`-less root first
+// navigation properties missing while resetting or booting. Even with a
+// finite TTL, rejecting an incomplete root avoids poisoning explorations until
+// that TTL elapses. The mock BMC here serves a `Chassis`-less root first
 // (rejected by the predicate, not cached), then a full root (re-fetched,
 // accepted, and served from cache afterwards).
 
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use axum::Router;
@@ -95,24 +96,16 @@ async fn chassis_collection() -> impl IntoResponse {
     )
 }
 
-#[tokio::test]
-async fn poisoned_service_root_cache_recovers_after_bmc_heals() {
-    rustls::crypto::aws_lc_rs::default_provider()
-        .install_default()
-        .ok();
-
-    let root_hits = Arc::new(AtomicUsize::new(0));
+fn spawn_mock_bmc(root_hits: Arc<AtomicUsize>) -> SocketAddr {
     let app = Router::new()
         .route("/redfish/v1", get(service_root))
         .route("/redfish/v1/", get(service_root))
         .route("/redfish/v1/Chassis", get(chassis_collection))
-        .with_state(AppState {
-            root_hits: root_hits.clone(),
-        });
+        .with_state(AppState { root_hits });
 
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     listener.set_nonblocking(true).unwrap();
-    let addr: SocketAddr = listener.local_addr().unwrap();
+    let addr = listener.local_addr().unwrap();
 
     let tls = bmc_mock::tls::server_config(None::<&str>).unwrap();
     let config = RustlsConfig::from_config(Arc::new(tls));
@@ -123,6 +116,18 @@ async fn poisoned_service_root_cache_recovers_after_bmc_heals() {
             .await
             .unwrap();
     });
+
+    addr
+}
+
+#[tokio::test]
+async fn poisoned_service_root_cache_recovers_after_bmc_heals() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    let root_hits = Arc::new(AtomicUsize::new(0));
+    let addr = spawn_mock_bmc(root_hits.clone());
 
     let pool = NvRedfishClientPool::new(Arc::new(ArcSwap::new(Arc::new(None))));
     let creds = || Credentials::UsernamePassword {
@@ -176,4 +181,35 @@ async fn poisoned_service_root_cache_recovers_after_bmc_heals() {
         .unwrap();
     assert_eq!(root_hits.load(Ordering::SeqCst), 2);
     assert!(third.chassis_links().await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn expired_service_root_is_refetched_without_invalidating_existing_holders() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    // Start at one so the mock serves a complete root on every request.
+    let root_hits = Arc::new(AtomicUsize::new(1));
+    let addr = spawn_mock_bmc(root_hits.clone());
+    let pool =
+        NvRedfishClientPool::with_cache_ttl(Arc::new(ArcSwap::new(Arc::new(None))), Duration::ZERO);
+    let creds = || Credentials::UsernamePassword {
+        username: "root".to_string(),
+        password: "placeholder".to_string(),
+    };
+
+    let first = pool.service_root(addr, creds()).await.unwrap();
+    let second = pool.service_root(addr, creds()).await.unwrap();
+
+    assert_eq!(
+        root_hits.load(Ordering::SeqCst),
+        3,
+        "an expired service root should be fetched again",
+    );
+    assert!(!Arc::ptr_eq(&first, &second));
+    assert!(
+        first.chassis_links().await.unwrap().is_some(),
+        "eviction must not invalidate callers that still hold the old root",
+    );
 }


### PR DESCRIPTION
## Related issues
Fixes #3554

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Service-root cache entries use an absolute one-hour production TTL and are passively evicted at the start of each request. Expirations are ordered in a min-heap, so requests inspect the nearest expiration in O(1) instead of scanning all cached BMCs. Expired entries are popped in O(log N), and generation IDs prevent stale expiration records from deleting a newer value for the same cache key.

Cache hits do not extend their lifetime, the mutex is released before network I/O, and existing `Arc<ServiceRoot>` holders remain valid after eviction. Tests can override the TTL; the zero-TTL integration case verifies refetching without sleeping and confirms an evicted root remains usable by existing holders.

Validation:
- `cargo test -p carbide-redfish --test service_root_cache_poisoning` — 2 passed
- `cargo clippy -p carbide-redfish --test service_root_cache_poisoning -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`