### PR TITLE
fix: Migrate config file to nico_api_cli.json (Sync with documentation)

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -67,7 +67,7 @@ pub struct CliOptions {
 
     #[clap(short, long, env = "API_URL", visible_alias = "carbide-url")]
     #[clap(
-        help = "Default to API_URL environment variable or $HOME/.config/carbide_api_cli.json file or https://carbide-api.forge-system.svc.cluster.local:1079."
+        help = "Default to API_URL environment variable or $HOME/.config/nico_api_cli.json file or https://carbide-api.forge-system.svc.cluster.local:1079."
     )]
     pub api_url: Option<String>,
 
@@ -79,19 +79,19 @@ pub struct CliOptions {
 
     #[clap(long, env = "ROOT_CA_PATH", visible_alias = "forge-root-ca-path")]
     #[clap(
-        help = "Default to ROOT_CA_PATH environment variable or $HOME/.config/carbide_api_cli.json file."
+        help = "Default to ROOT_CA_PATH environment variable or $HOME/.config/nico_api_cli.json file."
     )]
     pub root_ca_path: Option<String>,
 
     #[clap(long, env = "CLIENT_CERT_PATH")]
     #[clap(
-        help = "Default to CLIENT_CERT_PATH environment variable or $HOME/.config/carbide_api_cli.json file."
+        help = "Default to CLIENT_CERT_PATH environment variable or $HOME/.config/nico_api_cli.json file."
     )]
     pub client_cert_path: Option<String>,
 
     #[clap(long, env = "CLIENT_KEY_PATH")]
     #[clap(
-        help = "Default to CLIENT_KEY_PATH environment variable or $HOME/.config/carbide_api_cli.json file."
+        help = "Default to CLIENT_KEY_PATH environment variable or $HOME/.config/nico_api_cli.json file."
     )]
     pub client_key_path: Option<String>,
 

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -44,19 +44,19 @@ use crate::machine_state_machine::OsImage;
 pub struct MachineATronArgs {
     #[clap(long, env = "FORGE_ROOT_CA_PATH")]
     #[clap(
-        help = "Default to FORGE_ROOT_CA_PATH environment variable or $HOME/.config/carbide_api_cli.json file."
+        help = "Default to FORGE_ROOT_CA_PATH environment variable or $HOME/.config/nico_api_cli.json file."
     )]
     pub forge_root_ca_path: Option<String>,
 
     #[clap(long, env = "CLIENT_CERT_PATH")]
     #[clap(
-        help = "Default to CLIENT_CERT_PATH environment variable or $HOME/.config/carbide_api_cli.json file."
+        help = "Default to CLIENT_CERT_PATH environment variable or $HOME/.config/nico_api_cli.json file."
     )]
     pub client_cert_path: Option<String>,
 
     #[clap(long, env = "CLIENT_KEY_PATH")]
     #[clap(
-        help = "Default to CLIENT_KEY_PATH environment variable or $HOME/.config/carbide_api_cli.json file."
+        help = "Default to CLIENT_KEY_PATH environment variable or $HOME/.config/nico_api_cli.json file."
     )]
     pub client_key_path: Option<String>,
 

