### PR TITLE
docs(admin-cli): document `rack state-history` command

### DIFF
--- a/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
@@ -13,7 +13,11 @@ nico-admin-cli-rack-state-history - Show rack state history
 
 ## DESCRIPTION
 
-Show rack state history
+Show rack state history.
+
+Records are always returned in chronological order (oldest first). The
+global **--sort-by** option is inherited by this command but has no effect
+on the output.
 
 ## OPTIONS
 
@@ -26,6 +30,9 @@ internal UUIDs that are used to associate instances.
 
 **--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
 Sort output by specified field\
+
+Global option; **not used** by `rack state-history`. Records are always
+listed in chronological order regardless of this value.\
 
 \
 *Possible values:*

--- a/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
@@ -24,7 +24,7 @@ on the output.
 **--extended**  
 Extended result output.
 
-This used by measured boot, where basic output contains just what you
+This is used by measured boot, where basic output contains just what you
 probably care about, and "extended" output also dumps out all the
 internal UUIDs that are used to associate instances.
 

--- a/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md
@@ -1,0 +1,51 @@
+# `nico-admin-cli rack state-history`
+
+_[Hardware commands](../../hardware.md) › [rack](./rack.md) › **state-history**_
+
+## NAME
+
+nico-admin-cli-rack-state-history - Show rack state history
+
+## SYNOPSIS
+
+**nico-admin-cli rack state-history** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*RACK_ID*\>
+
+## DESCRIPTION
+
+Show rack state history
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary id
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+\<*RACK_ID*\>  
+Rack ID to show state history for
+
+## Examples
+
+```sh
+nico-admin-cli rack state-history 12345678-1234-5678-90ab-cdef01234567
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/rack/rack.md
+++ b/docs/manuals/nico-admin-cli/commands/rack/rack.md
@@ -48,6 +48,7 @@ Print help (see a summary with -h)
 | [`metadata`](./rack-metadata.md) | Edit Metadata associated with a Rack |
 | [`profile`](./rack-profile.md) | Rack profile |
 | [`maintenance`](./rack-maintenance.md) | On-demand rack maintenance |
+| [`state-history`](./rack-state-history.md) | Show rack state history |
 
 ---
 


### PR DESCRIPTION
## Description

Adds the missing operator reference page for the `nico-admin-cli rack state-history <RACK_ID>` command.

- New page `docs/manuals/nico-admin-cli/commands/rack/rack-state-history.md`, placed alongside the other `rack` subcommand pages (`rack-show.md`, `rack-profile-show.md`, etc.).
- Structured to match the sibling pages: NAME, SYNOPSIS, DESCRIPTION, OPTIONS (including the global `--extended` and `--sort-by` flags inherited from `cli_options.rs`), Examples, and the See-also footer.
- Adds a `state-history` row to the Subcommands table in `rack.md` so the new page is discoverable from the parent command doc.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

Content verified against the command's clap definition (`crates/admin-cli/src/rack/state_history/args.rs` and `rack/mod.rs`): required `RACK_ID` positional, `about = "Show rack state history"`, and the example mirrors the sibling docs' UUID style.

