### PR TITLE
Devspace deployment: Don't fail if not running kind

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -329,10 +329,6 @@ hooks:
             "${runtime.images.nico-rest-cert-manager.image}:${runtime.images.nico-rest-cert-manager.tag}" \
             "${runtime.images.nico-mcp.image}:${runtime.images.nico-mcp.tag}"
           ;;
-        *)
-          echo "Full-stack deployment requires a kind context; current context is ${CONTEXT:-unset}" >&2
-          exit 1
-          ;;
       esac
   - name: setup-rest-integration
     events: ["after:deploy"]


### PR DESCRIPTION
We discussed this when reviewing #3304 but I think this was accidentally left in. We shouldn't intentionally fail the deployment just because somebody isn't installing kubernetes the way our wrapper scripts do.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

