### PR TITLE
Allow required file in devspace Dockerfile.machine-a-tron.dockerignore

### DIFF
--- a/dev/deployment/devspace/Dockerfile.machine-a-tron.dockerignore
+++ b/dev/deployment/devspace/Dockerfile.machine-a-tron.dockerignore
@@ -16,3 +16,6 @@
 !pxe/ipxe/
 !pxe/ipxe/local/
 !pxe/ipxe/local/embed.ipxe
+!dev/
+!dev/ipmi/
+!dev/ipmi/ipmi_sim_chassiscontrol.sh


### PR DESCRIPTION
A recent change added this to bmc-mock:

```
include_bytes!("../../../dev/ipmi/ipmi_sim_chassiscontrol.sh")
```

But the devspace Dockerfiles ignore a lot of stuff to cut back on the amount of build context we upload, and stuff under toplevel dev has to be allow-listed in the Dockerignore file. Soooo, do that.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

