### PR TITLE
fix(site-explorer): don't fail BMC reset on timestamp-write error (#3471)

### DIFF
--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -2783,12 +2783,23 @@ impl SiteExplorer {
             .await
         {
             Ok(_) => {
-                let mut txn = self.txn_begin().await?;
+                let persist = async {
+                    let mut txn = self.txn_begin().await?;
 
-                db::explored_endpoints::set_last_ipmitool_bmc_reset(endpoint.address, &mut txn)
-                    .await?;
+                    db::explored_endpoints::set_last_ipmitool_bmc_reset(endpoint.address, &mut txn)
+                        .await?;
 
-                txn.commit().await?;
+                    txn.commit().await?;
+
+                    Ok::<(), SiteExplorerError>(())
+                };
+                if let Err(err) = persist.await {
+                    tracing::warn!(
+                        bmc_ip_address = %endpoint.address,
+                        error = %err,
+                        "Site Explorer reset BMC through ipmitool but failed to persist rate-limit timestamp"
+                    );
+                }
 
                 Ok(())
             }
@@ -2812,12 +2823,23 @@ impl SiteExplorer {
             .await
         {
             Ok(_) => {
-                let mut txn = self.txn_begin().await?;
+                let persist = async {
+                    let mut txn = self.txn_begin().await?;
 
-                db::explored_endpoints::set_last_redfish_bmc_reset(endpoint.address, &mut txn)
-                    .await?;
+                    db::explored_endpoints::set_last_redfish_bmc_reset(endpoint.address, &mut txn)
+                        .await?;
 
-                txn.commit().await?;
+                    txn.commit().await?;
+
+                    Ok::<(), SiteExplorerError>(())
+                };
+                if let Err(err) = persist.await {
+                    tracing::warn!(
+                        bmc_ip_address = %endpoint.address,
+                        error = %err,
+                        "Site Explorer reset BMC through redfish but failed to persist rate-limit timestamp"
+                    );
+                }
 
                 Ok(())
             }


### PR DESCRIPTION
## Summary

`redfish_reset_bmc` and `ipmitool_reset_bmc` in `crates/site-explorer/src/lib.rs` perform the physical BMC reset and then persist a rate-limit timestamp (`set_last_redfish_bmc_reset` / `set_last_ipmitool_bmc_reset`) in the same function, propagating the timestamp transaction's error with `?`.

Because of that, when a reset **physically succeeds** but its timestamp write fails (`txn_begin`, `set_last_*`, or `commit`), the function returned `Err`, which caused two problems:

- **Miscount:** the outcome was logged as a failed reset and `carbide_site_explorer_bmc_reset_count` was not incremented, even though the reset happened.
- **Redundant reset:** on the Redfish path the dispatch's `&&` short-circuits on the `false` return and falls through, issuing a second reset via IPMI — so the BMC was reset twice for one intended reset.

This change separates the physical-reset result from the timestamp bookkeeping: a successful physical reset now returns `Ok(())` (counted as a success, stopping the dispatch) even if the timestamp write fails, and the timestamp failure is surfaced as its own `warn!` log rather than masquerading as a reset failure. The genuine physical-reset failure path (`Err`) is unchanged.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

Built and ran the crate's tests on Linux (in the repo's Cargo build container) against a local Postgres:

    cargo test -p carbide-site-explorer

No new automated test was added: the fix is exercised only when the physical reset succeeds while the DB timestamp write fails, which the current test harness has no straightforward way to inject. The existing suite passes, confirming no regression.

## Additional Notes

The bug is pre-existing behavior (the `?`-propagation of the timestamp write and the Redfish→IPMI fall-through both predate #3179, which only changed how the outcome is counted). Surfaced by CodeRabbit during the review of #3469.