### PR TITLE
chore: bump libredfish to v0.44.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.20#67281482656423b4c1a9556112ee1dc6a04da930"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.21#63431424e2f5eea93e3df7eb41f0b2b3e98f72fb"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.20" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.21" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.1" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
bump libredfish to v0.44.21 to pull in changes to clear pending bios config jobs before configuring the boot order on dells

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
<!--
If checked, describe the breaking changes and migration steps. Breaking changes
are not generally permitted, please discuss on a GitHub discussion or with the
development team if you believe you need to break a backward compatibility
guarantee
-->
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

