### PR TITLE
feat(bmc): propagate discovered IPMI port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7668,9 +7668,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f381d59345a3974aacc20e44148621457b5002d32fe5c9850fbce9c11c22f90"
+checksum = "a479451ed177b194f1516905192cca7afcb19df746929a696cde25bb59505d22"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -7685,9 +7685,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abd866b1c01bd615cd18afc96305cd436076a16d7a76e53b25bed7fab8422b"
+checksum = "de3e56d83d55644a02a8df38e8708acaae92502e9365ed89283659e772f384e3"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -7709,9 +7709,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ec054643796ede5865fff5f0e3913ddc2bf7f954975f6f512b40d78be07db7"
+checksum = "a53785a0f2fe9ec12e7d5eea889878f9f6957dd71057685b65d4a67014382192"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -7724,9 +7724,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c88dbe8742e28c0e733596661d9c4605ef6cab438cf2c54d1ceb9577053f9a"
+checksum = "40e98d0fb2cfe55eef14406dc37abe45d8423eeff76e4f24bac222a30e9fd6b0"
 dependencies = [
  "clap",
  "clap_derive",
@@ -7742,9 +7742,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-schema"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0a401a80543b6d7c27f28614bc70aa37103cd95b03b0746419bd87e43977f3"
+checksum = "fab0ee38389eee599875be88eee81f6f879d0671e830d20ec424654b74097bd5"
 dependencies = [
  "glob",
 ]
@@ -10890,9 +10890,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ opentelemetry-semantic-conventions = "0.32.1"
 tracing-opentelemetry = "0.33.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.11.0" }
+nv-redfish = { version = "0.12.0" }
 
 ########
 # MARK: - Pinned packages that we can't upgrade due to conflicts or just bugs

--- a/crates/api-core/src/handlers/bmc_metadata.rs
+++ b/crates/api-core/src/handlers/bmc_metadata.rs
@@ -98,7 +98,8 @@ pub(crate) async fn get_inner(
     let ip_address = bmc_endpoint_request.ip_address.parse().map_err(|_| {
         CarbideError::internal("internal error: stored IP address is invalid".to_string())
     })?;
-    let vendor = db::explored_endpoints::lookup_vendor_by_ip(ip_address, pool).await?;
+    let explored_metadata =
+        db::explored_endpoints::lookup_bmc_metadata_by_ip(ip_address, pool).await?;
 
     let (username, password) = match credentials {
         Credentials::UsernamePassword { username, password } => (username, password),
@@ -108,10 +109,10 @@ pub(crate) async fn get_inner(
         ip: bmc_endpoint_request.ip_address,
         port: None,
         ssh_port: None,
-        ipmi_port: None,
+        ipmi_port: explored_metadata.ipmi_port.map(u32::from),
         mac: bmc_mac_address.to_string(),
         user: username,
         password,
-        vendor,
+        vendor: explored_metadata.vendor,
     })
 }

