### PR TITLE
fix(ci): align with other makefiles to use version for pkg_version

### DIFF
--- a/Makefile-package.toml
+++ b/Makefile-package.toml
@@ -19,8 +19,9 @@ CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 REPO_ROOT = { script = [
   "dirname $(cargo locate-project --message-format plain --workspace)",
 ] }
+
 PKG_VERSION = { script = [
-  "v=$(git describe --tags --first-parent --always --long | sed 's/^v//'); case \"$v\" in [0-9]*) echo \"$v\" ;; *) echo \"0.0.0-$v\" ;; esac",
+  "if [ -n \"$VERSION\" ]; then echo \"$VERSION\" | sed 's/^v//'; else v=$(git describe --tags --first-parent --always --long | sed 's/^v//'); case \"$v\" in [0-9]*) echo \"$v\" ;; *) echo \"0.0.0-$v\" ;; esac; fi",
 ] }
 
 [tasks.package-component-local]


### PR DESCRIPTION
Backports https://github.com/NVIDIA/infra-controller/pull/3621

Follow up to https://github.com/NVIDIA/infra-controller/pull/3508 where pkg version uses the tag over the git `--long` tag. Neither of the test runs caught the issue since the path only gets activated when running on a clean tag (eg. `v2.0.0-rc.7`). In CI we saw some deb files generating with the `--long` tags despite `version` being just the tag:

```sh
VERSION in container: v2.0.0-rc.7
...
creating package for x86_64 scout (forge-scout) (2.0.0-rc.7-0-g1795d8979) 
```

The fix is to apply the same version logic to the package makefile which also defines it's own `PKG_VERSION` var that wasn't updated from https://github.com/NVIDIA/infra-controller/pull/3508 . This was validated by manually running the equivalent ci commands as shown below:

```sh
# test command
VERSION=v2.0.0-rc.7 \
CARBIDE_PACKAGE=scout \
CARBIDE_CRATE=carbide-scout \
CARBIDE_CRATE_DIR=crates/scout \
CARBIDE_ARCH=x86_64 \
CARBIDE_PROFILE=release \
cargo make package-component

# output before fix, still using --long tag
creating package for x86_64 scout (forge-scout) (2.0.0-rc.7-0-g1795d8979) with install path /opt/forge

# output after fix, using tag
creating package for x86_64 scout (forge-scout) (2.0.0-rc.7) with install path /opt/forge
```

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
