### PR TITLE
feat(instrument): per-instance log messages via message = dynamic

### DIFF
--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -125,11 +125,19 @@ enum MetricSpec {
     None,
 }
 
+/// The `message` knob: absent, a static string, or `dynamic` -- the last routed
+/// through the hand-implemented `DynamicMessage`.
+enum MessageSpec {
+    None,
+    Static(LitStr),
+    Dynamic,
+}
+
 struct EventArgs {
     event_name: Option<LitStr>,
     metric_name: Option<LitStr>,
     component: Option<LitStr>,
-    message: Option<LitStr>,
+    message: MessageSpec,
     describe: Option<LitStr>,
     unit: Option<LitStr>,
     log: LogSpec,
@@ -143,7 +151,7 @@ fn parse_event_args(input: &DeriveInput) -> syn::Result<EventArgs> {
         event_name: None,
         metric_name: None,
         component: None,
-        message: None,
+        message: MessageSpec::None,
         describe: None,
         unit: None,
         log: LogSpec::Info,
@@ -177,7 +185,17 @@ fn parse_event_args(input: &DeriveInput) -> syn::Result<EventArgs> {
             } else if meta.path.is_ident("component") {
                 args.component = Some(meta.value()?.parse()?);
             } else if meta.path.is_ident("message") {
-                args.message = Some(meta.value()?.parse()?);
+                let value = meta.value()?;
+                args.message = if value.peek(LitStr) {
+                    MessageSpec::Static(value.parse()?)
+                } else {
+                    let ident: Ident = value.parse()?;
+                    if ident == "dynamic" {
+                        MessageSpec::Dynamic
+                    } else {
+                        return Err(meta.error("message must be a string literal or `dynamic`"));
+                    }
+                };
             } else if meta.path.is_ident("describe") {
                 args.describe = Some(meta.value()?.parse()?);
             } else if meta.path.is_ident("unit") {
@@ -460,11 +478,11 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         ));
     }
 
-    if args.message.is_none() && args.log != LogSpec::Off {
+    if matches!(args.message, MessageSpec::None) && args.log != LogSpec::Off {
         return Err(syn::Error::new_spanned(
             &input.ident,
-            "message = \"...\" is required when the event logs (or set log = off for a \
-             metric-only event)",
+            "a message is required when the event logs: set message = \"...\" or \
+             message = dynamic (or set log = off for a metric-only event)",
         ));
     }
     if args.log == LogSpec::Off && args.metric == MetricSpec::None {
@@ -555,7 +573,11 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         Some(metric_name) => quote! { ::std::option::Option::Some(#metric_name) },
         None => quote! { ::std::option::Option::None },
     };
-    let message_value = args.message.as_ref().map(LitStr::value).unwrap_or_default();
+    let message_body = match &args.message {
+        MessageSpec::Static(message) => quote! { #message },
+        MessageSpec::Dynamic => quote! { ::carbide_instrument::DynamicMessage::message(self) },
+        MessageSpec::None => quote! { "" },
+    };
     let describe_value = args
         .describe
         .as_ref()
@@ -638,7 +660,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
             type Labels = [::carbide_instrument::__private::opentelemetry::KeyValue; #n_labels];
 
             fn message(&self) -> &'static str {
-                #message_value
+                #message_body
             }
 
             fn labels(&self) -> Self::Labels {
@@ -817,5 +839,16 @@ mod tests {
 
         let machine_id = Ident::new("machine_id", Span::call_site());
         assert!(validate_event_log_field(LogSpec::Info, FieldKind::Context, &machine_id).is_ok());
+    }
+
+    #[test]
+    fn message_rejects_an_unknown_bare_word() {
+        let error = expansion_error(
+            r#"#[event(event_name = "demo", component = "demo", message = bogus)] struct Demo {}"#,
+        );
+        assert!(
+            error.contains("string literal or `dynamic`"),
+            "expected a message-value diagnostic, got `{error}`"
+        );
     }
 }

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -446,6 +446,17 @@ pub trait DynamicLog {
     fn log_at(&self) -> LogAt;
 }
 
+/// Per-instance message selection for `message = dynamic` events: implement
+/// this and the derive routes `Event::message` through it, choosing the log
+/// message from the event's own fields. Return a distinct `&'static str` per
+/// case, e.g. by matching on a `#[label]` enum. Reach for it only when the
+/// wording says something a label doesn't: where the label already names the
+/// case, a static `message` plus that label is the leaner choice.
+pub trait DynamicMessage {
+    /// The message for this instance's log line.
+    fn message(&self) -> &'static str;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -525,6 +536,62 @@ mod tests {
         assert_eq!(
             carbide_instrument::Event::log_at(&event),
             carbide_instrument::LogAt::Off
+        );
+    }
+
+    #[derive(carbide_instrument::Event)]
+    #[event(
+        event_name = "dynamic_message_test",
+        component = "instrument_test",
+        log = dynamic,
+        message = dynamic,
+    )]
+    struct DynamicMessageTest {
+        #[label]
+        outcome: carbide_instrument::Outcome,
+    }
+
+    impl carbide_instrument::DynamicLog for DynamicMessageTest {
+        fn log_at(&self) -> carbide_instrument::LogAt {
+            match self.outcome {
+                carbide_instrument::Outcome::Error => {
+                    carbide_instrument::LogAt::Level(tracing::Level::WARN)
+                }
+                carbide_instrument::Outcome::Ok => carbide_instrument::LogAt::Off,
+            }
+        }
+    }
+
+    impl carbide_instrument::DynamicMessage for DynamicMessageTest {
+        fn message(&self) -> &'static str {
+            match self.outcome {
+                carbide_instrument::Outcome::Error => "call failed",
+                carbide_instrument::Outcome::Ok => "call finished",
+            }
+        }
+    }
+
+    #[test]
+    fn dynamic_message_selects_wording_per_variant() {
+        let ok = DynamicMessageTest {
+            outcome: carbide_instrument::Outcome::Ok,
+        };
+        let err = DynamicMessageTest {
+            outcome: carbide_instrument::Outcome::Error,
+        };
+
+        // `message = dynamic` routes `Event::message` through `DynamicMessage`.
+        assert_eq!(carbide_instrument::Event::message(&ok), "call finished");
+        assert_eq!(carbide_instrument::Event::message(&err), "call failed");
+
+        // The message axis is independent of the level axis (`DynamicLog`).
+        assert_eq!(
+            carbide_instrument::Event::log_at(&ok),
+            carbide_instrument::LogAt::Off
+        );
+        assert_eq!(
+            carbide_instrument::Event::log_at(&err),
+            carbide_instrument::LogAt::Level(tracing::Level::WARN)
         );
     }
 }

