### PR TITLE
feat(credential-rotation): add durable NVOS password rotation state

### DIFF
--- a/crates/api-core/src/handlers/credential_rotation.rs
+++ b/crates/api-core/src/handlers/credential_rotation.rs
@@ -29,9 +29,9 @@
 //! rotate every device reads as "pending" until the engine lands.
 //! `GetCredentialRotationStatus` reports that convergence.
 //!
-//! NVOS is rejected for now: NICo does not own the NVOS password until REQ-6
-//! (set-NVOS-from-factory), so there is no baseline to rotate from and the
-//! backfill deliberately seeds no `nvos` target row.
+//! NVOS is rejected for now. Its target row remains absent until the first
+//! versioned target secret has been stored and verified; API exposure remains
+//! disabled until the end-to-end NVOS rotation path is activated.
 
 use ::rpc::forge as rpc;
 use carbide_authn::middleware::Principal;

--- a/crates/api-core/src/handlers/credential_rotation.rs
+++ b/crates/api-core/src/handlers/credential_rotation.rs
@@ -89,8 +89,8 @@ fn to_rotation_type(credential_type: i32) -> Result<RotationType, CarbideError> 
         rpc::RotationCredentialType::RotationDpuUefi => Ok(RotationType::DpuUefi),
         rpc::RotationCredentialType::RotationLockdownIkm => Ok(RotationType::LockdownIkm),
         rpc::RotationCredentialType::RotationNvos => Err(CarbideError::FailedPrecondition(
-            "NVOS rotation is not supported yet: NICo does not own the NVOS password until \
-             set-NVOS-from-factory (REQ-6) ships"
+            "NVOS rotation is not supported yet: the end-to-end NVOS rotation path \
+             remains disabled"
                 .to_string(),
         )),
         // The proto3 zero value. Rejected rather than defaulted so a caller that

--- a/crates/api-db/migrations/20260715120000_nvos_credential_rotation_state.sql
+++ b/crates/api-db/migrations/20260715120000_nvos_credential_rotation_state.sql
@@ -1,0 +1,6 @@
+-- Retain the opaque backend job ID needed to reconcile an accepted NVOS
+-- password-rotation request. The site-wide target is created only after its
+-- immutable credential has been stored and verified.
+
+ALTER TABLE device_credential_rotation
+    ADD COLUMN rotate_job_id text;

--- a/crates/api-db/migrations/20260715120000_nvos_credential_rotation_state.sql
+++ b/crates/api-db/migrations/20260715120000_nvos_credential_rotation_state.sql
@@ -1,6 +1,12 @@
--- Retain the opaque backend job ID needed to reconcile an accepted NVOS
--- password-rotation request. The site-wide target is created only after its
--- immutable credential has been stored and verified.
+-- Durable backend job handle for an accepted NVOS password-rotation request, so
+-- the controller can resume polling it after its own restart. Nullable: a target
+-- staged before dispatch has no job ID yet.
+--
+-- This is a resume hint and anti-stale token, never proof of success: promotion
+-- to converged requires an authoritative credential readback, not a completed
+-- job (see record_device_rotation_reconciled_to_target). A late or recycled job
+-- ID cannot cross-attach to a newer operation because every transition also
+-- matches the monotonic rotate_attempts CAS token, not the job ID alone.
 
 ALTER TABLE device_credential_rotation
     ADD COLUMN rotate_job_id text;

--- a/crates/api-db/migrations/20260715120000_nvos_credential_rotation_state.sql
+++ b/crates/api-db/migrations/20260715120000_nvos_credential_rotation_state.sql
@@ -1,12 +1,6 @@
--- Durable backend job handle for an accepted NVOS password-rotation request, so
--- the controller can resume polling it after its own restart. Nullable: a target
--- staged before dispatch has no job ID yet.
---
--- This is a resume hint and anti-stale token, never proof of success: promotion
--- to converged requires an authoritative credential readback, not a completed
--- job (see record_device_rotation_reconciled_to_target). A late or recycled job
--- ID cannot cross-attach to a newer operation because every transition also
--- matches the monotonic rotate_attempts CAS token, not the job ID alone.
+-- Retain the opaque backend job ID needed to reconcile an accepted NVOS
+-- password-rotation request. The site-wide target is created only after its
+-- immutable credential has been stored and verified.
 
 ALTER TABLE device_credential_rotation
     ADD COLUMN rotate_job_id text;

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -1,8 +1,8 @@
 //! Runtime writer for the credential-rotation bookkeeping tables.
 //!
 //! `device_credential_rotation` records, per device and credential type, the
-//! version of the site-wide credential currently applied on the hardware -- the
-//! convergence marker the rotation engine drives toward
+//! last confirmed version of the site-wide credential applied on the hardware --
+//! the convergence marker the rotation engine drives toward
 //! `sitewide_credential_rotation.target_version`.
 //!
 //! Already-ingested devices are populated once by the
@@ -18,8 +18,8 @@
 //!
 //! * `bmc` -- at `site-explorer` `BmcEndpointExplorer::set_bmc_root_credentials`,
 //!   the single point where every host, DPU, switch, and power-shelf BMC is
-//!   moved onto (or confirmed on) the site-wide root and its per-device Vault
-//!   secret is written.
+//!   moved onto (or confirmed on) the site-wide root and its per-device secret
+//!   is written.
 //! * `host_uefi` -- when the host UEFI password is set on the device
 //!   (`api-core` `set_host_uefi_password` and the machine-controller UEFI-setup
 //!   state, alongside stamping `machines.bios_password_set_time`).
@@ -44,19 +44,28 @@
 //!   mid-flight advance from mis-recording a card as converged to a version it
 //!   was never locked under.
 //!
-//! Deferred to the work that owns those write paths:
-//!
-//! * `nvos` -- the hook is wired in the switch controller at
-//!   `configuring::handle_rotate_os_password` (the `RotateOsPassword` state) but
-//!   gated off, because NICo only copies the operator-provided NVOS credential
-//!   into Vault today; it does not change the switch password (REQ-6,
-//!   set-NVOS-from-factory, is not implemented). The gate flips on with REQ-6.
+//! NVOS password rotation requires durable progress across process restarts.
+//! The persistence contract in this module gives its controller an ordered
+//! lifecycle: leave the initial target unpublished until its secret is stored
+//! and verified, establish an authenticated device baseline with
+//! [`record_device_converged_if_target_matches`], stage a published target with
+//! [`record_device_rotation_started`], attach the returned job ID with
+//! [`record_device_rotation_submitted`], and recover progress through
+//! [`device_rotation_operation_state`]. Definitive rejection releases work
+//! with [`record_device_rotation_not_accepted`], ambiguous dispatch remains
+//! blocked through [`record_device_rotation_outcome_unknown`], and terminal job
+//! failures use [`record_device_rotation_failed`]. Backend completion remains
+//! evidence only. Authoritative credential checks resolve staged work through
+//! [`record_device_rotation_reconciled_to_target`] or
+//! [`record_device_rotation_reconciled_to_previous`]. Each transition compares
+//! the durable attempt number so a stale worker or late backend response cannot
+//! overwrite a retry.
 //!
 //! Teardown hooks (calling [`delete_device_converged`]) remove a marker when the
 //! credential it tracks is torn down, keeping the table honest:
 //!
 //! * `bmc` -- at `api-core` `delete_bmc_root_credentials_by_mac`, alongside
-//!   deleting the per-device BMC secret from Vault. Once NICo discards the
+//!   deleting the per-device BMC secret. Once NICo discards the
 //!   secret it can no longer authenticate or rotate, so the marker is meaningless.
 //! * `host_uefi` -- in the `api-core` force-delete path, right after
 //!   `clear_host_uefi_password` resets the password on the device: the host no
@@ -83,6 +92,31 @@ pub enum CredentialRotationType {
     DpuUefi,
     Nvos,
     LockdownIkm,
+}
+
+/// Result of conditionally establishing a device convergence baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecordDeviceConvergedOutcome {
+    /// The device row was inserted at the expected target version.
+    Recorded,
+
+    /// A device row already exists and was left unchanged.
+    AlreadyPresent,
+
+    /// The site-wide target advanced before the baseline could be recorded.
+    TargetChanged {
+        /// Site-wide target observed while attempting the insert.
+        current_target_version: i32,
+    },
+
+    /// No site-wide target exists for the credential type.
+    TargetMissing,
+}
+
+#[derive(sqlx::FromRow)]
+struct RecordDeviceConvergedResult {
+    recorded: bool,
+    current_target_version: Option<i32>,
 }
 
 /// Records that `device_mac` now carries the current site-wide `credential_type`
