### PR TITLE
refactor: extend the error-message checker to format!-wrapped messages

### DIFF
--- a/crates/admin-cli/src/instance/reboot/cmd.rs
+++ b/crates/admin-cli/src/instance/reboot/cmd.rs
@@ -28,7 +28,7 @@ fn with_reboot_context<T>(
     instance_id: InstanceId,
 ) -> CarbideCliResult<T> {
     result
-        .wrap_err_with(|| format!("Failed to request reboot for instance {instance_id}"))
+        .wrap_err_with(|| format!("failed to request reboot for instance {instance_id}"))
         .map_err(CarbideCliError::from)
 }
 
@@ -73,7 +73,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            format!("Failed to request reboot for instance {instance_id}")
+            format!("failed to request reboot for instance {instance_id}")
         );
         let CarbideCliError::EyreReport(report) = error else {
             panic!("expected an EyreReport");

--- a/crates/agent/src/agent_platform.rs
+++ b/crates/agent/src/agent_platform.rs
@@ -59,7 +59,7 @@ impl ManagedFile {
     /// comparison of timestamps or contents is performed.
     pub fn copy_if_not_present(self, source_path: &Path) -> eyre::Result<()> {
         let destination_exists = self.path.try_exists().context(format!(
-            "Couldn't check existence of destination file {f}",
+            "couldn't check existence of destination file {f}",
             f = self.path.display()
         ))?;
         if !destination_exists {
@@ -120,7 +120,7 @@ fn safe_copy(destination_path: &Path, source_path: &Path) -> eyre::Result<()> {
         )
     })?;
     let mut source_file = File::open(source_path)
-        .with_context(|| format!("Couldn't open source file {f}", f = source_path.display()))?;
+        .with_context(|| format!("couldn't open source file {f}", f = source_path.display()))?;
     let mut tmp_destination = NamedTempFile::with_suffix_in(".tmp", destination_dirname)
         .with_context(|| {
             format!(

--- a/crates/agent/src/containerd/command/bash_command.rs
+++ b/crates/agent/src/containerd/command/bash_command.rs
@@ -59,7 +59,7 @@ impl Command for BashCommand {
 
         let output = tokio::time::timeout(COMMAND_TIMEOUT, fullcmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         let fout = String::from_utf8_lossy(&output.stdout).to_string();
         Ok(fout)

--- a/crates/agent/src/dpu/interface.rs
+++ b/crates/agent/src/dpu/interface.rs
@@ -156,7 +156,7 @@ impl Interface {
 
             let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
                 .await
-                .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+                .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
             let fout = String::from_utf8_lossy(&output.stdout).to_string();
             Ok(fout)
@@ -187,7 +187,7 @@ impl Interface {
 
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         let fout = String::from_utf8_lossy(&output.stdout).to_string();
         if output.status.success() {

--- a/crates/agent/src/dpu/link.rs
+++ b/crates/agent/src/dpu/link.rs
@@ -66,7 +66,7 @@ impl IpLink {
 
             let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
                 .await
-                .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+                .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
             let fout = String::from_utf8_lossy(&output.stdout).to_string();
             Ok(fout)

--- a/crates/agent/src/dpu/route.rs
+++ b/crates/agent/src/dpu/route.rs
@@ -141,7 +141,7 @@ impl Route {
 
             let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
                 .await
-                .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+                .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
             let fout = String::from_utf8_lossy(&output.stdout).to_string();
             Ok(fout)
@@ -177,7 +177,7 @@ impl Route {
 
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         let fout = String::from_utf8_lossy(&output.stdout).to_string();
         if output.status.success() {
@@ -216,7 +216,7 @@ impl Route {
 
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         let fout = String::from_utf8_lossy(&output.stdout).to_string();
         if output.status == ExitStatus::from_raw(0) {

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -2466,7 +2466,7 @@ mod tests {
                 let mut f = fs::File::create(ERR_FILE).unwrap();
                 f.write_all(startup_yaml.as_bytes()).unwrap();
             })
-            .wrap_err(format!("YAML parser error. Output written to {ERR_FILE}"))?;
+            .wrap_err(format!("YAML parser error. output written to {ERR_FILE}"))?;
 
         Ok(())
     }
@@ -2523,7 +2523,7 @@ mod tests {
                 let mut f = fs::File::create(ERR_FILE).unwrap();
                 f.write_all(startup_yaml.as_bytes()).unwrap();
             })
-            .wrap_err(format!("YAML parser error. Output written to {ERR_FILE}"))?;
+            .wrap_err(format!("YAML parser error. output written to {ERR_FILE}"))?;
 
         Ok(())
     }
@@ -2589,7 +2589,7 @@ mod tests {
                 let mut f = fs::File::create(ERR_FILE).unwrap();
                 f.write_all(startup_yaml.as_bytes()).unwrap();
             })
-            .wrap_err(format!("YAML parser error. Output written to {ERR_FILE}"))?;
+            .wrap_err(format!("YAML parser error. output written to {ERR_FILE}"))?;
 
         Ok(())
     }
@@ -2642,7 +2642,7 @@ mod tests {
                 let mut f = fs::File::create(ERR_FILE).unwrap();
                 f.write_all(startup_yaml.as_bytes()).unwrap();
             })
-            .wrap_err(format!("YAML parser error. Output written to {ERR_FILE}"))?;
+            .wrap_err(format!("YAML parser error. output written to {ERR_FILE}"))?;
 
         Ok(())
     }
@@ -3140,7 +3140,7 @@ mod tests {
         // check dhcp server
         let dhcp_path = hbn_root.join("etc/supervisor/conf.d/default-forge-dhcp-server.conf");
         let dhcp_contents =
-            super::read_limited(&dhcp_path).wrap_err(format!("Failed reading {dhcp_path:?}"))?;
+            super::read_limited(&dhcp_path).wrap_err(format!("failed reading {dhcp_path:?}"))?;
         assert_eq!(dhcp_contents, crate::dhcp::TMPL_EMPTY);
         Ok(())
     }
@@ -3330,7 +3330,7 @@ mod tests {
                 let mut f = fs::File::create(ERR_FILE).unwrap();
                 f.write_all(startup_yaml.as_bytes()).unwrap();
             })
-            .wrap_err(format!("YAML parser error. Output written to {ERR_FILE}"))?;
+            .wrap_err(format!("YAML parser error. output written to {ERR_FILE}"))?;
         assert_eq!(yaml_obj.len(), 2); // 'header' and 'set'
         Ok(())
     }

--- a/crates/agent/src/extension_services/k8s_pod_handler.rs
+++ b/crates/agent/src/extension_services/k8s_pod_handler.rs
@@ -209,7 +209,7 @@ impl KubernetesPodServicesHandler {
             .args(["restart", service])
             .output()
             .await
-            .wrap_err(format!("Failed to restart {}", service))?;
+            .wrap_err(format!("failed to restart {}", service))?;
 
         if !restart.status.success() {
             let stderr = String::from_utf8_lossy(&restart.stderr);
@@ -267,7 +267,7 @@ impl KubernetesPodServicesHandler {
             .truncate(true)
             .open(&tmp_path)
             .await
-            .wrap_err_with(|| format!("Failed to create tmp file {}", tmp_path.display()))?;
+            .wrap_err_with(|| format!("failed to create tmp file {}", tmp_path.display()))?;
 
         tmp_file
             .write_all(labeled_yaml.as_bytes())

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
         // development overrides
         Some(config_path) => (
             AgentConfig::load_from(&config_path).wrap_err(format!(
-                "Error loading agent configuration from {}",
+                "error loading agent configuration from {}",
                 config_path.display()
             ))?,
             config_path.display().to_string(),

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -1560,7 +1560,7 @@ async fn hack_dpu_os_to_load_atf_uefi_with_specific_versions() -> eyre::Result<(
         // bump it to a minute just in case
         let output = tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT * 6, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         String::from_utf8_lossy(&output.stdout).to_string()
     };
@@ -1605,11 +1605,11 @@ ATF: v2.2(release):4.9.3-")
         // This is not a typo, we have to run it twice as per NBU
         tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
         // This is not a typo, we have to run it twice as per NBU
         tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         let mut cmd = tokio::process::Command::new("bash");
         cmd.args(vec!["-c", "sync"]);
@@ -1618,7 +1618,7 @@ ATF: v2.2(release):4.9.3-")
         let cmd_str = pretty_cmd(cmd.as_std());
         tokio::time::timeout(crate::dpu::COMMAND_TIMEOUT, cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
 
         // And now for the pièce de résistance, a reboot inline on the dpu OS, and this command
         // takes a LONG time so we will put an egregiously large reboot time
@@ -1629,7 +1629,7 @@ ATF: v2.2(release):4.9.3-")
         let cmd_str = pretty_cmd(cmd.as_std());
         tokio::time::timeout(Duration::from_secs(60 * 10), cmd.output())
             .await
-            .wrap_err_with(|| format!("Timeout while running command: {cmd_str:?}"))??;
+            .wrap_err_with(|| format!("timeout while running command: {cmd_str:?}"))??;
     }
 
     // This method will either reboot a card or just return ok.

--- a/crates/agent/src/network_monitor.rs
+++ b/crates/agent/src/network_monitor.rs
@@ -405,7 +405,7 @@ pub(crate) async fn fetch_dpu_info_list(
         .await
         .map_err(|err| {
             eyre::Report::new(err).wrap_err(format!(
-                "Could not connect to Forge API server at {forge_api}"
+                "could not connect to forge API server at {forge_api}"
             ))
         })?;
 

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -151,7 +151,7 @@ async fn test_nvue_generic(
             let mut f = fs::File::create(ERR_FILE).unwrap();
             f.write_all(startup_yaml.as_bytes()).unwrap();
         })
-        .wrap_err(format!("YAML parser error. Output written to {ERR_FILE}"))?;
+        .wrap_err(format!("YAML parser error. output written to {ERR_FILE}"))?;
     assert_eq!(yaml_obj.len(), 2); // 'header' and 'set'
 
     let r = compare_lines(startup_yaml.as_str(), expected, None);

--- a/crates/agent/src/tests/test_network_monitor.rs
+++ b/crates/agent/src/tests/test_network_monitor.rs
@@ -87,7 +87,7 @@ pub async fn test_network_monitor() -> eyre::Result<()> {
         // development overrides
         Some(config_path) => (
             AgentConfig::load_from(&config_path).wrap_err(format!(
-                "Error loading agent configuration from {}",
+                "error loading agent configuration from {}",
                 config_path.display()
             ))?,
             config_path.display().to_string(),

--- a/crates/agent/src/upgrade.rs
+++ b/crates/agent/src/upgrade.rs
@@ -171,7 +171,7 @@ async fn upgrade_check(
 }
 
 fn mtime(p: &Path) -> eyre::Result<SystemTime> {
-    let stat = fs::metadata(p).wrap_err_with(|| format!("Failed stat of '{}'", p.display()))?;
+    let stat = fs::metadata(p).wrap_err_with(|| format!("failed stat of '{}'", p.display()))?;
     let Ok(binary_mtime) = stat.modified() else {
         eyre::bail!(
             "failed reading mtime of forge-dpu-agent binary at '{}'",

--- a/crates/api-core/src/attestation/measured_boot.rs
+++ b/crates/api-core/src/attestation/measured_boot.rs
@@ -144,23 +144,23 @@ pub fn cli_make_cred(
 ) -> Result<(Vec<u8>, Vec<u8>), CarbideError> {
     // now construct the temp directory
     let tmp_dir = TempDir::with_prefix("make_cred")
-        .map_err(|e| CarbideError::AttestBindKeyError(format!("Could not create TempDir: {e}")))?;
+        .map_err(|e| CarbideError::AttestBindKeyError(format!("could not create TempDir: {e}")))?;
     let tmp_dir_path = tmp_dir.path();
 
     // create a file to write the EK key to
     let ek_file_path = tmp_dir_path.join("ek.dat");
     let mut ek_file = File::create(ek_file_path.clone())
-        .map_err(|e| CarbideError::AttestBindKeyError(format!("Could not create EK file: {e}")))?;
+        .map_err(|e| CarbideError::AttestBindKeyError(format!("could not create EK file: {e}")))?;
 
     // serialize the public key to a PEM format and write it to the file
     let pem_pub_key = pub_key.to_pkcs1_pem(LineEnding::default()).map_err(|e| {
         CarbideError::AttestBindKeyError(format!(
-            "Could not convert EK RsaPublicKey to PEM format: {e}"
+            "could not convert EK RsaPublicKey to PEM format: {e}"
         ))
     })?;
 
     ek_file.write_all(pem_pub_key.as_bytes()).map_err(|e| {
-        CarbideError::AttestBindKeyError(format!("Could not write EK Pub to PEM file: {e}"))
+        CarbideError::AttestBindKeyError(format!("could not write EK pub to PEM file: {e}"))
     })?;
 
     // now write AK name to the file in hexadecimal format
@@ -175,10 +175,10 @@ pub fn cli_make_cred(
             ))?;
 
     let mut session_key_file = File::create(session_key_path.clone()).map_err(|e| {
-        CarbideError::AttestBindKeyError(format!("Could not create file for session key: {e}"))
+        CarbideError::AttestBindKeyError(format!("could not create file for session key: {e}"))
     })?;
     session_key_file.write_all(session_key).map_err(|e| {
-        CarbideError::AttestBindKeyError(format!("Could not write session key to file: {e}"))
+        CarbideError::AttestBindKeyError(format!("could not write session key to file: {e}"))
     })?;
 
     // construct the command to execute make_credential
@@ -210,7 +210,7 @@ pub fn cli_make_cred(
         .output()
         .map_err(|e| {
             CarbideError::AttestBindKeyError(format!(
-                "Could not execute makecredential command: {e}"
+                "could not execute makecredential command: {e}"
             ))
         })?;
 
@@ -222,7 +222,7 @@ pub fn cli_make_cred(
     }
 
     let creds = fs::read(cred_out_path).map_err(|e| {
-        CarbideError::AttestBindKeyError(format!("Could not create creds file: {e}"))
+        CarbideError::AttestBindKeyError(format!("could not create creds file: {e}"))
     })?;
 
     let (cred_blob, encr_secret) = extract_cred_secret(&creds)?;
@@ -242,11 +242,11 @@ pub fn verify_signature(
         use tss_esapi::traits::UnMarshall;
 
         let ak_pub = Public::unmarshall(ak_pub).map_err(|e| {
-            CarbideError::AttestQuoteError(format!("Could not unmarshal AK Pub: {e}"))
+            CarbideError::AttestQuoteError(format!("could not unmarshal AK pub: {e}"))
         })?;
 
         let signature = Signature::unmarshall(rsa_signature).map_err(|e| {
-            CarbideError::AttestQuoteError(format!("Could not unmarshall Signature struct: {e}"))
+            CarbideError::AttestQuoteError(format!("could not unmarshall signature struct: {e}"))
         })?;
 
         linux_build::verify_signature(&ak_pub, attest_vec, &signature)
@@ -264,7 +264,7 @@ pub fn verify_pcr_hash(attestation: &[u8], pcr_values: &[Vec<u8>]) -> CarbideRes
         use tss_esapi::structures::Attest;
         use tss_esapi::traits::UnMarshall;
         let attest = Attest::unmarshall(attestation).map_err(|e| {
-            CarbideError::AttestQuoteError(format!("Could not unmarshall Attest struct: {e}"))
+            CarbideError::AttestQuoteError(format!("could not unmarshall attest struct: {e}"))
         })?;
         linux_build::verify_pcr_hash(&attest, pcr_values)
     }
@@ -284,7 +284,7 @@ fn extract_cred_secret(creds: &[u8]) -> CarbideResult<(Vec<u8>, Vec<u8>)> {
 
     if creds.len() < magic_header_offset + cred_blob_offset {
         return Err(CarbideError::AttestBindKeyError(format!(
-            "Creds file is too short: {0} bytes",
+            "creds file is too short: {0} bytes",
             creds.len()
         )));
     }
@@ -298,7 +298,7 @@ fn extract_cred_secret(creds: &[u8]) -> CarbideResult<(Vec<u8>, Vec<u8>)> {
 
     if creds.len() < cred_blob_end_idx + secret_offset - 1 {
         return Err(CarbideError::AttestBindKeyError(format!(
-            "Creds file is too short: {0} bytes",
+            "creds file is too short: {0} bytes",
             creds.len()
         )));
     }
@@ -418,12 +418,12 @@ pub mod linux_build {
 
         let cert = X509Certificate::from_der(tpm_ek_cert.as_bytes())
             .map_err(|e| {
-                CarbideError::AttestBindKeyError(format!("Could not unmarshall EK Cert: {e}"))
+                CarbideError::AttestBindKeyError(format!("could not unmarshall EK cert: {e}"))
             })?
             .1;
 
         let pub_key_cert_data = cert.public_key().parsed().map_err(|e| {
-            CarbideError::AttestBindKeyError(format!("Could not get EK Cert Data: {e}"))
+            CarbideError::AttestBindKeyError(format!("could not get EK cert data: {e}"))
         })?;
 
         let ek_cert_modulus = match pub_key_cert_data {
@@ -443,12 +443,12 @@ pub mod linux_build {
         // actually do coincide!
         let pub_key_cert = RsaPublicKey::new(modulus, exponent).map_err(|e| {
             CarbideError::AttestBindKeyError(format!(
-                "Could not create RsaPublicKey from EK Cert: {e}"
+                "could not create RsaPublicKey from EK cert: {e}"
             ))
         })?;
         // construct the Public structure and extract the PublicKeyRsa from it, which is really just the modulus
         let ek_pub = Public::unmarshall(ek_pub).map_err(|e| {
-            CarbideError::AttestBindKeyError(format!("Could not unmarshall EK: {e}"))
+            CarbideError::AttestBindKeyError(format!("could not unmarshall EK: {e}"))
         })?;
 
         let unique = match ek_pub {
@@ -466,7 +466,7 @@ pub mod linux_build {
 
         let pub_key_ek = RsaPublicKey::new(modulus, exponent).map_err(|e| {
             CarbideError::AttestBindKeyError(format!(
-                "Could not create RsaPublicKey from TPM's EK Pub: {e}"
+                "could not create RsaPublicKey from TPM's EK pub: {e}"
             ))
         })?;
 
@@ -497,7 +497,7 @@ pub mod linux_build {
         let exponent: BigUint = BigUint::from(RSA_PUBKEY_EXPONENT);
 
         let pub_key = RsaPublicKey::new(modulus, exponent).map_err(|e| {
-            CarbideError::AttestQuoteError(format!("Could not create RsaPublicKey: {e}"))
+            CarbideError::AttestQuoteError(format!("could not create RsaPublicKey: {e}"))
         })?;
 
         let rsa_signature = match signature {
@@ -534,7 +534,7 @@ mod tests {
             Ok(..) => panic!("Failed: Should have received an error"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                "attest bind key error: Creds file is too short: 3 bytes"
+                "attest bind key error: creds file is too short: 3 bytes"
             ),
         }
     }

--- a/crates/api-core/src/attestation/mod.rs
+++ b/crates/api-core/src/attestation/mod.rs
@@ -49,7 +49,7 @@ pub async fn get_ek_cert_by_machine_id(
         },
     )
     .await?
-    .ok_or_else(|| CarbideError::internal(format!("Machine with id {machine_id} not found.")))?;
+    .ok_or_else(|| CarbideError::internal(format!("machine with id {machine_id} not found")))?;
 
     // obtain an ek cert
     let tpm_ek_cert = machine

--- a/crates/api-core/src/attestation/tpm_ca_cert.rs
+++ b/crates/api-core/src/attestation/tpm_ca_cert.rs
@@ -34,7 +34,7 @@ pub fn extract_ca_fields(
     ca_cert_bytes: &[u8],
 ) -> CarbideResult<(DateTime<Utc>, DateTime<Utc>, Vec<u8>)> {
     let ca_cert = X509Certificate::from_der(ca_cert_bytes)
-        .map_err(|e| CarbideError::InvalidArgument(format!("Could not parse CA cert: {e}")))?
+        .map_err(|e| CarbideError::InvalidArgument(format!("could not parse CA cert: {e}")))?
         .1;
 
     Ok((
@@ -54,7 +54,7 @@ pub async fn match_insert_new_ek_cert_status_against_ca(
     machine_id: &MachineId,
 ) -> CarbideResult<()> {
     let ek_cert = X509Certificate::from_der(tpm_ek_cert.as_bytes())
-        .map_err(|e| CarbideError::InvalidArgument(format!("Could not parse EK cert: {e}")))?
+        .map_err(|e| CarbideError::InvalidArgument(format!("could not parse EK cert: {e}")))?
         .1;
 
     // get the issuer
@@ -67,7 +67,7 @@ pub async fn match_insert_new_ek_cert_status_against_ca(
         Some(ca_cert_db_entry) => {
             let ca_cert = X509Certificate::from_der(ca_cert_db_entry.ca_cert_der.as_slice())
                 .map_err(|e| {
-                    CarbideError::InvalidArgument(format!("Could not parse CA cert: {e}"))
+                    CarbideError::InvalidArgument(format!("could not parse CA cert: {e}"))
                 })?
                 .1;
 
@@ -177,12 +177,12 @@ pub async fn match_update_existing_ek_cert_status_against_ca(
 
     // create X509 EK cert
     let ek_cert = X509Certificate::from_der(tpm_ek_cert.as_bytes())
-        .map_err(|e| CarbideError::internal(format!("Could not parse EK cert: {e}")))?
+        .map_err(|e| CarbideError::internal(format!("could not parse EK cert: {e}")))?
         .1;
 
     // create X509 CA cert
     let ca_cert = X509Certificate::from_der(ca_cert_bytes)
-        .map_err(|e| CarbideError::internal(format!("Could not parse CA cert: {e}")))?
+        .map_err(|e| CarbideError::internal(format!("could not parse CA cert: {e}")))?
         .1;
 
     // verify signature
@@ -207,7 +207,7 @@ pub async fn match_update_existing_ek_cert_status_against_ca(
     .await
     .map_err(|e| {
         CarbideError::internal(format!(
-            "Could not update CA verification status for EK serial - {}, issuer - {}, error: {}",
+            "could not update CA verification status for EK serial - {}, issuer - {}, error: {}",
             ek_cert.raw_serial_as_string(),
             ek_cert.issuer,
             e

--- a/crates/api-core/src/compat.rs
+++ b/crates/api-core/src/compat.rs
@@ -97,7 +97,7 @@ impl BuildAndFillLegacyFields for ForgeAgentControlResponse {
                                 value: serde_json::to_string(
                                     &DpaCommand::try_from(command.clone()).map_err(|e| {
                                         CarbideError::internal(format!(
-                                            "Error converting MlxAction to JSON for legacy fields: {e}"
+                                            "error converting MlxAction to JSON for legacy fields: {e}"
                                         ))
                                     })?,
                                 )?,

--- a/crates/api-core/src/credentials/mod.rs
+++ b/crates/api-core/src/credentials/mod.rs
@@ -44,7 +44,7 @@ impl UpdateCredentials {
             let credential_purpose = CredentialPurpose::try_from(credential.credential_purpose)
                 .map_err(|error| {
                     CarbideError::internal(format!(
-                        "invalid discriminant {error:?} for Credential Purpose from grpc?"
+                        "invalid discriminant {error:?} for credential purpose from grpc?"
                     ))
                 })?;
 

--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -116,12 +116,12 @@ pub async fn create_initial_networks(
                 }
                 [] => {
                     return Err(CarbideError::InvalidArgument(format!(
-                        "Network segment {name} references VPC {vpc_name}, but no VPC with that name exists"
+                        "network segment {name} references VPC {vpc_name}, but no VPC with that name exists"
                     )));
                 }
                 _ => {
                     return Err(CarbideError::InvalidArgument(format!(
-                        "Network segment {name} references VPC {vpc_name}, but multiple VPCs with that name exist"
+                        "network segment {name} references VPC {vpc_name}, but multiple VPCs with that name exist"
                     )));
                 }
             }
@@ -405,7 +405,7 @@ pub(crate) async fn create_admin_vpc(
             .await?;
             if vpcs.len() != 1 {
                 return Err(CarbideError::internal(format!(
-                    "Admin network segment references missing VPC {admin_vpc_id}."
+                    "admin network segment references missing VPC {admin_vpc_id}"
                 )));
             }
             Some(vpcs.remove(0))
@@ -417,7 +417,7 @@ pub(crate) async fn create_admin_vpc(
                 db::vpc::find_by_vni(&mut txn, configured_vni).await?.pop()
             {
                 return Err(CarbideError::internal(format!(
-                    "Configured admin VPC VNI {configured_vni} is already used by VPC {}, but no admin VPC is attached to admin network segments.",
+                    "configured admin VPC VNI {configured_vni} is already used by VPC {}, but no admin VPC is attached to admin network segments",
                     conflicting_vpc.id
                 )));
             }
@@ -425,7 +425,7 @@ pub(crate) async fn create_admin_vpc(
         }
         _ => {
             return Err(CarbideError::internal(format!(
-                "Admin network segments are attached to multiple VPCs: {}.",
+                "admin network segments are attached to multiple VPCs: {}",
                 attached_admin_vpc_ids.iter().join(", ")
             )));
         }
@@ -440,7 +440,7 @@ pub(crate) async fn create_admin_vpc(
                 .find(|vpc| vpc.id != existing_vpc.id)
             {
                 return Err(CarbideError::internal(format!(
-                    "Configured admin VPC VNI {configured_vni} is already used by VPC {}, but admin network segments are attached to VPC {}.",
+                    "configured admin VPC VNI {configured_vni} is already used by VPC {}, but admin network segments are attached to VPC {}",
                     conflicting_vpc.id, existing_vpc.id
                 )));
             }
@@ -458,7 +458,7 @@ pub(crate) async fn create_admin_vpc(
             match admin_segment.config.vpc_id {
                 Some(vpc_id) if vpc_id != existing_vpc.id => {
                     return Err(CarbideError::internal(format!(
-                        "Mismatch found in admin vpc id {} and admin network segment's attached vpc id {vpc_id}.",
+                        "mismatch found in admin vpc id {} and admin network segment's attached vpc id {vpc_id}",
                         existing_vpc.id
                     )));
                 }

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -671,7 +671,7 @@ pub async fn discover_dhcp(
             .or_else(|| network_segments.first())
             .ok_or_else(|| {
                 CarbideError::internal(format!(
-                    "No network segment defined for DHCPv6 relay address {parsed_relay}"
+                    "no network segment defined for DHCPv6 relay address {parsed_relay}"
                 ))
             })?;
         ensure_dhcpv6_enabled(segment)?;
@@ -794,7 +794,7 @@ pub async fn discover_dhcp(
         && segment.config.segment_type == NetworkSegmentType::Admin
     {
         return Err(CarbideError::FailedPrecondition(format!(
-            "DHCP request received on dormant non-primary admin interface {}. Ignoring.",
+            "DHCP request received on dormant non-primary admin interface {}. ignoring",
             machine_interface.id
         )));
     }
@@ -825,7 +825,7 @@ pub async fn discover_dhcp(
         let dpus = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine_id).await?;
         if !dpus.is_empty() {
             return Err(CarbideError::internal(format!(
-                "DHCP request received for instance: {instance_id}. Ignoring."
+                "DHCP request received for instance: {instance_id}. ignoring"
             )));
         }
     }

--- a/crates/api-core/src/ethernet_virtualization.rs
+++ b/crates/api-core/src/ethernet_virtualization.rs
@@ -337,7 +337,7 @@ pub async fn admin_network(
     let host_machine_id = snapshot.host_snapshot.id;
     let Some(interface) = interface else {
         return Err(CarbideError::InvalidArgument(format!(
-            "No admin interface found attached on host: {host_machine_id} with dpu: {dpu_machine_id}"
+            "no admin interface found attached on host: {host_machine_id} with dpu: {dpu_machine_id}"
         ))
         .into());
     };
@@ -355,7 +355,7 @@ pub async fn admin_network(
         })
         .ok_or_else(|| {
             CarbideError::InvalidArgument(format!(
-                "No primary admin interface found on host: {host_machine_id}"
+                "no primary admin interface found on host: {host_machine_id}"
             ))
         })?;
 
@@ -365,7 +365,7 @@ pub async fn admin_network(
 
     let Some(admin_segment) = admin_segment else {
         return Err(CarbideError::internal(format!(
-            "Unknown primary admin segment `{}` attached on host: {host_machine_id}",
+            "unknown primary admin segment `{}` attached on host: {host_machine_id}",
             active_interface.segment_id
         ))
         .into());
@@ -405,7 +405,7 @@ pub async fn admin_network(
         .find(|address| address.is_ipv4())
         .ok_or_else(|| {
             CarbideError::InvalidArgument(format!(
-                "No IPv4 address found on primary host admin interface {}",
+                "no IPv4 address found on primary host admin interface {}",
                 active_interface.id
             ))
         })?;
@@ -466,7 +466,7 @@ pub async fn admin_network(
                     None => {
                         // if FNN is enabled, VPC must be created and updated in admin_segment.
                         return Err(CarbideError::internal(format!(
-                            "Admin VPC is not found with id: {vpc_id}."
+                            "admin VPC is not found with id: {vpc_id}"
                         ))
                         .into());
                     }

--- a/crates/api-core/src/handlers/api.rs
+++ b/crates/api-core/src/handlers/api.rs
@@ -73,7 +73,7 @@ pub(crate) fn set_dynamic_config(
     let req = request.into_inner();
     let exp_str = req.expiry.as_deref().unwrap_or("1h");
     let expiry = duration_str::parse(exp_str).map_err(|err| {
-        CarbideError::InvalidArgument(format!("Invalid expiry string '{exp_str}'. {err}"))
+        CarbideError::InvalidArgument(format!("invalid expiry string '{exp_str}'. {err}"))
     })?;
     const MAX_SET_INTERNAL_EXPIRY: Duration = Duration::from_secs(60 * 60 * 60); // 60 hours
     if MAX_SET_INTERNAL_EXPIRY < expiry {
@@ -86,7 +86,7 @@ pub(crate) fn set_dynamic_config(
 
     let Ok(requested_setting) = rpc::ConfigSetting::try_from(req.setting) else {
         return Err(CarbideError::InvalidArgument(format!(
-            "Not a supported dynamic config setting: {}",
+            "not a supported dynamic config setting: {}",
             req.setting
         ))
         .into());
@@ -101,7 +101,7 @@ pub(crate) fn set_dynamic_config(
             let level = &api.dynamic_settings.log_filter;
             level.update(&req.value, Some(expire_at)).map_err(|err| {
                 CarbideError::InvalidArgument(format!(
-                    "Invalid log filter string '{}'. {err}",
+                    "invalid log filter string '{}'. {err}",
                     req.value
                 ))
             })?;
@@ -114,7 +114,7 @@ pub(crate) fn set_dynamic_config(
         rpc::ConfigSetting::CreateMachines => {
             let is_enabled = req.value.parse::<bool>().map_err(|err| {
                 CarbideError::InvalidArgument(format!(
-                    "Invalid create_machines string '{}'. {err}",
+                    "invalid create_machines string '{}'. {err}",
                     req.value
                 ))
             })?;
@@ -129,7 +129,7 @@ pub(crate) fn set_dynamic_config(
         rpc::ConfigSetting::SiteExplorerEnabled => {
             let is_enabled = req.value.parse::<bool>().map_err(|err| {
                 CarbideError::InvalidArgument(format!(
-                    "Invalid site_explorer_enabled string '{}'. {err}",
+                    "invalid site_explorer_enabled string '{}'. {err}",
                     req.value
                 ))
             })?;
@@ -154,7 +154,7 @@ pub(crate) fn set_dynamic_config(
             } else {
                 let host_port_pair = req.value.parse::<HostPortPair>().map_err(|err| {
                     CarbideError::InvalidArgument(format!(
-                        "Invalid bmc_proxy string '{}': {err}",
+                        "invalid bmc_proxy string '{}': {err}",
                         req.value
                     ))
                 })?;
@@ -178,7 +178,7 @@ pub(crate) fn set_dynamic_config(
             }
             let enable = req.value.parse().map_err(|_| {
                 CarbideError::InvalidArgument(format!(
-                    "Expected bool for TracingEnabled, got {}",
+                    "expected bool for TracingEnabled, got {}",
                     &req.value
                 ))
             })?;

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -752,13 +752,13 @@ pub(crate) async fn copy_bfb_to_dpu_rshim(
 
     let dpu_ip: std::net::IpAddr = ip_str
         .parse()
-        .map_err(|_| CarbideError::InvalidArgument(format!("Invalid DPU IP: {ip_str}")))?;
+        .map_err(|_| CarbideError::InvalidArgument(format!("invalid DPU IP: {ip_str}")))?;
 
     if req.host_bmc_ip.is_empty() {
         return Err(CarbideError::MissingArgument("host_bmc_ip").into());
     }
     let host_bmc_ip: std::net::IpAddr = req.host_bmc_ip.parse().map_err(|_| {
-        CarbideError::InvalidArgument(format!("Invalid host BMC IP: {}", req.host_bmc_ip))
+        CarbideError::InvalidArgument(format!("invalid host BMC IP: {}", req.host_bmc_ip))
     })?;
 
     let pre_copy_powercycle = req.pre_copy_powercycle;
@@ -769,8 +769,8 @@ pub(crate) async fn copy_bfb_to_dpu_rshim(
             .map_err(|e| CarbideError::internal(e.to_string()))?;
     if dpu_in_managed_host {
         return Err(CarbideError::InvalidArgument(format!(
-            "Cannot trigger BFB recovery: DPU {dpu_ip} is already ingested. \
-             Force-delete the managed host first.",
+            "cannot trigger BFB recovery: DPU {dpu_ip} is already ingested. \
+             force-delete the managed host first",
         ))
         .into());
     }
@@ -791,10 +791,10 @@ pub(crate) async fn copy_bfb_to_dpu_rshim(
     // eventually, time out (SLA), and then the host will mark as failed.
     if dpu_endpoint.report.nic_mode() == Some(NicMode::Nic) {
         return Err(CarbideError::InvalidArgument(format!(
-            "Cannot trigger BFB recovery: DPU {dpu_ip} is in NIC mode. \
-             Update the host's `ExpectedMachine.dpu_mode` to `DpuMode` \
+            "cannot trigger BFB recovery: DPU {dpu_ip} is in NIC mode. \
+             update the host's `ExpectedMachine.dpu_mode` to `DpuMode` \
              and wait for site-explorer to reconcile the DPU back to \
-             DPU mode before retrying.",
+             DPU mode before retrying",
         ))
         .into());
     }
@@ -805,8 +805,8 @@ pub(crate) async fn copy_bfb_to_dpu_rshim(
         | PreingestionState::Failed { .. } => {}
         other => {
             return Err(CarbideError::InvalidArgument(format!(
-                "Cannot trigger BFB recovery: DPU endpoint is in state {other:?}. \
-                 Wait for it to complete or fail first.",
+                "cannot trigger BFB recovery: DPU endpoint is in state {other:?}. \
+                 wait for it to complete or fail first",
             ))
             .into());
         }
@@ -825,8 +825,8 @@ pub(crate) async fn copy_bfb_to_dpu_rshim(
             PreingestionState::Complete | PreingestionState::Failed { .. } => {}
             other => {
                 return Err(CarbideError::InvalidArgument(format!(
-                    "Cannot power-cycle host: host {host_bmc_ip} is in state {other:?}. \
-                     Retry after host preingestion completes.",
+                    "cannot power-cycle host: host {host_bmc_ip} is in state {other:?}. \
+                     retry after host preingestion completes",
                 ))
                 .into());
             }
@@ -872,7 +872,7 @@ async fn resolve_bmc_interface(
     let mut addrs = lookup_host(address).await?;
     let Some(bmc_addr) = addrs.next() else {
         return Err(CarbideError::InvalidArgument(format!(
-            "Could not resolve {}. Must be hostname[:port] or IPv4[:port]",
+            "could not resolve {}. must be hostname[:port] or IPv4[:port]",
             request.ip_address
         ))
         .into());
@@ -1183,7 +1183,7 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
 
             let bmc_ip = machine.bmc_info.ip.as_ref().ok_or_else(|| {
                 CarbideError::internal(format!(
-                    "Machine found for {machine_id} but BMC IP is missing"
+                    "machine found for {machine_id} but BMC IP is missing"
                 ))
             })?;
 

--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -194,7 +194,7 @@ pub(crate) async fn resolve_cloud_init_instructions(
         ResolvedClient::MachineInterface(machine_interface) => {
             let domain_id = machine_interface.domain_id.ok_or_else(|| {
                 CarbideError::internal(format!(
-                    "Machine Interface did not have an associated domain {}",
+                    "machine interface did not have an associated domain {}",
                     machine_interface.id
                 ))
             })?;
@@ -203,7 +203,7 @@ pub(crate) async fn resolve_cloud_init_instructions(
                 .await
                 .map_err(CarbideError::from)?
                 .ok_or_else(|| {
-                    CarbideError::internal(format!("Could not find domain with id {domain_id}"))
+                    CarbideError::internal(format!("could not find domain with id {domain_id}"))
                 })?
                 .to_owned();
 

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -418,7 +418,7 @@ fn map_nv_switch_components(raw: &[i32]) -> Result<Vec<NvSwitchComponent>, Statu
             Ok(rpc::NvSwitchComponent::Bios) => Ok(NvSwitchComponent::Bios),
             Ok(rpc::NvSwitchComponent::Nvos) => Ok(NvSwitchComponent::Nvos),
             _ => Err(Status::invalid_argument(format!(
-                "unknown NV-Switch component: {v}"
+                "unknown NV-switch component: {v}"
             ))),
         })
         .collect()

--- a/crates/api-core/src/handlers/compute_allocation.rs
+++ b/crates/api-core/src/handlers/compute_allocation.rs
@@ -550,7 +550,7 @@ pub(crate) async fn delete(
     {
         if allocation.tenant_organization_id != tenant_organization_id {
             return Err(CarbideError::InvalidArgument(format!(
-                "ComputeAllocation `{}` is not owned by Tenant `{}`",
+                "ComputeAllocation `{}` is not owned by tenant `{}`",
                 allocation.id.clone(),
                 tenant_organization_id.clone()
             ))

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -76,7 +76,7 @@ pub(crate) async fn create_credential(
                 .await
                 .map_err(|e| {
                     CarbideError::internal(format!(
-                        "Error setting Site Wide BMC Root credentials: {e:?} "
+                        "error setting site wide BMC root credentials: {e:?} "
                     ))
                 })?;
         }
@@ -85,7 +85,7 @@ pub(crate) async fn create_credential(
                 .await
                 .map_err(|e| {
                     CarbideError::internal(format!(
-                        "Error setting Site Wide NIC lockdown IKM: {e:?} "
+                        "error setting site wide NIC lockdown IKM: {e:?} "
                     ))
                 })?;
         }
@@ -104,7 +104,7 @@ pub(crate) async fn create_credential(
                     .await
                     .map_err(|e| {
                         CarbideError::internal(format!(
-                            "Error setting credential for Ufm {}: {:?} ",
+                            "error setting credential for ufm {}: {:?} ",
                             username.clone(),
                             e
                         ))
@@ -141,7 +141,7 @@ pub(crate) async fn create_credential(
                 )
                 .await
                 .map_err(|e| {
-                    CarbideError::internal(format!("Error setting credential for DPU UEFI: {e:?} "))
+                    CarbideError::internal(format!("error setting credential for DPU UEFI: {e:?} "))
                 })?
         }
         rpc::CredentialType::HostUefi => {
@@ -170,7 +170,7 @@ pub(crate) async fn create_credential(
                 )
                 .await
                 .map_err(|e| {
-                    CarbideError::internal(format!("Error setting credential for Host UEFI: {e:?}"))
+                    CarbideError::internal(format!("error setting credential for host UEFI: {e:?}"))
                 })?
         }
         rpc::CredentialType::HostBmcFactoryDefault => {
@@ -191,7 +191,7 @@ pub(crate) async fn create_credential(
                 .await
                 .map_err(|e| {
                     CarbideError::internal(format!(
-                        "Error setting Host factory default credential: {e:?}"
+                        "error setting host factory default credential: {e:?}"
                     ))
                 })?
         }
@@ -209,7 +209,7 @@ pub(crate) async fn create_credential(
                 .await
                 .map_err(|e| {
                     CarbideError::internal(format!(
-                        "Error setting DPU factory default credential: {e:?}"
+                        "error setting DPU factory default credential: {e:?}"
                     ))
                 })?
         }
@@ -226,7 +226,7 @@ pub(crate) async fn create_credential(
                 .await
                 .map_err(|e| {
                     CarbideError::internal(format!(
-                        "Error setting Site Wide BMC Root credentials: {e:?} "
+                        "error setting site wide BMC root credentials: {e:?} "
                     ))
                 })?;
         }
@@ -252,7 +252,7 @@ pub(crate) async fn create_credential(
                     .await
                     .map_err(|e| {
                         CarbideError::internal(format!(
-                            "Error setting credential for NmxM {}: {:?} ",
+                            "error setting credential for NmxM {}: {:?} ",
                             username.clone(),
                             e
                         ))
@@ -278,7 +278,7 @@ pub(crate) async fn create_credential(
                 )
                 .await
                 .map_err(|e| {
-                    CarbideError::internal(format!("Error setting BGP credential: {e:?}"))
+                    CarbideError::internal(format!("error setting BGP credential: {e:?}"))
                 })?;
         }
     };
@@ -316,7 +316,7 @@ pub(crate) async fn delete_credential(
                     .await
                     .map_err(|e| {
                         CarbideError::internal(format!(
-                            "Error deleting credential for Ufm {}: {:?} ",
+                            "error deleting credential for ufm {}: {:?} ",
                             username.clone(),
                             e
                         ))
@@ -364,7 +364,7 @@ pub(crate) async fn delete_credential(
                 })
                 .await
                 .map_err(|e| {
-                    CarbideError::internal(format!("Error deleting BGP credential: {e:?}"))
+                    CarbideError::internal(format!("error deleting BGP credential: {e:?}"))
                 })?;
         }
     };
@@ -601,7 +601,7 @@ async fn set_sitewide_nic_lockdown_ikm(api: &Api, password: String) -> Result<()
         .set_credentials(&credential_key, &credentials)
         .await
         .map_err(|e| {
-            CarbideError::internal(format!("Error setting NIC lockdown IKM credential: {e:?}"))
+            CarbideError::internal(format!("error setting NIC lockdown IKM credential: {e:?}"))
         })
 }
 
@@ -617,7 +617,7 @@ pub(crate) async fn delete_bmc_root_credentials_by_mac(
         .delete_credentials(&credential_key)
         .await
         .map_err(|e| {
-            CarbideError::internal(format!("Error deleting credential for BMC: {e:?} "))
+            CarbideError::internal(format!("error deleting credential for BMC: {e:?} "))
         })?;
 
     // Drop the bmc convergence marker alongside the Vault secret it depends on:
@@ -673,7 +673,7 @@ async fn set_bmc_credentials(
     api.credential_manager
         .set_credentials(credential_key, credentials)
         .await
-        .map_err(|e| CarbideError::internal(format!("Error setting credential for BMC: {e:?} ")))
+        .map_err(|e| CarbideError::internal(format!("error setting credential for BMC: {e:?} ")))
 }
 
 pub async fn write_ufm_certs(api: &Api, fabric: String) -> Result<(), CarbideError> {
@@ -697,37 +697,37 @@ pub async fn write_ufm_certs(api: &Api, fabric: String) -> Result<(), CarbideErr
 
     let mut cert_filename = format!("{CERT_PATH}/{fabric}-ufm-ca-intermediate.crt");
     let mut cert_file = File::create(cert_filename.clone()).map_err(|e| {
-        CarbideError::internal(format!("Could not create: {cert_filename} err: {e:?}"))
+        CarbideError::internal(format!("could not create: {cert_filename} err: {e:?}"))
     })?;
     cert_file
         .write_all(certificate.issuing_ca.as_slice())
         .map_err(|e| {
             CarbideError::internal(format!(
-                "Failed to write certificate to: {cert_filename} error: {e:?}"
+                "failed to write certificate to: {cert_filename} error: {e:?}"
             ))
         })?;
 
     cert_filename = format!("{CERT_PATH}/{fabric}-ufm-server.key");
     cert_file = File::create(cert_filename.clone()).map_err(|e| {
-        CarbideError::internal(format!("Could not create: {cert_filename} err: {e:?}"))
+        CarbideError::internal(format!("could not create: {cert_filename} err: {e:?}"))
     })?;
     cert_file
         .write_all(certificate.private_key.as_slice())
         .map_err(|e| {
             CarbideError::internal(format!(
-                "Failed to write certificate to: {cert_filename} error: {e:?}"
+                "failed to write certificate to: {cert_filename} error: {e:?}"
             ))
         })?;
 
     cert_filename = format!("{CERT_PATH}/{fabric}-ufm-server.crt");
     cert_file = File::create(cert_filename.clone()).map_err(|e| {
-        CarbideError::internal(format!("Could not create: {cert_filename} err: {e:?}"))
+        CarbideError::internal(format!("could not create: {cert_filename} err: {e:?}"))
     })?;
     cert_file
         .write_all(certificate.public_key.as_slice())
         .map_err(|e| {
             CarbideError::internal(format!(
-                "Failed to write certificate to: {cert_filename} error: {e:?}"
+                "failed to write certificate to: {cert_filename} error: {e:?}"
             ))
         })?;
 

--- a/crates/api-core/src/handlers/dns.rs
+++ b/crates/api-core/src/handlers/dns.rs
@@ -210,7 +210,7 @@ pub async fn lookup_record(
     );
 
     let rrtype = DnsResourceRecordType::try_from(lookup_request.qtype)
-        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid qtype supplied: {}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("invalid qtype supplied: {}", e)))?;
 
     let qname = lookup_request.qname;
 

--- a/crates/api-core/src/handlers/dpf.rs
+++ b/crates/api-core/src/handlers/dpf.rs
@@ -51,7 +51,7 @@ pub(crate) async fn modify_dpf_state(
 
     if !request.dpf_enabled && machine_snapshot.host_snapshot.dpf.used_for_ingestion {
         return Err(CarbideError::FailedPrecondition(format!(
-            "Cannot disable DPF for host {}: machine was ingested via DPF.",
+            "cannot disable DPF for host {}: machine was ingested via DPF",
             machine_id
         ))
         .into());
@@ -133,7 +133,7 @@ pub(crate) async fn get_dpf_host_snapshot(
 
     let host_dpf_id = machine.dpf_id().ok_or_else(|| {
         CarbideError::InvalidArgument(format!(
-            "Host {machine_id} has no BMC MAC; cannot derive DPF node name"
+            "host {machine_id} has no BMC MAC; cannot derive DPF node name"
         ))
     })?;
     let node_name = dpu_node_cr_name(&host_dpf_id);
@@ -144,7 +144,7 @@ pub(crate) async fn get_dpf_host_snapshot(
         .map_err(CarbideError::DpfError)?;
 
     let json_payload = serde_json::to_string_pretty(&snapshot).map_err(|e| {
-        CarbideError::internal(format!("Failed to serialize DPF host snapshot: {e}"))
+        CarbideError::internal(format!("failed to serialize DPF host snapshot: {e}"))
     })?;
 
     Ok(Response::new(rpc::DpfHostSnapshotResponse { json_payload }))

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -120,7 +120,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
         Some(ip) => ip,
         None => {
             return Err(CarbideError::FailedPrecondition(format!(
-                "DPU {dpu_machine_id} needs discovery. Does not have a loopback IP yet."
+                "DPU {dpu_machine_id} needs discovery. does not have a loopback IP yet"
             ))
             .into());
         }
@@ -138,7 +138,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
             .is_none()
     {
         return Err(CarbideError::FailedPrecondition(format!(
-            "DPU {dpu_machine_id} needs discovery. Does not have a secondary VTEP IP yet."
+            "DPU {dpu_machine_id} needs discovery. does not have a secondary VTEP IP yet"
         ))
         .into());
     };
@@ -947,7 +947,7 @@ pub(crate) async fn record_dpu_network_status(
             &mut txn,
             *host_interface_id,
             Some(timestamp.parse().map_err(|e| {
-                CarbideError::InvalidArgument(format!("Failed parsing dhcp timestamp: {e}"))
+                CarbideError::InvalidArgument(format!("failed parsing dhcp timestamp: {e}"))
             })?),
         )
         .await?;
@@ -1224,7 +1224,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
             .contains(&health_report::HealthAlertClassification::prevent_allocations())
     }) {
         return Err(CarbideError::InvalidArgument(format!(
-            "Machine {machine_id} must have a 'HostUpdateInProgress' health alert with the 'PreventAllocations' classification before reprovisioning. Set this precondition with: `machine health-override add --template host-update <id>`.",
+            "machine {machine_id} must have a 'HostUpdateInProgress' health alert with the 'PreventAllocations' classification before reprovisioning. set this precondition with: `machine health-override add --template host-update <id>`",
         )).into());
     }
 
@@ -1305,7 +1305,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
 
             if ids.is_empty() {
                 return Err(CarbideError::InvalidArgument(
-                    format!("No DPUs are currently reprovisioning on {machine_id}, cannot restart reprovisioning. Use `set` to begin reprovisioning DPUs."),
+                    format!("no DPUs are currently reprovisioning on {machine_id}, cannot restart reprovisioning. use `set` to begin reprovisioning DPUs"),
                 )
                     .into());
             }

--- a/crates/api-core/src/handlers/expected_rack.rs
+++ b/crates/api-core/src/handlers/expected_rack.rs
@@ -44,7 +44,7 @@ pub async fn add_expected_rack(
         .is_none()
     {
         return Err(CarbideError::InvalidArgument(format!(
-            "Unknown rack_profile_id: {}. Must be one of: {:?}",
+            "unknown rack_profile_id: {}. must be one of: {:?}",
             rack.rack_profile_id,
             api.runtime_config.rack_profiles.keys().collect::<Vec<_>>()
         ))
@@ -72,7 +72,7 @@ pub async fn add_expected_rack(
         .is_none()
     {
         return Err(CarbideError::InvalidArgument(format!(
-            "Unknown rack_profile_id: {}. Must be one of: {:?}",
+            "unknown rack_profile_id: {}. must be one of: {:?}",
             rack.rack_profile_id,
             api.runtime_config.rack_profiles.keys().collect::<Vec<_>>()
         ))
@@ -93,7 +93,7 @@ pub async fn delete_expected_rack(
 ) -> Result<Response<()>, Status> {
     let req = request.into_inner();
     let rack_id = RackId::from_str(&req.rack_id)
-        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("invalid rack ID: {}", e)))?;
     let mut txn = api.txn_begin().await?;
     db_expected_rack::delete(&mut txn, &rack_id)
         .await
@@ -119,7 +119,7 @@ pub async fn update_expected_rack(
         .is_none()
     {
         return Err(CarbideError::InvalidArgument(format!(
-            "Unknown rack_profile_id: {}. Must be one of: {:?}",
+            "unknown rack_profile_id: {}. must be one of: {:?}",
             rack.rack_profile_id,
             api.runtime_config.rack_profiles.keys().collect::<Vec<_>>()
         ))
@@ -150,7 +150,7 @@ pub async fn get_expected_rack(
 ) -> Result<Response<rpc::ExpectedRack>, Status> {
     let req = request.into_inner();
     let rack_id = RackId::from_str(&req.rack_id)
-        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("invalid rack ID: {}", e)))?;
     let mut txn = api.txn_begin().await?;
     let expected_rack = db_expected_rack::find_by_rack_id(&mut txn, &rack_id)
         .await
@@ -202,7 +202,7 @@ pub async fn replace_all_expected_racks(
             .is_none()
         {
             return Err(CarbideError::InvalidArgument(format!(
-                "Unknown rack_profile_id: {}",
+                "unknown rack_profile_id: {}",
                 rack.rack_profile_id
             ))
             .into());

--- a/crates/api-core/src/handlers/extension_service.rs
+++ b/crates/api-core/src/handlers/extension_service.rs
@@ -328,7 +328,7 @@ pub(crate) async fn update(
 
         let version_change =
             ConfigVersion::new(current_service.version_ctr.try_into().map_err(|e| {
-                CarbideError::internal(format!("Invalid version for extension service: {e}"))
+                CarbideError::internal(format!("invalid version for extension service: {e}"))
             })?)
             .incremental_change();
 
@@ -782,7 +782,7 @@ fn validate_pod_spec_file(data: &str) -> Result<(), CarbideError> {
 
     let root = serde_yaml::from_str::<serde_yaml::Value>(data).map_err(|e| {
         CarbideError::InvalidArgument(format!(
-            "Invalid pod spec file for KubernetesPod service: {}",
+            "invalid pod spec file for KubernetesPod service: {}",
             e
         ))
     })?;
@@ -875,7 +875,7 @@ fn validate_extension_service_data(
 ) -> Result<(), CarbideError> {
     if data.len() > MAX_POD_SPEC_SIZE {
         return Err(CarbideError::InvalidArgument(format!(
-            "Extension service data exceeds the maximum size: {} bytes",
+            "extension service data exceeds the maximum size: {} bytes",
             MAX_POD_SPEC_SIZE
         )));
     }
@@ -944,14 +944,14 @@ fn detect_extension_service_spec_change(
             let old_data_yaml =
                 serde_yaml::from_str::<serde_yaml::Value>(old_data).map_err(|e| {
                     CarbideError::internal(format!(
-                        "Found corrupted data for KubernetesPod service: {}",
+                        "found corrupted data for KubernetesPod service: {}",
                         e
                     ))
                 })?;
             let new_data_yaml =
                 serde_yaml::from_str::<serde_yaml::Value>(new_data).map_err(|e| {
                     CarbideError::InvalidArgument(format!(
-                        "Invalid pod spec file for KubernetesPod service: {}",
+                        "invalid pod spec file for KubernetesPod service: {}",
                         e
                     ))
                 })?;
@@ -1009,7 +1009,7 @@ async fn create_extension_service_credential(
                         .await
                         .map_err(|e| {
                             CarbideError::internal(format!(
-                                "Error creating credential for extension service: {e}"
+                                "error creating credential for extension service: {e}"
                             ))
                         })
                 }

--- a/crates/api-core/src/handlers/host_reprovisioning.rs
+++ b/crates/api-core/src/handlers/host_reprovisioning.rs
@@ -190,7 +190,7 @@ pub async fn report_scout_firmware_upgrade_status(
     } = machine.current_state().clone()
     else {
         return Err(CarbideError::FailedPrecondition(format!(
-            "Machine {machine_id} is not in WaitingForScoutUpgrade state"
+            "machine {machine_id} is not in WaitingForScoutUpgrade state"
         ))
         .into());
     };
@@ -203,7 +203,7 @@ pub async fn report_scout_firmware_upgrade_status(
             "Rejecting stale scout firmware upgrade status report",
         );
         return Err(CarbideError::FailedPrecondition(format!(
-            "Scout firmware upgrade status task ID mismatch for machine {machine_id}"
+            "scout firmware upgrade status task ID mismatch for machine {machine_id}"
         ))
         .into());
     }

--- a/crates/api-core/src/handlers/ib_partition.rs
+++ b/crates/api-core/src/handlers/ib_partition.rs
@@ -319,7 +319,7 @@ async fn allocate_pkey(
         {
             Ok(val) => Ok(Some(
                 PartitionKey::try_from(val)
-                .map_err(|_| CarbideError::internal(format!("Partition key {val} return from pool is not a valid pkey. Pool Definition is invalid")))?)),
+                .map_err(|_| CarbideError::internal(format!("partition key {val} return from pool is not a valid pkey. pool definition is invalid")))?)),
             Err(ResourcePoolDatabaseError::ResourcePool(resource_pool::ResourcePoolError::Empty)) => {
                 tracing::error!(owner_id, pool = "pkey", "Pool exhausted, cannot allocate");
                 Err(CarbideError::ResourceExhausted("pool pkey".to_string()))

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -1015,7 +1015,7 @@ pub(crate) async fn invoke_power(
 
             if rr.started_at.is_some() {
                 return Err(CarbideError::DpuReprovisioningInProgress(format!(
-                    "Can't reboot host: {machine_id}"
+                    "can't reboot host: {machine_id}"
                 ))
                 .into());
             }
@@ -1108,7 +1108,7 @@ pub(crate) async fn invoke_power(
     client
         .power(libredfish::SystemPowerControl::ForceRestart)
         .await
-        .map_err(|e| CarbideError::internal(format!("Failed redfish ForceRestart subtask: {e}")))?;
+        .map_err(|e| CarbideError::internal(format!("failed redfish ForceRestart subtask: {e}")))?;
 
     Ok(Response::new(rpc::InstancePowerResult {}))
 }
@@ -1218,7 +1218,7 @@ pub(crate) async fn update_instance_config(
         Some(metadata) => metadata.try_into().map_err(CarbideError::from)?,
     };
     metadata.validate(true).map_err(|e| {
-        CarbideError::InvalidArgument(format!("Instance metadata is not valid: {e}"))
+        CarbideError::InvalidArgument(format!("instance metadata is not valid: {e}"))
     })?;
 
     let mut txn = api.txn_begin().await?;
@@ -1293,7 +1293,7 @@ pub(crate) async fn update_instance_config(
         .is_none()
         {
             return Err(CarbideError::FailedPrecondition(format!(
-                "NetworkSecurityGroup `{}` does not exist or is not owned by Tenant `{}`",
+                "NetworkSecurityGroup `{}` does not exist or is not owned by tenant `{}`",
                 nsg_id,
                 tenant_org.clone(),
             ))
@@ -1333,7 +1333,7 @@ pub(crate) async fn update_instance_config(
         for service in service_configs.iter() {
             if !services.contains_key(&service.service_id) {
                 return Err(CarbideError::FailedPrecondition(format!(
-                    "Extension service {} does not exist",
+                    "extension service {} does not exist",
                     service.service_id,
                 ))
                 .into());
@@ -1344,7 +1344,7 @@ pub(crate) async fn update_instance_config(
                 .contains(&service.version)
             {
                 return Err(CarbideError::FailedPrecondition(format!(
-                    "Extension service {} version {} does not exist or is deleted",
+                    "extension service {} version {} does not exist or is deleted",
                     service.service_id, service.version,
                 ))
                 .into());
@@ -1558,7 +1558,7 @@ async fn validate_auto_inband_segment_vpc_bindings(
 
         if vpc.id != requested_vpc_id {
             return Err(CarbideError::FailedPrecondition(format!(
-                "zero-DPU host {} has HostInband segment {} bound to VPC {}, but auto networking requested VPC {}; shared Flat segments must be left unbound",
+                "zero-DPU host {} has HostInband segment {} bound to VPC {}, but auto networking requested VPC {}; shared flat segments must be left unbound",
                 mh_snapshot.host_snapshot.id, segment_id, vpc.id, requested_vpc_id,
             )));
         }
@@ -1693,7 +1693,7 @@ fn snapshot_to_instance(
         .map_err(CarbideError::from)?
         .ok_or_else(|| {
             CarbideError::internal(format!(
-                "Instance on Machine {machine_id} can be converted from snapshot"
+                "instance on machine {machine_id} can be converted from snapshot"
             ))
         })
 }
@@ -1706,7 +1706,7 @@ pub async fn force_delete_instance(
     let instance = db::instance::find_by_id(&api.database_connection, instance_id)
         .await?
         .ok_or_else(|| {
-            CarbideError::internal(format!("Could not find an instance for {instance_id}"))
+            CarbideError::internal(format!("could not find an instance for {instance_id}"))
         })?
         .to_owned();
 

--- a/crates/api-core/src/handlers/instance_type.rs
+++ b/crates/api-core/src/handlers/instance_type.rs
@@ -655,7 +655,7 @@ pub(crate) async fn remove_machine_association(
         && instance.deleted.is_none()
     {
         return Err(CarbideError::FailedPrecondition(format!(
-            "machine {} has instance assigned. This operation is allowed only in terminating state.",
+            "machine {} has instance assigned. this operation is allowed only in terminating state",
             &machine.id
         ))
         .into());

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -429,10 +429,10 @@ pub(crate) async fn admin_force_delete_machine(
         && !request.allow_delete_with_orphaned_dpf_crds
     {
         return Err(CarbideError::FailedPrecondition(format!(
-            "Failed force-delete host {}: DPF was used for ingestion \
-                    but DPF is not configured. Use \
+            "failed force-delete host {}: DPF was used for ingestion \
+                    but DPF is not configured. use \
                     --allow-delete-with-orphaned-dpf-crds to proceed, \
-                    though this will require manual cleanup of DPF CRDs.",
+                    though this will require manual cleanup of DPF CRDs",
             machine.id
         ))
         .into());

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -90,7 +90,7 @@ pub(crate) async fn discover_machine(
     // Generate a stable Machine ID based on the hardware information
     let stable_machine_id = from_hardware_info(&hardware_info).map_err(|e| {
             CarbideError::InvalidArgument(
-                format!("Insufficient HardwareInfo to derive a Stable Machine ID for Machine on InterfaceId {interface_id:?}: {e}"),
+                format!("insufficient HardwareInfo to derive a stable machine ID for machine on InterfaceId {interface_id:?}: {e}"),
             )
         })?;
     log_machine_id(&stable_machine_id);
@@ -137,7 +137,7 @@ pub(crate) async fn discover_machine(
         && api.runtime_config.tpm_required
     {
         return Err(CarbideError::InvalidArgument(format!(
-                "Ignoring DiscoverMachine request for non-tpm enabled host with InterfaceId {interface_id:?}"
+                "ignoring DiscoverMachine request for non-tpm enabled host with InterfaceId {interface_id:?}"
             ))
             .into());
     } else if !hardware_info.is_dpu() && hardware_info.tpm_ek_certificate.is_some() {
@@ -193,7 +193,7 @@ pub(crate) async fn discover_machine(
             .await?
             .ok_or_else(|| {
                 CarbideError::InvalidArgument(format!(
-                    "Machine id {stable_machine_id} was not discovered by site-explorer."
+                    "machine id {stable_machine_id} was not discovered by site-explorer"
                 ))
             })?;
         }
@@ -227,7 +227,7 @@ pub(crate) async fn discover_machine(
             )
             .await?
             .ok_or_else(|| {
-                CarbideError::InvalidArgument(format!("Machine id {stable_machine_id} not found."))
+                CarbideError::InvalidArgument(format!("machine id {stable_machine_id} not found"))
             })?
         };
 

--- a/crates/api-core/src/handlers/machine_identity.rs
+++ b/crates/api-core/src/handlers/machine_identity.rs
@@ -165,7 +165,7 @@ pub(crate) async fn sign_machine_identity(
 
     let machine_id: MachineId = machine_id_str
         .parse()
-        .map_err(|e| CarbideError::InvalidArgument(format!("Invalid machine ID format: {e}")))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("invalid machine ID format: {e}")))?;
 
     let req = request.get_ref();
 

--- a/crates/api-core/src/handlers/machine_interface.rs
+++ b/crates/api-core/src/handlers/machine_interface.rs
@@ -45,7 +45,7 @@ pub(crate) async fn find_interfaces(
                 Some(interface) => vec![interface.into()],
                 None => {
                     return Err(CarbideError::internal(format!(
-                        "No machine interface with IP {ip} was found"
+                        "no machine interface with IP {ip} was found"
                     ))
                     .into());
                 }
@@ -90,12 +90,12 @@ pub(crate) async fn delete_interface(
     if let Some(machine_id) = interface.machine_id {
         if interface.interface_type == InterfaceType::Bmc {
             return Err(CarbideError::InvalidArgument(format!(
-                "This looks like a BMC interface and attached with machine: {machine_id}. Delete that first."
+                "this looks like a BMC interface and attached with machine: {machine_id}. delete that first"
             ))
             .into());
         }
         return Err(CarbideError::InvalidArgument(format!(
-            "Already a machine {machine_id} is attached to this interface. Delete that first."
+            "already a machine {machine_id} is attached to this interface. delete that first"
         ))
         .into());
     }
@@ -108,7 +108,7 @@ pub(crate) async fn delete_interface(
 
         if let Some(machine_id) = machine_id {
             return Err(CarbideError::InvalidArgument(format!(
-                "This looks like a BMC interface and attached with machine: {machine_id}. Delete that first."
+                "this looks like a BMC interface and attached with machine: {machine_id}. delete that first"
             ))
             .into());
         }
@@ -134,7 +134,7 @@ pub(crate) async fn find_mac_address_by_bmc_ip(
         &api.database_connection,
         bmc_ip
             .parse()
-            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid IP address: {e}")))?,
+            .map_err(|e| CarbideError::InvalidArgument(format!("invalid IP address: {e}")))?,
     )
     .await?
     .ok_or_else(|| CarbideError::NotFoundError {
@@ -163,7 +163,7 @@ pub(crate) async fn find_bmc_ips(
             db::machine_interface::lookup_bmc_ip_by_mac_address(
                 &api.database_connection,
                 mac_address.parse().map_err(|e| {
-                    CarbideError::InvalidArgument(format!("Invalid MAC address: {e}"))
+                    CarbideError::InvalidArgument(format!("invalid MAC address: {e}"))
                 })?,
             )
             .await?

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -668,7 +668,7 @@ pub(crate) async fn on_demand_machine_validation(
             )
             .await?
             .ok_or_else(|| {
-                CarbideError::InvalidArgument(format!("Machine id {machine_id} not found."))
+                CarbideError::InvalidArgument(format!("machine id {machine_id} not found"))
             })?;
             if machine
                 .on_demand_machine_validation_request

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -63,7 +63,7 @@ pub(crate) async fn set_primary_dpu(
             })?;
     if !snapshot.has_managed_dpus() {
         return Err(CarbideError::FailedPrecondition(format!(
-            "Host {host_machine_id} has no DPUs; set-primary-dpu does not apply to zero-DPU hosts."
+            "host {host_machine_id} has no DPUs; set-primary-dpu does not apply to zero-DPU hosts"
         ))
         .into());
     }
@@ -145,7 +145,7 @@ async fn set_primary_interface_core(
     // host id here, so this guards both entry points.
     if !host_machine_id.machine_type().is_host() {
         return Err(CarbideError::InvalidArgument(format!(
-            "Machine {host_machine_id} is not a host machine; set-primary-interface can \
+            "machine {host_machine_id} is not a host machine; set-primary-interface can \
              only promote an interface on a host"
         ))
         .into());
@@ -183,7 +183,7 @@ async fn set_primary_interface_core(
 
     let new_primary_interface = new_primary_interface.ok_or_else(|| {
         CarbideError::InvalidArgument(format!(
-            "Interface {new_primary_interface_id} not found on host {host_machine_id}"
+            "interface {new_primary_interface_id} not found on host {host_machine_id}"
         ))
     })?;
     if new_primary_interface.primary_interface {
@@ -210,8 +210,8 @@ async fn set_primary_interface_core(
         && new_primary_interface.network_segment_type != Some(NetworkSegmentType::Admin)
     {
         return Err(CarbideError::InvalidArgument(format!(
-            "Interface {new_primary_interface_id} is not on the Admin segment; a \
-             DPU-managed host's primary interface must be an Admin interface"
+            "interface {new_primary_interface_id} is not on the admin segment; a \
+             DPU-managed host's primary interface must be an admin interface"
         ))
         .into());
     }
@@ -431,7 +431,7 @@ pub(crate) async fn set_maintenance(
             for dpu_machine in dpu_machines.iter() {
                 if dpu_machine.reprovision_requested.is_some() {
                     return Err(CarbideError::InvalidArgument(format!(
-                        "Reprovisioning request is set on DPU: {}. Clear it first.",
+                        "reprovisioning request is set on DPU: {}. clear it first",
                         &dpu_machine.id
                     ))
                     .into());

--- a/crates/api-core/src/handlers/network_security_group.rs
+++ b/crates/api-core/src/handlers/network_security_group.rs
@@ -450,7 +450,7 @@ pub(crate) async fn delete(
 
     if nsg.tenant_organization_id != tenant_organization_id {
         return Err(CarbideError::InvalidArgument(format!(
-            "NetworkSecurityGroup `{}` is not owned by Tenant `{}`",
+            "NetworkSecurityGroup `{}` is not owned by tenant `{}`",
             nsg.id.clone(),
             tenant_organization_id.clone()
         ))

--- a/crates/api-core/src/handlers/network_segment.rs
+++ b/crates/api-core/src/handlers/network_segment.rs
@@ -141,7 +141,7 @@ pub(crate) async fn create(
 
         let vpc = vpcs
             .first()
-            .ok_or_else(|| CarbideError::internal(format!("VPC ID: {vpc_id} not found.")))?;
+            .ok_or_else(|| CarbideError::internal(format!("VPC ID: {vpc_id} not found")))?;
 
         let virtualization_type = vpc.config.network_virtualization_type;
 
@@ -208,7 +208,7 @@ pub(crate) async fn attach_to_vpc(
 
     if segment.config.segment_type != NetworkSegmentType::HostInband {
         return Err(CarbideError::InvalidArgument(format!(
-            "Only host_inband network segments can be attached to a VPC with this API, got {}",
+            "only host_inband network segments can be attached to a VPC with this API, got {}",
             segment.config.segment_type
         ))
         .into());
@@ -223,7 +223,7 @@ pub(crate) async fn attach_to_vpc(
         Some(current_vpc_id) if current_vpc_id == vpc_id => segment,
         Some(current_vpc_id) if !allow_replace => {
             return Err(CarbideError::FailedPrecondition(format!(
-                "Network segment {} is already attached to VPC {}",
+                "network segment {} is already attached to VPC {}",
                 segment.id, current_vpc_id
             ))
             .into());

--- a/crates/api-core/src/handlers/nmxc_browse.rs
+++ b/crates/api-core/src/handlers/nmxc_browse.rs
@@ -184,7 +184,7 @@ pub(crate) async fn nmxc_browse(
 
         nmxc.hello(NMX_C_GATEWAY_ID)
             .await
-            .map_err(|e| CarbideError::internal(format!("Failed to call NMX-C hello: {e}")))?;
+            .map_err(|e| CarbideError::internal(format!("failed to call NMX-C hello: {e}")))?;
 
         let result = match op {
             rpc::NmxcBrowseOperation::Unspecified => Err(CarbideError::InvalidArgument(

--- a/crates/api-core/src/handlers/power_options.rs
+++ b/crates/api-core/src/handlers/power_options.rs
@@ -117,7 +117,7 @@ pub(crate) async fn update_power_option(
     let desired_power_state = desired_power_state.into();
     if desired_power_state == current_power_options.desired_power_state {
         return Err(CarbideError::InvalidArgument(format!(
-            "Power State is already set as {desired_power_state:?}. No change is performed."
+            "power state is already set as {desired_power_state:?}. no change is performed"
         ))
         .into());
     }

--- a/crates/api-core/src/handlers/pxe.rs
+++ b/crates/api-core/src/handlers/pxe.rs
@@ -95,7 +95,7 @@ pub(crate) async fn get_cloud_init_instructions(
     let ip_str = &request.into_inner().ip;
     let ip: IpAddr = ip_str
         .parse()
-        .map_err(|e| CarbideError::InvalidArgument(format!("Failed parsing IP '{ip_str}': {e}")))?;
+        .map_err(|e| CarbideError::InvalidArgument(format!("failed parsing IP '{ip_str}': {e}")))?;
 
     // Note that this code path supports IPv6 at the *API layer*, but won't be
     // able to be exercised until DHCPv6 is working, which is a whole other thing
@@ -105,7 +105,7 @@ pub(crate) async fn get_cloud_init_instructions(
     // dual stacking interfaces, none of that means much until DHCPv6 is working
     // to actually hand those addresses out.
     let mut conn = api.database_connection.acquire().await.map_err(|e| {
-        CarbideError::internal(format!("Failed to acquire database connection: {e}"))
+        CarbideError::internal(format!("failed to acquire database connection: {e}"))
     })?;
     let instructions = resolve_cloud_init_instructions(api, &mut conn, ip).await?;
 

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -54,7 +54,7 @@ pub async fn get_rack(
 
     let racks = if let Some(id) = req.id {
         let rack_id = RackId::from_str(&id)
-            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
+            .map_err(|e| CarbideError::InvalidArgument(format!("invalid rack ID: {}", e)))?;
         db_rack::find_by(
             reader.as_mut(),
             ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
@@ -185,7 +185,7 @@ pub async fn delete_rack(
     api.with_txn(|txn| {
         async move {
             let rack_id = RackId::from_str(&req.id)
-                .map_err(|e| CarbideError::InvalidArgument(format!("Invalid rack ID: {}", e)))?;
+                .map_err(|e| CarbideError::InvalidArgument(format!("invalid rack ID: {}", e)))?;
             let _rack = db_rack::find_by(
                 txn.as_mut(),
                 ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
@@ -567,7 +567,7 @@ pub(crate) async fn on_demand_rack_maintenance(
         RackState::Ready | RackState::Error { .. }
     ) {
         return Err(CarbideError::InvalidArgument(format!(
-            "Rack {} is not in Ready or Error state (current: {:?}). Maintenance can only be requested when the rack is Ready or in Error.",
+            "rack {} is not in ready or error state (current: {:?}). maintenance can only be requested when the rack is ready or in error",
             rack_id, *rack.controller_state
         ))
         .into());
@@ -575,7 +575,7 @@ pub(crate) async fn on_demand_rack_maintenance(
 
     if rack.config.maintenance_requested.is_some() {
         return Err(CarbideError::InvalidArgument(format!(
-            "On-demand maintenance for rack {} is already scheduled.",
+            "on-demand maintenance for rack {} is already scheduled",
             rack_id,
         ))
         .into());
@@ -653,19 +653,19 @@ pub(crate) async fn on_demand_rack_maintenance(
             .iter()
             .map(|s| MachineId::from_str(s))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid machine_id: {e}")))?,
+            .map_err(|e| CarbideError::InvalidArgument(format!("invalid machine_id: {e}")))?,
         switch_ids: proto_scope
             .switch_ids
             .iter()
             .map(|s| SwitchId::from_str(s))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid switch_id: {e}")))?,
+            .map_err(|e| CarbideError::InvalidArgument(format!("invalid switch_id: {e}")))?,
         power_shelf_ids: proto_scope
             .power_shelf_ids
             .iter()
             .map(|s| PowerShelfId::from_str(s))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| CarbideError::InvalidArgument(format!("Invalid power_shelf_id: {e}")))?,
+            .map_err(|e| CarbideError::InvalidArgument(format!("invalid power_shelf_id: {e}")))?,
         activities,
     };
 

--- a/crates/api-core/src/handlers/redfish.rs
+++ b/crates/api-core/src/handlers/redfish.rs
@@ -50,7 +50,7 @@ pub async fn redfish_browse(
     let uri: http::Uri = match request.uri.clone().parse() {
         Ok(uri) => uri,
         Err(err) => {
-            return Err(CarbideError::internal(format!("Parsing uri failed: {err}")).into());
+            return Err(CarbideError::internal(format!("parsing uri failed: {err}")).into());
         }
     };
 
@@ -71,7 +71,7 @@ pub async fn redfish_browse(
     {
         Ok(response) => response,
         Err(e) => {
-            return Err(CarbideError::internal(format!("Http request failed: {e:?}")).into());
+            return Err(CarbideError::internal(format!("http request failed: {e:?}")).into());
         }
     };
 
@@ -89,7 +89,7 @@ pub async fn redfish_browse(
     let status = response.status();
     let text = response.text().await.map_err(|e| {
         CarbideError::internal(format!(
-            "Error reading response body: {e}, Status: {status}"
+            "error reading response body: {e}, status: {status}"
         ))
     })?;
 
@@ -464,7 +464,7 @@ pub(crate) async fn create_client(
             Err(err) => {
                 tracing::error!(error = %err, "build_http_client");
                 return Err(CarbideError::internal(format!(
-                    "Http building failed: {err}"
+                    "http building failed: {err}"
                 )));
             }
         };

--- a/crates/api-core/src/handlers/site_explorer.rs
+++ b/crates/api-core/src/handlers/site_explorer.rs
@@ -377,7 +377,7 @@ pub(crate) async fn refresh_endpoint_report(
         Some(guard) => guard,
         None => {
             return Err(CarbideError::AlreadyInProgress(format!(
-                "Endpoint refresh already in progress for {bmc_ip}"
+                "endpoint refresh already in progress for {bmc_ip}"
             ))
             .into());
         }
@@ -455,7 +455,7 @@ pub(crate) async fn refresh_endpoint_report(
 
         let ep = endpoints.into_iter().next().ok_or_else(|| {
             tonic::Status::from(CarbideError::internal(format!(
-                "Endpoint {bmc_ip} not found after update"
+                "endpoint {bmc_ip} not found after update"
             )))
         })?;
 
@@ -500,7 +500,7 @@ pub(crate) async fn pause_explored_endpoint_remediation(
 
     if in_managed_host {
         return Err(CarbideError::InvalidArgument(format!(
-            "Cannot pause/resume remediation for endpoint {bmc_ip} because a machine exists for it"
+            "cannot pause/resume remediation for endpoint {bmc_ip} because a machine exists for it"
         ))
         .into());
     }
@@ -527,7 +527,7 @@ pub(crate) async fn is_bmc_in_managed_host(
     let mut addrs = lookup_host(address).await?;
     let Some(bmc_addr) = addrs.next() else {
         return Err(CarbideError::InvalidArgument(format!(
-            "Could not resolve {}. Must be hostname[:port] or IPv4[:port]",
+            "could not resolve {}. must be hostname[:port] or IPv4[:port]",
             req.ip_address
         ))
         .into());
@@ -572,7 +572,7 @@ pub(crate) async fn delete_explored_endpoint(
 
     if in_managed_host {
         return Err(CarbideError::InvalidArgument(format!(
-            "Cannot delete endpoint {bmc_ip} because a machine exists for it. Did you mean to force-delete the machine?"
+            "cannot delete endpoint {bmc_ip} because a machine exists for it. did you mean to force-delete the machine?"
         ))
         .into());
     }

--- a/crates/api-core/src/handlers/sku.rs
+++ b/crates/api-core/src/handlers/sku.rs
@@ -56,7 +56,7 @@ pub(crate) async fn delete(api: &Api, request: Request<SkuIdList>) -> Result<Res
 
     let Some(sku) = skus.pop() else {
         return Err(CarbideError::InvalidArgument(format!(
-            "The SKU {} does not exist",
+            "the SKU {} does not exist",
             sku_id_list
                 .first()
                 .map(|id| id.to_string())
@@ -76,7 +76,7 @@ pub(crate) async fn delete(api: &Api, request: Request<SkuIdList>) -> Result<Res
         .unwrap_or(0);
     if machines_using_sku > 0 {
         return Err(CarbideError::InvalidArgument(format!(
-            "The SKU is in use by {machines_using_sku} machines"
+            "the SKU is in use by {machines_using_sku} machines"
         ))
         .into());
     }
@@ -121,7 +121,7 @@ pub(crate) async fn assign_to_machine(
     if !sku_machine_pair.force {
         if let Some(assigned_sku) = machine.hw_sku {
             return Err(CarbideError::FailedPrecondition(format!(
-                "The specified machine already has a SKU assigned ({assigned_sku})"
+                "the specified machine already has a SKU assigned ({assigned_sku})"
             ))
             .into());
         }
@@ -155,7 +155,7 @@ pub(crate) async fn assign_to_machine(
 
     if !skus.is_empty() {
         return Err(CarbideError::internal(format!(
-            "Unexpected additional SKUs found for ID: {}",
+            "unexpected additional SKUs found for ID: {}",
             sku_machine_pair.sku_id.clone()
         ))
         .into());

--- a/crates/api-core/src/handlers/uefi.rs
+++ b/crates/api-core/src/handlers/uefi.rs
@@ -259,7 +259,7 @@ pub(crate) async fn clear_host_uefi_password(
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to run clear_host_uefi_password call");
             CarbideError::internal(format!(
-                "Failed redfish clear_host_uefi_password subtask: {e}"
+                "failed redfish clear_host_uefi_password subtask: {e}"
             ))
         })?;
 
@@ -369,7 +369,7 @@ pub(crate) async fn set_host_uefi_password(
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to run uefi_setup call");
-            CarbideError::internal(format!("Failed redfish uefi_setup subtask: {e}"))
+            CarbideError::internal(format!("failed redfish uefi_setup subtask: {e}"))
         })?;
     // uefi_setup returns a BMC job_id; the password change completes
     // asynchronously on the device and we do not poll it here. We optimistically

--- a/crates/api-core/src/handlers/vpc.rs
+++ b/crates/api-core/src/handlers/vpc.rs
@@ -91,7 +91,7 @@ pub(crate) async fn create(
         .is_none()
         {
             return Err(CarbideError::FailedPrecondition(format!(
-                "NetworkSecurityGroup `{}` does not exist or is not owned by Tenant `{}`",
+                "NetworkSecurityGroup `{}` does not exist or is not owned by tenant `{}`",
                 id, vpc_creation_request.tenant_organization_id,
             ))
             .into());
@@ -203,7 +203,7 @@ pub(crate) async fn update(
         .is_none()
         {
             return Err(CarbideError::FailedPrecondition(format!(
-                "NetworkSecurityGroup `{}` does not exist or is not owned by Tenant `{}`",
+                "NetworkSecurityGroup `{}` does not exist or is not owned by tenant `{}`",
                 id, vpc.config.tenant_organization_id
             ))
             .into());

--- a/crates/api-core/src/handlers/vpc_prefix.rs
+++ b/crates/api-core/src/handlers/vpc_prefix.rs
@@ -56,7 +56,7 @@ pub async fn create(
         let prefix = new_prefix.config.prefix;
         if !site_prefixes.contains(prefix) {
             return Err(CarbideError::InvalidArgument(format!(
-                "The VPC prefix {prefix} is not contained within the site fabric prefixes"
+                "the VPC prefix {prefix} is not contained within the site fabric prefixes"
             ))
             .into());
         }
@@ -190,7 +190,7 @@ pub async fn create(
     .await?
     .pop()
     .ok_or_else(|| {
-        CarbideError::internal(format!("Created VPC prefix {vpc_prefix_id} was not found"))
+        CarbideError::internal(format!("created VPC prefix {vpc_prefix_id} was not found"))
     })?;
 
     txn.commit().await?;
@@ -232,7 +232,7 @@ pub async fn search(
                 .ok_or_else(|| CarbideError::MissingArgument("prefix_match_type"))?;
             let prefix_match_type = PrefixMatchType::try_from(prefix_match_type).map_err(|_e| {
                 CarbideError::InvalidArgument(format!(
-                    "Unknown PrefixMatchType value: {prefix_match_type}"
+                    "unknown PrefixMatchType value: {prefix_match_type}"
                 ))
             })?;
             use model::vpc_prefix::PrefixMatch;

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -103,14 +103,14 @@ async fn validate_zero_dpu_auto_vpc(
 
     if vpc.config.tenant_organization_id != tenant_organization_id.to_string() {
         return Err(CarbideError::FailedPrecondition(format!(
-            "VPC `{}` is not owned by Tenant `{}`",
+            "VPC `{}` is not owned by tenant `{}`",
             vpc.id, tenant_organization_id
         )));
     }
 
     if vpc.config.network_virtualization_type != VpcVirtualizationType::Flat {
         return Err(CarbideError::FailedPrecondition(format!(
-            "zero-DPU auto allocation requires a Flat VPC; VPC {} uses {}",
+            "zero-DPU auto allocation requires a flat VPC; VPC {} uses {}",
             vpc.id, vpc.config.network_virtualization_type
         )));
     }
@@ -142,19 +142,19 @@ pub async fn validate_os_definition_usable(
     };
     let row = db::operating_system::get(txn, os_id).await.map_err(|e| {
         if e.is_not_found() {
-            CarbideError::FailedPrecondition(format!("Operating system `{os_id}` does not exist"))
+            CarbideError::FailedPrecondition(format!("operating system `{os_id}` does not exist"))
         } else {
-            CarbideError::internal(format!("Failed to get operating system: {e}"))
+            CarbideError::internal(format!("failed to get operating system: {e}"))
         }
     })?;
     if !row.is_active {
         return Err(CarbideError::FailedPrecondition(format!(
-            "Operating system `{os_id}` is not active"
+            "operating system `{os_id}` is not active"
         )));
     }
     if row.status != db::operating_system::OS_STATUS_READY {
         return Err(CarbideError::FailedPrecondition(format!(
-            "Operating system `{os_id}` is not ready (status: {})",
+            "operating system `{os_id}` is not ready (status: {})",
             row.status
         )));
     }
@@ -326,7 +326,7 @@ pub async fn allocate_network(
                         .map(|vpc| (vpc.vpc_id, vpc.config.prefix, vpc.status.last_used_prefix))
                         .ok_or_else(|| {
                             CarbideError::internal(format!(
-                                "Unknown VPC prefix id: {vpc_prefix_id}"
+                                "unknown VPC prefix id: {vpc_prefix_id}"
                             ))
                         })?
                 };
@@ -372,7 +372,7 @@ pub async fn allocate_network(
                             .map(|vpc| (vpc.vpc_id, vpc.config.prefix, vpc.status.last_used_prefix))
                             .ok_or_else(|| {
                                 CarbideError::internal(format!(
-                                    "Unknown VPC prefix id: {v6_prefix_id}"
+                                    "unknown VPC prefix id: {v6_prefix_id}"
                                 ))
                             })?
                     };
@@ -451,7 +451,7 @@ pub fn allocate_ib_port_guid(
         // TOTO: will support VF in the future. Currently, it will return err when the function_id is not PF.
         if let InterfaceFunctionId::Virtual { .. } = request.function_id {
             return Err(CarbideError::InvalidArgument(format!(
-                "Not support VF {} (machine {})",
+                "not support VF {} (machine {})",
                 request.device, machine.id
             )));
         }
@@ -494,7 +494,7 @@ pub fn allocate_ib_port_guid(
             }
         } else {
             return Err(CarbideError::InvalidArgument(format!(
-                "Infiniband status information is not found (machine {})",
+                "infiniband status information is not found (machine {})",
                 machine.id
             )));
         }
@@ -574,7 +574,7 @@ pub async fn batch_allocate_instances(
         // Validate machine type
         if !request.machine_id.machine_type().is_host() {
             return Err(CarbideError::InvalidArgument(format!(
-                "Machine with UUID {} is of type {} and can not be converted into an instance",
+                "machine with UUID {} is of type {} and can not be converted into an instance",
                 request.machine_id,
                 request.machine_id.machine_type()
             )));
@@ -742,15 +742,15 @@ pub async fn batch_allocate_instances(
             );
             return Err(match e {
                 NotAllocatableReason::InvalidState(s) => CarbideError::InvalidArgument(format!(
-                    "Could not create instance on machine {machine_id} given machine state {s:?}"
+                    "could not create instance on machine {machine_id} given machine state {s:?}"
                 )),
                 NotAllocatableReason::PendingInstanceCreation => {
                     CarbideError::InvalidArgument(format!(
-                        "Could not create instance on machine {machine_id}. Machine is already used by another Instance creation request.",
+                        "could not create instance on machine {machine_id}. machine is already used by another instance creation request",
                     ))
                 }
                 NotAllocatableReason::NoDpuSnapshots => CarbideError::internal(format!(
-                    "Machine {machine_id} has no DPU. Cannot allocate."
+                    "machine {machine_id} has no DPU. cannot allocate"
                 )),
                 NotAllocatableReason::MaintenanceMode => CarbideError::MaintenanceMode,
                 NotAllocatableReason::HealthAlert(_) => CarbideError::UnhealthyHost,
@@ -784,7 +784,7 @@ pub async fn batch_allocate_instances(
         .is_none()
         {
             return Err(CarbideError::FailedPrecondition(format!(
-                "NetworkSecurityGroup `{}` does not exist or is not owned by Tenant `{}`",
+                "NetworkSecurityGroup `{}` does not exist or is not owned by tenant `{}`",
                 nsg_id, tenant_org_id
             )));
         }
@@ -809,7 +809,7 @@ pub async fn batch_allocate_instances(
             let unique_service_ids: HashSet<_> = service_ids.iter().collect();
             if service_ids.len() != unique_service_ids.len() {
                 return Err(CarbideError::InvalidArgument(format!(
-                    "Duplicate extension services in configuration. Only one version of each service is allowed. (machine {})",
+                    "duplicate extension services in configuration. only one version of each service is allowed. (machine {})",
                     request.machine_id
                 )));
             }
@@ -832,7 +832,7 @@ pub async fn batch_allocate_instances(
         for service in all_service_configs {
             if !services.contains_key(&service.service_id) {
                 return Err(CarbideError::FailedPrecondition(format!(
-                    "Extension service {} does not exist",
+                    "extension service {} does not exist",
                     service.service_id,
                 )));
             }
@@ -842,7 +842,7 @@ pub async fn batch_allocate_instances(
                 .contains(&service.version)
             {
                 return Err(CarbideError::FailedPrecondition(format!(
-                    "Extension service {} version {} does not exist or is deleted",
+                    "extension service {} version {} does not exist or is deleted",
                     service.service_id, service.version,
                 )));
             }
@@ -871,12 +871,12 @@ pub async fn batch_allocate_instances(
         if let Err(e) = db::os_image::get(&mut txn, *os_image_id).await {
             return if e.is_not_found() {
                 Err(CarbideError::FailedPrecondition(format!(
-                    "Image OS `{}` does not exist",
+                    "image OS `{}` does not exist",
                     os_image_id
                 )))
             } else {
                 Err(CarbideError::internal(format!(
-                    "Failed to get OS image error: {e}"
+                    "failed to get OS image error: {e}"
                 )))
             };
         }
@@ -998,7 +998,7 @@ pub async fn batch_allocate_instances(
                     && !allowed_segment_ids.contains(&ns_id)
                 {
                     return Err(CarbideError::InvalidArgument(format!(
-                        "zero-DPU host {} cannot serve an instance interface on network segment {ns_id}. must be a HostInband segment only (allowed: {allowed_segment_ids:?}).",
+                        "zero-DPU host {} cannot serve an instance interface on network segment {ns_id}. must be a HostInband segment only (allowed: {allowed_segment_ids:?})",
                         mh_snapshot.host_snapshot.id,
                     )));
                 }
@@ -1011,7 +1011,7 @@ pub async fn batch_allocate_instances(
                 if let Some(vpc) = db::vpc::find_by_segment(&mut txn, *segment_id).await? {
                     if vpc.id != requested_auto_config.vpc_id {
                         return Err(CarbideError::FailedPrecondition(format!(
-                            "zero-DPU host {} has HostInband segment {} bound to VPC {}, but allocation requested VPC {}; shared Flat segments must be left unbound",
+                            "zero-DPU host {} has HostInband segment {} bound to VPC {}, but allocation requested VPC {}; shared flat segments must be left unbound",
                             mh_snapshot.host_snapshot.id,
                             segment_id,
                             vpc.id,
@@ -1039,7 +1039,7 @@ pub async fn batch_allocate_instances(
             // would just report "Unknown" forever.
             if !request.config.extension_services.service_configs.is_empty() {
                 return Err(CarbideError::InvalidArgument(format!(
-                    "zero-DPU host {} cannot serve extension services; remove `dpu_extension_services` from the instance config.",
+                    "zero-DPU host {} cannot serve extension services; remove `dpu_extension_services` from the instance config",
                     mh_snapshot.host_snapshot.id,
                 )));
             }
@@ -1238,7 +1238,7 @@ pub async fn batch_allocate_instances(
         let machine_id = request.machine_id;
         mh_snapshot.instance = Some(final_instance_map.remove(&machine_id).ok_or_else(|| {
             CarbideError::internal(format!(
-                "Newly created instance for {machine_id} was not found"
+                "newly created instance for {machine_id} was not found"
             ))
         })?);
         snapshots.push(mh_snapshot);
@@ -1299,7 +1299,7 @@ pub async fn batch_validate_spx_partition_ownership(
                 "SPX partition is not owned by the tenant",
             );
             return Err(CarbideError::InvalidArgument(format!(
-                "SPX Partition {partition_id} is not owned by the tenant {expected_tenant}",
+                "SPX partition {partition_id} is not owned by the tenant {expected_tenant}",
             )));
         }
     }
@@ -1341,7 +1341,7 @@ pub async fn batch_validate_ib_partition_ownership(
 
         if &partition.config.tenant_organization_id != *expected_tenant {
             return Err(CarbideError::InvalidArgument(format!(
-                "IB Partition {partition_id} is not owned by the tenant {expected_tenant}",
+                "IB partition {partition_id} is not owned by the tenant {expected_tenant}",
             )));
         }
     }
@@ -1479,7 +1479,7 @@ pub fn allocate_spx_port_mac(
                 "SPX device not found",
             );
             return Err(CarbideError::InvalidArgument(format!(
-                "No SPX device with name {} in machine {}",
+                "no SPX device with name {} in machine {}",
                 spx_attachment.device, mh_snapshot.host_snapshot.id,
             )));
         }

--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -269,7 +269,7 @@ impl PxeInstructions {
 
         renderer
             .render(ipxeos, &reserved_params)
-            .map_err(|e| CarbideError::internal(format!("Failed to render iPXE script: {}", e)))
+            .map_err(|e| CarbideError::internal(format!("failed to render iPXE script: {}", e)))
     }
 
     pub async fn get_pxe_instructions(
@@ -391,7 +391,7 @@ exit ||
 
         let machine = db::machine::find_one(&mut *txn, &machine_id, MachineSearchConfig::default())
             .await
-            .map_err(|e| CarbideError::InvalidArgument(format!("Get machine failed, Error: {e}")))?
+            .map_err(|e| CarbideError::InvalidArgument(format!("get machine failed, error: {e}")))?
             .ok_or(CarbideError::InvalidArgument(
                 "invalid machine id. not found in db".to_string(),
             ))?;

--- a/crates/api-core/src/measured_boot/rpc/journal.rs
+++ b/crates/api-core/src/measured_boot/rpc/journal.rs
@@ -84,7 +84,7 @@ pub async fn handle_show_measurement_journal(
                 match db::measured_boot::journal::get_latest_journal_for_id(
                     &mut txn,
                     MachineId::from_str(&machine_id).map_err(|e| {
-                        CarbideError::InvalidArgument(format!("Could not parse MachineId: {e}"))
+                        CarbideError::InvalidArgument(format!("could not parse MachineId: {e}"))
                     })?,
                 )
                 .await

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1052,7 +1052,7 @@ async fn initialize_and_start_controllers<'a>(
         tracing::debug!(path = path_used, "Loading expected_machines.json");
         let file_str = tokio::fs::read_to_string(path_used)
             .await
-            .wrap_err_with(|| format!("Failed to read {path_used}"))?;
+            .wrap_err_with(|| format!("failed to read {path_used}"))?;
         let expected_machines = serde_json::from_str::<Vec<ExpectedMachine>>(file_str.as_str()).inspect_err(|err| {
                 tracing::error!(
                     error = %err,

--- a/crates/api-core/src/tests/expected_rack.rs
+++ b/crates/api-core/src/tests/expected_rack.rs
@@ -156,7 +156,7 @@ async fn test_add_expected_rack_invalid_type(pool: sqlx::PgPool) {
         .unwrap_err();
 
     assert!(
-        err.message().contains("Unknown rack_profile_id"),
+        err.message().contains("unknown rack_profile_id"),
         "Expected error about unknown rack_profile_id, got: {}",
         err.message()
     );

--- a/crates/api-core/src/tests/ib_instance.rs
+++ b/crates/api-core/src/tests/ib_instance.rs
@@ -460,7 +460,7 @@ async fn test_can_not_create_instance_with_inconsistent_tenant(pool: sqlx::PgPoo
 
     let error = result.expect_err("expected allocation to fail").to_string();
     let expected_err =
-        format!("IB Partition {ib_partition_id} is not owned by the tenant {DEFAULT_TENANT}",);
+        format!("IB partition {ib_partition_id} is not owned by the tenant {DEFAULT_TENANT}",);
     assert!(
         error.contains(&expected_err),
         "Error message should contain '{expected_err}', but is {error}"

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -6528,7 +6528,7 @@ async fn test_allocate_instance_with_duplicate_extension_services(
     assert!(instance.is_err());
     let err = instance.unwrap_err();
     assert!(err.message().starts_with(
-        "Duplicate extension services in configuration. Only one version of each service is allowed"
+        "duplicate extension services in configuration. only one version of each service is allowed"
     ));
 
     Ok(())

--- a/crates/api-core/src/tests/instance_allocate.rs
+++ b/crates/api-core/src/tests/instance_allocate.rs
@@ -613,7 +613,7 @@ async fn test_zero_dpu_auto_update_rejects_host_inband_segment_bound_to_differen
     assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     assert!(
         err.message()
-            .contains("shared Flat segments must be left unbound"),
+            .contains("shared flat segments must be left unbound"),
         "unexpected error message: {}",
         err.message()
     );
@@ -792,7 +792,7 @@ async fn test_zero_dpu_instance_allocation_rejects_non_flat_vpc_id(
     let err = result.expect_err("zero-DPU auto allocation into non-Flat VPC must be rejected");
     assert_eq!(err.code(), tonic::Code::FailedPrecondition, "got: {err}");
     assert!(
-        err.message().contains("Flat"),
+        err.message().contains("flat"),
         "error should mention Flat VPC requirement, got: {}",
         err.message()
     );

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -133,7 +133,7 @@ async fn test_reject_host_machine_with_disabled_tpm(
     let err = response.expect_err("Expected DiscoverMachine request to fail");
     assert!(
         err.to_string()
-            .contains("Ignoring DiscoverMachine request for non-tpm enabled host")
+            .contains("ignoring DiscoverMachine request for non-tpm enabled host")
     );
 
     // We shouldn't have created any machine

--- a/crates/api-core/src/tests/machine_interfaces.rs
+++ b/crates/api-core/src/tests/machine_interfaces.rs
@@ -812,7 +812,7 @@ async fn test_delete_interface_with_machine(
             match c {
                 Code::InvalidArgument => {
                     let msg = String::from(x.message());
-                    if !msg.contains("Already a machine") {
+                    if !msg.contains("already a machine") {
                         panic!("machine interface deletion failed with wrong message {msg}");
                     }
                     return Ok(());
@@ -862,7 +862,7 @@ async fn test_delete_bmc_interface_with_machine(
             match c {
                 Code::InvalidArgument => {
                     let msg = String::from(x.message());
-                    if !msg.contains("This looks like a BMC interface and attached") {
+                    if !msg.contains("this looks like a BMC interface and attached") {
                         panic!("machine interface deletion failed with wrong message {msg}");
                     }
                     return Ok(());

--- a/crates/api-core/src/tests/measured_boot.rs
+++ b/crates/api-core/src/tests/measured_boot.rs
@@ -227,7 +227,7 @@ pub mod tests {
                 assert_eq!(e.code(), Code::Internal);
                 assert_eq!(
                     e.message(),
-                    "attest quote error: Could not unmarshal AK Pub: response code not recognized"
+                    "attest quote error: could not unmarshal AK pub: response code not recognized"
                 );
             }
         }
@@ -260,7 +260,7 @@ pub mod tests {
                 assert_eq!(e.code(), Code::Internal);
                 assert_eq!(
                     e.message(),
-                    "attest quote error: Could not unmarshall Attest struct: not currently used"
+                    "attest quote error: could not unmarshall attest struct: not currently used"
                 );
             }
         }
@@ -293,7 +293,7 @@ pub mod tests {
                 assert_eq!(e.code(), Code::Internal);
                 assert_eq!(
                     e.message(),
-                    "attest quote error: Could not unmarshall Signature struct: response code not recognized"
+                    "attest quote error: could not unmarshall signature struct: response code not recognized"
                 );
             }
         }
@@ -482,7 +482,7 @@ pub mod tests {
             }
             Err(e) => match e {
                 AttestBindKeyError(d) => {
-                    assert_eq!(d, "Could not unmarshall EK: response code not recognized")
+                    assert_eq!(d, "could not unmarshall EK: response code not recognized")
                 }
                 _another_error => panic!("Failed: incorrect error type: {_another_error:?}"),
             },
@@ -559,7 +559,7 @@ pub mod tests {
                 AttestBindKeyError(d) => {
                     assert_eq!(
                         d,
-                        "Could not create RsaPublicKey from TPM's EK Pub: invalid modulus"
+                        "could not create RsaPublicKey from TPM's EK pub: invalid modulus"
                     )
                 }
                 _another_error => panic!("Failed: incorrect error type: {_another_error:?}"),
@@ -588,7 +588,7 @@ pub mod tests {
                 AttestBindKeyError(d) => {
                     assert_eq!(
                         d,
-                        "Could not unmarshall EK Cert: Parsing Error: NomError(Eof)"
+                        "could not unmarshall EK cert: Parsing Error: NomError(Eof)"
                     )
                 }
                 _another_error => panic!("Failed: incorrect error type: {_another_error:?}"),
@@ -756,7 +756,7 @@ pub mod tests {
             }
             Err(e) => match e {
                 AttestQuoteError(d) => {
-                    assert_eq!(d, "Could not create RsaPublicKey: invalid modulus")
+                    assert_eq!(d, "could not create RsaPublicKey: invalid modulus")
                 }
                 _another_error => panic!("Failed: incorrect error type: {_another_error:?}"),
             },

--- a/crates/api-core/src/tests/set_primary_interface.rs
+++ b/crates/api-core/src/tests/set_primary_interface.rs
@@ -253,7 +253,7 @@ async fn test_set_primary_interface_rejects_non_admin_interface_on_dpu_host(
         err.message(),
     );
     assert!(
-        err.message().contains("Admin segment"),
+        err.message().contains("admin segment"),
         "expected the Admin-segment guard message, got: {}",
         err.message(),
     );

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -594,7 +594,7 @@ async fn test_delete_explored_endpoint(pool: PgPool) -> Result<(), Box<dyn std::
     assert_eq!(
         error.message(),
         format!(
-            "Cannot delete endpoint {host_ip} because a machine exists for it. Did you mean to force-delete the machine?"
+            "cannot delete endpoint {host_ip} because a machine exists for it. did you mean to force-delete the machine?"
         )
     );
 
@@ -611,7 +611,7 @@ async fn test_delete_explored_endpoint(pool: PgPool) -> Result<(), Box<dyn std::
     assert_eq!(
         error.message(),
         format!(
-            "Cannot delete endpoint {dpu_ip} because a machine exists for it. Did you mean to force-delete the machine?"
+            "cannot delete endpoint {dpu_ip} because a machine exists for it. did you mean to force-delete the machine?"
         )
     );
 

--- a/crates/api-core/src/tests/tpm_ca.rs
+++ b/crates/api-core/src/tests/tpm_ca.rs
@@ -49,7 +49,7 @@ pub mod tests {
         match get_ek_cert_by_machine_id(&mut txn, &host_id).await {
             Err(e) => assert_eq!(
                 e.to_string(),
-                "internal error: Machine with id fm100hseddco33hvlofuqvg543p6p9aj60g76q5cq491g9m9tgtf2dk0530 not found."
+                "internal error: machine with id fm100hseddco33hvlofuqvg543p6p9aj60g76q5cq491g9m9tgtf2dk0530 not found"
             ),
             _ => panic!("Failed: should have returned an error"),
         }
@@ -174,7 +174,7 @@ pub mod tests {
         match extract_ca_fields(random_bytes) {
             Err(e) => assert_eq!(
                 e.to_string(),
-                "argument is invalid: Could not parse CA cert: Parsing Error: NomError(Eof)"
+                "argument is invalid: could not parse CA cert: Parsing Error: NomError(Eof)"
             ),
             _ => panic!("Failed: expected an error to be returned!"),
         }
@@ -206,7 +206,7 @@ pub mod tests {
         match match_insert_new_ek_cert_status_against_ca(&mut txn, &ek_cert, &host_id).await {
             Err(e) => assert_eq!(
                 e.to_string(),
-                "argument is invalid: Could not parse EK cert: Parsing Error: NomError(Eof)"
+                "argument is invalid: could not parse EK cert: Parsing Error: NomError(Eof)"
             ),
             _ => panic!("Failed: should have rertuned an error"),
         }
@@ -230,7 +230,7 @@ pub mod tests {
         match match_insert_new_ek_cert_status_against_ca(&mut txn, &ek_cert, &host_id).await {
             Err(e) => assert_eq!(
                 e.to_string(),
-                "argument is invalid: Could not parse CA cert: Parsing Error: NomError(Eof)"
+                "argument is invalid: could not parse CA cert: Parsing Error: NomError(Eof)"
             ),
             _ => panic!("Failed: should have rertuned an error"),
         }
@@ -336,7 +336,7 @@ pub mod tests {
             Ok(_) => panic!("Failed: should have returned an error!"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                "internal error: Machine with id fm100hseddco33hvlofuqvg543p6p9aj60g76q5cq491g9m9tgtf2dk0530 not found."
+                "internal error: machine with id fm100hseddco33hvlofuqvg543p6p9aj60g76q5cq491g9m9tgtf2dk0530 not found"
             ),
         }
 
@@ -376,7 +376,7 @@ pub mod tests {
             Ok(_) => panic!("Failed: should have returned an error!"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                "internal error: Could not parse EK cert: Parsing Error: NomError(Eof)"
+                "internal error: could not parse EK cert: Parsing Error: NomError(Eof)"
             ),
         }
 
@@ -417,7 +417,7 @@ pub mod tests {
             Ok(_) => panic!("Failed: should have returned an error!"),
             Err(e) => assert_eq!(
                 e.to_string(),
-                "internal error: Could not parse CA cert: Parsing Error: Der(UnexpectedTag { expected: Some(Tag(16)), actual: Tag(29) })"
+                "internal error: could not parse CA cert: Parsing Error: Der(UnexpectedTag { expected: Some(Tag(16)), actual: Tag(29) })"
             ),
         }
 

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -533,7 +533,7 @@ impl DnsServer {
 
         if records.is_empty() {
             return Err(tonic::Status::not_found(format!(
-                "No {} records found for {}",
+                "no {} records found for {}",
                 qtype, qname
             )));
         }

--- a/crates/dpf/build.rs
+++ b/crates/dpf/build.rs
@@ -77,7 +77,7 @@ fn main() -> Result<()> {
 
         let generated = generator
             .generate_rust_types_for(&crd, Some(format!("-f {}", crd_path.display())))
-            .with_context(|| format!("failed to generate Rust types for {}", crd_path.display()))?;
+            .with_context(|| format!("failed to generate rust types for {}", crd_path.display()))?;
 
         let output_path = out_dir.join(format!("{module_name}.rs"));
         fs::write(&output_path, generated)

--- a/crates/dpu-otel-agent/src/lib.rs
+++ b/crates/dpu-otel-agent/src/lib.rs
@@ -34,7 +34,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
         // development overrides
         Some(config_path) => (
             AgentConfig::load_from(&config_path).wrap_err(format!(
-                "Error loading agent configuration from {}",
+                "error loading agent configuration from {}",
                 config_path.display()
             ))?,
             config_path.display().to_string(),

--- a/crates/dsx-exchange-consumer/src/api_client.rs
+++ b/crates/dsx-exchange-consumer/src/api_client.rs
@@ -141,7 +141,7 @@ impl RackHealthReportSink for ConsoleRackHealthSink {
 fn parse_rack_id(rack_id: &str) -> Result<RackId, DsxConsumerError> {
     RackId::from_str(rack_id).map_err(|e| {
         DsxConsumerError::Api(tonic::Status::invalid_argument(format!(
-            "Invalid rack ID: {e}"
+            "invalid rack ID: {e}"
         )))
     })
 }

--- a/crates/firmware/src/downloader.rs
+++ b/crates/firmware/src/downloader.rs
@@ -240,13 +240,13 @@ async fn download_and_publish(
     download(filename, url, dst_filename, client, fake_sleep).await?;
     verify_sha256(dst_filename, sha256)
         .wrap_err(format!(
-            "Downloaded artifact from {} failed verification",
+            "downloaded artifact from {} failed verification",
             loggable_url(url)
         ))
         .map_err(fail(DownloadOutcome::Checksum))?;
     std::fs::rename(dst_filename, filename)
         .wrap_err(format!(
-            "Unable to rename {dst_filename} to {}",
+            "unable to rename {dst_filename} to {}",
             filename.display()
         ))
         .map_err(fail(DownloadOutcome::Io))?;
@@ -314,11 +314,11 @@ async fn download(
     };
 
     std::fs::create_dir_all(dirname)
-        .wrap_err(format!("Unable to create directory {}", dirname.display()))
+        .wrap_err(format!("unable to create directory {}", dirname.display()))
         .map_err(fail(DownloadOutcome::Io))?;
     let mut dst_file = File::create(dst_filename)
         .await
-        .wrap_err(format!("Unable to create file {dst_filename}"))
+        .wrap_err(format!("unable to create file {dst_filename}"))
         .map_err(fail(DownloadOutcome::Io))?;
 
     if let Some(duration) = fake_sleep {

--- a/crates/host-support/src/registration.rs
+++ b/crates/host-support/src/registration.rs
@@ -308,14 +308,14 @@ pub async fn write_certs(
         tokio::fs::write(client_cert, combined_cert)
             .await
             .wrap_err(format!(
-                "Failed to write new machine certificate PEM to {client_cert}"
+                "failed to write new machine certificate PEM to {client_cert}"
             ))?;
         tracing::info!(%client_cert, "Wrote new machine certificate PEM");
 
         tokio::fs::write(client_key, machine_certificate.private_key.as_slice())
             .await
             .wrap_err(format!(
-                "Failed to write new machine certificate key to: {client_key}"
+                "failed to write new machine certificate key to: {client_key}"
             ))?;
     } else {
         return Err(eyre::eyre!("write_certs: machine_certificate is empty"));

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -252,7 +252,7 @@ impl FromStr for VpcVirtualizationType {
             "etv" | "etv_nvue" => Ok(Self::EthernetVirtualizer),
             "fnn" => Ok(Self::Fnn),
             "flat" => Ok(Self::Flat),
-            x => Err(eyre::eyre!(format!("Unknown virt type {}", x))),
+            x => Err(eyre::eyre!(format!("unknown virt type {}", x))),
         }
     }
 }
@@ -303,7 +303,7 @@ pub fn get_svi_ip(
 ) -> eyre::Result<Option<IpNetwork>> {
     if virtualization_type == VpcVirtualizationType::Fnn && is_l2_segment {
         let Some(svi_ip) = svi_ip else {
-            return Err(eyre::eyre!(format!("SVI IP is not allocated.",)));
+            return Err(eyre::eyre!(format!("SVI IP is not allocated",)));
         };
 
         return Ok(Some(IpNetwork::new(*svi_ip, prefix)?));
@@ -375,11 +375,11 @@ mod tests {
                 Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
             };
             "error names the unknown token" {
-                ("bogus", &["Unknown virt type", "bogus"][..]) => Yields(true),
+                ("bogus", &["unknown virt type", "bogus"][..]) => Yields(true),
             }
 
             "error echoes a numeric token" {
-                ("42", &["Unknown virt type", "42"][..]) => Yields(true),
+                ("42", &["unknown virt type", "42"][..]) => Yields(true),
             }
         );
     }

--- a/crates/ssh-console-mock-api-server/src/api.rs
+++ b/crates/ssh-console-mock-api-server/src/api.rs
@@ -59,7 +59,7 @@ impl Forge for MockApiServer {
             .find(|host| host.instance_id == instance_id)
         else {
             return Err(Status::not_found(format!(
-                "No instance found with ID {instance_id}"
+                "no instance found with ID {instance_id}"
             )));
         };
 

--- a/crates/ssh-console/tests/util/ssh_client.rs
+++ b/crates/ssh-console/tests/util/ssh_client.rs
@@ -68,7 +68,7 @@ pub async fn assert_connection_works_with_retries_and_timeout(
                     tokio::time::sleep(Duration::from_secs(1)).await;
                 } else {
                     return Err(error).context(format!(
-                        "Could not connect to {} after {} retries",
+                        "could not connect to {} after {} retries",
                         connection_config.connection_name, retry_count,
                     ));
                 }
@@ -76,7 +76,7 @@ pub async fn assert_connection_works_with_retries_and_timeout(
             // Timed out
             Err(elapsed) => {
                 return Err(elapsed).context(format!(
-                    "Timed out asserting working connection to {}",
+                    "timed out asserting working connection to {}",
                     connection_config.connection_name
                 ));
             }
@@ -235,7 +235,7 @@ pub async fn assert_connection_works(
 
     if result.is_ok() && matches!(test_state, ConnectionTestState::WaitingForPrompt) {
         return Err(eyre::format_err!(format!(
-            "Did not detect a prompt after connecting to {connection_name}"
+            "did not detect a prompt after connecting to {connection_name}"
         )));
     }
 

--- a/crates/xtask/src/error_message_case.rs
+++ b/crates/xtask/src/error_message_case.rs
@@ -62,15 +62,20 @@ const ERROR_TYPE_OWNERS: &[&str] = &["CarbideError", "Status"];
 /// Conversion calls to peel through when hunting for the underlying literal
 /// (`CarbideError::internal("id is required".into())`).
 const CONV_METHODS: &[&str] = &["into", "to_string", "to_owned", "into_owned"];
+/// Format macros to peel through when they wrap the message in an error position
+/// (`CarbideError::invalid_argument(format!("..."))`, `.context(format!("..."))`).
+/// A format macro's first argument is always a string literal, so it lints like
+/// any other message; `{placeholder}` names are left alone by the rewriter.
+const FORMAT_MACROS: &[&str] = &["format", "format_args"];
 
-// TODO: this only reaches messages passed as a bare string literal to the
-// constructs above. It doesn't yet look inside `format!(...)` (e.g.
-// `.context(format!("Could not ..."))`) or at struct-literal error fields (e.g.
-// `CarbideError::Internal { message: "..." }`), nor at other error enums'
-// constructors. It also can't see an error site nested inside another macro's
-// body (e.g. a `bail!` inside `tokio::select!`), which `syn` keeps as an opaque
-// token stream. Those are left as-is for now; widening the checker, and
-// re-sweeping what it then catches, is a follow-up.
+// TODO: `format!(...)` is now peeled when it's the message argument of a
+// recognized error slot (see `leading_str_lit`), but a few forms remain out of
+// reach: a `format!` behind a *block*-bodied closure (`.wrap_err_with(|| {
+// format!(...) })`), struct-literal error fields (`CarbideError::Internal {
+// message: "..." }`), other error enums' constructors, a manual `impl Display`
+// (`write!`), and an error site nested inside another macro's body (a `bail!`
+// inside `tokio::select!`, which `syn` keeps as an opaque token stream). Those
+// are left as-is; widening the checker further, and re-sweeping, is a follow-up.
 
 pub fn check(fix: bool) -> eyre::Result<CheckOutcome> {
     let repo_root = PathBuf::from(REPO_ROOT).canonicalize()?;
@@ -344,7 +349,7 @@ impl<'ast> Visit<'ast> for Collector<'_> {
             && let Some(arg) = node.args.first()
             && let Some(lit) = leading_str_lit(arg)
         {
-            self.inspect(lit);
+            self.inspect(&lit);
         }
         visit::visit_expr_method_call(self, node);
     }
@@ -358,7 +363,7 @@ impl<'ast> Visit<'ast> for Collector<'_> {
                 && let Some(arg) = node.args.first()
                 && let Some(lit) = leading_str_lit(arg)
             {
-                self.inspect(lit);
+                self.inspect(&lit);
             }
         }
         visit::visit_expr_call(self, node);
@@ -400,18 +405,38 @@ fn macro_message(mac: &Macro) -> Option<LitStr> {
     let args = mac
         .parse_body_with(syn::punctuated::Punctuated::<Expr, syn::Token![,]>::parse_terminated)
         .ok()?;
-    leading_str_lit(args.iter().nth(index)?).cloned()
+    leading_str_lit(args.iter().nth(index)?)
 }
 
-/// Peels closures, references, and trivial conversions to find a leading string
-/// literal — the message inside `|| "...".into()`, `&"..."`, `"...".to_string()`.
-fn leading_str_lit(expr: &Expr) -> Option<&LitStr> {
+/// Peels closures, references, trivial conversions, and a wrapping `format!` to
+/// find a leading string literal — the message inside `|| "...".into()`, `&"..."`,
+/// `"...".to_string()`, or `CarbideError::invalid_argument(format!("...", x))`.
+/// Returns an owned `LitStr` (it may be parsed out of a `format!` body), but its
+/// span still points at the real source literal, so a fix rewrites the right bytes.
+fn leading_str_lit(expr: &Expr) -> Option<LitStr> {
     match expr {
         Expr::Lit(ExprLit {
             lit: Lit::Str(lit), ..
-        }) => Some(lit),
+        }) => Some(lit.clone()),
         Expr::MethodCall(call) if CONV_METHODS.contains(&call.method.to_string().as_str()) => {
             leading_str_lit(&call.receiver)
+        }
+        // A `format!(...)` sitting in a message slot: peel to its format string,
+        // which the compiler guarantees is a leading string literal.
+        Expr::Macro(m)
+            if m.mac
+                .path
+                .segments
+                .last()
+                .is_some_and(|s| FORMAT_MACROS.contains(&s.ident.to_string().as_str())) =>
+        {
+            let args = m
+                .mac
+                .parse_body_with(
+                    syn::punctuated::Punctuated::<Expr, syn::Token![,]>::parse_terminated,
+                )
+                .ok()?;
+            leading_str_lit(args.first()?)
         }
         Expr::Closure(closure) => leading_str_lit(&closure.body),
         Expr::Reference(reference) => leading_str_lit(&reference.expr),
@@ -717,5 +742,44 @@ mod tests {
             "{fixed}"
         );
         assert!(fixed.contains(r#"bail!("invalid config")"#), "{fixed}");
+    }
+
+    /// The `format!` peel reaches a message wrapped in a format macro inside an
+    /// error position (a `CarbideError` constructor or a `.context`) and only
+    /// there — a bare `format!` or log macro is left alone.
+    #[test]
+    fn end_to_end_rewrite_reaches_format() {
+        let src = concat!(
+            "fn f() -> anyhow::Result<()> {\n",
+            "    let _ = CarbideError::invalid_argument(format!(\"Duplicate services for {id}\"));\n",
+            "    thing().context(format!(\"Failed to open {MachineId}\"))?;\n",
+            "    tracing::info!(\"Bare log line stays\");\n",
+            "    let _ = format!(\"Plain format stays\");\n",
+            "    Ok(())\n",
+            "}\n",
+        );
+        let ast = syn::parse_file(src).unwrap();
+        let mut findings = Vec::new();
+        let mut collector = Collector {
+            lines: src.lines().collect(),
+            out: &mut findings,
+        };
+        collector.visit_file(&ast);
+
+        let (fixed, applied) = apply_fixes(src, &findings);
+        // only the two format! messages in error positions are rewritten
+        assert_eq!(applied, 2, "{fixed}");
+        assert!(
+            fixed.contains(r#"format!("duplicate services for {id}")"#),
+            "{fixed}"
+        );
+        // leading word lowered, the `{MachineId}` interpolation left intact
+        assert!(
+            fixed.contains(r#"format!("failed to open {MachineId}")"#),
+            "{fixed}"
+        );
+        // a bare format!/log macro outside an error slot is untouched
+        assert!(fixed.contains(r#""Bare log line stays""#), "{fixed}");
+        assert!(fixed.contains(r#""Plain format stays""#), "{fixed}");
     }
 }

--- a/crates/xtask/src/workspace_deps.rs
+++ b/crates/xtask/src/workspace_deps.rs
@@ -232,7 +232,7 @@ impl Workspace {
     fn write_all(&self) -> eyre::Result<()> {
         for (path, document) in &self.non_workspace_cargo_tomls {
             std::fs::write(path, document.to_string())
-                .with_context(|| format!("Error writing to {}", path.display()))?;
+                .with_context(|| format!("error writing to {}", path.display()))?;
         }
 
         let workspace_cargo_toml_path = self.toplevel_cargo_toml_path();


### PR DESCRIPTION
## Summary

A follow-up to #3566, as part of adopting the _Rust API Guidelines convention (C-GOOD-ERR)_: that extends the `lint-error-messages` checker to reach messages wrapped in a `format!`. The original checker only saw a bare string literal, so `CarbideError::invalid_argument(format!("Duplicate ..."))` and `.context(format!("Failed ..."))` kept their capital lead -- and because the checker couldn't `--fix` them, those were the sites that drifted between source and test as #3566 landed.

- `leading_str_lit` now peels a `format!`/`format_args!` down to its format-string literal, but only in the slots the checker already trusts -- a `CarbideError`/`Status` constructor or a `.context`/`.wrap_err` method. A bare `format!` (a log line, a command echo) is left alone, and `{placeholder}` names like `{MachineId}` are preserved.
- `--fix` then lowercased **246 messages across 69 files** that were previously invisible, with acronyms (`VPC`, `EK`), CamelCase types (`RsaPublicKey`), and placeholders preserved.
- Updated the test assertions that pinned the old strings -- attestation, tpm-ca, site-explorer, ib-partition, and the duplicate-extension-services allocate path, whose `format!` source now rejoins its already-lowercased twin.

Manual `impl Display`/`write!` bodies and struct-literal error fields (`CarbideError::Internal { message }`) stay out of reach, still marked with the checker's `TODO` -- a further follow-up.

Continues #3566 · supports #3468
