### PR TITLE
docs: clarify DPUs are preferred but not required in site controller nodes

### DIFF
--- a/docs/getting-started/prerequisites/hardware.md
+++ b/docs/getting-started/prerequisites/hardware.md
@@ -22,14 +22,27 @@ The site controller runs the NICo control plane on a Kubernetes cluster. A minim
 
 **Storage layout**: Total local NVMe capacity should be 4 TiB or greater. Mount 1.7 TiB on `/` (root) on the NVMe OS disk (ext4 or xfs) — typical usage is 200–500 GiB. Mount `/var/lib/containerd` and `/var/lib/kubelet` on a separate NVMe data disk (1+ TiB, ext4/xfs, `noatime`). Consider a dedicated `/var/log` if there is heavy logging. Persistent app storage (SAN/NAS, Rook-Ceph) is not required for NICo itself.
 
-### DPUs on Site Controller (Required)
+### DPUs on Site Controller
 
-Site-controller nodes must have Bluefield-3 DPUs. Ensure the following requirements are met:
+DPUs are generally preferred in nodes hosting the NICo control plane components, but not strictly required. DPUs in these nodes are, however, the configuration that NICo QA regularly tests. If your site controller nodes are equipped with Bluefield-3 DPUs, ensure the following requirements are met:
+
 - You have the correct DPU power cable from the server vendor.
-- The Bluefield-3's operating mode is DPU mode. NIC mode is not supported.
+- The Bluefield-3's operating mode is DPU mode.
 - For BF3 DPUs, verify link speed and optics: BF3 runs at 200 Gb, so match ports to 200 Gb-capable optics, fiber, or DACs.
 - Verify that the DPU can connect to the outside world (curl -I https://www.nvidia.com)
-- The DPUs are at the latest supported firmware version: DOCA 2.9.3 and HBN 2.4.3
+- The DPUs are at the latest tested firmware version: DOCA 3.2.2 and HBN 3.2.2
+
+### NICo Pod Network Reachability
+
+NICo's control plane pods (DHCP, DNS, API, PXE, SSH console, and others) must be externally reachable from the networks they serve. Regardless of whether site controller nodes have DPUs, these pods must be routable to and from:
+
+- DPU BMCs and Host BMCs of managed machines
+- The admin network
+- Tenant VPCs
+
+The reference architecture is MetalLB advertising L3 LoadBalancer VIPs to the site controller's DPU uplinks (if DPUs are present) or directly to the ToR switches (if site controller nodes have no DPUs).
+
+For better traffic isolation and routing, configure the LoadBalancer endpoints for NICo pods as route-tagged prefixes and import them into the admin and VPC routing profiles. See [VPC Routing Profiles](../../manuals/vpc/vpc_routing_profiles.md).
 
 ## Compute Systems (Managed Hosts)
 

--- a/docs/getting-started/prerequisites/network.md
+++ b/docs/getting-started/prerequisites/network.md
@@ -104,7 +104,7 @@ Standardized common route targets:
 
 | Route-Target | Purpose |
 |---|---|
-| `:50100` | Control-Plane / Service VIPs — exported by site controller DPUs |
+| `:50100` | Control-Plane / Service VIPs — exported by site controller DPUs (or ToR, if site controller nodes have no DPUs) |
 | `:50200` | Internal tenant routes |
 | `:50300` | Maintenance network routes |
 | `:50400` | Admin network routes |
@@ -118,6 +118,18 @@ These are defaults and can be changed, as long as all components agree on the va
 - Site controllers exporting `:50100` must import `:50200` through `:50500` to reach all managed endpoints.
 
 <Note>While many deployments align the route target number with the VNI for administrative simplicity, the routing policy is strictly governed by the route target import/export configuration, not the VNI itself.</Note>
+
+## NICo Pod Network Reachability
+
+NICo's control plane pods (DHCP, DNS, API, PXE, SSH console, and others) must be externally reachable from the networks they serve. Regardless of whether site controller nodes have DPUs, these pods must be routable to and from:
+
+- DPU BMCs and Host BMCs of managed machines
+- The admin network
+- Tenant VPCs
+
+The reference architecture is MetalLB advertising L3 LoadBalancer VIPs to the site controller's DPU uplinks (if DPUs are present) or directly to the ToR switches (if site controller nodes have no DPUs).
+
+For better traffic isolation and routing, configure the endpoints for NICo pods (whether exposed as `LoadBalancer` objects or otherwise) as route-tagged prefixes and import them into the admin and VPC routing profiles. See [VPC Routing Profiles](../../manuals/vpc/vpc_routing_profiles.md).
 
 ## Switch Configuration
 
@@ -145,7 +157,7 @@ Use one physical NIC carrying the following:
 
 ### Option 2: Dual-homed Uplink (Reference Design)
 
-This design requires the DPU to be in DPU mode on site controllers.
+This design uses the site controller's DPU (if present) in DPU mode.
 
 - The site controller typically uses a single DPU/NIC with two uplinks, each cabled to a different ToR switch participating in BGP unnumbered.
 - Both links carry management and Kubernetes traffic; isolation is done via VLANs/VRFs and policy, not by dedicating one NIC to management and one to the data plane.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -33,17 +33,17 @@ The cluster must have:
 
 ### Site controller node DPU requirements
 
-Site controller nodes must be equipped with fully provisioned DPUs (Bluefield-3s) which are configured **before** the Kubernetes cluster is set up. We do not support configuring site controller nodes without DPUs today. NICo does not provision the site controller nodes' own DPUs — it only manages DPUs on downstream bare-metal hosts after ingestion.
+DPUs are generally preferred in nodes hosting the NICo control plane components, but not strictly required. DPUs in these nodes are, however, the configuration that NICo QA regularly tests. NICo does not provision the site controller nodes' own DPUs — it only manages DPUs on downstream bare-metal hosts after ingestion.
 
-Specifically, you must complete the following before proceeding:
+If your site controller nodes are equipped with Bluefield-3 DPUs, they must be fully provisioned **before** the Kubernetes cluster is set up. Specifically, complete the following before proceeding:
 
-- Flash the DPU firmware to the latest supported version using the BlueField Firmware Bundle. Latest supported firmware versions:
+- Flash the DPU firmware to the latest tested version using the BlueField Firmware Bundle. Latest tested firmware versions:
 
   | DOCA  | HBN   |
   | ----- | ----- |
-  | 2.9.3 | 2.4.3 |
+  | 3.2.2 | 3.2.2 |
 
-- Configure the Bluefield-3 device in DPU mode (operating mode). We do not currently support NIC mode.
+- Configure the Bluefield-3 device in DPU mode (operating mode).
 - Ensure the DPU ARM OS is booted and reachable via its management interface.
 - Verify that the DPU can connect to the outside world (curl -I https://www.google.com)
 


### PR DESCRIPTION
DPUs are the QA-tested configuration but not a hard requirement for the control plane. Updates hardware, network, and quick-start prerequisites to reflect this, adds a NICo pod network reachability section covering the MetalLB/ToR reference architecture and a link to routing profiles docs, and bumps tested firmware versions to DOCA/HBN 3.2.2.

This adds flexibility to people deploying NICo components when all we actually require is a conformant Kubernetes and some traffic management policies.

## Related issues
<!-- Refer to existing GitHub issues here -->

## Type of Change
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] No testing required (docs, internal refactor, etc.)