--- a/crates/xtask/src/metric_docs.rs
+++ b/crates/xtask/src/metric_docs.rs
@@ -252,10 +252,16 @@ fn event_metric(item: &ItemStruct, source: &Path) -> eyre::Result<Option<Declare
             metric_name_unchecked = true;
         } else if meta.path.is_ident("describe_unchecked") {
             // A flag with no value, and no bearing on documentation.
-        } else if meta.path.is_ident("component")
-            || meta.path.is_ident("message")
-            || meta.path.is_ident("unit")
-        {
+        } else if meta.path.is_ident("message") {
+            // Either a string literal or the `dynamic` ident (message = dynamic);
+            // the gate ignores the value but must consume whichever form.
+            let value = meta.value()?;
+            if value.peek(syn::LitStr) {
+                let _: syn::LitStr = value.parse()?;
+            } else {
+                let _: syn::Ident = value.parse()?;
+            }
+        } else if meta.path.is_ident("component") || meta.path.is_ident("unit") {
             // String-valued keys the gate ignores; consumed to keep parsing.
             let _: syn::LitStr = meta.value()?.parse()?;
         } else if meta.path.is_ident("log") {
@@ -449,6 +455,22 @@ mod tests {
         );
         assert_eq!(metrics.len(), 1);
         assert_eq!(metrics[0].name, "carbide_cooked_total");
+    }
+
+    /// A metric-backed event may declare `message = dynamic` (per-variant log
+    /// wording); the gate consumes the ident form and still collects the row.
+    #[test]
+    fn dynamic_message_counter_is_collected() {
+        let metrics = declared(
+            r#"
+            #[derive(Event)]
+            #[event(metric_name = "carbide_dynmsg_total", component = "c", log = dynamic,
+                    metric = counter, message = dynamic, describe = "Number of dynmsg things")]
+            struct DynMsg;
+            "#,
+        );
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].name, "carbide_dynmsg_total");
     }
 
     /// Events under `#[cfg(test)]` -- on the struct or an enclosing module --


### PR DESCRIPTION
`Event`'s log `message` has been a single static string. `message = dynamic` lets an event pick its message per instance: declare it instead of a literal `message`, implement the new `DynamicMessage` trait, and the derive routes `Event::message()` through it, typically a match on a `#[label]` enum. Level and message stay independent axes.

That lets an event that today keeps a separate `tracing::` line per outcome (purely to preserve per-variant wording) fold that line into the `emit()`, so the metric and its message are one declaration.

- `DynamicMessage` trait plus the `message = dynamic` value; a `message` that is neither a string literal nor `dynamic` is a compile error.
- The `check-metric-docs` gate learns the ident form, so a metric-backed event can use `message = dynamic` without tripping the catalogue parser.

Guide docs are in a separate PR (#3707).

Part of the instrumentation-coherency initiative (#3169). Enables the folded metric+log form for outcome-enum events like the `/metrics` scrape-failure meta-metric (#3546, contributor PR #3686).
