### PR TITLE
test(integration): Stabilize machine-a-tron API integration tests

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1506,7 +1506,7 @@ where
         mac_address_pool: None,
     };
 
-    let (machine_handles, _mat_handle) = api_test_helper::machine_a_tron::run_local(
+    let (machine_handles, mat_handle) = api_test_helper::machine_a_tron::run_local(
         mat_config,
         additional_api_urls,
         &test_env.root_dir,
@@ -1517,9 +1517,13 @@ where
     .unwrap();
 
     let results = join_all(machine_handles.into_iter().map(run_assertions)).await;
-    assert_eq!(results.len(), host_count as usize);
+    let result_count = results.len();
+    let assertion_result: eyre::Result<()> = results.into_iter().try_collect();
+    let shutdown_result = mat_handle.shutdown().await;
 
-    results.into_iter().try_collect()
+    assert_eq!(result_count, host_count as usize);
+    assertion_result?;
+    shutdown_result
 }
 
 // Get the current number of rows in the dns_records view,

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1129,52 +1129,67 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     "Force-deleted machine; awaiting re-ingestion as NicMode",
                 );
 
-                // 4. Wait for the host to re-ingest as a zero-managed-DPU machine,
-                //    asserted directly against the database. The host's TPM-derived
-                //    MachineId is deterministic (a hash of its EK cert), so the
-                //    re-ingested host resurrects under the SAME id captured before
-                //    the flip -- the machine-a-tron handle's observed id is cleared
-                //    by the force-delete, so we key off the captured id. First
-                //    confirm the re-ingest milestone (the host row is back with its
-                //    NIC and no managed DPU); step 5 then drives it all the way to
-                //    Ready. Allow generous time for the rate-limited flip
-                //    power-cycle plus full rediscovery.
+                // 4. Wait for the physical host to re-ingest as a zero-managed-DPU
+                //    machine, asserted directly against the database. Zero-DPU
+                //    ingestion initially mints an `fm100ps...` predicted host ID
+                //    from the host serial. Later host discovery supplies the TPM
+                //    identity and atomically promotes that row back to its stable
+                //    `fm100ht...` ID. Follow the BMC MAC across that rename instead
+                //    of requiring promotion to have happened before declaring the
+                //    re-ingestion milestone complete.
                 let host_id = initial_machine_id.to_string();
                 let pool = &test_env.db_pool;
                 let reingest_deadline = time::Instant::now() + Duration::from_secs(180);
                 loop {
-                    // The host row is back under its stable TPM-derived id.
-                    let host_exists: bool =
-                        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM machines WHERE id = $1)")
-                            .bind(&host_id)
-                            .fetch_one(pool)
-                            .await?;
-                    // It re-ingested with at least one data-plane (non-BMC) NIC.
-                    let nic_count: i64 = sqlx::query_scalar(
-                        "SELECT COUNT(*) FROM machine_interfaces \
-                         WHERE machine_id = $1 AND interface_type != 'Bmc'",
+                    // The machine ID may still be predicted here. The BMC MAC is
+                    // the stable physical identity throughout re-ingestion.
+                    let current_host_id: Option<String> = sqlx::query_scalar(
+                        "SELECT machine_id FROM machine_interfaces \
+                         WHERE interface_type = 'Bmc' \
+                         AND machine_id IS NOT NULL \
+                         AND mac_address = $1::macaddr",
                     )
-                    .bind(&host_id)
-                    .fetch_one(pool)
+                    .bind(&bmc_mac)
+                    .fetch_optional(pool)
                     .await?;
+                    // It re-ingested with at least one data-plane (non-BMC) NIC.
+                    let nic_count: i64 = if let Some(current_host_id) = &current_host_id {
+                        sqlx::query_scalar(
+                            "SELECT COUNT(*) FROM machine_interfaces \
+                             WHERE machine_id = $1 AND interface_type != 'Bmc'",
+                        )
+                        .bind(current_host_id)
+                        .fetch_one(pool)
+                        .await?
+                    } else {
+                        0
+                    };
                     // Zero managed DPUs: no data-plane interface still points at a
                     // DPU (any non-null `attached_dpu_machine_id`), so the BlueField
                     // flipped to NIC mode and is no longer managed. Count attachments
                     // directly instead of joining `machines`, so a stale attachment
                     // pointing at an already-deleted DPU row still counts.
-                    let managed_dpu_count: i64 = sqlx::query_scalar(
-                        "SELECT COUNT(*) FROM machine_interfaces \
-                         WHERE machine_id = $1 \
-                         AND interface_type != 'Bmc' \
-                         AND attached_dpu_machine_id IS NOT NULL",
-                    )
-                    .bind(&host_id)
-                    .fetch_one(pool)
-                    .await?;
+                    let managed_dpu_count: i64 = if let Some(current_host_id) = &current_host_id {
+                        sqlx::query_scalar(
+                            "SELECT COUNT(*) FROM machine_interfaces \
+                             WHERE machine_id = $1 \
+                             AND interface_type != 'Bmc' \
+                             AND attached_dpu_machine_id IS NOT NULL",
+                        )
+                        .bind(current_host_id)
+                        .fetch_one(pool)
+                        .await?
+                    } else {
+                        0
+                    };
 
-                    if host_exists && nic_count >= 1 && managed_dpu_count == 0 {
+                    if let Some(current_host_id) = &current_host_id
+                        && nic_count >= 1
+                        && managed_dpu_count == 0
+                    {
                         tracing::info!(
-                            host_machine_id = %host_id,
+                            host_machine_id = %current_host_id,
+                            stable_host_machine_id = %host_id,
                             nic_interface_count = nic_count,
                             "Host re-ingested as a zero-managed-DPU machine; DPU-to-NIC flip applied",
                         );
@@ -1182,16 +1197,19 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     }
                     if time::Instant::now() >= reingest_deadline {
                         panic!(
-                            "host {host_id} did not re-ingest as a zero-managed-DPU NicMode machine \
-                             within the timeout (host_exists={host_exists}, nic_count={nic_count}, \
+                            "host with BMC MAC {bmc_mac} did not re-ingest as a zero-managed-DPU \
+                             NicMode machine within the timeout (stable_host_id={host_id}, \
+                             current_host_id={current_host_id:?}, nic_count={nic_count}, \
                              managed_dpu_count={managed_dpu_count})"
                         );
                     }
                     sleep(Duration::from_secs(2)).await;
                 }
 
-                // 5. Drive the re-ingested NicMode host all the way to Ready --
-                //    the host BMC now serves an event log so the controller's
+                // 5. Drive the re-ingested NicMode host all the way to Ready and
+                //    verify that discovery promoted its predicted ID back to the
+                //    original stable TPM-derived ID. The host BMC now serves an
+                //    event log so the controller's
                 //    restart verification can confirm reboots, and the zero-DPU
                 //    lockdown short-circuit lets it skip the DPU-down wait.
                 tracing::info!(
@@ -1200,17 +1218,41 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                 );
                 let ready_deadline = time::Instant::now() + Duration::from_secs(240);
                 loop {
+                    let current_host_id: Option<String> = sqlx::query_scalar(
+                        "SELECT machine_id FROM machine_interfaces \
+                         WHERE interface_type = 'Bmc' \
+                         AND machine_id IS NOT NULL \
+                         AND mac_address = $1::macaddr",
+                    )
+                    .bind(&bmc_mac)
+                    .fetch_optional(pool)
+                    .await?;
+                    let Some(current_host_id) = current_host_id else {
+                        if time::Instant::now() >= ready_deadline {
+                            panic!(
+                                "re-ingested NicMode host with BMC MAC {bmc_mac} disappeared \
+                                 before reaching Ready"
+                            );
+                        }
+                        sleep(Duration::from_secs(2)).await;
+                        continue;
+                    };
                     let resp = api_test_helper::grpcurl::grpcurl(
                         carbide_api_addrs,
                         "FindMachinesByIds",
-                        Some(&serde_json::json!({ "machine_ids": [{"id": host_id}] })),
+                        Some(&serde_json::json!({ "machine_ids": [{"id": current_host_id}] })),
                     )
                     .await?;
                     let resp: serde_json::Value = serde_json::from_str(&resp)?;
                     let state = resp["machines"][0]["state"].as_str().unwrap_or("");
                     if state == "Ready" {
+                        eyre::ensure!(
+                            current_host_id == host_id,
+                            "re-ingested NicMode host reached Ready without promotion to its \
+                             original stable ID (current={current_host_id}, expected={host_id})"
+                        );
                         tracing::info!(
-                            host_machine_id = %host_id,
+                            host_machine_id = %current_host_id,
                             machine_state = state,
                             "Re-ingested NicMode host reached Ready",
                         );
@@ -1218,7 +1260,9 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     }
                     if time::Instant::now() >= ready_deadline {
                         panic!(
-                            "re-ingested NicMode host {host_id} did not reach Ready within the timeout (last state: {state})"
+                            "re-ingested NicMode host with BMC MAC {bmc_mac} did not reach Ready \
+                             within the timeout (current_host_id={current_host_id}, \
+                             stable_host_id={host_id}, last_state={state})"
                         );
                     }
                     sleep(Duration::from_secs(2)).await;

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1248,7 +1248,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     if state == "Ready" {
                         eyre::ensure!(
                             current_host_id == host_id,
-                            "re-ingested NicMode host reached Ready without promotion to its \
+                            "re-ingested NicMode host reached ready without promotion to its \
                              original stable ID (current={current_host_id}, expected={host_id})"
                         );
                         tracing::info!(
@@ -1260,7 +1260,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
                     }
                     if time::Instant::now() >= ready_deadline {
                         panic!(
-                            "re-ingested NicMode host with BMC MAC {bmc_mac} did not reach Ready \
+                            "Re-ingested NicMode host with BMC MAC {bmc_mac} did not reach Ready \
                              within the timeout (current_host_id={current_host_id}, \
                              stable_host_id={host_id}, last_state={state})"
                         );

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -34,7 +34,7 @@ bmc-mock = { path = "../bmc-mock" }
 carbide-api = { path = "../api", default-features = false }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-version = { path = "../version" }
-carbide-rpc = { path = "../rpc" }
+carbide-rpc = { path = "../rpc", features = ["test-support"] }
 carbide-machine-a-tron = { path = "../machine-a-tron" }
 carbide-tls = { path = "../tls" }
 carbide-secrets = { path = "../secrets" }

--- a/crates/api-test-helper/src/lib.rs
+++ b/crates/api-test-helper/src/lib.rs
@@ -56,6 +56,8 @@ pub fn setup_logging() {
                 .add_directive("rustls=warn".parse().unwrap())
                 .add_directive("hyper=warn".parse().unwrap())
                 .add_directive("h2=warn".parse().unwrap())
+                // Suppress expected, repetitive environment diagnostics in integration tests.
+                .add_directive("carbide_diagnostics=off".parse().unwrap())
                 // Silence permissive mode related messages
                 .add_directive("carbide_api_core::auth=error".parse().unwrap()),
         )

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -47,7 +47,8 @@ pub async fn run_local(
     app_config.validate()?;
 
     let forge_root_ca_path = get_root_ca_path(None, None); // Will get it from the local repo
-    let forge_client_config = ForgeClientConfig::new(forge_root_ca_path.clone(), None);
+    let mut forge_client_config = ForgeClientConfig::new(forge_root_ca_path.clone(), None);
+    forge_client_config.suppress_insecure_tls_warning = true;
 
     let api_config = ApiConfig::new_with_multiple_urls(
         &app_config.carbide_api_url,

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -105,6 +105,13 @@ pub async fn run_local(
 
         try_join_all(
             machine_handles_clone
+                .iter()
+                .map(HostMachineHandle::abort_and_wait),
+        )
+        .await?;
+
+        try_join_all(
+            machine_handles_clone
                 .into_iter()
                 .map(|m| m.delete_from_api(app_context.api_client())),
         )
@@ -125,4 +132,12 @@ pub async fn run_local(
 pub struct MachineATronHandle {
     _stop_tx: oneshot::Sender<()>,
     _join_handle: JoinHandle<eyre::Result<()>>,
+}
+
+impl MachineATronHandle {
+    pub async fn shutdown(self) -> eyre::Result<()> {
+        drop(self._stop_tx);
+        self._join_handle.await??;
+        Ok(())
+    }
 }

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, path};
 
-use carbide_secrets::credentials::{CredentialKey, CredentialType, CredentialWriter, Credentials};
+use carbide_secrets::credentials::{
+    CredentialKey, CredentialType, CredentialWriter, Credentials, NicLockdownIkm,
+};
 use carbide_secrets::{CredentialConfig, VaultConfig, create_credential_manager};
 use carbide_utils::HostPortPair;
 use eyre::Report;
@@ -315,12 +317,36 @@ pub async fn populate_initial_vault_secrets(
 
     credential_manager
         .set_credentials(
+            &CredentialKey::DpuUefi {
+                credential_type: CredentialType::DpuHardwareDefault,
+            },
+            &Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "password".to_string(),
+            },
+        )
+        .await?;
+
+    credential_manager
+        .set_credentials(
             &CredentialKey::HostUefi {
                 credential_type: CredentialType::SiteDefault,
             },
             &Credentials::UsernamePassword {
                 username: "root".to_string(),
                 password: "password".to_string(),
+            },
+        )
+        .await?;
+
+    credential_manager
+        .set_credentials(
+            &CredentialKey::NicLockdownIkm {
+                credential_type: NicLockdownIkm::SiteWide { version: 0 },
+            },
+            &Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "test-lockdown-ikm".to_string(),
             },
         )
         .await?;

--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -189,6 +189,7 @@ impl<B: Bmc> ExploredManager<B> {
                     && is_locally_administered_mac(mac)
                 {
                     tracing::warn!(
+                        target: "carbide_diagnostics::locally_administered_mac",
                         manager_id = %self.manager.id().inner(),
                         eth0_mac_address = %mac,
                         "manager eth0 MAC is locally-administered (transient pre-sync data?)",

--- a/crates/machine-a-tron/src/api_throttler.rs
+++ b/crates/machine-a-tron/src/api_throttler.rs
@@ -86,7 +86,10 @@ pub fn run(mut interval: Interval, api_client: ApiClient) -> ApiThrottler {
                             get_machine_callers = HashMap::new()
                         }
                     }
-                    Some(cmd) = control_rx.recv() => {
+                    cmd = control_rx.recv() => {
+                        let Some(cmd) = cmd else {
+                            return;
+                        };
                         match cmd {
                             ApiCommand::GetMachine(machine_id, reply) => get_machine_callers.entry(machine_id).or_default().push(reply),
                         };

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -457,8 +457,23 @@ impl DpuMachineHandle {
     }
 
     pub fn abort(&self) {
-        if let Some(join_handle) = self.0.join_handle.lock().unwrap().take() {
-            join_handle.abort();
+        _ = self.abort_task();
+    }
+
+    pub(crate) fn abort_task(&self) -> Option<JoinHandle<()>> {
+        let join_handle = self.0.join_handle.lock().unwrap().take()?;
+        join_handle.abort();
+        Some(join_handle)
+    }
+
+    pub async fn abort_and_wait(&self) -> eyre::Result<()> {
+        if let Some(join_handle) = self.abort_task() {
+            match join_handle.await {
+                Ok(()) => {}
+                Err(error) if error.is_cancelled() => {}
+                Err(error) => return Err(error.into()),
+            }
         }
+        Ok(())
     }
 }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -705,6 +705,28 @@ impl HostMachineHandle {
         }
     }
 
+    pub async fn abort_and_wait(&self) -> eyre::Result<()> {
+        let mut join_handles = self
+            .0
+            .dpus
+            .iter()
+            .filter_map(DpuMachineHandle::abort_task)
+            .collect::<Vec<_>>();
+        if let Some(join_handle) = self.0.join_handle.lock().unwrap().take() {
+            join_handle.abort();
+            join_handles.push(join_handle);
+        }
+
+        for join_handle in join_handles {
+            match join_handle.await {
+                Ok(()) => {}
+                Err(error) if error.is_cancelled() => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
     pub fn bmc_ssh_host_pubkey(&self) -> Option<String> {
         self.0.live_state.read().unwrap().ssh_host_key.clone()
     }

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -529,10 +529,7 @@ impl<'a> ForgeTlsClient<'a> {
                     base_config_builder().with_root_certificates(roots)
                 } else {
                     #[cfg(feature = "test-support")]
-                    let verifier = if self
-                        .forge_client_config
-                        .suppress_insecure_tls_warning
-                    {
+                    let verifier = if self.forge_client_config.suppress_insecure_tls_warning {
                         DummyTlsVerifier::new_for_tests()
                     } else {
                         DummyTlsVerifier::new_for_prod()

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -89,6 +89,8 @@ pub struct ForgeClientConfig {
     pub root_ca_path: String,
     pub client_cert: Option<ClientCert>,
     pub enforce_tls: bool,
+    #[cfg(feature = "test-support")]
+    pub suppress_insecure_tls_warning: bool,
     pub use_mgmt_vrf: bool,
     pub max_decoding_message_size: Option<usize>,
     pub socks_proxy: Option<String>,
@@ -110,6 +112,8 @@ impl ForgeClientConfig {
             root_ca_path,
             client_cert,
             enforce_tls: !disabled,
+            #[cfg(feature = "test-support")]
+            suppress_insecure_tls_warning: false,
             use_mgmt_vrf: false,
             max_decoding_message_size,
             socks_proxy: None,
@@ -524,11 +528,20 @@ impl<'a> ForgeTlsClient<'a> {
                 if self.forge_client_config.enforce_tls {
                     base_config_builder().with_root_certificates(roots)
                 } else {
+                    #[cfg(feature = "test-support")]
+                    let verifier = if self
+                        .forge_client_config
+                        .suppress_insecure_tls_warning
+                    {
+                        DummyTlsVerifier::new_for_tests()
+                    } else {
+                        DummyTlsVerifier::new_for_prod()
+                    };
+                    #[cfg(not(feature = "test-support"))]
+                    let verifier = DummyTlsVerifier::new_for_prod();
                     base_config_builder()
                         .dangerous()
-                        .with_custom_certificate_verifier(
-                            Arc::new(DummyTlsVerifier::new_for_prod()),
-                        )
+                        .with_custom_certificate_verifier(Arc::new(verifier))
                 }
             };
 

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -710,6 +710,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
         };
 
         tracing::info!(
+            target: "carbide_diagnostics::bmc_redfish_supported",
             %bmc_ip_address,
             %vendor,
             "BMC supports Redfish"

--- a/crates/tls/src/dummy_tls_verifier.rs
+++ b/crates/tls/src/dummy_tls_verifier.rs
@@ -38,6 +38,14 @@ impl DummyTlsVerifier {
             print_warning: true,
         }
     }
+
+    fn warn_if_enabled(&self) {
+        if self.print_warning {
+            eprintln!(
+                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
+            );
+        }
+    }
 }
 
 impl ServerCertVerifier for DummyTlsVerifier {
@@ -49,11 +57,7 @@ impl ServerCertVerifier for DummyTlsVerifier {
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        if self.print_warning {
-            eprintln!(
-                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
-            );
-        }
+        self.warn_if_enabled();
         Ok(ServerCertVerified::assertion())
     }
 
@@ -63,11 +67,7 @@ impl ServerCertVerifier for DummyTlsVerifier {
         _cert: &CertificateDer<'_>,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        if self.print_warning {
-            eprintln!(
-                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
-            );
-        }
+        self.warn_if_enabled();
         Ok(HandshakeSignatureValid::assertion())
     }
 
@@ -77,11 +77,7 @@ impl ServerCertVerifier for DummyTlsVerifier {
         _cert: &CertificateDer<'_>,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        if self.print_warning {
-            eprintln!(
-                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
-            );
-        }
+        self.warn_if_enabled();
         Ok(HandshakeSignatureValid::assertion())
     }
 


### PR DESCRIPTION
Improve the reliability and signal quality of the machine-a-tron API integration tests.

The tests run multiple simulated machines against two shared API servers, which exposed several timing and lifecycle problems: missing test credentials, noisy but legitimate production diagnostics, machine tasks continuing during cleanup, leaked API throttler tasks, and a NIC-mode re-ingestion assertion that assumed predicted host IDs had  already been promoted to stable TPM-derived IDs.

This PR:
  - Seeds the DPU UEFI and NIC lockdown credentials required by the integration environment.
  - Suppresses selected expected diagnostics only in tests while preserving their production behavior.
  - Keeps the insecure-TLS warning enabled by default and gates test-only suppression behind the `test-support` feature.
  - Explicitly stops and awaits machine-a-tron host and DPU tasks before force-deleting their machines.
  - Stops the API throttler when its command channel closes, preventing retries after API shutdown.
  - Tracks NIC-mode re-ingestion by BMC MAC across the temporary `fm100ps...` to stable `fm100ht...` ID promotion.
  - Verifies that the re-ingested host has no managed DPUs and eventually reaches `Ready` under its original stable ID.

## Related issues

  - #2661
  - #2632

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The production security warning for disabled TLS verification remains enabled. Its suppression is available only through the `test-support` feature and is used by the integration-test harness.

The diagnostic messages filtered by this PR remain available in production. Only the integration-test tracing configuration disables their dedicated diagnostic target.
