### PR TITLE
docs(site-explorer): document the mlx-devices NIC-firmware report

### DIFF
--- a/docs/dpu-management/dpu-lifecycle-management.md
+++ b/docs/dpu-management/dpu-lifecycle-management.md
@@ -167,6 +167,22 @@ Operators can inspect DPU firmware status with:
 nico-admin-cli -a <api-url> dpu versions
 ```
 
+### Auditing NIC Firmware Across the Site
+
+A BlueField operating in NIC mode runs with its Arm OS down, so it cannot report its own NIC firmware and never appears in the `dpu versions` inventory. Site exploration already captures each host BMC's Redfish PCIe inventory, and `site-explorer mlx-devices` reports every BlueField and SuperNIC from that view - part number, serial, NIC firmware, and the mode the device's own BMC reports - so cards in NIC mode stay visible to firmware audits:
+
+```bash
+nico-admin-cli -a <api-url> site-explorer mlx-devices
+```
+
+You can filter to devices operating as NICs whose firmware is below a desired version:
+
+```bash
+nico-admin-cli -a <api-url> site-explorer mlx-devices --nic-mode-only --expected-version 32.42.1000
+```
+
+`--host <bmc-ip>` restricts the report to one host BMC. The report's `DPU BMC IP` column gives the address to target for an upgrade; a device whose DPU BMC has not been explored yet still appears, without the mode and DPU BMC fields. Refer to the [mlx-devices CLI reference](../manuals/nico-admin-cli/commands/site-explorer/site-explorer-mlx-devices.md) for the full flag and output list.
+
 ## Containerized Cumulus and NVUE
 
 After the DPU OS is installed, the `dpu-agent` keeps HBN configured by applying NVUE configuration generated from NICo Core state. The configuration covers:

--- a/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer-mlx-devices.md
+++ b/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer-mlx-devices.md
@@ -1,0 +1,63 @@
+# `nico-admin-cli site-explorer mlx-devices`
+
+_[Tenant commands](../../tenant.md) › [site-explorer](./site-explorer.md) › **mlx-devices**_
+
+## NAME
+
+nico-admin-cli-site-explorer-mlx-devices - Report Mellanox/BlueField
+device NIC firmware from explored Redfish data.
+
+## SYNOPSIS
+
+**nico-admin-cli site-explorer mlx-devices** \[**--host**\]
+\[**--nic-mode-only**\] \[**--expected-version**\] \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Report Mellanox/BlueField device NIC firmware from explored Redfish
+data.
+
+## OPTIONS
+
+**--host** *\<HOST\>*  
+Restrict to devices found under this host BMC IP
+
+**--nic-mode-only**  
+Only devices operating as NICs: their DPU BMC reports NIC mode, or they
+have a SuperNIC SKU and the mode is unknown
+
+**--expected-version** *\<EXPECTED_VERSION\>*  
+Only devices whose NIC firmware is below this version (e.g. 32.42.1000)
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field  
+
+  
+*Possible values:*
+
+> - primary-id: Sort by the primary id
+>
+> - state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli site-explorer mlx-devices
+nico-admin-cli site-explorer mlx-devices --host 192.0.2.20
+nico-admin-cli site-explorer mlx-devices --nic-mode-only --expected-version 32.42.1000
+```
+
+---
+
+**See also:** [Tenant commands](../../tenant.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer.md
+++ b/docs/manuals/nico-admin-cli/commands/site-explorer/site-explorer.md
@@ -25,14 +25,14 @@ probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
-Sort output by specified field\
+Sort output by specified field  
 
-\
+  
 *Possible values:*
 
-- primary-id: Sort by the primary id
-
-- state: Sort by state
+> - primary-id: Sort by the primary id
+>
+> - state: Sort by state
 
 **-h**, **--help**  
 Print help (see a summary with -h)
@@ -42,6 +42,7 @@ Print help (see a summary with -h)
 | Subcommand | Description |
 |---|---|
 | [`get-report`](./site-explorer-get-report.md) | Retrieves the latest site exploration report |
+| [`mlx-devices`](./site-explorer-mlx-devices.md) | Report Mellanox/BlueField device NIC firmware from explored Redfish data. |
 | [`explore`](./site-explorer-explore.md) | Asks carbide-api to explore a single host and prints the report. Does not store it. |
 | [`re-explore`](./site-explorer-re-explore.md) | Asks carbide-api to explore a single host in the next exploration cycle. The results will be stored. |
 | [`refresh`](./site-explorer-refresh.md) | Immediately probes a BMC endpoint and persists the report. |


### PR DESCRIPTION
`site-explorer mlx-devices` is the only way to see NIC firmware for a BlueField in NIC mode (its Arm OS is down, so `dpu versions` never sees it) -- and it had zero docs presence. This adds an auditing subsection to the DPU Lifecycle Management manual beside the existing `dpu versions` snippet, plus the generated CLI reference page and parent-page subcommand row (regen scoped to these two pages; the corpus has ~595 other stale pages and no CI gate -- follow-up material).

This supports https://github.com/NVIDIA/infra-controller/issues/3643

Closes #3643
