### PR TITLE
feat(docs): nico metrics and alerts

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -230,8 +230,12 @@ navigation:
               path: manuals/repair/repair_integration.md
         - section: Observability
           contents:
-            - page: Core Metrics
+            - page: Alerts
+              path: observability/alerts.md
+            - page: Core Metrics List
               path: observability/core_metrics.md
+            - page: Metrics and Dashboards
+              path: observability/metrics.md
             - page: Logging
               path: observability/logging.md
             - page: Machines and DPU Logging

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -4,7 +4,7 @@ This document defines critical metrics for alerting, recommended thresholds and 
 alert rules for monitoring NICo deployments. For metrics exposure and collection
 details, see [metrics.md](metrics.md).
 
-## NOTE: Alert rule format
+## Alert rule format
 
 NICo alerts use the Prometheus-compatible alerting rule format.
 The same rule body (groups, alert names, `expr`, `for`, `labels`, `annotations`) works
@@ -15,7 +15,7 @@ with both backends:
 
 All expressions, thresholds and annotations in this document are backend-neutral.
 
-## NOTE: Threshold ownership
+## Threshold ownership
 
 NICo is not the source of truth for hardware alert thresholds.
 The Baseboard Management Controller (BMC) on each server defines raw
@@ -34,7 +34,7 @@ makes an individual host "unhealthy" at the sensor level.
 
 The following thresholds are validated in production NICo deployments:
 
-### 1.1 Host health
+### Host health
 
 Alert when more than 10% of hosts are unhealthy, excluding hosts with `SuppressExternalAlerting`
 classification. Only applies to sites with more than 40 machines.
@@ -43,7 +43,7 @@ classification. Only applies to sites with more than 40 machines.
 |--------|-----------|----------|
 | Hosts unhealthy | > 10% (excluding suppressed) | 5m |
 
-### 1.2 IP capacity
+### IP capacity
 
 Use percentage-based thresholds for IP availability, not absolute counts.
 
@@ -51,21 +51,21 @@ Use percentage-based thresholds for IP availability, not absolute counts.
 |--------|-----------|----------|
 | Available IPs | < 15% for a given IP type | 60m |
 
-### 1.3 Machines stuck above SLA
+### Machines stuck above SLA
 
 | Severity | Threshold | Duration |
 |----------|-----------|----------|
 | Warning | < 10% stuck in assigned state | 30m |
 | Critical | >= 10% stuck in assigned state | 30m |
 
-### 1.4 Network segments / IB partitions stuck above SLA
+### Network segments / IB partitions stuck above SLA
 
 | Severity | Threshold | Duration |
 |----------|-----------|----------|
 | Warning |  < 10 stuck | 60m |
 | Critical | >= 10 stuck | 60m |
 
-### 1.5 State-handler latency
+### State-handler latency
 
 Alert when average iteration latency exceeds the threshold.
 
@@ -75,18 +75,18 @@ Alert when average iteration latency exceeds the threshold.
 
 Applies to machine, network-segment and IB-partition state handlers.
 
-### 1.6 API availability
+### API availability
 
 | Alert | Expression | Duration |
 |-------|------------|----------|
 | NicoAPIDown | `max(carbide_api_ready) == 0 or absent(carbide_api_ready)` | 15m |
 | NicoAPIFluctuating | `changes(carbide_api_ready[15m]) > 5` | 15m |
 
-### 1.7 DPU metrics
+### DPU metrics
 
-| Alert | Condition | Duration | Severity |
-|-------|-----------|----------|----------|
-| DPU metrics missing | Scrape target down or absent | 10m | warning |
+| Alert | Condition | Duration |
+|-------|-----------|----------|
+| DPU metrics missing | Scrape target down or absent | 10m |
 
 ## 2. SLO targets
 

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -1,0 +1,203 @@
+# NICo Alerting
+
+This document defines critical metrics for alerting, recommended thresholds and example
+alert rules for monitoring NICo deployments. For metrics exposure and collection
+details, see [metrics.md](metrics.md).
+
+## NOTE: Alert rule format
+
+NICo alerts use the Prometheus-compatible alerting rule format.
+The same rule body (groups, alert names, `expr`, `for`, `labels`, `annotations`) works
+with both backends:
+
+- **Prometheus Operator** - deploy as `PrometheusRule` resources
+- **VictoriaMetrics Operator** - deploy as `VMRule` resources
+
+All expressions, thresholds and annotations in this document are backend-neutral.
+
+## NOTE: Threshold ownership
+
+NICo is not the source of truth for hardware alert thresholds.
+The Baseboard Management Controller (BMC) on each server defines raw
+threshold values for hardware telemetry (temperature, fan speed, power, voltage).
+The BMC decides when a sensor reading is WARNING or CRITICAL based on its firmware
+policies.
+
+NICo's `nico-hardware-health` service collects these BMC-reported states via Redfish
+and transforms them into health classifications (`SensorWarning`, `SensorCritical`),
+aggregate metrics and operational impacts (`PreventAllocations`). The fleet-level
+thresholds documented here (e.g., "alert when >10% of hosts are unhealthy") are NICo
+policies for aggregating BMC decisions across the fleet - NICo does not define what
+makes an individual host "unhealthy" at the sensor level.
+
+## 1. Production-validated thresholds
+
+The following thresholds are validated in production NICo deployments:
+
+### 1.1 Host health
+
+Alert when more than 10% of hosts are unhealthy, excluding hosts with `SuppressExternalAlerting`
+classification. Only applies to sites with more than 40 machines.
+
+| Metric | Threshold | Duration |
+|--------|-----------|----------|
+| Hosts unhealthy | > 10% (excluding suppressed) | 5m |
+
+### 1.2 IP capacity
+
+Use percentage-based thresholds for IP availability, not absolute counts.
+
+| Metric | Threshold | Duration |
+|--------|-----------|----------|
+| Available IPs | < 15% for a given IP type | 60m |
+
+### 1.3 Machines stuck above SLA
+
+| Severity | Threshold | Duration |
+|----------|-----------|----------|
+| Warning | < 10% stuck in assigned state | 30m |
+| Critical | >= 10% stuck in assigned state | 30m |
+
+### 1.4 Network segments / IB partitions stuck above SLA
+
+| Severity | Threshold | Duration |
+|----------|-----------|----------|
+| Warning |  < 10 stuck | 60m |
+| Critical | >= 10 stuck | 60m |
+
+### 1.5 State-handler latency
+
+Alert when average iteration latency exceeds the threshold.
+
+| Metric | Threshold | Duration |
+|--------|-----------|----------|
+| State-handler latency | > 120 seconds | 10m |
+
+Applies to machine, network-segment and IB-partition state handlers.
+
+### 1.6 API availability
+
+| Alert | Expression | Duration |
+|-------|------------|----------|
+| NicoAPIDown | `(carbide_api_ready == 0) or absent(carbide_api_ready == 1)` | 15m |
+| NicoAPIFluctuating | `changes(carbide_api_ready[15m]) > 5` | 15m |
+
+### 1.7 DPU metrics
+
+| Alert | Condition | Duration | Severity |
+|-------|-----------|----------|----------|
+| DPU metrics missing | Scrape target down or absent | 10m | warning |
+
+## 2. SLO targets
+
+These are operational SLO targets, separate from alert thresholds:
+
+| SLO | Target |
+|-----|--------|
+| API availability | 99.9% (max 0.1% error rate) |
+| API latency | < 1 second |
+| State update / reconciliation | < 60 seconds |
+| External hardware monitoring latency | < 5 minutes |
+
+### Metrics for SLO monitoring
+
+**API availability** uses `carbide_api_grpc_server_duration_milliseconds` histogram. Compute
+error rate from the `_count` series split by gRPC status:
+
+```promql
+1 - (
+  sum(rate(carbide_api_grpc_server_duration_milliseconds_count{grpc_status!="OK"}[5m]))
+  /
+  sum(rate(carbide_api_grpc_server_duration_milliseconds_count[5m]))
+)
+```
+
+**API latency** uses the same histogram. Extract p95 or p99 percentiles:
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(carbide_api_grpc_server_duration_milliseconds_bucket[5m])) by (le)
+)
+```
+
+**State update / reconciliation** uses `carbide_machines_handler_latency_in_state_milliseconds`
+histogram. The production alert threshold (120s) is more lenient than the SLO target (60s) to
+reduce noise. Related metrics include `carbide_machines_iteration_latency_milliseconds` for
+full iteration time and `carbide_machines_per_state_above_sla` for objects exceeding configured
+per-state thresholds.
+
+## 3. Site-related thresholds
+
+The following metrics are useful for alerting but lack production-validated thresholds.
+Use these as starting points and tune based on your site characteristics:
+
+| Metric | Expression | Suggested approach |
+|--------|------------|-------------------|
+| Hosts usable | `carbide_hosts_usable_count` | Site-relative percentage of total hosts |
+| GPUs usable | `carbide_gpus_usable_count` | Site-relative percentage of total GPUs |
+| DPU unhealthy | `(carbide_dpus_up_count - carbide_dpus_healthy_count) / carbide_dpus_up_count` | Warning at > 5%, treat as warning-class with longer `for:` duration |
+| DB pool exhaustion | `carbide_db_pool_idle_conns` | Alert on low idle connections or pool timeout errors |
+
+No evidence was found that large sites use different alert thresholds.
+
+## 4. Deploying alert rules
+
+A start set of alert rules with production-validated thresholds is available at
+[`helm/observability/alerts/nico-alerts.yaml`](https://github.com/NVIDIA/nico/blob/main/helm/observability/alerts/nico-alerts.yaml).
+
+The file uses `PrometheusRule` as the CRD kind. For VictoriaMetrics Operator deployments,
+change `apiVersion` to `operator.victoriametrics.com/v1beta1` and `kind` to `VMRule` -
+the rule groups and expressions remain unchanged.
+
+Apply after reviewing and adjusting thresholds for your site:
+
+```bash
+# Review thresholds
+vim helm/observability/alerts/nico-alerts.yaml
+
+# For Prometheus Operator
+kubectl apply -f helm/observability/alerts/nico-alerts.yaml
+kubectl get prometheusrules -n nico-system
+
+# For VictoriaMetrics Operator (after changing apiVersion/kind)
+kubectl apply -f helm/observability/alerts/nico-alerts.yaml
+kubectl get vmrules -n nico-system
+```
+
+The alert rules include these groups:
+
+| Group | Alerts |
+|-------|--------|
+| `nico-api` | API down, API fluctuating, state-handler latency |
+| `nico-sla` | Machines stuck, network segments stuck, IB partitions stuck |
+| `nico-capacity` | Low IP availability |
+| `nico-health` | Hosts unhealthy, DPU metrics missing |
+
+## 5. Health alert classifications
+
+NICo's health system uses classifications to indicate alert severity and operational impact.
+These appear in `carbide_hosts_health_alerts_count` labels and affect threshold calculations.
+
+| Classification | Impact |
+|---------------|--------|
+| `PreventAllocations` | Host cannot be allocated to tenants |
+| `PreventHostStateChanges` | Host blocked from lifecycle transitions |
+| `SuppressExternalAlerting` | Excluded from fleet-health calculations and alerts |
+| `ExcludeFromStateMachineSla` | Not counted toward SLA metrics |
+| `Hardware` | Broad category for hardware/BMC issues |
+| `SensorWarning` | Sensor crossed caution threshold |
+| `SensorCritical` | Sensor crossed critical threshold |
+| `SensorFailure` | Sensor reading outside valid range |
+
+The `SuppressExternalAlerting` classification is important for alert thresholds - hosts with
+this classification should be excluded from unhealthy percentage calculations.
+
+For detailed troubleshooting of health alerts, see the
+[health alerts playbook](../playbooks/stuck_objects/health_alerts.md).
+
+## 6. References
+
+- [NICo alerting rules](https://github.com/NVIDIA/nico/tree/main/helm/observability/alerts/nico-alerts.yaml) - Prometheus-compatible rule examples
+- [Health alerts playbook](../playbooks/stuck_objects/health_alerts.md)
+- [Health alert classifications](../architecture/health/health_alert_classifications.md)
+- [Full metrics reference](core_metrics.md)

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -79,7 +79,7 @@ Applies to machine, network-segment and IB-partition state handlers.
 
 | Alert | Expression | Duration |
 |-------|------------|----------|
-| NicoAPIDown | `(carbide_api_ready == 0) or absent(carbide_api_ready == 1)` | 15m |
+| NicoAPIDown | `max(carbide_api_ready) == 0 or absent(carbide_api_ready)` | 15m |
 | NicoAPIFluctuating | `changes(carbide_api_ready[15m]) > 5` | 15m |
 
 ### 1.7 DPU metrics
@@ -112,12 +112,13 @@ error rate from the `_count` series split by gRPC status:
 )
 ```
 