--- a/crates/api-core/tests/integration/machine_bmc_metadata.rs
+++ b/crates/api-core/tests/integration/machine_bmc_metadata.rs
@@ -115,6 +115,7 @@ async fn fetch_bmc_credentials(pool: PgPool) {
 
         assert_eq!(metadata.ip, host_bmc_ip);
         assert_eq!(metadata.port, None);
+        assert_eq!(metadata.ipmi_port, None);
         assert_eq!(metadata.mac, host_bmc_mac.to_string());
         assert!(!metadata.password.is_empty());
         assert!(!metadata.user.is_empty());
@@ -129,6 +130,19 @@ async fn test_fetch_ipmi_metadata(pool: PgPool) {
     let bmc_info = host_machine.bmc_info.clone().unwrap();
     assert_eq!(bmc_info.mac, Some(host_bmc_mac.to_string()));
     let host_bmc_ip = bmc_info.ip.clone().expect("Host BMC IP must be available");
+
+    let mut txn = env.db_txn().await;
+    sqlx::query(
+        "UPDATE explored_endpoints SET exploration_report = \
+         jsonb_set(exploration_report, '{Managers,0,IpmiPort}', '1623'::jsonb, true) \
+         WHERE address = $1",
+    )
+    .bind(IpAddr::from_str(&host_bmc_ip).expect("invalid host IP"))
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
     let metadata = env
         .api()
         .get_bmc_meta_data(tonic::Request::new(rpc::forge::BmcMetaDataGetRequest {
@@ -142,10 +156,53 @@ async fn test_fetch_ipmi_metadata(pool: PgPool) {
         .into_inner();
     assert_eq!(metadata.ip, host_bmc_ip);
     assert_eq!(metadata.port, None);
+    assert_eq!(metadata.ipmi_port, Some(1623));
     assert_eq!(metadata.mac, host_bmc_mac.to_string());
     assert!(!metadata.password.is_empty());
     assert!(!metadata.user.is_empty());
     assert!(metadata.vendor.is_some_and(|v| !v.is_empty()));
+}
+
+#[sqlx_test]
+async fn test_fetch_ipmi_metadata_ignores_invalid_ports(pool: PgPool) {
+    let (env, mh) = init(pool).await;
+    let host_machine = mh.host.rpc_machine().await;
+    let host_bmc_ip = host_machine
+        .bmc_info
+        .as_ref()
+        .and_then(|bmc_info| bmc_info.ip.clone())
+        .expect("Host BMC IP must be available");
+    let host_bmc_ip = IpAddr::from_str(&host_bmc_ip).expect("invalid host IP");
+
+    for invalid_port in [r#""not-a-port""#, "65536", "2147483648"] {
+        let mut txn = env.db_txn().await;
+        sqlx::query(
+            "UPDATE explored_endpoints SET exploration_report = \
+             jsonb_set(exploration_report, '{Managers,0,IpmiPort}', $2::jsonb, true) \
+             WHERE address = $1",
+        )
+        .bind(host_bmc_ip)
+        .bind(invalid_port)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+        txn.commit().await.unwrap();
+
+        let metadata = env
+            .api()
+            .get_bmc_meta_data(tonic::Request::new(rpc::forge::BmcMetaDataGetRequest {
+                machine_id: host_machine.id,
+                request_type: rpc::forge::BmcRequestType::Ipmi.into(),
+                role: rpc::forge::UserRoles::Administrator.into(),
+                bmc_endpoint_request: None,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(metadata.ipmi_port, None, "stored port: {invalid_port}");
+        assert!(metadata.vendor.is_some_and(|vendor| !vendor.is_empty()));
+    }
 }
 
 #[sqlx_test]

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -322,20 +322,34 @@ pub async fn find_all_by_ip(
         .map_err(|e| DatabaseError::new("explored_endpoints find_all_by_ip", e))
 }
 
-pub async fn lookup_vendor_by_ip(
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ExploredBmcMetadata {
+    pub vendor: Option<String>,
+    pub ipmi_port: Option<u16>,
+}
+
+pub async fn lookup_bmc_metadata_by_ip(
     address: IpAddr,
     db_reader: impl DbReader<'_>,
-) -> Result<Option<String>, DatabaseError> {
-    let query = "SELECT exploration_report ->> 'Vendor' AS vendor FROM explored_endpoints WHERE address = $1";
+) -> Result<ExploredBmcMetadata, DatabaseError> {
+    let query = "SELECT exploration_report ->> 'Vendor' AS vendor, \
+                 exploration_report #>> '{Managers,0,IpmiPort}' AS ipmi_port \
+                 FROM explored_endpoints WHERE address = $1";
 
-    // exploration_report is JSONB and technically the Vendor field can be set to NULL, so we need 2 levels of Option<T>
-    let vendor: Option<Option<String>> = sqlx::query_scalar(query)
+    let metadata: Option<(Option<String>, Option<String>)> = sqlx::query_as(query)
         .bind(address)
         .fetch_optional(db_reader)
         .await
-        .map_err(|e| DatabaseError::new("explored_endpoints lookup_vendor_by_ip", e))?;
+        .map_err(|e| DatabaseError::new("explored_endpoints lookup_bmc_metadata_by_ip", e))?;
 
-    Ok(vendor.flatten())
+    Ok(
+        metadata.map_or_else(ExploredBmcMetadata::default, |(vendor, ipmi_port)| {
+            ExploredBmcMetadata {
+                vendor,
+                ipmi_port: ipmi_port.and_then(|port| port.parse().ok()),
+            }
+        }),
+    )
 }
 
 /// Updates the explored information about a node

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1496,6 +1496,8 @@ pub struct Manager {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ethernet_interfaces: Vec<EthernetInterface>,
     pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ipmi_port: Option<u16>,
 }
 
 /// `EthernetInterface` definition. Matches redfish definition
@@ -2900,6 +2902,7 @@ mod tests {
             managers: vec![Manager {
                 ethernet_interfaces: vec![],
                 id: "bmc".to_string(),
+                ipmi_port: None,
             }],
             systems: vec![ComputerSystem {
                 ethernet_interfaces: vec![],
@@ -2971,6 +2974,7 @@ mod tests {
             managers: vec![Manager {
                 ethernet_interfaces: vec![],
                 id: "bmc".to_string(),
+                ipmi_port: None,
             }],
             systems: vec![ComputerSystem {
                 ethernet_interfaces: vec![],

--- a/crates/api-model/src/test_support/dpu.rs
+++ b/crates/api-model/src/test_support/dpu.rs
@@ -71,6 +71,7 @@ impl From<DpuConfig> for EndpointExplorationReport {
             machine_id: None,
             managers: vec![Manager {
                 id: "bmc".to_string(),
+                ipmi_port: None,
                 ethernet_interfaces: vec![EthernetInterface {
                     id: Some("eth0".to_string()),
                     description: Some("Management Network Interface".to_string()),

--- a/crates/api-model/src/test_support/managed_host.rs
+++ b/crates/api-model/src/test_support/managed_host.rs
@@ -285,6 +285,7 @@ impl From<ManagedHostConfig> for EndpointExplorationReport {
             vendor: value.vendor,
             managers: vec![Manager {
                 id: "iDRAC.Embedded.1".to_string(),
+                ipmi_port: None,
                 ethernet_interfaces: vec![EthernetInterface {
                     id: Some("NIC.1".to_string()),
                     description: Some("Management Network Interface".to_string()),

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -45,6 +45,7 @@ nv-redfish = { workspace = true, features = [
   "computer-systems",
   "ethernet-interfaces",
   "host-interfaces",
+  "manager-network-protocol",
   "network-adapters",
   "network-device-functions",
   "managers",

--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::num::TryFromIntError;
 use std::str::FromStr;
 
 use carbide_network::{deserialize_input_mac_to_address, is_locally_administered_mac};
@@ -32,6 +33,17 @@ use nv_redfish::{Bmc, Resource};
 
 use crate::Error;
 
+fn enabled_ipmi_port(
+    protocol_enabled: Option<Option<bool>>,
+    port: Option<Option<i64>>,
+) -> Result<Option<u16>, TryFromIntError> {
+    if protocol_enabled != Some(Some(true)) {
+        return Ok(None);
+    }
+
+    port.flatten().map(u16::try_from).transpose()
+}
+
 #[derive(Default)]
 pub struct Config {
     pub need_host_interfaces: bool,
@@ -45,6 +57,7 @@ pub struct Config {
 pub struct ExploredManager<B: Bmc> {
     pub manager: Manager<B>,
     pub eth_interfaces: Vec<EthernetInterface<B>>,
+    pub ipmi_port: Option<u16>,
     pub host_interfaces: Option<Vec<HostInterface<B>>>,
     pub oem_dell_attributes: Option<DellAttributes<B>>,
     pub oem_lenovo_security_service: Option<LenovoSecurityService<B>>,
@@ -136,9 +149,33 @@ impl<B: Bmc> ExploredManager<B> {
             None
         };
 
+        let ipmi_port = manager
+            .network_protocol()
+            .await
+            .map_err(Error::nv_redfish("manager network protocol"))?
+            .and_then(|network_protocol| {
+                let raw = network_protocol.raw();
+                raw.ipmi.as_ref().and_then(|ipmi| {
+                    let reported_port = ipmi.port.flatten();
+                    match enabled_ipmi_port(ipmi.protocol_enabled, ipmi.port) {
+                        Ok(port) => port,
+                        Err(error) => {
+                            tracing::warn!(
+                                manager_id = %manager.id(),
+                                ipmi_port = ?reported_port,
+                                error = %error,
+                                "Ignoring invalid IPMI port reported by Redfish",
+                            );
+                            None
+                        }
+                    }
+                })
+            });
+
         Ok(Self {
             manager,
             eth_interfaces,
+            ipmi_port,
             host_interfaces,
             oem_dell_attributes,
             oem_lenovo_security_service,
@@ -217,6 +254,43 @@ impl<B: Bmc> ExploredManager<B> {
         Ok(ModelManager {
             id: self.manager.id().inner().to_string(),
             ethernet_interfaces,
+            ipmi_port: self.ipmi_port,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::enabled_ipmi_port;
+
+    #[test]
+    fn extracts_only_enabled_valid_ipmi_ports() {
+        let cases = [
+            (
+                "enabled",
+                Some(Some(true)),
+                Some(Some(1623)),
+                Ok(Some(1623)),
+            ),
+            ("disabled", Some(Some(false)), Some(Some(1623)), Ok(None)),
+            ("enabled state absent", None, Some(Some(1623)), Ok(None)),
+            ("port absent", Some(Some(true)), None, Ok(None)),
+            ("port null", Some(Some(true)), Some(None), Ok(None)),
+            ("negative port", Some(Some(true)), Some(Some(-1)), Err(())),
+            (
+                "port above u16 range",
+                Some(Some(true)),
+                Some(Some(65_536)),
+                Err(()),
+            ),
+        ];
+
+        for (name, protocol_enabled, port, expected) in cases {
+            assert_eq!(
+                enabled_ipmi_port(protocol_enabled, port).map_err(drop),
+                expected,
+                "{name}",
+            );
+        }
     }
 }

--- a/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
+++ b/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
@@ -30,6 +30,7 @@ use crate::common;
 #[test]
 async fn explore_supermicro_gb300() {
     let h = test_support::supermicro_gb300_bmc().await;
+    h.state.manager.set_ipmi_endpoint(Some(1623));
     let config = common::explorer_config();
 
     // Decisive assertion: an SMC GB300 must resolve to SupermicroGb300, not the
@@ -47,6 +48,10 @@ async fn explore_supermicro_gb300() {
         .unwrap();
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Supermicro));
+    assert_eq!(
+        report.managers.first().and_then(|m| m.ipmi_port),
+        Some(1623)
+    );
     assert!(!report.systems.is_empty(), "systems must be present");
     assert!(!report.chassis.is_empty(), "chassis must be present");
 }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -4328,6 +4328,7 @@ mod tests {
             }],
             managers: vec![Manager {
                 id: "Bluefield_BMC".to_string(),
+                ipmi_port: None,
                 ethernet_interfaces: vec![EthernetInterface {
                     id: Some("eth0".to_string()),
                     mac_address: Some(eth0_mac.parse().unwrap()),

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -722,6 +722,7 @@ async fn fetch_manager(client: &dyn Redfish) -> Result<Manager, RedfishError> {
     Ok(Manager {
         ethernet_interfaces,
         id: manager.id,
+        ipmi_port: None,
     })
 }
 


### PR DESCRIPTION
Redfish exposes the configured IPMI endpoint through ManagerNetworkProtocol. NICo previously discarded this information, causing consumers such as ssh-console to always fall back to the conventional IPMI port 623.

This change discovers the enabled IPMI port from ManagerNetworkProtocol, stores it in the exploration report, and returns it through the existing BMC metadata API. Consumers can now use the port reported by the BMC while retaining 623 as a fallback  when no port is available.

As a secondary benefit, this enables end-to-end IPMI SOL testing with machine-a-tron and bmc-mock, where IPMI simulators use dynamically allocated ports.

## Related issues

#3378 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

- Missing or disabled IPMI configuration remains None, allowing consumers to retain their existing fallback behavior.
- Invalid Redfish or stored port values are ignored safely.
- The exploration report change is backward compatible because IpmiPort is optional.
- ssh-console already consumes ipmi_port from the BMC metadata response, so no console-side changes are required.
- Current exploration stores one Redfish manager. Multi-manager discovery and manager-to-system association are outside this change.

