### PR TITLE
feat(helm): support separate image repository + tag fields

### DIFF
--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       initContainers:
         {{- range .Values.bootArtifactContainers }}
         - name: {{ .name }}
-          image: {{ if .repository }}{{ .repository }}:{{ .tag }}{{ else }}{{ .image }}{{ end }}
+          image: {{ if and .repository .tag }}{{ .repository }}:{{ .tag }}{{ else }}{{ .image }}{{ end }}
           {{- with .command }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       initContainers:
         {{- range .Values.bootArtifactContainers }}
         - name: {{ .name }}
-          image: {{ .image }}
+          image: {{ if .repository }}{{ .repository }}:{{ .tag }}{{ else }}{{ .image }}{{ end }}
           {{- with .command }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-api/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-api/tests/boot_artifacts_test.yaml
@@ -51,6 +51,31 @@ tests:
             name: boot-artifacts
             mountPath: /forge-boot-artifacts/blobs/internal
 
+  - it: should build image from repository + tag when provided (new fields win)
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          repository: registry.example.com/boot-artifacts-x86_64
+          tag: v1.2.3
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/boot-artifacts-x86_64:v1.2.3
+
+  - it: should ignore combined image when repository + tag are also set (new fields win)
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          repository: registry.example.com/boot-artifacts-x86_64
+          tag: v1.2.3
+          image: legacy.example.com/should-be-ignored:old
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/boot-artifacts-x86_64:v1.2.3
+
   - it: should add boot-artifacts volume and mount on main container
     set:
       bootArtifactContainers:

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -82,17 +82,22 @@ initContainers: []
 ## Boot-artifact init containers
 ## Each entry is rendered as a Kubernetes init container with the boot-artifacts
 ## volume automatically mounted at /forge-boot-artifacts/blobs/internal.
+## Prefer separate `repository` + `tag` fields (they win when set). The combined
+## `image: <ref>:<tag>` form is still honored for backward compatibility.
 bootArtifactContainers: []
 # bootArtifactContainers:
 #   - name: boot-artifacts-x86-64
-#     image: <your-registry>/boot-artifacts-x86_64:latest
+#     repository: <your-registry>/boot-artifacts-x86_64
+#     tag: latest
 #     command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
 #   - name: boot-artifacts-aarch64
-#     image: <your-registry>/boot-artifacts-aarch64:latest
+#     repository: <your-registry>/boot-artifacts-aarch64
+#     tag: latest
 #     # NOTE: the aarch64 image ships /aarch64 + /apt (NOT /firmware) — copying a missing dir crash-loops the init.
 #     command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
 #   - name: machine-validation-config
-#     image: <your-registry>/machine-validation-config:latest
+#     repository: <your-registry>/machine-validation-config
+#     tag: latest
 #     command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
 service:

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         {{- range .Values.bootArtifactContainers }}
         - name: {{ .name }}
-          image: {{ if .repository }}{{ .repository }}:{{ .tag }}{{ else }}{{ .image }}{{ end }}
+          image: {{ if and .repository .tag }}{{ .repository }}:{{ .tag }}{{ else }}{{ .image }}{{ end }}
           {{- with .command }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       initContainers:
         {{- range .Values.bootArtifactContainers }}
         - name: {{ .name }}
-          image: {{ .image }}
+          image: {{ if .repository }}{{ .repository }}:{{ .tag }}{{ else }}{{ .image }}{{ end }}
           {{- with .command }}
           command:
             {{- toYaml . | nindent 12 }}

--- a/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
@@ -48,6 +48,31 @@ tests:
             name: boot-artifacts
             mountPath: /forge-boot-artifacts/blobs/internal
 
+  - it: should build image from repository + tag when provided (new fields win)
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          repository: registry.example.com/boot-artifacts-x86_64
+          tag: v1.2.3
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/boot-artifacts-x86_64:v1.2.3
+
+  - it: should ignore combined image when repository + tag are also set (new fields win)
+    set:
+      bootArtifactContainers:
+        - name: boot-artifacts-x86-64
+          repository: registry.example.com/boot-artifacts-x86_64
+          tag: v1.2.3
+          image: legacy.example.com/should-be-ignored:old
+          command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/boot-artifacts-x86_64:v1.2.3
+
   - it: should add boot-artifacts volume and mount on main container
     set:
       bootArtifactContainers:

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -60,16 +60,21 @@ initContainers: []
 ## NOTE: copy ONLY directories that exist in the image. The boot-artifacts-aarch64 image
 ## ships /aarch64 and /apt (NOT /firmware); copying a missing dir makes `cp` exit non-zero
 ## and the init container crash-loops.
+## Prefer separate `repository` + `tag` fields (they win when set). The combined
+## `image: <ref>:<tag>` form is still honored for backward compatibility.
 bootArtifactContainers: []
 # bootArtifactContainers:
 #   - name: boot-artifacts-x86-64
-#     image: <your-registry>/boot-artifacts-x86_64:<tag>
+#     repository: <your-registry>/boot-artifacts-x86_64
+#     tag: <tag>
 #     command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
 #   - name: boot-artifacts-aarch64
-#     image: <your-registry>/boot-artifacts-aarch64:<tag>
+#     repository: <your-registry>/boot-artifacts-aarch64
+#     tag: <tag>
 #     command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
 #   - name: machine-validation-config
-#     image: <your-registry>/machine-validation-config:<tag>
+#     repository: <your-registry>/machine-validation-config
+#     tag: <tag>
 #     command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
 ## Boot artifact serving configuration

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -59,13 +59,16 @@ nico-api:
   ## is auto-injected by the template.
   bootArtifactContainers:
     - name: boot-artifacts-x86-64
-      image: "your-registry.example.com/boot-artifacts-x86_64:latest"
+      repository: "your-registry.example.com/boot-artifacts-x86_64"
+      tag: "latest"
       command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     - name: boot-artifacts-aarch64
-      image: "your-registry.example.com/boot-artifacts-aarch64:latest"
+      repository: "your-registry.example.com/boot-artifacts-aarch64"
+      tag: "latest"
       command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
     - name: machine-validation-config
-      image: "your-registry.example.com/machine-validation-config:latest"
+      repository: "your-registry.example.com/machine-validation-config"
+      tag: "latest"
       command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
   env:
@@ -245,13 +248,16 @@ nico-pxe:
 
   bootArtifactContainers:
     - name: boot-artifacts-x86-64
-      image: "your-registry.example.com/boot-artifacts-x86_64:latest"
+      repository: "your-registry.example.com/boot-artifacts-x86_64"
+      tag: "latest"
       command: ["sh", "-c", "cp -r /x86_64 /forge-boot-artifacts/blobs/internal"]
     - name: boot-artifacts-aarch64
-      image: "your-registry.example.com/boot-artifacts-aarch64:latest"
+      repository: "your-registry.example.com/boot-artifacts-aarch64"
+      tag: "latest"
       command: ["sh", "-c", "cp -r /aarch64 /apt /forge-boot-artifacts/blobs/internal"]
     - name: machine-validation-config
-      image: "your-registry.example.com/machine-validation-config:latest"
+      repository: "your-registry.example.com/machine-validation-config"
+      tag: "latest"
       command: ["sh", "-c", "cp -r /machine-validation /forge-boot-artifacts/blobs/internal"]
 
   externalService:

--- a/helm/rest/nico-rest-site-agent/templates/bootstrap.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/bootstrap.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: {{ include "nico-rest-site-agent.name" . }}-bootstrap
       containers:
         - name: bootstrap
-          image: {{ if .Values.bootstrap.repository }}{{ .Values.bootstrap.repository }}:{{ .Values.bootstrap.tag }}{{ else }}{{ .Values.bootstrap.image }}{{ end }}
+          image: {{ if and .Values.bootstrap.repository .Values.bootstrap.tag }}{{ .Values.bootstrap.repository }}:{{ .Values.bootstrap.tag }}{{ else }}{{ .Values.bootstrap.image }}{{ end }}
           env:
             - name: SITE_UUID
               value: {{ .Values.envConfig.CLUSTER_ID | quote }}

--- a/helm/rest/nico-rest-site-agent/templates/bootstrap.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/bootstrap.yaml
@@ -74,7 +74,7 @@ spec:
       serviceAccountName: {{ include "nico-rest-site-agent.name" . }}-bootstrap
       containers:
         - name: bootstrap
-          image: {{ .Values.bootstrap.image }}
+          image: {{ if .Values.bootstrap.repository }}{{ .Values.bootstrap.repository }}:{{ .Values.bootstrap.tag }}{{ else }}{{ .Values.bootstrap.image }}{{ end }}
           env:
             - name: SITE_UUID
               value: {{ .Values.envConfig.CLUSTER_ID | quote }}

--- a/helm/rest/nico-rest-site-agent/values.yaml
+++ b/helm/rest/nico-rest-site-agent/values.yaml
@@ -69,7 +69,10 @@ bootstrap:
   # this site with nico-rest-site-manager and creates the site-registration secret.
   # Requires envConfig.CLUSTER_ID to be set.
   enabled: false
-  image: alpine/k8s:1.29.4
+  # Prefer repository + tag (they win when set); combined `image` kept for backward compat.
+  repository: alpine/k8s
+  tag: 1.29.4
+  # image: alpine/k8s:1.29.4
   siteManager:
     address: nico-rest-site-manager.nico-rest
     tlsSecret: site-manager-tls

--- a/helm/rest/nico-rest-site-agent/values.yaml
+++ b/helm/rest/nico-rest-site-agent/values.yaml
@@ -69,10 +69,11 @@ bootstrap:
   # this site with nico-rest-site-manager and creates the site-registration secret.
   # Requires envConfig.CLUSTER_ID to be set.
   enabled: false
-  # Prefer repository + tag (they win when set); combined `image` kept for backward compat.
-  repository: alpine/k8s
-  tag: 1.29.4
-  # image: alpine/k8s:1.29.4
+  # Set `repository` + `tag` to override (they win when both are set); otherwise the
+  # combined `image` below is used.
+  # repository: alpine/k8s
+  # tag: 1.29.4
+  image: alpine/k8s:1.29.4
   siteManager:
     address: nico-rest-site-manager.nico-rest
     tlsSecret: site-manager-tls

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-postgres
-          image: {{ if .Values.waitForPostgres.repository }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}
+          image: {{ if and .Values.waitForPostgres.repository .Values.waitForPostgres.tag }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}
           command:
             - pg_isready
             - -h

--- a/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/templates/migration-job.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-postgres
-          image: {{ .Values.waitForPostgres.image }}
+          image: {{ if .Values.waitForPostgres.repository }}{{ .Values.waitForPostgres.repository }}:{{ .Values.waitForPostgres.tag }}{{ else }}{{ .Values.waitForPostgres.image }}{{ end }}
           command:
             - pg_isready
             - -h

--- a/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
@@ -8,7 +8,10 @@ image:
   name: nico-rest-db
 
 waitForPostgres:
-  image: postgres:14.4-alpine
+  # Prefer repository + tag (they win when set); combined `image` kept for backward compat.
+  repository: postgres
+  tag: 14.4-alpine
+  # image: postgres:14.4-alpine
 
 db:
   host: nico-pg-cluster.postgres.svc.cluster.local

--- a/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-db/values.yaml
@@ -8,10 +8,11 @@ image:
   name: nico-rest-db
 
 waitForPostgres:
-  # Prefer repository + tag (they win when set); combined `image` kept for backward compat.
-  repository: postgres
-  tag: 14.4-alpine
-  # image: postgres:14.4-alpine
+  # Set `repository` + `tag` to override (they win when both are set); otherwise the
+  # combined `image` below is used.
+  # repository: postgres
+  # tag: 14.4-alpine
+  image: postgres:14.4-alpine
 
 db:
   host: nico-pg-cluster.postgres.svc.cluster.local


### PR DESCRIPTION
Add `repository` + `tag` fields (new fields win) alongside the existing combined `image` string for boot-artifact init containers (nico-api, nico-pxe), the site-agent bootstrap job, and the nico-rest-db wait-for-postgres init container. The combined `image` form still renders for backward compatibility.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3620

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