-**API latency** uses the same histogram. Extract p95 or p99 percentiles:
+**API latency** uses the same histogram. Extract p95 or p99 percentiles and convert to
+seconds (metric is in milliseconds, SLO target is 1 second = 1000ms):
 
 ```promql
 histogram_quantile(0.95,
   sum(rate(carbide_api_grpc_server_duration_milliseconds_bucket[5m])) by (le)
-)
+) / 1000 < 1
 ```
 
 **State update / reconciliation** uses `carbide_machines_handler_latency_in_state_milliseconds`
@@ -128,17 +129,15 @@ per-state thresholds.
 
 ## 3. Site-related thresholds
 
-The following metrics are useful for alerting but lack production-validated thresholds.
+The following metrics are useful for alerting but site-specific.
 Use these as starting points and tune based on your site characteristics:
 
 | Metric | Expression | Suggested approach |
-|--------|------------|-------------------|
+|--------|------------|--------------------|
 | Hosts usable | `carbide_hosts_usable_count` | Site-relative percentage of total hosts |
 | GPUs usable | `carbide_gpus_usable_count` | Site-relative percentage of total GPUs |
 | DPU unhealthy | `(carbide_dpus_up_count - carbide_dpus_healthy_count) / carbide_dpus_up_count` | Warning at > 5%, treat as warning-class with longer `for:` duration |
 | DB pool exhaustion | `carbide_db_pool_idle_conns` | Alert on low idle connections or pool timeout errors |
-
-No evidence was found that large sites use different alert thresholds.
 
 ## 4. Deploying alert rules
 
@@ -197,7 +196,7 @@ For detailed troubleshooting of health alerts, see the
 
 ## 6. References
 
