### PR TITLE
chore: exclude the generated metrics catalogue from docs review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,5 +23,10 @@
 /docs/ @polarweasel
 /fern/ @polarweasel
 
+# The metrics catalogue is generated (`test_integration` regenerates it from the
+# `/metrics` scrape; `cargo xtask check-metric-docs --fix` adds the rest), not
+# authored prose -- exclude it so metric-only changes don't wait on docs review.
+/docs/observability/core_metrics.md
+
 # Network IP module
 /common/network/src/ip/ @DrewBloechl


### PR DESCRIPTION
`docs/observability/core_metrics.md` is generated — `test_integration` regenerates it from the `/metrics` scrape and `cargo xtask check-metric-docs --fix` fills in the rest — so it's not prose a technical writer reviews. But the `/docs/ @polarweasel` rule makes every metric-only change wait on a docs approval it doesn't need.

This adds a more-specific `CODEOWNERS` entry that removes ownership for just that one file (last match wins); the rest of `/docs/` stays under `@polarweasel`.
