### PR TITLE
feat(rest-api): Add per-claim-mapping audience validation for custom issuers

### DIFF
--- a/rest-api/api/internal/config/config_test.go
+++ b/rest-api/api/internal/config/config_test.go
@@ -61,6 +61,30 @@ func TestNewConfig(t *testing.T) {
 	}
 }
 
+func TestGetIssuersConfigClaimMappingAudiences(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(`
+issuers:
+  - name: custom-issuer
+    issuer: https://auth.example.com
+    jwks: https://auth.example.com/.well-known/jwks.json
+    origin: custom
+    audiences: [issuer-audience]
+    claimMappings:
+      - orgName: acme
+        roles: [TENANT_ADMIN]
+        audiences: [org-audience]
+`)))
+
+	c := &Config{v: v}
+	issuers := c.GetIssuersConfig()
+	require.Len(t, issuers, 1)
+	require.Len(t, issuers[0].ClaimMappings, 1)
+	assert.Equal(t, []string{"issuer-audience"}, issuers[0].Audiences)
+	assert.Equal(t, []string{"org-audience"}, issuers[0].ClaimMappings[0].Audiences)
+}
+
 func TestConfig_WatchConfigFile(t *testing.T) {
 	const initialSitePhoneHomeURL = "http://initial.example/phone_home"
 

--- a/rest-api/auth/README.md
+++ b/rest-api/auth/README.md
@@ -31,6 +31,7 @@ issuers:
 - **Only two roles allowed:** `TENANT_ADMIN`, `PROVIDER_ADMIN`
 - **Audiences:** token needs at least one match → 401 on failure
 - **Scopes:** token needs all configured → 403 on failure (checks `scope`, `scopes`, `scp` claims)
+- **Mapping audiences:** each mapping may require any one exact `aud` match → 403 for that organization
 
 ---
 
@@ -135,6 +136,30 @@ claimMappings:
     rolesAttribute: "main_roles"
 ```
 
+### Shared Issuer with Per-Org Audiences
+
+Issuer-level and mapping-level `audiences` both use ANY-match semantics. When both are configured, the token must satisfy both gates. Mapping audience values are compared exactly and case-sensitively. Omit mapping `audiences` to preserve the existing unrestricted mapping behavior.
+
+```yaml
+issuers:
+  - name: shared-issuer
+    issuer: https://idp.example.com
+    jwks: https://idp.example.com/.well-known/jwks.json
+    origin: custom
+    audiences: ["nico-api"]
+    claimMappings:
+      - orgName: orgA
+        orgDisplayName: Organization A
+        isServiceAccount: true
+        audiences: ["clientA"]
+      - orgName: orgB
+        orgDisplayName: Organization B
+        roles: ["TENANT_ADMIN"]
+        audiences: ["clientB"]
+```
+
+A token with `aud: ["nico-api", "clientA"]` can access only `orgA`; a token with `aud: ["nico-api", "clientB"]` can access only `orgB`. 
+
 ---
 
 ## Validation Rules
@@ -161,6 +186,7 @@ claimMappings:
 | Error | Solution |
 |-------|----------|
 | Token audience mismatch | Check `aud` claim; update `audiences` or remove to skip |
+| Organization audience mismatch | Check the selected claim mapping's `audiences`; token `aud` must match at least one |
 | Token scopes mismatch | Check `scope`/`scopes`/`scp` claim; ensure all required scopes present |
 | Invalid token | Verify `jwks` URL accessible; `issuer` matches `iss` claim exactly |
 | Invalid claim mapping | Add `roles`, `rolesAttribute`, or `isServiceAccount` |

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -576,7 +576,7 @@ func (jcfg *JwksConfig) ValidateScopes(claims jwt.MapClaims) error {
 // GetOrgDataFromClaim extracts org data for the requested org from claim mappings.
 // This method validates org access and returns errors if:
 //   - core.ErrReservedOrgName: dynamic org claims a statically-configured org name
-//   - core.ErrOrgAudienceDenied: token audience is not authorized for the requested org
+//   - core.ErrInvalidAudience: token audience is not authorized for the requested org
 //   - core.ErrInvalidConfiguration: no claim mapping configured for the requested org
 //   - core.ErrNoClaimRoles: no roles found for the requested org
 //
@@ -595,7 +595,7 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 		}
 
 		if !hasAnyAudience(claims, cm.Audiences) {
-			return nil, false, core.ErrOrgAudienceDenied
+			return nil, false, core.ErrInvalidAudience
 		}
 
 		roles, err := cm.GetRoles(claims)

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -113,12 +113,6 @@ func (cm *ClaimMapping) GetRoles(claims jwt.MapClaims) ([]string, error) {
 	return cm.Roles, nil
 }
 
-// HasAnyAudience reports whether the token satisfies this mapping's audience requirements.
-// It returns true when the mapping has no configured audiences.
-func (cm *ClaimMapping) HasAnyAudience(claims jwt.MapClaims) bool {
-	return hasAnyAudience(claims, cm.Audiences)
-}
-
 // GetOrgNameAndDisplayName extracts org and display name from claims (dynamic mappings only).
 func (cm *ClaimMapping) GetOrgNameAndDisplayName(claims jwt.MapClaims) (orgName string, displayName string) {
 	if !cm.IsOrgDynamic() {
@@ -600,7 +594,7 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 			return nil, false, core.ErrReservedOrgName
 		}
 
-		if !cm.HasAnyAudience(claims) {
+		if !hasAnyAudience(claims, cm.Audiences) {
 			return nil, false, core.ErrOrgAudienceDenied
 		}
 

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -537,7 +537,10 @@ func (jcfg *JwksConfig) GetSubjectPrefix() string {
 	return jcfg.subjectPrefix
 }
 
-func hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
+func (jcfg *JwksConfig) hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
+	if audiences == nil {
+		audiences = jcfg.Audiences
+	}
 	if len(audiences) == 0 {
 		return true
 	}
@@ -553,7 +556,7 @@ func hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
 
 // ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
 func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
-	if !hasAnyAudience(claims, jcfg.Audiences) {
+	if !jcfg.hasAnyAudience(claims, nil) {
 		return core.ErrInvalidAudience
 	}
 	return nil
@@ -594,7 +597,7 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 			return nil, false, core.ErrReservedOrgName
 		}
 
-		if !hasAnyAudience(claims, cm.Audiences) {
+		if !jcfg.hasAnyAudience(claims, cm.Audiences) {
 			return nil, false, core.ErrInvalidAudience
 		}
 

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -537,8 +537,9 @@ func (jcfg *JwksConfig) GetSubjectPrefix() string {
 	return jcfg.subjectPrefix
 }
 
-func hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
-	if len(audiences) == 0 {
+// hasAnyAudience checks if the token has any of the configured audiences.
+func (jcfg *JwksConfig) hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
+	if audiences == nil || len(audiences) == 0 {
 		return true
 	}
 
@@ -553,7 +554,7 @@ func hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
 
 // ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
 func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
-	if !hasAnyAudience(claims, jcfg.Audiences) {
+	if !jcfg.hasAnyAudience(claims, jcfg.Audiences) {
 		return core.ErrInvalidAudience
 	}
 	return nil
@@ -594,7 +595,7 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 			return nil, false, core.ErrReservedOrgName
 		}
 
-		if !hasAnyAudience(claims, cm.Audiences) {
+		if !jcfg.hasAnyAudience(claims, cm.Audiences) {
 			return nil, false, core.ErrInvalidAudience
 		}
 

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -537,10 +537,7 @@ func (jcfg *JwksConfig) GetSubjectPrefix() string {
 	return jcfg.subjectPrefix
 }
 
-func (jcfg *JwksConfig) hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
-	if audiences == nil {
-		audiences = jcfg.Audiences
-	}
+func hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
 	if len(audiences) == 0 {
 		return true
 	}
@@ -556,7 +553,7 @@ func (jcfg *JwksConfig) hasAnyAudience(claims jwt.MapClaims, audiences []string)
 
 // ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
 func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
-	if !jcfg.hasAnyAudience(claims, nil) {
+	if !hasAnyAudience(claims, jcfg.Audiences) {
 		return core.ErrInvalidAudience
 	}
 	return nil
@@ -597,7 +594,7 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 			return nil, false, core.ErrReservedOrgName
 		}
 
-		if !jcfg.hasAnyAudience(claims, cm.Audiences) {
+		if !hasAnyAudience(claims, cm.Audiences) {
 			return nil, false, core.ErrInvalidAudience
 		}
 

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -81,6 +81,9 @@ type ClaimMapping struct {
 	// Roles: static role list. Used when RolesAttribute is empty and IsServiceAccount is false.
 	Roles []string `mapstructure:"roles"`
 
+	// Audiences: optional token audiences allowed to authorize this mapping. Any one exact match is sufficient.
+	Audiences []string `mapstructure:"audiences"`
+
 	// IsServiceAccount: if true, assigns admin roles (PROVIDER_ADMIN, TENANT_ADMIN). Ignores RolesAttribute/Roles.
 	IsServiceAccount bool `mapstructure:"isServiceAccount"`
 }
@@ -108,6 +111,12 @@ func (cm *ClaimMapping) GetRoles(claims jwt.MapClaims) ([]string, error) {
 		return GetRolesFromAttribute(claims, cm.RolesAttribute)
 	}
 	return cm.Roles, nil
+}
+
+// HasAnyAudience reports whether the token satisfies this mapping's audience requirements.
+// It returns true when the mapping has no configured audiences.
+func (cm *ClaimMapping) HasAnyAudience(claims jwt.MapClaims) bool {
+	return hasAnyAudience(claims, cm.Audiences)
 }
 
 // GetOrgNameAndDisplayName extracts org and display name from claims (dynamic mappings only).
@@ -534,18 +543,23 @@ func (jcfg *JwksConfig) GetSubjectPrefix() string {
 	return jcfg.subjectPrefix
 }
 
-// ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
-func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
-	if len(jcfg.Audiences) == 0 {
-		return nil
+func hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
+	if len(audiences) == 0 {
+		return true
 	}
+
 	tokenAudiences, err := claims.GetAudience()
 	if err != nil {
-		return core.ErrInvalidAudience
+		return false
 	}
 	tokenAudSet := mapset.NewSet([]string(tokenAudiences)...)
-	requiredAudSet := mapset.NewSet(jcfg.Audiences...)
-	if tokenAudSet.Intersect(requiredAudSet).Cardinality() == 0 {
+	allowedAudSet := mapset.NewSet(audiences...)
+	return tokenAudSet.Intersect(allowedAudSet).Cardinality() > 0
+}
+
+// ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
+func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
+	if !hasAnyAudience(claims, jcfg.Audiences) {
 		return core.ErrInvalidAudience
 	}
 	return nil
@@ -568,6 +582,7 @@ func (jcfg *JwksConfig) ValidateScopes(claims jwt.MapClaims) error {
 // GetOrgDataFromClaim extracts org data for the requested org from claim mappings.
 // This method validates org access and returns errors if:
 //   - core.ErrReservedOrgName: dynamic org claims a statically-configured org name
+//   - core.ErrOrgAudienceDenied: token audience is not authorized for the requested org
 //   - core.ErrInvalidConfiguration: no claim mapping configured for the requested org
 //   - core.ErrNoClaimRoles: no roles found for the requested org
 //
@@ -583,6 +598,10 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 
 		if cm.IsOrgDynamic() && jcfg.ReservedOrgNames != nil && jcfg.ReservedOrgNames[orgName] {
 			return nil, false, core.ErrReservedOrgName
+		}
+
+		if !cm.HasAnyAudience(claims) {
+			return nil, false, core.ErrOrgAudienceDenied
 		}
 
 		roles, err := cm.GetRoles(claims)

--- a/rest-api/auth/pkg/config/jwks_test.go
+++ b/rest-api/auth/pkg/config/jwks_test.go
@@ -927,3 +927,72 @@ func TestValidateAudiences(t *testing.T) {
 		assert.ErrorIs(t, err, core.ErrInvalidAudience)
 	})
 }
+
+func TestGetOrgDataFromClaimMappingAudiences(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *JwksConfig
+		claims     jwt.MapClaims
+		requestOrg string
+		wantErr    error
+	}{
+		{
+			name: "matching audience authorizes org",
+			config: &JwksConfig{ClaimMappings: []ClaimMapping{{
+				OrgName:   "acme",
+				Roles:     []string{"TENANT_ADMIN"},
+				Audiences: []string{"org-acme"},
+			}}},
+			claims:     jwt.MapClaims{"aud": []string{"issuer-audience", "org-acme"}},
+			requestOrg: "acme",
+		},
+		{
+			name: "wrong audience denies org",
+			config: &JwksConfig{ClaimMappings: []ClaimMapping{{
+				OrgName:   "acme",
+				Roles:     []string{"TENANT_ADMIN"},
+				Audiences: []string{"org-acme"},
+			}}},
+			claims:     jwt.MapClaims{"aud": "different-audience"},
+			requestOrg: "acme",
+			wantErr:    core.ErrOrgAudienceDenied,
+		},
+		{
+			name: "mapping without audiences remains allowed",
+			config: &JwksConfig{ClaimMappings: []ClaimMapping{{
+				OrgName: "acme",
+				Roles:   []string{"TENANT_ADMIN"},
+			}}},
+			claims:     jwt.MapClaims{},
+			requestOrg: "acme",
+		},
+		{
+			name: "reserved dynamic org is rejected before audience",
+			config: &JwksConfig{
+				ClaimMappings: []ClaimMapping{{
+					OrgAttribute:   "org",
+					RolesAttribute: "roles",
+					Audiences:      []string{"org-acme"},
+				}},
+				ReservedOrgNames: map[string]bool{"acme": true},
+			},
+			claims:     jwt.MapClaims{"org": "acme", "roles": []string{"TENANT_ADMIN"}, "aud": "different-audience"},
+			requestOrg: "acme",
+			wantErr:    core.ErrReservedOrgName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orgData, _, err := tt.config.GetOrgDataFromClaim(tt.claims, tt.requestOrg)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, orgData)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Contains(t, orgData, strings.ToLower(tt.requestOrg))
+		})
+	}
+}

--- a/rest-api/auth/pkg/config/jwks_test.go
+++ b/rest-api/auth/pkg/config/jwks_test.go
@@ -955,7 +955,7 @@ func TestGetOrgDataFromClaimMappingAudiences(t *testing.T) {
 			}}},
 			claims:     jwt.MapClaims{"aud": "different-audience"},
 			requestOrg: "acme",
-			wantErr:    core.ErrOrgAudienceDenied,
+			wantErr:    core.ErrInvalidAudience,
 		},
 		{
 			name: "mapping without audiences remains allowed",

--- a/rest-api/auth/pkg/core/errors.go
+++ b/rest-api/auth/pkg/core/errors.go
@@ -40,6 +40,8 @@ var (
 	ErrNoClaimRoles = errors.New("no roles found in token claims for organization")
 	// ErrReservedOrgName is returned when token claims a reserved organization name (403)
 	ErrReservedOrgName = errors.New("token claims a reserved organization name")
+	// ErrOrgAudienceDenied is returned when token audience is not authorized for the requested organization (403)
+	ErrOrgAudienceDenied = errors.New("token audience is not authorized for the requested organization")
 	// ErrInvalidRole is returned when role is not in allowed roles set
 	ErrInvalidRole = errors.New("role is not in allowed roles set")
 )

--- a/rest-api/auth/pkg/core/errors.go
+++ b/rest-api/auth/pkg/core/errors.go
@@ -40,8 +40,6 @@ var (
 	ErrNoClaimRoles = errors.New("no roles found in token claims for organization")
 	// ErrReservedOrgName is returned when token claims a reserved organization name (403)
 	ErrReservedOrgName = errors.New("token claims a reserved organization name")
-	// ErrOrgAudienceDenied is returned when token audience is not authorized for the requested organization (403)
-	ErrOrgAudienceDenied = errors.New("token audience is not authorized for the requested organization")
 	// ErrInvalidRole is returned when role is not in allowed roles set
 	ErrInvalidRole = errors.New("role is not in allowed roles set")
 )

--- a/rest-api/auth/pkg/processors/custom.go
+++ b/rest-api/auth/pkg/processors/custom.go
@@ -93,7 +93,7 @@ func (h *CustomProcessor) ProcessToken(c echo.Context, tokenStr string, jwksConf
 		case errors.Is(err, core.ErrReservedOrgName):
 			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("Organization cannot be authorized dynamically using claims data")
 			return nil, util.NewAPIError(http.StatusForbidden, "Organization cannot be authorized dynamically using claims data", nil)
-		case errors.Is(err, core.ErrOrgAudienceDenied):
+		case errors.Is(err, core.ErrInvalidAudience):
 			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("Token audience is not authorized for organization specified in URL")
 			return nil, util.NewAPIError(http.StatusForbidden, "Token audience is not authorized for organization specified in URL", nil)
 		case errors.Is(err, core.ErrInvalidConfiguration):

--- a/rest-api/auth/pkg/processors/custom.go
+++ b/rest-api/auth/pkg/processors/custom.go
@@ -93,6 +93,9 @@ func (h *CustomProcessor) ProcessToken(c echo.Context, tokenStr string, jwksConf
 		case errors.Is(err, core.ErrReservedOrgName):
 			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("Organization cannot be authorized dynamically using claims data")
 			return nil, util.NewAPIError(http.StatusForbidden, "Organization cannot be authorized dynamically using claims data", nil)
+		case errors.Is(err, core.ErrOrgAudienceDenied):
+			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("Token audience is not authorized for organization specified in URL")
+			return nil, util.NewAPIError(http.StatusForbidden, "Token audience is not authorized for organization specified in URL", nil)
 		case errors.Is(err, core.ErrInvalidConfiguration):
 			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("No authorization configuration exists for organization specified in URL")
 			return nil, util.NewAPIError(http.StatusUnauthorized, "No authorization configuration exists for organization specified in URL", nil)

--- a/rest-api/auth/pkg/processors/custom_test.go
+++ b/rest-api/auth/pkg/processors/custom_test.go
@@ -228,6 +228,66 @@ func TestCustomProcessor_ValidateAudiences_Failure(t *testing.T) {
 	}
 }
 
+func TestCustomProcessor_ClaimMappingAudiences(t *testing.T) {
+	tests := []struct {
+		name             string
+		mappingAudiences []string
+		tokenAudiences   any
+		wantCode         int
+	}{
+		{
+			name:             "mapping audience mismatch returns forbidden",
+			mappingAudiences: []string{"org-audience"},
+			tokenAudiences:   []string{"issuer-audience"},
+			wantCode:         http.StatusForbidden,
+		},
+		{
+			name:             "issuer and mapping audiences pass",
+			mappingAudiences: []string{"org-audience"},
+			tokenAudiences:   []string{"issuer-audience", "org-audience"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor, jwksConfig, privateKey, _, cleanup := setupTestEnvironment(t, []string{"issuer-audience"}, []string{"carbide"})
+			defer cleanup()
+
+			jwksConfig.ClaimMappings = []config.ClaimMapping{{
+				OrgName:   "acme",
+				Roles:     []string{"TENANT_ADMIN"},
+				Audiences: tt.mappingAudiences,
+			}}
+			claims := jwt.MapClaims{
+				"sub":   "mapping-audience-" + tt.name,
+				"iss":   "https://custom.example.com",
+				"aud":   tt.tokenAudiences,
+				"scope": "carbide",
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			}
+			tokenString := createTestToken(t, privateKey, claims)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/org/acme/test", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("orgName")
+			c.SetParamValues("acme")
+
+			_, apiErr := processor.ProcessToken(c, tokenString, jwksConfig, zerolog.Nop())
+			if tt.wantCode == 0 {
+				require.Nil(t, apiErr)
+				return
+			}
+
+			require.NotNil(t, apiErr)
+			assert.Equal(t, tt.wantCode, apiErr.Code)
+			assert.Contains(t, apiErr.Message, "not authorized for organization")
+		})
+	}
+}
+
 func TestCustomProcessor_ValidateScopes_Success(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/rest-api/openapi/auth.md
+++ b/rest-api/openapi/auth.md
@@ -135,6 +135,7 @@ Key fields:
 - `audiences` is optional. If set, the token `aud` claim must contain at least one configured audience.
 - `scopes` is optional. If set, the token must contain all configured scopes. NICo checks the `scope`, `scopes`, and `scp` claims.
 - `claimMappings` is required and controls the organization and roles assigned to authenticated users.
+- A claim mapping may also set `audiences`. The token `aud` claim must contain at least one exact, case-sensitive match for the requested organization's mapping. If issuer and mapping audiences are both configured, both gates must pass.
 
 NICo supports `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, and `EdDSA` signed tokens.
 
@@ -215,7 +216,7 @@ All three attributes support dot notation for nested claims. For example, if `or
 }
 ```
 
-Dynamic organizations cannot use an organization name already reserved by a static `orgName` mapping.
+Dynamic organizations cannot use an organization name already reserved by a static `orgName` mapping. A dynamic mapping may set `audiences`, but the same flat audience set gates every organization it resolves; audience values are not bound to resolved organization names.
 
 ### Common Configuration Examples
 #### SaaS Service Account
@@ -341,6 +342,7 @@ Use these rules when reviewing a configuration before rollout:
 If requests fail after authentication is enabled, check the token and REST API configuration together.
 
 - `401 Unauthorized` with an audience error usually means the token `aud` claim does not match any configured `audiences`. Update the IdP client audience, update NICo `audiences`, or omit `audiences` if audience enforcement is not needed.
+- `403 Forbidden` with an organization audience error means issuer validation passed, but token `aud` did not match the requested claim mapping's `audiences`.
 - `403 Forbidden` with a scope error usually means the token is missing one or more configured `scopes`. NICo checks `scope`, `scopes`, and `scp`.
 - Invalid token errors often come from an unreachable `jwks` URL, an unsupported signing key, or an `issuer` value that does not exactly match the token `iss` claim.
 - Missing authorization usually means the selected `claimMappings` entry did not produce a valid organization and role set. Check `orgName`, `orgAttribute`, `roles`, and `rolesAttribute`.

--- a/rest-api/openapi/auth.md
+++ b/rest-api/openapi/auth.md
@@ -137,6 +137,97 @@ Key fields:
 - `claimMappings` is required and controls the organization and roles assigned to authenticated users.
 - A claim mapping may also set `audiences`. The token `aud` claim must contain at least one exact, case-sensitive match for the requested organization's mapping. If issuer and mapping audiences are both configured, both gates must pass.
 
+#### Audience Matching Examples
+
+Audience matching is an exact, case-sensitive overlap check. A configured list uses ANY-match semantics: the token needs at least one value from that list.
+
+With one issuer-level audience:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    audiences: ["api-audience"]
+    claimMappings:
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+```
+
+A token with `aud: ["api-audience", "tenant-client-a"]` passes because `api-audience` overlaps the configured issuer list.
+
+With multiple issuer-level audiences:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    audiences: ["api-audience", "admin-api-audience"]
+    claimMappings:
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+```
+
+The token needs either `api-audience` or `admin-api-audience`; it does not need both.
+
+Mapping audiences can be used without issuer-level audiences:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    claimMappings:
+      - orgName: "automation-org"
+        orgDisplayName: "Automation Organization"
+        isServiceAccount: true
+        audiences: ["automation-client-a"]
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+        audiences: ["tenant-client-a", "tenant-client-b"]
+```
+
+For `automation-org`, the token must contain `automation-client-a`. For `tenant-org`, either `tenant-client-a` or `tenant-client-b` is sufficient. The service-account mapping requires disconnected mode.
+
+When issuer-level and mapping audiences are both configured, they are independent gates:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    audiences: ["api-audience", "admin-api-audience"]
+    claimMappings:
+      - orgName: "automation-org"
+        orgDisplayName: "Automation Organization"
+        isServiceAccount: true
+        audiences: ["automation-client-a", "automation-client-b"]
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+        audiences: ["tenant-client-a", "tenant-client-b"]
+```
+
+A token requesting `automation-org` needs:
+
+- at least one of `api-audience` or `admin-api-audience`; and
+- at least one of `automation-client-a` or `automation-client-b`.
+
+A token requesting `tenant-org` needs:
+
+- at least one of `api-audience` or `admin-api-audience`; and
+- at least one of `tenant-client-a` or `tenant-client-b`.
+
+For example, `aud: ["api-audience", "tenant-client-a"]` authorizes `tenant-org` but not `automation-org`.
+
 NICo supports `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, and `EdDSA` signed tokens.
 
 ### Claim Mapping Recipes


### PR DESCRIPTION
Custom issuers can map multiple organizations, but issuer-level audience validation allows every accepted token to match every configured mapping. Add optional mapping audiences so shared issuers can confine each client to its intended organization while preserving existing configurations.

Closes #3612

## Type of Change
- [x] **Add** - New feature or capability

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed: configured keycloak's realm, client, aud, and included as custom issuer instead of keycloak type

Mapping audiences are optional. Existing issuer configurations retain their current behavior when no mapping audiences are configured.

## Test
Configured nico-rest-api with following change in configmap
```
   keycloak:
      enabled: false
      baseURL: http://keycloak:8082
      externalBaseURL: http://localhost:8082
      realm: nico-dev
      clientID: nico-api
      clientSecretPath: /var/secrets/keycloak/client-secret
      serviceAccount: true


    # Custom-origin issuers with issuer-level (global) audience validation and
    # per-org (claimMapping-level) audience gating. Same shared Keycloak issuer
    # confines each client to its intended organization via mapping audiences.
    issuers:
      - name: kc-primary
        origin: custom
        jwks: http://keycloak:8082/realms/nico-dev/protocol/openid-connect/certs
        issuer: http://localhost:8082/realms/nico-dev
        audiences:
          - nico-global
        claimMappings:
          - orgName: acme
            roles:
              - TENANT_ADMIN
            audiences:
              - org-acme-aud
          - orgName: beta
            roles:
              - TENANT_ADMIN
            audiences:
              - org-beta-aud
          - orgName: shared-noaud
            roles:
              - TENANT_ADMIN
      - name: kc-secondary
        origin: custom
        jwks: http://keycloak:8082/realms/nico-dev2/protocol/openid-connect/certs
        issuer: http://localhost:8082/realms/nico-dev2
        audiences:
          - nico-global
        claimMappings:
          - orgName: gamma
            roles:
              - TENANT_ADMIN
              - PROVIDER_ADMIN
            audiences:
              - org-gamma-aud```
              
Updated the existing keycloak realm json with new clients to emit proper aud in the claim 
```},
        {
          "clientId": "acme-client",
          "name": "ACME Org Client (per-org audience: org-acme-aud)",
          "enabled": true,
          "clientAuthenticatorType": "client-secret",
          "secret": "acme-secret",
          "publicClient": false,
          "protocol": "openid-connect",
          "directAccessGrantsEnabled": true,
          "serviceAccountsEnabled": true,
          "standardFlowEnabled": false,
          "implicitFlowEnabled": false,
          "fullScopeAllowed": true,
          "protocolMappers": [
            {
              "name": "aud-global",
              "protocol": "openid-connect",
              "protocolMapper": "oidc-audience-mapper",
              "consentRequired": false,
              "config": {
                "included.custom.audience": "nico-global",
                "id.token.claim": "false",
                "access.token.claim": "true"
              }
            },
            {
              "name": "aud-org-acme",
              "protocol": "openid-connect",
              "protocolMapper": "oidc-audience-mapper",
              "consentRequired": false,
              "config": {
                "included.custom.audience": "org-acme-aud",
                "id.token.claim": "false",
                "access.token.claim": "true"
              }
            }
          ]
        },
        {
          "clientId": "beta-client",
          "name": "Beta Org Client (per-org audience: org-beta-aud)",
          "enabled": true,
          "clientAuthenticatorType": "client-secret",
          "secret": "beta-secret",
          "publicClient": false,
          "protocol": "openid-connect",
          "directAccessGrantsEnabled": true,
          "serviceAccountsEnabled": true,
          "standardFlowEnabled": false,
          "implicitFlowEnabled": false,
          "fullScopeAllowed": true,
          "protocolMappers": [
            {
              "name": "aud-global",
              "protocol": "openid-connect",
              "protocolMapper": "oidc-audience-mapper",
              "consentRequired": false,
              "config": {
                "included.custom.audience": "nico-global",
                "id.token.claim": "false",
                "access.token.claim": "true"
              }
            },
            {
              "name": "aud-org-beta",
              "protocol": "openid-connect",
              "protocolMapper": "oidc-audience-mapper",
              "consentRequired": false,
              "config": {
                "included.custom.audience": "org-beta-aud",
                "id.token.claim": "false",
                "access.token.claim": "true"
              }
            }
          ]
        }
      ],```

second realm in keycloak 
```nico-dev2-realm.json: |
    {
      "realm": "nico-dev2",
      "enabled": true,
      "displayName": "NICo Development (second issuer)",
      "sslRequired": "none",
      "registrationAllowed": false,
      "loginWithEmailAllowed": true,
      "clients": [
        {
          "clientId": "gamma-client",
          "name": "Gamma Org Client (per-org audience: org-gamma-aud)",
          "enabled": true,
          "clientAuthenticatorType": "client-secret",
          "secret": "gamma-secret",
          "publicClient": false,
          "protocol": "openid-connect",
          "directAccessGrantsEnabled": true,
          "serviceAccountsEnabled": true,
          "standardFlowEnabled": false,
          "implicitFlowEnabled": false,
          "fullScopeAllowed": true,
          "protocolMappers": [
            {
              "name": "aud-global",
              "protocol": "openid-connect",
              "protocolMapper": "oidc-audience-mapper",
              "consentRequired": false,
              "config": {
                "included.custom.audience": "nico-global",
                "id.token.claim": "false",
                "access.token.claim": "true"
              }
            },
            {
              "name": "aud-org-gamma",
              "protocol": "openid-connect",
              "protocolMapper": "oidc-audience-mapper",
              "consentRequired": false,
              "config": {
                "included.custom.audience": "org-gamma-aud",
                "id.token.claim": "false",
                "access.token.claim": "true"
              }
            }
          ]
        }
      ]
    }```
keycloak realms 
```
realms:            master, nico-dev, nico-dev2
nico-dev clients:  nico-api, acme-client, beta-client
nico-dev2 clients: gamma-client
```

Tokens by keycloak 
``````bash
cc() { curl -s -X POST "http://localhost:8082/realms/$1/protocol/openid-connect/token" \
  -d client_id=$2 -d client_secret=$3 -d grant_type=client_credentials | jq -r .access_token; }
ACME=$(cc  nico-dev  acme-client  acme-secret)
BETA=$(cc  nico-dev  beta-client  beta-secret)
GAMMA=$(cc nico-dev2 gamma-client gamma-secret)
NICOAPI=$(cc nico-dev nico-api    nico-local-secret)
``````

resulting tokens 
```acme-client : iss=http://localhost:8082/realms/nico-dev   aud=[nico-global, org-acme-aud, account]  sub=6375544f-...  azp=acme-client
beta-client : iss=http://localhost:8082/realms/nico-dev   aud=[org-beta-aud, nico-global, account]  sub=7bd9a970-...  azp=beta-client
gamma-client: iss=http://localhost:8082/realms/nico-dev2  aud=[nico-global, org-gamma-aud, account] sub=16edbc56-...  azp=gamma-client
nico-api    : iss=http://localhost:8082/realms/nico-dev   aud=[nico-api, account]                    sub=c472e872-...  azp=nico-api   (no nico-global)```

