### PR TITLE
docs(repair): catch the label guidance up to the 16-label cap

### DIFF
--- a/docs/manuals/repair/online_repair.md
+++ b/docs/manuals/repair/online_repair.md
@@ -169,7 +169,7 @@ The OpenAPI operation ID is `update-instance`. Restish command shape:
 restish <api-profile> update-instance <tenant-org-id> <instance-id> < <request-body-json>
 ```
 
-First inspect the instance and preserve any existing labels. Instance label updates replace the full label map; labels not included in the update request are removed. Labels are limited to 10 key/value pairs, so use the minimum failure labels if the instance is already near that limit.
+First inspect the instance and preserve any existing labels. Instance label updates replace the full label map; labels not included in the update request are removed. Labels are limited to 16 key/value pairs, so use the minimum failure labels if the instance is already near that limit.
 
 ```bash
 restish nico-stg get-instance <tenant-org-id> <instance-id>

--- a/docs/manuals/repair/release_instance_for_repair.md
+++ b/docs/manuals/repair/release_instance_for_repair.md
@@ -88,7 +88,7 @@ First fetch the instance and preserve any labels that should remain:
 restish nico-stg get-instance <tenant-org-id> <instance-id>
 ```
 
-Instance label updates replace the full label map. Labels not included in the update request are removed. Labels are limited to 10 key/value pairs, so use the minimum failure labels if the instance is already near that limit.
+Instance label updates replace the full label map. Labels not included in the update request are removed. Labels are limited to 16 key/value pairs, so use the minimum failure labels if the instance is already near that limit.
 
 Example `online-repair-failed-labels.json`:
 

--- a/docs/manuals/repair/repair_tenant_workflow.md
+++ b/docs/manuals/repair/repair_tenant_workflow.md
@@ -180,7 +180,7 @@ Before releasing the repair instance, inspect the machine again and preserve any
 restish nico-stg get-machine <repair-tenant-org-id> <machine-id>
 ```
 
-Machine label updates replace the full label map. Labels not included in the update request are removed. Labels are limited to 10 key/value pairs, so keep repair labels short and preserve required placement labels such as rack, site, or pool hints.
+Machine label updates replace the full label map. Labels not included in the update request are removed. Labels are limited to 16 key/value pairs, so keep repair labels short and preserve required placement labels such as rack, site, or pool hints.
 
 When repair succeeds, create `repair-status-completed-labels.json`:
 


### PR DESCRIPTION
The repair manuals still coach operators around a 10-label ceiling, but the metadata label cap moved to 16 back in #2279 (`MAX_LABELS` in `crates/api-model/src/metadata.rs`). All three label-update warnings now state the real limit, so nobody trims placement labels to make room they already have.

This supports https://github.com/NVIDIA/infra-controller/issues/3645

Closes #3645
