### PR TITLE
feat(bmc-mock): populate Lenovo GB300 discovery info

### DIFF
--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -18,8 +18,10 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use carbide_utils::arch::CpuArchitecture;
 use mac_address::MacAddress;
-use rpc::DiscoveryInfo;
+use rpc::machine_discovery::{CpuInfo, Gpu, GpuPlatformInfo, MemoryDevice, TpmDescription};
+use rpc::{BlockDevice, DiscoveryInfo, DmiData, NetworkInterface, NvmeDevice, PciDeviceProperties};
 use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
@@ -29,6 +31,7 @@ pub struct LenovoGB300Nvl<'a> {
     pub system_0_serial_number: Cow<'a, str>,
     pub chassis_0_serial_number: Cow<'a, str>,
     pub dpu: hw::bluefield3::Bluefield3<'a>,
+    pub cx8_mac_addresses: [MacAddress; 10],
     pub embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
     pub bmc_mac_address_eth0: MacAddress,
     pub bmc_mac_address_eth1: MacAddress,
@@ -280,10 +283,196 @@ impl LenovoGB300Nvl<'_> {
     }
 
     pub fn discovery_info(&self) -> DiscoveryInfo {
+        let storage = [
+            ("SAMSUNG MZTL63T8HFLT-00AW7", "LDDL4U2Q", "LENOVOGB300NVME0"),
+            ("SAMSUNG MZTL63T8HFLT-00AW7", "LDDL4U2Q", "LENOVOGB300NVME1"),
+            ("SAMSUNG MZTL63T8HFLT-00AW7", "LDDL4U2Q", "LENOVOGB300NVME2"),
+            ("SAMSUNG MZTL63T8HFLT-00AW7", "LDDL4U2Q", "LENOVOGB300NVME3"),
+            ("SAMSUNG MZ1L21T9HCLS-00A07", "GDC7802Q", "LENOVOGB300NVME4"),
+        ];
+
         DiscoveryInfo {
-            network_interfaces: vec![self.dpu.host_nic().discovery_info(0x0603)],
+            network_interfaces: self.discovery_network_interfaces(),
+            infiniband_interfaces: vec![],
+            cpu_info: vec![CpuInfo {
+                model: "Neoverse-V2".into(),
+                vendor: "ARM".into(),
+                sockets: 2,
+                cores: 72,
+                threads: 72,
+            }],
+            block_devices: storage
+                .iter()
+                .map(|(model, revision, serial)| BlockDevice {
+                    model: (*model).into(),
+                    revision: (*revision).into(),
+                    serial: (*serial).into(),
+                    device_type: "disk".into(),
+                })
+                .collect(),
+            machine_type: CpuArchitecture::Aarch64.to_string(),
+            machine_arch: Some(rpc::utils::cpu_architecture_to_rpc(
+                CpuArchitecture::Aarch64,
+            )),
+            nvme_devices: storage
+                .iter()
+                .map(|(model, firmware_rev, serial)| NvmeDevice {
+                    model: (*model).into(),
+                    firmware_rev: (*firmware_rev).into(),
+                    serial: (*serial).into(),
+                })
+                .collect(),
+            dmi_data: Some(DmiData {
+                board_name: "PG548".into(),
+                board_version: "699-2G548-0301-B00".into(),
+                bios_version: "GBHC01A_01.05.0".into(),
+                product_serial: self.system_0_serial_number.to_string(),
+                board_serial: self.gpu[0].serial_number.to_string(),
+                chassis_serial: self.chassis_0_serial_number.to_string(),
+                bios_date: "03/05/2026".into(),
+                product_name: "HG635N_V2".into(),
+                sys_vendor: "Lenovo".into(),
+            }),
+            dpu_info: None,
+            gpus: self
+                .gpu
+                .iter()
+                .enumerate()
+                .map(|(index, gpu)| Gpu {
+                    name: "NVIDIA GB300".into(),
+                    serial: gpu.serial_number.to_string(),
+                    driver_version: "580.126.16".into(),
+                    vbios_version: "97.10.4A.00.1A".into(),
+                    inforom_version: "G548.0301.00.03".into(),
+                    total_memory: "284208 MiB".into(),
+                    frequency: "2070 MHz".into(),
+                    pci_bus_id: [
+                        "00000008:06:00.0",
+                        "00000009:06:00.0",
+                        "00000018:06:00.0",
+                        "00000019:06:00.0",
+                    ][index]
+                        .into(),
+                    platform_info: Some(GpuPlatformInfo {
+                        chassis_serial: self.chassis_0_serial_number.to_string(),
+                        slot_number: 4,
+                        tray_index: 3,
+                        host_id: 1,
+                        module_id: [2, 1, 4, 3][index],
+                        fabric_guid: format!("0xfeeeeeeeeeeeee{index:02x}"),
+                    }),
+                })
+                .collect(),
+            memory_devices: (0..2)
+                .map(|_| MemoryDevice {
+                    size_mb: Some(491520),
+                    mem_type: Some("LPDDR5".into()),
+                })
+                .collect(),
+            tpm_ek_certificate: None,
+            tpm_description: Some(TpmDescription {
+                vendor: "Could not convert spec_version672".into(),
+                firmware_version: "0xf0018.0x4a0a00".into(),
+                tpm_spec: "2.0".into(),
+            }),
             ..Default::default()
         }
+    }
+
+    fn discovery_network_interfaces(&self) -> Vec<NetworkInterface> {
+        let cx8_interfaces = [
+            (0x0000, 0, 0),
+            (0x0000, 1, 0),
+            (0x0000, 2, 0),
+            (0x0000, 3, 0),
+            (0x0002, 0, 0),
+            (0x0002, 1, 0),
+            (0x0010, 0, 1),
+            (0x0010, 1, 1),
+            (0x0012, 0, 1),
+            (0x0012, 1, 1),
+        ];
+
+        self.cx8_mac_addresses[..6]
+            .iter()
+            .zip(&cx8_interfaces[..6])
+            .map(|(mac, (domain, function, numa_node))| {
+                cx8_network_interface(*mac, *domain, *function, *numa_node)
+            })
+            .chain(std::iter::once(network_interface(
+                self.embedded_1g_nic.mac_address,
+                "Intel Corporation",
+                "I210 Gigabit Network Connection",
+                "/devices/pci0005:00/0005:00:00.0/0005:01:00.0/0005:02:06.0/0005:09:00.0/net/enP5p9s0",
+                "0005:09:00.0",
+                0,
+            )))
+            .chain(
+                self.cx8_mac_addresses[6..]
+                    .iter()
+                    .zip(&cx8_interfaces[6..])
+                    .map(|(mac, (domain, function, numa_node))| {
+                        cx8_network_interface(*mac, *domain, *function, *numa_node)
+                    }),
+            )
+            .chain(std::iter::once(self.dpu.host_nic_discovery_info(
+                "/devices/pci0016:00/0016:00:00.0/0016:01:00.0/net/enP22s22np0",
+                "0016:01:00.0",
+                1,
+            )))
+            .collect()
+    }
+}
+
+fn cx8_network_interface(
+    mac_address: MacAddress,
+    domain: u16,
+    function: u8,
+    numa_node: i32,
+) -> NetworkInterface {
+    let device_name = if domain == 0 {
+        format!("enp3s0f{function}np{function}")
+    } else {
+        format!("enP{domain}p3s0f{function}np{function}")
+    };
+    let path = format!(
+        "/devices/pci{domain:04x}:00\
+         /{domain:04x}:00:00.0\
+         /{domain:04x}:01:00.0\
+         /{domain:04x}:02:00.0\
+         /{domain:04x}:03:00.{function}\
+         /net/{device_name}"
+    );
+    let slot = format!("{domain:04x}:03:00.{function}");
+
+    network_interface(
+        mac_address,
+        "Mellanox Technologies",
+        "CX8 Family [ConnectX-8]",
+        &path,
+        &slot,
+        numa_node,
+    )
+}
+
+fn network_interface(
+    mac_address: MacAddress,
+    vendor: &str,
+    device: &str,
+    path: &str,
+    slot: &str,
+    numa_node: i32,
+) -> NetworkInterface {
+    NetworkInterface {
+        mac_address: mac_address.to_string(),
+        pci_properties: Some(PciDeviceProperties {
+            vendor: vendor.into(),
+            device: device.into(),
+            path: path.into(),
+            numa_node,
+            description: Some(device.into()),
+            slot: Some(slot.into()),
+        }),
     }
 }
 

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -748,6 +748,7 @@ impl HostMachineInfo {
         let io_board1_sn = "MT2524000002";
         let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
         let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
+        let cx8_mac_addresses = std::array::from_fn(|_| next_mac());
         hw::lenovo_gb300_nvl::LenovoGB300Nvl {
             system_0_serial_number: Cow::Borrowed(&self.serial),
             chassis_0_serial_number: Cow::Borrowed(&self.serial),
@@ -755,6 +756,7 @@ impl HostMachineInfo {
                 .next()
                 .expect("One DPU must present for GB300 NVL")
                 .bluefield3(),
+            cx8_mac_addresses,
             embedded_1g_nic: hw::nic_intel_i210::NicIntelI210 {
                 mac_address: next_mac(),
             },
@@ -1155,5 +1157,174 @@ mod tests {
             supermicro.serial
         );
         assert_ne!(dgx.serial, supermicro.serial);
+    }
+
+    #[test]
+    fn lenovo_gb300_discovery_info_matches_platform_shape() {
+        let pool_config =
+            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+        let mut pool = MacAddressPool::new(Config {
+            ranges: None,
+            pool: Some(pool_config),
+        });
+        let host = gb300_host_info(HostHardwareType::LenovoGB300Nvl, &mut pool);
+        let mock = host.lenovo_gb300_nvl();
+        let discovery = mock.discovery_info();
+
+        assert_eq!(discovery.network_interfaces.len(), 12);
+        assert_eq!(
+            discovery
+                .network_interfaces
+                .iter()
+                .map(|nic| nic.mac_address.as_str())
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            12
+        );
+        let pci_properties = discovery
+            .network_interfaces
+            .iter()
+            .map(|nic| nic.pci_properties.as_ref().expect("PCI properties"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            pci_properties
+                .iter()
+                .map(|pci| pci.slot.as_deref().expect("PCI slot"))
+                .collect::<Vec<_>>(),
+            [
+                "0000:03:00.0",
+                "0000:03:00.1",
+                "0000:03:00.2",
+                "0000:03:00.3",
+                "0002:03:00.0",
+                "0002:03:00.1",
+                "0005:09:00.0",
+                "0010:03:00.0",
+                "0010:03:00.1",
+                "0012:03:00.0",
+                "0012:03:00.1",
+                "0016:01:00.0",
+            ]
+        );
+        assert_eq!(
+            pci_properties
+                .iter()
+                .map(|pci| pci.numa_node)
+                .collect::<Vec<_>>(),
+            [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+        );
+        assert!(
+            pci_properties[..6]
+                .iter()
+                .all(|pci| pci.device == "CX8 Family [ConnectX-8]")
+        );
+        assert_eq!(pci_properties[6].device, "I210 Gigabit Network Connection");
+        assert!(
+            pci_properties[7..11]
+                .iter()
+                .all(|pci| pci.device == "CX8 Family [ConnectX-8]")
+        );
+        assert!(pci_properties[11].device.contains("BlueField-3"));
+        assert!(pci_properties[0].path.ends_with("/net/enp3s0f0np0"));
+        assert!(pci_properties[4].path.ends_with("/net/enP2p3s0f0np0"));
+        assert!(pci_properties[7].path.ends_with("/net/enP16p3s0f0np0"));
+        assert!(pci_properties[9].path.ends_with("/net/enP18p3s0f0np0"));
+
+        assert_eq!(discovery.infiniband_interfaces.len(), 0);
+        assert_eq!(discovery.cpu_info.len(), 1);
+        assert_eq!(discovery.cpu_info[0].model, "Neoverse-V2");
+        assert_eq!(discovery.cpu_info[0].sockets, 2);
+        assert_eq!(discovery.cpu_info[0].cores, 72);
+        assert_eq!(discovery.cpu_info[0].threads, 72);
+        assert_eq!(discovery.machine_type, "aarch64");
+        assert_eq!(
+            discovery.machine_arch,
+            Some(rpc::utils::cpu_architecture_to_rpc(
+                carbide_utils::arch::CpuArchitecture::Aarch64
+            ))
+        );
+
+        assert_eq!(discovery.block_devices.len(), 5);
+        assert_eq!(discovery.nvme_devices.len(), 5);
+        for (block, nvme) in discovery.block_devices.iter().zip(&discovery.nvme_devices) {
+            assert_eq!(block.model, nvme.model);
+            assert_eq!(block.revision, nvme.firmware_rev);
+            assert_eq!(block.serial, nvme.serial);
+        }
+        assert_eq!(
+            discovery.block_devices[0].model,
+            "SAMSUNG MZTL63T8HFLT-00AW7"
+        );
+        assert_eq!(
+            discovery.block_devices[4].model,
+            "SAMSUNG MZ1L21T9HCLS-00A07"
+        );
+
+        let dmi = discovery.dmi_data.as_ref().expect("DMI data");
+        assert_eq!(dmi.board_name, "PG548");
+        assert_eq!(dmi.board_version, "699-2G548-0301-B00");
+        assert_eq!(dmi.bios_version, "GBHC01A_01.05.0");
+        assert_eq!(dmi.bios_date, "03/05/2026");
+        assert_eq!(dmi.product_name, "HG635N_V2");
+        assert_eq!(dmi.sys_vendor, "Lenovo");
+        assert_eq!(dmi.product_serial, mock.system_0_serial_number);
+        assert_eq!(dmi.chassis_serial, mock.chassis_0_serial_number);
+        assert_eq!(dmi.board_serial, mock.gpu[0].serial_number);
+
+        assert_eq!(discovery.gpus.len(), 4);
+        assert_eq!(
+            discovery
+                .gpus
+                .iter()
+                .map(|gpu| gpu.pci_bus_id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "00000008:06:00.0",
+                "00000009:06:00.0",
+                "00000018:06:00.0",
+                "00000019:06:00.0",
+            ]
+        );
+        assert!(discovery.gpus.iter().all(|gpu| gpu.name == "NVIDIA GB300"));
+        assert_eq!(
+            discovery
+                .gpus
+                .iter()
+                .map(|gpu| {
+                    gpu.platform_info
+                        .as_ref()
+                        .expect("GPU platform info")
+                        .module_id
+                })
+                .collect::<Vec<_>>(),
+            [2, 1, 4, 3]
+        );
+        assert_eq!(
+            discovery
+                .gpus
+                .iter()
+                .map(|gpu| {
+                    gpu.platform_info
+                        .as_ref()
+                        .expect("GPU platform info")
+                        .fabric_guid
+                        .as_str()
+                })
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            4
+        );
+
+        assert_eq!(discovery.memory_devices.len(), 2);
+        assert!(discovery.memory_devices.iter().all(|memory| {
+            memory.size_mb == Some(491520) && memory.mem_type.as_deref() == Some("LPDDR5")
+        }));
+        assert!(discovery.dpu_info.is_none());
+        assert!(discovery.tpm_ek_certificate.is_none());
+        assert!(discovery.attest_key_info.is_none());
+        let tpm = discovery.tpm_description.as_ref().expect("TPM description");
+        assert_eq!(tpm.vendor, "Could not convert spec_version672");
+        assert_eq!(tpm.firmware_version, "0xf0018.0x4a0a00");
+        assert_eq!(tpm.tpm_spec, "2.0");
     }
 }

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -381,14 +381,16 @@ mod test {
         };
 
         let interfaces = machine.discovery_info().network_interfaces;
-        assert_eq!(interfaces.len(), 1);
-        assert_eq!(interfaces[0].mac_address, expected_mac);
-
-        let pci = interfaces[0]
+        assert_eq!(interfaces.len(), 12);
+        let dpu_interface = interfaces
+            .iter()
+            .find(|interface| interface.mac_address == expected_mac)
+            .expect("discovery must include the DPU host interface");
+        let pci = dpu_interface
             .pci_properties
             .as_ref()
             .expect("DPU host interface must include PCI properties");
         assert!(pci.vendor.to_ascii_lowercase().contains("mellanox"));
-        assert_eq!(pci.slot.as_deref(), Some("0000:03:00.0"));
+        assert_eq!(pci.slot.as_deref(), Some("0016:01:00.0"));
     }
 }


### PR DESCRIPTION
The Lenovo GB300 BMC mock previously reported only the DPU host network interface during machine discovery. This left local simulations and discovery tests without a representative view of the platform hardware.

This PR populates the Lenovo GB300 discovery response with:

  - CPU architecture and topology
  - NVMe and block storage devices
  - DMI platform information
  - GB300 GPUs and platform metadata
  - Memory and TPM information
  - CX-8, embedded Intel, and BlueField network interfaces

CX-8 PCI paths, slots, and predictable interface names are generated from compact PCI domain/function descriptors, following the existing GB200 pattern.

## Related issues

N/A

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
