### PR TITLE
fix: Don't duplicate error messages in logs

### DIFF
--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::backtrace::{Backtrace, BacktraceStatus};
+use std::fmt::{Display, Formatter};
+use std::panic::Location;
+use std::sync::Arc;
 
 use ::rpc::errors::RpcDataConversionError;
 use carbide_ib_fabric::errors::IbError;
@@ -28,7 +30,7 @@ use db::resource_pool::ResourcePoolDatabaseError;
 use db::{AnnotatedSqlxError, DatabaseError};
 use librms::RackManagerError;
 use mac_address::MacAddress;
-use model::errors::{ErrorCode, ErrorSubsystem, ModelError, OperatorError, OperatorErrorSchema};
+use model::errors::{ErrorCode, ErrorSubsystem, ModelError, OperatorError};
 use model::hardware_info::HardwareInfoError;
 use model::network_devices::LldpError;
 use model::site_explorer::EndpointExplorationError;
@@ -427,141 +429,89 @@ impl From<::measured_boot::Error> for CarbideError {
 }
 
 impl From<CarbideError> for tonic::Status {
-    fn from(from: CarbideError) -> Self {
-        let schema = from.operator_error_schema();
-        log_carbide_error(&from, &schema);
+    #[track_caller] // get the source Location from the caller, not this function
+    fn from(error: CarbideError) -> Self {
+        let schema = error.operator_error_schema();
 
-        let status = status_from_carbide_error(&from);
-        status_with_operator_error_schema(status, &schema)
-    }
-}
-
-fn log_carbide_error(error: &CarbideError, schema: &OperatorErrorSchema) {
-    if matches!(error, CarbideError::NotImplemented) {
-        return;
-    }
-
-    if let Some((handler, location)) = carbide_backtrace_location() {
-        tracing::error!(
-            error = %error,
-            error_code = %schema.error_code,
-            mitigation = %schema.mitigation_for_log(),
-            text = %schema.text,
-            error_location = %location,
-            handler = %handler,
-            "Request failed"
-        );
-    } else {
-        tracing::error!(
-            error = %error,
-            error_code = %schema.error_code,
-            mitigation = %schema.mitigation_for_log(),
-            text = %schema.text,
-            "Request failed"
-        );
-    }
-}
-
-fn carbide_backtrace_location() -> Option<(String, String)> {
-    // If env RUST_BACKTRACE is set extract handler and err location.
-    // If it's not set, `Backtrace::capture()` is very cheap to call.
-    let backtrace = Backtrace::capture();
-    if backtrace.status() != BacktraceStatus::Captured {
-        return None;
-    }
-
-    let rendered = backtrace.to_string();
-    parse_carbide_backtrace_location(&rendered)
-        .map(|(handler, location)| (handler.to_owned(), location.to_owned()))
-}
-
-fn parse_carbide_backtrace_location(backtrace: &str) -> Option<(&str, &str)> {
-    const ERROR_MODULE_PATH: &str = "crates/api-core/src/errors.rs:";
-    const ERROR_MODULE_SYMBOL: &str = "carbide_api_core::errors";
-
-    let mut lines = backtrace.lines().peekable();
-    while let Some(handler) = lines.next() {
-        let handler = handler.trim();
-        let Some(location) = lines
-            .peek()
-            .and_then(|line| line.trim().strip_prefix("at "))
-        else {
-            continue;
+        // TODO: There's many more mapped to `Status::internal` which are likely
+        // user errors instead
+        let mut status = match &error {
+            e @ CarbideError::Internal { .. } => Status::internal(e.to_string()),
+            CarbideError::InvalidArgument(msg) => Status::invalid_argument(msg),
+            error @ CarbideError::VpcCapability(_) => Status::invalid_argument(error.to_string()),
+            CarbideError::InvalidConfiguration(e) => Status::invalid_argument(e.to_string()),
+            CarbideError::RpcDataConversionError(e) => Status::invalid_argument(e.to_string()),
+            e @ CarbideError::DhcpError(_) => Status::resource_exhausted(e.to_string()),
+            CarbideError::MissingArgument(msg) => Status::invalid_argument(*msg),
+            CarbideError::NetworkSegmentDelete(msg) => Status::invalid_argument(msg),
+            CarbideError::NotFoundError { kind, id } => {
+                Status::not_found(format!("{kind} not found: {id}"))
+            }
+            CarbideError::AlreadyFoundError { kind, id } => {
+                Status::already_exists(format!("{kind} already exists: {id}"))
+            }
+            CarbideError::MaintenanceMode => {
+                Status::failed_precondition("MaintenanceMode".to_string())
+            }
+            e @ CarbideError::BmcMacIpMismatch { .. } => Status::invalid_argument(e.to_string()),
+            CarbideError::UnhealthyHost => Status::failed_precondition(error.to_string()),
+            CarbideError::ResourceExhausted(kind) => Status::resource_exhausted(kind),
+            error @ CarbideError::ConcurrentModificationError(_, _) => {
+                Status::failed_precondition(error.to_string())
+            }
+            error @ CarbideError::FailedPrecondition(_) => {
+                Status::failed_precondition(error.to_string())
+            }
+            error @ CarbideError::ExpectedSwitchDuplicateNvosMacAddress(_) => {
+                Status::failed_precondition(error.to_string())
+            }
+            error @ CarbideError::AddressAlreadyInUse(_) => {
+                Status::failed_precondition(error.to_string())
+            }
+            error @ CarbideError::ClientCertificateMissingInformation(_) => {
+                Status::unauthenticated(error.to_string())
+            }
+            CarbideError::UnavailableError(msg) => Status::unavailable(msg),
+            CarbideError::PermissionDeniedError(msg) => Status::permission_denied(msg),
+            CarbideError::AlreadyInProgress(msg) => Status::already_exists(msg),
+            other => Status::internal(other.to_string()),
         };
-        lines.next();
 
-        // Conversion frames can be sourced from this module or from core while
-        // still naming CarbideError in the symbol. Neither identifies the RPC handler.
-        if !handler.contains("carbide")
-            || handler.contains(ERROR_MODULE_SYMBOL)
-            || location.contains(ERROR_MODULE_PATH)
-        {
-            continue;
+        insert_ascii_metadata(
+            &mut status,
+            "nico-error-code",
+            &schema.error_code.to_string(),
+        );
+        insert_ascii_metadata(&mut status, "nico-error-text", &schema.text);
+        if let Some(mitigation) = &schema.mitigation {
+            insert_ascii_metadata(&mut status, "nico-error-mitigation", mitigation);
         }
 
-        return Some((handler, location));
-    }
+        let error_with_location = CarbideErrorWithLocation {
+            error,
+            location: Location::caller().to_string(),
+        };
 
-    None
-}
-
-fn status_from_carbide_error(error: &CarbideError) -> Status {
-    // TODO: There's many more mapped to `Status::internal` which are likely
-    // user errors instead
-    match error {
-        e @ CarbideError::Internal { .. } => Status::internal(e.to_string()),
-        CarbideError::InvalidArgument(msg) => Status::invalid_argument(msg),
-        error @ CarbideError::VpcCapability(_) => Status::invalid_argument(error.to_string()),
-        CarbideError::InvalidConfiguration(e) => Status::invalid_argument(e.to_string()),
-        CarbideError::RpcDataConversionError(e) => Status::invalid_argument(e.to_string()),
-        e @ CarbideError::DhcpError(_) => Status::resource_exhausted(e.to_string()),
-        CarbideError::MissingArgument(msg) => Status::invalid_argument(*msg),
-        CarbideError::NetworkSegmentDelete(msg) => Status::invalid_argument(msg),
-        CarbideError::NotFoundError { kind, id } => {
-            Status::not_found(format!("{kind} not found: {id}"))
-        }
-        CarbideError::AlreadyFoundError { kind, id } => {
-            Status::already_exists(format!("{kind} already exists: {id}"))
-        }
-        CarbideError::MaintenanceMode => Status::failed_precondition("MaintenanceMode".to_string()),
-        e @ CarbideError::BmcMacIpMismatch { .. } => Status::invalid_argument(e.to_string()),
-        CarbideError::UnhealthyHost => Status::failed_precondition(error.to_string()),
-        CarbideError::ResourceExhausted(kind) => Status::resource_exhausted(kind),
-        error @ CarbideError::ConcurrentModificationError(_, _) => {
-            Status::failed_precondition(error.to_string())
-        }
-        error @ CarbideError::FailedPrecondition(_) => {
-            Status::failed_precondition(error.to_string())
-        }
-        error @ CarbideError::ExpectedSwitchDuplicateNvosMacAddress(_) => {
-            Status::failed_precondition(error.to_string())
-        }
-        error @ CarbideError::AddressAlreadyInUse(_) => {
-            Status::failed_precondition(error.to_string())
-        }
-        error @ CarbideError::ClientCertificateMissingInformation(_) => {
-            Status::unauthenticated(error.to_string())
-        }
-        CarbideError::UnavailableError(msg) => Status::unavailable(msg),
-        CarbideError::PermissionDeniedError(msg) => Status::permission_denied(msg),
-        CarbideError::AlreadyInProgress(msg) => Status::already_exists(msg),
-        other => Status::internal(other.to_string()),
+        // Set the inner error to the CarbideError, which can be inspected by our LogService layer
+        status.set_source(Arc::new(error_with_location));
+        status
     }
 }
 
-fn status_with_operator_error_schema(mut status: Status, schema: &OperatorErrorSchema) -> Status {
-    insert_ascii_metadata(
-        &mut status,
-        "nico-error-code",
-        &schema.error_code.to_string(),
-    );
-    insert_ascii_metadata(&mut status, "nico-error-text", &schema.text);
-    if let Some(mitigation) = &schema.mitigation {
-        insert_ascii_metadata(&mut status, "nico-error-mitigation", mitigation);
-    }
-
-    status
+/// A CarbideError with the corresponding source location where it was converted to a tonic::Status
+#[derive(Debug)]
+pub struct CarbideErrorWithLocation {
+    pub error: CarbideError,
+    pub location: String,
 }
+
+impl Display for CarbideErrorWithLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.error, f)
+    }
+}
+
+impl std::error::Error for CarbideErrorWithLocation {}
 
 fn insert_ascii_metadata(status: &mut Status, key: &'static str, value: &str) {
     match MetadataValue::try_from(value) {
@@ -616,43 +566,6 @@ fn unavailable_error_schema_describes_who_should_retry() {
     let mitigation = schema.mitigation.expect("has a mitigation");
     assert!(mitigation.contains("Admin CLI"));
     assert!(mitigation.contains("REST API"));
-}
-
-#[test]
-fn backtrace_location_skips_error_conversion_frames() {
-    use carbide_test_support::value_scenarios;
-
-    const WITH_OUTER_HANDLER: &str = r#"
-   3: carbide_api_core::errors::carbide_backtrace_location
-             at ./crates/api-core/src/errors.rs:461:13
-   4: carbide_api_core::errors::log_carbide_error
-             at /workspace/infra-controller/crates/api-core/src/errors.rs:437:9
-   5: <tonic::status::Status as core::convert::From<carbide_api_core::errors::CarbideError>>::from
-             at ./crates/api-core/src/errors.rs:425:9
-   6: <carbide_api_core::errors::CarbideError as core::convert::Into<tonic::status::Status>>::into
-             at /rustc/library/core/src/convert/mod.rs:761:9
-   7: carbide_api_core::handlers::machine::create_machine
-             at ./crates/api-core/src/handlers/machine.rs:412:24
-"#;
-    const ERROR_FRAMES_ONLY: &str = r#"
-   3: carbide_api_core::errors::carbide_backtrace_location
-             at ./crates/api-core/src/errors.rs:461:13
-   4: carbide_api_core::errors::log_carbide_error
-             at ./crates/api-core/src/errors.rs:437:9
-   5: <tonic::status::Status as core::convert::From<carbide_api_core::errors::CarbideError>>::from
-             at ./crates/api-core/src/errors.rs:425:9
-"#;
-
-    value_scenarios!(
-        run = parse_carbide_backtrace_location;
-        "frame selection" {
-            WITH_OUTER_HANDLER => Some((
-                "7: carbide_api_core::handlers::machine::create_machine",
-                "./crates/api-core/src/handlers/machine.rs:412:24",
-            )),
-            ERROR_FRAMES_ONLY => None,
-        }
-    );
 }
 
 #[test]

--- a/crates/api-core/src/logging/api_logs.rs
+++ b/crates/api-core/src/logging/api_logs.rs
@@ -17,12 +17,17 @@
 
 //! A logging middleware for carbide API server requests
 
+use std::error::Error;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use carbide_utils::none_if_empty::NoneIfEmpty;
+use model::errors::OperatorError;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};
 use tracing::Instrument;
+
+use crate::errors::CarbideErrorWithLocation;
 
 /// A tower Layer which creates a `LogService` for every request
 #[derive(Debug, Clone)]
@@ -165,6 +170,10 @@ where
                 sql_total_query_duration_us = 0,
                 user.id = tracing::field::Empty, // Populated by auth layer
                 tenant.organization_id = tracing::field::Empty,
+                nico.error = tracing::field::Empty,
+                nico.error_code = tracing::field::Empty,
+                nico.mitigation = tracing::field::Empty,
+                nico.error_location = tracing::field::Empty,
             );
 
             // Continue any distributed trace the caller started: make the inbound W3C trace
@@ -210,9 +219,10 @@ where
             let elapsed = start.elapsed();
 
             // Holds the overall outcome of the request as a single log message
-            let mut outcome: Result<(), String> = Ok(());
-            let mut http_code = None;
-            let mut grpc_status = None;
+            let outcome: Result<(), String>;
+            let http_code: Option<http::StatusCode>;
+            let grpc_status: Option<tonic::Code>;
+            let carbide_error: Option<&CarbideErrorWithLocation>;
 
             match &result {
                 Ok(result) => {
@@ -221,32 +231,18 @@ where
 
                     if result.status() == hyper::http::StatusCode::OK {
                         // In gRPC the actual message status is not in the http status code,
-                        // but actually in a header (and sometimes even a trailer - but we ignore this case here since
-                        // we don't do streaming).
-                        //
-                        // Unfortunately we have to reconstruct the status here, by parsing
-                        // those headers again
-                        let code = match result.headers().get("grpc-status") {
-                            Some(header) => tonic::Code::from_bytes(header.as_ref()),
-                            None => {
-                                // The header is not set in case of successful responses
-                                tonic::Code::Ok
-                            }
-                        };
+                        // but actually in a header/trailer. Tonic stores the tonic::Status
+                        // object in the HTTP response extensions, so we use that.
+                        let tonic_status = result.extensions().get::<tonic::Status>();
+                        carbide_error = tonic_status
+                            .and_then(|s| s.source())
+                            .and_then(|source| source.downcast_ref::<CarbideErrorWithLocation>());
+                        let code = tonic_status.map(|s| s.code()).unwrap_or(tonic::Code::Ok);
                         grpc_status = Some(code);
-                        let message = result
-                            .headers()
-                            .get("grpc-message")
-                            .map(|header| {
-                                // TODO: The header is percent encoded
-                                // We only do basic (space) decoding for now
-                                // percent_decode(header.as_bytes())
-                                //     .decode_utf8()
-                                //     .map(|cow| cow.to_string())
-                                std::str::from_utf8(header.as_bytes())
-                                    .unwrap_or("Invalid UTF8 Message")
-                                    .replace("%20", " ")
-                            })
+
+                        let message = tonic_status
+                            .as_ref()
+                            .map(|s| s.message().to_owned())
                             .unwrap_or_else(String::new);
 
                         request_span.record("rpc.grpc.status_code", code as u64);
@@ -254,20 +250,49 @@ where
                             "rpc.grpc.status_description",
                             format!("Code: {}, Message: {}", code.description(), message),
                         );
-                        if code != tonic::Code::Ok {
-                            outcome = Err(format!(
+
+                        outcome = if code == tonic::Code::Ok {
+                            Ok(())
+                        } else {
+                            Err(format!(
                                 "gRPC Error: {}. Message: {}",
                                 code.description(),
                                 message
-                            ));
+                            ))
                         }
                     } else {
                         outcome = Err(format!("HTTP status: {}", result.status()));
+                        grpc_status = None;
+                        carbide_error = None;
                     }
                 }
                 Err(_) => {
+                    http_code = None;
+                    grpc_status = None;
+                    carbide_error = None;
                     outcome = Err("HTTP execution error".to_string());
                 }
+            }
+
+            // If the tonic::Status came from a CarbideError, log interesting fields from it like
+            // the nico-internal error code and mitigation.
+            if let Some(CarbideErrorWithLocation { error, location }) = carbide_error {
+                let schema = error.operator_error_schema();
+                // Note: don't add schema.text here, it's always identical to what we already add to e.g. rpc.grpc.status_description
+                request_span.record("nico.error_code", schema.error_code.to_string());
+                if let Some(mitigation) = schema.mitigation {
+                    request_span.record("nico.mitigation", mitigation);
+                }
+
+                // This represents the source location where the error was converted to a tonic::Status.
+                request_span.record(
+                    "nico.error_location",
+                    location
+                        .to_string()
+                        .as_str()
+                        .none_if_empty()
+                        .unwrap_or("foo"),
+                );
             }
 
             request_span.record(

--- a/crates/api-core/src/logging/api_logs.rs
+++ b/crates/api-core/src/logging/api_logs.rs
@@ -285,14 +285,7 @@ where
                 }
 
                 // This represents the source location where the error was converted to a tonic::Status.
-                request_span.record(
-                    "nico.error_location",
-                    location
-                        .to_string()
-                        .as_str()
-                        .none_if_empty()
-                        .unwrap_or("foo"),
-                );
+                request_span.record("nico.error_location", location.to_string());
             }
 
             request_span.record(

--- a/crates/api-core/src/logging/api_logs.rs
+++ b/crates/api-core/src/logging/api_logs.rs
@@ -21,7 +21,6 @@ use std::error::Error;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use carbide_utils::none_if_empty::NoneIfEmpty;
 use model::errors::OperatorError;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};


