### PR TITLE
feat(nvlink): update docs and return unsupported for NMX-M admin-cli command.

### DIFF
--- a/crates/admin-cli/src/credential/add_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/args.rs
@@ -16,31 +16,21 @@
  */
 
 use clap::Parser;
-use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
-#[command(after_long_help = "\
+#[command(
+    long_about = "Deprecated compatibility command. NMX-M is no longer supported. This command always returns an error and does not modify credentials. Use NMX-C for NVLink partition management.",
+    after_long_help = "\
 EXAMPLES:
 
-Add an NMX-M credential:
+Invoke the retained compatibility command (returns an unsupported error):
     $ nico-admin-cli credential add-nmx-m --username admin --password mypassword
 
-")]
+"
+)]
 pub struct Args {
     #[clap(long, required(true), help = "Username")]
     pub username: String,
     #[clap(long, required(true), help = "password")]
     pub password: String,
-}
-
-impl From<Args> for forgerpc::CredentialCreationRequest {
-    fn from(args: Args) -> Self {
-        Self {
-            credential_type: CredentialType::NmxM.into(),
-            username: Some(args.username),
-            password: args.password,
-            mac_address: None,
-            vendor: None,
-        }
-    }
 }

--- a/crates/admin-cli/src/credential/add_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/args.rs
@@ -24,13 +24,13 @@ use clap::Parser;
 EXAMPLES:
 
 Invoke the retained compatibility command (returns an unsupported error):
-    $ nico-admin-cli credential add-nmx-m --username admin --password mypassword
+    $ nico-admin-cli credential add-nmx-m
 
 "
 )]
 pub struct Args {
-    #[clap(long, required(true), help = "Username")]
-    pub username: String,
-    #[clap(long, required(true), help = "password")]
-    pub password: String,
+    #[clap(long, help = "Username")]
+    pub username: Option<String>,
+    #[clap(long, help = "password")]
+    pub password: Option<String>,
 }

--- a/crates/admin-cli/src/credential/add_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/cmd.rs
@@ -32,8 +32,8 @@ mod tests {
     #[test]
     fn returns_unsupported_without_creating_a_credential() {
         let error = add_nmxm(Args {
-            username: "admin".to_string(),
-            password: "password".to_string(),
+            username: None,
+            password: None,
         })
         .expect_err("the compatibility command must not create a credential");
 

--- a/crates/admin-cli/src/credential/add_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/cmd.rs
@@ -16,10 +16,30 @@
  */
 
 use super::args::Args;
-use crate::errors::CarbideCliResult;
-use crate::rpc::ApiClient;
+use crate::credential::NMX_M_UNSUPPORTED_MESSAGE;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
-pub async fn add_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client.0.create_credential(data).await?;
-    Ok(())
+pub fn add_nmxm(_data: Args) -> CarbideCliResult<()> {
+    Err(CarbideCliError::UnsupportedOperation(
+        NMX_M_UNSUPPORTED_MESSAGE,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_unsupported_without_creating_a_credential() {
+        let error = add_nmxm(Args {
+            username: "admin".to_string(),
+            password: "password".to_string(),
+        })
+        .expect_err("the compatibility command must not create a credential");
+
+        assert_eq!(
+            error.to_string(),
+            format!("unsupported operation: {NMX_M_UNSUPPORTED_MESSAGE}")
+        );
+    }
 }

--- a/crates/admin-cli/src/credential/add_nmxm/mod.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/mod.rs
@@ -25,7 +25,7 @@ use crate::cfg::runtime::RuntimeContext;
 use crate::errors::CarbideCliResult;
 
 impl Run for Args {
-    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::add_nmxm(self, &ctx.api_client).await
+    async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::add_nmxm(self)
     }
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/args.rs
@@ -16,27 +16,19 @@
  */
 
 use clap::Parser;
-use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
-#[command(after_long_help = "\
+#[command(
+    long_about = "Deprecated compatibility command. NMX-M is no longer supported. This command always returns an error and does not modify credentials. Use NMX-C for NVLink partition management.",
+    after_long_help = "\
 EXAMPLES:
 
-Delete an NMX-M credential by username:
+Invoke the retained compatibility command (returns an unsupported error):
     $ nico-admin-cli credential delete-nmx-m --username admin
 
-")]
+"
+)]
 pub struct Args {
-    #[clap(long, required(true), help = "NmxM url")]
+    #[clap(long, required(true), help = "Legacy NMX-M credential username")]
     pub username: String,
-}
-
-impl From<Args> for forgerpc::CredentialDeletionRequest {
-    fn from(args: Args) -> Self {
-        Self {
-            credential_type: CredentialType::NmxM.into(),
-            username: Some(args.username),
-            mac_address: None,
-        }
-    }
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/args.rs
@@ -29,6 +29,6 @@ Invoke the retained compatibility command (returns an unsupported error):
 "
 )]
 pub struct Args {
-    #[clap(long, required(true), help = "Legacy NMX-M credential username")]
-    pub username: String,
+    #[clap(long, help = "Legacy NMX-M credential username")]
+    pub username: Option<String>,
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
@@ -16,10 +16,29 @@
  */
 
 use super::args::Args;
-use crate::errors::CarbideCliResult;
-use crate::rpc::ApiClient;
+use crate::credential::NMX_M_UNSUPPORTED_MESSAGE;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
-pub async fn delete_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
-    api_client.0.delete_credential(data).await?;
-    Ok(())
+pub fn delete_nmxm(_data: Args) -> CarbideCliResult<()> {
+    Err(CarbideCliError::UnsupportedOperation(
+        NMX_M_UNSUPPORTED_MESSAGE,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_unsupported_without_deleting_a_credential() {
+        let error = delete_nmxm(Args {
+            username: "admin".to_string(),
+        })
+        .expect_err("the compatibility command must not delete a credential");
+
+        assert_eq!(
+            error.to_string(),
+            format!("unsupported operation: {NMX_M_UNSUPPORTED_MESSAGE}")
+        );
+    }
 }

--- a/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
@@ -31,10 +31,8 @@ mod tests {
 
     #[test]
     fn returns_unsupported_without_deleting_a_credential() {
-        let error = delete_nmxm(Args {
-            username: "admin".to_string(),
-        })
-        .expect_err("the compatibility command must not delete a credential");
+        let error = delete_nmxm(Args { username: None })
+            .expect_err("the compatibility command must not delete a credential");
 
         assert_eq!(
             error.to_string(),

--- a/crates/admin-cli/src/credential/delete_nmxm/mod.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/mod.rs
@@ -25,7 +25,7 @@ use crate::cfg::runtime::RuntimeContext;
 use crate::errors::CarbideCliResult;
 
 impl Run for Args {
-    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::delete_nmxm(self, &ctx.api_client).await
+    async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::delete_nmxm(self)
     }
 }

--- a/crates/admin-cli/src/credential/mod.rs
+++ b/crates/admin-cli/src/credential/mod.rs
@@ -38,6 +38,9 @@ use clap::Parser;
 
 use crate::cfg::dispatch::Dispatch;
 
+pub(crate) const NMX_M_UNSUPPORTED_MESSAGE: &str =
+    "NMX-M is no longer supported; use NMX-C for NVLink partition management";
+
 #[derive(Parser, Debug, Clone, Dispatch)]
 #[clap(rename_all = "kebab_case")]
 pub enum Cmd {
@@ -61,9 +64,9 @@ pub enum Cmd {
     AddHostFactoryDefault(add_host_factory_default::Args),
     #[clap(about = "Add manufacturer factory default BMC user/pass for the DPUs")]
     AddDpuFactoryDefault(add_dpu_factory_default::Args),
-    #[clap(about = "Add NmxM credentials")]
+    #[clap(about = "Deprecated compatibility command; NMX-M is no longer supported")]
     AddNmxM(add_nmxm::Args),
-    #[clap(about = "Delete NmxM credentials")]
+    #[clap(about = "Deprecated compatibility command; NMX-M is no longer supported")]
     DeleteNmxM(delete_nmxm::Args),
     #[clap(about = "Manage leaf BGP passwords", subcommand)]
     Bgp(bgp::Cmd),

--- a/crates/admin-cli/src/credential/tests.rs
+++ b/crates/admin-cli/src/credential/tests.rs
@@ -86,6 +86,53 @@ fn parse_add_ufm_fields() {
     );
 }
 
+// The retained NMX-M commands accept both argument-free invocations and the
+// legacy credential flags before returning their unsupported-operation error.
+#[test]
+fn parse_nmx_m_compatibility_commands() {
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::AddNmxM(args) => ("add", args.username, args.password),
+                    Cmd::DeleteNmxM(args) => ("delete", args.username, None),
+                    _ => panic!("expected an NMX-M compatibility command"),
+                })
+                .map_err(drop)
+        };
+        "add without legacy arguments" {
+            &["credential", "add-nmx-m"][..] => Yields(("add", None, None)),
+        }
+
+        "add with legacy arguments" {
+            &[
+                "credential",
+                "add-nmx-m",
+                "--username",
+                "admin",
+                "--password",
+                "mypassword",
+            ][..] => Yields((
+                "add",
+                Some("admin".to_string()),
+                Some("mypassword".to_string()),
+            )),
+        }
+
+        "delete without legacy arguments" {
+            &["credential", "delete-nmx-m"][..] => Yields(("delete", None, None)),
+        }
+
+        "delete with legacy arguments" {
+            &["credential", "delete-nmx-m", "--username", "admin"][..] => Yields((
+                "delete",
+                Some("admin".to_string()),
+                None,
+            )),
+        }
+    );
+}
+
 // parse_add_bmc_with_all_args ensures add-bmc parses
 // with all arguments.
 #[test]

--- a/crates/admin-cli/src/errors.rs
+++ b/crates/admin-cli/src/errors.rs
@@ -101,6 +101,9 @@ pub enum CarbideCliError {
     #[error("not implemented {0}")]
     NotImplemented(String),
 
+    #[error("unsupported operation: {0}")]
+    UnsupportedOperation(&'static str),
+
     #[error("invalid machine id: {0}")]
     InvalidMachineId(#[from] MachineIdParseError),
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -178,7 +178,7 @@ IB Fabric Monitor emits metrics with prefix `nico_ib_monitor_`.
 
 NVLink Manager is a background module within the `nico-api` binary. Its implementation lives in the separate `crates/nvlink-manager` crate to keep the `crates/api` crate smaller, but it is still started and run as part of NICo Core.
 
-Its `NvlPartitionMonitor` reconciles NVLink logical partition desired state with the state reported by NMX-M. In each run, it loads MNNVL-capable machines and NVLink partition records from the database, queries NMX-M for GPU and partition state, records `MachineNvLinkStatusObservation` data, and creates, updates, or removes NMX-M partitions as needed.
+Its `NvlPartitionMonitor` reconciles NVLink logical partition desired state with the state reported by NMX-C. In each run, it groups MNNVL-capable machines by chassis, resolves the corresponding NMX-C endpoint, queries GPU, compute-node, and partition state, records `MachineNvLinkStatusObservation` data, and creates, updates, or removes NMX-C partitions as needed.
 
 ## Dependency services
 

--- a/docs/configuration/network-isolation.md
+++ b/docs/configuration/network-isolation.md
@@ -28,7 +28,7 @@ nicocli tui
 
 ## NVLink
 
-NMX-M APIs configure NVLink partition assignments, ensuring that NVLink domains are dedicated to a single tenant. For GB200 NVL72 systems, NICo gates instance allocation on NVLink cluster readiness -- if the fabric is not healthy, provisioning is blocked.
+NMX-C APIs configure GPU membership in NVLink partitions. A physical NVLink domain can contain multiple isolated partitions belonging to different tenants; GPUs can communicate only with other GPUs in the same partition. For GB200 NVL72 systems, NICo gates instance allocation on NVLink cluster readiness -- if the fabric is not healthy, provisioning is blocked.
 
 View NVLink partition state:
 
@@ -46,5 +46,5 @@ nicocli tui
 | Network | Traffic within own VPCs and subnets | Management networks, other tenants' VPCs (unless peered) |
 | Storage | NVMe on assigned machines | Storage on unassigned machines |
 | InfiniBand | P_Key partitions assigned to their instances | Other tenants' IB partitions |
-| NVLink | NVLink domains allocated to their instances | Other tenants' NVLink domains |
+| NVLink | GPUs in NVLink partitions assigned to their instances | GPUs in partitions not assigned to their instances |
 | BMC/UEFI | No access (managed by NICo) | All BMC and UEFI interfaces |

--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -937,7 +937,7 @@ Flag-first ordering -- always put flags before positional args.
 - [VPC Routing Profiles](../manuals/vpc/vpc_routing_profiles.md) -- Profile configuration and behavior
 - [VPC Network Virtualization](../manuals/vpc/vpc_network_virtualization.md) -- Full networking architecture
 - [VPC Peering](../manuals/vpc/vpc_peering_management.md) -- Connecting VPCs (gRPC only)
-- [NVLink Partitioning](../manuals/nvlink_partitioning.md) -- NVLink domain management
+- [NVLink Partitioning](../manuals/nvlink_partitioning.md) -- NVLink logical partition management
 - [Machine Reboot Playbook](../playbooks/machine_reboot.md) -- Emergency BMC reboot procedures
 - [Force Delete Playbook](../playbooks/force_delete.md) -- Removing stuck machines
 - [Day 0/1/2 Lifecycle](../overview/lifecycle.md) -- NICo lifecycle model overview

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -87,9 +87,9 @@ Yes, NICo supports NVLink partitioning.
 * **Ethernet**: VXLAN with EVPN for VPC creation on DPUs
 * **E/W Ethernet (Spectrum-X)**: A CX-based firmware, named "DPA", which uses VXLAN on CX switches (as part of a future release)
 * **Infiniband**: UFM-based partition key (P_Key) assignment
-* **NVLink**: NMX-M-based partition management
+* **NVLink**: NMX-C-based partition management
 
-DPUs enforce Ethernet isolation in hardware, UFM enforces InfiniBand isolation, and NMX-M enforces NVLink isolation--all coordinated by NICo.
+DPUs enforce Ethernet isolation in hardware, UFM enforces InfiniBand isolation, and NMX-C enforces NVLink isolation--all coordinated by NICo.
 
 **When NICo is used to maintain tenancy enforcement for Ethernet (N/S), does it require access to make changes to Spectrum (SN) switches running Cumulus, or are all changes limited to HBN (Host-Based Networking) on the DPU?**
 
@@ -107,7 +107,7 @@ NICo configures the host BMC to disable connectivity from within the host to the
 
 **Can NICo be used to manage a portion of a cluster?**
 
-NICo requires the N/S and OOB Ethernet DHCP relays pointed to the NICo DHCP service as well as access to UFM and NMX-M for E/W. Additionally, the EVPN topology must be visible to all nodes that are managed by the same cluster. If the DC operator wants to separate EVPN/DHCP into VLANs and VRFs, then you can arbitrarily assign nodes to NICo management or not. NMX-M and UFM are not multi–tenant aware, so there's a possibility of two things configuring NMX-M and UFM from interfering with each other.
+NICo requires the N/S and OOB Ethernet DHCP relays pointed to the NICo DHCP service as well as access to UFM and NMX-C for E/W. Additionally, the EVPN topology must be visible to all nodes that are managed by the same cluster. If the DC operator wants to separate EVPN/DHCP into VLANs and VRFs, then you can arbitrarily assign nodes to NICo management or not. NMX-C and UFM are not multi-tenant aware, so multiple controllers configuring the same fabric can interfere with each other.
 
 **How does NICo select a bare metal host to satisfy the request for an instance? What selection criteria is supported?**
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -185,9 +185,9 @@ NICo coordinates tenant isolation across four network fabrics, each with its own
 | Ethernet north-south | VXLAN with EVPN for VPC creation | DPU through HBN |
 | East-west Ethernet | ConnectX-based firmware paths where configured | Outside the current DPU HBN path |
 | InfiniBand | Partition key assignment | UFM |
-| NVLink | Partition management | NMX-M |
+| NVLink | Partition management | NMX-C |
 
-DPUs enforce Ethernet isolation in hardware, UFM enforces InfiniBand isolation, and NMX-M enforces NVLink isolation, all coordinated by NICo.
+DPUs enforce Ethernet isolation in hardware, UFM enforces InfiniBand isolation, and NMX-C enforces NVLink isolation, all coordinated by NICo.
 
 ### VRF
 
@@ -213,7 +213,7 @@ InfiniBand partition key. P_Keys are the isolation mechanism used by UFM for Inf
 
 ### NVLink
 
-The high-speed GPU-to-GPU fabric managed outside NICo Core by NMX-M. NICo coordinates with NVLink management so GPU partitioning aligns with tenant isolation.
+The high-speed GPU-to-GPU fabric managed outside NICo Core by NMX-C. NICo coordinates with NMX-C so GPU partitioning aligns with tenant isolation.
 
 ### FMDS
 
@@ -370,7 +370,7 @@ NICo Core is site-local and continues to manage hardware independently of the RE
 | LLDP | Link Layer Discovery Protocol | Neighbor discovery protocol used for network topology visibility |
 | NCP | NVIDIA Cloud Partner | Infrastructure partner operating NICo-managed environments |
 | NICo | NVIDIA Infra Controller | This platform, also known historically as NICo, NICo, and BMM |
-| NMX-M | NVLink Management | NVLink partition management for GPU-to-GPU isolation |
+| NMX-C | NMX Controller | NVLink partition management for GPU-to-GPU isolation |
 | OOB | Out of Band | Management network path independent from the Host OS |
 | P_Key | Partition Key | InfiniBand isolation identifier assigned by UFM |
 | protobuf | Protocol Buffers | Interface definition and serialization format for Core APIs |

--- a/docs/manuals/network_isolation.md
+++ b/docs/manuals/network_isolation.md
@@ -10,7 +10,7 @@ configuration guides linked below.
 |---|---|---|
 | Ethernet | VPC + VpcPrefix (+ optional Network Security Group) | DPU VRF per VPC (HBN / NVUE) over a pure type-5 EVPN overlay |
 | InfiniBand | InfiniBand partition | UFM P_Key partition membership; `IbFabricMonitor` reconciler |
-| NVLink | NVLink logical partition | NMX-M / NMX-C partition lifecycle; `NvlPartitionMonitor` reconciler |
+| NVLink | NVLink logical partition | NMX-C partition lifecycle; `NvlPartitionMonitor` reconciler |
 
 ---
 
@@ -119,12 +119,11 @@ UFM / OpenSM hardening.
 
 ## NVLink
 
-NVLink logical partitions group GPUs across hosts into a single isolated
-NVLink domain. NICo drives partition lifecycle against the NMX-M REST API and
-the NMX-C gRPC API and reconciles desired partitions periodically. Each tenant
-instance that requests NVLink connectivity is placed into the partition
-corresponding to its allocation; a host whose GPUs are not in a partition
-cannot reach any other host's GPUs over NVLink.
+NVLink logical partitions express how GPUs should be grouped across hosts.
+Within each physical NVLink domain, NICo places the requested GPUs into an
+NMX-C partition and reconciles that partition through the NMX-C gRPC API.
+Multiple tenants' partitions can coexist in one physical domain, while GPUs in
+different partitions remain isolated from each other.
 
 See [NVLink Partitioning](nvlink_partitioning.md) for the operator
 configuration guide.
@@ -155,7 +154,7 @@ The following invariants apply to every fabric.
   APIs the normal lifecycle uses, so external fabric managers do not retain
   stale tenant references.
 - **External fabric reachability is monitored.** Each external fabric service
-  (UFM, NMX-M, NMX-C) is monitored from NICo with request-success and latency
+  (UFM and NMX-C) is monitored from NICo with request-success and latency
   metrics so that fabric-side outages can be distinguished from NICo-side
   configuration errors.
 

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-add-nmx-m.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-add-nmx-m.md
@@ -9,8 +9,8 @@ NMX-M is no longer supported
 
 ## SYNOPSIS
 
-**nico-admin-cli credential add-nmx-m** \<**--username**\>
-\<**--password**\> \[**--extended**\] \[**--sort-by**\]
+**nico-admin-cli credential add-nmx-m** \[**--username**\]
+\[**--password**\] \[**--extended**\] \[**--sort-by**\]
 \[**-h**\|**--help**\]
 
 ## DESCRIPTION
@@ -50,7 +50,7 @@ Print help (see a summary with -h)
 ## Examples
 
 ```sh
-nico-admin-cli credential add-nmx-m --username admin --password mypassword
+nico-admin-cli credential add-nmx-m
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-add-nmx-m.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-add-nmx-m.md
@@ -4,7 +4,8 @@ _[Hardware commands](../../hardware.md) › [credential](./credential.md) › **
 
 ## NAME
 
-nico-admin-cli-credential-add-nmx-m - Add NmxM credentials
+nico-admin-cli-credential-add-nmx-m - Deprecated compatibility command;
+NMX-M is no longer supported
 
 ## SYNOPSIS
 
@@ -14,7 +15,9 @@ nico-admin-cli-credential-add-nmx-m - Add NmxM credentials
 
 ## DESCRIPTION
 
-Add NmxM credentials
+Deprecated compatibility command. NMX-M is no longer supported. This
+command always returns an error and does not modify credentials. Use
+NMX-C for NVLink partition management.
 
 ## OPTIONS
 

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-delete-nmx-m.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-delete-nmx-m.md
@@ -9,7 +9,7 @@ command; NMX-M is no longer supported
 
 ## SYNOPSIS
 
-**nico-admin-cli credential delete-nmx-m** \<**--username**\>
+**nico-admin-cli credential delete-nmx-m** \[**--username**\]
 \[**--extended**\] \[**--sort-by**\] \[**-h**\|**--help**\]
 
 ## DESCRIPTION

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-delete-nmx-m.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-delete-nmx-m.md
@@ -4,7 +4,8 @@ _[Hardware commands](../../hardware.md) › [credential](./credential.md) › **
 
 ## NAME
 
-nico-admin-cli-credential-delete-nmx-m - Delete NmxM credentials
+nico-admin-cli-credential-delete-nmx-m - Deprecated compatibility
+command; NMX-M is no longer supported
 
 ## SYNOPSIS
 

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-delete-nmx-m.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-delete-nmx-m.md
@@ -13,12 +13,14 @@ nico-admin-cli-credential-delete-nmx-m - Delete NmxM credentials
 
 ## DESCRIPTION
 
-Delete NmxM credentials
+Deprecated compatibility command. NMX-M is no longer supported. This
+command always returns an error and does not modify credentials. Use
+NMX-C for NVLink partition management.
 
 ## OPTIONS
 
 **--username** *\<USERNAME\>*  
-NmxM url
+Legacy NMX-M credential username
 
 **--extended**  
 Extended result output.

--- a/docs/manuals/nico-admin-cli/commands/credential/credential.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential.md
@@ -49,8 +49,8 @@ Print help (see a summary with -h)
 | [`add-uefi`](./credential-add-uefi.md) | Add site-wide DPU UEFI default credential (NOTE: this parameter can be set only once) |
 | [`add-host-factory-default`](./credential-add-host-factory-default.md) | Add manufacturer factory default BMC user/pass for a given vendor |
 | [`add-dpu-factory-default`](./credential-add-dpu-factory-default.md) | Add manufacturer factory default BMC user/pass for the DPUs |
-| [`add-nmx-m`](./credential-add-nmx-m.md) | Add NmxM credentials |
-| [`delete-nmx-m`](./credential-delete-nmx-m.md) | Delete NmxM credentials |
+| [`add-nmx-m`](./credential-add-nmx-m.md) | Deprecated compatibility command; NMX-M is no longer supported |
+| [`delete-nmx-m`](./credential-delete-nmx-m.md) | Deprecated compatibility command; NMX-M is no longer supported |
 | [`bgp`](./credential-bgp.md) | Manage leaf BGP passwords |
 
 ---

--- a/docs/manuals/nvlink_partitioning.md
+++ b/docs/manuals/nvlink_partitioning.md
@@ -6,7 +6,7 @@ is allowed between all GPUs in an *NVLink Partition*. An *NVLink Partition* must
 NVIDIA Infra Controller (NICo) allows you to do the following with NVLink:
 
 * Create, update, and delete NVLink Logical Partitions using the NICo REST API.
-* Provision Instances with GPUs partitioned into NVLink Domains by way of NVLink Logical Partitions without knowledge of the underlying NVLink topology.
+* Provision Instances with GPUs assigned to partitions within NVLink Domains by way of NVLink Logical Partitions, without knowledge of the underlying NVLink topology.
 * Update Instances to change NVLink Logical Partition assignment for its GPUs
 
 NICo extends the concept of an *NVLink Partition* with the *NVLink Logical Partition*, which allows users to manage NVLink Partitions without having to learn the datacenter topology.
@@ -15,26 +15,24 @@ NICo extends the concept of an *NVLink Partition* with the *NVLink Logical Parti
 
 ## Operations: Who Does What
 
-NVLink splits between operator site setup against NMX-M / NMX-C and tenant
-partition management. Notably, several operator steps (NMX-C endpoint
-registration, the GPU-mapping populate step) are **not exposed via the REST
-API** and are therefore driven through `nico-admin-cli` over gRPC. See
+NVLink splits between operator site setup against NMX-C and tenant partition
+management. Notably, several operator steps (fallback NMX-C endpoint
+registration and the GPU-mapping populate step) are **not exposed via the
+REST API** and are therefore driven through `nico-admin-cli` over gRPC. See
 [Network Isolation → Who configures what, and how](network_isolation.md#who-configures-what-and-how)
 for the role and interface model.
 
 | Task | Role | Interface |
 |---|---|---|
-| Enable NVLink; NMX-M / NMX-C connection and TLS settings | Operator | **TOML** (`[nvlink_config]`) — Day 0 / rare |
-| NMX-M credentials | Operator | `nico-admin-cli credential add-nmx-m` (gRPC) — not in REST |
-| NMX-C endpoints (per chassis serial) | Operator | `nico-admin-cli nvlink-nmxc-endpoints …` (gRPC) — not in REST |
-| Populate the machine → NMX-M GPU mapping | Operator | `nico-admin-cli nvlink-info populate` (gRPC) — not in REST |
+| Enable NVLink; NMX-C connection and TLS settings | Operator | **TOML** (`[nvlink_config]`) — Day 0 / rare |
+| Fallback NMX-C endpoints (per chassis serial) | Operator | `nico-admin-cli nvlink-nmxc-endpoints …` (gRPC) — not in REST |
+| Populate the machine → NMX-C GPU mapping | Operator | `nico-admin-cli machine nvlink-info populate` (gRPC) — not in REST |
 | Create / update / delete an NVLink Logical Partition | Tenant | **REST** `…/nico/nvlink-logical-partition` · `nicocli nvlink-logical-partition create` |
 | Assign or change an instance's GPUs' partition | Tenant | **REST** `…/nico/instance` (`nvLinkInterfaces`) · `nicocli instance update` |
 | Inspect a machine's GPU domain placement (triage) | Operator | `nico-admin-cli machine nvlink-info` (gRPC) |
 
-The operator NMX setup (the first four rows) is detailed under
-[Enabling NMX-C-based NVLink Partitioning](#enabling-nmx-c-based-nvlink-partitioning)
-and [Enabling NMX-M-based NVLink Partitioning](#enabling-nmx-m-based-nvlink-partitioning).
+The operator NMX setup (the first three rows) is detailed under
+[Enabling NMX-C-based NVLink Partitioning](#enabling-nmx-c-based-nvlink-partitioning).
 The tenant rows are the REST / `nicocli` flow described next.
 
 ### Creating a NVLink Logical Partition
@@ -110,17 +108,17 @@ If you want finer control, leave `nvLinkLogicalPartitionId` unset on the VPC and
 
 ### How NICo Reconciles NVLink State
 
-NICo runs a periodic reconciler against NMX-M and NMX-C to keep the actual
-NVLink partition topology aligned with the desired state implied by tenant
-instance configurations. The behaviour matters whenever an operator is
+NICo runs a periodic reconciler against NMX-C to keep the actual NVLink
+partition topology aligned with the desired state implied by tenant instance
+configurations. The behaviour matters whenever an operator is
 diagnosing latency between an API call and an instance becoming `Ready`.
 
 Each reconciliation pass does the following:
 
 1. Loads every NVLink Logical Partition and every NVLink Physical Partition
    from the NICo database.
-2. Queries each configured NMX-M and / or NMX-C endpoint for the current
-   partition list and GPU membership on that endpoint's chassis or domain.
+2. Resolves the NMX-C endpoint for each chassis and queries its current
+   partition list, compute nodes, and GPU membership.
 3. Compares observed state against desired state.
 4. Issues create / update / remove operations to the fabric-management
    service to converge it onto desired state.
@@ -154,13 +152,13 @@ When an instance is released (via `ReleaseInstance`):
 1. The instance's NVLink configuration is cleared from the database.
 2. The reconciler observes that GPUs previously assigned to the instance
    are no longer requested in any live partition.
-3. The reconciler removes those GPUs from their NMX-M / NMX-C partitions.
+3. The reconciler removes those GPUs from their NMX-C partitions.
 4. Once all NVLink state is removed, the machine's GPU status observation
    reflects an empty domain assignment and the host becomes eligible for
    reuse.
 
 When a Logical Partition is deleted, every underlying NVLink Physical
-Partition on each NMX-M / NMX-C endpoint backing it is also deleted. The
+Partition on each NMX-C endpoint backing it is also deleted. The
 deletion is rejected if any instance still references the Logical
 Partition.
 
@@ -170,12 +168,14 @@ NVLink configuration manually before force-deleting.
 
 ### Enabling NMX-C-based NVLink Partitioning
 
-NMX-C is the gRPC control path for NVLink partition management and is the
-current default for new deployments. NMX-M remains supported and is
-covered in the next section; the two are not mutually exclusive and a
-single site may use both.
+NMX-C is the supported gRPC control path for NVLink partition management.
 
-The TOML toggles live alongside the NMX-M ones under `[nvlink_config]`:
+> **Compatibility note**: NMX-M is no longer supported. The legacy
+> `nico-admin-cli credential add-nmx-m` and `delete-nmx-m` command names remain
+> available temporarily so existing scripts receive a clear unsupported error;
+> they do not modify credentials.
+
+Configure the NMX-C client under `[nvlink_config]`:
 
 ```toml
 [nvlink_config]
@@ -188,6 +188,7 @@ nmx_c_tls_ca_cert_path     = "/etc/nico/nmxc/ca.pem"
 nmx_c_tls_client_cert_path = "/etc/nico/nmxc/client.crt"
 nmx_c_tls_client_key_path  = "/etc/nico/nmxc/client.key"
 nmx_c_tls_authority        = "nmxc.example.internal"
+nmx_c_endpoint_port        = 9370
 
 allow_insecure = false
 ```
@@ -198,11 +199,14 @@ allow_insecure = false
 | `nmx_c_tls_client_cert_path` | Optional client certificate for mTLS to NMX-C |
 | `nmx_c_tls_client_key_path` | Optional client key matching the certificate above |
 | `nmx_c_tls_authority` | Optional override for the expected server name during certificate verification (SNI / hostname check) |
+| `nmx_c_endpoint_port` | Optional gRPC port used when deriving an endpoint from a switch NVOS IP; defaults to `9370` |
 | `allow_insecure` | When `true`, disables TLS verification entirely. Intended for development |
 
-Unlike NMX-M, where a single endpoint URL is set in TOML, NMX-C endpoints
-are **per-chassis** and stored in the NICo database. Register them with
-`nico-admin-cli`, keyed by the chassis serial:
+NMX-C endpoints are resolved per chassis. NICo first uses the NVOS IP of a
+ready switch with its Fabric Manager control plane configured. If no suitable
+switch endpoint is available, NICo falls back to an explicit chassis mapping
+stored in the database. Register fallback mappings with `nico-admin-cli`,
+keyed by chassis serial:
 
 ```bash
 nico-admin-cli nvlink-nmxc-endpoints create \
@@ -219,55 +223,15 @@ The TLS material in TOML applies uniformly to every NMX-C endpoint NICo
 talks to. Per-endpoint credential overrides are not currently supported;
 deploy a uniform trust posture across the site's NMX-C control plane.
 
-### Enabling NMX-M-based NVLink Partitioning
+For machines discovered before NVLink partitioning was enabled, populate the
+machine's GPU mapping from Redfish and NMX-C:
 
-This section describes how to enable NVLink support via the [NMX-M platform](https://docs.nvidia.com/networking/display/nmxmv8513000).
+```bash
+nico-admin-cli machine nvlink-info populate --update-db <machine-id>
+```
 
-#### Prerequisites
-
-* nico-core/NICo is deployed and running.
-* vault is running.
-* nico-core can reach the NMX-M endpoint over the network.
-* NMX-M has an API user with permissions to read GPUs/partitions and create/update/delete partitions.
-
-#### Steps to Enable NMX-M
-
-1. Enable NVLink Partitioning in nico-core config. Add or update the configmap nico-api-site-config-files consumed by nico-core:
-
-    ```
-      [nvlink_config]
-      enabled = true
-      nmx_m_endpoint = "https://<nmx-m-host>:<port>"
-    
-      monitor_run_interval = "60s"
-      nmx_m_operation_timeout = "10s"
-    
-      allow_insecure = true
-    ```
-
-2. Restart nico-core
-
-3. Configure the NMX-M credentials. Store the NMX-M username and password in vault through nico admin CLI:
-
-    ```
-      nico-admin-cli credential add-nmx-m \
-        --username <nmx-m-username> \
-        --password <nmx-m-password>
-    ```
-
-4. Populate the NVLink GPU mapping. After enabling NVLink in the site config, for already discovered machines, populate the machine-to-NMX-M GPU mapping. Partitioning will not work until this step is complete.
-
-   <Note>Machines discovered after enabling NVLink do not require this step.</Note>
-
-    ```
-    nico-admin-cli nvlink-info populate --update-db <machine-id>
-    ```
-
-5. Validate the NVLink configuration for NMX-M:
-
-    * nico-core logs should not show "Failed to create NMXM client".
-    * Logs should not show failures getting NMX-M partitions or GPU list.
-    * Metrics show that `nico_nvlink_partition_monitor_nmxm_connect_error_count` is `0`.
+Machines discovered after NVLink partitioning is enabled are populated during
+discovery and do not require this step.
 
 ### Verifying a Tenant's NVLink Placement
 
@@ -277,12 +241,11 @@ following checks. There is no single all-in-one health command; the steps
 below should be repeatable as a checklist.
 
 1. **Reconciler is running.**
-   `nico_nvlink_partition_monitor_iteration_latency` is being recorded
-   and both `nico_nvlink_partition_monitor_nmxc_connect_error_count`
-   and `nico_nvlink_partition_monitor_nmxm_connect_error_count` are
-   flat.
+   `carbide_nvlink_partition_monitor_iteration_latency_milliseconds` is being
+   recorded and
+   `carbide_nvlink_partition_monitor_nmxc_connect_error_count` is `0`.
 2. **Logical-partition count matches expectation.**
-   `nico_nvlink_partition_monitor_num_logical_partitions` reflects
+   `carbide_nvlink_partition_monitor_num_logical_partitions` reflects
    the partitions a site planner expects to exist. A sudden change is
    worth correlating with recent tenant API activity.
 3. **Per-instance configuration has converged.** The instance's
@@ -304,6 +267,6 @@ below should be repeatable as a checklist.
 5. **Cleanup after release.** After releasing an instance, the same
    `machine nvlink-info` output should show an empty Domain assignment
    on the affected GPUs within one or two reconcile intervals. Failure
-   to clear indicates the reconciler could not remove the GPU from its
-   NMX-M / NMX-C partition; investigate the corresponding connect-error
-   and op-latency metrics.
+   to clear indicates the reconciler could not remove the GPU from its NMX-C
+   partition; investigate the corresponding connect-error and op-latency
+   metrics.

--- a/docs/manuals/nvlink_partitioning.md
+++ b/docs/manuals/nvlink_partitioning.md
@@ -242,8 +242,10 @@ below should be repeatable as a checklist.
 
 1. **Reconciler is running.**
    `carbide_nvlink_partition_monitor_iteration_latency_milliseconds` is being
-   recorded and
-   `carbide_nvlink_partition_monitor_nmxc_connect_error_count` is `0`.
+   recorded. Evaluate the recent increase or rate of
+   `carbide_nvlink_partition_monitor_nmxc_connect_error_count` over a time
+   window appropriate to the reconcile interval; its historical total alone
+   does not indicate a current connection problem.
 2. **Logical-partition count matches expectation.**
    `carbide_nvlink_partition_monitor_num_logical_partitions` reflects
    the partitions a site planner expects to exist. A sudden change is

--- a/docs/manuals/nvlink_partitioning.md
+++ b/docs/manuals/nvlink_partitioning.md
@@ -16,7 +16,7 @@ NICo extends the concept of an *NVLink Partition* with the *NVLink Logical Parti
 ## Operations: Who Does What
 
 NVLink splits between operator site setup against NMX-C and tenant partition
-management. Notably, several operator steps (fallback NMX-C endpoint
+management. Notably, two operator steps (fallback NMX-C endpoint
 registration and the GPU-mapping populate step) are **not exposed via the
 REST API** and are therefore driven through `nico-admin-cli` over gRPC. See
 [Network Isolation → Who configures what, and how](network_isolation.md#who-configures-what-and-how)
@@ -25,10 +25,10 @@ for the role and interface model.
 | Task | Role | Interface |
 |---|---|---|
 | Enable NVLink; NMX-C connection and TLS settings | Operator | **TOML** (`[nvlink_config]`) — Day 0 / rare |
-| Fallback NMX-C endpoints (per chassis serial) | Operator | `nico-admin-cli nvlink-nmxc-endpoints …` (gRPC) — not in REST |
+| Fallback NMX-C endpoints (per chassis serial) | Operator | `nico-admin-cli nvlink-nmxc-endpoints ...` (gRPC) — not in REST |
 | Populate the machine → NMX-C GPU mapping | Operator | `nico-admin-cli machine nvlink-info populate` (gRPC) — not in REST |
-| Create / update / delete an NVLink Logical Partition | Tenant | **REST** `…/nico/nvlink-logical-partition` · `nicocli nvlink-logical-partition create` |
-| Assign or change an instance's GPUs' partition | Tenant | **REST** `…/nico/instance` (`nvLinkInterfaces`) · `nicocli instance update` |
+| Create / update / delete an NVLink Logical Partition | Tenant | **REST** `.../nico/nvlink-logical-partition` · `nicocli nvlink-logical-partition create` |
+| Assign or change an instance's GPUs' partition | Tenant | **REST** `.../nico/instance` (`nvLinkInterfaces`) · `nicocli instance update` |
 | Inspect a machine's GPU domain placement (triage) | Operator | `nico-admin-cli machine nvlink-info` (gRPC) |
 
 The operator NMX setup (the first three rows) is detailed under
@@ -170,10 +170,12 @@ NVLink configuration manually before force-deleting.
 
 NMX-C is the supported gRPC control path for NVLink partition management.
 
-> **Compatibility note**: NMX-M is no longer supported. The legacy
-> `nico-admin-cli credential add-nmx-m` and `delete-nmx-m` command names remain
-> available temporarily so existing scripts receive a clear unsupported error;
-> they do not modify credentials.
+<Note title="Compatibility note">
+NMX-M is no longer supported. The legacy
+`nico-admin-cli credential add-nmx-m` and `delete-nmx-m` command names remain
+available temporarily so existing scripts receive a clear unsupported error;
+they do not modify credentials.
+</Note>
 
 Configure the NMX-C client under `[nvlink_config]`:
 

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -132,7 +132,7 @@ through nico-api. The standard `TraceContextPropagator` is installed once at sta
   - **gRPC** - Forge and NMX-C (`crates/rpc`), the NSM and power-shelf (PSM) backends
     (`crates/component-manager`), and the NMX-C client pool (`crates/libnmxc`), through a shared tower
     layer applied to every request.
-  - **HTTP** - the BMC/Redfish handler, machine-identity token exchange, admin-UI OAuth2, NMX-M, NRAS,
+  - **HTTP** - the BMC/Redfish handler, machine-identity token exchange, admin-UI OAuth2, NRAS,
     the MQTT OAuth2 token provider, and firmware downloads.
 - **Interaction with the enable flag.** `tracing-enabled` is the master switch for what nico-api
   *records*: an inbound `sampled` flag never turns recording on here. When `tracing-enabled` is on, the inbound

--- a/docs/overview/capabilities.md
+++ b/docs/overview/capabilities.md
@@ -26,7 +26,7 @@ NICo enforces workload isolation across all network planes without reconfiguring
 |---|---|
 | Ethernet (N/S) | BlueField HBN — L3 VXLAN/EVPN, VRFs, Network Security Groups |
 | InfiniBand (E/W) | UFM-based P_Key partition assignment per tenant |
-| NVLink | NMX-M API partition management |
+| NVLink | NMX-C gRPC partition management |
 | Spectrum-X (E/W) | SP-X partitioning for high-performance East-West traffic |
 
 VPC and subnet configuration are API-driven. Tenant transitions fully clear and re-establish isolation boundaries.

--- a/docs/overview/lifecycle.md
+++ b/docs/overview/lifecycle.md
@@ -62,8 +62,8 @@ applicable network planes:
   VRFs. This requires no leaf switch configuration changes.
 - **InfiniBand**: UFM assigns P_Key partitions to the host's InfiniBand ports
   for the specific tenant.
-- **NVLink**: NMX-M APIs configure NVLink partition assignments for the tenant's
-  NVL domain.
+- **NVLink**: NMX-C APIs configure GPU membership in the requested NVLink
+  logical partitions.
 
 ### Host Lockdown
 

--- a/docs/overview/operational-principles.md
+++ b/docs/overview/operational-principles.md
@@ -26,4 +26,4 @@ NICo monitors hardware health, firmware state, and machine status exclusively vi
 
 ## The network fabric stays static even during tenancy changes
 
-Leaf switches and routers are not reconfigured when tenants change or when hosts are provisioned and released. Isolation is enforced entirely at the DPU layer (Ethernet via HBN) and via fabric management APIs (InfiniBand via UFM, NVLink via NMX-M). Keeping the physical underlay stable reduces operational risk and simplifies network operations at scale.
+Leaf switches and routers are not reconfigured when tenants change or when hosts are provisioned and released. Isolation is enforced entirely at the DPU layer (Ethernet via HBN) and via fabric management APIs (InfiniBand via UFM, NVLink via NMX-C). Keeping the physical underlay stable reduces operational risk and simplifies network operations at scale.

--- a/docs/overview/scope-and-boundaries.md
+++ b/docs/overview/scope-and-boundaries.md
@@ -30,7 +30,7 @@ NICo provisions hosts and assigns them to tenants as instances via API. Building
 |---|---|
 | Tenant isolation at the DPU layer (Ethernet via HBN) | Leaf switch, spine switch, and router configuration |
 | InfiniBand partition assignment via UFM APIs | UFM deployment and management |
-| NVLink partition management via NMX-M APIs | NMX-M deployment and management |
+| NVLink partition management via NMX-C APIs | NMX-C deployment and management |
 | BGP route advertisement from DPUs | Physical underlay design and cabling |
 
 NICo enforces isolation without reconfiguring physical switches — the underlay is expected to be stable and pre-configured. NICo does not install or manage Cumulus Linux on switches, UFM, or network observability tools such as NetQ.

--- a/docs/playbooks/stuck_objects/instance_and_fabric_issues.md
+++ b/docs/playbooks/stuck_objects/instance_and_fabric_issues.md
@@ -91,7 +91,7 @@ Common causes:
 | Symptom | Likely cause |
 |---|---|
 | no `nvlink_info` | pre-existing machine has not been populated. |
-| NMX-C or NMX-M connect error | TLS, credentials, endpoint, or network issue. |
+| NMX-C connect error | TLS, endpoint, or network issue. |
 | partition cleanup pending | stale binding or delayed fabric observation. |
 | placement failure | topology, domain health, or requested instance shape mismatch. |
 


### PR DESCRIPTION
## Description
Update the docs to reflect that NMX-M has been dropped in favour of direct management of the NMX-C instances. Also, return an unsupported error for the NMX-M credential admin-cli command.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2471

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

