### PR TITLE
docs(dns): add an operator guide for forward and reverse DNS

### DIFF
--- a/docs/configuration/dns.md
+++ b/docs/configuration/dns.md
@@ -1,0 +1,68 @@
+# DNS
+
+NICo answers DNS for everything it manages. Records are never authored by hand: they derive from the machine, BMC, and instance inventory in the `nico-api` database, appear when an interface or instance gains an address, and disappear when it loses one. This page covers the names NICo serves, how the site zone and per-segment subdomains are configured, and how reverse (PTR) resolution works. For the deployment side - the `nico-dns` service, the recursive resolver in front of it, and the fixed infrastructure service names - refer to [IP and Network Configuration](../provisioning/ip-and-network-configuration.md#3-dns-configuration).
+
+## What Gets a Name
+
+Every managed machine interface gets a hostname; [Host Naming](host-naming.md) covers how that label is chosen. These are the forward records NICo serves:
+
+| Name | Answers for | Notes |
+|---|---|---|
+| `<hostname>.<domain>` | A host's primary interface and every BMC interface | The human-facing name, built by the host-naming strategy |
+| `<machine-id>.adm.<domain>` | A host's primary interface | Keyed on the stable machine id |
+| `<machine-id>.bmc.<domain>` | A machine's BMC interface | Host, predicted-host, and DPU machine ids |
+| `<ip-hostname>.<segment subdomain>` | An overlay (DPU-managed) instance address | Always IP-derived (`10-1-2-3`, or the fully expanded IPv6 form), independent of the host-naming strategy |
+
+Records serve as A or AAAA per address family, with a 300-second TTL by default. An interface that loses all of its addresses drops out of DNS until it has one again. Instances on `host_inband` segments publish no instance record: their address is the host's own interface address, which the machine records above already serve.
+
+## The Site Zone and Segment Subdomains
+
+The site's forward zone is seeded once, at first startup, from the `nico-api` config:
+
+```toml
+initial_domain_name = "mysite.example.com"
+```
+
+The domain is created only when no domain exists yet, and most sites use a single domain for their lifetime. Network segments then decide which of their interfaces and instances get names:
+
+- Segments seeded from the config (`[networks.*]`) inherit the site domain automatically.
+- Segments created later through the API or CLI name their subdomain explicitly: `nico-admin-cli network-segment create ... --subdomain-id <domain-id>` (required for `host-inband` segments; list domains with `nico-admin-cli domain show`).
+- A segment with no subdomain produces no DNS at all: its interfaces and instances have no zone to live in.
+
+## Reverse DNS
+
+Reverse resolution mirrors the forward records that matter to humans:
+
+- An address on a primary interface or a BMC interface answers PTR with `<hostname>.<domain>`.
+- An overlay instance address answers PTR with its instance name.
+- The `adm` and `bmc` machine-id forms are forward-only.
+
+Reverse zones are derived, not managed. When a network segment is created, NICo derives the matching `in-addr.arpa` / `ip6.arpa` zone from each of its prefixes (for example, `192.0.2.0/24` becomes `2.0.192.in-addr.arpa`) and removes it again when the segment is deleted. Only octet-aligned IPv4 prefixes (/8, /16, /24, /32) and nibble-aligned IPv6 prefixes get a zone; anything else is skipped, since RFC 2317 classless delegation is out of scope. PTR answers themselves are matched by address, so alignment never blocks an answer; the derived zone rows define which reverse zones you delegate.
+
+Like the forward zone, reverse zones must be delegated from your upstream DNS - or forwarded by your recursive resolver - to the `nico-dns` service address. NICo creates the zones but cannot delegate them for you.
+
+## Server Behavior Worth Knowing
+
+- `nico-dns` answers A, AAAA, and PTR queries only; every other type answers "not implemented". It never recurses, and it serves no SOA or NS records and no zone transfers, so put it behind your recursive resolver (a forward zone works best) rather than in a client's resolver list.
+- Answers reflect the database live: there is no positive cache and no zone-serial machinery. A record change is visible on the next query.
+- A name that exists with only the other address family answers NXDomain rather than an empty answer, and negative answers are cached at the edge briefly (120 seconds by default).
+- Hosts learn their own FQDN over DHCP option 12 on every path; hosts served by a DPU also receive it as DHCP option 15.
+
+## Resolvers Handed to Hosts
+
+DHCP option 6 tells managed machines where to resolve, and it must point at the recursive resolver, never at `nico-dns` directly (`nico-dns` cannot answer external names or the infrastructure service names):
+
+- On the site DHCP path, option 6 comes from the `nico-dhcp` Kea hook parameter `carbide-nameservers` (the `config.kea.hookParameters.nameservers` Helm value emits it).
+- Hosts behind a DPU receive the DPU's own resolver set.
+- The IPv6 side (DHCPv6 option 23) is implemented in the hook, but no DHCPv6 server ships yet, so IPv6 resolver advertisement is inert today.
+
+## Troubleshooting
+
+The following table lists common situations and where to look:
+
+| Symptom | Likely cause / action |
+|---|---|
+| A machine interface has no name | Only primary and BMC interfaces publish records; the interface can also be addressless, or its segment can lack a subdomain. `nico-admin-cli managed-host show <machine-id>` shows interfaces and the primary flag; the `/admin/ipam/dns` web page lists every record NICo is serving. |
+| An instance has no name | The segment's `--subdomain-id` is unset, the address predates instance-hostname population (records populate for addresses allocated going forward), or the instance is on a `host_inband` segment (the host's machine record serves that address). |
+| PTR is missing while the forward name resolves | Only the `<hostname>.<domain>` and instance forms answer PTR; the `adm` and `bmc` machine-id forms are forward-only. |
+| Hosts cannot resolve external names | DHCP option 6 points at `nico-dns` (authoritative only) instead of the recursive resolver. Refer to [IP and Network Configuration](../provisioning/ip-and-network-configuration.md#32-unbound-recursive-resolver-for-managed-machines). |

--- a/docs/configuration/host-naming.md
+++ b/docs/configuration/host-naming.md
@@ -1,6 +1,6 @@
 # Host Naming
 
-Every machine interface NICo manages gets a hostname, and that hostname is what NICo's DNS serves -- the A/AAAA records for a machine are built from its stored hostname and current addresses. How those hostnames are derived is a site-wide choice, set once in the `nico-api` config:
+Every machine interface NICo manages gets a hostname, and that hostname is what [NICo's DNS](dns.md) serves -- the A/AAAA records for a machine are built from its stored hostname and current addresses. How those hostnames are derived is a site-wide choice, set once in the `nico-api` config:
 
 ```toml
 # nico-api config TOML

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -141,6 +141,8 @@ navigation:
           path: configuration/machine_identity.md
         - page: Host Naming
           path: configuration/host-naming.md
+        - page: DNS
+          path: configuration/dns.md
         - page: Component Manager RMS Backends
           path: configuration/component-manager-rms.md
 

--- a/docs/provisioning/ip-and-network-configuration.md
+++ b/docs/provisioning/ip-and-network-configuration.md
@@ -226,21 +226,14 @@ NICo's DNS layer has two distinct pieces:
 
 | Piece | Backed by | Serves |
 |---|---|---|
-| `nico-dns` | Either a PowerDNS Authoritative Server bridged to `nico-api`, or a standalone DNS server inside the `nico-dns` binary itself (see [section 3.1](#31-nico-dns-zones-and-what-they-serve)) — both modes call `nico-api` for record data | The site's authoritative zones — generated from machine, instance, and tenant records in the `nico-api` database |
+| `nico-dns` | A standalone DNS server (the `carbide-dns` binary) that answers every query from `nico-api` record data (see [section 3.1](#31-nico-dns-zones-and-what-they-serve)) | The site's authoritative zones — generated from machine, instance, and tenant records in the `nico-api` database |
 | `unbound` (recursive resolver) | Unbound | The resolver that managed machines (host BMCs, host OS, DPU OS, DPU BMCs) use for *all* DNS lookups |
 
 These two roles are independent. Managed machines never query `nico-dns` directly — they query the recursive resolver, which forwards or recurses as needed.
 
 ### 3.1 `nico-dns` Zones and What They Serve
 
-`nico-dns` serves the site's authoritative zones from `nico-api`'s database. It can run in either of two modes — pick one at deploy time:
-
-| Mode | How DNS reaches `nico-dns` | Selected by |
-|---|---|---|
-| **PowerDNS remote backend** (default) | PowerDNS Authoritative Server listens on UDP/TCP 53 and connects to `nico-dns` over a Unix domain socket using PowerDNS's JSON remote-backend protocol. `nico-dns` translates each request into a gRPC call to `nico-api`. | Default; no `--listen` flag set on the `nico-dns` binary. |
-| **Standalone DNS server** | `nico-dns` itself listens on UDP/TCP 53 and answers queries directly, calling `nico-api` over gRPC for record data. PowerDNS is not in the path. | Pass `--listen=[::]:53` (or another address) to the `nico-dns` binary. |
-
-Both modes resolve the same records from the same source — the difference is only whether PowerDNS sits in front. Production deployments use both: choose based on whether you already operate PowerDNS at your site or prefer one fewer process to manage. The rest of this page applies to either mode.
+`nico-dns` serves the site's authoritative zones from `nico-api`'s database. It is a standalone DNS server: the binary listens on UDP and TCP 53 (`--listen`, default `[::]:53`) and answers each query by calling `nico-api` over gRPC for record data. It serves A, AAAA, and PTR records only, and it does not recurse; clients reach it through the recursive resolver ([section 3.2](#32-unbound-recursive-resolver-for-managed-machines)), not directly.
 
 The zones served are seeded by the `initial_domain_name` field in `siteConfig` (for example, `mysite.example.com`). On first start, `nico-api` creates the corresponding domain record; `nico-dns` then exposes whatever records exist in that zone in `nico-api`'s database.
 
@@ -248,23 +241,25 @@ UFM endpoints under `default.ufm.<initial_domain_name>` are one example of recor
 
 Operators do not edit `nico-dns` zone files directly. Zone content is a function of `nico-api`'s database state.
 
+For the record catalog these zones serve - machine, BMC, and instance names, plus the automatically derived reverse zones and their lifecycle - refer to [DNS](../configuration/dns.md).
+
 To configure `nico-dns`:
 
 1. Set `initial_domain_name` in `siteConfig` to your site's DNS domain.
-2. Choose the mode (PowerDNS remote backend or standalone) and configure the `nico-dns` Deployment / StatefulSet accordingly — set or omit `--listen` on the binary's command line, and include or exclude PowerDNS from the pod spec.
-3. Assign a stable LoadBalancer VIP to the front-end service that listens on UDP/TCP 53 (one per replica via `perPodAnnotations`; see [Quick Start Step 3h](../getting-started/quick-start.md#3h-assign-service-vips)). In PowerDNS mode this is the PowerDNS service; in standalone mode it is the `nico-dns` service.
+2. Deploy the `nico-dns` StatefulSet; the binary listens on UDP/TCP 53 by default (`--listen=[::]:53`).
+3. Assign a stable LoadBalancer VIP to the `nico-dns` service that listens on UDP/TCP 53 (one per replica via `perPodAnnotations`; see [Quick Start Step 3h](../getting-started/quick-start.md#3h-assign-service-vips)).
 4. Delegate the `initial_domain_name` zone from your upstream DNS to those VIPs, or configure your recursive resolver to forward queries for the zone to them.
 
 ### 3.2 `unbound` Recursive Resolver for Managed Machines
 
 Managed machines (host OS, DPU OS, host BMCs, DPU BMCs) need a recursive resolver that can resolve **both** the site-internal NICo service zone and external names. NICo deploys an `unbound` instance for this purpose.
 
-The resolver address is distributed to managed machines via **DHCP option 6**, set in the `nico-dhcp` Kea hook parameter `nico-nameserver`. Managed machines have no compiled-in resolver address — changing the resolver is a DHCP configuration change, not a rebuild.
+The resolver address is distributed to managed machines via **DHCP option 6**, set in the `nico-dhcp` Kea hook parameter `carbide-nameservers` (the `config.kea.hookParameters.nameservers` Helm value emits it). Managed machines have no compiled-in resolver address — changing the resolver is a DHCP configuration change, not a rebuild.
 
 The resolver is responsible for:
 
 - Recursive resolution of external (public-internet) names — needed for package fetches, NTP, etc.
-- Authoritative resolution of the NICo service zone (`.nico`, `.nico`, or whichever convention your deployment uses; see below).
+- Authoritative resolution of the NICo service zone (`.forge`, `.nico`, or whichever convention your deployment uses; see below).
 - Forwarding to `nico-dns` for the site domain configured in `initial_domain_name`.
 
 To configure `unbound`:
@@ -281,10 +276,10 @@ A fixed set of NICo service hostnames are resolved by DPU agents, host PXE loade
 
 Two TLD conventions exist:
 
-- **`.nico`** is the compiled default in `crates/agent/src/util.rs` and the host PXE loader scripts. The agent resolves `nico-pxe.nico`, `nico-ntp.nico`, etc. at startup. This is the TLD used by deployments built from the current binaries.
+- **`.forge`** is the compiled default in `crates/agent/src/util.rs` and the host PXE loader scripts. The agent resolves `carbide-pxe.forge`, `carbide-ntp.forge`, etc. at startup. This is the TLD used by deployments built from the current binaries.
 - **`.nico`** is the rebranded TLD documented in [`deploy/DNS.md`](https://github.com/NVIDIA/infra-controller/blob/main/deploy/DNS.md). New deployments may use this convention, but only if the agent and PXE images have been rebuilt with the new TLD.
 
-Choose the convention that matches your binaries — do not mix. Verify by checking what the agent actually resolves at startup (`kubectl exec -n nico-system <agent-pod> -- getent hosts nico-pxe.nico` or the `.nico` equivalent).
+Choose the convention that matches your binaries — do not mix. Verify by checking what the agent actually resolves at startup (`kubectl exec -n nico-system <agent-pod> -- getent hosts carbide-pxe.forge` or the `.nico` equivalent).
 
 The required A records (shown for `.nico`; substitute `.nico` if your binaries use it) are:
 


### PR DESCRIPTION
Adds `docs/configuration/dns.md` -- the operator guide for NICo name resolution: the record catalog (hostname, `adm`/`bmc` machine-id, and instance forms), `initial_domain_name` and per-segment subdomains, the derived reverse-zone lifecycle and PTR round-trip rules, server behavior, resolver advertisement, and troubleshooting.

Writing it against the code surfaced real errors in `ip-and-network-configuration.md`'s DNS section, fixed here so the pages agree: the documented "PowerDNS remote backend (default)" mode does not exist in the repo, the Kea hook parameter is `carbide-nameservers` (not `nico-nameserver`), and the compiled service-name TLD is `.forge` (the section said `.nico` twice). `host-naming.md` cross-links the new page.

This supports https://github.com/NVIDIA/infra-controller/issues/3641

Closes #3641