### PR DESCRIPTION
There's an issue with the automatic logging of OperatorErrorSchema from CarbideError: we were logging both the error itself and the inner schema.text field, but both resolve to the same string.

In addition, logging CarbideError at the moment it's converted to a tonic::Status is a bit of a hacky approach, as it emits logs even if the request isn't complete yet (maybe the error will be handled, etc.) Plus, the actual error itself is already being logged by our custom logfmt layer which logs the moment a request span is closed, so it's duplicated on two levels.

Fix these and more issues:

- Don't automatically log a CarbideError when it's converted to a tonic::Status, instead, pack the CarbideError inside the tonic::Status through tonic::Status::set_source(carbide_error).

- Then, our existing LogService layer can use `result.extensions().get::<tonic::Status>()` to get the Status object from the response, then get its source, and if it's a CarbideError, it can log it then. Particularly, we don't add an additional tracing::error! statement or anything, but instead just add the fields we want to the existing span we're already logging on. This means the error code shows up as `nico_error_code=NICO-API-500`, the mitigation shows up as `nico_mitigation=...`, etc, all on the same log line we're already logging at the end of each request.

- Instead of Backtrace::capture(), use Location::caller(), which gets the source location of just the caller. It has the advantage of working even if RUST_BACKTRACE is not enabled, and doesn't need the expensive work of gathering a whole backtrace just to find who called the function. We can use #[track_caller] to ensure that we get the caller's location instead of ours.

This cuts down on the duplicate logging and puts the additional information we want into the log lines that are already happening.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes