### PR TITLE
docs: Document nico-admin-cli boot-interface commands

### DIFF
--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -198,6 +198,9 @@ All of these are **admin-only**; the Forge gRPC service enforces admin authoriza
 |---|---|---|
 | `managed-host set-primary-interface <host-id> <interface-id> [--reboot]` | `SetPrimaryInterface` | Designate a machine interface as the host's primary/boot interface. **The modern form.** |
 | `managed-host set-primary-dpu <host-id> <dpu-id> [--reboot]` | `SetPrimaryDpu` | Designate a DPU as primary. *Deprecated — prefer `set-primary-interface`.* |
+| `boot-interface show <machine-id>` | `GetMachineBootInterfaces` | Show a machine's boot interface across every store (managed, predicted, explored, retained), the effective interface the system would select, and any disagreement between stores. Read-only. |
+| `boot-interface candidates <machine-id>` | `GetMachineBootInterfaces` | List a machine's candidate boot NICs and the picks among them (`current`, `default`, `explored`); underlay rows are listed but ineligible. Read-only. |
+| `boot-interface set <machine-id> <interface> [--reboot]` | `SetPrimaryInterface` | Set a machine's boot interface by promoting it to the primary interface — the same operation as `set-primary-interface`. `<interface>` is a machine-interface UUID or a MAC (a MAC must match exactly one managed interface row). |
 | `boot-override set <interface-id> [--custom-pxe <f>] [--custom-user-data <f>]` | `SetMachineBootOverride` | Override the iPXE script / cloud-init user-data served at boot. |
 | `boot-override get <interface-id>` | `GetMachineBootOverride` | Show the current boot override. |
 | `boot-override clear <interface-id>` | `ClearMachineBootOverride` | Revert to the default PXE/cloud-init. |
@@ -328,6 +331,8 @@ nico-admin-cli -a <api-url> managed-host show <machine-id>
 ```
 
 The interfaces section shows each NIC's MAC, segment, and which one is `primary` (the boot interface). The web UI machine-detail page shows the same with a primary indicator.
+
+To inspect the boot interface itself — every store (managed, predicted, explored, retained) side by side, the effective interface the system would select, and a flag when the stores disagree — use `boot-interface show <machine-id>`; `boot-interface candidates <machine-id>` narrows it to the candidate NICs and the picks among them. Both are read-only ([Section 4](#4-admin-cli-and-grpc-reference)).
 
 **Common situations:**
 


### PR DESCRIPTION
Documents the `nico-admin-cli boot-interface` commands that landed in #3341 but were missing from the hand-maintained provisioning guide. The guide now covers `show`, `candidates`, and `set`, including their argument shapes and Core RPC mappings, and points troubleshooting readers to the read-only inspection commands.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This is a documentation-only change.