-- [NICo alerting rules](https://github.com/NVIDIA/infra-controller/tree/main/helm/observability/alerts/nico-alerts.yaml) - Prometheus-compatible rule examples
+- [NICo alerting rules](https://github.com/NVIDIA/infra-controller/blob/main/helm/observability/alerts/nico-alerts.yaml) - Prometheus-compatible rule examples
 - [Health alerts playbook](../playbooks/stuck_objects/health_alerts.md)
 - [Health alert classifications](../architecture/health/health_alert_classifications.md)
 - [Full metrics reference](core_metrics.md)

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -143,7 +143,7 @@ No evidence was found that large sites use different alert thresholds.
 ## 4. Deploying alert rules
 
 A start set of alert rules with production-validated thresholds is available at
-[`helm/observability/alerts/nico-alerts.yaml`](https://github.com/NVIDIA/nico/blob/main/helm/observability/alerts/nico-alerts.yaml).
+[`helm/observability/alerts/nico-alerts.yaml`](https://github.com/NVIDIA/infra-controller/blob/main/helm/observability/alerts/nico-alerts.yaml).
 
 The file uses `PrometheusRule` as the CRD kind. For VictoriaMetrics Operator deployments,
 change `apiVersion` to `operator.victoriametrics.com/v1beta1` and `kind` to `VMRule` -
@@ -197,7 +197,7 @@ For detailed troubleshooting of health alerts, see the
 
 ## 6. References
 
-- [NICo alerting rules](https://github.com/NVIDIA/nico/tree/main/helm/observability/alerts/nico-alerts.yaml) - Prometheus-compatible rule examples
+- [NICo alerting rules](https://github.com/NVIDIA/infra-controller/tree/main/helm/observability/alerts/nico-alerts.yaml) - Prometheus-compatible rule examples
 - [Health alerts playbook](../playbooks/stuck_objects/health_alerts.md)
 - [Health alert classifications](../architecture/health/health_alert_classifications.md)
 - [Full metrics reference](core_metrics.md)

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -104,7 +104,7 @@ These are operational SLO targets, separate from alert thresholds:
 **API availability** uses `carbide_api_grpc_server_duration_milliseconds` histogram. Compute
 error rate from the `_count` series split by gRPC status:
 
-```promql
+```text
 1 - (
   sum(rate(carbide_api_grpc_server_duration_milliseconds_count{grpc_status!="OK"}[5m]))
   /
@@ -115,7 +115,7 @@ error rate from the `_count` series split by gRPC status:
 **API latency** uses the same histogram. Extract p95 or p99 percentiles and convert to
 seconds (metric is in milliseconds, SLO target is 1 second = 1000ms):
 
-```promql
+```text
 histogram_quantile(0.95,
   sum(rate(carbide_api_grpc_server_duration_milliseconds_bucket[5m])) by (le)
 ) / 1000 < 1
@@ -172,7 +172,99 @@ The alert rules include these groups:
 | `nico-capacity` | Low IP availability |
 | `nico-health` | Hosts unhealthy, DPU metrics missing |
 
-## 5. Health alert classifications
+## 5. Per-object alerting
+
+The nico-api state controller can expose optional **per-object state metrics** for
+identifying individual stuck or failing objects, not just fleet-wide counts. While
+aggregate metrics like `carbide_machines_per_state_above_sla` tell you *how many*
+machines are stuck, per-object metrics tell you *which*.
+
+This feature is **opt-in** and exposes O(fleet) cardinality. Enable it only when your
+metrics backend can handle the volume. See [metrics.md](metrics.md#4-per-object-state-metrics-endpoint)
+for configuration and collection details.
+
+### Per-object SLA alerts
+
+These alerts identify individual objects that have exceeded their configured SLA
+for the current state. The alerts are written replica-safe using `max by (...)` to
+handle multi-replica deployments.
+
+**Stuck beyond per-object SLA (warning):**
+
+```text
+max by (object_type, object_id, state, substate)
+    (time() - carbide_object_state_entered_timestamp_seconds)
+  > on(object_type, object_id, state, substate) group_left()
+    max by (object_type, object_id, state, substate)
+        (carbide_object_state_sla_seconds)
+```
+
+**Stuck beyond 2× SLA (critical):**
+
+```text
+max by (object_type, object_id, state, substate)
+    (time() - carbide_object_state_entered_timestamp_seconds)
+  > on(object_type, object_id, state, substate) group_left()
+    (2 * max by (object_type, object_id, state, substate)
+        (carbide_object_state_sla_seconds))
+```
+
+These rules automatically adapt when SLA policy changes - there's no need to update
+thresholds in alert rules.
+
+### Manual intervention alerts
+
+**Objects requiring operator intervention:**
+
+```text
+max by (object_type, object_id, reason)
+    (carbide_object_manual_intervention_required == 1)
+```
+
+This alert fires for objects in terminal failed states or where the handler has
+explicitly flagged manual intervention is required. The `reason` label is a bounded
+token (not free text) identifying the failure cause.
+
+**Manual intervention ratio:**
+
+```text
+count(carbide_object_manual_intervention_required{object_type="machine"} == 1)
+  /
+count(carbide_object_state_entered_timestamp_seconds{object_type="machine"})
+```
+
+### Joining with object traits
+
+Use `carbide_object_info` to add context (rack, SKU, vendor, model) to alerts:
+
+```text
+(
+  max by (object_type, object_id, state, substate)
+    (time() - carbide_object_state_entered_timestamp_seconds)
+    > on(object_type, object_id, state, substate) group_left()
+    max by (object_type, object_id, state, substate)
+        (carbide_object_state_sla_seconds)
+)
+  * on(object_type, object_id) group_left(rack, sku, vendor, model)
+    max by (object_type, object_id, rack, sku, vendor, model)
+        (carbide_object_info)
+```
+
+### Multi-replica considerations
+
+With `replicas > 1`, per-object series live in the memory of whichever replica
+last processed the object. A stale copy can briefly appear from a different pod
+until it ages out (within the hold period). Always aggregate away the scrape
+instance **before** joining:
+
+```text
+max by (object_type, object_id, state, substate) (...)
+```
+
+Alerts using these joins should carry a `for:` duration of at least one scrape
+interval (60-120s recommended) to handle transient disagreements during transitions.
+
+## 6. Health alert classifications
 
 NICo's health system uses classifications to indicate alert severity and operational impact.
 These appear in `carbide_hosts_health_alerts_count` labels and affect threshold calculations.
@@ -194,7 +286,7 @@ this classification should be excluded from unhealthy percentage calculations.
 For detailed troubleshooting of health alerts, see the
 [health alerts playbook](../playbooks/stuck_objects/health_alerts.md).
 
-## 6. References
+## 7. References
 
 - [NICo alerting rules](https://github.com/NVIDIA/infra-controller/blob/main/helm/observability/alerts/nico-alerts.yaml) - Prometheus-compatible rule examples
 - [Health alerts playbook](../playbooks/stuck_objects/health_alerts.md)

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -34,7 +34,7 @@ the `# TYPE` metadata to determine the actual metric type.
 
 NICo metrics fall into several categories, each answering different operational questions.
 
-### 2.1 State lifecycle: "Are machines progressing normally?"
+### State lifecycle: "Are machines progressing normally?"
 
 The state controller is the heart of NICo's lifecycle management. It tracks machines,
 network segments, IB partitions and other objects through their lifecycle states. For
@@ -51,7 +51,7 @@ Related metrics include `carbide_<object>_per_state` (current count per state),
 `carbide_<object>_state_time_in_state_seconds` (histogram of time spent) and
 `carbide_<object>_state_handler_errors_total` (processing failures).
 
-### 2.2 Capacity: "How much headroom do we have?"
+### Capacity: "How much headroom do we have?"
 
 Capacity metrics answer whether you can accept new workloads. The machine controller
 exposes `carbide_hosts_usable_count` and `carbide_gpus_usable_count` showing hosts and
@@ -62,7 +62,7 @@ For multi-tenant deployments, `carbide_resource_pool_*` metrics break down capac
 resource pool. Watch for pools approaching zero availability before tenants start seeing
 allocation failures.
 
-### 2.3 Health: "What's broken right now?"
+### Health: "What's broken right now?"
 
 Health metrics reveal infrastructure problems. The machine controller exposes
 `carbide_hosts_health_status_count` and `carbide_dpus_healthy_count` / `carbide_dpus_up_count`
@@ -77,21 +77,21 @@ DPU health is tracked separately with `carbide_dpus_*` metrics showing total, on
 healthy counts. A gap between online and healthy indicates DPUs that are reachable but
 failing health checks.
 
-### 2.4 Discovery: "Is site explorer finding everything?"
+### Discovery: "Is site explorer finding everything?"
 
 Site explorer continuously discovers infrastructure. The `carbide_site_explorer_*` metrics
 show discovery status, result counts and any mismatches between expected and actual
 inventory. Rising error counts or stale discovery timestamps indicate connectivity issues
 with BMCs or switches.
 
-### 2.5 Firmware management
+### Firmware management
 
 Firmware update metrics track the upgrade queue and active operations.
 `carbide_firmware_queue_length` shows pending updates while
 `carbide_firmware_active_updates` shows concurrent operations. The pre-ingestion manager
 metrics (`carbide_preingestion_*`) track firmware image preparation.
 
-### 2.6 API performance
+### API performance
 
 The nico-api exposes detailed request metrics. `carbide_api_grpc_server_duration_milliseconds`
 is a histogram of request latency by method. Watch p95 and p99 for SLO monitoring.
@@ -102,25 +102,27 @@ utilization. Low idle connections or high wait times indicate database contentio
 Vault metrics (`carbide_api_vault_requests_*`) track secret management operations. Failures
 here cascade to certificate issuance and machine provisioning.
 
-### 2.7 Hardware health service
+### Hardware health service
 
 The nico-hardware-health component has two separate endpoints. The `/metrics` endpoint
 exposes service-level metrics (probe success rates, scrape latency). The `/telemetry`
 endpoint exposes raw sensor readings (temperatures, power, fan speeds) collected via
 Redfish from BMCs.
 
+<Tip>
 The telemetry endpoint is high-cardinality due to per-sensor labels. Enable it only when
 your metrics backend can handle the volume and you need sensor-level visibility.
+</Tip>
 
-### 2.8 Network services
+### Network services
 
 Supporting services expose their own metrics. nico-dhcp tracks lease operations and
 request handling. nico-dns exposes query rates and resolution latency.
 
-### 2.9 Console services
+### Console services
 
 nico-ssh-console-rs exposes `carbide_ssh_console_*` metrics for BMC connection counts,
-session durations and error rates. Useful for debugging console access issues.
+session durations and error rates. This is useful for debugging console access issues.
 
 ## 3. Collection architecture
 
@@ -140,7 +142,7 @@ flowchart LR
     D -->|OTLP/HTTP| E
 ```
 
-### 3.1 ServiceMonitor configuration
+### ServiceMonitor configuration
 
 NICo Helm charts include ServiceMonitor resources for Prometheus Operator environments.
 This requires Prometheus Operator CRDs to be installed in the cluster. Enable ServiceMonitors
@@ -162,15 +164,17 @@ telemetryServiceMonitor:
   enabled: false       # /telemetry endpoint (high cardinality)
 ```
 
-### 3.2 OTel Collector configuration
+### OTel Collector configuration
 
 Configure the prometheus receiver for Kubernetes service discovery. This example scrapes
 only the `/metrics` endpoint. For nico-hardware-health `/telemetry` (high-cardinality
 sensor data), add a separate scrape job targeting the `telemetry` port name.
 
-> **Note:** If running as a DaemonSet, each replica will independently discover and scrape
-> all targets, duplicating samples. For DaemonSet deployments implement target
-> allocation/sharding via the [Target Allocator](https://opentelemetry.io/docs/kubernetes/operator/target-allocator/).
+<Note>
+If running as a DaemonSet, each replica will independently discover and scrape
+all targets, duplicating samples. For DaemonSet deployments, implement target
+allocation/sharding via the [Target Allocator](https://opentelemetry.io/docs/kubernetes/operator/target-allocator/).
+</Note>
 
 ```yaml
 receivers:
@@ -214,9 +218,9 @@ NICo ships three Grafana dashboards in the Helm chart at `helm/observability/das
 Import these JSON files into your Grafana instance or enable the Helm chart's dashboard
 provisioning.
 
-### 4.1 Site overview (`nico-overview.json`)
+### Site overview dashboard
 
-The main operational dashboard showing fleet status at a glance:
+The site overview (`nico-overview.json`) is the main operational dashboard showing fleet status at a glance:
 
 **Service and site health** - API status indicator (READY/DOWN), running version with Git SHA,
 unhealthy host count, DPU online and healthy counts. These stat panels give immediate
@@ -235,10 +239,11 @@ machines in transitional states that may need attention.
 which health check is failing and what impact it has (PreventAllocations,
 PreventHostStateChanges, etc.).
 
-### 4.2 Object lifecycle (`nico-lifecycle.json`)
+### Object lifecycle dashboard
 
-Deep dive into state machine behavior for any object type (machines, network segments,
-IB partitions). Uses a `$object_type` variable to switch between types.
+The object lifecycle board (`nico-lifecycle.json`) provides a deep dive
+into state machine behavior for any object type (machines, network segments,
+IB partitions). Uses an `$object_type` variable to switch between types.
 
 **Current state** - Object count, objects above SLA, current handling errors. The "above SLA"
 panel is key - any non-zero value indicates stuck objects.
@@ -258,9 +263,10 @@ state before transition p95. Shows whether the system is keeping up with demand.
 **Controller work rate** - Iteration rate and latency for the state controller loop. High
 latency here suggests database or processing bottlenecks.
 
-### 4.3 API performance (`nico-api-performance.json`)
+### API performance dashboard
 
-Control plane health and performance metrics:
+The API performance dashboard (`nico-api-performance.json`) tracks
+control plane health and performance metrics:
 
 **Request summary** - API status, request rate, p95 latency, gRPC error rate. Top-level
 indicators for SLO monitoring.
@@ -274,7 +280,7 @@ contention is a common cause of API slowdowns.
 **Vault and transport** - Vault request rates, token refresh timing, TLS connection counts.
 Catches secret management issues before they cause auth failures.
 
-### 4.4 Deploying dashboards
+### Deploying dashboards
 
 **Option A: Helm provisioning (recommended)**
 
@@ -304,7 +310,7 @@ The prefix defaults to `carbide_` (NICo's current emission prefix). If your site
 
 ## 5. Troubleshooting
 
-### 5.1 Missing metrics
+### Missing metrics
 
 If a component's metrics aren't appearing in your backend, first verify the endpoint works:
 
@@ -323,7 +329,7 @@ kubectl logs -n monitoring -l app.kubernetes.io/name=opentelemetry-collector | g
 Common causes: ServiceMonitor labels don't match, scrape config namespace wrong, network
 policy blocking scrape, exporter authentication failure.
 
-### 5.2 High cardinality
+### High cardinality
 
 If your metrics backend is growing rapidly or queries are slow, you may have high-cardinality
 metrics. Hardware telemetry (`/telemetry` endpoint) is the most common culprit due to
@@ -335,7 +341,7 @@ Solutions:
 - Add recording rules to aggregate before storage
 - Filter high-cardinality labels in the collector
 
-### 5.3 Stale metrics
+### Stale metrics
 
 If metrics show old values, check that the scrape target is healthy and the endpoint isn't
 hanging. Use `kubectl describe servicemonitor` to verify scrape configuration. If endpoints

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -1,0 +1,349 @@
+# NICo Metrics
+
+NICo components expose metrics in Prometheus format. This document describes how metrics
+are exposed, what they measure and how to collect them using an OpenTelemetry Collector
+DaemonSet or Prometheus ServiceMonitors.
+
+For alerting thresholds, KPIs and PrometheusRule examples, see [alerts.md](alerts.md).
+
+## 1. How metrics are exposed
+
+Each NICo component runs an HTTP server exposing a `/metrics` endpoint in Prometheus text
+format. The OpenTelemetry SDK creates metrics using the Meter API, then the
+`opentelemetry-prometheus` exporter bridges them to a Prometheus registry served over HTTP.
+
+Components also expose `/health` (liveness) and `/ready` (readiness) endpoints on the same
+metrics port for each component:
+
+| Component | Port | Primary metrics |
+|-----------|------|-----------------|
+| nico-api | 1080 | State lifecycle, capacity, health, API performance |
+| nico-hardware-health | 9009 | Hardware telemetry, sensor readings |
+| nico-bmc-proxy | 1080 | BMC connection stats |
+| nico-dhcp | 1089 | Lease counts, request handling |
+| nico-dns | 8053 | Query rates, resolution latency |
+| nico-pxe | 8080 | Boot request counts |
+| nico-ssh-console-rs | 9009 | Console sessions, BMC connections |
+
+All NICo metrics use the `carbide_` prefix. Metric types are indicated by the `# TYPE`
+comment in Prometheus exposition format. Note that NICo uses `_count` as a suffix for
+some gauges (e.g., `carbide_hosts_usable_count`, `carbide_dpus_healthy_count`) - check
+the `# TYPE` metadata to determine the actual metric type.
+
+## 2. What the metrics tell you
+
+NICo metrics fall into several categories, each answering different operational questions.
+
+### 2.1 State lifecycle: "Are machines progressing normally?"
+
+The state controller is the heart of NICo's lifecycle management. It tracks machines,
+network segments, IB partitions and other objects through their lifecycle states. For
+each object type, you get metrics showing current distribution across states, SLA
+violations, time-in-state histograms and transition counts.
+
+The most important metric pattern is `carbide_<object>_per_state_above_sla`. This counts
+objects stuck longer than the configured threshold for that state. Any non-zero value
+means something is blocking normal lifecycle progression and warrants investigation.
+Common causes include BMC connectivity issues, PXE boot failures or external service
+timeouts.
+
+Related metrics include `carbide_<object>_per_state` (current count per state),
+`carbide_<object>_state_time_in_state_seconds` (histogram of time spent) and
+`carbide_<object>_state_handler_errors_total` (processing failures).
+
+### 2.2 Capacity: "How much headroom do we have?"
+
+Capacity metrics answer whether you can accept new workloads. The machine controller
+exposes `carbide_hosts_usable_count` and `carbide_gpus_usable_count` showing hosts and
+GPUs available for allocation. The `carbide_available_ips_count` metric tracks IP
+address pool exhaustion.
+
+For multi-tenant deployments, `carbide_resource_pool_*` metrics break down capacity by
+resource pool. Watch for pools approaching zero availability before tenants start seeing
+allocation failures.
+
+### 2.3 Health: "What's broken right now?"
+
+Health metrics reveal infrastructure problems. The machine controller exposes
+`carbide_hosts_health_status_count` and `carbide_dpus_healthy_count` / `carbide_dpus_up_count`
+showing aggregate health across the fleet.
+
+For detailed breakdowns, `carbide_hosts_unhealthy_by_probe_id_count` and
+`carbide_hosts_unhealthy_by_classification_count` label unhealthy hosts by probe type
+and classification. This tells you not just how many hosts are unhealthy but why - sensor
+warnings, agent connectivity failures, validation errors, etc.
+
+DPU health is tracked separately with `carbide_dpus_*` metrics showing total, online and
+healthy counts. A gap between online and healthy indicates DPUs that are reachable but
+failing health checks.
+
+### 2.4 Discovery: "Is site explorer finding everything?"
+
+Site explorer continuously discovers infrastructure. The `carbide_site_explorer_*` metrics
+show discovery status, result counts and any mismatches between expected and actual
+inventory. Rising error counts or stale discovery timestamps indicate connectivity issues
+with BMCs or switches.
+
+### 2.5 Firmware management
+
+Firmware update metrics track the upgrade queue and active operations.
+`carbide_firmware_queue_length` shows pending updates while
+`carbide_firmware_active_updates` shows concurrent operations. The pre-ingestion manager
+metrics (`carbide_preingestion_*`) track firmware image preparation.
+
+### 2.6 API performance
+
+The nico-api exposes detailed request metrics. `carbide_api_grpc_server_duration_milliseconds`
+is a histogram of request latency by method. Watch p95 and p99 for SLO monitoring.
+
+Database performance appears in `carbide_db_pool_*` metrics showing connection pool
+utilization. Low idle connections or high wait times indicate database contention.
+
+Vault metrics (`carbide_api_vault_requests_*`) track secret management operations. Failures
+here cascade to certificate issuance and machine provisioning.
+
+### 2.7 Hardware health service
+
+The nico-hardware-health component has two separate endpoints. The `/metrics` endpoint
+exposes service-level metrics (probe success rates, scrape latency). The `/telemetry`
+endpoint exposes raw sensor readings (temperatures, power, fan speeds) collected via
+Redfish from BMCs.
+
+The telemetry endpoint is high-cardinality due to per-sensor labels. Enable it only when
+your metrics backend can handle the volume and you need sensor-level visibility.
+
+### 2.8 Network services
+
+Supporting services expose their own metrics. nico-dhcp tracks lease operations and
+request handling. nico-dns exposes query rates and resolution latency.
+
+### 2.9 Console services
+
+nico-ssh-console-rs exposes `carbide_ssh_console_*` metrics for BMC connection counts,
+session durations and error rates. Useful for debugging console access issues.
+
+## 3. Collection architecture
+
+```mermaid
+flowchart LR
+    subgraph Node
+        A[nico-api :1080]
+        B[nico-bmc-proxy :1080]
+        C[other components]
+    end
+    D[otel-collector DaemonSet]
+    E["OTLP Backend<br/>(VictoriaMetrics, Mimir, etc.)"]
+
+    A --> D
+    B --> D
+    C --> D
+    D -->|OTLP/HTTP| E
+```
+
+### 3.1 ServiceMonitor configuration
+
+NICo Helm charts include ServiceMonitor resources for Prometheus Operator environments.
+This requires Prometheus Operator CRDs to be installed in the cluster. Enable ServiceMonitors
+in Helm values:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  interval: 30s
+```
+
+For nico-hardware-health, there are separate ServiceMonitors for service metrics and
+hardware telemetry. Enable telemetry scraping only when storage allows:
+
+```yaml
+serviceMonitor:
+  enabled: true        # /metrics endpoint
+telemetryServiceMonitor:
+  enabled: false       # /telemetry endpoint (high cardinality)
+```
+
+### 3.2 OTel Collector configuration
+
+Configure the prometheus receiver for Kubernetes service discovery.
+
+> **Note:** If running as a DaemonSet, each replica will independently discover and scrape
+> all targets, duplicating samples. For DaemonSet deployments implement target
+> allocation/sharding via the [Target Allocator](https://opentelemetry.io/docs/kubernetes/operator/target-allocator/).
+
+```yaml
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: 'nico'
+          kubernetes_sd_configs:
+            - role: endpoints
+              namespaces:
+                names: [nico-system]
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+              action: keep
+              regex: true
+            - source_labels: [__meta_kubernetes_endpoint_port_name]
+              action: keep
+              regex: metrics
+
+processors:
+  batch: {}
+
+exporters:
+  # VictoriaMetrics single-node
+  otlphttp:
+    endpoint: http://victoriametrics:8428/opentelemetry/v1/metrics
+  # VictoriaMetrics cluster: http://vminsert:8480/insert/0/opentelemetry/v1/metrics
+  # Grafana Mimir: http://mimir:8080/otlp/v1/metrics
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [batch]
+      exporters: [otlphttp]
+```
+
+## 4. Dashboards
+
+NICo ships three Grafana dashboards in the Helm chart at `helm/observability/dashboards/`.
+Import these JSON files into your Grafana instance or enable the Helm chart's dashboard
+provisioning.
+
+### 4.1 Site overview (`nico-overview.json`)
+
+The main operational dashboard showing fleet status at a glance:
+
+**Service and site health** - API status indicator (READY/DOWN), running version with Git SHA,
+unhealthy host count, DPU online and healthy counts. These stat panels give immediate
+visibility into control plane and fleet health.
+
+**Capacity** - Host and GPU availability gauges, resource pool utilization. Shows how much
+headroom remains before new allocations fail.
+
+**Tenancy and inventory** - Tenant allocation breakdown, managed entity counts. Useful for
+capacity planning and understanding fleet composition.
+
+**Host lifecycle states** - Current distribution of hosts across lifecycle states. Highlights
+machines in transitional states that may need attention.
+
+**Health alerts** - Unhealthy hosts broken down by probe type and classification. Shows
+which health check is failing and what impact it has (PreventAllocations,
+PreventHostStateChanges, etc.).
+
+### 4.2 Object lifecycle (`nico-lifecycle.json`)
+
+Deep dive into state machine behavior for any object type (machines, network segments,
+IB partitions). Uses a `$object_type` variable to switch between types.
+
+**Current state** - Object count, objects above SLA, current handling errors. The "above SLA"
+panel is key - any non-zero value indicates stuck objects.
+
+**Objects by state** - Stacked area chart showing distribution over time. Helps identify
+patterns (e.g., provisioning backlog during business hours).
+
+**Above SLA by state** - Which specific states have stuck objects. Narrows investigation to
+the failing transition.
+
+**State-handler errors** - Error counts from controllers processing state transitions.
+Indicates bugs or external service failures.
+
+**Transitions and latency** - State entry rate (throughput), handler latency p95, time in
+state before transition p95. Shows whether the system is keeping up with demand.
+
+**Controller work rate** - Iteration rate and latency for the state controller loop. High
+latency here suggests database or processing bottlenecks.
+
+### 4.3 API performance (`nico-api-performance.json`)
+
+Control plane health and performance metrics:
+
+**Request summary** - API status, request rate, p95 latency, gRPC error rate. Top-level
+indicators for SLO monitoring.
+
+**Requests by method and status** - Heatmap of request latency by gRPC method. Identifies
+which endpoints are slow or failing.
+
+**Database** - Queries per second, time per request, connection pool utilization. Database
+contention is a common cause of API slowdowns.
+
+**Vault and transport** - Vault request rates, token refresh timing, TLS connection counts.
+Catches secret management issues before they cause auth failures.
+
+### 4.4 Deploying dashboards
+
+**Option A: Helm provisioning (recommended)**
+
+Enable dashboard provisioning in your Helm values. The chart creates a ConfigMap that
+Grafana's sidecar picks up automatically:
+
+```yaml
+grafanaDashboards:
+  enabled: true
+  namespace: monitoring        # Where Grafana runs
+  folder: NICo                 # Grafana folder name
+  labels:
+    grafana_dashboard: "1"     # Matches kube-prometheus-stack default
+```
+
+The target namespace must exist and the Grafana sidecar must watch it. For kube-prometheus-stack,
+configure `grafana.sidecar.dashboards.searchNamespace` if Grafana is in a different namespace.
+
+**Option B: Manual import**
+
+Download the JSON files from `helm/observability/dashboards/` and import via Grafana UI
+(Dashboards -> Import -> Upload JSON file). Set the Prometheus datasource when prompted.
+
+Each dashboard provides variables for datasource selection and metric prefix customization.
+The prefix defaults to `carbide_` (NICo's current emission prefix). If your site uses
+`alt_metric_prefix`, update the dashboard variable accordingly.
+
+## 5. Troubleshooting
+
+### 5.1 Missing metrics
+
+If a component's metrics aren't appearing in your backend, first verify the endpoint works:
+
+```bash
+kubectl port-forward -n nico-system svc/nico-api-metrics 1080:1080
+curl -s http://localhost:1080/metrics | head -20
+```
+
+If this fails, check pod status (`kubectl get pods -n nico-system`) and logs. If it succeeds,
+the issue is in collection - check OTel Collector logs for scrape errors or export failures:
+
+```bash
+kubectl logs -n monitoring -l app.kubernetes.io/name=opentelemetry-collector | grep -i error
+```
+
+Common causes: ServiceMonitor labels don't match, scrape config namespace wrong, network
+policy blocking scrape, exporter authentication failure.
+
+### 5.2 High cardinality
+
+If your metrics backend is growing rapidly or queries are slow, you may have high-cardinality
+metrics. Hardware telemetry (`/telemetry` endpoint) is the most common culprit due to
+per-sensor labels.
+
+Solutions:
+
+- Disable telemetry scraping if not needed
+- Add recording rules to aggregate before storage
+- Filter high-cardinality labels in the collector
+
+### 5.3 Stale metrics
+
+If metrics show old values, check that the scrape target is healthy and the endpoint isn't
+hanging. Use `kubectl describe servicemonitor` to verify scrape configuration. If endpoints
+are slow to respond, increase scrape timeout - but keep it at or below the scrape interval
+(e.g., `scrape_interval: 30s` with `scrape_timeout: 25s`).
+
+## 6. References
+
+- [NICo Helm charts](https://github.com/NVIDIA/nico/tree/main/helm/charts) - ServiceMonitor configs, metrics ports
+- [NICo Grafana dashboards](https://github.com/NVIDIA/nico/tree/main/helm/observability/dashboards) - JSON dashboard files
+- [Full metrics reference](core_metrics.md) - Auto-generated list
+- [OpenTelemetry Collector Helm chart](https://opentelemetry.io/docs/platforms/kubernetes/helm/collector/)
+- [Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -164,7 +164,9 @@ telemetryServiceMonitor:
 
 ### 3.2 OTel Collector configuration
 
-Configure the prometheus receiver for Kubernetes service discovery.
+Configure the prometheus receiver for Kubernetes service discovery. This example scrapes
+only the `/metrics` endpoint. For nico-hardware-health `/telemetry` (high-cardinality
+sensor data), add a separate scrape job targeting the `telemetry` port name.
 
 > **Note:** If running as a DaemonSet, each replica will independently discover and scrape
 > all targets, duplicating samples. For DaemonSet deployments implement target

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -18,6 +18,7 @@ metrics port for each component:
 | Component | Port | Primary metrics |
 |-----------|------|-----------------|
 | nico-api | 1080 | State lifecycle, capacity, health, API performance |
+| nico-api (per-object) | 9091 | Per-object state progress (disabled by default, high cardinality) |
 | nico-hardware-health | 9009 | Hardware telemetry, sensor readings |
 | nico-bmc-proxy | 1080 | BMC connection stats |
 | nico-dhcp | 1089 | Lease counts, request handling |
@@ -212,7 +213,129 @@ service:
       exporters: [otlphttp]
 ```
 
-## 4. Dashboards
+## 4. Per-object state metrics endpoint
+
+The nico-api state controller can expose per-object state progress metrics from a
+**dedicated listener** separate from the main `/metrics` endpoint. This feature is
+disabled by default because it produces O(fleet) cardinality - one series per object
+for each metric.
+
+While aggregate metrics like `carbide_machines_per_state_above_sla` tell you *how many*
+machines are stuck, per-object metrics tell you *which* - critical at 100k-machine scale
+for identifying individual stuck objects.
+
+### Metrics exposed
+
+| Metric | Type | Purpose |
+|--------|------|---------|
+| `carbide_object_state_entered_timestamp_seconds` | gauge | Current state as join key + exact state age (`time() - value`). One series per live object. |
+| `carbide_object_state_sla_seconds` | gauge | Resolved SLA for current state. Alerts never change when SLA policy does. |
+| `carbide_object_manual_intervention_required` | gauge | Value 1 when operator action needed; `reason` is a bounded token. |
+| `carbide_object_info` | gauge | Stable traits (rack, SKU, vendor, model) for joins, similar to `kube_node_info`. |
+| `carbide_machine_dpu_info` | gauge | Host-to-DPU associations (one series per DPU). |
+| `carbide_machine_instance_info` | gauge | Machine-to-instance and tenant associations. |
+
+All metrics use labels `object_type` and `object_id`. State metrics add `state` and
+`substate` labels. These series exist only while true: transitions replace entries,
+deletions clear them immediately.
+
+### Configuration
+
+Enable via TOML configuration:
+
+```toml
+[observability.per_object_state_metrics]
+enabled = true                    # default: false
+listen_address = "[::]:9091"      # dual-stack default
+# Defaults to all supported types; also valid: network_segment, vpc_prefix,
+# spdm_attestation, ib_partition
+object_types = ["machine", "switch", "power_shelf", "rack"]
+```
+
+The `object_types` field deserializes into an enum, so a mistyped token fails config
+parsing instead of silently emitting nothing.
+
+### Helm configuration
+
+Enable via Helm values:
+
+```yaml
+service:
+  perObjectStateMetrics:
+    enabled: true
+    port: 9091
+    objectTypes:
+      - machine
+      - switch
+      - power_shelf
+      - rack
+      - network_segment
+      - vpc_prefix
+      - spdm_attestation
+      - ib_partition
+
+perObjectStateMetricsServiceMonitor:
+  enabled: true
+  interval: 60s       # slow scrape is sufficient
+  scrapeTimeout: 25s
+```
+
+This creates:
+
+- The application listener and container port
+- A dedicated Kubernetes Service (`nico-api-object-metrics`)
+- An optional ServiceMonitor with a slower scrape interval
+
+If using `configFiles.nicoApiConfig` to replace the chart's bundled configuration, that
+custom TOML must include the `[observability.per_object_state_metrics]` section explicitly.
+
+### Scrape guidance
+
+- **Interval:** 60-120 seconds is sufficient. Series change only on state transitions.
+- **Same Prometheus:** Both endpoints must be scraped into the same Prometheus instance
+  for joins to work.
+- **Multi-replica caveat:** With `replicas > 1`, aggregate away the scrape instance before
+  joining:
+
+  ```text
+  max by (object_type, object_id, state, substate) (...)
+  ```
+
+### Example queries
+
+**Objects stuck beyond their SLA:**
+
+```text
+max by (object_type, object_id, state, substate)
+    (time() - carbide_object_state_entered_timestamp_seconds)
+  > on(object_type, object_id, state, substate) group_left()
+    max by (object_type, object_id, state, substate)
+        (carbide_object_state_sla_seconds)
+```
+
+**Objects requiring manual intervention:**
+
+```text
+max by (object_type, object_id, reason)
+    (carbide_object_manual_intervention_required == 1)
+```
+
+**Join stuck machines with rack info:**
+
+```text
+(
+  max by (object_type, object_id, state, substate)
+    (time() - carbide_object_state_entered_timestamp_seconds{object_type="machine"})
+    > 3600
+)
+  * on(object_type, object_id) group_left(rack, sku)
+    max by (object_type, object_id, rack, sku)
+        (carbide_object_info)
+```
+
+For alerting rules using these metrics, see [alerts.md](alerts.md#5-per-object-alerting).
+
+## 5. Dashboards
 
 NICo ships three Grafana dashboards in the Helm chart at `helm/observability/dashboards/`.
 Import these JSON files into your Grafana instance or enable the Helm chart's dashboard
@@ -308,7 +431,7 @@ Each dashboard provides variables for datasource selection and metric prefix cus
 The prefix defaults to `carbide_` (NICo's current emission prefix). If your site uses
 `alt_metric_prefix`, update the dashboard variable accordingly.
 
-## 5. Troubleshooting
+## 6. Troubleshooting
 
 ### Missing metrics
 
@@ -348,7 +471,7 @@ hanging. Use `kubectl describe servicemonitor` to verify scrape configuration. I
 are slow to respond, increase scrape timeout - but keep it at or below the scrape interval
 (e.g., `scrape_interval: 30s` with `scrape_timeout: 25s`).
 
-## 6. References
+## 7. References
 
 - [NICo Helm charts](https://github.com/NVIDIA/infra-controller/tree/main/helm/charts) - ServiceMonitor configs, metrics ports
 - [NICo Grafana dashboards](https://github.com/NVIDIA/infra-controller/tree/main/helm/observability/dashboards) - JSON dashboard files

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -342,8 +342,8 @@ are slow to respond, increase scrape timeout - but keep it at or below the scrap
 
 ## 6. References
 
-- [NICo Helm charts](https://github.com/NVIDIA/nico/tree/main/helm/charts) - ServiceMonitor configs, metrics ports
-- [NICo Grafana dashboards](https://github.com/NVIDIA/nico/tree/main/helm/observability/dashboards) - JSON dashboard files
+- [NICo Helm charts](https://github.com/NVIDIA/infra-controller/tree/main/helm/charts) - ServiceMonitor configs, metrics ports
+- [NICo Grafana dashboards](https://github.com/NVIDIA/infra-controller/tree/main/helm/observability/dashboards) - JSON dashboard files
 - [Full metrics reference](core_metrics.md) - Auto-generated list
 - [OpenTelemetry Collector Helm chart](https://opentelemetry.io/docs/platforms/kubernetes/helm/collector/)
 - [Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)

--- a/helm/README.md
+++ b/helm/README.md
@@ -79,7 +79,7 @@ Top-level `global:` values are automatically passed to all subcharts.
 The chart packages three dashboards built from NICo's exported Prometheus
 metrics: a site overview, object lifecycle diagnostics, and API performance.
 They are disabled by default because this chart does not install Grafana.
-The source JSON files live in [`dashboards/`](./dashboards/) and can also be
+The source JSON files live in [`observability/dashboards/`](./observability/dashboards/) and can also be
 imported into Grafana directly.
 
 To expose the dashboards to a Grafana dashboard sidecar in the release

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -58,7 +58,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: "More than 10% of machines stuck above SLA"
+            summary: "At least 10% of machines stuck above SLA"
             description: "Critical: machines have been in assigned state longer than allowed."
             runbook_url: "https://github.com/NVIDIA/infra-controller/blob/main/docs/playbooks/stuck_objects/stuck_objects.md"
 

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -1,0 +1,158 @@
+# NICo PrometheusRule - Production-validated alerting rules
+#
+# These thresholds are validated in production NICo/Carbide deployments.
+# Review and adjust for your site before applying.
+#
+# Apply with: kubectl apply -f nico-alerts.yaml
+#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: nico-alerts
+  namespace: nico-system
+spec:
+  groups:
+    - name: nico-api
+      rules:
+        # Production-validated: API not ready for 15m
+        - alert: NicoAPIDown
+          expr: (carbide_api_ready == 0) or absent(carbide_api_ready == 1)
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "NICo API is down"
+            description: "nico-api has been unavailable for 15 minutes."
+
+        # Production-validated: API fluctuating (>5 state changes in 15m)
+        - alert: NicoAPIFluctuating
+          expr: changes(carbide_api_ready[15m]) > 5
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "NICo API is fluctuating"
+            description: "nico-api ready state changed more than 5 times in 15 minutes."
+
+        # Production-validated: State-handler latency >120s for 10m
+        - alert: NicoStateHandlerLatency
+          expr: |
+            avg(carbide_machines_state_handler_latency_seconds) > 120
+            or avg(carbide_network_segments_state_handler_latency_seconds) > 120
+            or avg(carbide_ib_partitions_state_handler_latency_seconds) > 120
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "State handler latency exceeds 120 seconds"
+            description: "State controller iteration latency is high, indicating processing bottlenecks."
+
+    - name: nico-sla
+      rules:
+        # Production-validated: Machines stuck >10% is critical, >0% is warning
+        - alert: NicoMachinesStuckAboveSLACritical
+          expr: |
+            (sum(carbide_machines_per_state_above_sla{state="assigned"})
+            / sum(carbide_machines_total)) > 0.1
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "More than 10% of machines stuck above SLA"
+            description: "Critical: machines have been in assigned state longer than allowed."
+            runbook_url: "https://github.com/NVIDIA/nico/blob/main/docs/playbooks/stuck_objects/"
+
+        - alert: NicoMachinesStuckAboveSLAWarning
+          expr: |
+            (sum(carbide_machines_per_state_above_sla{state="assigned"})
+            / sum(carbide_machines_total)) > 0
+            and
+            (sum(carbide_machines_per_state_above_sla{state="assigned"})
+            / sum(carbide_machines_total)) <= 0.1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Machines stuck above SLA (< 10%)"
+            description: "Some machines have been in assigned state longer than allowed."
+            runbook_url: "https://github.com/NVIDIA/nico/blob/main/docs/playbooks/stuck_objects/"
+
+        # Production-validated: Network segments/IB partitions stuck
+        - alert: NicoNetworkSegmentsStuckCritical
+          expr: sum(carbide_network_segments_per_state_above_sla) > 10
+          for: 60m
+          labels:
+            severity: critical
+          annotations:
+            summary: "More than 10 network segments stuck above SLA"
+
+        - alert: NicoNetworkSegmentsStuckWarning
+          expr: |
+            sum(carbide_network_segments_per_state_above_sla) > 0
+            and sum(carbide_network_segments_per_state_above_sla) <= 10
+          for: 60m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Network segments stuck above SLA (1-10)"
+
+        - alert: NicoIBPartitionsStuckCritical
+          expr: sum(carbide_ib_partitions_per_state_above_sla) > 10
+          for: 60m
+          labels:
+            severity: critical
+          annotations:
+            summary: "More than 10 IB partitions stuck above SLA"
+
+        - alert: NicoIBPartitionsStuckWarning
+          expr: |
+            sum(carbide_ib_partitions_per_state_above_sla) > 0
+            and sum(carbide_ib_partitions_per_state_above_sla) <= 10
+          for: 60m
+          labels:
+            severity: warning
+          annotations:
+            summary: "IB partitions stuck above SLA (1-10)"
+
+    - name: nico-capacity
+      rules:
+        # Production-validated: IP availability <15% for 60m
+        - alert: NicoLowIPCapacity
+          expr: |
+            (carbide_available_ips_count / carbide_total_ips_count) < 0.15
+          for: 60m
+          labels:
+            severity: warning
+          annotations:
+            summary: "IP availability below 15%"
+            description: "Available IPs have fallen below 15% of total capacity."
+
+    - name: nico-health
+      rules:
+        # Production-validated: >10% hosts unhealthy (excluding suppressed), sites >40 machines
+        - alert: NicoHostsUnhealthy
+          expr: |
+            (
+              sum(carbide_hosts_health_status_count{healthy="false"})
+              - sum(carbide_hosts_unhealthy_by_classification_count{classification="SuppressExternalAlerting"})
+            )
+            / sum(carbide_hosts_health_status_count) > 0.1
+            and sum(carbide_machines_total) > 40
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "More than 10% of hosts unhealthy"
+            description: "Excludes hosts with SuppressExternalAlerting classification."
+
+        # Production-validated: DPU metrics missing
+        - alert: NicoDPUMetricsMissing
+          expr: |
+            up{job=~".*dpu.*"} == 0
+            or absent(up{job=~".*dpu.*"})
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "DPU metrics scrape target down"
+            description: "DPU metrics have not been collected for 10 minutes."

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -84,7 +84,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: "More than 10 network segments stuck above SLA"
+            summary: "At least 10 network segments stuck above SLA"
 
         - alert: NicoNetworkSegmentsStuckWarning
           expr: |
@@ -102,7 +102,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: "More than 10 IB partitions stuck above SLA"
+            summary: "At least 10 IB partitions stuck above SLA"
 
         - alert: NicoIBPartitionsStuckWarning
           expr: |

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -16,7 +16,7 @@ spec:
       rules:
         # Production-validated: API not ready for 15m
         - alert: NicoAPIDown
-          expr: (carbide_api_ready == 0) or absent(carbide_api_ready == 1)
+          expr: max(carbide_api_ready) == 0 or absent(carbide_api_ready)
           for: 15m
           labels:
             severity: critical
@@ -49,18 +49,18 @@ spec:
 
     - name: nico-sla
       rules:
-        # Production-validated: Machines stuck >10% is critical, >0% is warning
+        # Production-validated: Machines stuck >=10% is critical, <10% is warning
         - alert: NicoMachinesStuckAboveSLACritical
           expr: |
             (sum(carbide_machines_per_state_above_sla{state="assigned"})
-            / sum(carbide_machines_total)) > 0.1
+            / sum(carbide_machines_total)) >= 0.1
           for: 30m
           labels:
             severity: critical
           annotations:
             summary: "More than 10% of machines stuck above SLA"
             description: "Critical: machines have been in assigned state longer than allowed."
-            runbook_url: "https://github.com/NVIDIA/nico/blob/main/docs/playbooks/stuck_objects/"
+            runbook_url: "https://github.com/NVIDIA/infra-controller/blob/main/docs/playbooks/stuck_objects/stuck_objects.md"
 
         - alert: NicoMachinesStuckAboveSLAWarning
           expr: |
@@ -68,18 +68,18 @@ spec:
             / sum(carbide_machines_total)) > 0
             and
             (sum(carbide_machines_per_state_above_sla{state="assigned"})
-            / sum(carbide_machines_total)) <= 0.1
+            / sum(carbide_machines_total)) < 0.1
           for: 30m
           labels:
             severity: warning
           annotations:
             summary: "Machines stuck above SLA (< 10%)"
             description: "Some machines have been in assigned state longer than allowed."
-            runbook_url: "https://github.com/NVIDIA/nico/blob/main/docs/playbooks/stuck_objects/"
+            runbook_url: "https://github.com/NVIDIA/infra-controller/blob/main/docs/playbooks/stuck_objects/stuck_objects.md"
 
         # Production-validated: Network segments/IB partitions stuck
         - alert: NicoNetworkSegmentsStuckCritical
-          expr: sum(carbide_network_segments_per_state_above_sla) > 10
+          expr: sum(carbide_network_segments_per_state_above_sla) >= 10
           for: 60m
           labels:
             severity: critical
@@ -89,15 +89,15 @@ spec:
         - alert: NicoNetworkSegmentsStuckWarning
           expr: |
             sum(carbide_network_segments_per_state_above_sla) > 0
-            and sum(carbide_network_segments_per_state_above_sla) <= 10
+            and sum(carbide_network_segments_per_state_above_sla) < 10
           for: 60m
           labels:
             severity: warning
           annotations:
-            summary: "Network segments stuck above SLA (1-10)"
+            summary: "Network segments stuck above SLA (1-9)"
 
         - alert: NicoIBPartitionsStuckCritical
-          expr: sum(carbide_ib_partitions_per_state_above_sla) > 10
+          expr: sum(carbide_ib_partitions_per_state_above_sla) >= 10
           for: 60m
           labels:
             severity: critical
@@ -107,12 +107,12 @@ spec:
         - alert: NicoIBPartitionsStuckWarning
           expr: |
             sum(carbide_ib_partitions_per_state_above_sla) > 0
-            and sum(carbide_ib_partitions_per_state_above_sla) <= 10
+            and sum(carbide_ib_partitions_per_state_above_sla) < 10
           for: 60m
           labels:
             severity: warning
           annotations:
-            summary: "IB partitions stuck above SLA (1-10)"
+            summary: "IB partitions stuck above SLA (1-9)"
 
     - name: nico-capacity
       rules:

--- a/helm/observability/dashboards/nico-api-performance.json
+++ b/helm/observability/dashboards/nico-api-performance.json
@@ -1,0 +1,256 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Request summary",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [ { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "READY" } }, "type": "value" } ], "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_api_ready{job=~\"$job\"}) or vector(0)", "instant": true, "legendFormat": "NICo API", "range": false, "refId": "A" }
+      ],
+      "title": "API status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_grpc_server_duration_milliseconds_count{job=~\"$job\"}[$__rate_interval]))", "instant": true, "legendFormat": "Requests / s", "range": false, "refId": "A" }
+      ],
+      "title": "Request rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 250 }, { "color": "red", "value": 1000 } ] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(${metric_prefix}_api_grpc_server_duration_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": true, "legendFormat": "p95", "range": false, "refId": "A" }
+      ],
+      "title": "Request latency p95",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "gRPC responses whose status code is not Ok.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.001 } ] }, "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_grpc_server_duration_milliseconds_count{job=~\"$job\",grpc_status_code!=\"Ok\"}[$__rate_interval]))", "instant": true, "legendFormat": "Errors / s", "range": false, "refId": "A" }
+      ],
+      "title": "gRPC error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "reqps" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "id": 6,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (grpc_method, grpc_status_code) (rate(${metric_prefix}_api_grpc_server_duration_milliseconds_count{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "{{grpc_method}} — {{grpc_status_code}}", "range": true, "refId": "A" }
+      ],
+      "title": "Requests by method and status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "id": 7,
+      "options": { "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.50, sum by (le) (rate(${metric_prefix}_api_grpc_server_duration_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "p50", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(${metric_prefix}_api_grpc_server_duration_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "p95", "range": true, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.99, sum by (le) (rate(${metric_prefix}_api_grpc_server_duration_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "p99", "range": true, "refId": "C" }
+      ],
+      "title": "Request latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 8,
+      "panels": [],
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Database queries attributed to gRPC request spans.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "id": 9,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (grpc_method) (rate(${metric_prefix}_api_db_queries_total{job=~\"$job\",operation=\"grpc\"}[$__rate_interval]))", "instant": false, "legendFormat": "{{grpc_method}}", "range": true, "refId": "A" }
+      ],
+      "title": "Database queries / second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 15 },
+      "id": 10,
+      "options": { "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, grpc_method) (rate(${metric_prefix}_api_db_span_query_time_milliseconds_bucket{job=~\"$job\",operation=\"grpc\"}[$__rate_interval])))", "instant": false, "legendFormat": "{{grpc_method}}", "range": true, "refId": "A" }
+      ],
+      "title": "Database time per request p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 12, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 24 },
+      "id": 11,
+      "options": { "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_db_pool_total_conns{job=~\"$job\"})", "instant": false, "legendFormat": "Total connections", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_db_pool_idle_conns{job=~\"$job\"})", "instant": false, "legendFormat": "Idle connections", "range": true, "refId": "B" }
+      ],
+      "title": "Database connection pool",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 31 },
+      "id": 12,
+      "panels": [],
+      "title": "Vault and transport",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 32 },
+      "id": 13,
+      "options": { "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_vault_requests_attempted_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Attempted / s", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_vault_requests_failed_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Failed / s", "range": true, "refId": "B" }
+      ],
+      "title": "Vault requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "yellow", "value": 300 }, { "color": "green", "value": 900 } ] }, "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 4, "x": 8, "y": 32 },
+      "id": 14,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "min(${metric_prefix}_api_vault_token_time_until_refresh_seconds{job=~\"$job\"})", "instant": true, "legendFormat": "Until refresh", "range": false, "refId": "A" }
+      ],
+      "title": "Vault token refresh",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 6, "x": 12, "y": 32 },
+      "id": 15,
+      "options": { "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(${metric_prefix}_api_vault_request_duration_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "p95", "range": true, "refId": "A" }
+      ],
+      "title": "Vault request latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 6, "x": 18, "y": 32 },
+      "id": 16,
+      "options": { "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_tls_connection_attempted_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Attempted / s", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_tls_connection_success_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Succeeded / s", "range": true, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_api_tls_connection_fail_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Failed / s", "range": true, "refId": "C" }
+      ],
+      "title": "TLS connections",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [ "nico", "api", "performance" ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "label": "Prometheus",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": true, "text": "carbide", "value": "carbide" },
+        "description": "Prefix configured for NICo core metrics.",
+        "label": "Metric prefix",
+        "name": "metric_prefix",
+        "options": [ { "selected": true, "text": "carbide", "value": "carbide" } ],
+        "query": "carbide",
+        "type": "textbox"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(${metric_prefix}_api_ready, job)",
+        "includeAll": true,
+        "label": "NICo scrape job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": { "query": "label_values(${metric_prefix}_api_ready, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "NICo / API Performance",
+  "uid": "nico-api-performance",
+  "version": 1
+}

--- a/helm/observability/dashboards/nico-lifecycle.json
+++ b/helm/observability/dashboards/nico-lifecycle.json
@@ -148,7 +148,7 @@
     },
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ops" }, "overrides": [] },
       "gridPos": { "h": 9, "w": 12, "x": 12, "y": 32 },
       "id": 12,
       "options": { "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },

--- a/helm/observability/dashboards/nico-lifecycle.json
+++ b/helm/observability/dashboards/nico-lifecycle.json
@@ -1,0 +1,243 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Current $object_type state",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Total objects in the selected state controller's latest fresh snapshot.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_${object_type}_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Total", "range": false, "refId": "A" }
+      ],
+      "title": "Objects",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Objects that have remained in their current state beyond its configured SLA.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(max by (state, substate) (${metric_prefix}_${object_type}_per_state_above_sla{job=~\"$job\",fresh=\"true\"}))", "instant": true, "legendFormat": "Above SLA", "range": false, "refId": "A" }
+      ],
+      "title": "Objects above SLA",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Objects whose most recent state-handler run failed.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(max by (state, substate) (${metric_prefix}_${object_type}_with_state_handling_errors_per_state{job=~\"$job\",fresh=\"true\",error=\"any\"}))", "instant": true, "legendFormat": "Handler errors", "range": false, "refId": "A" }
+      ],
+      "title": "Current handling errors",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 5 },
+      "id": 5,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (state, substate) (${metric_prefix}_${object_type}_per_state{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "{{state}} / {{substate}}", "range": false, "refId": "A" }
+      ],
+      "title": "Objects by state",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Only states with objects above SLA are shown.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 5 },
+      "id": 6,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (state, substate) (${metric_prefix}_${object_type}_per_state_above_sla{job=~\"$job\",fresh=\"true\"} > 0)", "instant": true, "legendFormat": "{{state}} / {{substate}}", "range": false, "refId": "A" }
+      ],
+      "title": "Above SLA by state",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "The latest handler failures by state and concrete error type. The aggregate error=any series is excluded.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 7,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (state, substate, error) (${metric_prefix}_${object_type}_with_state_handling_errors_per_state{job=~\"$job\",fresh=\"true\",error!=\"any\"} > 0)", "instant": true, "legendFormat": "{{state}} / {{substate}} — {{error}}", "range": false, "refId": "A" }
+      ],
+      "title": "State-handler errors",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "id": 8,
+      "panels": [],
+      "title": "Transitions and latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 12, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ops" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 23 },
+      "id": 9,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (state, substate) (rate(${metric_prefix}_${object_type}_state_entered_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "{{state}} / {{substate}}", "range": true, "refId": "A" }
+      ],
+      "title": "State entries / second",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 23 },
+      "id": 10,
+      "options": { "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, state, substate) (rate(${metric_prefix}_${object_type}_handler_latency_in_state_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "{{state}} / {{substate}}", "range": true, "refId": "A" }
+      ],
+      "title": "State-handler latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Time objects spent in a state before transitioning. A series is emitted only when a transition occurs.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "s" }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 32 },
+      "id": 11,
+      "options": { "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, state, substate, next_state, next_substate) (rate(${metric_prefix}_${object_type}_time_in_state_seconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "{{state}}/{{substate}} → {{next_state}}/{{next_substate}}", "range": true, "refId": "A" }
+      ],
+      "title": "Time in state before transition p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 32 },
+      "id": 12,
+      "options": { "legend": { "calcs": [ "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_${object_type}_object_tasks_enqueued_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Enqueued / s", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_${object_type}_object_tasks_dispatched_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Dispatched / s", "range": true, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_${object_type}_object_tasks_completed_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Completed / s", "range": true, "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(rate(${metric_prefix}_${object_type}_object_tasks_requeued_total{job=~\"$job\"}[$__rate_interval]))", "instant": false, "legendFormat": "Requeued / s", "range": true, "refId": "D" }
+      ],
+      "title": "Controller work rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 2, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "ms" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 41 },
+      "id": 13,
+      "options": { "legend": { "calcs": [ "lastNotNull", "max" ], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(${metric_prefix}_${object_type}_iteration_latency_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "Processor iteration p95", "range": true, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(${metric_prefix}_${object_type}_enqueuer_iteration_latency_milliseconds_bucket{job=~\"$job\"}[$__rate_interval])))", "instant": false, "legendFormat": "Enqueuer iteration p95", "range": true, "refId": "B" }
+      ],
+      "title": "Controller iteration latency p95",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [ "nico", "lifecycle", "state-controller" ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "label": "Prometheus",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": true, "text": "carbide", "value": "carbide" },
+        "description": "Prefix configured for NICo core metrics.",
+        "label": "Metric prefix",
+        "name": "metric_prefix",
+        "options": [ { "selected": true, "text": "carbide", "value": "carbide" } ],
+        "query": "carbide",
+        "type": "textbox"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(${metric_prefix}_api_ready, job)",
+        "includeAll": true,
+        "label": "NICo scrape job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": { "query": "label_values(${metric_prefix}_api_ready, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": true, "text": "machines", "value": "machines" },
+        "description": "State-controller object family.",
+        "label": "Object type",
+        "name": "object_type",
+        "options": [
+          { "selected": true, "text": "machines", "value": "machines" },
+          { "selected": false, "text": "network_segments", "value": "network_segments" },
+          { "selected": false, "text": "vpc_prefixes", "value": "vpc_prefixes" },
+          { "selected": false, "text": "ib_partitions", "value": "ib_partitions" },
+          { "selected": false, "text": "switches", "value": "switches" },
+          { "selected": false, "text": "racks", "value": "racks" },
+          { "selected": false, "text": "power_shelves", "value": "power_shelves" }
+        ],
+        "query": "machines,network_segments,vpc_prefixes,ib_partitions,switches,racks,power_shelves",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "NICo / Object Lifecycle",
+  "uid": "nico-lifecycle",
+  "version": 1
+}

--- a/helm/observability/dashboards/nico-overview.json
+++ b/helm/observability/dashboards/nico-overview.json
@@ -1,0 +1,287 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Service and site health",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "1 means that the NICo API process is serving metrics.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "DOWN" }, "1": { "color": "green", "text": "READY" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_api_ready{job=~\"$job\"}) or vector(0)", "instant": true, "legendFormat": "NICo API", "range": false, "refId": "A" }
+      ],
+      "title": "API status",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Build version and Git SHA reported by the running NICo API.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 8, "x": 4, "y": 1 },
+      "id": 3,
+      "options": { "colorMode": "none", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "name", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (build_version, git_sha) (${metric_prefix}_api_version{job=~\"$job\"})", "instant": true, "legendFormat": "{{build_version}} ({{git_sha}})", "range": false, "refId": "A" }
+      ],
+      "title": "Running version",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Managed hosts with one or more active health alerts, summed across tenant-assignment states.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] } }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": { "colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum(max by (healthy, in_use) (${metric_prefix}_hosts_health_status_count{job=~\"$job\",fresh=\"true\",healthy=\"false\"}))", "instant": true, "legendFormat": "Unhealthy hosts", "range": false, "refId": "A" }
+      ],
+      "title": "Unhealthy hosts",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "DPUs with a recent health report (less than five minutes old).",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_dpus_up_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Online DPUs", "range": false, "refId": "A" }
+      ],
+      "title": "DPUs online",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "DPUs whose most recent report declared them healthy.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 6,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_dpus_healthy_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Healthy DPUs", "range": false, "refId": "A" }
+      ],
+      "title": "DPUs healthy",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 7,
+      "panels": [],
+      "title": "Capacity",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 7, "x": 0, "y": 6 },
+      "id": 8,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_machines_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Managed", "range": false, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_hosts_usable_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Usable", "range": false, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_hosts_in_use_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "In use", "range": false, "refId": "C" }
+      ],
+      "title": "Host capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 7, "x": 7, "y": 6 },
+      "id": 9,
+      "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_gpus_total_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Managed", "range": false, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_gpus_usable_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Usable", "range": false, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_gpus_in_use_count{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "In use", "range": false, "refId": "C" }
+      ],
+      "title": "GPU capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Free and allocated values in each NICo resource pool.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 5, "w": 10, "x": 14, "y": 6 },
+      "id": 10,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (pool) (${metric_prefix}_resourcepool_free_count{job=~\"$job\"})", "instant": true, "legendFormat": "{{pool}} free", "range": false, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (pool) (${metric_prefix}_resourcepool_used_count{job=~\"$job\"})", "instant": true, "legendFormat": "{{pool}} used", "range": false, "refId": "B" }
+      ],
+      "title": "Resource pools",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 11 },
+      "id": 11,
+      "panels": [],
+      "title": "Tenancy and inventory",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Allocated hosts and GPUs by tenant organization ID.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] } }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 10, "x": 0, "y": 12 },
+      "id": 12,
+      "options": { "cellHeight": "sm", "footer": { "countRows": false, "fields": "", "reducer": [ "sum" ], "show": false }, "showHeader": true },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (tenant_org_id) (${metric_prefix}_hosts_in_use_by_tenant_count{job=~\"$job\",fresh=\"true\"})", "format": "table", "instant": true, "legendFormat": "Hosts", "range": false, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (tenant_org_id) (${metric_prefix}_gpus_in_use_by_tenant_count{job=~\"$job\",fresh=\"true\"})", "format": "table", "instant": true, "legendFormat": "GPUs", "range": false, "refId": "B" }
+      ],
+      "title": "Tenant allocations",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 7, "x": 10, "y": 12 },
+      "id": 13,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_machines_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Hosts", "range": false, "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_network_segments_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Network segments", "range": false, "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_vpc_prefixes_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "VPC prefixes", "range": false, "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_ib_partitions_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "IB partitions", "range": false, "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_switches_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Switches", "range": false, "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_racks_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Racks", "range": false, "refId": "F" },
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max(${metric_prefix}_power_shelves_total{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "Power shelves", "range": false, "refId": "G" }
+      ],
+      "title": "Managed entities",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Current managed-host lifecycle distribution. For SLA and handling errors, see the nico-lifecycle dashboard.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } }, "mappings": [] }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 7, "x": 17, "y": 12 },
+      "id": 14,
+      "options": { "displayLabels": [ "name", "percent" ], "legend": { "displayMode": "list", "placement": "right", "showLegend": true }, "pieType": "pie", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "max by (state, substate) (${metric_prefix}_machines_per_state{job=~\"$job\",fresh=\"true\"})", "instant": true, "legendFormat": "{{state}} / {{substate}}", "range": false, "refId": "A" }
+      ],
+      "title": "Host lifecycle states",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 20 },
+      "id": 15,
+      "panels": [],
+      "title": "Health alerts",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Managed hosts reporting each health probe alert. Counts are combined across tenant-assignment states.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "id": 16,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (probe_id, probe_target) (max by (probe_id, probe_target, in_use) (${metric_prefix}_hosts_unhealthy_by_probe_id_count{job=~\"$job\",fresh=\"true\"}))", "instant": true, "legendFormat": "{{probe_id}} / {{probe_target}}", "range": false, "refId": "A" }
+      ],
+      "title": "Unhealthy hosts by probe",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Managed hosts with active health classifications, combined across tenant-assignment states.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "id": 17,
+      "options": { "displayMode": "gradient", "maxVizHeight": 300, "minVizHeight": 16, "minVizWidth": 8, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "showUnfilled": true, "sizing": "auto", "valueMode": "color" },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "editorMode": "code", "expr": "sum by (classification) (max by (classification, in_use) (${metric_prefix}_hosts_unhealthy_by_classification_count{job=~\"$job\",fresh=\"true\"}))", "instant": true, "legendFormat": "{{classification}}", "range": false, "refId": "A" }
+      ],
+      "title": "Unhealthy hosts by classification",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [ "nico", "infrastructure", "overview" ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "label": "Prometheus",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": true, "text": "carbide", "value": "carbide" },
+        "description": "Prefix configured for NICo core metrics (carbide by default; alt_metric_prefix can add another prefix).",
+        "label": "Metric prefix",
+        "name": "metric_prefix",
+        "options": [ { "selected": true, "text": "carbide", "value": "carbide" } ],
+        "query": "carbide",
+        "type": "textbox"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "definition": "label_values(${metric_prefix}_api_ready, job)",
+        "includeAll": true,
+        "label": "NICo scrape job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": { "query": "label_values(${metric_prefix}_api_ready, job)", "refId": "PrometheusVariableQueryEditor-VariableQuery" },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "NICo / Site Overview",
+  "uid": "nico-overview",
+  "version": 1
+}

