### PR TITLE
fix(dns): request dual-stack ClusterIP for nico-dns Service

### DIFF
--- a/deploy/nico-base/dns/service.yaml
+++ b/deploy/nico-base/dns/service.yaml
@@ -19,6 +19,7 @@ kind: Service
 metadata:
   name: nico-dns
 spec:
+  ipFamilyPolicy: PreferDualStack
   ports:
     - port: 53
       name: tcp

--- a/helm/charts/nico-dns/templates/service.yaml
+++ b/helm/charts/nico-dns/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
 spec:
+  ipFamilyPolicy: PreferDualStack
   selector:
     {{- include "nico-dns.selectorLabels" . | nindent 4 }}
   ports:


### PR DESCRIPTION
## Summary

Adds `ipFamilyPolicy: PreferDualStack` to the `nico-dns` Service spec so it receives a second (IPv6) ClusterIP. This is what the DPU's `resolv.conf` points to and what the external DHCPv6 component advertises as RDNSS (option 23).

Applied in both Service definitions:
- `helm/charts/nico-dns/templates/service.yaml` (Helm-deployed path)
- `deploy/nico-base/dns/service.yaml` (kustomize base manifest)

`PreferDualStack` is used rather than `RequireDualStack` so the Service still schedules on IPv4-only clusters instead of failing.

This is Task 0 of the parent effort — operational, no code dependencies.

Closes #2636.