### PR TITLE
fix: migrate four straggler events to event_name/metric_name

### DIFF
--- a/crates/dsx-exchange-consumer/src/metrics.rs
+++ b/crates/dsx-exchange-consumer/src/metrics.rs
@@ -185,7 +185,8 @@ pub struct MessageAge {
 /// `/metrics` shows.
 #[derive(Event)]
 #[event(
-    name = "carbide_dsx_exchange_consumer_health_report_persist_failures_total",
+    event_name = "dsx_exchange_health_report_persist_failed",
+    metric_name = "carbide_dsx_exchange_consumer_health_report_persist_failures_total",
     component = "nico-dsx-exchange-consumer",
     log = warn,
     metric = counter,

--- a/crates/fmds/src/grpc_server.rs
+++ b/crates/fmds/src/grpc_server.rs
@@ -39,7 +39,8 @@ impl FmdsGrpcServer {
 /// WARN line (the success path keeps its own "Received config update" INFO log).
 #[derive(Event)]
 #[event(
-    name = "carbide_fmds_config_updates_total",
+    event_name = "fmds_config_update_ingested",
+    metric_name = "carbide_fmds_config_updates_total",
     component = "fmds",
     log = dynamic,
     metric = counter,

--- a/crates/fmds/src/phone_home.rs
+++ b/crates/fmds/src/phone_home.rs
@@ -42,7 +42,8 @@ enum PhoneHomeOutcome {
 /// (the success path keeps its own "Successfully phoned home" INFO log).
 #[derive(Event)]
 #[event(
-    name = "carbide_fmds_phone_home_total",
+    event_name = "fmds_phone_home_completed",
+    metric_name = "carbide_fmds_phone_home_total",
     component = "fmds",
     log = dynamic,
     metric = counter,

--- a/crates/spdm-controller/src/handler.rs
+++ b/crates/spdm-controller/src/handler.rs
@@ -337,7 +337,8 @@ enum AttestedDeviceType {
 /// certificates, and the nonce are never put on a label or in the log line.
 #[derive(Event)]
 #[event(
-    name = "carbide_attestation_total",
+    event_name = "attestation_performed",
+    metric_name = "carbide_attestation_total",
     component = "carbide-spdm-controller",
     log = dynamic,
     metric = counter,


### PR DESCRIPTION
`#[event(name = "...")]` was split into `event_name` + `metric_name` (#3581), turning the bare `name` key into a compile error. Four events that merged in the same window still used `name`, so `fmds`, `dsx-exchange-consumer`, and `spdm-controller` don't build on `main` right now.

Each now declares an `event_name` identity alongside its `metric_name` — no metric-name or behavior change. `cargo xtask check-event-names` passes (64 unique).
