### PR TITLE
ci(v2.0): safely handle commit messages in REST build info

### DIFF
--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Generate version and build information
         id: generate-version
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
         run: |
           git fetch --tags --force
           RAW_VERSION=$(git describe --tags --first-parent --always --long)
@@ -96,7 +98,7 @@ jobs:
             RELEASE_TAG=""
           fi
 
-          if echo "${{ github.event.head_commit.message }}" | grep -q "push-container"; then
+          if printf '%s' "${COMMIT_MESSAGE}" | grep -q "push-container"; then
             PUSH_REQUESTED="true"
           else
             PUSH_REQUESTED="false"


### PR DESCRIPTION
## What

- Pass the full commit message through the step environment instead of interpolating it directly into the generated shell script.
- Preserve the existing `push-container` detection with `printf`.

## Why

The `release/v2.0` workflow directly interpolates `github.event.head_commit.message` into Bash. PR #3615 has a multiline commit body containing backticks and shell/Python reproduction snippets, so parts of that body are parsed as commands and the build-info job hangs.

This is a minimal partial backport of the safe handling from #3126 (`2ccf3a6dc`). It intentionally excludes the other registry-related changes from that commit.

## Impact

Commit messages remain data rather than shell source. The existing `push-container` behavior is unchanged.

## Validation

- `git diff --check`
- `yq '.' .github/workflows/rest-prepare-build-info.yml`
- `actionlint -ignore 'SC2001|SC2086|SC2129' .github/workflows/rest-prepare-build-info.yml` (ignores existing findings in this release workflow)
- Controlled regression probe with backticks in `COMMIT_MESSAGE` returned only `SAFE_MATCH`; no embedded command was executed

This unblocks a fresh CI run for #3615 after the release branch is updated.
