### PR TITLE
fix: Bound Core proxy workflow lifetime

### DIFF
--- a/rest-api/AGENTS.md
+++ b/rest-api/AGENTS.md
@@ -302,7 +302,10 @@ Keep handlers thin and reuse the common surfaces already in the tree:
 6. For synchronous Temporal workflows, reuse the existing workflow ID,
    timeout, task queue, `common.UnwrapWorkflowError`, and
    `common.TerminateWorkflowOnTimeOut` patterns from the nearest handler instead
-   of inventing new error plumbing.
+   of inventing new error plumbing. When a request spans caller, workflow, and
+   activity or RPC deadlines, keep those budgets strictly increasing toward the
+   caller and test every boundary; an outer timeout alone does not bound work
+   that has already started.
 7. Return curated REST models, not DB models, Core protobufs, Flow protobufs, or
    secret-bearing request bodies. Log identifiers, method names, kinds, and
    site IDs; do not log raw request bodies that may contain credentials

--- a/rest-api/api/pkg/api/handler/util/common/coreproxy.go
+++ b/rest-api/api/pkg/api/handler/util/common/coreproxy.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"time"
 
 	"github.com/google/uuid"
 	temporalEnums "go.temporal.io/api/enums/v1"
@@ -22,8 +21,6 @@ import (
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
 )
-
-const coreProxyWorkflowExecutionTimeout = 45 * time.Second
 
 // ExecuteCoreGRPC proxies one already-validated NICo Core (forge.Forge) gRPC
 // request via the generic site proxy workflow (coreproxy.WorkflowName). A REST
@@ -60,7 +57,7 @@ func ExecuteCoreGRPC(ctx context.Context, stc tclient.Client, fullMethod string,
 	workflowID := fmt.Sprintf("core-grpc-%s-%s", path.Base(fullMethod), uuid.NewString())
 	workflowOptions := tclient.StartWorkflowOptions{
 		ID:                       workflowID,
-		WorkflowExecutionTimeout: coreProxyWorkflowExecutionTimeout,
+		WorkflowExecutionTimeout: coreproxy.WorkflowExecutionTimeout,
 		TaskQueue:                queue.SiteTaskQueue,
 		WorkflowIDReusePolicy:    temporalEnums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 	}

--- a/rest-api/api/pkg/api/handler/util/common/coreproxy.go
+++ b/rest-api/api/pkg/api/handler/util/common/coreproxy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"time"
 
 	"github.com/google/uuid"
 	temporalEnums "go.temporal.io/api/enums/v1"
@@ -21,6 +22,8 @@ import (
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
 )
+
+const coreProxyWorkflowExecutionTimeout = 45 * time.Second
 
 // ExecuteCoreGRPC proxies one already-validated NICo Core (forge.Forge) gRPC
 // request via the generic site proxy workflow (coreproxy.WorkflowName). A REST
@@ -57,7 +60,7 @@ func ExecuteCoreGRPC(ctx context.Context, stc tclient.Client, fullMethod string,
 	workflowID := fmt.Sprintf("core-grpc-%s-%s", path.Base(fullMethod), uuid.NewString())
 	workflowOptions := tclient.StartWorkflowOptions{
 		ID:                       workflowID,
-		WorkflowExecutionTimeout: cutil.WorkflowExecutionTimeout,
+		WorkflowExecutionTimeout: coreProxyWorkflowExecutionTimeout,
 		TaskQueue:                queue.SiteTaskQueue,
 		WorkflowIDReusePolicy:    temporalEnums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 	}

--- a/rest-api/api/pkg/api/handler/util/common/coreproxy_test.go
+++ b/rest-api/api/pkg/api/handler/util/common/coreproxy_test.go
@@ -5,7 +5,9 @@ package common
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -13,6 +15,7 @@ import (
 	tmocks "go.temporal.io/sdk/mocks"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/coreproxy"
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 )
 
@@ -42,6 +45,10 @@ func TestExecuteCoreGRPCWorkflowExpiresBeforeCallerTimeout(t *testing.T) {
 		"",
 	)
 
-	require.NotNil(t, err)
+	require.Equal(t, 45*time.Second, coreproxy.WorkflowExecutionTimeout)
+	require.Equal(t, coreproxy.WorkflowExecutionTimeout, workflowOptions.WorkflowExecutionTimeout)
 	require.Less(t, workflowOptions.WorkflowExecutionTimeout, cutil.WorkflowContextTimeout)
+	require.NotNil(t, err)
+	require.Equal(t, http.StatusGatewayTimeout, err.Code)
+	require.Equal(t, "Core proxy request timed out", err.Message)
 }

--- a/rest-api/api/pkg/api/handler/util/common/coreproxy_test.go
+++ b/rest-api/api/pkg/api/handler/util/common/coreproxy_test.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	tclient "go.temporal.io/sdk/client"
+	tmocks "go.temporal.io/sdk/mocks"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+)
+
+func TestExecuteCoreGRPCWorkflowExpiresBeforeCallerTimeout(t *testing.T) {
+	workflowRun := &tmocks.WorkflowRun{}
+	workflowRun.On("Get", mock.Anything, mock.Anything).Return(context.DeadlineExceeded)
+
+	var workflowOptions tclient.StartWorkflowOptions
+	temporalClient := &tmocks.Client{}
+	temporalClient.On(
+		"ExecuteWorkflow",
+		mock.Anything,
+		mock.MatchedBy(func(options tclient.StartWorkflowOptions) bool {
+			workflowOptions = options
+			return true
+		}),
+		mock.Anything,
+		mock.Anything,
+	).Return(workflowRun, nil)
+
+	err := ExecuteCoreGRPC(
+		context.Background(),
+		temporalClient,
+		"/forge.Forge/Test",
+		&emptypb.Empty{},
+		nil,
+		"",
+	)
+
+	require.NotNil(t, err)
+	require.Less(t, workflowOptions.WorkflowExecutionTimeout, cutil.WorkflowContextTimeout)
+}

