### PR TITLE
Don't run grype scan on PR's

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1046,7 +1046,7 @@ jobs:
       # init container on both amd64 and arm64 control-plane nodes; the payload
       # it ships is unchanged (x86_64 boot blobs). The Dockerfile has no RUN
       # steps (FROM alpine + COPY only), so no QEMU is needed. Single-arch on PR
-      # so the image loads to the daemon for the Grype scan.
+      # so the image can load to the daemon.
       platforms: ${{ needs.prepare.outputs.publish_images == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       runner: linux-amd64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1079,7 +1079,7 @@ jobs:
       # the aarch64 boot blobs as files. Build it multi-arch on push so it can
       # run as an init container on both amd64 and arm64 control-plane nodes. The
       # Dockerfile has no RUN steps (FROM alpine + COPY only), so no QEMU is
-      # needed. Single-arch on PR so the image loads to the daemon for Grype.
+      # needed. Single-arch on PR so the image can load to the daemon.
       platforms: ${{ needs.prepare.outputs.publish_images == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
       runner: linux-amd64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1171,7 +1171,7 @@ jobs:
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
-      load: true  # load to daemon so the Grype scan can read it on PR builds
+      load: true
       scan: true
     secrets: inherit
 
@@ -1191,7 +1191,7 @@ jobs:
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
-      load: true  # load to daemon so the Grype scan can read it on PR builds
+      load: true
       scan: true
     secrets: inherit
 
@@ -1217,7 +1217,7 @@ jobs:
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
-      load: true  # load to daemon so the Grype scan can read it on PR builds
+      load: true
       scan: true
     secrets: inherit
 
@@ -1860,34 +1860,6 @@ jobs:
       SOURCE_PASSWORD: ${{ secrets.NVCR_TOKEN }}
       DEST_USERNAME: ${{ secrets.NVCR_PROD_USERNAME }}
       DEST_PASSWORD: ${{ secrets.NVCR_PROD_TOKEN }}
-
-  # ============================================================================
-  # CONTAINER SCAN SUMMARY
-  # ============================================================================
-  # Aggregates the per-image `grype-*` artifacts produced by the `scan: true`
-  # docker-build jobs into a single sticky comment on copy-pr-bot
-  # `pull-request/N` PRs. Inline Grype only runs on PRs (images are loaded, not
-  # pushed), so this job is PR-only. Advisory only — intentionally NOT wired
-  # into `core-ci-pass` so a scan/aggregation hiccup never blocks a merge.
-  security-container-scan-summary:
-    name: Container Scan Summary
-    runs-on: linux-amd64-cpu4
-    needs:
-      - build-release-container-x86_64
-      - build-machine-a-tron
-      - build-forge-cli-x86_64
-      - build-release-artifacts-x86-host
-      - build-release-artifacts-arm-host
-      - build-release-machine-validation-runner
-      - build-release-machine-validation-artifacts-x86-host
-    if: ${{ always() && contains(github.ref, 'pull-request/') }}
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
-        with:
-          post-pr-comment: 'true'
 
   # ============================================================================
   # NOTIFICATION STAGE

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -71,7 +71,7 @@ on:
         default: false
         type: boolean
       scan:
-        description: 'Run a Grype vulnerability scan on the built image. Only effective when the image is loaded to the daemon (load=true and not pushing, i.e. PR builds); a no-op otherwise.'
+        description: 'Run a Grype vulnerability scan on main after the built image has been pushed.'
         required: false
         default: false
         type: boolean
@@ -255,12 +255,12 @@ jobs:
           DIGEST=$(docker inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${PRIMARY}" | grep -m1 -F "${PRIMARY%:*}@")
           echo "digest=${DIGEST##*@}" >> "$GITHUB_OUTPUT"
 
-      # Scan the image the build step just loaded into the daemon — no rebuild.
-      # Only runs when the image is actually loaded (load=true and not pushing,
-      # i.e. PR builds); on push refs the image isn't loaded so this is skipped.
+      # Scan only the image pushed by the main branch build. This avoids a
+      # vulnerability scan on every pull request while retaining the mainline
+      # security signal.
       - name: Compute Grype scan key
         id: scankey
-        if: ${{ inputs.scan && inputs.load && !inputs.push && steps.build.outcome == 'success' }}
+        if: ${{ inputs.scan && github.ref == 'refs/heads/main' && steps.build.outcome == 'success' }}
         env:
           IMAGE_NAME: ${{ inputs.image_name }}
         run: |
@@ -268,7 +268,7 @@ jobs:
           printf 'key=%s\n' "$key" >> "$GITHUB_OUTPUT"
 
       - name: Grype vulnerability scan
-        if: ${{ inputs.scan && inputs.load && !inputs.push && steps.build.outcome == 'success' }}
+        if: ${{ inputs.scan && github.ref == 'refs/heads/main' && steps.build.outcome == 'success' }}
         continue-on-error: true
         uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -427,25 +427,3 @@ jobs:
 
           ARTIFACTS=$(jq -c . artifacts.json)
           echo "artifacts=$ARTIFACTS" >> $GITHUB_OUTPUT
-
-  security-container-scan-summary:
-    name: Container Scan Summary
-    runs-on: ${{ inputs.runner }}
-    needs:
-      - build-nico-rest-api
-      - build-nico-rest-db
-      - build-nico-rest-site-manager
-      - build-nico-rest-workflow
-      - build-nico-rest-site-agent
-      - build-nico-rest-cert-manager
-      - build-nico-flow
-      - build-nico-psm
-      - build-nico-nsm
-    if: always()
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan-aggregate@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
-        with:
-          post-pr-comment: 'true'

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -179,7 +179,7 @@ jobs:
             org.opencontainers.image.url=${{ github.repositoryUrl }}
 
       - name: Grype vulnerability scan
-        if: matrix.arch == 'amd64'
+        if: matrix.arch == 'amd64' && github.ref == 'refs/heads/main'
         continue-on-error: true
         uses: NVIDIA/dsx-github-actions/.github/actions/security-container-scan@aa4e470cc53f3886545c7d72a984eb81f1d203e2 # v1.16.2
         with:


### PR DESCRIPTION
grype can take upwards of 25 minutes to run, delaying every PR for very little benefit.

Its main job is to scan the resulting container itself, but that's almost never touched by a PR... the vulnerabilities you find by scanning the reuslting container are nearly always the fault of the base image or the prereqs we put in it, and happen *after* vulnerabilies are found in those prereqs: not due to some change we're making in a PR. This is how e.g. dependabot works: we don't block on dependabot for every PR.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Can't really test github workflow changes :-/

## Additional Notes

