### PR TITLE
chore(rest-api): Update subnet gRPC calls to use structured fields (config/status)

### DIFF
--- a/rest-api/api/pkg/api/model/subnet.go
+++ b/rest-api/api/pkg/api/model/subnet.go
@@ -88,20 +88,27 @@ func (scr *APISubnetCreateRequest) Validate() error {
 // cannot see.
 func (scr *APISubnetCreateRequest) ToProto(subnet *cdbm.Subnet, vpc *cdbm.Vpc, reservedIPCount int32) *corev1.NetworkSegmentCreationRequest {
 	subnetProto := subnet.ToProto()
-	// `prefixes` aliases `subnetProto.Prefixes`; the slice + its `NetworkPrefix`
+	cfg := subnetProto.GetConfig()
+	// `prefixes` aliases `cfg.Prefixes`; the slice + its `NetworkPrefix`
 	// elements are freshly allocated by `subnet.ToProto()` on every call, so
 	// mutating `ReserveFirst` here is safe -- nothing else holds a reference
 	// to those values.
-	prefixes := subnetProto.Prefixes
+	prefixes := cfg.GetPrefixes()
 	for _, p := range prefixes {
 		p.ReserveFirst = reservedIPCount
 	}
+	var subdomainID *corev1.DomainId
+	var mtu *int32
+	if cfg != nil {
+		subdomainID = cfg.SubdomainId
+		mtu = cfg.Mtu
+	}
 	return &corev1.NetworkSegmentCreationRequest{
 		Id:          subnetProto.Id,
-		Name:        subnetProto.Name,
-		SubdomainId: subnetProto.SubdomainId,
+		Name:        subnetProto.GetMetadata().GetName(),
+		SubdomainId: subdomainID,
 		VpcId:       &corev1.VpcId{Value: vpc.GetSiteID().String()},
-		Mtu:         subnetProto.Mtu,
+		Mtu:         mtu,
 		Prefixes:    prefixes,
 	}
 }

--- a/rest-api/db/pkg/db/model/subnet.go
+++ b/rest-api/db/pkg/db/model/subnet.go
@@ -119,10 +119,25 @@ func (s *Subnet) GetSiteID() *uuid.UUID {
 	return &s.ID
 }
 
+func (s *Subnet) toMetadataProto() *corev1.Metadata {
+	md := &corev1.Metadata{
+		Name:        s.Name,
+		Description: "",
+	}
+	if s.Description != nil {
+		md.Description = *s.Description
+	}
+	return md
+}
+
 // ToProto converts this Subnet into its workflow proto representation.
 // Used as the canonical entity-to-proto conversion; request-shape protos
 // (create) are produced by `ToProto` methods on the corresponding API
 // request types in api/pkg/api/model/subnet.go.
+//
+// Desired configuration is emitted via the structured `config` field and
+// identity metadata via `metadata`. The deprecated flat mirror fields are
+// no longer populated.
 //
 // `Prefixes` is built from `IPv4Prefix` + `PrefixLength` when
 // `IPv4Prefix` is set; otherwise the field is left nil. The Site-facing
@@ -130,27 +145,30 @@ func (s *Subnet) GetSiteID() *uuid.UUID {
 // entity, so this method emits prefixes with a zero `ReserveFirst` and
 // the request-shape `ToProto` overlays the policy value.
 func (s *Subnet) ToProto() *corev1.NetworkSegment {
-	proto := &corev1.NetworkSegment{
-		Id:    &corev1.NetworkSegmentId{Value: s.GetSiteID().String()},
+	config := &corev1.NetworkSegmentConfig{
 		VpcId: &corev1.VpcId{Value: s.VpcID.String()},
-		Name:  s.Name,
 	}
 	if s.DomainID != nil {
-		proto.SubdomainId = &corev1.DomainId{Value: s.DomainID.String()}
+		config.SubdomainId = &corev1.DomainId{Value: s.DomainID.String()}
 	}
 	if s.MTU != nil {
 		mtu := int32(*s.MTU)
-		proto.Mtu = &mtu
+		config.Mtu = &mtu
 	}
 	if s.IPv4Prefix != nil {
-		proto.Prefixes = []*corev1.NetworkPrefix{
+		config.Prefixes = []*corev1.NetworkPrefix{
 			{
 				Gateway: s.IPv4Gateway,
 				Prefix:  fmt.Sprintf("%s/%d", *s.IPv4Prefix, s.PrefixLength),
 			},
 		}
 	}
-	return proto
+
+	return &corev1.NetworkSegment{
+		Id:       &corev1.NetworkSegmentId{Value: s.GetSiteID().String()},
+		Metadata: s.toMetadataProto(),
+		Config:   config,
+	}
 }
 
 // FromProto populates this Subnet from its workflow proto representation.
@@ -163,6 +181,10 @@ func (s *Subnet) ToProto() *corev1.NetworkSegment {
 // Field-level contract:
 //   - `s.ID` is preserved on a missing or unparseable `proto.Id`,
 //     because callers pre-validate the UUID before calling.
+//   - `Name` is sourced from the structured `proto.Metadata.Name`.
+//   - Desired-configuration fields (VpcID, DomainID, MTU, prefixes) are
+//     read from the structured `config` only. Deprecated flat mirrors are
+//     not consulted during entity reconstruction.
 //   - Optional pointer fields (DomainID, MTU, IPv4Prefix, IPv4Gateway)
 //     are cleared when the proto omits them OR when the proto value is
 //     invalid (e.g. an unparseable UUID, an unparseable prefix). This
@@ -176,38 +198,48 @@ func (s *Subnet) FromProto(proto *corev1.NetworkSegment) {
 			s.ID = id
 		}
 	}
-	if proto.VpcId != nil {
-		if id, err := uuid.Parse(proto.VpcId.Value); err == nil {
+	s.Name = ""
+	s.Description = nil
+	if proto.Metadata != nil {
+		if proto.Metadata.Name != "" {
+			s.Name = proto.Metadata.Name
+		}
+		if proto.Metadata.Description != "" {
+			s.Description = &proto.Metadata.Description
+		}
+	}
+
+	cfg := proto.Config
+	if cfg == nil {
+		cfg = &corev1.NetworkSegmentConfig{}
+	}
+	if cfg.VpcId != nil {
+		if id, err := uuid.Parse(cfg.VpcId.Value); err == nil {
 			s.VpcID = id
 		}
 	}
-	s.Name = proto.Name
-	if proto.SubdomainId != nil {
-		if id, err := uuid.Parse(proto.SubdomainId.Value); err == nil {
+	s.DomainID = nil
+	if cfg.SubdomainId != nil {
+		if id, err := uuid.Parse(cfg.SubdomainId.Value); err == nil {
 			s.DomainID = &id
-		} else {
-			s.DomainID = nil
 		}
-	} else {
-		s.DomainID = nil
 	}
-	if proto.Mtu != nil {
-		m := int(*proto.Mtu)
+	s.MTU = nil
+	if cfg.Mtu != nil {
+		m := int(*cfg.Mtu)
 		s.MTU = &m
-	} else {
-		s.MTU = nil
 	}
 	s.IPv4Prefix = nil
 	s.IPv4Gateway = nil
-	if len(proto.Prefixes) > 0 && proto.Prefixes[0] != nil {
+	if len(cfg.Prefixes) > 0 && cfg.Prefixes[0] != nil {
 		// The proto carries `<prefix>/<length>` as a single string; split
 		// it back into the entity's two fields. A malformed value clears
 		// both rather than leaving the receiver in a partial state.
-		prefix, length, ok := splitNetworkPrefix(proto.Prefixes[0].Prefix)
+		prefix, length, ok := splitNetworkPrefix(cfg.Prefixes[0].Prefix)
 		if ok {
 			s.IPv4Prefix = &prefix
 			s.PrefixLength = length
-			s.IPv4Gateway = proto.Prefixes[0].Gateway
+			s.IPv4Gateway = cfg.Prefixes[0].Gateway
 		}
 	}
 }

--- a/rest-api/db/pkg/db/model/subnet.go
+++ b/rest-api/db/pkg/db/model/subnet.go
@@ -231,6 +231,7 @@ func (s *Subnet) FromProto(proto *corev1.NetworkSegment) {
 	}
 	s.IPv4Prefix = nil
 	s.IPv4Gateway = nil
+	s.PrefixLength = 0
 	if len(cfg.Prefixes) > 0 && cfg.Prefixes[0] != nil {
 		// The proto carries `<prefix>/<length>` as a single string; split
 		// it back into the entity's two fields. A malformed value clears

--- a/rest-api/db/pkg/db/model/subnet_test.go
+++ b/rest-api/db/pkg/db/model/subnet_test.go
@@ -48,11 +48,12 @@ func TestSubnet_ToProto(t *testing.T) {
 	gateway := "10.0.0.1"
 	mtu := 9000
 
-	t.Run("emits id/vpcId/name/subdomain/mtu/prefixes from entity", func(t *testing.T) {
+	t.Run("emits config and metadata from entity", func(t *testing.T) {
 		s := &Subnet{
 			ID:           subID,
 			VpcID:        vpcID,
 			Name:         "subnet-a",
+			Description:  cutil.GetPtr("primary"),
 			DomainID:     &domainID,
 			IPv4Prefix:   &prefix,
 			IPv4Gateway:  &gateway,
@@ -63,20 +64,33 @@ func TestSubnet_ToProto(t *testing.T) {
 		require.NotNil(t, proto)
 		require.NotNil(t, proto.Id)
 		assert.Equal(t, subID.String(), proto.Id.Value)
-		require.NotNil(t, proto.VpcId)
-		assert.Equal(t, vpcID.String(), proto.VpcId.Value)
-		assert.Equal(t, "subnet-a", proto.Name)
-		require.NotNil(t, proto.SubdomainId)
-		assert.Equal(t, domainID.String(), proto.SubdomainId.Value)
-		require.NotNil(t, proto.Mtu)
-		assert.Equal(t, int32(9000), *proto.Mtu)
-		require.Len(t, proto.Prefixes, 1)
-		assert.Equal(t, "10.0.0.0/16", proto.Prefixes[0].Prefix)
-		require.NotNil(t, proto.Prefixes[0].Gateway)
-		assert.Equal(t, gateway, *proto.Prefixes[0].Gateway)
+
+		require.NotNil(t, proto.Metadata)
+		assert.Equal(t, "subnet-a", proto.Metadata.Name)
+		assert.Equal(t, "primary", proto.Metadata.Description)
+
+		require.NotNil(t, proto.Config)
+		require.NotNil(t, proto.Config.VpcId)
+		assert.Equal(t, vpcID.String(), proto.Config.VpcId.Value)
+		require.NotNil(t, proto.Config.SubdomainId)
+		assert.Equal(t, domainID.String(), proto.Config.SubdomainId.Value)
+		require.NotNil(t, proto.Config.Mtu)
+		assert.Equal(t, int32(9000), *proto.Config.Mtu)
+		assert.Equal(t, corev1.NetworkSegmentType_TENANT, proto.Config.SegmentType)
+		require.Len(t, proto.Config.Prefixes, 1)
+		assert.Equal(t, "10.0.0.0/16", proto.Config.Prefixes[0].Prefix)
+		require.NotNil(t, proto.Config.Prefixes[0].Gateway)
+		assert.Equal(t, gateway, *proto.Config.Prefixes[0].Gateway)
 		// ReserveFirst is a deployment-policy value overlaid by the
 		// request-shape ToProto; the entity emits zero.
-		assert.Equal(t, int32(0), proto.Prefixes[0].ReserveFirst)
+		assert.Equal(t, int32(0), proto.Config.Prefixes[0].ReserveFirst)
+
+		// Deprecated flat mirrors are no longer populated.
+		assert.Empty(t, proto.Name)
+		assert.Nil(t, proto.VpcId)
+		assert.Nil(t, proto.SubdomainId)
+		assert.Nil(t, proto.Mtu)
+		assert.Nil(t, proto.Prefixes)
 	})
 
 	t.Run("prefers ControllerNetworkSegmentID for the Site-facing ID", func(t *testing.T) {
@@ -91,9 +105,12 @@ func TestSubnet_ToProto(t *testing.T) {
 		s := &Subnet{ID: subID, VpcID: vpcID, Name: "subnet-a"}
 		proto := s.ToProto()
 		require.NotNil(t, proto)
-		assert.Nil(t, proto.SubdomainId)
-		assert.Nil(t, proto.Mtu)
-		assert.Nil(t, proto.Prefixes)
+		require.NotNil(t, proto.Metadata)
+		assert.Equal(t, "", proto.Metadata.Description)
+		require.NotNil(t, proto.Config)
+		assert.Nil(t, proto.Config.SubdomainId)
+		assert.Nil(t, proto.Config.Mtu)
+		assert.Nil(t, proto.Config.Prefixes)
 	})
 }
 
@@ -104,23 +121,30 @@ func TestSubnet_FromProto(t *testing.T) {
 	gateway := "10.0.0.1"
 
 	t.Run("nil proto leaves the receiver untouched", func(t *testing.T) {
-		s := &Subnet{ID: subID, Name: "existing", VpcID: vpcID}
+		s := &Subnet{ID: subID, Name: "existing", Description: cutil.GetPtr("kept"), VpcID: vpcID}
 		s.FromProto(nil)
 		assert.Equal(t, subID, s.ID)
 		assert.Equal(t, "existing", s.Name)
+		require.NotNil(t, s.Description)
+		assert.Equal(t, "kept", *s.Description)
 		assert.Equal(t, vpcID, s.VpcID)
 	})
 
-	t.Run("populates fields from a full proto", func(t *testing.T) {
+	t.Run("populates fields from structured config and status", func(t *testing.T) {
 		mtu := int32(9000)
 		proto := &corev1.NetworkSegment{
-			Id:          &corev1.NetworkSegmentId{Value: subID.String()},
-			VpcId:       &corev1.VpcId{Value: vpcID.String()},
-			Name:        "subnet-a",
-			SubdomainId: &corev1.DomainId{Value: domainID.String()},
-			Mtu:         &mtu,
-			Prefixes: []*corev1.NetworkPrefix{
-				{Prefix: "10.0.0.0/16", Gateway: &gateway},
+			Id: &corev1.NetworkSegmentId{Value: subID.String()},
+			Metadata: &corev1.Metadata{
+				Name:        "subnet-a",
+				Description: "primary",
+			},
+			Config: &corev1.NetworkSegmentConfig{
+				VpcId:       &corev1.VpcId{Value: vpcID.String()},
+				SubdomainId: &corev1.DomainId{Value: domainID.String()},
+				Mtu:         &mtu,
+				Prefixes: []*corev1.NetworkPrefix{
+					{Prefix: "10.0.0.0/16", Gateway: &gateway},
+				},
 			},
 		}
 		s := &Subnet{}
@@ -128,6 +152,8 @@ func TestSubnet_FromProto(t *testing.T) {
 		assert.Equal(t, subID, s.ID)
 		assert.Equal(t, vpcID, s.VpcID)
 		assert.Equal(t, "subnet-a", s.Name)
+		require.NotNil(t, s.Description)
+		assert.Equal(t, "primary", *s.Description)
 		require.NotNil(t, s.DomainID)
 		assert.Equal(t, domainID, *s.DomainID)
 		require.NotNil(t, s.MTU)
@@ -139,6 +165,33 @@ func TestSubnet_FromProto(t *testing.T) {
 		assert.Equal(t, gateway, *s.IPv4Gateway)
 	})
 
+	t.Run("clears optionals and preserves VpcID when config is absent", func(t *testing.T) {
+		s := &Subnet{
+			ID:           subID,
+			VpcID:        vpcID,
+			Name:         "stale-name",
+			Description:  cutil.GetPtr("stale"),
+			DomainID:     &domainID,
+			MTU:          cutil.GetPtr(1500),
+			IPv4Prefix:   cutil.GetPtr("192.168.0.0"),
+			IPv4Gateway:  cutil.GetPtr("192.168.0.1"),
+			PrefixLength: 24,
+		}
+		proto := &corev1.NetworkSegment{
+			Id:       &corev1.NetworkSegmentId{Value: subID.String()},
+			Metadata: &corev1.Metadata{Name: "subnet-a"},
+		}
+		s.FromProto(proto)
+		assert.Equal(t, "subnet-a", s.Name)
+		assert.Nil(t, s.Description)
+		// VpcID is a required ID field; with config absent it is preserved.
+		assert.Equal(t, vpcID, s.VpcID)
+		assert.Nil(t, s.DomainID)
+		assert.Nil(t, s.MTU)
+		assert.Nil(t, s.IPv4Prefix)
+		assert.Nil(t, s.IPv4Gateway)
+	})
+
 	t.Run("clears optional fields when proto omits them", func(t *testing.T) {
 		existing := "stale"
 		existingGW := "stale-gw"
@@ -146,6 +199,7 @@ func TestSubnet_FromProto(t *testing.T) {
 		s := &Subnet{
 			ID:           subID,
 			Name:         "stale-name",
+			Description:  cutil.GetPtr("stale"),
 			DomainID:     &domainID,
 			MTU:          &mtu,
 			IPv4Prefix:   &existing,
@@ -153,28 +207,98 @@ func TestSubnet_FromProto(t *testing.T) {
 			PrefixLength: 24,
 		}
 		proto := &corev1.NetworkSegment{
-			Id:    &corev1.NetworkSegmentId{Value: subID.String()},
-			VpcId: &corev1.VpcId{Value: vpcID.String()},
-			Name:  "fresh-name",
+			Id: &corev1.NetworkSegmentId{Value: subID.String()},
+			Metadata: &corev1.Metadata{
+				Name: "fresh-name",
+			},
+			Config: &corev1.NetworkSegmentConfig{
+				VpcId: &corev1.VpcId{Value: vpcID.String()},
+			},
 		}
 		s.FromProto(proto)
 		assert.Equal(t, "fresh-name", s.Name)
+		assert.Nil(t, s.Description)
 		assert.Nil(t, s.DomainID)
 		assert.Nil(t, s.MTU)
 		assert.Nil(t, s.IPv4Prefix)
 		assert.Nil(t, s.IPv4Gateway)
 	})
 
+	t.Run("clears stale fields and ignores deprecated flat mirrors", func(t *testing.T) {
+		stale := "stale"
+		staleGW := "stale-gw"
+		staleDomain := uuid.New()
+		staleVpc := uuid.New()
+		flatMtu := int32(9000)
+		flatGateway := "10.0.0.1"
+		flatDomain := uuid.New()
+		flatVpc := uuid.New()
+
+		s := &Subnet{
+			ID:           subID,
+			VpcID:        staleVpc,
+			Name:         "stale-name",
+			Description:  cutil.GetPtr("stale"),
+			DomainID:     &staleDomain,
+			MTU:          cutil.GetPtr(1500),
+			IPv4Prefix:   &stale,
+			IPv4Gateway:  &staleGW,
+			PrefixLength: 24,
+		}
+		proto := &corev1.NetworkSegment{
+			Id: &corev1.NetworkSegmentId{Value: subID.String()},
+			Metadata: &corev1.Metadata{
+				Name: "fresh-name",
+			},
+			Config: &corev1.NetworkSegmentConfig{
+				VpcId: &corev1.VpcId{Value: vpcID.String()},
+			},
+			// Deprecated flat mirrors must not leak into the entity.
+			VpcId:       &corev1.VpcId{Value: flatVpc.String()},
+			Name:        "flat-name",
+			SubdomainId: &corev1.DomainId{Value: flatDomain.String()},
+			Mtu:         &flatMtu,
+			Prefixes: []*corev1.NetworkPrefix{
+				{Prefix: "10.0.0.0/16", Gateway: &flatGateway},
+			},
+		}
+		s.FromProto(proto)
+		assert.Equal(t, "fresh-name", s.Name)
+		assert.Nil(t, s.Description)
+		assert.Equal(t, vpcID, s.VpcID)
+		assert.Nil(t, s.DomainID)
+		assert.Nil(t, s.MTU)
+		assert.Nil(t, s.IPv4Prefix)
+		assert.Nil(t, s.IPv4Gateway)
+	})
+
+	t.Run("clears Description when proto omits it", func(t *testing.T) {
+		desc := "existing"
+		s := &Subnet{ID: subID, Name: "subnet-a", Description: &desc}
+		s.FromProto(&corev1.NetworkSegment{
+			Metadata: &corev1.Metadata{Name: "subnet-a"},
+		})
+		assert.Nil(t, s.Description)
+	})
+
 	t.Run("preserves entity ID when proto Id is unparseable", func(t *testing.T) {
 		s := &Subnet{ID: subID, Name: "x"}
-		proto := &corev1.NetworkSegment{Id: &corev1.NetworkSegmentId{Value: "not-a-uuid"}, Name: "x"}
+		proto := &corev1.NetworkSegment{
+			Id:       &corev1.NetworkSegmentId{Value: "not-a-uuid"},
+			Metadata: &corev1.Metadata{Name: "x"},
+		}
 		s.FromProto(proto)
 		assert.Equal(t, subID, s.ID)
 	})
 
 	t.Run("clears DomainID when proto subdomain is unparseable", func(t *testing.T) {
 		s := &Subnet{ID: subID, DomainID: &domainID, Name: "x"}
-		proto := &corev1.NetworkSegment{Name: "x", SubdomainId: &corev1.DomainId{Value: "not-a-uuid"}}
+		proto := &corev1.NetworkSegment{
+			Metadata: &corev1.Metadata{Name: "x"},
+			Config: &corev1.NetworkSegmentConfig{
+				SubdomainId: &corev1.DomainId{Value: "not-a-uuid"},
+			},
+		}
 		s.FromProto(proto)
 		assert.Nil(t, s.DomainID)
 	})
@@ -184,8 +308,10 @@ func TestSubnet_FromProto(t *testing.T) {
 		gw := "192.168.0.1"
 		s := &Subnet{ID: subID, IPv4Prefix: &existing, PrefixLength: 24, Name: "x"}
 		proto := &corev1.NetworkSegment{
-			Name:     "x",
-			Prefixes: []*corev1.NetworkPrefix{{Prefix: "garbage", Gateway: &gw}},
+			Metadata: &corev1.Metadata{Name: "x"},
+			Config: &corev1.NetworkSegmentConfig{
+				Prefixes: []*corev1.NetworkPrefix{{Prefix: "garbage", Gateway: &gw}},
+			},
 		}
 		s.FromProto(proto)
 		assert.Nil(t, s.IPv4Prefix)

--- a/rest-api/db/pkg/db/model/subnet_test.go
+++ b/rest-api/db/pkg/db/model/subnet_test.go
@@ -190,6 +190,7 @@ func TestSubnet_FromProto(t *testing.T) {
 		assert.Nil(t, s.MTU)
 		assert.Nil(t, s.IPv4Prefix)
 		assert.Nil(t, s.IPv4Gateway)
+		assert.Zero(t, s.PrefixLength)
 	})
 
 	t.Run("clears optional fields when proto omits them", func(t *testing.T) {
@@ -222,6 +223,7 @@ func TestSubnet_FromProto(t *testing.T) {
 		assert.Nil(t, s.MTU)
 		assert.Nil(t, s.IPv4Prefix)
 		assert.Nil(t, s.IPv4Gateway)
+		assert.Zero(t, s.PrefixLength)
 	})
 
 	t.Run("clears stale fields and ignores deprecated flat mirrors", func(t *testing.T) {
@@ -316,6 +318,7 @@ func TestSubnet_FromProto(t *testing.T) {
 		s.FromProto(proto)
 		assert.Nil(t, s.IPv4Prefix)
 		assert.Nil(t, s.IPv4Gateway)
+		assert.Zero(t, s.PrefixLength)
 	})
 }
 

--- a/rest-api/workflow/pkg/activity/subnet/subnet.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet.go
@@ -120,15 +120,15 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 
 		subnet, ok := existingSubnetCtrlIDMap[controllerSegment.Id.Value]
 		if !ok {
-			// Check if the Subnet is found by ID (controllerSegment.Name == cloudSubnet.ID)
-			subnet, ok = existingSubnetIDMap[controllerSegment.Name]
+			// Check if the Subnet is found by ID (segment name == cloudSubnet.ID)
+			subnet, ok = existingSubnetIDMap[controllerSegment.GetMetadata().GetName()]
 			if ok {
 				existingSubnetCtrlIDMap[controllerSegment.Id.Value] = subnet
 			}
 		}
 
 		if subnet == nil {
-			if controllerSegment.SegmentType == corev1.NetworkSegmentType_TENANT {
+			if controllerSegment.GetConfig().GetSegmentType() == corev1.NetworkSegmentType_TENANT {
 				logger.Error().Str("Controller Segment ID", controllerSegment.Id.Value).Msg("Network Segment does not have a Subnet record in DB, possibly created directly on Site")
 			}
 			continue
@@ -154,8 +154,9 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 		}
 
 		var mtu *int
-		if controllerSegment.Mtu != nil {
-			mtuVal := int(*controllerSegment.Mtu)
+		cfg := controllerSegment.GetConfig()
+		if cfg != nil && cfg.Mtu != nil {
+			mtuVal := int(*cfg.Mtu)
 			mtu = &mtuVal
 		}
 
@@ -168,7 +169,7 @@ func (ms ManageSubnet) UpdateSubnetsInDB(ctx context.Context, siteID uuid.UUID, 
 		}
 
 		// Update Subnet in DB
-		status, statusMessage := getNICoSubnetStatus(controllerSegment.State)
+		status, statusMessage := getNICoSubnetStatus(controllerSegment.GetStatus().GetTenantState())
 
 		// If Subnet is already in Deleting state then no need to update status
 		if subnet.Status == cdbm.SubnetStatusDeleting {

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -289,7 +289,7 @@ func testSubnetBuildIPBlock(t *testing.T, dbSession *cdb.Session, name string, s
 	return ipb
 }
 
-func structuredNetworkSegment(id, name string, mtu *int32, state corev1.TenantState, segmentType corev1.NetworkSegmentType) *corev1.NetworkSegment {
+func testBuildNetworkSegment(id, name string, mtu *int32, state corev1.TenantState, segmentType corev1.NetworkSegmentType) *corev1.NetworkSegment {
 	seg := &corev1.NetworkSegment{
 		Id:       &corev1.NetworkSegmentId{Value: id},
 		Metadata: &corev1.Metadata{Name: name},
@@ -480,7 +480,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 				siteID: uuid.New(),
 				subnetInventory: &corev1.SubnetInventory{
 					Segments: []*corev1.NetworkSegment{
-						structuredNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), "", nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), "", nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 					},
 				},
 			},
@@ -499,11 +499,11 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 				siteID: st.ID,
 				subnetInventory: &corev1.SubnetInventory{
 					Segments: []*corev1.NetworkSegment{
-						structuredNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), subnet1.Name, &mtu, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
-						structuredNetworkSegment(subnet5.ControllerNetworkSegmentID.String(), subnet5.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
-						structuredNetworkSegment(subnet6.ControllerNetworkSegmentID.String(), subnet6.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
-						structuredNetworkSegment(uuid.NewString(), subnet8.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
-						structuredNetworkSegment(uuid.NewString(), subnet9.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), subnet1.Name, &mtu, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(subnet5.ControllerNetworkSegmentID.String(), subnet5.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(subnet6.ControllerNetworkSegmentID.String(), subnet6.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(uuid.NewString(), subnet8.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						testBuildNetworkSegment(uuid.NewString(), subnet9.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 					},
 				},
 			},

--- a/rest-api/workflow/pkg/activity/subnet/subnet_test.go
+++ b/rest-api/workflow/pkg/activity/subnet/subnet_test.go
@@ -289,6 +289,23 @@ func testSubnetBuildIPBlock(t *testing.T, dbSession *cdb.Session, name string, s
 	return ipb
 }
 
+func structuredNetworkSegment(id, name string, mtu *int32, state corev1.TenantState, segmentType corev1.NetworkSegmentType) *corev1.NetworkSegment {
+	seg := &corev1.NetworkSegment{
+		Id:       &corev1.NetworkSegmentId{Value: id},
+		Metadata: &corev1.Metadata{Name: name},
+		Config: &corev1.NetworkSegmentConfig{
+			SegmentType: segmentType,
+		},
+		Status: &corev1.NetworkSegmentStatus{
+			TenantState: state,
+		},
+	}
+	if mtu != nil {
+		seg.Config.Mtu = mtu
+	}
+	return seg
+}
+
 func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 	ctx := context.Background()
 
@@ -409,8 +426,8 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 	pagedCtrlSubnets := []*corev1.NetworkSegment{}
 	for i := 0; i < 34; i++ {
 		ctrlSubnet := &corev1.NetworkSegment{
-			Id:   &corev1.NetworkSegmentId{Value: pagedSubnets[i].ControllerNetworkSegmentID.String()},
-			Name: pagedSubnets[i].Name,
+			Id:       &corev1.NetworkSegmentId{Value: pagedSubnets[i].ControllerNetworkSegmentID.String()},
+			Metadata: &corev1.Metadata{Name: pagedSubnets[i].Name},
 		}
 		pagedCtrlSubnets = append(pagedCtrlSubnets, ctrlSubnet)
 	}
@@ -463,10 +480,7 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 				siteID: uuid.New(),
 				subnetInventory: &corev1.SubnetInventory{
 					Segments: []*corev1.NetworkSegment{
-						{
-							Id:    &corev1.NetworkSegmentId{Value: subnet1.ControllerNetworkSegmentID.String()},
-							State: corev1.TenantState_READY,
-						},
+						structuredNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), "", nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 					},
 				},
 			},
@@ -485,32 +499,11 @@ func TestManageSubnet_UpdateSubnetsInDB(t *testing.T) {
 				siteID: st.ID,
 				subnetInventory: &corev1.SubnetInventory{
 					Segments: []*corev1.NetworkSegment{
-						{
-							Id:    &corev1.NetworkSegmentId{Value: subnet1.ControllerNetworkSegmentID.String()},
-							Name:  subnet1.Name,
-							State: corev1.TenantState_READY,
-							Mtu:   &mtu,
-						},
-						{
-							Id:    &corev1.NetworkSegmentId{Value: subnet5.ControllerNetworkSegmentID.String()},
-							Name:  subnet5.Name,
-							State: corev1.TenantState_READY,
-						},
-						{
-							Id:    &corev1.NetworkSegmentId{Value: subnet6.ControllerNetworkSegmentID.String()},
-							Name:  subnet6.Name,
-							State: corev1.TenantState_READY,
-						},
-						{
-							Id:    &corev1.NetworkSegmentId{Value: uuid.NewString()},
-							Name:  subnet8.ID.String(),
-							State: corev1.TenantState_READY,
-						},
-						{
-							Id:    &corev1.NetworkSegmentId{Value: uuid.NewString()},
-							Name:  subnet9.ID.String(),
-							State: corev1.TenantState_READY,
-						},
+						structuredNetworkSegment(subnet1.ControllerNetworkSegmentID.String(), subnet1.Name, &mtu, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						structuredNetworkSegment(subnet5.ControllerNetworkSegmentID.String(), subnet5.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						structuredNetworkSegment(subnet6.ControllerNetworkSegmentID.String(), subnet6.Name, nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						structuredNetworkSegment(uuid.NewString(), subnet8.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
+						structuredNetworkSegment(uuid.NewString(), subnet9.ID.String(), nil, corev1.TenantState_READY, corev1.NetworkSegmentType_TENANT),
 					},
 				},
 			},


### PR DESCRIPTION
A couple of month ago there were changes made in Core (https://github.com/NVIDIA/infra-controller/pull/1541) that reworked the NetworkSegment (aka subnet) gRPC proto to better conform to convention by sending config, status and metadata information as structs rather than a bunch of flat fields. This PR transitions the REST API to use these new structured fields and ignore the now deprecated flat fields.
## Related issues
https://github.com/NVIDIA/infra-controller/issues/2793

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This work is a prerequisite for https://github.com/NVIDIA/infra-controller/issues/2796. That work to fully remove the flat fields must wait for another release (2.2). That way we don't have to risk trouble during release deployment if the Core is temporarily a minor ahead of the REST, as we know the REST API will not be relying on the flat fields.