--- a/helm/observability/dashboards/nico-overview.json
+++ b/helm/observability/dashboards/nico-overview.json
@@ -75,7 +75,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "DPUs with a recent health report (less than five minutes old).",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } }, "overrides": [] },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "text" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }, "unit": "none" }, "overrides": [] },
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
       "id": 5,
       "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },
@@ -88,7 +88,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "DPUs whose most recent report declared them healthy.",
-      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } }, "overrides": [] },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "text" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null } ] }, "unit": "none" }, "overrides": [] },
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
       "id": 6,
       "options": { "colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false }, "textMode": "auto", "wideLayout": true },

--- a/helm/templates/grafana-dashboards.yaml
+++ b/helm/templates/grafana-dashboards.yaml
@@ -15,5 +15,5 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{- (.Files.Glob "dashboards/*.json").AsConfig | nindent 2 }}
+  {{- (.Files.Glob "observability/dashboards/*.json").AsConfig | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
 ## Description
 
Adds NICo observability documentation covering metrics exposure, collection architecture, alerting thresholds and SLO monitoring for NICo deployments.

**Why this change?**
NICo lacked centralized documentation for operators to understand:
- Which metrics exist and what they measure
- How to collect metrics using OTel Collector or ServiceMonitors
- What alert thresholds are production-validated vs. site-specific
- How to map SLO targets to specific PromQL expressions

**What's included:**
`docs/observability/metrics.md`:
- Component metrics ports and endpoints
- Metric categories (state lifecycle, capacity, health, discovery, API performance)
- OTel Collector and ServiceMonitor configuration examples
- Grafana dashboard documentation (site overview, object lifecycle, API performance)
- Troubleshooting guide for missing metrics, high cardinality, stale data

`docs/observability/alerts.md`:

- Production-validated thresholds (host health >10%, IP capacity <15%, SLA violations)
- SLO targets with specific metrics and PromQL:
  - API availability (99.9%) via `carbide_api_grpc_server_duration_milliseconds`
  - API latency (<1s p95)
  - State reconciliation (<60s) via `carbide_machines_handler_latency_in_state_milliseconds`
- Health alert classifications and their operational impact
- Deployment instructions for PrometheusRule/VMRule resources

## Related issues

- Closes #2826

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Documentation references metrics from `docs/observability/core_metrics.md` (auto-generated) and alert rules from `helm/observability/alerts/nico-alerts.yaml`.
