### PR TITLE
feat(helm): deploy BMC proxy as part of NICo Core by default

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -13,7 +13,7 @@ The chart is designed for production environments where NICo manages the full li
 | #  | Subchart | Description |
 |----|----------|-------------|
 | 1  | **nico-api** | Core API server (gRPC + REST). Manages machines, provisioning, networking, and firmware. Requires PostgreSQL and Vault. |
-| 2  | **nico-bmc-proxy** | Authenticating proxy for connecting to BMCs over HTTPS (Redfish). |
+| 2  | **nico-bmc-proxy** | Authenticating proxy for connecting to BMCs over HTTPS (Redfish). Required for DPS-based power provisioning. |
 | 3  | **nico-dhcp** | Kea DHCP server for bare-metal PXE boot and IP assignment. |
 | 4  | **nico-dns** | Authoritative DNS server (StatefulSet) for managed machines and VPCs. |
 | 5  | **nico-dsx-exchange-consumer** | Consumes DSX exchange messages for machine telemetry and state updates. Disabled by default. |
@@ -124,6 +124,10 @@ Each subchart can be independently enabled or disabled. All core NICo services a
 ```yaml
 nico-api:
   enabled: true        # Core API -- usually always enabled
+nico-bmc-proxy:
+  enabled: true        # BMC proxy — required for DPS-based power provisioning;
+                       # disable only when an external BMC proxy is deployed
+                       # and wired separately
 nico-dhcp:
   enabled: true        # DHCP for PXE boot
 nico-dns:

--- a/helm/tests/bmc_proxy_default_test.yaml
+++ b/helm/tests/bmc_proxy_default_test.yaml
@@ -1,0 +1,23 @@
+suite: BMC proxy default deployment
+templates:
+  - charts/nico-bmc-proxy/templates/deployment.yaml
+release:
+  name: test-nico
+  namespace: nico-system
+tests:
+  - it: deploys BMC proxy by default with the shared Core image
+    set:
+      global.image.repository: registry.example.com/nvmetal-carbide
+      global.image.tag: test
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: nico-bmc-proxy
+      - equal:
+          path: metadata.namespace
+          value: nico-system
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.com/nvmetal-carbide:test

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -82,11 +82,13 @@ nico-api:
   enabled: true
 
 ## ---------------------------------------------------------------------------
-## nico-bmc-proxy — Standalone BMC proxy
-## Provides an authenticated HTTP proxy to each BMC known by nico
+## nico-bmc-proxy — BMC proxy used by DPS-based power provisioning
+## Provides an authenticated HTTP proxy to each BMC known by nico.
+## Enabled by default as part of NICo Core; set enabled=false only when an
+## external BMC proxy is deployed and wired separately.
 ## ---------------------------------------------------------------------------
 nico-bmc-proxy:
-  enabled: false
+  enabled: true
 
 ## ---------------------------------------------------------------------------
 ## nico-dhcp — DHCP server (Kea-based)


### PR DESCRIPTION
BMC Proxy is required for DPS-based power provisioning, so it shall always be deployed as part of NICo Core (#3298). This flips the umbrella chart default for `nico-bmc-proxy` to enabled and documents when it can be turned off (only when an external BMC proxy is deployed and wired separately).

The subchart already ships with safe defaults for a default-on component: the ServiceMonitor and the external LoadBalancer Service remain opt-in, and its certificate/vault/database dependencies are the standard NICo Core prerequisites.

Adds a chart test asserting the BMC proxy Deployment renders by default into the release namespace using the shared Core image.

## Related issues
Fixes #3298

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`helm unittest` passes for the new suite; the full chart test run shows no new failures relative to main.