--- a/crates/tls/src/client_config.rs
+++ b/crates/tls/src/client_config.rs
@@ -187,12 +187,12 @@ fn get_config_file_location() -> Result<Option<PathBuf>, ClientConfigError> {
     let home = Path::new(&home);
 
     let config_path = home.join(CONFIG_FILE_LOCATION);
-    if config_path.exists() {
+    if config_path.is_file() {
         return Ok(Some(config_path));
     }
 
     let legacy_path = home.join(LEGACY_CONFIG_FILE_LOCATION);
-    if legacy_path.exists() {
+    if legacy_path.is_file() {
         eprintln!(
             "warning: config file `$HOME/{LEGACY_CONFIG_FILE_LOCATION}` is deprecated; \
              rename it to `$HOME/{CONFIG_FILE_LOCATION}`."

--- a/crates/tls/src/client_config.rs
+++ b/crates/tls/src/client_config.rs
@@ -23,7 +23,10 @@ use serde::Deserialize;
 use tonic::transport::Uri;
 
 use crate::default as tls_default;
-pub const CONFIG_FILE_LOCATION: &str = ".config/carbide_api_cli.json";
+pub const CONFIG_FILE_LOCATION: &str = ".config/nico_api_cli.json";
+/// Previous name for [`CONFIG_FILE_LOCATION`]. Still read as a fallback (with a
+/// deprecation warning) so existing setups keep working after the rename.
+pub const LEGACY_CONFIG_FILE_LOCATION: &str = ".config/carbide_api_cli.json";
 
 #[derive(thiserror::Error, Debug)]
 pub enum ClientConfigError {
@@ -181,12 +184,23 @@ fn get_config_file_location() -> Result<Option<PathBuf>, ClientConfigError> {
     let Ok(home) = env::var("HOME") else {
         return Ok(None);
     };
-    let legacy = Path::new(&home).join(CONFIG_FILE_LOCATION);
-    if legacy.exists() {
-        Ok(Some(legacy))
-    } else {
-        Ok(None)
+    let home = Path::new(&home);
+
+    let config_path = home.join(CONFIG_FILE_LOCATION);
+    if config_path.exists() {
+        return Ok(Some(config_path));
     }
+
+    let legacy_path = home.join(LEGACY_CONFIG_FILE_LOCATION);
+    if legacy_path.exists() {
+        eprintln!(
+            "warning: config file `$HOME/{LEGACY_CONFIG_FILE_LOCATION}` is deprecated; \
+             rename it to `$HOME/{CONFIG_FILE_LOCATION}`."
+        );
+        return Ok(Some(legacy_path));
+    }
+
+    Ok(None)
 }
 pub fn get_config_from_file() -> Option<FileConfig> {
     // Third config file
@@ -504,7 +518,7 @@ mod tests {
     }
 
     #[test]
-    fn reads_legacy_config_file_from_home() {
+    fn reads_config_file_from_home() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _snapshot = EnvSnapshot::capture(&["HOME"]);
         let home = TempHome::create();

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -44,12 +44,12 @@ RUN apt update && \
 WORKDIR /app
 COPY --from=builder /carbide/target/release/nico-admin-cli ./
 RUN ln -s /app/nico-admin-cli /app/carbide-admin-cli
-# Cert paths read by nico-admin-cli via carbide_api_cli.json.
+# Cert paths read by nico-admin-cli via nico_api_cli.json.
 # Internal deployments: mount provisioned client certs into /root/.config/carbide/certs/.
 RUN mkdir -p /root/.config/carbide/certs && \
 mkdir -p /opt/forge
 COPY ./dev/certs/forge_root.pem /opt/forge
-RUN echo '{"forge_root_ca_path": "/opt/forge/forge_root.pem","client_key_path": "/root/.config/carbide/certs/client","client_cert_path": "/root/.config/carbide/certs/client.crt"}' > /root/.config/carbide_api_cli.json
+RUN echo '{"forge_root_ca_path": "/opt/forge/forge_root.pem","client_key_path": "/root/.config/carbide/certs/client","client_cert_path": "/root/.config/carbide/certs/client.crt"}' > /root/.config/nico_api_cli.json
 ENV PATH="$PATH:/app"
 
 ENTRYPOINT ["/app/nico-admin-cli"]

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -49,7 +49,7 @@ RUN ln -s /app/nico-admin-cli /app/carbide-admin-cli
 RUN mkdir -p /root/.config/carbide/certs && \
 mkdir -p /opt/forge
 COPY ./dev/certs/forge_root.pem /opt/forge
-RUN echo '{"forge_root_ca_path": "/opt/forge/forge_root.pem","client_key_path": "/root/.config/carbide/certs/client","client_cert_path": "/root/.config/carbide/certs/client.crt"}' > /root/.config/nico_api_cli.json
+RUN echo '{"root_ca_path": "/opt/forge/forge_root.pem","client_key_path": "/root/.config/carbide/certs/client","client_cert_path": "/root/.config/carbide/certs/client.crt"}' > /root/.config/nico_api_cli.json
 ENV PATH="$PATH:/app"
 
 ENTRYPOINT ["/app/nico-admin-cli"]

--- a/docs/provisioning/ingesting-hosts.md
+++ b/docs/provisioning/ingesting-hosts.md
@@ -71,10 +71,10 @@ You can run admin cli commands as
 ```bash
 nico-admin-cli https://api-<ENVIRONMENT_NAME>.<SITE_DOMAIN_NAME> --forge-root-ca-path /path/to/ca.crt --client-cert-path /path/to/client.crt  --client-key-path /path/to/client.key <command> ...
 ```
-Alternatively to shorten the command line you can create a file named `carbide_api_cli.json` in folder `$HOME/.config` and add the following content:
+Alternatively to shorten the command line you can create a file named `nico_api_cli.json` in folder `$HOME/.config` and add the following content:
 ```json
 {
-  "carbide_api_url": "https://api-<ENVIRONMENT_NAME>.<SITE_DOMAIN_NAME>:443",
+  "api_url": "https://api-<ENVIRONMENT_NAME>.<SITE_DOMAIN_NAME>:443",
   "root_ca_path": "/path/to/ca.crt",
   "client_cert_path": "/path/to/client.crt",
   "client_key_path": "/path/to/client.key"


### PR DESCRIPTION
Despite the documentation on https://github.com/NVIDIA/infra-controller/blob/main/docs/manuals/nico-admin-cli.md stating "Instead of passing flags every time, create $HOME/.config/nico_api_cli.json", nico-admin-cli is not able to locate the config file unless named "carbide_api_cli.json". Furthermore the help page printed after running "nico-admin-cli -h" mentions "$HOME/.config/carbide_api_cli.json" as the configuration file.

The fix means that NICo will look for nico_api_cli.json initially and if not found fall back to the legacy carbide_api_cli.json and print a deprecated warning.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3600

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