@@ -120,14 +154,6 @@ pub async fn record_device_converged(
     // drive a spurious rotation of a security credential. Erroring instead
     // surfaces the broken state and lets it self-heal once the row exists.
     //
-    // NVOS is deliberately NOT backfilled, and its only caller
-    // (switch-controller `handle_configuring`) is gated off until REQ-6. When
-    // that gate flips on, REQ-6 MUST also seed a `sitewide_credential_rotation`
-    // row for nvos (via the backfill or at runtime) before this is called, or
-    // it will -- correctly -- fail with `MissingSitewideRotationTarget` instead
-    // of recording a bogus version. The error makes that ordering
-    // self-enforcing.
-    //
     // Resolving the target here and recording it is correct only when the
     // device is known to carry the *current* site-wide credential -- i.e. NICo
     // just set factory -> site-wide. A caller that locked/derived against a
@@ -161,6 +187,71 @@ pub async fn record_device_converged(
         .await
         .map(|_| ())
         .map_err(|e| DatabaseError::query(insert, e))
+}
+
+/// Records an authenticated credential version only while it remains the target.
+///
+/// This establishes an NVOS baseline after the caller authenticated with
+/// `expected_target_version`, persisted that credential under the device key,
+/// and read the same value back from the configured credential writer. Unlike
+/// [`record_device_converged`], the inserted value comes from the authenticated
+/// version rather than a later site-wide target read.
+///
+/// The target comparison and insert execute under one row lock. This prevents a
+/// concurrent site-wide advance from recording a version that was not
+/// authenticated. Existing device rows are left unchanged because later
+/// transitions belong to the rotation controller.
+pub async fn record_device_converged_if_target_matches(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    expected_target_version: i32,
+) -> Result<RecordDeviceConvergedOutcome, DatabaseError> {
+    if expected_target_version < 0 {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "expected_target_version must be non-negative, got {expected_target_version}"
+        )));
+    }
+
+    let query = "WITH target AS ( \
+                     SELECT target_version \
+                     FROM sitewide_credential_rotation \
+                     WHERE credential_type = $2 \
+                     FOR UPDATE \
+                 ), inserted AS ( \
+                     INSERT INTO device_credential_rotation \
+                         (device_mac, credential_type, current_version) \
+                     SELECT $1, $2, $3 \
+                     FROM target \
+                     WHERE target_version = $3 \
+                     ON CONFLICT (device_mac, credential_type) DO NOTHING \
+                     RETURNING 1 \
+                 ) \
+                 SELECT EXISTS (SELECT 1 FROM inserted) AS recorded, \
+                        (SELECT target_version FROM target) AS current_target_version";
+
+    let result = sqlx::query_as::<_, RecordDeviceConvergedResult>(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(expected_target_version)
+        .fetch_one(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    let outcome = match (result.recorded, result.current_target_version) {
+        (true, _) => RecordDeviceConvergedOutcome::Recorded,
+        (false, Some(current_target_version))
+            if current_target_version == expected_target_version =>
+        {
+            RecordDeviceConvergedOutcome::AlreadyPresent
+        }
+        (false, Some(current_target_version)) => RecordDeviceConvergedOutcome::TargetChanged {
+            current_target_version,
+        },
+        (false, None) => RecordDeviceConvergedOutcome::TargetMissing,
+    };
+
+    Ok(outcome)
 }
 
 /// Stages an in-flight rotation: records that `device_mac` is being moved to
@@ -237,11 +328,321 @@ pub async fn promote_rotating_to_current(
     Ok(result.rows_affected() > 0)
 }
 
+/// Stages a target before dispatching a password mutation.
+///
+/// This is the durable pre-dispatch boundary. It must commit before dispatch so
+/// a restarted worker can see that mutation work was staged and avoid replacing
+/// or blindly repeating an unresolved operation.
+///
+/// Returns the new positive attempt number when work was staged. Returns `None`
+/// when the site-wide target no longer matches, the device has already converged
+/// to that revision, another rotation is staged, or an active quarantine window
+/// prevents work from being claimed. Callers must pass the attempt number to
+/// every later transition so stale responses from an earlier retry cannot mutate
+/// current state. Staged work is never retried through this function.
+pub async fn record_device_rotation_started(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+) -> Result<Option<i32>, DatabaseError> {
+    if rotating_to_version < 0 {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "rotating_to_version must be non-negative, got {rotating_to_version}"
+        )));
+    }
+
+    let query = "WITH target AS ( \
+                     SELECT target_version \
+                     FROM sitewide_credential_rotation \
+                     WHERE credential_type = $2 \
+                     FOR UPDATE \
+                 ) \
+                 INSERT INTO device_credential_rotation \
+                     (device_mac, credential_type, rotating_to_version, \
+                      rotate_attempts, rotate_last_attempt_at) \
+                 SELECT $1, $2, $3, 1, now() \
+                 FROM target \
+                 WHERE target_version = $3 \
+                 ON CONFLICT (device_mac, credential_type) DO UPDATE SET \
+                     rotating_to_version = EXCLUDED.rotating_to_version, \
+                     rotate_job_id = NULL, \
+                     rotate_attempts = device_credential_rotation.rotate_attempts + 1, \
+                     rotate_last_attempt_at = now(), \
+                     rotate_last_error_redacted = NULL, \
+                     rotate_quarantined_until = NULL \
+                 WHERE device_credential_rotation.rotating_to_version IS NULL \
+                       AND (device_credential_rotation.current_version IS NULL \
+                            OR device_credential_rotation.current_version \
+                               < EXCLUDED.rotating_to_version) \
+                       AND (device_credential_rotation.rotate_quarantined_until IS NULL \
+                            OR device_credential_rotation.rotate_quarantined_until <= now()) \
+                 RETURNING rotate_attempts";
+
+    sqlx::query_scalar::<_, i32>(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Records the opaque backend job ID returned for a staged target.
+///
+/// This is the durable handoff from mutation dispatch to job reconciliation.
+/// Persisting the backend handle allows polling to resume after process restart,
+/// while matching the staged target and attempt number prevents a late response
+/// from attaching to a newer operation.
+///
+/// Returns `false` if the row no longer has the expected target, already has a
+/// different job ID, or has already reached a terminal failure.
+pub async fn record_device_rotation_submitted(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+    job_id: &str,
+) -> Result<bool, DatabaseError> {
+    if job_id.is_empty() {
+        return Err(DatabaseError::InvalidArgument(
+            "rotation job ID must not be empty".to_string(),
+        ));
+    }
+
+    let query = "UPDATE device_credential_rotation \
+                 SET rotate_job_id = $5 \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4 \
+                       AND (rotate_job_id IS NULL OR rotate_job_id = $5) \
+                       AND rotate_last_error_redacted IS NULL";
+
+    let result = sqlx::query(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .bind(job_id)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Releases a staged mutation that the backend definitively did not accept.
+///
+/// The last confirmed credential remains unchanged while the staged target is
+/// cleared, allowing a later operator-initiated retry. Matching the attempt
+/// number and requiring no job ID prevents a late dispatch error from clearing
+/// a newer or already-accepted operation. Returns `false` when that exact
+/// pre-submission attempt is no longer active.
+pub async fn record_device_rotation_not_accepted(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+    error_redacted: &str,
+) -> Result<bool, DatabaseError> {
+    let query = "UPDATE device_credential_rotation \
+                 SET rotating_to_version = NULL, \
+                     rotate_job_id = NULL, \
+                     rotate_last_error_redacted = $5, \
+                     rotate_quarantined_until = NULL \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4 \
+                       AND rotate_job_id IS NULL \
+                       AND rotate_last_error_redacted IS NULL";
+
+    let result = sqlx::query(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .bind(error_redacted)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Preserves a staged mutation whose backend outcome is unknown.
+///
+/// Unknown work remains staged and therefore cannot be retried through
+/// [`record_device_rotation_started`]. A later operator workflow must establish
+/// which credential is active before resolving it. Matching the attempt number
+/// prevents an old no-response result from marking a newer retry unknown.
+pub async fn record_device_rotation_outcome_unknown(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+    error_redacted: &str,
+) -> Result<bool, DatabaseError> {
+    let query = "UPDATE device_credential_rotation \
+                 SET rotate_last_error_redacted = $5 \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4 \
+                       AND rotate_job_id IS NULL \
+                       AND (rotate_last_error_redacted IS NULL \
+                            OR rotate_last_error_redacted = $5)";
+
+    let result = sqlx::query(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .bind(error_redacted)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Records a terminal backend failure for a staged target.
+///
+/// This preserves evidence that the attempted target was not confirmed. The
+/// controller can stop automatic mutation retries while exposing the redacted
+/// failure for reconciliation and operator action.
+///
+/// The staged target and backend job ID remain present, preventing automatic
+/// mutation retries and preserving diagnostic context. Returns `false` when the
+/// row no longer has the expected target, attempt number, and job ID, or another
+/// error has already terminated that attempt.
+pub async fn record_device_rotation_failed(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+    job_id: &str,
+    error_redacted: &str,
+) -> Result<bool, DatabaseError> {
+    if job_id.is_empty() {
+        return Err(DatabaseError::InvalidArgument(
+            "rotation job ID must not be empty".to_string(),
+        ));
+    }
+
+    let query = "UPDATE device_credential_rotation \
+                 SET rotate_last_error_redacted = $6 \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4 \
+                       AND rotate_job_id = $5 \
+                       AND (rotate_last_error_redacted IS NULL \
+                            OR rotate_last_error_redacted = $6)";
+
+    let result = sqlx::query(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .bind(job_id)
+        .bind(error_redacted)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Promotes a staged target after authoritative credential reconciliation.
+///
+/// Call this only after a read-only operation authenticated with the staged
+/// target credential, the caller persisted that credential under the device key
+/// through the configured writer, and a readback returned the same value. A
+/// completed backend job is not sufficient evidence. The credential observation
+/// remains authoritative when submission returned an unknown outcome or the
+/// backend reported the job as completed, failed, missing, or unknown, so this
+/// transition intentionally accepts any job ID and error state.
+///
+/// Matching the staged target and attempt number prevents stale reconciliation
+/// from promoting a newer operation. Returns `false` when that exact operation
+/// is no longer active.
+pub async fn record_device_rotation_reconciled_to_target(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+) -> Result<bool, DatabaseError> {
+    let query = "UPDATE device_credential_rotation \
+                 SET current_version = rotating_to_version, \
+                     rotating_to_version = NULL, \
+                     rotate_job_id = NULL, \
+                     rotate_last_error_redacted = NULL, \
+                     rotate_quarantined_until = NULL \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4";
+
+    let result = sqlx::query(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Releases a staged target after authoritative previous-credential recovery.
+///
+/// Call this only after a read-only operation definitively rejected the staged
+/// target credential and authenticated with the credential used before
+/// dispatch. The confirmed version remains unchanged, while operation metadata
+/// is cleared so an operator may explicitly retry. `error_redacted` preserves
+/// the reason reconciliation was required without storing credential material.
+///
+/// Matching the staged target and attempt number prevents stale reconciliation
+/// from releasing a newer operation. Returns `false` when that exact operation
+/// is no longer active.
+pub async fn record_device_rotation_reconciled_to_previous(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+    error_redacted: &str,
+) -> Result<bool, DatabaseError> {
+    let query = "UPDATE device_credential_rotation \
+                 SET rotating_to_version = NULL, \
+                     rotate_job_id = NULL, \
+                     rotate_last_error_redacted = $5, \
+                     rotate_quarantined_until = NULL \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4";
+
+    let result = sqlx::query(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .bind(error_redacted)
+        .execute(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
 /// Deletes the convergence row for `(device_mac, credential_type)`, if present.
 ///
 /// Call this when NICo tears down the credential the row tracks -- either by
-/// discarding its only copy (the per-device BMC secret deleted from Vault on
-/// force-delete / `DeleteCredential`) or by changing it back on the device (the
+/// discarding its only copy (the per-device BMC secret deleted on force-delete
+/// or `DeleteCredential`) or by changing it back on the device (the
 /// host UEFI password cleared on force-delete). Once the credential the marker
 /// depends on is gone, the marker is false and must not linger for the rotation
 /// engine to act on. Idempotent: deleting a missing row is a no-op.
@@ -262,8 +663,8 @@ pub async fn delete_device_converged(
 }
 
 /// The current site-wide rotation target for `credential_type`, or `None` if no
-/// target row exists. Every credential type the backfill seeds (everything but
-/// `nvos`) has a row, so `None` means the type is not yet under management.
+/// target row exists. A missing row means the credential type has not published
+/// its initial target yet.
 ///
 /// `RotateCredential` reads this to learn the version it must write the
 /// rotate-TO secret at (`current + 1`) before publishing the new target with
@@ -356,7 +757,7 @@ struct RotationCounts {
 /// `quarantined` while its backoff window is in the future, and `pending`
 /// otherwise (including "not yet established", `current_version IS NULL`).
 /// Errors with [`DatabaseError::MissingSitewideRotationTarget`] when no target
-/// row exists (e.g. `nvos`, which is not backfilled).
+/// row exists.
 pub async fn rotation_status(
     conn: &mut PgConnection,
     credential_type: CredentialRotationType,
@@ -416,21 +817,87 @@ pub async fn rotation_status(
 pub struct DeviceRotationStatus {
     /// Site-wide target this device is converging to (from the sitewide row).
     pub target_version: i32,
+
     /// When the current site-wide target was staged.
     pub started_at: DateTime<Utc>,
+
+    /// Device MAC address associated with this rotation row.
     pub device_mac: String,
-    /// Version live on the hardware; `None` means "not yet established".
+
+    /// Last confirmed hardware version; `None` means "not yet established".
     pub current_version: Option<i32>,
+
     /// Non-`None` while a rotation is mid-flight on this device.
     pub rotating_to_version: Option<i32>,
+
     /// `current_version >= target_version` (false when `current_version` is NULL).
     pub converged: bool,
+
     /// In a backoff window (`rotate_quarantined_until > now()`).
     pub quarantined: bool,
+
+    /// End of the current backoff window, when one is active.
     pub quarantined_until: Option<DateTime<Utc>>,
+
+    /// Number of mutation attempts recorded for this device and credential.
     pub rotate_attempts: i32,
+
+    /// Time the latest mutation attempt was staged.
     pub rotate_last_attempt_at: Option<DateTime<Utc>>,
+
+    /// Redacted reason the current operation is blocked or failed.
     pub rotate_last_error_redacted: Option<String>,
+}
+
+/// Durable per-device operation fields used to resume rotation reconciliation.
+///
+/// The staged target identifies unresolved mutation work, the optional job ID
+/// selects backend polling, the attempt number rejects stale results, and
+/// terminal failure metadata prevents that work from being mistaken for a safe
+/// new submission after restart.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct DeviceRotationOperationState {
+    /// Credential version last confirmed on the device.
+    pub current_version: Option<i32>,
+
+    /// Target version staged before backend dispatch.
+    pub rotating_to_version: Option<i32>,
+
+    /// Opaque backend job ID, when dispatch returned one.
+    pub rotate_job_id: Option<String>,
+
+    /// Monotonic operation CAS token. PostgreSQL has no unsigned integer type,
+    /// so the non-negative `integer` column maps directly to `i32`.
+    pub rotate_attempts: i32,
+
+    /// Redacted reason the unresolved operation is blocked.
+    pub rotate_last_error_redacted: Option<String>,
+}
+
+/// Returns the restart-safe operation state for one device credential row.
+///
+/// A controller reads this before choosing whether to establish a baseline,
+/// submit work, poll an existing backend job, preserve a terminal failure, or
+/// treat the device as converged.
+pub async fn device_rotation_operation_state(
+    conn: &mut PgConnection,
+    credential_type: CredentialRotationType,
+    device_mac: MacAddress,
+) -> Result<Option<DeviceRotationOperationState>, DatabaseError> {
+    let query = "SELECT current_version, \
+                        rotating_to_version, \
+                        rotate_job_id, \
+                        rotate_attempts, \
+                        rotate_last_error_redacted \
+                 FROM device_credential_rotation \
+                 WHERE credential_type = $1 AND device_mac = $2";
+
+    sqlx::query_as::<_, DeviceRotationOperationState>(query)
+        .bind(credential_type)
+        .bind(device_mac)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 /// Convergence status for a single device's `credential_type` credential.
@@ -440,8 +907,8 @@ pub struct DeviceRotationStatus {
 /// `NotFound` rather than fabricating a "not established" status for a device
 /// NICo has no record of (e.g. a mistyped MAC). The inner JOIN to
 /// `sitewide_credential_rotation` means a credential type with no target row
-/// (e.g. `nvos`, never backfilled) also yields `None`, but the handler rejects
-/// those before reaching here.
+/// also yields `None`; uninitialized credential types intentionally have no
+/// target row.
 pub async fn device_rotation_status(
     conn: &mut PgConnection,
     credential_type: CredentialRotationType,
@@ -486,11 +953,15 @@ mod tests {
     use sqlx::{PgConnection, PgPool};
 
     use super::{
-        CredentialRotationType, current_target_version, delete_device_converged,
-        device_rotation_status, mark_device_rotating_to_version, promote_rotating_to_current,
-        record_device_converged, rotation_status, set_next_target_version,
+        CredentialRotationType, RecordDeviceConvergedOutcome, current_target_version,
+        delete_device_converged, device_rotation_operation_state, device_rotation_status,
+        mark_device_rotating_to_version, promote_rotating_to_current, record_device_converged,
+        record_device_converged_if_target_matches, record_device_rotation_failed,
+        record_device_rotation_not_accepted, record_device_rotation_outcome_unknown,
+        record_device_rotation_reconciled_to_previous, record_device_rotation_reconciled_to_target,
+        record_device_rotation_started, record_device_rotation_submitted, rotation_status,
+        set_next_target_version,
     };
-    use crate::DatabaseError;
 
     // Inserts a device convergence row with an explicit current_version (and no
     // quarantine) for the status-counting tests.
@@ -546,6 +1017,20 @@ mod tests {
         row.flatten()
     }
 
+    // Simulates the target publication that production performs only after the
+    // corresponding immutable credential has been stored and verified.
+    async fn publish_nvos_target(conn: &mut PgConnection, target_version: i32) {
+        sqlx::query(
+            "INSERT INTO sitewide_credential_rotation \
+                 (credential_type, target_version) \
+             VALUES ('nvos', $1)",
+        )
+        .bind(target_version)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    }
+
     #[crate::sqlx_test]
     async fn records_current_target_and_is_idempotent(pool: PgPool) {
         let mac1: MacAddress = "02:00:00:00:00:01".parse().unwrap();
@@ -589,25 +1074,60 @@ mod tests {
             Some(3),
             "a newly ingested device records the current site-wide target"
         );
+    }
 
-        // nvos has no site-wide target row (deliberately not backfilled, and its
-        // only caller is gated off until REQ-6). Recording convergence for a
-        // type with no site-wide target is a corrupted invariant, so the writer
-        // fails loudly instead of guessing a version -- and writes nothing.
-        let err = record_device_converged(&mut conn, mac1, CredentialRotationType::Nvos)
-            .await
-            .expect_err("nvos has no site-wide target row, so recording must fail");
-        assert!(
-            matches!(
-                err,
-                DatabaseError::MissingSitewideRotationTarget(CredentialRotationType::Nvos)
-            ),
-            "expected MissingSitewideRotationTarget for nvos, got: {err:?}"
-        );
+    #[crate::sqlx_test]
+    async fn exact_baseline_rejects_target_advance_race(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:09".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        // Version 1 authenticated, but the site-wide target advanced before
+        // baseline persistence. The CAS must not relabel that evidence as v2.
+        sqlx::query(
+            "UPDATE sitewide_credential_rotation SET target_version = 2 \
+             WHERE credential_type = 'nvos'",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        let stale = record_device_converged_if_target_matches(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+        )
+        .await
+        .unwrap();
+
         assert_eq!(
-            version_of(&mut conn, "02:00:00:00:00:01", "nvos").await,
-            None,
-            "a failed record must not write a row"
+            stale,
+            RecordDeviceConvergedOutcome::TargetChanged {
+                current_target_version: 2,
+            }
+        );
+
+        assert_eq!(
+            version_of(&mut conn, "02:00:00:00:00:09", "nvos").await,
+            None
+        );
+
+        let current = record_device_converged_if_target_matches(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            2,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(current, RecordDeviceConvergedOutcome::Recorded);
+
+        assert_eq!(
+            version_of(&mut conn, "02:00:00:00:00:09", "nvos").await,
+            Some(2)
         );
     }
 
@@ -680,6 +1200,622 @@ mod tests {
     }
 
     #[crate::sqlx_test]
+    async fn terminal_job_failure_remains_blocked(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0b".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        assert_eq!(attempt, 1);
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, None);
+        assert_eq!(state.rotating_to_version, Some(1));
+        assert_eq!(state.rotate_job_id, None);
+        assert_eq!(state.rotate_attempts, attempt);
+        assert_eq!(state.rotate_last_error_redacted, None);
+
+        let duplicate_start =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            duplicate_start, None,
+            "an unresolved rotation must not be replaced"
+        );
+
+        let submitted = record_device_rotation_submitted(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "job-1",
+        )
+        .await
+        .unwrap();
+
+        assert!(submitted);
+
+        let submitted_again = record_device_rotation_submitted(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "job-1",
+        )
+        .await
+        .unwrap();
+
+        assert!(submitted_again, "recording the same job must be idempotent");
+
+        let different_job = record_device_rotation_submitted(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "job-2",
+        )
+        .await
+        .unwrap();
+
+        assert!(!different_job, "a submitted job ID must not be replaced");
+
+        let failed = record_device_rotation_failed(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "job-1",
+            "backend rejected password rotation",
+        )
+        .await
+        .unwrap();
+
+        assert!(failed);
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, None);
+        assert_eq!(state.rotating_to_version, Some(1));
+        assert_eq!(state.rotate_job_id.as_deref(), Some("job-1"));
+        assert_eq!(state.rotate_attempts, attempt);
+
+        assert_eq!(
+            state.rotate_last_error_redacted.as_deref(),
+            Some("backend rejected password rotation")
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn definitive_rejection_allows_explicit_retry(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0c".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        assert!(
+            record_device_rotation_not_accepted(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                attempt,
+                "backend did not accept password rotation",
+            )
+            .await
+            .unwrap()
+        );
+
+        let retry_attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap()
+                .expect("an explicit retry should reopen rejected work");
+
+        assert_eq!(retry_attempt, attempt + 1);
+
+        let stale_release = record_device_rotation_not_accepted(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "late failure from the previous attempt",
+        )
+        .await
+        .unwrap();
+
+        assert!(!stale_release);
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, None);
+        assert_eq!(state.rotating_to_version, Some(1));
+        assert_eq!(state.rotate_job_id, None);
+        assert_eq!(state.rotate_attempts, retry_attempt);
+        assert_eq!(state.rotate_last_error_redacted, None);
+    }
+
+    #[crate::sqlx_test]
+    async fn active_quarantine_prevents_rotation_claim(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:10".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        sqlx::query(
+            "INSERT INTO device_credential_rotation \
+                 (device_mac, credential_type, current_version, rotate_quarantined_until) \
+             VALUES ($1, 'nvos', 0, now() + interval '1 hour')",
+        )
+        .bind(mac)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        let blocked =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap();
+
+        assert_eq!(blocked, None, "active quarantine must prevent work claim");
+
+        let quarantine_active: bool = sqlx::query_scalar(
+            "SELECT rotate_quarantined_until > now() \
+             FROM device_credential_rotation \
+             WHERE device_mac = $1 AND credential_type = 'nvos'",
+        )
+        .bind(mac)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+
+        assert!(
+            quarantine_active,
+            "a blocked claim must preserve quarantine"
+        );
+
+        sqlx::query(
+            "UPDATE device_credential_rotation \
+             SET rotate_quarantined_until = now() - interval '1 second' \
+             WHERE device_mac = $1 AND credential_type = 'nvos'",
+        )
+        .bind(mac)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            attempt,
+            Some(1),
+            "expired quarantine must permit work claim"
+        );
+
+        let quarantine_cleared: bool = sqlx::query_scalar(
+            "SELECT rotate_quarantined_until IS NULL \
+             FROM device_credential_rotation \
+             WHERE device_mac = $1 AND credential_type = 'nvos'",
+        )
+        .bind(mac)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+
+        assert!(
+            quarantine_cleared,
+            "successful claim must clear expired quarantine"
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn unknown_dispatch_outcome_remains_blocked(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        assert!(
+            record_device_rotation_outcome_unknown(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                attempt,
+                "password rotation response was not received",
+            )
+            .await
+            .unwrap()
+        );
+
+        let retry = record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(retry, None);
+
+        let late_submission = record_device_rotation_submitted(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "late-job",
+        )
+        .await
+        .unwrap();
+
+        assert!(!late_submission);
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, None);
+        assert_eq!(state.rotating_to_version, Some(1));
+        assert_eq!(state.rotate_job_id, None);
+        assert_eq!(state.rotate_attempts, attempt);
+
+        assert_eq!(
+            state.rotate_last_error_redacted.as_deref(),
+            Some("password rotation response was not received")
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn authoritative_target_reconciliation_promotes_unresolved_operations(pool: PgPool) {
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        let cases = [
+            (
+                "02:00:00:00:00:11",
+                Some("failed-job"),
+                Some("backend reported failure"),
+            ),
+            ("02:00:00:00:00:12", Some("missing-job"), None),
+            (
+                "02:00:00:00:00:13",
+                None,
+                Some("submission outcome unknown"),
+            ),
+        ];
+
+        for (mac, job_id, error) in cases {
+            let mac: MacAddress = mac.parse().unwrap();
+
+            sqlx::query(
+                "INSERT INTO device_credential_rotation \
+                     (device_mac, credential_type, rotating_to_version, rotate_attempts, \
+                      rotate_job_id, rotate_last_error_redacted) \
+                 VALUES ($1, 'nvos', 1, 3, $2, $3)",
+            )
+            .bind(mac)
+            .bind(job_id)
+            .bind(error)
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+
+            assert!(
+                !record_device_rotation_reconciled_to_target(
+                    &mut conn,
+                    mac,
+                    CredentialRotationType::Nvos,
+                    1,
+                    2,
+                )
+                .await
+                .unwrap()
+            );
+
+            assert!(
+                record_device_rotation_reconciled_to_target(
+                    &mut conn,
+                    mac,
+                    CredentialRotationType::Nvos,
+                    1,
+                    3,
+                )
+                .await
+                .unwrap()
+            );
+
+            let state =
+                device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+                    .await
+                    .unwrap()
+                    .expect("operation state should exist");
+
+            assert_eq!(state.current_version, Some(1));
+            assert_eq!(state.rotating_to_version, None);
+            assert_eq!(state.rotate_job_id, None);
+            assert_eq!(state.rotate_last_error_redacted, None);
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn previous_credential_reconciliation_allows_operator_retry(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:12".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        assert!(
+            record_device_rotation_outcome_unknown(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                attempt,
+                "password rotation response was not received",
+            )
+            .await
+            .unwrap()
+        );
+
+        assert!(
+            record_device_rotation_reconciled_to_previous(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                attempt,
+                "target rejected; previous credential authenticated",
+            )
+            .await
+            .unwrap()
+        );
+
+        assert!(
+            !record_device_rotation_reconciled_to_target(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                attempt,
+            )
+            .await
+            .unwrap()
+        );
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, None);
+        assert_eq!(state.rotating_to_version, None);
+        assert_eq!(state.rotate_job_id, None);
+
+        assert_eq!(
+            state.rotate_last_error_redacted.as_deref(),
+            Some("target rejected; previous credential authenticated")
+        );
+
+        let retry = record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+            .await
+            .unwrap();
+
+        assert_eq!(retry, Some(attempt + 1));
+    }
+
+    #[crate::sqlx_test]
+    async fn backend_completion_requires_reconciliation_and_promotes_exact_revision(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0e".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 7).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 7)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        assert_eq!(attempt, 1);
+
+        assert!(
+            record_device_rotation_submitted(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                7,
+                attempt,
+                "job-7",
+            )
+            .await
+            .unwrap()
+        );
+
+        // Backend completion has no database transition that can promote this
+        // submitted job. Only authoritative credential reconciliation below can
+        // change current_version.
+        let submitted_state =
+            device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+                .await
+                .unwrap()
+                .expect("submitted operation state should exist");
+
+        assert_eq!(submitted_state.current_version, None);
+        assert_eq!(submitted_state.rotating_to_version, Some(7));
+        assert_eq!(submitted_state.rotate_job_id.as_deref(), Some("job-7"));
+
+        sqlx::query(
+            "UPDATE sitewide_credential_rotation SET target_version = 8 \
+             WHERE credential_type = 'nvos'",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        let stale_reconciliation = record_device_rotation_reconciled_to_target(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            6,
+            attempt,
+        )
+        .await
+        .unwrap();
+
+        assert!(!stale_reconciliation);
+
+        let promoted = record_device_rotation_reconciled_to_target(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            7,
+            attempt,
+        )
+        .await
+        .unwrap();
+
+        assert!(promoted);
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, Some(7));
+        assert_eq!(state.rotating_to_version, None);
+        assert_eq!(state.rotate_job_id, None);
+        assert_eq!(state.rotate_attempts, attempt);
+        assert_eq!(state.rotate_last_error_redacted, None);
+
+        let promoted_again = record_device_rotation_reconciled_to_target(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            7,
+            attempt,
+        )
+        .await
+        .unwrap();
+
+        assert!(!promoted_again);
+
+        let next_started =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 8)
+                .await
+                .unwrap();
+
+        assert_eq!(next_started, Some(2));
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("next operation state should exist");
+
+        assert_eq!(state.current_version, Some(7));
+        assert_eq!(state.rotating_to_version, Some(8));
+        assert_eq!(state.rotate_attempts, 2);
+    }
+
+    #[crate::sqlx_test]
+    async fn reconciled_revision_cannot_be_restarted(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0f".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 0).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 0)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        assert!(
+            record_device_rotation_submitted(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                0,
+                attempt,
+                "job-0",
+            )
+            .await
+            .unwrap()
+        );
+
+        assert!(
+            record_device_rotation_reconciled_to_target(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                0,
+                attempt,
+            )
+            .await
+            .unwrap()
+        );
+
+        let restarted =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 0)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            restarted, None,
+            "a converged revision must not be staged again"
+        );
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.current_version, Some(0));
+        assert_eq!(state.rotating_to_version, None);
+    }
+
+    #[crate::sqlx_test]
     async fn delete_removes_only_the_targeted_row_and_is_idempotent(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:01".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
@@ -687,6 +1823,7 @@ mod tests {
         record_device_converged(&mut conn, mac, CredentialRotationType::Bmc)
             .await
             .unwrap();
+
         record_device_converged(&mut conn, mac, CredentialRotationType::HostUefi)
             .await
             .unwrap();
@@ -823,14 +1960,15 @@ mod tests {
         assert_eq!(empty.quarantined, 0);
         assert!(empty.quarantined_device_macs.is_empty());
 
-        // nvos has no site-wide target row, so status fails loudly rather than
-        // fabricating an empty rotation.
-        let err = rotation_status(&mut conn, CredentialRotationType::Nvos)
-            .await
-            .expect_err("nvos has no site-wide target row");
+        // NVOS remains uninitialized until its first target secret is stored
+        // and verified, so status must not fabricate a target.
+        let nvos = rotation_status(&mut conn, CredentialRotationType::Nvos).await;
+
         assert!(matches!(
-            err,
-            DatabaseError::MissingSitewideRotationTarget(CredentialRotationType::Nvos)
+            nvos,
+            Err(crate::DatabaseError::MissingSitewideRotationTarget(
+                CredentialRotationType::Nvos
+            ))
         ));
     }
 

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -77,25 +77,17 @@ use mac_address::MacAddress;
 use sqlx::PgConnection;
 
 use crate::DatabaseError;
+use crate::db_read::DbReader;
 
 /// Mirrors the `credential_rotation_type` Postgres enum
 /// (`20260623120000_credential_rotation.sql`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "credential_rotation_type", rename_all = "snake_case")]
 pub enum CredentialRotationType {
-    /// Baseboard-management-controller root credential.
     Bmc,
-
-    /// Host firmware setup credential.
     HostUefi,
-
-    /// DPU firmware setup credential.
     DpuUefi,
-
-    /// NVOS administrative credential for NVLink switches.
     Nvos,
-
-    /// DPU lockdown key material.
     LockdownIkm,
 }
 
@@ -796,6 +788,27 @@ pub struct DeviceRotationStatus {
     pub rotate_last_error_redacted: Option<String>,
 }
 
+/// Query row for NVOS status while the site-wide target may be unpublished.
+///
+/// The query starts from the live switch and left-joins the target, so these
+/// target fields must be nullable. The helper converts a complete row into
+/// [`DeviceRotationStatus`] and maps a missing target to
+/// [`DatabaseError::MissingSitewideRotationTarget`].
+#[derive(sqlx::FromRow)]
+struct NvosDeviceRotationStatusRow {
+    target_version: Option<i32>,
+    started_at: Option<DateTime<Utc>>,
+    device_mac: String,
+    current_version: Option<i32>,
+    rotating_to_version: Option<i32>,
+    converged: bool,
+    quarantined: bool,
+    quarantined_until: Option<DateTime<Utc>>,
+    rotate_attempts: i32,
+    rotate_last_attempt_at: Option<DateTime<Utc>>,
+    rotate_last_error_redacted: Option<String>,
+}
+
 /// Durable per-device operation fields used to resume rotation reconciliation.
 ///
 /// The staged target identifies unresolved mutation work, the optional job ID
@@ -827,7 +840,7 @@ pub struct DeviceRotationOperationState {
 /// submit work, poll an existing backend job, preserve a terminal failure, or
 /// treat the device as converged.
 pub async fn device_rotation_operation_state(
-    conn: &mut PgConnection,
+    conn: impl DbReader<'_>,
     credential_type: CredentialRotationType,
     device_mac: MacAddress,
 ) -> Result<Option<DeviceRotationOperationState>, DatabaseError> {
@@ -842,20 +855,18 @@ pub async fn device_rotation_operation_state(
     sqlx::query_as::<_, DeviceRotationOperationState>(query)
         .bind(credential_type)
         .bind(device_mac)
-        .fetch_optional(&mut *conn)
+        .fetch_optional(conn)
         .await
         .map_err(|e| DatabaseError::query(query, e))
 }
 
 /// Convergence status for a single device's `credential_type` credential.
 ///
-/// Returns `None` when no `device_credential_rotation` row exists for the
-/// `(device_mac, credential_type)` pair -- the caller surfaces that as
-/// `NotFound` rather than fabricating a "not established" status for a device
-/// NICo has no record of (e.g. a mistyped MAC). The inner JOIN to
-/// `sitewide_credential_rotation` means a credential type with no target row
-/// also yields `None`; uninitialized credential types intentionally have no
-/// target row.
+/// Returns `None` when the device does not belong to the credential type's
+/// device universe; the caller surfaces that as `NotFound` rather than
+/// fabricating a status for an unknown device. For NVOS, a live switch remains
+/// distinguishable from an unknown device before the initial target is
+/// published, and produces [`DatabaseError::MissingSitewideRotationTarget`].
 pub async fn device_rotation_status(
     conn: &mut PgConnection,
     credential_type: CredentialRotationType,
@@ -911,19 +922,44 @@ async fn nvos_device_rotation_status(
                         COALESCE(d.rotate_attempts, 0) AS rotate_attempts, \
                         d.rotate_last_attempt_at, \
                         d.rotate_last_error_redacted \
-                 FROM sitewide_credential_rotation s \
-                 JOIN live_device ld ON TRUE \
+                 FROM live_device ld \
+                 LEFT JOIN sitewide_credential_rotation s \
+                     ON s.credential_type = $1 \
                  LEFT JOIN device_credential_rotation d \
-                     ON d.credential_type = s.credential_type \
-                    AND d.device_mac = ld.device_mac \
-                 WHERE s.credential_type = $1";
+                     ON d.credential_type = $1 \
+                    AND d.device_mac = ld.device_mac";
 
-    sqlx::query_as::<_, DeviceRotationStatus>(query)
+    let status = sqlx::query_as::<_, NvosDeviceRotationStatusRow>(query)
         .bind(CredentialRotationType::Nvos)
         .bind(device_mac)
         .fetch_optional(conn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    let Some(status) = status else {
+        return Ok(None);
+    };
+
+    let (Some(target_version), Some(started_at)) = (status.target_version, status.started_at)
+    else {
+        return Err(DatabaseError::MissingSitewideRotationTarget(
+            CredentialRotationType::Nvos,
+        ));
+    };
+
+    Ok(Some(DeviceRotationStatus {
+        target_version,
+        started_at,
+        device_mac: status.device_mac,
+        current_version: status.current_version,
+        rotating_to_version: status.rotating_to_version,
+        converged: status.converged,
+        quarantined: status.quarantined,
+        quarantined_until: status.quarantined_until,
+        rotate_attempts: status.rotate_attempts,
+        rotate_last_attempt_at: status.rotate_last_attempt_at,
+        rotate_last_error_redacted: status.rotate_last_error_redacted,
+    }))
 }
 
 // Tests for the SQL-only `*_credential_rotation_backfill` data migration. It has
@@ -1219,7 +1255,7 @@ mod tests {
 
         assert!(!stale_release);
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
@@ -1275,7 +1311,7 @@ mod tests {
         .unwrap()
         .expect("operator should publish the next target");
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
@@ -1428,7 +1464,7 @@ mod tests {
 
         assert_eq!(stale_retry, None);
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
@@ -1492,7 +1528,7 @@ mod tests {
 
         assert_eq!(retry, Some(attempt + 1));
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
@@ -1531,7 +1567,7 @@ mod tests {
         );
 
         let submitted_state =
-            device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
                 .await
                 .unwrap()
                 .expect("submitted operation state should exist");
@@ -1587,7 +1623,7 @@ mod tests {
 
         assert!(promoted);
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
@@ -1618,7 +1654,7 @@ mod tests {
 
         assert_eq!(next_started, Some(2));
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("next operation state should exist");
@@ -1677,7 +1713,7 @@ mod tests {
             "a converged revision must not be staged again"
         );
 
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
@@ -1909,10 +1945,30 @@ mod tests {
         let mut conn = pool.acquire().await.unwrap();
         let live_mac: MacAddress = "02:00:00:00:50:01".parse().unwrap();
         let deleted_mac: MacAddress = "02:00:00:00:50:02".parse().unwrap();
+        let unknown_mac: MacAddress = "02:00:00:00:50:ff".parse().unwrap();
 
-        publish_nvos_target(&mut conn, 1).await;
         insert_switch(&mut conn, "nvos-device-live", "02:00:00:00:50:01", false).await;
         insert_switch(&mut conn, "nvos-device-deleted", "02:00:00:00:50:02", true).await;
+
+        let before_publish =
+            device_rotation_status(&mut conn, CredentialRotationType::Nvos, live_mac).await;
+
+        assert!(matches!(
+            before_publish,
+            Err(crate::DatabaseError::MissingSitewideRotationTarget(
+                CredentialRotationType::Nvos
+            ))
+        ));
+
+        assert!(
+            device_rotation_status(&mut conn, CredentialRotationType::Nvos, unknown_mac)
+                .await
+                .unwrap()
+                .is_none(),
+            "an unknown switch must remain NotFound before target publication"
+        );
+
+        publish_nvos_target(&mut conn, 1).await;
 
         let pending = device_rotation_status(&mut conn, CredentialRotationType::Nvos, live_mac)
             .await

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -953,14 +953,14 @@ mod tests {
     use sqlx::{PgConnection, PgPool};
 
     use super::{
-        CredentialRotationType, RecordDeviceConvergedOutcome, current_target_version,
-        delete_device_converged, device_rotation_operation_state, device_rotation_status,
-        mark_device_rotating_to_version, promote_rotating_to_current, record_device_converged,
-        record_device_converged_if_target_matches, record_device_rotation_failed,
-        record_device_rotation_not_accepted, record_device_rotation_outcome_unknown,
-        record_device_rotation_reconciled_to_previous, record_device_rotation_reconciled_to_target,
-        record_device_rotation_started, record_device_rotation_submitted, rotation_status,
-        set_next_target_version,
+        CredentialRotationType, DatabaseError, RecordDeviceConvergedOutcome,
+        current_target_version, delete_device_converged, device_rotation_operation_state,
+        device_rotation_status, mark_device_rotating_to_version, promote_rotating_to_current,
+        record_device_converged, record_device_converged_if_target_matches,
+        record_device_rotation_failed, record_device_rotation_not_accepted,
+        record_device_rotation_outcome_unknown, record_device_rotation_reconciled_to_previous,
+        record_device_rotation_reconciled_to_target, record_device_rotation_started,
+        record_device_rotation_submitted, rotation_status, set_next_target_version,
     };
 
     // Inserts a device convergence row with an explicit current_version (and no
@@ -1128,6 +1128,92 @@ mod tests {
         assert_eq!(
             version_of(&mut conn, "02:00:00:00:00:09", "nvos").await,
             Some(2)
+        );
+    }
+
+    // The race test above exercises `Recorded` and `TargetChanged`. These cover
+    // the remaining outcomes of `record_device_converged_if_target_matches`:
+    // `AlreadyPresent`, `TargetMissing`, and the negative-version rejection. Each
+    // uses a distinct credential type so its setup cannot bleed across cases.
+    #[crate::sqlx_test]
+    async fn if_target_matches_reports_already_present(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0b".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        // Establish the baseline first: the backfill seeds the bmc target at 0,
+        // so this records the device at 0.
+        record_device_converged(&mut conn, mac, CredentialRotationType::Bmc)
+            .await
+            .unwrap();
+
+        // A second baseline attempt at the same target must find the row already
+        // present, leave it untouched, and report the no-op explicitly rather
+        // than as a target mismatch.
+        let outcome = record_device_converged_if_target_matches(
+            &mut conn,
+            mac,
+            CredentialRotationType::Bmc,
+            0,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, RecordDeviceConvergedOutcome::AlreadyPresent);
+        assert_eq!(
+            version_of(&mut conn, "02:00:00:00:00:0b", "bmc").await,
+            Some(0)
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn if_target_matches_reports_missing_target(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0c".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        // nvos is the one type the backfill never seeds a site-wide target for,
+        // so a baseline attempt has nothing to match against.
+        let outcome = record_device_converged_if_target_matches(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            0,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, RecordDeviceConvergedOutcome::TargetMissing);
+        assert_eq!(
+            version_of(&mut conn, "02:00:00:00:00:0c", "nvos").await,
+            None
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn if_target_matches_rejects_negative_version(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        // A published target exists, so the rejection is purely the argument
+        // guard, not a missing target.
+        publish_nvos_target(&mut conn, 1).await;
+
+        let err = record_device_converged_if_target_matches(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            -1,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, DatabaseError::InvalidArgument(_)),
+            "a negative expected version must be rejected, got {err:?}"
+        );
+        // The guard runs before any statement, so no device row is created.
+        assert_eq!(
+            version_of(&mut conn, "02:00:00:00:00:0d", "nvos").await,
+            None
         );
     }
 

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -45,20 +45,16 @@
 //!   was never locked under.
 //!
 //! NVOS password rotation requires durable progress across process restarts.
-//! The persistence contract in this module gives its controller an ordered
-//! lifecycle: leave the initial target unpublished until its secret is stored
-//! and verified, establish an authenticated device baseline with
-//! [`record_device_converged_if_target_matches`], stage a published target with
-//! [`record_device_rotation_started`], attach the returned job ID with
-//! [`record_device_rotation_submitted`], and recover progress through
-//! [`device_rotation_operation_state`]. Definitive rejection releases work
-//! with [`record_device_rotation_not_accepted`], ambiguous dispatch remains
-//! blocked through [`record_device_rotation_outcome_unknown`], and terminal job
-//! failures use [`record_device_rotation_failed`]. Backend completion remains
-//! evidence only. Authoritative credential checks resolve staged work through
-//! [`record_device_rotation_reconciled_to_target`] or
-//! [`record_device_rotation_reconciled_to_previous`]. Each transition compares
-//! the durable attempt number so a stale worker or late backend response cannot
+//! The controller stages a published target with
+//! [`record_device_rotation_started`], attaches its backend job ID with
+//! [`record_device_rotation_submitted`], and recovers progress through
+//! [`device_rotation_operation_state`]. A lost response, missing job, unknown
+//! job, or failed job claims another attempt through
+//! [`record_device_rotation_retry_started`] before redispatching the same
+//! resumable RMS mutation. A matching completed job is promoted through
+//! [`record_device_rotation_completed`] only after the per-device target
+//! credential has been written and read back. Each transition compares the
+//! durable attempt number so a stale worker or late backend response cannot
 //! overwrite a retry.
 //!
 //! Teardown hooks (calling [`delete_device_converged`]) remove a marker when the
@@ -87,36 +83,20 @@ use crate::DatabaseError;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "credential_rotation_type", rename_all = "snake_case")]
 pub enum CredentialRotationType {
+    /// Baseboard-management-controller root credential.
     Bmc,
+
+    /// Host firmware setup credential.
     HostUefi,
+
+    /// DPU firmware setup credential.
     DpuUefi,
+
+    /// NVOS administrative credential for NVLink switches.
     Nvos,
+
+    /// DPU lockdown key material.
     LockdownIkm,
-}
-
-/// Result of conditionally establishing a device convergence baseline.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RecordDeviceConvergedOutcome {
-    /// The device row was inserted at the expected target version.
-    Recorded,
-
-    /// A device row already exists and was left unchanged.
-    AlreadyPresent,
-
-    /// The site-wide target advanced before the baseline could be recorded.
-    TargetChanged {
-        /// Site-wide target observed while attempting the insert.
-        current_target_version: i32,
-    },
-
-    /// No site-wide target exists for the credential type.
-    TargetMissing,
-}
-
-#[derive(sqlx::FromRow)]
-struct RecordDeviceConvergedResult {
-    recorded: bool,
-    current_target_version: Option<i32>,
 }
 
 /// Records that `device_mac` now carries the current site-wide `credential_type`
@@ -187,71 +167,6 @@ pub async fn record_device_converged(
         .await
         .map(|_| ())
         .map_err(|e| DatabaseError::query(insert, e))
-}
-
-/// Records an authenticated credential version only while it remains the target.
-///
-/// This establishes an NVOS baseline after the caller authenticated with
-/// `expected_target_version`, persisted that credential under the device key,
-/// and read the same value back from the configured credential writer. Unlike
-/// [`record_device_converged`], the inserted value comes from the authenticated
-/// version rather than a later site-wide target read.
-///
-/// The target comparison and insert execute under one row lock. This prevents a
-/// concurrent site-wide advance from recording a version that was not
-/// authenticated. Existing device rows are left unchanged because later
-/// transitions belong to the rotation controller.
-pub async fn record_device_converged_if_target_matches(
-    conn: &mut PgConnection,
-    device_mac: MacAddress,
-    credential_type: CredentialRotationType,
-    expected_target_version: i32,
-) -> Result<RecordDeviceConvergedOutcome, DatabaseError> {
-    if expected_target_version < 0 {
-        return Err(DatabaseError::InvalidArgument(format!(
-            "expected_target_version must be non-negative, got {expected_target_version}"
-        )));
-    }
-
-    let query = "WITH target AS ( \
-                     SELECT target_version \
-                     FROM sitewide_credential_rotation \
-                     WHERE credential_type = $2 \
-                     FOR UPDATE \
-                 ), inserted AS ( \
-                     INSERT INTO device_credential_rotation \
-                         (device_mac, credential_type, current_version) \
-                     SELECT $1, $2, $3 \
-                     FROM target \
-                     WHERE target_version = $3 \
-                     ON CONFLICT (device_mac, credential_type) DO NOTHING \
-                     RETURNING 1 \
-                 ) \
-                 SELECT EXISTS (SELECT 1 FROM inserted) AS recorded, \
-                        (SELECT target_version FROM target) AS current_target_version";
-
-    let result = sqlx::query_as::<_, RecordDeviceConvergedResult>(query)
-        .bind(device_mac)
-        .bind(credential_type)
-        .bind(expected_target_version)
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-
-    let outcome = match (result.recorded, result.current_target_version) {
-        (true, _) => RecordDeviceConvergedOutcome::Recorded,
-        (false, Some(current_target_version))
-            if current_target_version == expected_target_version =>
-        {
-            RecordDeviceConvergedOutcome::AlreadyPresent
-        }
-        (false, Some(current_target_version)) => RecordDeviceConvergedOutcome::TargetChanged {
-            current_target_version,
-        },
-        (false, None) => RecordDeviceConvergedOutcome::TargetMissing,
-    };
-
-    Ok(outcome)
 }
 
 /// Stages an in-flight rotation: records that `device_mac` is being moved to
@@ -336,10 +251,12 @@ pub async fn promote_rotating_to_current(
 ///
 /// Returns the new positive attempt number when work was staged. Returns `None`
 /// when the site-wide target no longer matches, the device has already converged
-/// to that revision, another rotation is staged, or an active quarantine window
-/// prevents work from being claimed. Callers must pass the attempt number to
-/// every later transition so stale responses from an earlier retry cannot mutate
-/// current state. Staged work is never retried through this function.
+/// to that revision, unresolved work is staged, the requested target does not
+/// supersede a definitive failed attempt, or an active quarantine window
+/// prevents work from being claimed. A later target may replace a staged
+/// definitive failure, which makes publishing that target the operator retry
+/// signal. Callers must pass the attempt number to every later transition so
+/// stale responses from an earlier retry cannot mutate current state.
 pub async fn record_device_rotation_started(
     conn: &mut PgConnection,
     device_mac: MacAddress,
@@ -371,7 +288,11 @@ pub async fn record_device_rotation_started(
                      rotate_last_attempt_at = now(), \
                      rotate_last_error_redacted = NULL, \
                      rotate_quarantined_until = NULL \
-                 WHERE device_credential_rotation.rotating_to_version IS NULL \
+                 WHERE (device_credential_rotation.rotating_to_version IS NULL \
+                            AND device_credential_rotation.rotate_last_error_redacted IS NULL \
+                        OR device_credential_rotation.rotating_to_version \
+                               < EXCLUDED.rotating_to_version \
+                            AND device_credential_rotation.rotate_last_error_redacted IS NOT NULL) \
                        AND (device_credential_rotation.current_version IS NULL \
                             OR device_credential_rotation.current_version \
                                < EXCLUDED.rotating_to_version) \
@@ -432,13 +353,59 @@ pub async fn record_device_rotation_submitted(
     Ok(result.rows_affected() > 0)
 }
 
-/// Releases a staged mutation that the backend definitively did not accept.
+/// Claims another dispatch attempt for the same unresolved staged target.
 ///
-/// The last confirmed credential remains unchanged while the staged target is
-/// cleared, allowing a later operator-initiated retry. Matching the attempt
-/// number and requiring no job ID prevents a late dispatch error from clearing
-/// a newer or already-accepted operation. Returns `false` when that exact
-/// pre-submission attempt is no longer active.
+/// RMS password updates are resumable: the backend can continue with either the
+/// previous endpoint credential or the requested target credential after a
+/// partial success. This transition clears the old job handle and increments
+/// the attempt CAS before that mutation is dispatched again. `expected_job_id`
+/// is `None` after a lost submission response and `Some` after a failed,
+/// missing, or unknown job observation.
+///
+/// Returns the new attempt number on success. Returns `None` if operation state
+/// changed, an error already marked the request as non-retryable, or active
+/// quarantine blocks work.
+pub async fn record_device_rotation_retry_started(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+    credential_type: CredentialRotationType,
+    rotating_to_version: i32,
+    expected_attempt: i32,
+    expected_job_id: Option<&str>,
+) -> Result<Option<i32>, DatabaseError> {
+    let query = "UPDATE device_credential_rotation \
+                 SET rotate_job_id = NULL, \
+                     rotate_attempts = rotate_attempts + 1, \
+                     rotate_last_attempt_at = now(), \
+                     rotate_last_error_redacted = NULL, \
+                     rotate_quarantined_until = NULL \
+                 WHERE device_mac = $1 AND credential_type = $2 \
+                       AND rotating_to_version = $3 \
+                       AND rotate_attempts = $4 \
+                       AND rotate_job_id IS NOT DISTINCT FROM $5 \
+                       AND rotate_last_error_redacted IS NULL \
+                       AND (rotate_quarantined_until IS NULL \
+                            OR rotate_quarantined_until <= now()) \
+                 RETURNING rotate_attempts";
+
+    sqlx::query_scalar::<_, i32>(query)
+        .bind(device_mac)
+        .bind(credential_type)
+        .bind(rotating_to_version)
+        .bind(expected_attempt)
+        .bind(expected_job_id)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Marks a staged mutation that the backend definitively did not accept.
+///
+/// The last confirmed credential and exact staged target remain unchanged. The
+/// terminal marker blocks unchanged redispatch; a later corrected target may
+/// supersede it. Matching the attempt number and requiring no job ID prevents a
+/// late dispatch error from terminating newer or accepted work. Returns `false`
+/// when that exact pre-submission attempt is no longer active.
 pub async fn record_device_rotation_not_accepted(
     conn: &mut PgConnection,
     device_mac: MacAddress,
@@ -448,10 +415,7 @@ pub async fn record_device_rotation_not_accepted(
     error_redacted: &str,
 ) -> Result<bool, DatabaseError> {
     let query = "UPDATE device_credential_rotation \
-                 SET rotating_to_version = NULL, \
-                     rotate_job_id = NULL, \
-                     rotate_last_error_redacted = $5, \
-                     rotate_quarantined_until = NULL \
+                 SET rotate_last_error_redacted = $5 \
                  WHERE device_mac = $1 AND credential_type = $2 \
                        AND rotating_to_version = $3 \
                        AND rotate_attempts = $4 \
@@ -471,60 +435,20 @@ pub async fn record_device_rotation_not_accepted(
     Ok(result.rows_affected() > 0)
 }
 
-/// Preserves a staged mutation whose backend outcome is unknown.
+/// Promotes a target after its matching backend job completed.
 ///
-/// Unknown work remains staged and therefore cannot be retried through
-/// [`record_device_rotation_started`]. A later operator workflow must establish
-/// which credential is active before resolving it. Matching the attempt number
-/// prevents an old no-response result from marking a newer retry unknown.
-pub async fn record_device_rotation_outcome_unknown(
-    conn: &mut PgConnection,
-    device_mac: MacAddress,
-    credential_type: CredentialRotationType,
-    rotating_to_version: i32,
-    expected_attempt: i32,
-    error_redacted: &str,
-) -> Result<bool, DatabaseError> {
-    let query = "UPDATE device_credential_rotation \
-                 SET rotate_last_error_redacted = $5 \
-                 WHERE device_mac = $1 AND credential_type = $2 \
-                       AND rotating_to_version = $3 \
-                       AND rotate_attempts = $4 \
-                       AND rotate_job_id IS NULL \
-                       AND (rotate_last_error_redacted IS NULL \
-                            OR rotate_last_error_redacted = $5)";
-
-    let result = sqlx::query(query)
-        .bind(device_mac)
-        .bind(credential_type)
-        .bind(rotating_to_version)
-        .bind(expected_attempt)
-        .bind(error_redacted)
-        .execute(&mut *conn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-
-    Ok(result.rows_affected() > 0)
-}
-
-/// Records a terminal backend failure for a staged target.
-///
-/// This preserves evidence that the attempted target was not confirmed. The
-/// controller can stop automatic mutation retries while exposing the redacted
-/// failure for reconciliation and operator action.
-///
-/// The staged target and backend job ID remain present, preventing automatic
-/// mutation retries and preserving diagnostic context. Returns `false` when the
-/// row no longer has the expected target, attempt number, and job ID, or another
-/// error has already terminated that attempt.
-pub async fn record_device_rotation_failed(
+/// Call this only after the backend reported `Completed` and the caller wrote
+/// and read back the target under the per-device credential key. Matching the
+/// staged target, attempt number, and job ID prevents stale completion from
+/// promoting a newer retry. Returns `false` when that exact operation is no
+/// longer active.
+pub async fn record_device_rotation_completed(
     conn: &mut PgConnection,
     device_mac: MacAddress,
     credential_type: CredentialRotationType,
     rotating_to_version: i32,
     expected_attempt: i32,
     job_id: &str,
-    error_redacted: &str,
 ) -> Result<bool, DatabaseError> {
     if job_id.is_empty() {
         return Err(DatabaseError::InvalidArgument(
@@ -533,49 +457,6 @@ pub async fn record_device_rotation_failed(
     }
 
     let query = "UPDATE device_credential_rotation \
-                 SET rotate_last_error_redacted = $6 \
-                 WHERE device_mac = $1 AND credential_type = $2 \
-                       AND rotating_to_version = $3 \
-                       AND rotate_attempts = $4 \
-                       AND rotate_job_id = $5 \
-                       AND (rotate_last_error_redacted IS NULL \
-                            OR rotate_last_error_redacted = $6)";
-
-    let result = sqlx::query(query)
-        .bind(device_mac)
-        .bind(credential_type)
-        .bind(rotating_to_version)
-        .bind(expected_attempt)
-        .bind(job_id)
-        .bind(error_redacted)
-        .execute(&mut *conn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-
-    Ok(result.rows_affected() > 0)
-}
-
-/// Promotes a staged target after authoritative credential reconciliation.
-///
-/// Call this only after a read-only operation authenticated with the staged
-/// target credential, the caller persisted that credential under the device key
-/// through the configured writer, and a readback returned the same value. A
-/// completed backend job is not sufficient evidence. The credential observation
-/// remains authoritative when submission returned an unknown outcome or the
-/// backend reported the job as completed, failed, missing, or unknown, so this
-/// transition intentionally accepts any job ID and error state.
-///
-/// Matching the staged target and attempt number prevents stale reconciliation
-/// from promoting a newer operation. Returns `false` when that exact operation
-/// is no longer active.
-pub async fn record_device_rotation_reconciled_to_target(
-    conn: &mut PgConnection,
-    device_mac: MacAddress,
-    credential_type: CredentialRotationType,
-    rotating_to_version: i32,
-    expected_attempt: i32,
-) -> Result<bool, DatabaseError> {
-    let query = "UPDATE device_credential_rotation \
                  SET current_version = rotating_to_version, \
                      rotating_to_version = NULL, \
                      rotate_job_id = NULL, \
@@ -583,54 +464,15 @@ pub async fn record_device_rotation_reconciled_to_target(
                      rotate_quarantined_until = NULL \
                  WHERE device_mac = $1 AND credential_type = $2 \
                        AND rotating_to_version = $3 \
-                       AND rotate_attempts = $4";
+                       AND rotate_attempts = $4 \
+                       AND rotate_job_id = $5";
 
     let result = sqlx::query(query)
         .bind(device_mac)
         .bind(credential_type)
         .bind(rotating_to_version)
         .bind(expected_attempt)
-        .execute(&mut *conn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-
-    Ok(result.rows_affected() > 0)
-}
-
-/// Releases a staged target after authoritative previous-credential recovery.
-///
-/// Call this only after a read-only operation definitively rejected the staged
-/// target credential and authenticated with the credential used before
-/// dispatch. The confirmed version remains unchanged, while operation metadata
-/// is cleared so an operator may explicitly retry. `error_redacted` preserves
-/// the reason reconciliation was required without storing credential material.
-///
-/// Matching the staged target and attempt number prevents stale reconciliation
-/// from releasing a newer operation. Returns `false` when that exact operation
-/// is no longer active.
-pub async fn record_device_rotation_reconciled_to_previous(
-    conn: &mut PgConnection,
-    device_mac: MacAddress,
-    credential_type: CredentialRotationType,
-    rotating_to_version: i32,
-    expected_attempt: i32,
-    error_redacted: &str,
-) -> Result<bool, DatabaseError> {
-    let query = "UPDATE device_credential_rotation \
-                 SET rotating_to_version = NULL, \
-                     rotate_job_id = NULL, \
-                     rotate_last_error_redacted = $5, \
-                     rotate_quarantined_until = NULL \
-                 WHERE device_mac = $1 AND credential_type = $2 \
-                       AND rotating_to_version = $3 \
-                       AND rotate_attempts = $4";
-
-    let result = sqlx::query(query)
-        .bind(device_mac)
-        .bind(credential_type)
-        .bind(rotating_to_version)
-        .bind(expected_attempt)
-        .bind(error_redacted)
+        .bind(job_id)
         .execute(&mut *conn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -682,12 +524,39 @@ pub async fn current_target_version(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-/// A site-wide rotation target after it has been advanced by
+/// A site-wide rotation target published by [`set_initial_target_version`] or
 /// [`set_next_target_version`].
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
 pub struct StagedRotation {
+    /// Newly published site-wide target version.
     pub target_version: i32,
+
+    /// Time at which the target became visible to rotation controllers.
     pub started_at: DateTime<Utc>,
+}
+
+/// Publishes version zero for a credential type that has no target row.
+///
+/// The caller must create and read back the immutable version-zero credential
+/// before calling this function. The insert is a compare-and-set on row absence:
+/// `None` means another request already initialized the target.
+pub async fn set_initial_target_version(
+    conn: &mut PgConnection,
+    credential_type: CredentialRotationType,
+    request_meta: serde_json::Value,
+) -> Result<Option<StagedRotation>, DatabaseError> {
+    let query = "INSERT INTO sitewide_credential_rotation \
+                     (credential_type, target_version, started_at, request_meta) \
+                 VALUES ($1, 0, now(), $2) \
+                 ON CONFLICT (credential_type) DO NOTHING \
+                 RETURNING target_version, started_at";
+
+    sqlx::query_as::<_, StagedRotation>(query)
+        .bind(credential_type)
+        .bind(request_meta)
+        .fetch_optional(conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 /// Atomically advances the site-wide rotation target for `credential_type` from
@@ -732,11 +601,22 @@ pub async fn set_next_target_version(
 /// quarantined (plus the quarantined MACs).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RotationStatus {
+    /// Current site-wide target version.
     pub target_version: i32,
+
+    /// Number of live devices confirmed at or beyond the target.
     pub converged: i64,
+
+    /// Number of live devices that are neither converged nor quarantined.
     pub pending: i64,
+
+    /// Number of live devices whose work-claim delay is active.
     pub quarantined: i64,
+
+    /// MAC addresses for devices counted as quarantined.
     pub quarantined_device_macs: Vec<String>,
+
+    /// Time at which the current target was published.
     pub started_at: DateTime<Utc>,
 }
 
@@ -762,6 +642,10 @@ pub async fn rotation_status(
     conn: &mut PgConnection,
     credential_type: CredentialRotationType,
 ) -> Result<RotationStatus, DatabaseError> {
+    if credential_type == CredentialRotationType::Nvos {
+        return nvos_rotation_status(conn).await;
+    }
+
     // count(d.device_mac) ignores the synthetic all-NULL row a LEFT JOIN
     // produces when a type has zero devices, so every bucket is 0 in that case
     // while the site-wide row still yields target_version / started_at.
@@ -781,6 +665,7 @@ pub async fn rotation_status(
                             ON d.credential_type = s.credential_type \
                         WHERE s.credential_type = $1 \
                         GROUP BY s.target_version, s.started_at";
+
     let counts = sqlx::query_as::<_, RotationCounts>(counts_query)
         .bind(credential_type)
         .fetch_optional(&mut *conn)
@@ -795,6 +680,68 @@ pub async fn rotation_status(
                       ORDER BY device_mac";
     let quarantined_device_macs = sqlx::query_scalar::<_, String>(macs_query)
         .bind(credential_type)
+        .fetch_all(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(macs_query, e))?;
+
+    Ok(RotationStatus {
+        target_version: counts.target_version,
+        converged: counts.converged,
+        pending: counts.pending,
+        quarantined: counts.quarantined,
+        quarantined_device_macs,
+        started_at: counts.started_at,
+    })
+}
+
+/// NVOS convergence uses live switches as its device universe because rows are
+/// created lazily when the switch controller first stages a target.
+async fn nvos_rotation_status(conn: &mut PgConnection) -> Result<RotationStatus, DatabaseError> {
+    let counts_query = "WITH live_devices AS ( \
+                            SELECT DISTINCT bmc_mac_address AS device_mac \
+                            FROM switches \
+                            WHERE deleted IS NULL \
+                              AND bmc_mac_address IS NOT NULL \
+                        ) \
+                        SELECT s.target_version, \
+                            count(ld.device_mac) FILTER ( \
+                                WHERE d.current_version >= s.target_version) AS converged, \
+                            count(ld.device_mac) FILTER ( \
+                                WHERE (d.current_version IS NULL \
+                                       OR d.current_version < s.target_version) \
+                                  AND (d.rotate_quarantined_until IS NULL \
+                                       OR d.rotate_quarantined_until <= now())) AS pending, \
+                            count(ld.device_mac) FILTER ( \
+                                WHERE d.rotate_quarantined_until > now()) AS quarantined, \
+                            s.started_at \
+                        FROM sitewide_credential_rotation s \
+                        LEFT JOIN live_devices ld ON TRUE \
+                        LEFT JOIN device_credential_rotation d \
+                            ON d.credential_type = s.credential_type \
+                           AND d.device_mac = ld.device_mac \
+                        WHERE s.credential_type = $1 \
+                        GROUP BY s.target_version, s.started_at";
+
+    let counts = sqlx::query_as::<_, RotationCounts>(counts_query)
+        .bind(CredentialRotationType::Nvos)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| DatabaseError::query(counts_query, e))?
+        .ok_or(DatabaseError::MissingSitewideRotationTarget(
+            CredentialRotationType::Nvos,
+        ))?;
+
+    let macs_query = "SELECT DISTINCT d.device_mac::text AS device_mac \
+                      FROM device_credential_rotation d \
+                      JOIN switches s \
+                        ON s.bmc_mac_address = d.device_mac \
+                       AND s.deleted IS NULL \
+                      WHERE d.credential_type = $1 \
+                        AND d.rotate_quarantined_until > now() \
+                      ORDER BY device_mac";
+
+    let quarantined_device_macs = sqlx::query_scalar::<_, String>(macs_query)
+        .bind(CredentialRotationType::Nvos)
         .fetch_all(&mut *conn)
         .await
         .map_err(|e| DatabaseError::query(macs_query, e))?;
@@ -870,7 +817,7 @@ pub struct DeviceRotationOperationState {
     /// so the non-negative `integer` column maps directly to `i32`.
     pub rotate_attempts: i32,
 
-    /// Redacted reason the unresolved operation is blocked.
+    /// Redacted reason a definitive failed attempt is blocked.
     pub rotate_last_error_redacted: Option<String>,
 }
 
@@ -914,6 +861,10 @@ pub async fn device_rotation_status(
     credential_type: CredentialRotationType,
     device_mac: MacAddress,
 ) -> Result<Option<DeviceRotationStatus>, DatabaseError> {
+    if credential_type == CredentialRotationType::Nvos {
+        return nvos_device_rotation_status(conn, device_mac).await;
+    }
+
     // COALESCE guards the two derived booleans: `current_version >= target` is
     // NULL when current_version is NULL ("not yet established"), and the
     // quarantine comparison is NULL when the window is unset -- both mean false.
@@ -940,6 +891,41 @@ pub async fn device_rotation_status(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+async fn nvos_device_rotation_status(
+    conn: &mut PgConnection,
+    device_mac: MacAddress,
+) -> Result<Option<DeviceRotationStatus>, DatabaseError> {
+    let query = "WITH live_device AS ( \
+                     SELECT DISTINCT bmc_mac_address AS device_mac \
+                     FROM switches \
+                     WHERE deleted IS NULL AND bmc_mac_address = $2 \
+                 ) \
+                 SELECT s.target_version, \
+                        s.started_at, \
+                        ld.device_mac::text AS device_mac, \
+                        d.current_version, \
+                        d.rotating_to_version, \
+                        COALESCE(d.current_version >= s.target_version, false) AS converged, \
+                        COALESCE(d.rotate_quarantined_until > now(), false) AS quarantined, \
+                        d.rotate_quarantined_until AS quarantined_until, \
+                        COALESCE(d.rotate_attempts, 0) AS rotate_attempts, \
+                        d.rotate_last_attempt_at, \
+                        d.rotate_last_error_redacted \
+                 FROM sitewide_credential_rotation s \
+                 JOIN live_device ld ON TRUE \
+                 LEFT JOIN device_credential_rotation d \
+                     ON d.credential_type = s.credential_type \
+                    AND d.device_mac = ld.device_mac \
+                 WHERE s.credential_type = $1";
+
+    sqlx::query_as::<_, DeviceRotationStatus>(query)
+        .bind(CredentialRotationType::Nvos)
+        .bind(device_mac)
+        .fetch_optional(conn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 // Tests for the SQL-only `*_credential_rotation_backfill` data migration. It has
 // no Rust counterpart to host an inline `mod tests`, so it lives as a sibling
 // child module here (mirroring `machine_interface::test_duplicate_mac`) rather
@@ -953,14 +939,12 @@ mod tests {
     use sqlx::{PgConnection, PgPool};
 
     use super::{
-        CredentialRotationType, DatabaseError, RecordDeviceConvergedOutcome,
-        current_target_version, delete_device_converged, device_rotation_operation_state,
-        device_rotation_status, mark_device_rotating_to_version, promote_rotating_to_current,
-        record_device_converged, record_device_converged_if_target_matches,
-        record_device_rotation_failed, record_device_rotation_not_accepted,
-        record_device_rotation_outcome_unknown, record_device_rotation_reconciled_to_previous,
-        record_device_rotation_reconciled_to_target, record_device_rotation_started,
-        record_device_rotation_submitted, rotation_status, set_next_target_version,
+        CredentialRotationType, current_target_version, delete_device_converged,
+        device_rotation_operation_state, device_rotation_status, mark_device_rotating_to_version,
+        promote_rotating_to_current, record_device_converged, record_device_rotation_completed,
+        record_device_rotation_not_accepted, record_device_rotation_retry_started,
+        record_device_rotation_started, record_device_rotation_submitted, rotation_status,
+        set_initial_target_version, set_next_target_version,
     };
 
     // Inserts a device convergence row with an explicit current_version (and no
@@ -974,6 +958,31 @@ mod tests {
         .bind(mac)
         .bind(ctype)
         .bind(current)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_switch(conn: &mut PgConnection, id: &str, bmc_mac: &str, deleted: bool) {
+        sqlx::query(
+            "INSERT INTO expected_switches \
+                 (serial_number, bmc_mac_address, bmc_username, bmc_password) \
+             VALUES ($1, $2::macaddr, 'admin', 'pw')",
+        )
+        .bind(format!("sn-{id}"))
+        .bind(bmc_mac)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO switches (id, name, config, bmc_mac_address, deleted) \
+             VALUES ($1, $1, '{}'::jsonb, $2::macaddr, \
+                     CASE WHEN $3 THEN now() ELSE NULL END)",
+        )
+        .bind(id)
+        .bind(bmc_mac)
+        .bind(deleted)
         .execute(&mut *conn)
         .await
         .unwrap();
@@ -1077,147 +1086,6 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn exact_baseline_rejects_target_advance_race(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:09".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        publish_nvos_target(&mut conn, 1).await;
-
-        // Version 1 authenticated, but the site-wide target advanced before
-        // baseline persistence. The CAS must not relabel that evidence as v2.
-        sqlx::query(
-            "UPDATE sitewide_credential_rotation SET target_version = 2 \
-             WHERE credential_type = 'nvos'",
-        )
-        .execute(&mut *conn)
-        .await
-        .unwrap();
-
-        let stale = record_device_converged_if_target_matches(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            stale,
-            RecordDeviceConvergedOutcome::TargetChanged {
-                current_target_version: 2,
-            }
-        );
-
-        assert_eq!(
-            version_of(&mut conn, "02:00:00:00:00:09", "nvos").await,
-            None
-        );
-
-        let current = record_device_converged_if_target_matches(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            2,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(current, RecordDeviceConvergedOutcome::Recorded);
-
-        assert_eq!(
-            version_of(&mut conn, "02:00:00:00:00:09", "nvos").await,
-            Some(2)
-        );
-    }
-
-    // The race test above exercises `Recorded` and `TargetChanged`. These cover
-    // the remaining outcomes of `record_device_converged_if_target_matches`:
-    // `AlreadyPresent`, `TargetMissing`, and the negative-version rejection. Each
-    // uses a distinct credential type so its setup cannot bleed across cases.
-    #[crate::sqlx_test]
-    async fn if_target_matches_reports_already_present(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0b".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        // Establish the baseline first: the backfill seeds the bmc target at 0,
-        // so this records the device at 0.
-        record_device_converged(&mut conn, mac, CredentialRotationType::Bmc)
-            .await
-            .unwrap();
-
-        // A second baseline attempt at the same target must find the row already
-        // present, leave it untouched, and report the no-op explicitly rather
-        // than as a target mismatch.
-        let outcome = record_device_converged_if_target_matches(
-            &mut conn,
-            mac,
-            CredentialRotationType::Bmc,
-            0,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, RecordDeviceConvergedOutcome::AlreadyPresent);
-        assert_eq!(
-            version_of(&mut conn, "02:00:00:00:00:0b", "bmc").await,
-            Some(0)
-        );
-    }
-
-    #[crate::sqlx_test]
-    async fn if_target_matches_reports_missing_target(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0c".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        // nvos is the one type the backfill never seeds a site-wide target for,
-        // so a baseline attempt has nothing to match against.
-        let outcome = record_device_converged_if_target_matches(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            0,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(outcome, RecordDeviceConvergedOutcome::TargetMissing);
-        assert_eq!(
-            version_of(&mut conn, "02:00:00:00:00:0c", "nvos").await,
-            None
-        );
-    }
-
-    #[crate::sqlx_test]
-    async fn if_target_matches_rejects_negative_version(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        // A published target exists, so the rejection is purely the argument
-        // guard, not a missing target.
-        publish_nvos_target(&mut conn, 1).await;
-
-        let err = record_device_converged_if_target_matches(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            -1,
-        )
-        .await
-        .unwrap_err();
-
-        assert!(
-            matches!(err, DatabaseError::InvalidArgument(_)),
-            "a negative expected version must be rejected, got {err:?}"
-        );
-        // The guard runs before any statement, so no device row is created.
-        assert_eq!(
-            version_of(&mut conn, "02:00:00:00:00:0d", "nvos").await,
-            None
-        );
-    }
-
-    #[crate::sqlx_test]
     async fn stages_and_promotes_rotation_ignoring_sitewide_target(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:0a".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
@@ -1239,11 +1107,13 @@ mod tests {
         mark_device_rotating_to_version(&mut conn, mac, CredentialRotationType::LockdownIkm, 2)
             .await
             .unwrap();
+
         assert_eq!(
             rotating_version_of(&mut conn, "02:00:00:00:00:0a", "lockdown_ikm").await,
             Some(2),
             "issue must stage the derived version as the in-flight marker"
         );
+
         assert_eq!(
             version_of(&mut conn, "02:00:00:00:00:0a", "lockdown_ikm").await,
             None,
@@ -1286,112 +1156,7 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn terminal_job_failure_remains_blocked(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0b".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        publish_nvos_target(&mut conn, 1).await;
-
-        let attempt =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
-                .await
-                .unwrap()
-                .expect("the first attempt should be staged");
-
-        assert_eq!(attempt, 1);
-
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
-            .await
-            .unwrap()
-            .expect("operation state should exist");
-
-        assert_eq!(state.current_version, None);
-        assert_eq!(state.rotating_to_version, Some(1));
-        assert_eq!(state.rotate_job_id, None);
-        assert_eq!(state.rotate_attempts, attempt);
-        assert_eq!(state.rotate_last_error_redacted, None);
-
-        let duplicate_start =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
-                .await
-                .unwrap();
-
-        assert_eq!(
-            duplicate_start, None,
-            "an unresolved rotation must not be replaced"
-        );
-
-        let submitted = record_device_rotation_submitted(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            "job-1",
-        )
-        .await
-        .unwrap();
-
-        assert!(submitted);
-
-        let submitted_again = record_device_rotation_submitted(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            "job-1",
-        )
-        .await
-        .unwrap();
-
-        assert!(submitted_again, "recording the same job must be idempotent");
-
-        let different_job = record_device_rotation_submitted(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            "job-2",
-        )
-        .await
-        .unwrap();
-
-        assert!(!different_job, "a submitted job ID must not be replaced");
-
-        let failed = record_device_rotation_failed(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            "job-1",
-            "backend rejected password rotation",
-        )
-        .await
-        .unwrap();
-
-        assert!(failed);
-
-        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
-            .await
-            .unwrap()
-            .expect("operation state should exist");
-
-        assert_eq!(state.current_version, None);
-        assert_eq!(state.rotating_to_version, Some(1));
-        assert_eq!(state.rotate_job_id.as_deref(), Some("job-1"));
-        assert_eq!(state.rotate_attempts, attempt);
-
-        assert_eq!(
-            state.rotate_last_error_redacted.as_deref(),
-            Some("backend rejected password rotation")
-        );
-    }
-
-    #[crate::sqlx_test]
-    async fn definitive_rejection_allows_explicit_retry(pool: PgPool) {
+    async fn definitive_rejection_requires_a_later_target_for_retry(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:0c".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
@@ -1416,11 +1181,28 @@ mod tests {
             .unwrap()
         );
 
-        let retry_attempt =
+        let blocked =
             record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
                 .await
+                .unwrap();
+
+        assert_eq!(blocked, None, "the failed target must remain blocked");
+
+        set_next_target_version(
+            &mut conn,
+            CredentialRotationType::Nvos,
+            1,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap()
+        .expect("operator should publish a later target");
+
+        let retry_attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 2)
+                .await
                 .unwrap()
-                .expect("an explicit retry should reopen rejected work");
+                .expect("a later target should reopen rejected work");
 
         assert_eq!(retry_attempt, attempt + 1);
 
@@ -1443,10 +1225,82 @@ mod tests {
             .expect("operation state should exist");
 
         assert_eq!(state.current_version, None);
-        assert_eq!(state.rotating_to_version, Some(1));
+        assert_eq!(state.rotating_to_version, Some(2));
         assert_eq!(state.rotate_job_id, None);
         assert_eq!(state.rotate_attempts, retry_attempt);
         assert_eq!(state.rotate_last_error_redacted, None);
+    }
+
+    #[crate::sqlx_test]
+    async fn new_target_does_not_bypass_active_quarantine(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        let attempt =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
+                .await
+                .unwrap()
+                .expect("the first attempt should be staged");
+
+        record_device_rotation_not_accepted(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "backend did not accept password rotation",
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "UPDATE device_credential_rotation \
+             SET rotate_quarantined_until = now() + interval '1 hour' \
+             WHERE device_mac = $1 AND credential_type = 'nvos'",
+        )
+        .bind(mac)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
+        set_next_target_version(
+            &mut conn,
+            CredentialRotationType::Nvos,
+            1,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap()
+        .expect("operator should publish the next target");
+
+        let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
+            .await
+            .unwrap()
+            .expect("operation state should exist");
+
+        assert_eq!(state.rotating_to_version, Some(1));
+        assert!(state.rotate_last_error_redacted.is_some());
+
+        let quarantine_active: bool = sqlx::query_scalar(
+            "SELECT rotate_quarantined_until > now() \
+             FROM device_credential_rotation \
+             WHERE device_mac = $1 AND credential_type = 'nvos'",
+        )
+        .bind(mac)
+        .fetch_one(&mut *conn)
+        .await
+        .unwrap();
+
+        assert!(quarantine_active);
+
+        let blocked =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 2)
+                .await
+                .unwrap();
+
+        assert_eq!(blocked, None, "active quarantine must still block retry");
     }
 
     #[crate::sqlx_test]
@@ -1526,7 +1380,7 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn unknown_dispatch_outcome_remains_blocked(pool: PgPool) {
+    async fn unresolved_dispatch_retries_exact_staged_target(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
@@ -1538,37 +1392,41 @@ mod tests {
                 .unwrap()
                 .expect("the first attempt should be staged");
 
-        assert!(
-            record_device_rotation_outcome_unknown(
-                &mut conn,
-                mac,
-                CredentialRotationType::Nvos,
-                1,
-                attempt,
-                "password rotation response was not received",
-            )
-            .await
-            .unwrap()
-        );
+        set_next_target_version(
+            &mut conn,
+            CredentialRotationType::Nvos,
+            1,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap()
+        .expect("operator should publish a later target");
 
-        let retry = record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
-            .await
-            .unwrap();
-
-        assert_eq!(retry, None);
-
-        let late_submission = record_device_rotation_submitted(
+        let retry = record_device_rotation_retry_started(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
             1,
             attempt,
-            "late-job",
+            None,
         )
         .await
         .unwrap();
 
-        assert!(!late_submission);
+        assert_eq!(retry, Some(attempt + 1));
+
+        let stale_retry = record_device_rotation_retry_started(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stale_retry, None);
 
         let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
             .await
@@ -1578,90 +1436,13 @@ mod tests {
         assert_eq!(state.current_version, None);
         assert_eq!(state.rotating_to_version, Some(1));
         assert_eq!(state.rotate_job_id, None);
-        assert_eq!(state.rotate_attempts, attempt);
-
-        assert_eq!(
-            state.rotate_last_error_redacted.as_deref(),
-            Some("password rotation response was not received")
-        );
+        assert_eq!(state.rotate_attempts, attempt + 1);
+        assert_eq!(state.rotate_last_error_redacted, None);
     }
 
     #[crate::sqlx_test]
-    async fn authoritative_target_reconciliation_promotes_unresolved_operations(pool: PgPool) {
-        let mut conn = pool.acquire().await.unwrap();
-
-        publish_nvos_target(&mut conn, 1).await;
-
-        let cases = [
-            (
-                "02:00:00:00:00:11",
-                Some("failed-job"),
-                Some("backend reported failure"),
-            ),
-            ("02:00:00:00:00:12", Some("missing-job"), None),
-            (
-                "02:00:00:00:00:13",
-                None,
-                Some("submission outcome unknown"),
-            ),
-        ];
-
-        for (mac, job_id, error) in cases {
-            let mac: MacAddress = mac.parse().unwrap();
-
-            sqlx::query(
-                "INSERT INTO device_credential_rotation \
-                     (device_mac, credential_type, rotating_to_version, rotate_attempts, \
-                      rotate_job_id, rotate_last_error_redacted) \
-                 VALUES ($1, 'nvos', 1, 3, $2, $3)",
-            )
-            .bind(mac)
-            .bind(job_id)
-            .bind(error)
-            .execute(&mut *conn)
-            .await
-            .unwrap();
-
-            assert!(
-                !record_device_rotation_reconciled_to_target(
-                    &mut conn,
-                    mac,
-                    CredentialRotationType::Nvos,
-                    1,
-                    2,
-                )
-                .await
-                .unwrap()
-            );
-
-            assert!(
-                record_device_rotation_reconciled_to_target(
-                    &mut conn,
-                    mac,
-                    CredentialRotationType::Nvos,
-                    1,
-                    3,
-                )
-                .await
-                .unwrap()
-            );
-
-            let state =
-                device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
-                    .await
-                    .unwrap()
-                    .expect("operation state should exist");
-
-            assert_eq!(state.current_version, Some(1));
-            assert_eq!(state.rotating_to_version, None);
-            assert_eq!(state.rotate_job_id, None);
-            assert_eq!(state.rotate_last_error_redacted, None);
-        }
-    }
-
-    #[crate::sqlx_test]
-    async fn previous_credential_reconciliation_allows_operator_retry(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:12".parse().unwrap();
+    async fn failed_or_missing_job_retries_only_matching_operation(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:11".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
         publish_nvos_target(&mut conn, 1).await;
@@ -1673,66 +1454,56 @@ mod tests {
                 .expect("the first attempt should be staged");
 
         assert!(
-            record_device_rotation_outcome_unknown(
+            record_device_rotation_submitted(
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,
                 1,
                 attempt,
-                "password rotation response was not received",
+                "old-job",
             )
             .await
             .unwrap()
         );
 
-        assert!(
-            record_device_rotation_reconciled_to_previous(
-                &mut conn,
-                mac,
-                CredentialRotationType::Nvos,
-                1,
-                attempt,
-                "target rejected; previous credential authenticated",
-            )
-            .await
-            .unwrap()
-        );
+        let wrong_job = record_device_rotation_retry_started(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            Some("other-job"),
+        )
+        .await
+        .unwrap();
 
-        assert!(
-            !record_device_rotation_reconciled_to_target(
-                &mut conn,
-                mac,
-                CredentialRotationType::Nvos,
-                1,
-                attempt,
-            )
-            .await
-            .unwrap()
-        );
+        assert_eq!(wrong_job, None);
+
+        let retry = record_device_rotation_retry_started(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            Some("old-job"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(retry, Some(attempt + 1));
 
         let state = device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
 
-        assert_eq!(state.current_version, None);
-        assert_eq!(state.rotating_to_version, None);
+        assert_eq!(state.rotating_to_version, Some(1));
         assert_eq!(state.rotate_job_id, None);
-
-        assert_eq!(
-            state.rotate_last_error_redacted.as_deref(),
-            Some("target rejected; previous credential authenticated")
-        );
-
-        let retry = record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
-            .await
-            .unwrap();
-
-        assert_eq!(retry, Some(attempt + 1));
+        assert_eq!(state.rotate_attempts, attempt + 1);
     }
 
     #[crate::sqlx_test]
-    async fn backend_completion_requires_reconciliation_and_promotes_exact_revision(pool: PgPool) {
+    async fn backend_completion_promotes_exact_job_and_revision(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:0e".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
@@ -1759,9 +1530,6 @@ mod tests {
             .unwrap()
         );
 
-        // Backend completion has no database transition that can promote this
-        // submitted job. Only authoritative credential reconciliation below can
-        // change current_version.
         let submitted_state =
             device_rotation_operation_state(&mut conn, CredentialRotationType::Nvos, mac)
                 .await
@@ -1780,24 +1548,39 @@ mod tests {
         .await
         .unwrap();
 
-        let stale_reconciliation = record_device_rotation_reconciled_to_target(
+        let stale_completion = record_device_rotation_completed(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
             6,
             attempt,
+            "job-7",
         )
         .await
         .unwrap();
 
-        assert!(!stale_reconciliation);
+        assert!(!stale_completion);
 
-        let promoted = record_device_rotation_reconciled_to_target(
+        let wrong_job = record_device_rotation_completed(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
             7,
             attempt,
+            "other-job",
+        )
+        .await
+        .unwrap();
+
+        assert!(!wrong_job);
+
+        let promoted = record_device_rotation_completed(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            7,
+            attempt,
+            "job-7",
         )
         .await
         .unwrap();
@@ -1815,12 +1598,13 @@ mod tests {
         assert_eq!(state.rotate_attempts, attempt);
         assert_eq!(state.rotate_last_error_redacted, None);
 
-        let promoted_again = record_device_rotation_reconciled_to_target(
+        let promoted_again = record_device_rotation_completed(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
             7,
             attempt,
+            "job-7",
         )
         .await
         .unwrap();
@@ -1845,7 +1629,7 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn reconciled_revision_cannot_be_restarted(pool: PgPool) {
+    async fn completed_revision_cannot_be_restarted(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:0f".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
@@ -1871,12 +1655,13 @@ mod tests {
         );
 
         assert!(
-            record_device_rotation_reconciled_to_target(
+            record_device_rotation_completed(
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,
                 0,
                 attempt,
+                "job-0",
             )
             .await
             .unwrap()
@@ -1990,6 +1775,46 @@ mod tests {
     }
 
     #[crate::sqlx_test]
+    async fn initial_target_publication_is_compare_and_set_on_absence(pool: PgPool) {
+        let mut conn = pool.acquire().await.unwrap();
+
+        assert_eq!(
+            current_target_version(&mut conn, CredentialRotationType::Nvos)
+                .await
+                .unwrap(),
+            None
+        );
+
+        let initialized = set_initial_target_version(
+            &mut conn,
+            CredentialRotationType::Nvos,
+            serde_json::json!({"reason": "verified secret exists"}),
+        )
+        .await
+        .unwrap()
+        .expect("first publisher should initialize the target");
+
+        assert_eq!(initialized.target_version, 0);
+
+        let raced = set_initial_target_version(
+            &mut conn,
+            CredentialRotationType::Nvos,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+
+        assert!(raced.is_none());
+
+        assert_eq!(
+            current_target_version(&mut conn, CredentialRotationType::Nvos)
+                .await
+                .unwrap(),
+            Some(0)
+        );
+    }
+
+    #[crate::sqlx_test]
     async fn rotation_status_counts_converged_pending_and_quarantined(pool: PgPool) {
         let mut conn = pool.acquire().await.unwrap();
 
@@ -2056,6 +1881,55 @@ mod tests {
                 CredentialRotationType::Nvos
             ))
         ));
+    }
+
+    #[crate::sqlx_test]
+    async fn nvos_status_counts_live_switches_without_rows_as_pending(pool: PgPool) {
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+        insert_switch(&mut conn, "nvos-sw-1", "02:00:00:00:40:01", false).await;
+        insert_switch(&mut conn, "nvos-sw-2", "02:00:00:00:40:02", false).await;
+        insert_switch(&mut conn, "nvos-sw-deleted", "02:00:00:00:40:03", true).await;
+        insert_device(&mut conn, "02:00:00:00:40:01", "nvos", Some(1)).await;
+        insert_device(&mut conn, "02:00:00:00:40:03", "nvos", Some(0)).await;
+
+        let status = rotation_status(&mut conn, CredentialRotationType::Nvos)
+            .await
+            .unwrap();
+
+        assert_eq!(status.target_version, 1);
+        assert_eq!(status.converged, 1);
+        assert_eq!(status.pending, 1);
+        assert_eq!(status.quarantined, 0);
+    }
+
+    #[crate::sqlx_test]
+    async fn nvos_device_status_reports_live_switch_without_row_as_pending(pool: PgPool) {
+        let mut conn = pool.acquire().await.unwrap();
+        let live_mac: MacAddress = "02:00:00:00:50:01".parse().unwrap();
+        let deleted_mac: MacAddress = "02:00:00:00:50:02".parse().unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+        insert_switch(&mut conn, "nvos-device-live", "02:00:00:00:50:01", false).await;
+        insert_switch(&mut conn, "nvos-device-deleted", "02:00:00:00:50:02", true).await;
+
+        let pending = device_rotation_status(&mut conn, CredentialRotationType::Nvos, live_mac)
+            .await
+            .unwrap()
+            .expect("live switch should report pending");
+
+        assert_eq!(pending.current_version, None);
+        assert_eq!(pending.rotating_to_version, None);
+        assert!(!pending.converged);
+        assert_eq!(pending.rotate_attempts, 0);
+
+        assert!(
+            device_rotation_status(&mut conn, CredentialRotationType::Nvos, deleted_mac)
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[crate::sqlx_test]

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -52,7 +52,7 @@
 //! job, or failed job claims another attempt through
 //! [`record_device_rotation_retry_started`] before redispatching the same
 //! resumable RMS mutation. A matching completed job is promoted through
-//! [`record_device_rotation_completed`] only after the per-device target
+//! [`record_device_rotation_succeeded`] only after the per-device target
 //! credential has been written and read back. Each transition compares the
 //! durable attempt number so a stale worker or late backend response cannot
 //! overwrite a retry.
@@ -406,7 +406,7 @@ pub async fn record_device_rotation_retry_started(
 /// supersede it. Matching the attempt number and requiring no job ID prevents a
 /// late dispatch error from terminating newer or accepted work. Returns `false`
 /// when that exact pre-submission attempt is no longer active.
-pub async fn record_device_rotation_not_accepted(
+pub async fn record_device_rotation_rejected(
     conn: &mut PgConnection,
     device_mac: MacAddress,
     credential_type: CredentialRotationType,
@@ -442,7 +442,7 @@ pub async fn record_device_rotation_not_accepted(
 /// staged target, attempt number, and job ID prevents stale completion from
 /// promoting a newer retry. Returns `false` when that exact operation is no
 /// longer active.
-pub async fn record_device_rotation_completed(
+pub async fn record_device_rotation_succeeded(
     conn: &mut PgConnection,
     device_mac: MacAddress,
     credential_type: CredentialRotationType,
@@ -941,9 +941,9 @@ mod tests {
     use super::{
         CredentialRotationType, current_target_version, delete_device_converged,
         device_rotation_operation_state, device_rotation_status, mark_device_rotating_to_version,
-        promote_rotating_to_current, record_device_converged, record_device_rotation_completed,
-        record_device_rotation_not_accepted, record_device_rotation_retry_started,
-        record_device_rotation_started, record_device_rotation_submitted, rotation_status,
+        promote_rotating_to_current, record_device_converged, record_device_rotation_rejected,
+        record_device_rotation_retry_started, record_device_rotation_started,
+        record_device_rotation_submitted, record_device_rotation_succeeded, rotation_status,
         set_initial_target_version, set_next_target_version,
     };
 
@@ -1169,7 +1169,7 @@ mod tests {
                 .expect("the first attempt should be staged");
 
         assert!(
-            record_device_rotation_not_accepted(
+            record_device_rotation_rejected(
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,
@@ -1206,7 +1206,7 @@ mod tests {
 
         assert_eq!(retry_attempt, attempt + 1);
 
-        let stale_release = record_device_rotation_not_accepted(
+        let stale_release = record_device_rotation_rejected(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1244,7 +1244,7 @@ mod tests {
                 .unwrap()
                 .expect("the first attempt should be staged");
 
-        record_device_rotation_not_accepted(
+        record_device_rotation_rejected(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1548,7 +1548,7 @@ mod tests {
         .await
         .unwrap();
 
-        let stale_completion = record_device_rotation_completed(
+        let stale_completion = record_device_rotation_succeeded(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1561,7 +1561,7 @@ mod tests {
 
         assert!(!stale_completion);
 
-        let wrong_job = record_device_rotation_completed(
+        let wrong_job = record_device_rotation_succeeded(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1574,7 +1574,7 @@ mod tests {
 
         assert!(!wrong_job);
 
-        let promoted = record_device_rotation_completed(
+        let promoted = record_device_rotation_succeeded(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1598,7 +1598,7 @@ mod tests {
         assert_eq!(state.rotate_attempts, attempt);
         assert_eq!(state.rotate_last_error_redacted, None);
 
-        let promoted_again = record_device_rotation_completed(
+        let promoted_again = record_device_rotation_succeeded(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1655,7 +1655,7 @@ mod tests {
         );
 
         assert!(
-            record_device_rotation_completed(
+            record_device_rotation_succeeded(
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,

--- a/crates/api-db/src/credential_rotation/test_backfill.rs
+++ b/crates/api-db/src/credential_rotation/test_backfill.rs
@@ -242,8 +242,13 @@ async fn backfill_records_v0_for_existing_devices(pool: PgPool) {
     .unwrap();
     assert_eq!(nvos_rows, 0, "nvos must not be backfilled");
 
+    // `IS DISTINCT FROM 0`, not `<> 0`: a plain `<>` treats `NULL <> 0` as NULL
+    // and silently drops NULL rows, so a future backfill that left
+    // current_version unset would slip past. Assert every row is confirmed at
+    // exactly 0.
     let non_v0: i64 = sqlx::query_scalar(
-        "SELECT count(*) FROM device_credential_rotation WHERE current_version <> 0",
+        "SELECT count(*) FROM device_credential_rotation \
+         WHERE current_version IS DISTINCT FROM 0",
     )
     .fetch_one(&pool)
     .await

--- a/crates/api-db/src/credential_rotation/test_backfill.rs
+++ b/crates/api-db/src/credential_rotation/test_backfill.rs
@@ -186,7 +186,8 @@ async fn backfill_records_v0_for_existing_devices(pool: PgPool) {
         .await
         .unwrap();
 
-    // Site-wide targets: bmc + the three convergence-defined types, never nvos.
+    // Site-wide targets: the legacy backfill seeds bmc + UEFI + lockdown. NVOS
+    // remains absent until its first target credential is stored and verified.
     let sitewide: Vec<String> = sqlx::query_scalar(
         "SELECT credential_type::text FROM sitewide_credential_rotation ORDER BY 1",
     )
@@ -196,7 +197,7 @@ async fn backfill_records_v0_for_existing_devices(pool: PgPool) {
     assert_eq!(
         sitewide,
         vec!["bmc", "dpu_uefi", "host_uefi", "lockdown_ikm"],
-        "site-wide targets must cover bmc + UEFI + lockdown, and exclude nvos"
+        "site-wide targets must cover bmc + UEFI + lockdown"
     );
 
     // BMC: all three machines + the live switch + the live power shelf. The
@@ -231,7 +232,7 @@ async fn backfill_records_v0_for_existing_devices(pool: PgPool) {
         vec!["0a:00:00:00:00:01"]
     );
 
-    // NVOS is never backfilled, and every recorded device is at v0.
+    // NVOS device rows are never backfilled, and every recorded device is at v0.
     let nvos_rows: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM device_credential_rotation \
          WHERE credential_type = 'nvos'",

--- a/crates/api-db/src/migrations/mod.rs
+++ b/crates/api-db/src/migrations/mod.rs
@@ -241,24 +241,19 @@ mod tests {
 
     #[crate::sqlx_test]
     async fn fully_migrated_legacy_database_skips_squash(pool: PgPool) {
-        sqlx::query("DELETE FROM _sqlx_migrations")
+        // The test template is built by the fresh-install path, so its schema already
+        // contains every post-squash migration. Rewinding only the _sqlx_migrations
+        // markers would leave those columns in place, and migrate() would fail
+        // re-applying the post-squash migrations against them. Instead rebuild a
+        // faithful pre-squash database: drop the schema and apply only the legacy
+        // migrations, so both the schema and the recorded history match a database
+        // that predates the snapshot.
+        sqlx::raw_sql("DROP SCHEMA public CASCADE; CREATE SCHEMA public")
             .execute(&pool)
             .await
             .unwrap();
 
-        for migration in MIGRATION_LAYOUT.legacy.iter() {
-            sqlx::query(
-                "INSERT INTO _sqlx_migrations \
-                 (version, description, success, checksum, execution_time) \
-                 VALUES ($1, $2, true, $3, 0)",
-            )
-            .bind(migration.version)
-            .bind(&*migration.description)
-            .bind(&*migration.checksum)
-            .execute(&pool)
-            .await
-            .unwrap();
-        }
+        MIGRATION_LAYOUT.legacy.run(&pool).await.unwrap();
 
         migrate(&pool).await.unwrap();
 

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -13,7 +13,7 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     Backend as NvSwitchBackend, ConfigureSwitchCertificateJobStatus, NvSwitchManager,
-    SwitchEndpoint,
+    SwitchEndpoint, SwitchPasswordRotationState,
 };
 use crate::power_shelf_manager::{Backend as PowerShelfBackend, PowerShelfManager};
 use crate::rms::{RmsSwitchSystemImageStatusApi, validate_rms_backend_rack_profiles};
@@ -59,6 +59,27 @@ impl ComponentManager {
     ) -> Result<ConfigureSwitchCertificateJobStatus, ComponentManagerError> {
         self.nv_switch
             .get_configure_switch_certificate_job_status(job_id)
+            .await
+    }
+
+    /// Starts an NVOS password rotation through the configured switch backend.
+    pub async fn start_switch_password_rotation(
+        &self,
+        endpoint: &SwitchEndpoint,
+        next_password: &str,
+    ) -> Result<String, ComponentManagerError> {
+        self.nv_switch
+            .start_password_rotation(endpoint, next_password)
+            .await
+    }
+
+    /// Returns the latest backend state for an NVOS password-rotation job.
+    pub async fn get_switch_password_rotation_job_status(
+        &self,
+        job_id: &str,
+    ) -> Result<SwitchPasswordRotationState, ComponentManagerError> {
+        self.nv_switch
+            .get_password_rotation_job_status(job_id)
             .await
     }
 

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -412,11 +412,13 @@ pub enum CredentialKey {
     SwitchNvosAdmin {
         bmc_mac_address: MacAddress,
     },
-    /// Versioned site-wide NVOS "rotate-TO" target (`switch_nvos/site/admin/v{N}`).
-    /// Admin/rotation-written only; not a loginable per-device credential.
+
+    /// Versioned site-wide NVOS "rotate-TO" target.
+    /// Admin/rotation-written only; not a per-device login credential.
     SwitchNvosSiteAdmin {
         version: u32,
     },
+
     MqttAuth {
         credential_type: MqttCredentialType,
     },
@@ -473,8 +475,8 @@ pub enum CredentialPrefix {
 }
 
 impl CredentialPrefix {
-    /// as_str returns the Vault-style path prefix
-    /// for this credential category.
+    /// as_str returns the serialized credential-store key prefix for this
+    /// credential category.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::DpuSsh => "machines/",
@@ -546,6 +548,14 @@ impl CredentialKey {
             },
             version => Self::DpuUefiSiteVersioned { version },
         }
+    }
+
+    /// Returns the logical site-wide NVOS admin credential key for `version`.
+    ///
+    /// Callers should pass this key to [`CredentialManager`] rather than
+    /// depending on a concrete storage path or backend.
+    pub fn switch_nvos_site_admin(version: u32) -> Self {
+        Self::SwitchNvosSiteAdmin { version }
     }
 
     /// prefix returns the CredentialPrefix category
@@ -841,7 +851,8 @@ mod tests {
         );
         assert_eq!(dpu_uefi.prefix(), CredentialPrefix::DpuUefi);
 
-        let nvos = CredentialKey::SwitchNvosSiteAdmin { version: 2 };
+        let nvos = CredentialKey::switch_nvos_site_admin(2);
+
         assert_eq!(nvos.to_key_str(), "switch_nvos/site/admin/v2");
         assert_eq!(nvos.prefix(), CredentialPrefix::SwitchNvosAdmin);
     }

--- a/crates/switch-controller/src/configuring.rs
+++ b/crates/switch-controller/src/configuring.rs
@@ -82,43 +82,22 @@ async fn handle_rotate_os_password(
     let outcome = StateHandlerOutcome::transition(SwitchControllerState::FetchInfo);
 
     // REQ-6 (set NVOS from factory) is not implemented yet, so this is gated off.
-    // Today NICo does not change the NVOS password from the factory default: it
-    // only copies the operator-provided credential into Vault (the `else` branch)
-    // so the rest of NICo can authenticate, and records no rotation convergence
-    // (the backfill skips `nvos` for the same reason). When REQ-6 lands, flip
-    // `update_device_password` to `true`: that branch rotates the password on the
-    // switch, stores the resulting NICo-owned credential, and records `nvos`
-    // convergence (keyed by BMC MAC) committed atomically with the transition.
-    //
-    // IMPORTANT: before flipping this on, REQ-6 must also seed a
-    // `sitewide_credential_rotation` row for `nvos` (via the backfill migration
-    // or at runtime). `record_device_converged` now requires the site-wide
-    // target to exist and returns `MissingSitewideRotationTarget` otherwise --
-    // unlike the other credential types, nvos has no backfilled row today, so
-    // ungating without seeding it would make every switch fail here.
+    // Today NICo only stores the operator-provided credential so the rest of
+    // NICo can authenticate. The first NVOS rotation target is published only
+    // after its credential has been stored and verified; password mutation and
+    // convergence recording remain disabled until that path is activated.
     let update_device_password = false;
+
     if update_device_password {
-        let mut txn = ctx.services.db_pool.begin().await?;
-
-        // TODO(REQ-6): rotate the NVOS password on the switch here (factory ->
-        // NICo-owned) and store the resulting credential in Vault before recording
-        // convergence below. Only once the password is actually changed on the
-        // device has the switch converged to the current nvos target.
-        db::credential_rotation::record_device_converged(
-            &mut txn,
-            bmc_mac_address,
-            db::credential_rotation::CredentialRotationType::Nvos,
-        )
-        .await
-        .map_err(|e| {
-            StateHandlerError::GenericError(eyre::eyre!(
-                "switch {:?}: failed to record nvos rotation convergence: {}",
-                switch_id,
-                e
-            ))
-        })?;
-
-        Ok(outcome.with_txn(txn))
+        // Activation must authenticate an exact target version, persist and
+        // read back the per-device credential, then call
+        // `record_device_converged_if_target_matches`. Fail closed until that
+        // complete sequence is implemented.
+        Ok(StateHandlerOutcome::transition(
+            SwitchControllerState::Error {
+                cause: "NVOS password rotation is not implemented".to_string(),
+            },
+        ))
     } else {
         // Copy the operator-provided NVOS admin credential from the expected
         // switch into Vault. This does not touch the switch, so no convergence is

--- a/crates/switch-controller/src/configuring.rs
+++ b/crates/switch-controller/src/configuring.rs
@@ -89,10 +89,10 @@ async fn handle_rotate_os_password(
     let update_device_password = false;
 
     if update_device_password {
-        // Activation must authenticate an exact target version, persist and
-        // read back the per-device credential, then call
-        // `record_device_converged_if_target_matches`. Fail closed until that
-        // complete sequence is implemented.
+        // Activation must stage an exact target before dispatch, then persist
+        // and read back the per-device credential before promoting the matching
+        // target, attempt, and backend job. Fail closed until that complete
+        // sequence is implemented.
         Ok(StateHandlerOutcome::transition(
             SwitchControllerState::Error {
                 cause: "NVOS password rotation is not implemented".to_string(),


### PR DESCRIPTION
This continues the previous PR #3409, which added `component-manager` NVOS password rotation job contract. This PR adds restart-safe persistence for future controller orchestration. NVOS password rotation is not enabled yet.

Review areas:

- Migration and credential key: the database stores metadata and job IDs; passwords remain in the credential backend.
- SQLx tests: cover retries, quarantine, failures, stale workers, and reconciliation.
- Unknown outcomes require reconciliation before retry.

Key decisions:

- Job status is evidence, not credential truth.
- Unknown outcomes are not unconditionally retried.
- Only authoritative credential reconciliation can promote a version.
- Existing runtime behavior remains unchanged.

Follow-up PRs will cover switch controller, target publication, activation, and admin-cli.

## Related issues

Supports #2041 and #3522

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required