### PR TITLE
Omit misleading free IP count from fast path error

### DIFF
--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1382,9 +1382,15 @@ async fn create_fast_path(
         }
     }
 
+    let segment_list = segments
+        .iter()
+        .map(|segment| format!("`{}` ({})", segment.config.name, segment.id))
+        .collect::<Vec<_>>()
+        .join(", ");
+
     Err(DatabaseError::internal(format!(
-        "unable to create machine interface in fast path out of segments {:?} after {} retries",
-        segments, FAST_PATH_MAX_RETRIES
+        "unable to create machine interface in fast path out of segments {} after {} retries",
+        segment_list, FAST_PATH_MAX_RETRIES
     )))
 }
 


### PR DESCRIPTION
Fast-path machine-interface creation errors currently report
`NetworkPrefix.num_free_ips: 0` even when the number of available IPs was not
computed. Because the DHCP discovery path does not request that computation,
the reported zero is only the field's default value and can mislead operators
into diagnosing address-pool exhaustion.

This change replaces the raw `Debug` output with a concise list of segment
names and IDs constructed directly in `create_fast_path`. Each segment is
reported as `<name> (<id>)`, retaining useful identification without exposing
uncomputed fields such as `num_free_ips`.

## Related issues

Fixes NVIDIA/infra-controller#3384

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands run:

- `cargo fmt --all -- --check`
- `cargo check -p carbide-api-db --lib`
- `cargo test -p carbide-api-db --lib --no-run`

The full `cargo test -p carbide-api-db --lib` suite was also attempted. It
could not complete because database-backed tests require `DATABASE_URL`, which
is not configured on this host. Before the suite reported the database setup
failures, 81 tests passed.

## Additional Notes

This is a diagnostic-only change. IP allocation behavior and free-IP
calculation are unchanged.
