### PR TITLE
feat: Add per-machine BMC fault injection controls

### DIFF
--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -47,6 +47,7 @@ pub use machine_info::{
 };
 pub use mock_machine_router::{
     BmcCommand, SetSystemPowerError, SetSystemPowerResult, machine_router,
+    machine_router_with_injection_store,
 };
 
 pub const DUMMY_FACTORY_USERNAME: &str = "root";

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -67,6 +67,23 @@ pub fn machine_router(
     mat_host_id: String,
     redfish_auth: bool,
 ) -> (Router, BmcState) {
+    machine_router_with_injection_store(
+        machine_info,
+        callbacks,
+        mat_host_id,
+        redfish_auth,
+        Arc::new(InjectionStore::new()),
+    )
+}
+
+/// Return a machine router backed by a caller-provided injection store.
+pub fn machine_router_with_injection_store(
+    machine_info: &MachineInfo,
+    callbacks: Arc<dyn Callbacks>,
+    mat_host_id: String,
+    redfish_auth: bool,
+    injection: Arc<InjectionStore>,
+) -> (Router, BmcState) {
     let system_config = machine_info.system_config(callbacks.clone());
     let chassis_config = machine_info.chassis_config();
     let update_service_config = machine_info.update_service_config();
@@ -110,7 +127,6 @@ pub fn machine_router(
     );
     let session_service_state =
         Arc::new(crate::redfish::session_service::SessionServiceState::new());
-    let injection = Arc::new(InjectionStore::new());
     let state = BmcState {
         bmc_vendor,
         bmc_product,

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -308,12 +308,49 @@ pub async fn generic_ami_bmc() -> TestBmcHandle {
 mod test {
 
     use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
     use nv_redfish::bmc_http::{BmcCredentials, HttpClient};
+    use tower::ServiceExt;
     use url::Url;
 
     use super::*;
+    use crate::injection::{Action, InjectionStore, Rule, RuleId, Selector};
     use crate::test_support::axum_http_client::Error;
     use crate::test_support::host_info;
+
+    #[tokio::test]
+    async fn caller_provided_injection_store_is_active() {
+        let injection = Arc::new(InjectionStore::new());
+        injection.upsert(Rule {
+            id: RuleId::from("unavailable"),
+            selector: Selector::Path {
+                method: Some("GET".to_string()),
+                glob: "/redfish/v1".to_string(),
+            },
+            action: Action::Status(StatusCode::SERVICE_UNAVAILABLE.as_u16()),
+            remaining: None,
+        });
+        let (router, state) = crate::machine_router_with_injection_store(
+            &host_info(HostHardwareType::DellPowerEdgeR750),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+            injection.clone(),
+        );
+
+        assert!(Arc::ptr_eq(&injection, &state.injection));
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
 
     #[tokio::test]
     async fn transport_supports_expand_query_through_mock_expander() {

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -20,6 +20,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
+use bmc_mock::injection::InjectionStore;
 use bmc_mock::ipmi_sim::{IpmiSimConfig, IpmiSimHandle};
 use bmc_mock::{
     BmcState, Callbacks, CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo,
@@ -53,9 +54,15 @@ impl BmcMockWrapper {
         callbacks: Arc<dyn Callbacks>,
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
+        injection: Arc<InjectionStore>,
     ) -> Self {
-        let (bmc_mock_router, bmc_mock_state) =
-            bmc_mock::machine_router(machine_info, callbacks, host_id.to_string(), true);
+        let (bmc_mock_router, bmc_mock_state) = bmc_mock::machine_router_with_injection_store(
+            machine_info,
+            callbacks,
+            host_id.to_string(),
+            true,
+            injection,
+        );
 
         BmcMockWrapper {
             ssh_prompt_behavior: match machine_info {

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -22,7 +22,7 @@ use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{any, get};
 use axum::{Json, Router};
-use bmc_mock::injection::{Rule, RuleId};
+use bmc_mock::injection::{InjectionStore, Rule, RuleId};
 use carbide_uuid::machine::MachineId;
 use tower::Service;
 use uuid::Uuid;
@@ -76,18 +76,29 @@ impl ControlState {
         }
     }
 
-    fn machine(&self, id: &str) -> Option<HostMachineHandle> {
+    fn machine(&self, id: &str) -> Option<Arc<InjectionStore>> {
         let mat_id = Uuid::parse_str(id).ok();
         let machine_id = id.parse::<MachineId>().ok();
-        self.machine_handles
-            .iter()
-            .find(|machine| {
-                mat_id.is_some_and(|id| machine.mat_id() == id)
-                    || machine_id
-                        .as_ref()
-                        .is_some_and(|id| machine.observed_machine_id().as_ref() == Some(id))
-            })
-            .cloned()
+        let matches = |candidate_mat_id, candidate_machine_id: Option<MachineId>| {
+            mat_id.is_some_and(|id| candidate_mat_id == id)
+                || machine_id
+                    .as_ref()
+                    .is_some_and(|id| candidate_machine_id.as_ref() == Some(id))
+        };
+
+        for machine in self.machine_handles.iter() {
+            if matches(machine.mat_id(), machine.observed_machine_id()) {
+                return Some(machine.bmc_injection_store());
+            }
+            if let Some(dpu) = machine
+                .dpus()
+                .iter()
+                .find(|dpu| matches(dpu.mat_id(), dpu.observed_machine_id()))
+            {
+                return Some(dpu.bmc_injection_store());
+            }
+        }
+        None
     }
 }
 
@@ -112,7 +123,7 @@ async fn list_bmc_injection_rules(
     let Some(machine) = state.control_state.machine(&id) else {
         return machine_not_found();
     };
-    Json(machine.list_bmc_injection_rules()).into_response()
+    Json(list_rules(&machine)).into_response()
 }
 
 async fn upsert_bmc_injection_rule(
@@ -123,7 +134,8 @@ async fn upsert_bmc_injection_rule(
     let Some(machine) = state.control_state.machine(&id) else {
         return machine_not_found();
     };
-    Json(machine.upsert_bmc_injection_rule(rule)).into_response()
+    machine.upsert(rule);
+    Json(list_rules(&machine)).into_response()
 }
 
 async fn delete_bmc_injection_rule(
@@ -134,8 +146,8 @@ async fn delete_bmc_injection_rule(
         return machine_not_found();
     };
     let rule_id = RuleId::from(rule_id);
-    if machine.delete_bmc_injection_rule(&rule_id) {
-        Json(machine.list_bmc_injection_rules()).into_response()
+    if machine.delete(&rule_id) {
+        Json(list_rules(&machine)).into_response()
     } else {
         (
             StatusCode::NOT_FOUND,
@@ -143,6 +155,14 @@ async fn delete_bmc_injection_rule(
         )
             .into_response()
     }
+}
+
+fn list_rules(machine: &InjectionStore) -> Vec<Rule> {
+    machine
+        .list()
+        .into_iter()
+        .map(|rule| (*rule).clone())
+        .collect()
 }
 
 fn machine_not_found() -> Response {
@@ -172,8 +192,11 @@ mod tests {
     use axum::http::{Method, Request, StatusCode};
     use axum::routing::get;
     use tower::ServiceExt;
+    use uuid::Uuid;
 
     use super::{ControlState, append};
+    use crate::dpu_machine::DpuMachineHandle;
+    use crate::host_machine::HostMachineHandle;
     use crate::status::MachineStatusConfig;
 
     #[tokio::test]
@@ -266,6 +289,54 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(delete_response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn bmc_injection_rules_accept_dpu_id() {
+        let dpu_id = Uuid::new_v4();
+        let observed_dpu_id = "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng"
+            .parse()
+            .unwrap();
+        let dpu = DpuMachineHandle::for_control_test(dpu_id, Some(observed_dpu_id));
+        let host = HostMachineHandle::for_control_test(vec![dpu]);
+        let router = append(
+            Router::new(),
+            ControlState::new(vec![host.clone()], MachineStatusConfig::new(1266)),
+        );
+
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/machines/{dpu_id}/bmc/injection/rules"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"id":"dpu-test","selector":{"Path":{"method":"GET","glob":"/**"}},"action":{"Status":503}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("dpu-test"));
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/machines/{observed_dpu_id}/bmc/injection/rules"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("dpu-test"));
+        assert!(host.bmc_injection_store().list().is_empty());
     }
 
     #[tokio::test]

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -17,11 +17,15 @@
 use std::sync::Arc;
 
 use axum::body::Body;
-use axum::extract::{Request, State};
-use axum::response::{Html, Response};
+use axum::extract::{Path, Request, State};
+use axum::http::StatusCode;
+use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{any, get};
 use axum::{Json, Router};
+use bmc_mock::injection::{Rule, RuleId};
+use carbide_uuid::machine::MachineId;
 use tower::Service;
+use uuid::Uuid;
 
 use crate::host_machine::HostMachineHandle;
 use crate::status::{MachineStatusConfig, MachinesStatusResponse};
@@ -30,6 +34,14 @@ pub fn append(router: Router, control_state: ControlState) -> Router {
     Router::new()
         .route("/", get(get_machines_ui))
         .route("/machines/status", get(get_machines_status))
+        .route(
+            "/machines/{id}/bmc/injection/rules",
+            get(list_bmc_injection_rules).post(upsert_bmc_injection_rule),
+        )
+        .route(
+            "/machines/{id}/bmc/injection/rules/{rule_id}",
+            axum::routing::delete(delete_bmc_injection_rule),
+        )
         .route("/{*all}", any(process))
         .with_state(ControlRouter {
             inner: router,
@@ -63,6 +75,20 @@ impl ControlState {
                 .collect(),
         }
     }
+
+    fn machine(&self, id: &str) -> Option<HostMachineHandle> {
+        let mat_id = Uuid::parse_str(id).ok();
+        let machine_id = id.parse::<MachineId>().ok();
+        self.machine_handles
+            .iter()
+            .find(|machine| {
+                mat_id.is_some_and(|id| machine.mat_id() == id)
+                    || machine_id
+                        .as_ref()
+                        .is_some_and(|id| machine.observed_machine_id().as_ref() == Some(id))
+            })
+            .cloned()
+    }
 }
 
 #[derive(Clone)]
@@ -77,6 +103,50 @@ async fn get_machines_status(State(state): State<ControlRouter>) -> Json<Machine
 
 async fn get_machines_ui() -> Html<&'static str> {
     Html(include_str!("../web/index.html"))
+}
+
+async fn list_bmc_injection_rules(
+    State(state): State<ControlRouter>,
+    Path(id): Path<String>,
+) -> Response {
+    let Some(machine) = state.control_state.machine(&id) else {
+        return machine_not_found();
+    };
+    Json(machine.list_bmc_injection_rules()).into_response()
+}
+
+async fn upsert_bmc_injection_rule(
+    State(state): State<ControlRouter>,
+    Path(id): Path<String>,
+    Json(rule): Json<Rule>,
+) -> Response {
+    let Some(machine) = state.control_state.machine(&id) else {
+        return machine_not_found();
+    };
+    Json(machine.upsert_bmc_injection_rule(rule)).into_response()
+}
+
+async fn delete_bmc_injection_rule(
+    State(state): State<ControlRouter>,
+    Path((id, rule_id)): Path<(String, String)>,
+) -> Response {
+    let Some(machine) = state.control_state.machine(&id) else {
+        return machine_not_found();
+    };
+    let rule_id = RuleId::from(rule_id);
+    if machine.delete_bmc_injection_rule(&rule_id) {
+        Json(machine.list_bmc_injection_rules()).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            format!("BMC injection rule not found: {rule_id}"),
+        )
+            .into_response()
+    }
+}
+
+fn machine_not_found() -> Response {
+    (StatusCode::NOT_FOUND, "machine not found").into_response()
 }
 
 async fn process(State(mut state): State<ControlRouter>, request: Request<Body>) -> Response {
@@ -99,7 +169,7 @@ async fn call_inner_router(router: &mut Router, request: Request<Body>) -> Respo
 mod tests {
     use axum::Router;
     use axum::body::{Body, to_bytes};
-    use axum::http::{Request, StatusCode};
+    use axum::http::{Method, Request, StatusCode};
     use axum::routing::get;
     use tower::ServiceExt;
 
@@ -143,6 +213,59 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert!(String::from_utf8_lossy(&body).contains("machine-a-tron machines"));
+    }
+
+    #[tokio::test]
+    async fn bmc_injection_rules_require_known_machine() {
+        let router = append(
+            Router::new(),
+            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
+        );
+
+        let get_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/machines/unknown/bmc/injection/rules")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+
+        let body = to_bytes(get_response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"machine not found");
+
+        let post_response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/machines/unknown/bmc/injection/rules")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"id":"test","selector":{"Path":{"method":"GET","glob":"/**"}},"action":{"Status":503}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(post_response.status(), StatusCode::NOT_FOUND);
+
+        let delete_response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::DELETE)
+                    .uri("/machines/unknown/bmc/injection/rules/test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(delete_response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -376,8 +376,10 @@ impl DpuMachineHandle {
     pub(crate) fn for_control_test(mat_id: Uuid, observed_machine_id: Option<MachineId>) -> Self {
         let (message_tx, _message_rx) = mpsc::unbounded_channel();
         let mac = mac_address::MacAddress::new([2, 0, 0, 0, 0, 1]);
-        let mut live_state = LiveState::default();
-        live_state.observed_machine_id = observed_machine_id;
+        let live_state = LiveState {
+            observed_machine_id,
+            ..LiveState::default()
+        };
         Self(Arc::new(DpuMachineActor {
             message_tx,
             live_state: Arc::new(RwLock::new(live_state)),

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -18,11 +18,13 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use bmc_mock::injection::InjectionStore;
 use bmc_mock::mac_address_pool::MacAddressPool;
 use bmc_mock::{
     BmcCommand, DpuMachineInfo, DpuSettings, HostHardwareType, MachineInfo, SetSystemPowerResult,
     SystemPowerControl,
 };
+use carbide_uuid::machine::MachineId;
 use eyre::Context;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
@@ -177,6 +179,7 @@ impl DpuMachine {
         let dpu_info = self.dpu_info.clone();
         let dpu_index = self.dpu_index;
         let live_state = self.state_machine.live_state.clone();
+        let bmc_injection = self.state_machine.bmc_injection_store();
         let join_handle = tokio::task::Builder::new()
             .name(&format!("DPU {}", self.mat_id))
             .spawn({
@@ -199,6 +202,7 @@ impl DpuMachine {
             mat_id,
             dpu_info,
             dpu_index,
+            bmc_injection,
             join_handle: Mutex::new(Some(join_handle)),
         }))
     }
@@ -342,6 +346,7 @@ struct DpuMachineActor {
     mat_id: Uuid,
     dpu_info: DpuMachineInfo,
     dpu_index: u8,
+    bmc_injection: Arc<InjectionStore>,
     join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
@@ -349,6 +354,48 @@ struct DpuMachineActor {
 pub struct DpuMachineHandle(Arc<DpuMachineActor>);
 
 impl DpuMachineHandle {
+    pub fn mat_id(&self) -> Uuid {
+        self.0.mat_id
+    }
+
+    pub fn observed_machine_id(&self) -> Option<MachineId> {
+        self.0
+            .live_state
+            .read()
+            .unwrap()
+            .observed_machine_id
+            .as_ref()
+            .map(ToOwned::to_owned)
+    }
+
+    pub(crate) fn bmc_injection_store(&self) -> Arc<InjectionStore> {
+        self.0.bmc_injection.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_control_test(mat_id: Uuid, observed_machine_id: Option<MachineId>) -> Self {
+        let (message_tx, _message_rx) = mpsc::unbounded_channel();
+        let mac = mac_address::MacAddress::new([2, 0, 0, 0, 0, 1]);
+        let mut live_state = LiveState::default();
+        live_state.observed_machine_id = observed_machine_id;
+        Self(Arc::new(DpuMachineActor {
+            message_tx,
+            live_state: Arc::new(RwLock::new(live_state)),
+            mat_id,
+            dpu_info: DpuMachineInfo {
+                hw_type: HostHardwareType::default(),
+                bmc_mac_address: mac,
+                host_mac_address: mac,
+                oob_mac_address: mac,
+                serial: "test-dpu".to_string(),
+                settings: DpuSettings::default(),
+            },
+            dpu_index: 0,
+            bmc_injection: Arc::new(InjectionStore::new()),
+            join_handle: Mutex::new(None),
+        }))
+    }
+
     pub fn set_system_power(&self, request: SystemPowerControl) -> eyre::Result<()> {
         Ok(self.0.message_tx.send(DpuMachineMessage::SetSystemPower {
             request,

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -19,6 +19,7 @@ use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
+use bmc_mock::injection::{InjectionStore, Rule, RuleId};
 use bmc_mock::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use bmc_mock::{
     BmcCommand, HostMachineInfo, MachineInfo, SetSystemPowerResult, SystemPowerControl,
@@ -239,6 +240,7 @@ impl HostMachine {
         let host_info = self.host_info.clone();
         let dpus = self.dpus.clone();
         let machine_config_section = self.machine_config_section.clone();
+        let bmc_injection = self.state_machine.bmc_injection_store();
 
         if !paused {
             self.resume_dpus();
@@ -265,6 +267,7 @@ impl HostMachine {
             host_info,
             dpus,
             machine_config_section,
+            bmc_injection,
 
             join_handle: Mutex::new(Some(join_handle)),
         }))
@@ -535,6 +538,7 @@ struct HostMachineActor {
     host_info: HostMachineInfo,
     dpus: Vec<DpuMachineHandle>,
     machine_config_section: String,
+    bmc_injection: Arc<InjectionStore>,
 }
 
 #[derive(Debug, Clone)]
@@ -561,6 +565,24 @@ impl HostMachineHandle {
             .message_tx
             .send(HostMachineMessage::GetApiState(tx))?;
         Ok(rx.await?)
+    }
+
+    pub(crate) fn list_bmc_injection_rules(&self) -> Vec<Rule> {
+        self.0
+            .bmc_injection
+            .list()
+            .into_iter()
+            .map(|rule| (*rule).clone())
+            .collect()
+    }
+
+    pub(crate) fn upsert_bmc_injection_rule(&self, rule: Rule) -> Vec<Rule> {
+        self.0.bmc_injection.upsert(rule);
+        self.list_bmc_injection_rules()
+    }
+
+    pub(crate) fn delete_bmc_injection_rule(&self, rule_id: &RuleId) -> bool {
+        self.0.bmc_injection.delete(rule_id)
     }
 
     pub async fn wait_until_machine_up_with_api_state(

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -19,7 +19,7 @@ use std::net::Ipv4Addr;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
-use bmc_mock::injection::{InjectionStore, Rule, RuleId};
+use bmc_mock::injection::InjectionStore;
 use bmc_mock::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use bmc_mock::{
     BmcCommand, HostMachineInfo, MachineInfo, SetSystemPowerResult, SystemPowerControl,
@@ -545,6 +545,32 @@ struct HostMachineActor {
 pub struct HostMachineHandle(Arc<HostMachineActor>);
 
 impl HostMachineHandle {
+    #[cfg(test)]
+    pub(crate) fn for_control_test(dpus: Vec<DpuMachineHandle>) -> Self {
+        let (message_tx, _message_rx) = mpsc::unbounded_channel();
+        let mac = mac_address::MacAddress::new([2, 0, 0, 0, 0, 2]);
+        Self(Arc::new(HostMachineActor {
+            message_tx,
+            join_handle: Mutex::new(None),
+            live_state: Arc::new(RwLock::new(LiveState::default())),
+            mat_id: Uuid::new_v4(),
+            host_info: HostMachineInfo {
+                hw_type: Default::default(),
+                bmc_mac_address: mac,
+                serial: "test-host".to_string(),
+                dpus: Vec::new(),
+                non_dpu_mac_address: None,
+                nvos_mac_addresses: Vec::new(),
+                switch_serial_number: None,
+                hw_mac_addr_pool: MacAddressPoolConfig::new(mac, 24).unwrap(),
+                delta_psu_power: None,
+            },
+            dpus,
+            machine_config_section: "test".to_string(),
+            bmc_injection: Arc::new(InjectionStore::new()),
+        }))
+    }
+
     pub fn mat_id(&self) -> Uuid {
         self.0.mat_id
     }
@@ -567,22 +593,8 @@ impl HostMachineHandle {
         Ok(rx.await?)
     }
 
-    pub(crate) fn list_bmc_injection_rules(&self) -> Vec<Rule> {
-        self.0
-            .bmc_injection
-            .list()
-            .into_iter()
-            .map(|rule| (*rule).clone())
-            .collect()
-    }
-
-    pub(crate) fn upsert_bmc_injection_rule(&self, rule: Rule) -> Vec<Rule> {
-        self.0.bmc_injection.upsert(rule);
-        self.list_bmc_injection_rules()
-    }
-
-    pub(crate) fn delete_bmc_injection_rule(&self, rule_id: &RuleId) -> bool {
-        self.0.bmc_injection.delete(rule_id)
+    pub(crate) fn bmc_injection_store(&self) -> Arc<InjectionStore> {
+        self.0.bmc_injection.clone()
     }
 
     pub async fn wait_until_machine_up_with_api_state(

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -21,6 +21,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
+use bmc_mock::injection::InjectionStore;
 use bmc_mock::{
     BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostnameQuerying,
     MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
@@ -74,6 +75,7 @@ pub struct MachineStateMachine {
     fsm: MachineFsm,
     bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
     bmc_state: Option<BmcState>,
+    bmc_injection: Arc<InjectionStore>,
     power_cycle_deadline: Option<Instant>,
     machine_on_deadline: Option<Instant>,
     agent_polling_deadline: Option<(Instant, Timer)>,
@@ -242,6 +244,7 @@ impl MachineStateMachine {
             actions: actions.into_iter().collect(),
             bmc_mock: None,
             bmc_state: None,
+            bmc_injection: Arc::new(InjectionStore::new()),
             power_cycle_deadline: None,
             machine_on_deadline: None,
             agent_polling_deadline: None,
@@ -285,6 +288,7 @@ impl MachineStateMachine {
             bmc_dhcp_info: None,
             bmc_mock: None,
             bmc_state: None,
+            bmc_injection: Arc::new(InjectionStore::new()),
             machine_dhcp_info: None,
             machine_discovery_result: None,
             machine_on_deadline: None,
@@ -1025,6 +1029,10 @@ impl MachineStateMachine {
         self.bmc_dhcp_info.as_ref().map(|v| v.ip_address)
     }
 
+    pub(crate) fn bmc_injection_store(&self) -> Arc<InjectionStore> {
+        self.bmc_injection.clone()
+    }
+
     pub fn booted_os(&self) -> MaybeOsImage {
         MaybeOsImage(self.fsm.booted_os())
     }
@@ -1042,6 +1050,7 @@ impl MachineStateMachine {
             )),
             Arc::new(LiveStateHostnameQuery(self.live_state.clone())),
             self.mat_host_id,
+            self.bmc_injection.clone(),
         );
 
         let pw_override = match &self.machine_info {

--- a/dev/deployment/devspace/Dockerfile.machine-a-tron.dockerignore
+++ b/dev/deployment/devspace/Dockerfile.machine-a-tron.dockerignore
@@ -12,6 +12,12 @@
 !include
 !include/
 !include/**
+!dev
+!dev/
+!dev/ipmi
+!dev/ipmi/
+!dev/ipmi/cmd.conf
+!dev/ipmi/ipmi_sim_chassiscontrol.sh
 !pxe/
 !pxe/ipxe/
 !pxe/ipxe/local/


### PR DESCRIPTION
### What this PR does

Adds a machine-a-tron control API for managing BMC response-injection rules on one simulated machine:

- `GET /machines/{id}/bmc/injection/rules`
- `POST /machines/{id}/bmc/injection/rules`
- `DELETE /machines/{id}/bmc/injection/rules/{rule_id}`

`{id}` can be either the machine-a-tron UUID or the observed NICo MachineId. Each machine owns a dedicated injection store connected to its BMC router before startup, so a fault can be staged without affecting other simulated machines. The API reuses bmc-mock's existing path and OData selectors plus JSON merge, body replacement, status, latency, and bounded firing-count actions.

This makes issue #2886 reproducible: one Dell BIOS response can omit `SerialComm`, the selected host remains in `HostInitializing/PollingBiosSetup`, and deleting the rule lets the same host recover while the other hosts continue normally.

The machine-a-tron Docker build context also includes the IPMI files embedded by bmc-mock at compile time.

Related to #2886.

### How we verified it

Hands-on verification used signed revision `4dc6ce09f3c924a05b4dac11187718cfd0c316db` on `kfelter-nico-dev.nvidia.com`, with the integrated `kind-kind` cluster and the repository DevSpace deployment.

Starting from a clean cluster created by `devspace purge -n nico-system`, I deployed the PR head, selected machine-a-tron host `9f275fbc-f8d7-4119-9832-d068a788ec07`, and installed a `Replace` rule for `GET /redfish/v1/Systems/System.Embedded.1/Bios` whose response omitted only `SerialComm` from the required BIOS keys.

Expected result: only the selected host should remain in BIOS polling, NICo should report the missing key and retry, the other nine hosts should reach Ready, and removing the rule should let the selected host recover without restarting the stack.

Actual result:

- The rule POST returned HTTP 200, and machine-a-tron logged `injection: replacing body` for the selected BIOS path.
- NICo logged `Missing key SerialComm in JSON at bios` followed by `Failed to check BIOS setup status, will retry`.
- The selected NICo machine `fm100ht7au1sj77codn6pof95ri4renuo13hcqj7uv4fojk4t8c7700ojg0` remained in `HostInitializing/PollingBiosSetup { retry_count: 0 }` while the other nine hosts reached Ready.
- PostgreSQL showed `hostinit|3` and `ready|27`, matching the selected host plus its two DPUs versus the nine control hosts plus their 18 DPUs.
- Deleting `missing-serial-comm` by the observed NICo MachineId returned HTTP 200. The rules endpoint then returned `[]`.
- The selected host reached Ready without a restart. PostgreSQL then showed `ready|30`, and a final rules read still returned `[]`.

The DevSpace after-deploy check sampled the stack while the intentional fault was active and exited nonzero at 9 of 10 Core hosts Ready. The direct Core, database, machine-a-tron, and NICo log checks above continued through recovery and showed the final 30-of-30 Ready result.

Supporting checks on the same revision:

- `cargo test -p carbide-machine-a-tron --lib`: 11 passed
- `cargo test -p bmc-mock --lib`: 57 passed
- `cargo fmt -p bmc-mock -p carbide-machine-a-tron -- --check`: passed
- `git diff --check`: passed
- The machine-a-tron DevSpace image built from the repository Docker context
- DCO and CodeRabbit status checks: passed

### How to reproduce the verification

Prerequisites: the NICo development VM tools, Docker, the `kind-kind` context, and a clean checkout of this PR.

1. Check out the exact revision and confirm the context:

   ```bash
   git fetch https://github.com/kfelternv/infra-controller.git codex/mat-configured-injections
   git checkout --detach 4dc6ce09f3c924a05b4dac11187718cfd0c316db
   kubectl config use-context kind-kind
   ```

2. In terminal A, recreate and deploy the integrated stack:

   ```bash
   devspace purge -n nico-system
   devspace deploy -n nico-system
   ```

3. While terminal A is deploying, in terminal B wait for machine-a-tron and forward its shared HTTPS listener:

   ```bash
   kubectl wait --for=condition=available deployment/machine-a-tron -n nico-system --timeout=300s
   kubectl port-forward deployment/machine-a-tron -n nico-system 1266:1266
   ```

4. In terminal C, choose one simulated host before initial discovery and save this rule as `rule.json`:

   ```bash
   MAT_ID=$(curl -kfsS https://127.0.0.1:1266/machines/status | jq -er '.machines[0].mat_id')
   ```

   ```json
   {
     "id": "missing-serial-comm",
     "selector": {
       "Path": {
         "method": "GET",
         "glob": "/redfish/v1/Systems/System.Embedded.1/Bios"
       }
     },
     "action": {
       "Replace": {
         "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios",
         "@odata.type": "#Bios.v1_2_0.Bios",
         "Id": "BIOS",
         "Name": "BIOS Configuration",
         "Attributes": {
           "BootSeqRetry": "Disabled",
           "SetBootOrderEn": "NIC.HttpDevice.1-1,Disk.Bay.2:Enclosure.Internal.0-1",
           "InBandManageabilityInterface": "Disabled",
           "UefiVariableAccess": "Standard",
           "SerialPortAddress": "Com1",
           "FailSafeBaud": "115200",
           "ConTermType": "Vt100Vt220",
           "RedirAfterBoot": "Enabled",
           "SriovGlobalEnable": "Enabled",
           "TpmSecurity": "On",
           "Tpm2Algorithm": "SHA256",
           "Tpm2Hierarchy": "Enabled",
           "HttpDev1EnDis": "Enabled",
           "PxeDev1EnDis": "Disabled",
           "HttpDev1Interface": "NIC.Slot.5-1"
         }
       }
     },
     "remaining": null
   }
   ```

5. Install the rule and confirm it is active:

   ```bash
   curl -kfsS -X POST -H 'Content-Type: application/json' --data-binary @rule.json \
     "https://127.0.0.1:1266/machines/${MAT_ID}/bmc/injection/rules" | jq .
   curl -kfsS "https://127.0.0.1:1266/machines/${MAT_ID}/bmc/injection/rules" | jq .
   ```

   Expected: the response contains rule `missing-serial-comm`.

6. Inspect the full NICo API log, machine status, and machine-a-tron log:

   ```bash
   kubectl logs deployment/nico-api -n nico-system --since=10m
   curl -kfsS https://127.0.0.1:1266/machines/status | jq .
   kubectl logs deployment/machine-a-tron -n nico-system --since=10m
   ```

   Expected: NICo reports the missing `SerialComm` key and retries; the selected host stays in BIOS polling; the other nine hosts reach Ready; machine-a-tron reports that the replacement rule matched.

7. Read the selected host's observed NICo MachineId, delete the rule through that identifier, and confirm cleanup:

   ```bash
   MACHINE_ID=$(curl -kfsS https://127.0.0.1:1266/machines/status | \
     jq -er --arg id "$MAT_ID" '.machines[] | select(.mat_id == $id) | .machine_id')
   curl -kfsS -X DELETE \
     "https://127.0.0.1:1266/machines/${MACHINE_ID}/bmc/injection/rules/missing-serial-comm" | jq .
   curl -kfsS "https://127.0.0.1:1266/machines/${MAT_ID}/bmc/injection/rules" | jq .
   ```

   Expected: the rules read returns `[]`, the selected host resumes initialization and reaches Ready, and all 10 hosts plus 20 DPUs finish Ready without restarting machine-a-tron or NICo.
