### PR TITLE
patch(v2.0): Add per-claim-mapping audience validation for custom issuer 

### DIFF
--- a/rest-api/api/internal/config/config_test.go
+++ b/rest-api/api/internal/config/config_test.go
@@ -61,6 +61,30 @@ func TestNewConfig(t *testing.T) {
 	}
 }
 
+func TestGetIssuersConfigClaimMappingAudiences(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(`
+issuers:
+  - name: custom-issuer
+    issuer: https://auth.example.com
+    jwks: https://auth.example.com/.well-known/jwks.json
+    origin: custom
+    audiences: [issuer-audience]
+    claimMappings:
+      - orgName: acme
+        roles: [TENANT_ADMIN]
+        audiences: [org-audience]
+`)))
+
+	c := &Config{v: v}
+	issuers := c.GetIssuersConfig()
+	require.Len(t, issuers, 1)
+	require.Len(t, issuers[0].ClaimMappings, 1)
+	assert.Equal(t, []string{"issuer-audience"}, issuers[0].Audiences)
+	assert.Equal(t, []string{"org-audience"}, issuers[0].ClaimMappings[0].Audiences)
+}
+
 func TestConfig_WatchConfigFile(t *testing.T) {
 	const initialSitePhoneHomeURL = "http://initial.example/phone_home"
 

--- a/rest-api/auth/README.md
+++ b/rest-api/auth/README.md
@@ -31,6 +31,7 @@ issuers:
 - **Only two roles allowed:** `TENANT_ADMIN`, `PROVIDER_ADMIN`
 - **Audiences:** token needs at least one match → 401 on failure
 - **Scopes:** token needs all configured → 403 on failure (checks `scope`, `scopes`, `scp` claims)
+- **Mapping audiences:** each mapping may require any one exact `aud` match → 403 for that organization
 
 ---
 
@@ -135,6 +136,30 @@ claimMappings:
     rolesAttribute: "main_roles"
 ```
 
+### Shared Issuer with Per-Org Audiences
+
+Issuer-level and mapping-level `audiences` both use ANY-match semantics. When both are configured, the token must satisfy both gates. Mapping audience values are compared exactly and case-sensitively. Omit mapping `audiences` to preserve the existing unrestricted mapping behavior.
+
+```yaml
+issuers:
+  - name: shared-issuer
+    issuer: https://idp.example.com
+    jwks: https://idp.example.com/.well-known/jwks.json
+    origin: custom
+    audiences: ["nico-api"]
+    claimMappings:
+      - orgName: orgA
+        orgDisplayName: Organization A
+        isServiceAccount: true
+        audiences: ["clientA"]
+      - orgName: orgB
+        orgDisplayName: Organization B
+        roles: ["TENANT_ADMIN"]
+        audiences: ["clientB"]
+```
+
+A token with `aud: ["nico-api", "clientA"]` can access only `orgA`; a token with `aud: ["nico-api", "clientB"]` can access only `orgB`. 
+
 ---
 
 ## Validation Rules
@@ -161,6 +186,7 @@ claimMappings:
 | Error | Solution |
 |-------|----------|
 | Token audience mismatch | Check `aud` claim; update `audiences` or remove to skip |
+| Organization audience mismatch | Check the selected claim mapping's `audiences`; token `aud` must match at least one |
 | Token scopes mismatch | Check `scope`/`scopes`/`scp` claim; ensure all required scopes present |
 | Invalid token | Verify `jwks` URL accessible; `issuer` matches `iss` claim exactly |
 | Invalid claim mapping | Add `roles`, `rolesAttribute`, or `isServiceAccount` |

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -81,6 +81,9 @@ type ClaimMapping struct {
 	// Roles: static role list. Used when RolesAttribute is empty and IsServiceAccount is false.
 	Roles []string `mapstructure:"roles"`
 
+	// Audiences: optional token audiences allowed to authorize this mapping. Any one exact match is sufficient.
+	Audiences []string `mapstructure:"audiences"`
+
 	// IsServiceAccount: if true, assigns admin roles (PROVIDER_ADMIN, TENANT_ADMIN). Ignores RolesAttribute/Roles.
 	IsServiceAccount bool `mapstructure:"isServiceAccount"`
 }
@@ -534,18 +537,24 @@ func (jcfg *JwksConfig) GetSubjectPrefix() string {
 	return jcfg.subjectPrefix
 }
 
-// ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
-func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
-	if len(jcfg.Audiences) == 0 {
-		return nil
+// hasAnyAudience checks if the token has any of the configured audiences.
+func (jcfg *JwksConfig) hasAnyAudience(claims jwt.MapClaims, audiences []string) bool {
+	if audiences == nil || len(audiences) == 0 {
+		return true
 	}
+
 	tokenAudiences, err := claims.GetAudience()
 	if err != nil {
-		return core.ErrInvalidAudience
+		return false
 	}
 	tokenAudSet := mapset.NewSet([]string(tokenAudiences)...)
-	requiredAudSet := mapset.NewSet(jcfg.Audiences...)
-	if tokenAudSet.Intersect(requiredAudSet).Cardinality() == 0 {
+	allowedAudSet := mapset.NewSet(audiences...)
+	return tokenAudSet.Intersect(allowedAudSet).Cardinality() > 0
+}
+
+// ValidateAudience checks token has at least one configured audience. Returns nil if none configured.
+func (jcfg *JwksConfig) ValidateAudience(claims jwt.MapClaims) error {
+	if !jcfg.hasAnyAudience(claims, jcfg.Audiences) {
 		return core.ErrInvalidAudience
 	}
 	return nil
@@ -568,6 +577,7 @@ func (jcfg *JwksConfig) ValidateScopes(claims jwt.MapClaims) error {
 // GetOrgDataFromClaim extracts org data for the requested org from claim mappings.
 // This method validates org access and returns errors if:
 //   - core.ErrReservedOrgName: dynamic org claims a statically-configured org name
+//   - core.ErrInvalidAudience: token audience is not authorized for the requested org
 //   - core.ErrInvalidConfiguration: no claim mapping configured for the requested org
 //   - core.ErrNoClaimRoles: no roles found for the requested org
 //
@@ -583,6 +593,10 @@ func (jcfg *JwksConfig) GetOrgDataFromClaim(claims jwt.MapClaims, reqOrgFromRout
 
 		if cm.IsOrgDynamic() && jcfg.ReservedOrgNames != nil && jcfg.ReservedOrgNames[orgName] {
 			return nil, false, core.ErrReservedOrgName
+		}
+
+		if !jcfg.hasAnyAudience(claims, cm.Audiences) {
+			return nil, false, core.ErrInvalidAudience
 		}
 
 		roles, err := cm.GetRoles(claims)

--- a/rest-api/auth/pkg/config/jwks_test.go
+++ b/rest-api/auth/pkg/config/jwks_test.go
@@ -927,3 +927,72 @@ func TestValidateAudiences(t *testing.T) {
 		assert.ErrorIs(t, err, core.ErrInvalidAudience)
 	})
 }
+
+func TestGetOrgDataFromClaimMappingAudiences(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *JwksConfig
+		claims     jwt.MapClaims
+		requestOrg string
+		wantErr    error
+	}{
+		{
+			name: "matching audience authorizes org",
+			config: &JwksConfig{ClaimMappings: []ClaimMapping{{
+				OrgName:   "acme",
+				Roles:     []string{"TENANT_ADMIN"},
+				Audiences: []string{"org-acme"},
+			}}},
+			claims:     jwt.MapClaims{"aud": []string{"issuer-audience", "org-acme"}},
+			requestOrg: "acme",
+		},
+		{
+			name: "wrong audience denies org",
+			config: &JwksConfig{ClaimMappings: []ClaimMapping{{
+				OrgName:   "acme",
+				Roles:     []string{"TENANT_ADMIN"},
+				Audiences: []string{"org-acme"},
+			}}},
+			claims:     jwt.MapClaims{"aud": "different-audience"},
+			requestOrg: "acme",
+			wantErr:    core.ErrInvalidAudience,
+		},
+		{
+			name: "mapping without audiences remains allowed",
+			config: &JwksConfig{ClaimMappings: []ClaimMapping{{
+				OrgName: "acme",
+				Roles:   []string{"TENANT_ADMIN"},
+			}}},
+			claims:     jwt.MapClaims{},
+			requestOrg: "acme",
+		},
+		{
+			name: "reserved dynamic org is rejected before audience",
+			config: &JwksConfig{
+				ClaimMappings: []ClaimMapping{{
+					OrgAttribute:   "org",
+					RolesAttribute: "roles",
+					Audiences:      []string{"org-acme"},
+				}},
+				ReservedOrgNames: map[string]bool{"acme": true},
+			},
+			claims:     jwt.MapClaims{"org": "acme", "roles": []string{"TENANT_ADMIN"}, "aud": "different-audience"},
+			requestOrg: "acme",
+			wantErr:    core.ErrReservedOrgName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orgData, _, err := tt.config.GetOrgDataFromClaim(tt.claims, tt.requestOrg)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, orgData)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Contains(t, orgData, strings.ToLower(tt.requestOrg))
+		})
+	}
+}

--- a/rest-api/auth/pkg/processors/custom.go
+++ b/rest-api/auth/pkg/processors/custom.go
@@ -93,6 +93,9 @@ func (h *CustomProcessor) ProcessToken(c echo.Context, tokenStr string, jwksConf
 		case errors.Is(err, core.ErrReservedOrgName):
 			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("Organization cannot be authorized dynamically using claims data")
 			return nil, util.NewAPIError(http.StatusForbidden, "Organization cannot be authorized dynamically using claims data", nil)
+		case errors.Is(err, core.ErrInvalidAudience):
+			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("Token audience is not authorized for organization specified in URL")
+			return nil, util.NewAPIError(http.StatusForbidden, "Token audience is not authorized for organization specified in URL", nil)
 		case errors.Is(err, core.ErrInvalidConfiguration):
 			logger.Warn().Err(err).Str("requested_org", reqOrgFromRoute).Msg("No authorization configuration exists for organization specified in URL")
 			return nil, util.NewAPIError(http.StatusUnauthorized, "No authorization configuration exists for organization specified in URL", nil)

--- a/rest-api/auth/pkg/processors/custom_test.go
+++ b/rest-api/auth/pkg/processors/custom_test.go
@@ -228,6 +228,66 @@ func TestCustomProcessor_ValidateAudiences_Failure(t *testing.T) {
 	}
 }
 
+func TestCustomProcessor_ClaimMappingAudiences(t *testing.T) {
+	tests := []struct {
+		name             string
+		mappingAudiences []string
+		tokenAudiences   any
+		wantCode         int
+	}{
+		{
+			name:             "mapping audience mismatch returns forbidden",
+			mappingAudiences: []string{"org-audience"},
+			tokenAudiences:   []string{"issuer-audience"},
+			wantCode:         http.StatusForbidden,
+		},
+		{
+			name:             "issuer and mapping audiences pass",
+			mappingAudiences: []string{"org-audience"},
+			tokenAudiences:   []string{"issuer-audience", "org-audience"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor, jwksConfig, privateKey, _, cleanup := setupTestEnvironment(t, []string{"issuer-audience"}, []string{"carbide"})
+			defer cleanup()
+
+			jwksConfig.ClaimMappings = []config.ClaimMapping{{
+				OrgName:   "acme",
+				Roles:     []string{"TENANT_ADMIN"},
+				Audiences: tt.mappingAudiences,
+			}}
+			claims := jwt.MapClaims{
+				"sub":   "mapping-audience-" + tt.name,
+				"iss":   "https://custom.example.com",
+				"aud":   tt.tokenAudiences,
+				"scope": "carbide",
+				"exp":   time.Now().Add(time.Hour).Unix(),
+				"iat":   time.Now().Unix(),
+			}
+			tokenString := createTestToken(t, privateKey, claims)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/org/acme/test", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("orgName")
+			c.SetParamValues("acme")
+
+			_, apiErr := processor.ProcessToken(c, tokenString, jwksConfig, zerolog.Nop())
+			if tt.wantCode == 0 {
+				require.Nil(t, apiErr)
+				return
+			}
+
+			require.NotNil(t, apiErr)
+			assert.Equal(t, tt.wantCode, apiErr.Code)
+			assert.Contains(t, apiErr.Message, "not authorized for organization")
+		})
+	}
+}
+
 func TestCustomProcessor_ValidateScopes_Success(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/rest-api/openapi/auth.md
+++ b/rest-api/openapi/auth.md
@@ -135,6 +135,98 @@ Key fields:
 - `audiences` is optional. If set, the token `aud` claim must contain at least one configured audience.
 - `scopes` is optional. If set, the token must contain all configured scopes. NICo checks the `scope`, `scopes`, and `scp` claims.
 - `claimMappings` is required and controls the organization and roles assigned to authenticated users.
+- A claim mapping may also set `audiences`. The token `aud` claim must contain at least one exact, case-sensitive match for the requested organization's mapping. If issuer and mapping audiences are both configured, both gates must pass.
+
+#### Audience Matching Examples
+
+Audience matching is an exact, case-sensitive overlap check. A configured list uses ANY-match semantics: the token needs at least one value from that list.
+
+With one issuer-level audience:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    audiences: ["api-audience"]
+    claimMappings:
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+```
+
+A token with `aud: ["api-audience", "tenant-client-a"]` passes because `api-audience` overlaps the configured issuer list.
+
+With multiple issuer-level audiences:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    audiences: ["api-audience", "admin-api-audience"]
+    claimMappings:
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+```
+
+The token needs either `api-audience` or `admin-api-audience`; it does not need both.
+
+Mapping audiences can be used without issuer-level audiences:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    claimMappings:
+      - orgName: "automation-org"
+        orgDisplayName: "Automation Organization"
+        isServiceAccount: true
+        audiences: ["automation-client-a"]
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+        audiences: ["tenant-client-a", "tenant-client-b"]
+```
+
+For `automation-org`, the token must contain `automation-client-a`. For `tenant-org`, either `tenant-client-a` or `tenant-client-b` is sufficient. The service-account mapping requires disconnected mode.
+
+When issuer-level and mapping audiences are both configured, they are independent gates:
+
+```yaml
+issuers:
+  - name: "shared-issuer"
+    issuer: "https://idp.example.com"
+    jwks: "https://idp.example.com/.well-known/jwks.json"
+    origin: "custom"
+    audiences: ["api-audience", "admin-api-audience"]
+    claimMappings:
+      - orgName: "automation-org"
+        orgDisplayName: "Automation Organization"
+        isServiceAccount: true
+        audiences: ["automation-client-a", "automation-client-b"]
+      - orgName: "tenant-org"
+        orgDisplayName: "Tenant Organization"
+        roles: ["TENANT_ADMIN"]
+        audiences: ["tenant-client-a", "tenant-client-b"]
+```
+
+A token requesting `automation-org` needs:
+
+- at least one of `api-audience` or `admin-api-audience`; and
+- at least one of `automation-client-a` or `automation-client-b`.
+
+A token requesting `tenant-org` needs:
+
+- at least one of `api-audience` or `admin-api-audience`; and
+- at least one of `tenant-client-a` or `tenant-client-b`.
+
+For example, `aud: ["api-audience", "tenant-client-a"]` authorizes `tenant-org` but not `automation-org`.
 
 NICo supports `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, and `EdDSA` signed tokens.
 
@@ -215,7 +307,7 @@ All three attributes support dot notation for nested claims. For example, if `or
 }
 ```
 
-Dynamic organizations cannot use an organization name already reserved by a static `orgName` mapping.
+Dynamic organizations cannot use an organization name already reserved by a static `orgName` mapping. A dynamic mapping may set `audiences`, but the same flat audience set gates every organization it resolves; audience values are not bound to resolved organization names.
 
 ### Common Configuration Examples
 #### SaaS Service Account
@@ -341,6 +433,7 @@ Use these rules when reviewing a configuration before rollout:
 If requests fail after authentication is enabled, check the token and REST API configuration together.
 
 - `401 Unauthorized` with an audience error usually means the token `aud` claim does not match any configured `audiences`. Update the IdP client audience, update NICo `audiences`, or omit `audiences` if audience enforcement is not needed.
+- `403 Forbidden` with an organization audience error means issuer validation passed, but token `aud` did not match the requested claim mapping's `audiences`.
 - `403 Forbidden` with a scope error usually means the token is missing one or more configured `scopes`. NICo checks `scope`, `scopes`, and `scp`.
 - Invalid token errors often come from an unreachable `jwks` URL, an unsupported signing key, or an `issuer` value that does not exactly match the token `iss` claim.
 - Missing authorization usually means the selected `claimMappings` entry did not produce a valid organization and role set. Check `orgName`, `orgAttribute`, `roles`, and `rolesAttribute`.


### PR DESCRIPTION
> [!IMPORTANT]
> This PR cherry-picks a previously merged PR: #3618  into `release/v2.0`

Custom issuers can map multiple organizations, but issuer-level audience validation allows every accepted token to match every configured mapping. Add optional mapping audiences so shared issuers can confine each client to its intended organization while preserving existing configurations.

## Type of Change
- [x] **Add** - New feature or capability

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Related Issues
Closes #3612

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed: configured keycloak's realm, client, aud, and included as custom issuer instead of keycloak type

Mapping audiences are optional. Existing issuer configurations retain their current behavior when no mapping audiences are configured.
