### PR TITLE
error_message_case xtask: only look in crates/

### DIFF
--- a/crates/xtask/src/error_message_case.rs
+++ b/crates/xtask/src/error_message_case.rs
@@ -85,12 +85,14 @@ pub fn check(fix: bool) -> eyre::Result<CheckOutcome> {
     // vendored crate sources land *inside* the walk root; those are third-party
     // and must never be linted or rewritten, so skip CARGO_HOME's conventional
     // directory names alongside `target/` and `.git`.
-    let walk = WalkDir::new(&repo_root).into_iter().filter_entry(|e| {
-        !matches!(
-            e.file_name().to_str(),
-            Some("target" | ".git" | "cargo" | ".cargo")
-        )
-    });
+    let walk = WalkDir::new(repo_root.join("crates"))
+        .into_iter()
+        .filter_entry(|e| {
+            !matches!(
+                e.file_name().to_str(),
+                Some("target" | ".git" | "cargo" | ".cargo")
+            )
+        });
     for entry in walk.filter_map(Result::ok) {
         let path = entry.path();
         if path.extension().is_none_or(|ext| ext != "rs") {


### PR DESCRIPTION
I have a .gitignored directory with tons of stuff in it and this started complaining about .rs source files that happened to be inside, heh.

Our toplevel Cargo.toml has:

```
members = ["crates/*", "crates/libnmxc/tests"]
```

so there's no rust code we care about that's not inside the crates directory (carbide-lints notwithstanding, but those aren't anything we run outside of our build process.) So let's just scan the crates directory.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

