### PR TITLE
feat(dhcp-server): support configurable UDP ports

### DIFF
--- a/crates/dhcp-server/src/command_line.rs
+++ b/crates/dhcp-server/src/command_line.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::net::SocketAddrV4;
+
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser, Debug, Clone)]
@@ -22,6 +24,20 @@ use clap::{Parser, ValueEnum};
 pub struct Args {
     #[arg(long, help = "Interface name where to bind this server.")]
     pub interfaces: Vec<String>,
+
+    #[arg(
+        long,
+        help = "UDP address where the DHCP server listens.",
+        default_value = "0.0.0.0:67"
+    )]
+    pub listen_addr: SocketAddrV4,
+
+    #[arg(
+        long,
+        help = "UDP destination port for responses to DHCP relays.",
+        default_value_t = 67
+    )]
+    pub relay_response_port: u16,
 
     #[arg(
         long,
@@ -64,5 +80,42 @@ pub enum ServerMode {
 impl Args {
     pub fn load() -> Self {
         Self::parse()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use clap::Parser;
+
+    use super::Args;
+
+    #[test]
+    fn dhcp_port_arguments() {
+        let defaults = Args::try_parse_from(["forge-dhcp-server"]).unwrap();
+        assert_eq!(
+            defaults.listen_addr,
+            SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 67)
+        );
+        assert_eq!(defaults.relay_response_port, 67);
+
+        let overridden = Args::try_parse_from([
+            "forge-dhcp-server",
+            "--listen-addr",
+            "127.0.0.1:6767",
+            "--relay-response-port",
+            "6768",
+        ])
+        .unwrap();
+        assert_eq!(
+            overridden.listen_addr,
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 6767)
+        );
+        assert_eq!(overridden.relay_response_port, 6768);
+
+        assert!(
+            Args::try_parse_from(["forge-dhcp-server", "--listen-addr", "[::]:6767",]).is_err()
+        );
     }
 }

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -106,13 +106,13 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
     for interface in args.interfaces {
         let config_ = config__.clone();
         let args_mode = args.mode.clone();
+        let listen_address = args.listen_addr;
         let dhcp_timestamps_ = dhcp_timestamps.clone();
         let rate_limiter = rate_limiter_.clone();
         let cancel = cancel_token.clone();
 
         let handle = tokio::spawn(async move {
             let handler: Arc<Box<dyn DhcpMode>> = Arc::new(get_mode(&args_mode));
-            let listen_address = SocketAddr::new(std::net::IpAddr::from([0, 0, 0, 0]), 67);
 
             let socket = get_socket(listen_address, interface.clone()).await;
             tracing::info!(
@@ -557,6 +557,7 @@ fn get_mode(args_mode: &ServerMode) -> Box<dyn DhcpMode> {
 pub struct Config {
     dhcp_config: DhcpConfig,
     host_config: Option<HostConfig>, // Valid only for Dpu mode.
+    relay_response_port: u16,
 }
 
 async fn init(args: Args) -> Result<Config, DhcpError> {
@@ -573,6 +574,7 @@ async fn init(args: Args) -> Result<Config, DhcpError> {
     Ok(Config {
         dhcp_config,
         host_config,
+        relay_response_port: args.relay_response_port,
     })
 }
 
@@ -736,6 +738,8 @@ mod test {
     fn make_reload_args(td: &TempDir, interfaces: Vec<String>) -> Args {
         Args {
             interfaces,
+            listen_addr: "0.0.0.0:67".parse().unwrap(),
+            relay_response_port: 67,
             dhcp_config: td.path().join("dhcp.yaml").display().to_string(),
             host_config: Some(td.path().join("host.yaml").display().to_string()),
             mode: ServerMode::Dpu,
@@ -901,6 +905,8 @@ mod test {
 
         Args {
             interfaces: vec!["eth0".to_string()],
+            listen_addr: "0.0.0.0:67".parse().unwrap(),
+            relay_response_port: 67,
             dhcp_config: base_path.join("conf/conf.yaml").display().to_string(),
             host_config: Some(
                 base_path
@@ -973,7 +979,9 @@ mod test {
             MessageType::Request,
         );
         let handler: Box<dyn DhcpMode> = Box::new(Test {});
-        let config = init(get_test_args()).await.unwrap();
+        let mut args = get_test_args();
+        args.relay_response_port = 6768;
+        let config = init(args).await.unwrap();
         let mut machine_cache = Arc::new(Mutex::new(LruCache::new(
             std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE).unwrap(),
         )));
@@ -989,7 +997,7 @@ mod test {
 
         assert_eq!(
             packet.dst_address(),
-            SocketAddrV4::new(Ipv4Addr::from([0x0a, 0xd9, 0x05, 0x29]), 67)
+            SocketAddrV4::new(Ipv4Addr::from([0x0a, 0xd9, 0x05, 0x29]), 6768)
         );
         let packet = Message::decode(&mut dhcproto::Decoder::new(packet.encoded_packet())).unwrap();
 
@@ -1178,6 +1186,11 @@ mod test {
         )
         .await
         .unwrap();
+
+        assert_eq!(
+            encoded_packet.dst_address(),
+            SocketAddrV4::new(Ipv4Addr::BROADCAST, 68)
+        );
 
         // The reply type the send path counts lease grants under matches the
         // encoded reply.

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -188,10 +188,14 @@ impl DecodedPacket {
     /// Relay/Gateway IP is used as destination ip.
     /// Only exception is if ciaddr is not empty. If it is not empty means client already has a IP
     /// and listening on it.
-    fn decide_dst_ip(&self, _message_type: MessageType) -> (Ipv4Addr, u16) {
+    fn decide_dst_ip(
+        &self,
+        _message_type: MessageType,
+        relay_response_port: u16,
+    ) -> (Ipv4Addr, u16) {
         // Relayed packet.
         if self.packet.giaddr() != Ipv4Addr::from([0, 0, 0, 0]) {
-            return (self.packet.giaddr(), 67); // Relayed packet. Relay listen on 67
+            return (self.packet.giaddr(), relay_response_port);
         }
 
         // Client unicast packet. Lease renewal case.
@@ -283,7 +287,8 @@ pub async fn process_packet(
         )
         .await?;
 
-    let (dst_address, dst_port) = decoded_packet.decide_dst_ip(msg_type);
+    let (dst_address, dst_port) =
+        decoded_packet.decide_dst_ip(msg_type, config.relay_response_port);
 
     let packet =
         create_dhcp_reply_packet(&decoded_packet, circuit_id, dhcp_response, config, msg_type)?;

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -87,7 +87,7 @@ pub fn machine_get_filename(
 }
 
 /// Create a UDP socket and set non_blocking, broadcast and other options flag on it.
-pub async fn get_socket(listen_address: core::net::SocketAddr, interface: String) -> UdpSocket {
+pub async fn get_socket(listen_address: core::net::SocketAddrV4, interface: String) -> UdpSocket {
     for retry in 0..10 {
         // Create a socket2.socket. std and tokio sockets do not support advance options like
         // reuseaddr to be set.


### PR DESCRIPTION
Allow `forge-dhcp-server` to use configurable UDP ports instead of requiring the standard privileged DHCP ports in every environment.

The server previously hardcoded both its listen address to `0.0.0.0:67` and relayed response destinations to UDP port 67. This prevented local and integration environments from exercising the real DHCP packet path without elevated privileges.

This change adds:
  - `--listen-addr`, defaulting to `0.0.0.0:67`.
  - `--relay-response-port`, defaulting to `67`.

The defaults preserve existing production behavior. Direct client and broadcast responses continue to use UDP port 68. Because the server creates an IPv4 socket, IPv6 listen addresses are rejected during argument parsing instead of failing later during  socket setup.

## Related issues

#3366 

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