API req results
```| # | Token (aud) | org | HTTP | Response body | Result |
|---|-------------|-----|------|---------------|--------|
| 1 | acme-client `[nico-global, org-acme-aud]` | `acme` | **200** | `{"org":"acme",...}` | ✅ per-org aud match → authorized |
| 2 | acme-client | `beta` | **403** | `{"message":"Token audience is not authorized for organization specified in URL"}` | ✅ **per-org gate blocks (ErrOrgAudienceDenied)** |
| 3 | beta-client `[nico-global, org-beta-aud]` | `beta` | **200** | `{"org":"beta",...}` | ✅ per-org aud match → authorized |
| 4 | beta-client | `acme` | **403** | `{"message":"Token audience is not authorized for organization specified in URL"}` | ✅ **per-org gate blocks (ErrOrgAudienceDenied)** |
| 5 | acme-client | `shared-noaud` | **200** | `{"org":"shared-noaud",...}` | ✅ backward-compat: mapping with no audiences accepts token |
| 6 | nico-api `[nico-api]` (no global) | `acme` | **401** | `{"message":"Token audience does not match issuer configuration"}` | ✅ global/issuer-level gate (ErrInvalidAudience) |
| 7 | gamma-client `[nico-global, org-gamma-aud]` (issuer 2) | `gamma` | **200** | `{"org":"gamma",...}` | ✅ second issuer + per-org aud match |
| 8 | gamma-client (issuer 2) | `acme` | **401** | `{"message":"No authorization configuration exists for organization specified in URL"}` | ✅ cross-issuer isolation (issuer 2 has no `acme` mapping) |
```
Resulting user in the user table
```auxiliary_id                                     | org_data
-------------------------------------------------+---------------------------------------------------------------
37f8314691:6375544f-...(acme-client)             | {"acme":{...roles:[TENANT_ADMIN]...},
                                                 |  "shared-noaud":{...roles:[TENANT_ADMIN]...}}
37f8314691:7bd9a970-...(beta-client)             | {"beta":{...roles:[TENANT_ADMIN]...}}
eff50c2a44:16edbc56-...(gamma-client, nico-dev2) | {"gamma":{...roles:[TENANT_ADMIN,PROVIDER_ADMIN]...}}```