### PR TITLE
feat(cherry-pick): re-enable adhoc endpoint exploration

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -715,7 +715,7 @@ script = [
 workspace = false
 description = "Check cargo-deny against licenses we're using to validate that we're not introducing new licenses inadvertently"
 category = "Licensing"
-script = ["cargo deny check license"]
+script = ["cargo deny check licenses"]
 
 [tasks.check-bans]
 workspace = false

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -32,7 +32,7 @@ use ::rpc::protos::dns::{
 use ::rpc::protos::{measured_boot as measured_boot_pb, mlx_device as mlx_device_pb};
 use carbide_ib_fabric::ib::IBFabricManager;
 use carbide_redfish::libredfish::RedfishClientPool;
-use carbide_site_explorer::EndpointExplorer;
+use carbide_site_explorer::{EndpointExplorationLocks, EndpointExplorer};
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
@@ -78,6 +78,9 @@ pub struct Api {
     pub(crate) rms_client: Option<Arc<dyn RmsApi>>,
     pub(crate) nmxc_client_pool: Arc<dyn NmxcPool>,
     pub(crate) work_lock_manager_handle: WorkLockManagerHandle,
+    /// In-process per-endpoint exploration locks, shared with the site-explorer loop so periodic
+    /// exploration and ad-hoc `RefreshEndpointReport` calls never probe the same BMC at once.
+    pub(crate) endpoint_exploration_locks: EndpointExplorationLocks,
     pub(crate) dpf_sdk: Option<Arc<dyn DpfOperations>>,
     pub(crate) machine_state_handler_enqueuer: Enqueuer<MachineStateControllerIO>,
     pub(crate) metric_emitter: ApiMetricsEmitter,

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -222,19 +222,11 @@ pub(crate) async fn re_explore_endpoint(
     Ok(Response::new(()))
 }
 
-// Short-circuited: adhoc endpoint refresh is temporarily disabled. The probe
-// path below is retained but unreachable until the feature is re-enabled.
-#[allow(unreachable_code, unused_variables, txn_without_commit)]
 pub(crate) async fn refresh_endpoint_report(
     api: &Api,
     request: Request<rpc::RefreshEndpointReportRequest>,
 ) -> Result<Response<::rpc::site_explorer::ExploredEndpoint>, tonic::Status> {
     log_request_data(&request);
-
-    return Err(CarbideError::UnavailableError(
-        "Endpoint refresh is temporarily unavailable".to_string(),
-    )
-    .into());
 
     let req = request.into_inner();
 
@@ -278,14 +270,29 @@ pub(crate) async fn refresh_endpoint_report(
             .map(ExpectedEntity::PowerShelf)
     };
 
-    // Run the probe + persist on a detached tokio task. Awaiting the JoinHandle
-    // preserves the synchronous UX. Even if the caller navigates away mid-fetch,
-    // the probe will still run to completion.
+    // Claim the per-endpoint exploration lock before probing. If the periodic site-explorer loop or
+    // another concurrent refresh is already probing this endpoint, return immediately rather than
+    // running a redundant Redfish call.
+    let endpoint_guard = match api.endpoint_exploration_locks.try_claim(bmc_ip) {
+        Some(guard) => guard,
+        None => {
+            return Err(CarbideError::AlreadyInProgress(format!(
+                "Endpoint refresh already in progress for {bmc_ip}"
+            ))
+            .into());
+        }
+    };
+
+    // Run the probe + persist on a detached tokio task that owns the endpoint guard. Awaiting the
+    // JoinHandle preserves the synchronous UX. Even if the caller navigates away mid-fetch, the
+    // probe will still run to completion.
     let endpoint_explorer = api.endpoint_explorer.clone();
     let database_connection = api.database_connection.clone();
     let runtime_config = api.runtime_config.clone();
 
     let join_handle = tokio::spawn(async move {
+        let _endpoint_guard = endpoint_guard;
+
         let start = std::time::Instant::now();
         let result = endpoint_explorer
             .explore_endpoint(

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -40,7 +40,7 @@ use carbide_nvlink_manager::NvlPartitionMonitor;
 use carbide_preingestion_manager::PreingestionManager;
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
-use carbide_site_explorer::SiteExplorer;
+use carbide_site_explorer::{EndpointExplorationLocks, SiteExplorer};
 use carbide_spdm_controller::context::SpdmStateHandlerServices;
 use carbide_spdm_controller::handler::SpdmAttestationStateHandler;
 use carbide_spdm_controller::io::SpdmStateControllerIO;
@@ -727,6 +727,10 @@ pub async fn start_api(
         None
     };
 
+    // Shared between the API's `RefreshEndpointReport` handler and the site-explorer loop so they
+    // never probe the same endpoint at once. In-process only; see `EndpointExplorationLocks`.
+    let endpoint_exploration_locks = EndpointExplorationLocks::default();
+
     let api_service = Arc::new(Api {
         certificate_provider,
         common_pools,
@@ -743,6 +747,7 @@ pub async fn start_api(
         rms_client: rms_client.clone(),
         nmxc_client_pool: shared_nmxc_pool.clone(),
         work_lock_manager_handle,
+        endpoint_exploration_locks,
         dpf_sdk: dpf_sdk.clone(),
         machine_state_handler_enqueuer: Enqueuer::new(db_pool),
         metric_emitter: ApiMetricsEmitter::new(&meter),
@@ -809,6 +814,7 @@ pub async fn initialize_and_start_controllers<'a>(
         ib_fabric_manager,
         redfish_pool: shared_redfish_pool,
         work_lock_manager_handle,
+        endpoint_exploration_locks,
         rms_client,
         dpf_sdk,
         credential_manager,
@@ -1321,6 +1327,7 @@ pub async fn initialize_and_start_controllers<'a>(
         rms_client.clone(),
         credential_manager.clone(),
     )
+    .with_endpoint_exploration_locks(endpoint_exploration_locks.clone())
     .start(join_set, cancel_token.clone())?;
 
     MachineUpdateManager::new(

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -28,8 +28,11 @@ use model::site_explorer::{
     NicMode,
 };
 
-/// EndpointExplorer which returns predefined data
-#[derive(Clone, Default, Debug)]
+/// EndpointExplorer which returns predefined data.
+///
+/// Exploration is served from injected reports. A real explorer can be attached with
+/// [`Self::with_redfish_backend`] so machine setup and boot-order calls still use `RedfishSim`.
+#[derive(Clone)]
 pub struct MockEndpointExplorer {
     pub reports:
         Arc<Mutex<HashMap<IpAddr, Result<EndpointExplorationReport, EndpointExplorationError>>>>,
@@ -41,6 +44,20 @@ pub struct MockEndpointExplorer {
     pub set_nic_mode_calls: Arc<Mutex<Vec<(SocketAddr, NicMode)>>>,
     /// Records IPs that `explore_endpoint` was called for.
     pub explore_endpoint_calls: Arc<Mutex<Vec<IpAddr>>>,
+    redfish_backend: Option<Arc<dyn EndpointExplorer>>,
+}
+
+impl Default for MockEndpointExplorer {
+    fn default() -> Self {
+        Self {
+            reports: Arc::default(),
+            power_states: Arc::default(),
+            redfish_power_control_calls: Arc::default(),
+            set_nic_mode_calls: Arc::default(),
+            explore_endpoint_calls: Arc::default(),
+            redfish_backend: None,
+        }
+    }
 }
 
 impl MockEndpointExplorer {
@@ -76,6 +93,11 @@ impl MockEndpointExplorer {
         for (address, result) in endpoints {
             guard.insert(address, result);
         }
+    }
+
+    pub fn with_redfish_backend(mut self, backend: Arc<dyn EndpointExplorer>) -> Self {
+        self.redfish_backend = Some(backend);
+        self
     }
 }
 
@@ -188,20 +210,34 @@ impl EndpointExplorer for MockEndpointExplorer {
 
     async fn machine_setup(
         &self,
-        _address: SocketAddr,
-        _interface: &MachineInterfaceSnapshot,
-        _boot_interface_mac: Option<&str>,
+        address: SocketAddr,
+        interface: &MachineInterfaceSnapshot,
+        boot_interface_mac: Option<&str>,
     ) -> Result<(), EndpointExplorationError> {
-        Ok(())
+        match &self.redfish_backend {
+            Some(backend) => {
+                backend
+                    .machine_setup(address, interface, boot_interface_mac)
+                    .await
+            }
+            None => Ok(()),
+        }
     }
 
     async fn set_boot_order_dpu_first(
         &self,
-        _address: SocketAddr,
-        _interface: &MachineInterfaceSnapshot,
-        _boot_interface_mac: &str,
+        address: SocketAddr,
+        interface: &MachineInterfaceSnapshot,
+        boot_interface_mac: &str,
     ) -> Result<(), EndpointExplorationError> {
-        Ok(())
+        match &self.redfish_backend {
+            Some(backend) => {
+                backend
+                    .set_boot_order_dpu_first(address, interface, boot_interface_mac)
+                    .await
+            }
+            None => Ok(()),
+        }
     }
 
     async fn set_nic_mode(

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -32,7 +32,7 @@ use model::site_explorer::{
 ///
 /// Exploration is served from injected reports. A real explorer can be attached with
 /// [`Self::with_redfish_backend`] so machine setup and boot-order calls still use `RedfishSim`.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct MockEndpointExplorer {
     pub reports:
         Arc<Mutex<HashMap<IpAddr, Result<EndpointExplorationReport, EndpointExplorationError>>>>,
@@ -45,19 +45,6 @@ pub struct MockEndpointExplorer {
     /// Records IPs that `explore_endpoint` was called for.
     pub explore_endpoint_calls: Arc<Mutex<Vec<IpAddr>>>,
     redfish_backend: Option<Arc<dyn EndpointExplorer>>,
-}
-
-impl Default for MockEndpointExplorer {
-    fn default() -> Self {
-        Self {
-            reports: Arc::default(),
-            power_states: Arc::default(),
-            redfish_power_control_calls: Arc::default(),
-            set_nic_mode_calls: Arc::default(),
-            explore_endpoint_calls: Arc::default(),
-            redfish_backend: None,
-        }
-    }
 }
 
 impl MockEndpointExplorer {

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -40,8 +40,8 @@ use carbide_nvlink_manager::NvlPartitionMonitor;
 use carbide_nvlink_manager::config::NvLinkConfig;
 use carbide_nvlink_manager::nvlink::test_support::NmxcSimClient;
 use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimTestOverrides};
-use carbide_site_explorer::SiteExplorer;
 use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
+use carbide_site_explorer::{EndpointExplorationLocks, EndpointExplorer, SiteExplorer};
 use carbide_spdm_controller::context::SpdmStateHandlerServices;
 use carbide_spdm_controller::handler::SpdmAttestationStateHandler;
 use carbide_spdm_controller::io::SpdmStateControllerIO;
@@ -1621,6 +1621,9 @@ pub async fn create_test_env_with_overrides(
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
         SiteExplorerExploreMode::NvRedfish,
     );
+    let fake_endpoint_explorer = MockEndpointExplorer::default().with_redfish_backend(bmc_explorer);
+    let endpoint_explorer: Arc<dyn EndpointExplorer> = Arc::new(fake_endpoint_explorer.clone());
+    let endpoint_exploration_locks = EndpointExplorationLocks::default();
 
     let reachability_params = ReachabilityParams {
         dpu_wait_time: Duration::seconds(0),
@@ -1646,12 +1649,13 @@ pub async fn create_test_env_with_overrides(
         common_pools: common_pools.clone(),
         ib_fabric_manager: ib_fabric_manager.clone(),
         dynamic_settings: dyn_settings,
-        endpoint_explorer: bmc_explorer,
+        endpoint_explorer: endpoint_explorer.clone(),
         dpu_health_log_limiter: LogLimiter::default(),
         scout_stream_registry: scout_stream::ConnectionRegistry::new(),
         rms_client: rms_sim.as_rms_client(),
         nmxc_client_pool: nmxc_sim.clone(),
         work_lock_manager_handle: work_lock_manager_handle.clone(),
+        endpoint_exploration_locks: endpoint_exploration_locks.clone(),
         machine_state_handler_enqueuer: Enqueuer::new(db_pool.clone()),
         metric_emitter: ApiMetricsEmitter::new(&test_meter.meter()),
         component_manager: None,
@@ -1853,14 +1857,6 @@ pub async fn create_test_env_with_overrides(
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build RackStateController");
 
-    let fake_endpoint_explorer = MockEndpointExplorer {
-        reports: Arc::new(std::sync::Mutex::new(Default::default())),
-        power_states: Arc::new(std::sync::Mutex::new(Default::default())),
-        redfish_power_control_calls: Arc::new(std::sync::Mutex::new(Default::default())),
-        set_nic_mode_calls: Arc::new(std::sync::Mutex::new(Default::default())),
-        explore_endpoint_calls: Arc::new(std::sync::Mutex::new(Default::default())),
-    };
-
     // The API server is launched with a disabled site-explorer config so that it doesn't launch one
     // on its own. TestEnv's site_explorer is a separate instance talking to the same database that
     // *is* enabled, so it gets a different config. The purpose is so that tests can manually run
@@ -1894,13 +1890,14 @@ pub async fn create_test_env_with_overrides(
             explore_mode: SiteExplorerExploreMode::NvRedfish,
         },
         test_meter.meter(),
-        Arc::new(fake_endpoint_explorer.clone()),
+        endpoint_explorer,
         Arc::new(config.get_firmware_config()),
         common_pools.clone(),
         work_lock_manager_handle.clone(),
         rms_sim.as_rms_client(),
         credential_manager.clone(),
-    );
+    )
+    .with_endpoint_exploration_locks(endpoint_exploration_locks);
 
     // Create some instance types
     let mut txn = api.txn_begin().await.unwrap();

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -5150,13 +5150,87 @@ async fn host_bmc_ip(
     Ok(bmc_ip)
 }
 
+async fn explored_endpoint(
+    env: &TestEnv,
+    bmc_ip: IpAddr,
+) -> Result<model::site_explorer::ExploredEndpoint, Box<dyn std::error::Error>> {
+    let mut txn = env.pool.begin().await?;
+    let endpoint = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| format!("expected endpoint {bmc_ip} to exist"))?;
+    txn.commit().await?;
+    Ok(endpoint)
+}
+
+fn endpoint_explore_call_count(env: &TestEnv, bmc_ip: IpAddr) -> usize {
+    env.endpoint_explorer
+        .explore_endpoint_calls
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|called_ip| **called_ip == bmc_ip)
+        .count()
+}
+
 #[crate::sqlx_test]
-async fn test_refresh_endpoint_report_is_unavailable(
+async fn test_refresh_endpoint_report_bumps_report_version(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
     let mh = common::api_fixtures::create_managed_host(&env).await;
     let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let initial_version = explored_endpoint(&env, bmc_ip).await?.report_version;
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await?;
+
+    let refreshed = explored_endpoint(&env, bmc_ip).await?;
+    assert!(
+        refreshed.report_version.version_nr() > initial_version.version_nr(),
+        "refresh should bump report version from {} to a newer version, got {}",
+        initial_version.version_nr(),
+        refreshed.report_version.version_nr()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_rejects_nonexistent_endpoint(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let err = env
+        .api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: "99.99.99.99".to_string(),
+        }))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_rejects_duplicate_refresh(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let _endpoint_lock = env
+        .api
+        .endpoint_exploration_locks
+        .try_claim(bmc_ip)
+        .expect("test should be able to claim the endpoint exploration lock");
 
     let err = env
         .api
@@ -5166,7 +5240,139 @@ async fn test_refresh_endpoint_report_is_unavailable(
         .await
         .unwrap_err();
 
-    assert_eq!(err.code(), tonic::Code::Unavailable);
+    assert_eq!(err.code(), tonic::Code::AlreadyExists);
+    assert!(
+        err.message().contains(&bmc_ip.to_string()),
+        "error should identify the locked endpoint"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_lock_blocks_periodic_probe(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+
+    env.api
+        .re_explore_endpoint(Request::new(rpc::forge::ReExploreEndpointRequest {
+            ip_address: bmc_ip.to_string(),
+            if_version_match: None,
+        }))
+        .await?;
+
+    let calls_before = endpoint_explore_call_count(&env, bmc_ip);
+    let _endpoint_lock = env
+        .api
+        .endpoint_exploration_locks
+        .try_claim(bmc_ip)
+        .expect("test should be able to claim the endpoint exploration lock");
+
+    env.run_site_explorer_iteration().await;
+
+    assert_eq!(
+        endpoint_explore_call_count(&env, bmc_ip),
+        calls_before,
+        "periodic site explorer probe should be skipped while refresh lock is held"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_failure_persists_error_and_bumps_version(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let initial_version = explored_endpoint(&env, bmc_ip).await?.report_version;
+    env.endpoint_explorer.insert_endpoint_result(
+        bmc_ip,
+        Err(EndpointExplorationError::Unreachable {
+            details: Some("refresh failure".to_string()),
+        }),
+    );
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await?;
+
+    let refreshed = explored_endpoint(&env, bmc_ip).await?;
+    assert!(
+        refreshed.report_version.version_nr() > initial_version.version_nr(),
+        "failed refresh should still bump report version"
+    );
+    assert!(
+        refreshed.report.last_exploration_error.is_some(),
+        "failed refresh should persist the exploration error"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_clears_pending_requested_exploration(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+
+    env.api
+        .re_explore_endpoint(Request::new(rpc::forge::ReExploreEndpointRequest {
+            ip_address: bmc_ip.to_string(),
+            if_version_match: None,
+        }))
+        .await?;
+    assert!(explored_endpoint(&env, bmc_ip).await?.exploration_requested);
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await?;
+
+    assert!(
+        !explored_endpoint(&env, bmc_ip).await?.exploration_requested,
+        "refresh should clear the pending requested exploration"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_lock_is_per_endpoint(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh_a = common::api_fixtures::create_managed_host(&env).await;
+    let mh_b = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip_a = host_bmc_ip(&env, &mh_a).await?;
+    let bmc_ip_b = host_bmc_ip(&env, &mh_b).await?;
+    let initial_version_b = explored_endpoint(&env, bmc_ip_b).await?.report_version;
+    let _endpoint_lock = env
+        .api
+        .endpoint_exploration_locks
+        .try_claim(bmc_ip_a)
+        .expect("test should be able to claim the endpoint exploration lock");
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip_b.to_string(),
+        }))
+        .await?;
+
+    let refreshed_b = explored_endpoint(&env, bmc_ip_b).await?;
+    assert!(
+        refreshed_b.report_version.version_nr() > initial_version_b.version_nr(),
+        "lock for endpoint {bmc_ip_a} should not block refresh for endpoint {bmc_ip_b}"
+    );
 
     Ok(())
 }

--- a/crates/api/templates/explored_endpoint_detail.html
+++ b/crates/api/templates/explored_endpoint_detail.html
@@ -9,8 +9,8 @@
     {% endif %}
     <a id="logs-link" href="" target="_blank">Logs</a>
     <a id="json-link" href="">JSON</a>
-    <a id="refresh-endpoint" href="#" title="Refresh this endpoint's report immediately. If you stay on this page, you will see the status message and spinner until the refresh finishes." aria-label="Refresh endpoint report">
-        <span>Refresh</span>
+    <a id="refresh-endpoint" href="#" title="Explore this endpoint's report immediately. If you stay on this page, you will see the status message and spinner until the exploration finishes." aria-label="Explore endpoint report">
+        <span>Explore</span>
         <svg class="refresh-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="M21.5 2v6h-6"/>
             <path d="M2.5 22v-6h6"/>
@@ -218,13 +218,13 @@
 					</div>
 					{% endif %}
 					<!-- Secure Boot Card -->
+					{% if secure_boot_status != "Unknown" %}
 					<div class="config-card">
 						<div class="config-card-header">
 						<div class="config-card-title">Secure Boot</div>
 						<span class="bubble
 						{% if secure_boot_status == "Disabled" %}
 							success
-						{% else if secure_boot_status == "Unknown" %}
 						{% else %}
 							error
 						{% endif %}
@@ -232,7 +232,7 @@
 						</div>
 					<form id="disable_secure_boot" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/disable-secure-boot" class="config-card-action">
 						<div class="config-card-reminder">Reboot required to take effect.</div>
-						<input type="submit" value="Disable Secure Boot" class="{% if secure_boot_status == "Unknown" %}disabled{% endif %}" {% if secure_boot_status == "Unknown" %}onclick="return false;"{% endif %}>
+						<input type="submit" value="Disable Secure Boot">
 						<span class="action-spinner"></span>
 					</form>
 					{% if let Some(status) = action_status %}
@@ -241,7 +241,9 @@
 					{% endif %}
 					{% endif %}
 					</div>
+					{% endif %}
 					<!-- Lockdown Card -->
+					{% if lockdown_status != "Unknown" %}
 					<div class="config-card">
 						<div class="config-card-header">
 							<div class="config-card-title">Lockdown</div>
@@ -250,7 +252,6 @@
 							success
 						{% else if lockdown_status == "Partial" %}
 							warning
-						{% else if lockdown_status == "Unknown" %}
 						{% else %}
 							error
 						{% endif %}
@@ -265,7 +266,7 @@
 					{% else %}
 					<form id="disable_lockdown" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/disable-lockdown" class="config-card-action">
 						<div class="config-card-reminder">Reboot required to take effect.</div>
-						<input type="submit" value="Disable Lockdown" class="{% if lockdown_status == "Unknown" %}disabled{% endif %}" {% if lockdown_status == "Unknown" %}onclick="return false;"{% endif %}>
+						<input type="submit" value="Disable Lockdown">
 						<span class="action-spinner"></span>
 					</form>
 					{% endif %}
@@ -275,6 +276,7 @@
 					{% endif %}
 					{% endif %}
 					</div>
+					{% endif %}
 				</div>
 			</td>
 		</tr>
@@ -517,7 +519,7 @@ document.addEventListener('DOMContentLoaded', function() {
 					return res.json().catch(function() { return {}; }).then(function(body) {
 						if (res.ok) {
 							sessionStorage.setItem('refreshToast', JSON.stringify({
-								message: 'Report Refreshed',
+								message: 'Endpoint Explored',
 								error: body.has_exploration_error || false
 							}));
 						} else {

--- a/crates/api/templates/static/carbide.css
+++ b/crates/api/templates/static/carbide.css
@@ -1162,6 +1162,7 @@ details > *:not(summary) {
   grid-template-columns: repeat(auto-fill, 260px);
   gap: 1rem;
   width: 100%;
+  overflow: visible;
 }
 
 /* Individual configuration card */
@@ -1183,6 +1184,7 @@ details > *:not(summary) {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  min-height: 2.8rem;
 }
 
 .config-card .bubble {

--- a/crates/site-explorer/src/endpoint_lock.rs
+++ b/crates/site-explorer/src/endpoint_lock.rs
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//! In-process coordination for endpoint exploration.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::sync::{Arc, Mutex};
+
+/// Tracks endpoints currently being explored so periodic site exploration and ad-hoc
+/// `RefreshEndpointReport` calls do not probe the same BMC at the same time.
+///
+/// Coordination is per-process only. `nico-api` runs a single replica, so the only window in which
+/// two processes could probe the same endpoint is the brief overlap of a rolling deploy, where a
+/// duplicate probe is harmless and writes are still guarded by optimistic concurrency. If `nico-api`
+/// is ever scaled to multiple active replicas, this would no longer dedupe across them.
+#[derive(Clone, Default)]
+pub struct EndpointExplorationLocks {
+    in_flight: Arc<Mutex<HashSet<IpAddr>>>,
+}
+
+/// A claim on exploring a single endpoint. The endpoint is released when this is dropped, including
+/// on panic or task cancellation.
+pub struct EndpointExplorationGuard {
+    in_flight: Arc<Mutex<HashSet<IpAddr>>>,
+    bmc_ip: IpAddr,
+}
+
+impl Drop for EndpointExplorationGuard {
+    fn drop(&mut self) {
+        self.in_flight
+            .lock()
+            .expect("EndpointExplorationLocks mutex poisoned")
+            .remove(&self.bmc_ip);
+    }
+}
+
+impl EndpointExplorationLocks {
+    /// Try to claim exclusive exploration of `bmc_ip` within this process. Returns `None` if another
+    /// task is already exploring it.
+    pub fn try_claim(&self, bmc_ip: IpAddr) -> Option<EndpointExplorationGuard> {
+        let claimed = self
+            .in_flight
+            .lock()
+            .expect("EndpointExplorationLocks mutex poisoned")
+            .insert(bmc_ip);
+
+        claimed.then(|| EndpointExplorationGuard {
+            in_flight: self.in_flight.clone(),
+            bmc_ip,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::*;
+
+    fn ip(last: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, last))
+    }
+
+    #[test]
+    fn second_claim_for_same_endpoint_is_rejected_until_released() {
+        let locks = EndpointExplorationLocks::default();
+
+        let guard = locks.try_claim(ip(1)).expect("first claim should succeed");
+        assert!(
+            locks.try_claim(ip(1)).is_none(),
+            "second claim for the same endpoint should be rejected while held"
+        );
+
+        drop(guard);
+        assert!(
+            locks.try_claim(ip(1)).is_some(),
+            "claim should succeed again once the previous guard is dropped"
+        );
+    }
+
+    #[test]
+    fn claims_are_per_endpoint() {
+        let locks = EndpointExplorationLocks::default();
+
+        let _guard_a = locks.try_claim(ip(1)).expect("claim for a should succeed");
+        assert!(
+            locks.try_claim(ip(2)).is_some(),
+            "a claim on one endpoint must not block a different endpoint"
+        );
+    }
+}

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -60,6 +60,8 @@ use tracing::Instrument;
 use version_compare::Cmp;
 mod endpoint_explorer;
 pub use endpoint_explorer::EndpointExplorer;
+mod endpoint_lock;
+pub use endpoint_lock::{EndpointExplorationGuard, EndpointExplorationLocks};
 mod credentials;
 mod metrics;
 pub use metrics::SiteExplorationMetrics;
@@ -259,6 +261,8 @@ pub struct SiteExplorer {
     endpoint_explorer: Arc<dyn EndpointExplorer>,
     firmware_config: Arc<FirmwareConfig>,
     work_lock_manager_handle: WorkLockManagerHandle,
+    /// Per-endpoint, in-process exploration locks shared with the API's ad-hoc refresh handler.
+    endpoint_exploration_locks: EndpointExplorationLocks,
     machine_creator: MachineCreator,
     switch_creator: SwitchCreator,
     boot_order_tracker: BootOrderTracker,
@@ -311,8 +315,17 @@ impl SiteExplorer {
             endpoint_explorer,
             firmware_config,
             work_lock_manager_handle,
+            endpoint_exploration_locks: EndpointExplorationLocks::default(),
             boot_order_tracker: BootOrderTracker::default(),
         }
+    }
+
+    pub fn with_endpoint_exploration_locks(
+        mut self,
+        endpoint_exploration_locks: EndpointExplorationLocks,
+    ) -> Self {
+        self.endpoint_exploration_locks = endpoint_exploration_locks;
+        self
     }
 
     /// Start the SiteExplorer background task. The task always runs and checks
@@ -1727,6 +1740,7 @@ impl SiteExplorer {
 
         for endpoint in explore_endpoint_data.into_iter() {
             let endpoint_explorer = self.endpoint_explorer.clone();
+            let endpoint_exploration_locks = self.endpoint_exploration_locks.clone();
             let concurrency_limiter = concurrency_limiter.clone();
 
             let bmc_target_port = self.config.override_target_port.unwrap_or(443);
@@ -1747,6 +1761,20 @@ impl SiteExplorer {
                         .acquire()
                         .await
                         .expect("Semaphore can't be closed");
+
+                    // If an ad-hoc refresh or another periodic task is already exploring this
+                    // endpoint, skip it for this iteration.
+                    let _endpoint_guard =
+                        match endpoint_exploration_locks.try_claim(endpoint.address) {
+                            Some(guard) => guard,
+                            None => {
+                                tracing::info!(
+                                    address = %endpoint.address,
+                                    "Skipping periodic endpoint exploration; endpoint already in progress"
+                                );
+                                return Ok(None);
+                            }
+                        };
 
                     let mut result = endpoint_explorer
                         .explore_endpoint(


### PR DESCRIPTION
PR #1635 introduced endpoint refresh using per-endpoint database WorkLocks, which did not scale at large sites. PR #2890 temporarily disabled refresh and removed that dependency. This backports PR #2990, re-enabling refresh with lightweight in-process locks that prevent concurrent ad-hoc and periodic probes of the same BMC.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
