### PR TITLE
fix: lenovo gb300 network boot configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6706,7 +6706,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.19#b52345f45212c674245dffb6053b34dec53ac57b"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.20#67281482656423b4c1a9556112ee1dc6a04da930"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.19" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.20" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.1" }
 ansi-to-html = "0.2.2"
 

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -324,7 +324,30 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         &self,
         boot_interface_mac: MacAddress,
     ) -> Option<MachineSetupDiff> {
-        let expected = self
+        let expected = self.boot_option_by_uefi_prefix(boot_interface_mac);
+
+        // Find actual option that is first in boot_order.
+        let actual = self.boot_order_first_option();
+        compare_boot_options(expected, actual)
+    }
+
+    pub fn check_boot_option_enabled_by_uefi_prefix(
+        &self,
+        boot_interface_mac: MacAddress,
+    ) -> Option<MachineSetupDiff> {
+        let option = self.boot_option_by_uefi_prefix(boot_interface_mac)?;
+        (option.enabled() != Some(true)).then(|| MachineSetupDiff {
+            key: "boot_option_enabled".to_string(),
+            expected: "true".to_string(),
+            actual: option
+                .enabled()
+                .map(|enabled| enabled.to_string())
+                .unwrap_or_else(|| "Not provided".to_string()),
+        })
+    }
+
+    fn boot_option_by_uefi_prefix(&self, boot_interface_mac: MacAddress) -> Option<&BootOption<B>> {
+        self
             // Find UEFI device path of the ethernet interface
             // that has boot_interface_mac MAC address.
             .ethernet_interfaces
@@ -348,11 +371,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                             && path.inner().contains("/IPv4(")
                     })
                 })
-            });
-
-        // Find actual option that is first in boot_order.
-        let actual = self.boot_order_first_option();
-        compare_boot_options(expected, actual)
+            })
     }
 
     fn ethernet_interfaces(

--- a/crates/bmc-explorer/src/hw/lenovo_gb300.rs
+++ b/crates/bmc-explorer/src/hw/lenovo_gb300.rs
@@ -19,7 +19,7 @@ use crate::hw::BiosAttr;
 
 pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 8] = [
     BiosAttr::new_str("PCIS007", "PCIS007Enabled"), // SR-IOV Support
-    BiosAttr::new_int("LEM0001", 3),                // PXE retry count
+    BiosAttr::new_int("LEM0001", 0),                // PXE retry count
     BiosAttr::new_str("NWSK000", "NWSK000Enabled"), // Network Stack
     BiosAttr::new_str("NWSK001", "NWSK001Disabled"), // IPv4 PXE Support
     BiosAttr::new_str("NWSK006", "NWSK006Enabled"), // IPv4 HTTP Support

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -889,10 +889,13 @@ fn machine_setup_status<B: Bmc>(
                     .iter()
                     .flat_map(|expected| explored_system.verify_bios_attr(expected)),
             );
-            if let Some(mac) = boot_interface_mac
-                && let Some(diff) = explored_system.check_boot_by_uefi_prefix(mac)
-            {
-                diffs.push(diff)
+            if let Some(mac) = boot_interface_mac {
+                if let Some(diff) = explored_system.check_boot_by_uefi_prefix(mac) {
+                    diffs.push(diff);
+                }
+                if let Some(diff) = explored_system.check_boot_option_enabled_by_uefi_prefix(mac) {
+                    diffs.push(diff);
+                }
             }
         }
 


### PR DESCRIPTION
Lenovo GB300s can retain multiple enabled PXE/UEFI HTTP boot options, causing firmware to select an unintended network interface during boot.

This change:

- Updates libredfish to `v0.44.20`, which configures the intended boot option and disables competing network boot options.
- Updates BMC Explorer’s Lenovo GB300 PXE retry expectation to `0`.
- Reports a machine setup mismatch when the selected UEFI boot option is disabled.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3574

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