--- a/rest-api/common/pkg/coreproxy/coreproxy.go
+++ b/rest-api/common/pkg/coreproxy/coreproxy.go
@@ -25,12 +25,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"time"
 )
 
-// WorkflowName is the Temporal workflow type registered by the site-agent and
-// started by the cloud REST API. It must match the workflow function name in
-// site-workflow/pkg/workflow (InvokeCoreGRPC).
-const WorkflowName = "InvokeCoreGRPC"
+const (
+	// WorkflowName is the Temporal workflow type registered by the site-agent
+	// and started by the cloud REST API. It must match the workflow function
+	// name in site-workflow/pkg/workflow (InvokeCoreGRPC).
+	WorkflowName = "InvokeCoreGRPC"
+
+	// ActivityStartToCloseTimeout bounds the on-site Core request before the
+	// workflow and REST caller time out.
+	ActivityStartToCloseTimeout = 40 * time.Second
+
+	// WorkflowExecutionTimeout leaves the REST caller time to observe and
+	// translate a terminal workflow result.
+	WorkflowExecutionTimeout = 45 * time.Second
+)
 
 // RedactedPlaceholder is the value substituted for a redacted secret field in
 // the Temporal-visible request JSON.

--- a/rest-api/site-workflow/pkg/workflow/coreproxy.go
+++ b/rest-api/site-workflow/pkg/workflow/coreproxy.go
@@ -4,8 +4,6 @@
 package workflow
 
 import (
-	"time"
-
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/coreproxy"
 	"github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/activity"
 	"github.com/rs/zerolog/log"
@@ -27,7 +25,7 @@ func InvokeCoreGRPC(ctx workflow.Context, req coreproxy.Request) (coreproxy.Resp
 	// No automatic retries: a proxied call may be a non-idempotent mutation, so
 	// the activity runs exactly once and the caller decides whether to retry.
 	options := workflow.ActivityOptions{
-		StartToCloseTimeout: 2 * time.Minute,
+		StartToCloseTimeout: coreproxy.ActivityStartToCloseTimeout,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},

--- a/rest-api/site-workflow/pkg/workflow/coreproxy_test.go
+++ b/rest-api/site-workflow/pkg/workflow/coreproxy_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workflow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdkactivity "go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/coreproxy"
+)
+
+func TestInvokeCoreGRPCActivityDeadlinePrecedesWorkflowTimeout(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	var activityDeadline time.Time
+	var hasActivityDeadline bool
+
+	env.RegisterActivityWithOptions(
+		func(ctx context.Context, _ coreproxy.Request) (coreproxy.Response, error) {
+			activityDeadline, hasActivityDeadline = ctx.Deadline()
+			return coreproxy.Response{}, nil
+		},
+		sdkactivity.RegisterOptions{Name: "InvokeCoreGRPCOnSite"},
+	)
+
+	env.ExecuteWorkflow(InvokeCoreGRPC, coreproxy.Request{FullMethod: "/forge.Forge/Test"})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.True(t, hasActivityDeadline)
+	require.Equal(t, 40*time.Second, coreproxy.ActivityStartToCloseTimeout)
+	remaining := time.Until(activityDeadline)
+	require.Greater(t, remaining, coreproxy.ActivityStartToCloseTimeout-time.Second)
+	require.LessOrEqual(t, remaining, coreproxy.ActivityStartToCloseTimeout)
+	require.Less(t, coreproxy.ActivityStartToCloseTimeout, coreproxy.WorkflowExecutionTimeout)
+}


### PR DESCRIPTION
The REST caller previously stopped waiting before the shared REST-to-Core Temporal workflow expired, allowing a non-idempotent Core mutation to execute after REST had already returned HTTP 504. This change sets the Core proxy workflow timeout to 45 seconds, below the 50-second caller timeout, and adds regression coverage for that ordering. The REST response shape is unchanged.

## Related issues

Resolves #3570.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The PR remains in draft while its broader workflow contract is under discussion.
