### PR TITLE
feat(nvos): support password rotation

### DIFF
--- a/crates/admin-cli/src/credential/common.rs
+++ b/crates/admin-cli/src/credential/common.rs
@@ -52,13 +52,8 @@ pub enum UefiCredentialType {
 /// 1:1 onto `rpc::forge::RotationCredentialType` (minus its proto3 `Unspecified`
 /// zero value).
 ///
-/// NVOS is listed even though the server does not own that password yet:
-/// requesting it today returns a `FailedPrecondition` explaining it is gated on
-/// set-NVOS-from-factory (REQ-6). Exposing it here keeps the "which families are
-/// supported" policy in exactly one place -- the server's `to_rotation_type` --
-/// so enabling NVOS later is a pure server change, and an operator who tries it
-/// now gets that actionable error instead of a bare "invalid value" from argument
-/// parsing.
+/// NVOS is listed because the server can stage site-wide NVOS targets. Device
+/// convergence depends on the switch-controller and component-manager path.
 #[derive(ValueEnum, Parser, Debug, Clone)]
 pub enum RotationCredentialKind {
     Bmc,

--- a/crates/admin-cli/src/credential/rotate/args.rs
+++ b/crates/admin-cli/src/credential/rotate/args.rs
@@ -31,6 +31,9 @@ Rotate the site-wide BMC root password, letting the server auto-generate a stron
 Rotate the host UEFI password to an explicit value:
     $ nico-admin-cli credential rotate --type=host-uefi --password=Str0ng-Explicit-Pw!
 
+Stage a site-wide NVOS target password after seeding current per-switch credentials:
+    $ nico-admin-cli credential rotate --type=nvos --password=MyNvosPassword-2026
+
 Rotate the SuperNIC lockdown IKM with an audit note:
     $ nico-admin-cli credential rotate --type=lockdown-ikm --reason=\"quarterly rotation\"
 

--- a/crates/admin-cli/src/credential/tests.rs
+++ b/crates/admin-cli/src/credential/tests.rs
@@ -387,6 +387,7 @@ fn rotate_maps_to_proto() {
         req.credential_type,
         RotationCredentialType::RotationBmc as i32
     );
+
     assert!(req.password.is_none());
 }
 
@@ -451,8 +452,7 @@ fn rotation_credential_kind_to_proto() {
         RotationCredentialType::from(RotationCredentialKind::DpuUefi),
         RotationCredentialType::RotationDpuUefi
     ));
-    // NVOS maps through even though the server rejects it today (FailedPrecondition
-    // until REQ-6); the CLI exposes it so support is a pure server-side change.
+
     assert!(matches!(
         RotationCredentialType::from(RotationCredentialKind::Nvos),
         RotationCredentialType::RotationNvos
@@ -510,8 +510,7 @@ fn uefi_credential_type_value_enum() {
 }
 
 // rotation_credential_kind_value_enum ensures RotationCredentialKind parses from
-// kebab-case strings, including nvos (which the CLI exposes so the server can
-// return its FailedPrecondition rather than arg parsing rejecting it outright).
+// kebab-case strings.
 #[test]
 fn rotation_credential_kind_value_enum() {
     use clap::ValueEnum;

--- a/crates/admin-cli/src/expected_switch/update/cmd.rs
+++ b/crates/admin-cli/src/expected_switch/update/cmd.rs
@@ -16,12 +16,19 @@
  */
 
 use rpc::forge::ExpectedSwitch;
+use rpc::forge_api_client::expected_switch_update_mask;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
 
 pub async fn update(data: Args, api_client: &ApiClient) -> color_eyre::Result<()> {
-    let request: ExpectedSwitch = data.try_into()?;
-    api_client.0.update_expected_switch(request).await?;
+    let patch: ExpectedSwitch = data.try_into()?;
+    let update_mask = expected_switch_update_mask(&patch);
+
+    api_client
+        .0
+        .patch_expected_switch(patch, &update_mask)
+        .await?;
+
     Ok(())
 }

--- a/crates/api-core/src/credentials/bmc_session_manager.rs
+++ b/crates/api-core/src/credentials/bmc_session_manager.rs
@@ -1244,6 +1244,13 @@ mod tests {
 
     #[async_trait]
     impl CredentialWriter for CountingCredentialManager {
+        async fn get_credentials_from_writer(
+            &self,
+            key: &CredentialKey,
+        ) -> Result<Option<Credentials>, SecretsError> {
+            CredentialReader::get_credentials(self, key).await
+        }
+
         async fn set_credentials(
             &self,
             _key: &CredentialKey,

--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -25,6 +25,7 @@ use carbide_redfish::libredfish::dpu_bios::is_dpu_bios_attributes_not_ready;
 use carbide_site_explorer::EndpointExplorationServiceError;
 use carbide_uuid::machine::MachineId;
 use config_version::ConfigVersionParseError;
+use db::credential_rotation::CredentialRotationType;
 use db::ip_allocator::DhcpError;
 use db::machine_interface_address::AddressAlreadyInUseError;
 use db::resource_pool::ResourcePoolDatabaseError;
@@ -305,8 +306,15 @@ impl From<DatabaseError> for CarbideError {
             DatabaseError::InvalidArgument(e) => InvalidArgument(e),
             DatabaseError::InvalidConfiguration(e) => InvalidConfiguration(e),
             DatabaseError::MissingArgument(e) => MissingArgument(e),
-            // A corrupted/absent site-wide rotation invariant is an internal
-            // state error, not a client-correctable one.
+            // NVOS intentionally has no target until its first versioned secret
+            // is published, so status requests can encounter this normal state.
+            DatabaseError::MissingSitewideRotationTarget(CredentialRotationType::Nvos) => {
+                FailedPrecondition(
+                    "no site-wide NVOS credential rotation target has been published".to_string(),
+                )
+            }
+            // Other credential families are seeded during migration. A missing
+            // target for them is a corrupted invariant.
             DatabaseError::MissingSitewideRotationTarget(credential_type) => Internal {
                 message: format!(
                     "no site-wide rotation target for credential type: {credential_type:?}"

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -78,7 +78,8 @@ pub(crate) fn component_manager_error_to_status(err: ComponentManagerError) -> S
         ComponentManagerError::NotFound(msg) => Status::not_found(msg),
         ComponentManagerError::InvalidArgument(msg) => Status::invalid_argument(msg),
         ComponentManagerError::Unsupported(msg) => Status::unimplemented(msg),
-        ComponentManagerError::OperationOutcomeUnknown(msg) => Status::failed_precondition(msg),
+        ComponentManagerError::RejectedBeforeDispatch(msg) => Status::failed_precondition(msg),
+        ComponentManagerError::OperationOutcomeUnknown(msg) => Status::unavailable(msg),
         ComponentManagerError::Internal(msg) => Status::internal(msg),
         ComponentManagerError::Transport(e) => Status::unavailable(format!("transport error: {e}")),
         ComponentManagerError::Status(s) => s,
@@ -2844,9 +2845,15 @@ mod tests {
                 message_contains: Some("not implemented"),
             },
             ErrorToStatusCase {
+                scenario: "operation rejected before dispatch",
+                error: ComponentManagerError::RejectedBeforeDispatch("request rejected".into()),
+                expected_code: Code::FailedPrecondition,
+                message_contains: Some("request rejected"),
+            },
+            ErrorToStatusCase {
                 scenario: "operation outcome unknown",
                 error: ComponentManagerError::OperationOutcomeUnknown("lost job id".into()),
-                expected_code: Code::FailedPrecondition,
+                expected_code: Code::Unavailable,
                 message_contains: Some("lost job id"),
             },
             ErrorToStatusCase {

--- a/crates/api-core/src/handlers/credential_rotation.rs
+++ b/crates/api-core/src/handlers/credential_rotation.rs
@@ -417,7 +417,11 @@ pub(crate) async fn get_credential_rotation_status(
     }
 
     let mut txn = api.txn_begin().await?;
-    let status = db::credential_rotation::rotation_status(&mut txn, rotation_type).await?;
+
+    let status = db::credential_rotation::rotation_status(&mut txn, rotation_type)
+        .await
+        .map_err(CarbideError::from)?;
+
     txn.commit().await?;
 
     Ok(Response::new(rpc::CredentialRotationStatusResult {
@@ -455,8 +459,11 @@ async fn device_rotation_status_response(
     })?;
 
     let mut txn = api.txn_begin().await?;
-    let status =
-        db::credential_rotation::device_rotation_status(&mut txn, rotation_type, mac).await?;
+
+    let status = db::credential_rotation::device_rotation_status(&mut txn, rotation_type, mac)
+        .await
+        .map_err(CarbideError::from)?;
+
     txn.commit().await?;
 
     let status = status.ok_or(CarbideError::NotFoundError {

--- a/crates/api-core/src/handlers/credential_rotation.rs
+++ b/crates/api-core/src/handlers/credential_rotation.rs
@@ -154,6 +154,8 @@ pub(crate) async fn rotate_credential(
             )
             .into());
         }
+
+        require_nvos_credential_sources(api).await?;
     }
 
     // Resolve the rotate-TO password: an operator-supplied password is validated
@@ -278,6 +280,61 @@ pub(crate) async fn rotate_credential(
         })?,
         started_at: Some(staged.started_at.into()),
     }))
+}
+
+/// Rejects target publication when a live switch currently has no credential source.
+///
+/// Reconciliation remains authoritative if a credential source changes after
+/// this point-in-time check.
+async fn require_nvos_credential_sources(api: &Api) -> Result<(), CarbideError> {
+    let mut txn = api.txn_begin().await?;
+    let gaps = db::credential_rotation::nvos_credential_source_gaps(&mut txn).await?;
+
+    txn.commit().await?;
+
+    let mut missing = Vec::new();
+
+    for (switch_id, bmc_mac_address, malformed_expected_credentials) in gaps {
+        let Some(bmc_mac_address) = bmc_mac_address else {
+            missing.push(format!("{switch_id} (BMC MAC unavailable)"));
+            continue;
+        };
+
+        if malformed_expected_credentials {
+            missing.push(format!(
+                "{bmc_mac_address} (expected-switch NVOS credentials are partial or empty)"
+            ));
+            continue;
+        }
+
+        let credentials = api
+            .credential_manager
+            .get_credentials(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+            .await
+            .map_err(|error| {
+                CarbideError::internal(format!(
+                    "failed to check current NVOS credential for {bmc_mac_address}: {error}"
+                ))
+            })?;
+
+        if !matches!(
+            credentials,
+            Some(Credentials::UsernamePassword { username, password })
+                if !username.is_empty() && !password.is_empty()
+        ) {
+            missing.push(bmc_mac_address.to_string());
+        }
+    }
+
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(CarbideError::FailedPrecondition(format!(
+            "NVOS rotation requires current credentials for all live switches; missing \
+             credential source for {}",
+            missing.join(", ")
+        )))
+    }
 }
 
 /// Wakes live switches after publishing a new NVOS target.

--- a/crates/api-core/src/handlers/credential_rotation.rs
+++ b/crates/api-core/src/handlers/credential_rotation.rs
@@ -20,29 +20,34 @@
 //! `RotateCredential` *stages* a site-wide rotation: it writes the rotate-TO
 //! secret at the next version and then publishes the new `target_version` with a
 //! compare-and-set. The current site-wide credential is defined by
-//! `sitewide_credential_rotation.target_version` -- consumers resolve the live
-//! version from that table rather than from a fixed unversioned path -- so the
-//! CAS bump is what makes the new version current (table-driven contract). This
-//! holds for every family (BMC, Host/DPU UEFI, lockdown IKM); a rotation never
-//! writes an unversioned alias. It does **not** converge existing devices --
-//! that is the rotation engine's job (a later change) -- so immediately after a
-//! rotate every device reads as "pending" until the engine lands.
-//! `GetCredentialRotationStatus` reports that convergence.
-//!
-//! NVOS is rejected for now. Its target row remains absent until the first
-//! versioned target secret has been stored and verified; API exposure remains
-//! disabled until the end-to-end NVOS rotation path is activated.
+//! `sitewide_credential_rotation.target_version`; consumers resolve the live
+//! version from that table rather than from a fixed unversioned path. A rotation
+//! never writes an unversioned alias. The handler publishes a target only after
+//! its immutable secret has been written and read back. Device convergence is
+//! owned by each credential family's writer or rotation controller.
 
 use ::rpc::forge as rpc;
 use carbide_authn::middleware::Principal;
-use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials, NicLockdownIkm};
+use carbide_secrets::credentials::{
+    BmcCredentialType, CredentialKey, CredentialReader, Credentials, NicLockdownIkm,
+};
+use carbide_switch_controller::io::SwitchStateControllerIO;
 use mac_address::MacAddress;
+use model::switch::SwitchSearchFilter;
+use state_controller::io::StateControllerIO;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
 
 type RotationType = db::credential_rotation::CredentialRotationType;
+
+/// Non-secret request context stored with a published rotation target.
+#[derive(serde::Serialize)]
+struct RotationRequestMeta {
+    reason: Option<String>,
+    initiator: Vec<String>,
+}
 
 /// Narrows a non-negative DB `integer` to the proto `uint32`, surfacing the
 /// (impossible, given the column CHECKs) negative/overflow case as an internal
@@ -74,8 +79,7 @@ fn initiator_identifiers<T>(request: &Request<T>) -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Maps the proto rotation family onto the DB enum, rejecting `nvos` (not yet
-/// managed; see the module docs) and an unknown wire value.
+/// Maps a specific proto rotation family onto its database representation.
 fn to_rotation_type(credential_type: i32) -> Result<RotationType, CarbideError> {
     let parsed = rpc::RotationCredentialType::try_from(credential_type).map_err(|_| {
         CarbideError::NotFoundError {
@@ -88,11 +92,7 @@ fn to_rotation_type(credential_type: i32) -> Result<RotationType, CarbideError> 
         rpc::RotationCredentialType::RotationHostUefi => Ok(RotationType::HostUefi),
         rpc::RotationCredentialType::RotationDpuUefi => Ok(RotationType::DpuUefi),
         rpc::RotationCredentialType::RotationLockdownIkm => Ok(RotationType::LockdownIkm),
-        rpc::RotationCredentialType::RotationNvos => Err(CarbideError::FailedPrecondition(
-            "NVOS rotation is not supported yet: the end-to-end NVOS rotation path \
-             remains disabled"
-                .to_string(),
-        )),
+        rpc::RotationCredentialType::RotationNvos => Ok(RotationType::Nvos),
         // The proto3 zero value. Rejected rather than defaulted so a caller that
         // omits the family never silently rotates BMC (the most sensitive one).
         rpc::RotationCredentialType::Unspecified => Err(CarbideError::InvalidArgument(
@@ -105,11 +105,8 @@ fn to_rotation_type(credential_type: i32) -> Result<RotationType, CarbideError> 
 /// (`.../v{N}`): the rotation stages version N's secret here and consumers read
 /// it back by version. Which version is "current" is resolved from
 /// `sitewide_credential_rotation.target_version`, not from any fixed path -- the
-/// table-driven contract. Every family is fully table-driven (BMC, Host/DPU
-/// UEFI, lockdown IKM): a rotation only writes the versioned secret and bumps
-/// the target, never an unversioned alias. Consumers resolve the live key via
-/// the per-family helpers ([`BmcCredentialType::site_wide_root`],
-/// [`CredentialKey::host_uefi_site_default`], [`CredentialKey::dpu_uefi_site_default`]).
+/// table-driven contract. Consumers resolve the live key via the per-family
+/// helpers rather than depending on a concrete secrets backend.
 fn versioned_rotation_key(rotation_type: RotationType, version: u32) -> CredentialKey {
     match rotation_type {
         RotationType::Bmc => CredentialKey::BmcCredentials {
@@ -120,11 +117,15 @@ fn versioned_rotation_key(rotation_type: RotationType, version: u32) -> Credenti
         RotationType::LockdownIkm => CredentialKey::NicLockdownIkm {
             credential_type: NicLockdownIkm::SiteWide { version },
         },
-        // nvos is rejected in `to_rotation_type` before we ever build keys.
-        RotationType::Nvos => unreachable!("nvos is rejected before key construction"),
+        RotationType::Nvos => CredentialKey::switch_nvos_site_admin(version),
     }
 }
 
+/// Stores and publishes the next site-wide credential target.
+///
+/// The versioned credential is created and read back before its database target
+/// is published. Existing targets advance through a version CAS; NVOS publishes
+/// version zero through a row-absence CAS when initialized for the first time.
 pub(crate) async fn rotate_credential(
     api: &Api,
     request: Request<rpc::RotateCredentialRequest>,
@@ -134,7 +135,26 @@ pub(crate) async fn rotate_credential(
     // request (the extensions, including the AuthContext, live on the envelope).
     let initiator = initiator_identifiers(&request);
     let req = request.into_inner();
-    let rotation_type = to_rotation_type(req.credential_type)?;
+    let credential_type = req.credential_type;
+    let rotation_type = to_rotation_type(credential_type)?;
+
+    // Check if the backend supports NVOS password rotation.
+    if rotation_type == RotationType::Nvos {
+        let Some(component_manager) = api.component_manager.as_ref() else {
+            return Err(CarbideError::FailedPrecondition(
+                "NVOS rotation requires component manager to be configured".to_string(),
+            )
+            .into());
+        };
+
+        if !component_manager.nv_switch.supports_password_rotation() {
+            return Err(CarbideError::FailedPrecondition(
+                "NVOS rotation requires a component-manager switch backend that supports password rotation"
+                    .to_string(),
+            )
+            .into());
+        }
+    }
 
     // Resolve the rotate-TO password: an operator-supplied password is validated
     // against the same policy the generator guarantees; otherwise we
@@ -155,19 +175,31 @@ pub(crate) async fn rotate_credential(
         password,
     };
 
-    // Read the current target so we know the version to stage at (current + 1).
-    // Every supported type has a backfilled target row.
+    // Existing targets advance by one. NVOS is initialized at version zero only
+    // after that immutable secret has been stored and read back below.
     let mut txn = api.txn_begin().await?;
     let current = db::credential_rotation::current_target_version(&mut txn, rotation_type).await?;
+
     txn.commit().await?;
-    let current = current.ok_or_else(|| {
-        CarbideError::FailedPrecondition(format!(
-            "no site-wide rotation target exists for {rotation_type:?}"
-        ))
-    })?;
-    let next_version = u32::try_from(current + 1).map_err(|e| {
+
+    let next_version_i32 = match current {
+        Some(current) => current.checked_add(1).ok_or_else(|| {
+            CarbideError::internal(format!(
+                "rotation target version {current} cannot be advanced"
+            ))
+        })?,
+        None if rotation_type == RotationType::Nvos => 0,
+        None => {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "no site-wide rotation target exists for {rotation_type:?}"
+            ))
+            .into());
+        }
+    };
+
+    let next_version = u32::try_from(next_version_i32).map_err(|e| {
         CarbideError::internal(format!(
-            "rotation target version {current} + 1 overflows: {e}"
+            "rotation target version {next_version_i32} is not representable: {e}"
         ))
     })?;
 
@@ -189,32 +221,55 @@ pub(crate) async fn rotate_credential(
     )
     .await?;
 
-    // Publish the new target with a compare-and-set against the version we read.
-    // `None` means another rotation advanced the target first; surface that as a
-    // precondition failure so the operator re-checks status and retries rather
-    // than assume this rotation took effect.
-    let request_meta = serde_json::json!({ "reason": req.reason, "initiator": initiator });
+    let request_meta = serde_json::to_value(RotationRequestMeta {
+        reason: req.reason,
+        initiator,
+    })
+    .map_err(|e| {
+        CarbideError::internal(format!(
+            "failed to serialize rotation request metadata: {e}"
+        ))
+    })?;
+
+    // Publish last. Existing rows use a version CAS; initial NVOS publication
+    // uses row absence as its CAS.
     let mut txn = api.txn_begin().await?;
-    let staged = db::credential_rotation::set_next_target_version(
-        &mut txn,
-        rotation_type,
-        current,
-        request_meta,
-    )
-    .await?;
+
+    let staged = match current {
+        Some(current) => {
+            db::credential_rotation::set_next_target_version(
+                &mut txn,
+                rotation_type,
+                current,
+                request_meta,
+            )
+            .await?
+        }
+        None => {
+            db::credential_rotation::set_initial_target_version(
+                &mut txn,
+                rotation_type,
+                request_meta,
+            )
+            .await?
+        }
+    };
+
     let staged = staged.ok_or_else(|| {
         CarbideError::ConcurrentModificationError(
             "credential rotation",
-            format!(
-                "the site-wide target for {rotation_type:?} advanced past version {current} \
-                 during this rotation"
-            ),
+            format!("the site-wide target for {rotation_type:?} changed during this rotation"),
         )
     })?;
+
+    if rotation_type == RotationType::Nvos {
+        enqueue_nvos_rotation_switches(&mut txn).await?;
+    }
+
     txn.commit().await?;
 
     Ok(Response::new(rpc::RotateCredentialResult {
-        credential_type: req.credential_type,
+        credential_type,
         target_version: u32::try_from(staged.target_version).map_err(|e| {
             CarbideError::internal(format!(
                 "staged target version {} is not representable: {e}",
@@ -225,8 +280,37 @@ pub(crate) async fn rotate_credential(
     }))
 }
 
-/// Writes the rotate-TO secret at its versioned path, returning the value now
-/// stored there.
+/// Wakes live switches after publishing a new NVOS target.
+///
+/// Enqueuing in the publication transaction gives Ready switches a prompt pass;
+/// the controller's periodic scan remains the fallback for an already queued
+/// switch whose concurrent pass did not observe this commit.
+async fn enqueue_nvos_rotation_switches(
+    txn: &mut sqlx::PgConnection,
+) -> Result<usize, db::DatabaseError> {
+    let switch_ids = db::switch::find_ids(
+        &mut *txn,
+        SwitchSearchFilter {
+            deleted: model::DeletedFilter::Exclude,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let queued_objects: Vec<String> = switch_ids
+        .into_iter()
+        .map(|switch_id| switch_id.to_string())
+        .collect();
+
+    state_controller::controller::db::queue_objects(
+        txn,
+        SwitchStateControllerIO::DB_QUEUED_OBJECTS_TABLE_NAME,
+        &queued_objects,
+    )
+    .await
+}
+
+/// Writes the rotate-TO secret at its versioned path and verifies writer readback.
 ///
 /// `create_credentials` is create-only (write-once per version). A failure means
 /// either the slot is already populated -- a concurrent rotation, or a prior
@@ -246,34 +330,78 @@ async fn stage_versioned_secret(
     new_credentials: &Credentials,
     operator_supplied_password: bool,
     next_version: u32,
-) -> Result<Credentials, CarbideError> {
-    match api
+) -> Result<(), CarbideError> {
+    let staged = match api
         .credential_manager
         .create_credentials(versioned_key, new_credentials)
         .await
     {
-        Ok(()) => Ok(new_credentials.clone()),
-        Err(create_err) => match api.credential_manager.get_credentials(versioned_key).await {
+        Ok(()) => new_credentials.clone(),
+        Err(create_err) => match api
+            .credential_manager
+            .get_credentials_from_writer(versioned_key)
+            .await
+        {
             Ok(Some(existing)) => {
                 if operator_supplied_password && existing != *new_credentials {
-                    Err(CarbideError::ConcurrentModificationError(
+                    return Err(CarbideError::ConcurrentModificationError(
                         "credential rotation",
                         format!(
                             "rotate-to version {next_version} is already staged with a \
                              different password"
                         ),
-                    ))
-                } else {
-                    Ok(existing)
+                    ));
                 }
+
+                existing
             }
-            _ => Err(CarbideError::internal(format!(
-                "failed to stage the rotate-to secret at version {next_version}: {create_err:?}"
-            ))),
+            _ => {
+                return Err(CarbideError::internal(format!(
+                    "failed to stage the rotate-to secret at version {next_version}: {create_err:?}"
+                )));
+            }
         },
+    };
+
+    let persisted = api
+        .credential_manager
+        .get_credentials_from_writer(versioned_key)
+        .await
+        .map_err(|e| {
+            CarbideError::internal(format!(
+                "failed to read back the rotate-to secret at version {next_version}: {e:?}"
+            ))
+        })?;
+
+    if persisted.as_ref() != Some(&staged) {
+        return Err(CarbideError::internal(format!(
+            "rotate-to secret readback did not match version {next_version}"
+        )));
     }
+
+    let effective = api
+        .credential_manager
+        .get_credentials(versioned_key)
+        .await
+        .map_err(|e| {
+            CarbideError::internal(format!(
+                "failed to read the effective rotate-to secret at version {next_version}: {e:?}"
+            ))
+        })?;
+
+    if effective.as_ref() != Some(&staged) {
+        return Err(CarbideError::internal(format!(
+            "effective rotate-to secret readback did not match version {next_version}"
+        )));
+    }
+
+    Ok(())
 }
 
+/// Reports site-wide or per-device progress toward a credential target.
+///
+/// NVOS status is evaluated over live switches, including switches whose
+/// per-device convergence row has not been established yet.
 pub(crate) async fn get_credential_rotation_status(
     api: &Api,
     request: Request<rpc::CredentialRotationStatusRequest>,

--- a/crates/api-core/src/handlers/expected_switch.rs
+++ b/crates/api-core/src/handlers/expected_switch.rs
@@ -18,9 +18,7 @@
 use std::collections::HashSet;
 
 use ::rpc::forge as rpc;
-use ::rpc::forge_api_client::{
-    EXPECTED_SWITCH_UPDATE_MASK_HEADER, expected_switch_update_field as patch_field,
-};
+use ::rpc::forge_api_client::{EXPECTED_SWITCH_UPDATE_MASK_HEADER, ExpectedSwitchUpdateField};
 use db::{DatabaseError, expected_switch as db_expected_switch};
 use mac_address::MacAddress;
 use model::expected_switch::{ExpectedSwitch, ExpectedSwitchRequest};
@@ -32,7 +30,7 @@ use crate::handlers::machine_interface_address::update_preallocated_machine_inte
 
 fn parse_expected_switch_update_mask(
     request: &Request<rpc::ExpectedSwitch>,
-) -> Result<Option<HashSet<String>>, CarbideError> {
+) -> Result<Option<HashSet<ExpectedSwitchUpdateField>>, CarbideError> {
     let Some(value) = request.metadata().get(EXPECTED_SWITCH_UPDATE_MASK_HEADER) else {
         return Ok(None);
     };
@@ -41,17 +39,13 @@ fn parse_expected_switch_update_mask(
         CarbideError::InvalidArgument(format!("invalid expected-switch update mask: {error}"))
     })?;
 
-    let fields: HashSet<String> = value.split(',').map(str::to_string).collect();
-
-    if fields.is_empty()
-        || fields
-            .iter()
-            .any(|field| !patch_field::ALL.contains(&field.as_str()))
-    {
-        return Err(CarbideError::InvalidArgument(format!(
-            "invalid expected-switch update mask: {value}"
-        )));
-    }
+    let fields = value
+        .split(',')
+        .map(str::parse)
+        .collect::<Result<HashSet<_>, _>>()
+        .map_err(|_| {
+            CarbideError::InvalidArgument(format!("invalid expected-switch update mask: {value}"))
+        })?;
 
     Ok(Some(fields))
 }
@@ -59,63 +53,63 @@ fn parse_expected_switch_update_mask(
 fn merge_expected_switch_patch(
     mut patch: rpc::ExpectedSwitch,
     current: rpc::ExpectedSwitch,
-    fields: &HashSet<String>,
+    fields: &HashSet<ExpectedSwitchUpdateField>,
 ) -> rpc::ExpectedSwitch {
     patch.expected_switch_id = current.expected_switch_id;
     patch.bmc_mac_address = current.bmc_mac_address;
 
-    if !fields.contains(patch_field::BMC_USERNAME) {
+    if !fields.contains(&ExpectedSwitchUpdateField::BmcUsername) {
         patch.bmc_username = current.bmc_username;
     }
 
-    if !fields.contains(patch_field::BMC_PASSWORD) {
+    if !fields.contains(&ExpectedSwitchUpdateField::BmcPassword) {
         patch.bmc_password = current.bmc_password;
     }
 
-    if !fields.contains(patch_field::SWITCH_SERIAL_NUMBER) {
+    if !fields.contains(&ExpectedSwitchUpdateField::SwitchSerialNumber) {
         patch.switch_serial_number = current.switch_serial_number;
     }
 
-    if !fields.contains(patch_field::NVOS_MAC_ADDRESSES) {
+    if !fields.contains(&ExpectedSwitchUpdateField::NvosMacAddresses) {
         patch.nvos_mac_addresses = current.nvos_mac_addresses;
     }
 
-    if !fields.contains(patch_field::NVOS_USERNAME) {
+    if !fields.contains(&ExpectedSwitchUpdateField::NvosUsername) {
         patch.nvos_username = current.nvos_username;
     }
 
-    if !fields.contains(patch_field::NVOS_PASSWORD) {
+    if !fields.contains(&ExpectedSwitchUpdateField::NvosPassword) {
         patch.nvos_password = current.nvos_password;
     }
 
-    if !fields.contains(patch_field::RACK_ID) {
+    if !fields.contains(&ExpectedSwitchUpdateField::RackId) {
         patch.rack_id = current.rack_id;
     }
 
-    if !fields.contains(patch_field::BMC_IP_ADDRESS) {
+    if !fields.contains(&ExpectedSwitchUpdateField::BmcIpAddress) {
         patch.bmc_ip_address = current.bmc_ip_address;
     }
 
-    if !fields.contains(patch_field::NVOS_IP_ADDRESS) {
+    if !fields.contains(&ExpectedSwitchUpdateField::NvosIpAddress) {
         patch.nvos_ip_address = current.nvos_ip_address;
     }
 
-    if !fields.contains(patch_field::BMC_RETAIN_CREDENTIALS) {
+    if !fields.contains(&ExpectedSwitchUpdateField::BmcRetainCredentials) {
         patch.bmc_retain_credentials = current.bmc_retain_credentials;
     }
 
     let mut patch_metadata = patch.metadata.unwrap_or_default();
     let current_metadata = current.metadata.unwrap_or_default();
 
-    if !fields.contains(patch_field::METADATA_NAME) {
+    if !fields.contains(&ExpectedSwitchUpdateField::MetadataName) {
         patch_metadata.name = current_metadata.name;
     }
 
-    if !fields.contains(patch_field::METADATA_DESCRIPTION) {
+    if !fields.contains(&ExpectedSwitchUpdateField::MetadataDescription) {
         patch_metadata.description = current_metadata.description;
     }
 
-    if !fields.contains(patch_field::METADATA_LABELS) {
+    if !fields.contains(&ExpectedSwitchUpdateField::MetadataLabels) {
         patch_metadata.labels = current_metadata.labels;
     }
 

--- a/crates/api-core/src/handlers/expected_switch.rs
+++ b/crates/api-core/src/handlers/expected_switch.rs
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
+use std::collections::HashSet;
+
 use ::rpc::forge as rpc;
+use ::rpc::forge_api_client::{
+    EXPECTED_SWITCH_UPDATE_MASK_HEADER, expected_switch_update_field as patch_field,
+};
 use db::{DatabaseError, expected_switch as db_expected_switch};
 use mac_address::MacAddress;
 use model::expected_switch::{ExpectedSwitch, ExpectedSwitchRequest};
@@ -24,6 +29,100 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::Api;
 use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
+
+fn parse_expected_switch_update_mask(
+    request: &Request<rpc::ExpectedSwitch>,
+) -> Result<Option<HashSet<String>>, CarbideError> {
+    let Some(value) = request.metadata().get(EXPECTED_SWITCH_UPDATE_MASK_HEADER) else {
+        return Ok(None);
+    };
+
+    let value = value.to_str().map_err(|error| {
+        CarbideError::InvalidArgument(format!("invalid expected-switch update mask: {error}"))
+    })?;
+
+    let fields: HashSet<String> = value.split(',').map(str::to_string).collect();
+
+    if fields.is_empty()
+        || fields
+            .iter()
+            .any(|field| !patch_field::ALL.contains(&field.as_str()))
+    {
+        return Err(CarbideError::InvalidArgument(format!(
+            "invalid expected-switch update mask: {value}"
+        )));
+    }
+
+    Ok(Some(fields))
+}
+
+fn merge_expected_switch_patch(
+    mut patch: rpc::ExpectedSwitch,
+    current: rpc::ExpectedSwitch,
+    fields: &HashSet<String>,
+) -> rpc::ExpectedSwitch {
+    patch.expected_switch_id = current.expected_switch_id;
+    patch.bmc_mac_address = current.bmc_mac_address;
+
+    if !fields.contains(patch_field::BMC_USERNAME) {
+        patch.bmc_username = current.bmc_username;
+    }
+
+    if !fields.contains(patch_field::BMC_PASSWORD) {
+        patch.bmc_password = current.bmc_password;
+    }
+
+    if !fields.contains(patch_field::SWITCH_SERIAL_NUMBER) {
+        patch.switch_serial_number = current.switch_serial_number;
+    }
+
+    if !fields.contains(patch_field::NVOS_MAC_ADDRESSES) {
+        patch.nvos_mac_addresses = current.nvos_mac_addresses;
+    }
+
+    if !fields.contains(patch_field::NVOS_USERNAME) {
+        patch.nvos_username = current.nvos_username;
+    }
+
+    if !fields.contains(patch_field::NVOS_PASSWORD) {
+        patch.nvos_password = current.nvos_password;
+    }
+
+    if !fields.contains(patch_field::RACK_ID) {
+        patch.rack_id = current.rack_id;
+    }
+
+    if !fields.contains(patch_field::BMC_IP_ADDRESS) {
+        patch.bmc_ip_address = current.bmc_ip_address;
+    }
+
+    if !fields.contains(patch_field::NVOS_IP_ADDRESS) {
+        patch.nvos_ip_address = current.nvos_ip_address;
+    }
+
+    if !fields.contains(patch_field::BMC_RETAIN_CREDENTIALS) {
+        patch.bmc_retain_credentials = current.bmc_retain_credentials;
+    }
+
+    let mut patch_metadata = patch.metadata.unwrap_or_default();
+    let current_metadata = current.metadata.unwrap_or_default();
+
+    if !fields.contains(patch_field::METADATA_NAME) {
+        patch_metadata.name = current_metadata.name;
+    }
+
+    if !fields.contains(patch_field::METADATA_DESCRIPTION) {
+        patch_metadata.description = current_metadata.description;
+    }
+
+    if !fields.contains(patch_field::METADATA_LABELS) {
+        patch_metadata.labels = current_metadata.labels;
+    }
+
+    patch.metadata = Some(patch_metadata);
+
+    patch
+}
 
 /// `nvos_ip_address` is paired with the single wired NVOS port. We reject any
 /// caller that sets it alongside zero-or-multiple `nvos_mac_addresses`, so the
@@ -39,6 +138,29 @@ fn validate_nvos_ip_pairing(switch: &ExpectedSwitch) -> Result<(), CarbideError>
     Ok(())
 }
 
+/// Requires NVOS username and password to be present together and non-empty.
+fn validate_nvos_credentials_pair(switch: &ExpectedSwitch) -> Result<(), CarbideError> {
+    match (&switch.nvos_username, &switch.nvos_password) {
+        (Some(username), Some(_)) if username.is_empty() => Err(CarbideError::InvalidArgument(
+            "nvos_username must not be empty".to_string(),
+        )),
+        (Some(_), Some(password)) if password.is_empty() => Err(CarbideError::InvalidArgument(
+            "nvos_password must not be empty".to_string(),
+        )),
+        (Some(_), Some(_)) | (None, None) => Ok(()),
+        _ => Err(CarbideError::InvalidArgument(
+            "nvos_username and nvos_password must be set together".to_string(),
+        )),
+    }
+}
+
+fn validate_expected_switch(switch: &ExpectedSwitch) -> Result<(), CarbideError> {
+    validate_nvos_ip_pairing(switch)?;
+    validate_nvos_credentials_pair(switch)?;
+
+    Ok(())
+}
+
 pub async fn add_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitch>,
@@ -51,7 +173,7 @@ pub async fn add_expected_switch(
                 CarbideError::InvalidArgument(e.to_string())
             })?;
 
-    validate_nvos_ip_pairing(&switch)?;
+    validate_expected_switch(&switch)?;
 
     let mut txn = api
         .database_connection
@@ -107,15 +229,8 @@ pub async fn update_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitch>,
 ) -> Result<Response<()>, Status> {
-    let switch: ExpectedSwitch =
-        request
-            .into_inner()
-            .try_into()
-            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
-                CarbideError::InvalidArgument(e.to_string())
-            })?;
-
-    validate_nvos_ip_pairing(&switch)?;
+    let update_mask = parse_expected_switch_update_mask(&request)?;
+    let patch = request.into_inner();
 
     let mut txn = api
         .database_connection
@@ -124,6 +239,43 @@ pub async fn update_expected_switch(
         .map_err(|e| CarbideError::Internal {
             message: format!("Database error: {}", e),
         })?;
+
+    let switch: ExpectedSwitch = if let Some(update_mask) = update_mask {
+        let lookup: ExpectedSwitchRequest = rpc::ExpectedSwitchRequest {
+            bmc_mac_address: patch.bmc_mac_address.clone(),
+            expected_switch_id: patch.expected_switch_id.clone(),
+        }
+        .try_into()
+        .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+            CarbideError::InvalidArgument(e.to_string())
+        })?;
+
+        let current = db_expected_switch::find_for_update(&mut txn, &lookup)
+            .await
+            .map_err(CarbideError::from)?
+            .ok_or_else(|| DatabaseError::NotFoundError {
+                kind: "expected_switch",
+                id: lookup
+                    .expected_switch_id
+                    .map(|id| id.to_string())
+                    .or_else(|| lookup.bmc_mac_address.map(|mac| mac.to_string()))
+                    .unwrap_or_default(),
+            })?;
+
+        merge_expected_switch_patch(patch, current.into(), &update_mask)
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?
+    } else {
+        patch
+            .try_into()
+            .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                CarbideError::InvalidArgument(e.to_string())
+            })?
+    };
+
+    validate_expected_switch(&switch)?;
 
     if let Some(bmc_ip) = switch.bmc_ip_address {
         update_preallocated_machine_interface(
@@ -231,6 +383,21 @@ pub async fn replace_all_expected_switches(
 ) -> Result<Response<()>, Status> {
     let req = request.into_inner();
 
+    let mut switches = Vec::with_capacity(req.expected_switches.len());
+
+    for expected_switch in req.expected_switches {
+        let switch: ExpectedSwitch =
+            expected_switch
+                .try_into()
+                .map_err(|e: ::rpc::errors::RpcDataConversionError| {
+                    CarbideError::InvalidArgument(e.to_string())
+                })?;
+
+        validate_expected_switch(&switch)?;
+
+        switches.push(switch);
+    }
+
     let mut txn = api
         .database_connection
         .begin()
@@ -245,13 +412,7 @@ pub async fn replace_all_expected_switches(
         .map_err(CarbideError::from)?;
 
     // Add all new expected switches
-    for expected_switch in req.expected_switches {
-        let switch: ExpectedSwitch =
-            expected_switch
-                .try_into()
-                .map_err(|e: ::rpc::errors::RpcDataConversionError| {
-                    CarbideError::InvalidArgument(e.to_string())
-                })?;
+    for switch in switches {
         db_expected_switch::create(&mut txn, switch)
             .await
             .map_err(CarbideError::from)?;

--- a/crates/api-core/src/secrets/mod.rs
+++ b/crates/api-core/src/secrets/mod.rs
@@ -375,6 +375,13 @@ impl CredentialReader for PostgresCredentialManager {
 
 #[async_trait]
 impl CredentialWriter for PostgresCredentialManager {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        CredentialReader::get_credentials(self, key).await
+    }
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,

--- a/crates/api-core/src/tests/expected_switch.rs
+++ b/crates/api-core/src/tests/expected_switch.rs
@@ -22,6 +22,7 @@ use common::api_fixtures::site_explorer::create_expected_switches;
 use mac_address::MacAddress;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{ExpectedSwitchList, ExpectedSwitchRequest};
+use rpc::forge_api_client::EXPECTED_SWITCH_UPDATE_MASK_HEADER;
 
 use crate::tests::common;
 
@@ -118,6 +119,49 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
         expected_switch.expected_switch_id = retrieved_expected_switch.expected_switch_id.clone();
 
         assert_eq!(retrieved_expected_switch, expected_switch);
+    }
+}
+
+#[crate::sqlx_test()]
+async fn test_add_expected_switch_validates_nvos_credentials_pair(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    for (nvos_username, nvos_password, bmc_mac_address, valid) in [
+        (None, None, "3A:3B:3C:3D:3E:44", true),
+        (Some("admin".to_string()), None, "3A:3B:3C:3D:3E:42", false),
+        (
+            None,
+            Some("nvos-pass".to_string()),
+            "3A:3B:3C:3D:3E:43",
+            false,
+        ),
+    ] {
+        let result = env
+            .api
+            .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+                bmc_mac_address: bmc_mac_address.into(),
+                nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:42".to_string()],
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                switch_serial_number: "SW-NVOS-PARTIAL".into(),
+                nvos_username,
+                nvos_password,
+                ..Default::default()
+            }))
+            .await;
+
+        if valid {
+            result.expect("absent NVOS credentials should be accepted");
+        } else {
+            let err = result.expect_err("partial NVOS credentials should be rejected");
+
+            assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+            assert_eq!(
+                err.message(),
+                "nvos_username and nvos_password must be set together"
+            );
+        }
     }
 }
 
@@ -273,9 +317,11 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
 
     let mut txn = env.pool.begin().await.unwrap();
     let switches = create_expected_switches(&mut txn).await;
+
     txn.commit().await.unwrap();
 
     let bmc_mac_address: MacAddress = switches[1].bmc_mac_address;
+
     let nvos_mac_addresses: Vec<String> = switches[1]
         .nvos_mac_addresses
         .iter()
@@ -370,6 +416,60 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
 
         assert_eq!(retrieved_expected_switch, updated_switch);
     }
+}
+
+#[crate::sqlx_test()]
+async fn test_sparse_update_expected_switch_preserves_omitted_fields(pool: sqlx::PgPool) {
+    let env = create_test_env(pool.clone()).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let switches = create_expected_switches(&mut txn).await;
+
+    txn.commit().await.unwrap();
+
+    let bmc_mac_address: MacAddress = switches[1].bmc_mac_address;
+    let original_serial_number = switches[1].serial_number.clone();
+    let original_nvos_mac_addresses = switches[1].nvos_mac_addresses.clone();
+
+    let mut request = tonic::Request::new(rpc::forge::ExpectedSwitch {
+        bmc_mac_address: bmc_mac_address.to_string(),
+        nvos_username: Some("nvos_upd_user".into()),
+        nvos_password: Some("nvos_upd_pass".into()),
+        ..Default::default()
+    });
+
+    request.metadata_mut().insert(
+        EXPECTED_SWITCH_UPDATE_MASK_HEADER,
+        "nvos_username,nvos_password".parse().unwrap(),
+    );
+
+    env.api
+        .update_expected_switch(request)
+        .await
+        .expect("unable to update expected switch");
+
+    let updated = env
+        .api
+        .get_expected_switch(tonic::Request::new(ExpectedSwitchRequest {
+            bmc_mac_address: bmc_mac_address.to_string(),
+            expected_switch_id: None,
+        }))
+        .await
+        .expect("unable to read updated expected switch")
+        .into_inner();
+
+    assert_eq!(updated.switch_serial_number, original_serial_number);
+
+    assert_eq!(
+        updated.nvos_mac_addresses,
+        original_nvos_mac_addresses
+            .into_iter()
+            .map(|mac| mac.to_string())
+            .collect::<Vec<_>>()
+    );
+
+    assert_eq!(updated.nvos_username.as_deref(), Some("nvos_upd_user"));
+    assert_eq!(updated.nvos_password.as_deref(), Some("nvos_upd_pass"));
 }
 
 #[crate::sqlx_test()]

--- a/crates/api-core/src/tests/expected_switch.rs
+++ b/crates/api-core/src/tests/expected_switch.rs
@@ -126,14 +126,31 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
 async fn test_add_expected_switch_validates_nvos_credentials_pair(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
 
-    for (nvos_username, nvos_password, bmc_mac_address, valid) in [
-        (None, None, "3A:3B:3C:3D:3E:44", true),
-        (Some("admin".to_string()), None, "3A:3B:3C:3D:3E:42", false),
+    for (nvos_username, nvos_password, bmc_mac_address, expected_error) in [
+        (None, None, "3A:3B:3C:3D:3E:44", None),
+        (
+            Some("admin".to_string()),
+            None,
+            "3A:3B:3C:3D:3E:42",
+            Some("nvos_username and nvos_password must be set together"),
+        ),
         (
             None,
             Some("nvos-pass".to_string()),
             "3A:3B:3C:3D:3E:43",
-            false,
+            Some("nvos_username and nvos_password must be set together"),
+        ),
+        (
+            Some(String::new()),
+            Some("nvos-pass".to_string()),
+            "3A:3B:3C:3D:3E:45",
+            Some("nvos_username must not be empty"),
+        ),
+        (
+            Some("admin".to_string()),
+            Some(String::new()),
+            "3A:3B:3C:3D:3E:46",
+            Some("nvos_password must not be empty"),
         ),
     ] {
         let result = env
@@ -150,17 +167,13 @@ async fn test_add_expected_switch_validates_nvos_credentials_pair(pool: sqlx::Pg
             }))
             .await;
 
-        if valid {
-            result.expect("absent NVOS credentials should be accepted");
-        } else {
-            let err = result.expect_err("partial NVOS credentials should be rejected");
+        if let Some(expected_error) = expected_error {
+            let err = result.expect_err("invalid NVOS credentials should be rejected");
 
             assert_eq!(err.code(), tonic::Code::InvalidArgument);
-
-            assert_eq!(
-                err.message(),
-                "nvos_username and nvos_password must be set together"
-            );
+            assert_eq!(err.message(), expected_error);
+        } else {
+            result.expect("absent NVOS credentials should be accepted");
         }
     }
 }

--- a/crates/api-core/src/tests/switch_state_controller/mod.rs
+++ b/crates/api-core/src/tests/switch_state_controller/mod.rs
@@ -43,6 +43,7 @@ use crate::tests::common::api_fixtures::{create_test_env, get_config_with_rack_p
 
 mod fixtures;
 mod maintenance;
+mod nvos_password_rotation;
 use fixtures::switch::{
     configure_certificate_start_state, configure_certificate_wait_state, mark_switch_as_deleted,
     set_switch_controller_state, set_switch_rack_id, transition_switch_controller_state,

--- a/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
@@ -336,6 +336,9 @@ async fn configuring_skips_credentials_when_rotation_is_not_actionable(
             matches!(
                 switch.controller_state.value,
                 SwitchControllerState::FetchInfo
+                    | SwitchControllerState::Validating { .. }
+                    | SwitchControllerState::BomValidating { .. }
+                    | SwitchControllerState::Ready
             ),
             "{case} should bypass malformed credential data"
         );
@@ -580,6 +583,54 @@ async fn corrected_target_supersedes_rejected_submission(pool: sqlx::PgPool) -> 
     assert_eq!(recovered.rotate_job_id.as_deref(), Some("recovered-job"));
     assert_eq!(recovered.rotate_attempts, 2);
     assert_eq!(recovered.rotate_last_error_redacted, None);
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn staged_target_credential_survives_recovery_before_promotion(
+    pool: sqlx::PgPool,
+) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+    let (switch_id, bmc_mac_address) = prepare_version_one_rotation(&env, &pool).await?;
+
+    stage_submitted_rotation(&pool, bmc_mac_address, 1, "pending-job").await?;
+
+    let target_credentials = Credentials::UsernamePassword {
+        username: "nvos-admin".to_string(),
+        password: TARGET_PASSWORD.to_string(),
+    };
+
+    env.test_credential_manager
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin { bmc_mac_address },
+            &target_credentials,
+        )
+        .await
+        .expect("failed to stage target NVOS credential");
+
+    let manager = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_password_rotation_job_status(SwitchPasswordRotationState::Pending);
+
+    assert!(matches!(
+        reconcile(&env, &pool, &switch_id, manager).await?,
+        NvosPasswordRotationOutcome::Waiting(_)
+    ));
+
+    let operation = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(operation.current_version, Some(0));
+    assert_eq!(operation.rotating_to_version, Some(1));
+
+    let stored = env
+        .test_credential_manager
+        .get_credentials_from_writer(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+        .await
+        .expect("failed to read staged target NVOS credential")
+        .expect("staged target credential should remain available");
+
+    assert_eq!(stored, target_credentials);
+
     Ok(())
 }
 

--- a/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
@@ -554,10 +554,14 @@ async fn corrected_target_supersedes_rejected_submission(pool: sqlx::PgPool) -> 
         .with_password_rotation_enabled()
         .with_expected_password_rotation_password("Different-Nvos-Password-1!");
 
-    assert!(matches!(
-        reconcile(&env, &pool, &switch_id, rejected).await?,
-        NvosPasswordRotationOutcome::Waiting(_)
-    ));
+    let error = reconcile(&env, &pool, &switch_id, rejected)
+        .await
+        .expect_err("rejected submission should return an error");
+    assert!(
+        error
+            .to_string()
+            .contains("NVOS submission is not retryable without correction")
+    );
 
     let rejected = operation_state(&pool, bmc_mac_address).await?;
     assert_eq!(rejected.rotating_to_version, Some(1));

--- a/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
@@ -1,0 +1,663 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use carbide_secrets::credentials::{
+    CredentialKey, CredentialReader, CredentialWriter, Credentials,
+};
+use carbide_switch_controller::context::{
+    SwitchStateHandlerContextObjects, SwitchStateHandlerServices,
+};
+use carbide_switch_controller::metrics::SwitchMetrics;
+use carbide_switch_controller::nvos_password_rotation::{
+    NvosPasswordRotationOutcome, reconcile_nvos_password_rotation,
+};
+use component_manager::mock::MockNvSwitchManager;
+use component_manager::nv_switch_manager::SwitchPasswordRotationState;
+use db::switch as db_switch;
+use model::switch::{ConfiguringState, Switch, SwitchControllerState};
+use state_controller::db_write_batch::DbWriteBatch;
+use state_controller::state_handler::StateHandlerContext;
+
+use super::fixtures::switch::transition_switch_controller_state;
+use super::{
+    common, default_switch_mtls_services, mock_component_manager,
+    run_switch_controller_with_services,
+};
+use crate::tests::common::api_fixtures::create_test_env;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const CURRENT_PASSWORD: &str = "Current-Nvos-Password-0!";
+const TARGET_PASSWORD: &str = "Next-Nvos-Password-1!";
+
+async fn create_switch(
+    env: &common::api_fixtures::TestEnv,
+    pool: &sqlx::PgPool,
+    name: Option<String>,
+) -> TestResult<(carbide_uuid::switch::SwitchId, mac_address::MacAddress)> {
+    let switch_id = common::api_fixtures::site_explorer::new_switch(env, name, None).await?;
+
+    let bmc_mac_address = db_switch::find_switch_endpoints_by_ids(pool, &[switch_id])
+        .await?
+        .first()
+        .expect("switch endpoint row")
+        .bmc_mac;
+
+    env.test_credential_manager
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin { bmc_mac_address },
+            &Credentials::UsernamePassword {
+                username: "nvos-admin".to_string(),
+                password: CURRENT_PASSWORD.to_string(),
+            },
+        )
+        .await
+        .expect("failed to seed per-switch NVOS credential");
+
+    Ok((switch_id, bmc_mac_address))
+}
+
+async fn publish_target(
+    env: &common::api_fixtures::TestEnv,
+    pool: &sqlx::PgPool,
+    current_version: Option<i32>,
+    password: &str,
+) -> TestResult {
+    let target_version = current_version.map_or(0, |version| version + 1);
+    let target_version_u32 = u32::try_from(target_version)?;
+
+    env.test_credential_manager
+        .create_credentials(
+            &CredentialKey::switch_nvos_site_admin(target_version_u32),
+            &Credentials::UsernamePassword {
+                username: String::new(),
+                password: password.to_string(),
+            },
+        )
+        .await
+        .expect("failed to seed NVOS target credential");
+
+    let mut txn = pool.begin().await?;
+
+    let staged = match current_version {
+        Some(current_version) => {
+            db::credential_rotation::set_next_target_version(
+                txn.as_mut(),
+                db::credential_rotation::CredentialRotationType::Nvos,
+                current_version,
+                serde_json::json!({}),
+            )
+            .await?
+        }
+        None => {
+            db::credential_rotation::set_initial_target_version(
+                txn.as_mut(),
+                db::credential_rotation::CredentialRotationType::Nvos,
+                serde_json::json!({}),
+            )
+            .await?
+        }
+    };
+
+    txn.commit().await?;
+
+    assert_eq!(
+        staged.map(|target| target.target_version),
+        Some(target_version)
+    );
+
+    Ok(())
+}
+
+async fn insert_current_version(
+    pool: &sqlx::PgPool,
+    bmc_mac_address: mac_address::MacAddress,
+    version: i32,
+) -> TestResult {
+    sqlx::query(
+        "INSERT INTO device_credential_rotation \
+             (device_mac, credential_type, current_version) \
+         VALUES ($1, 'nvos', $2)",
+    )
+    .bind(bmc_mac_address)
+    .bind(version)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn stage_submitted_rotation(
+    pool: &sqlx::PgPool,
+    bmc_mac_address: mac_address::MacAddress,
+    target_version: i32,
+    job_id: &str,
+) -> TestResult<i32> {
+    let mut txn = pool.begin().await?;
+
+    let attempt = db::credential_rotation::record_device_rotation_started(
+        txn.as_mut(),
+        bmc_mac_address,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        target_version,
+    )
+    .await?
+    .expect("stage rotation");
+
+    let submitted = db::credential_rotation::record_device_rotation_submitted(
+        txn.as_mut(),
+        bmc_mac_address,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        target_version,
+        attempt,
+        job_id,
+    )
+    .await?;
+
+    txn.commit().await?;
+    assert!(submitted);
+    Ok(attempt)
+}
+
+async fn load_switch(
+    pool: &sqlx::PgPool,
+    switch_id: &carbide_uuid::switch::SwitchId,
+) -> TestResult<Switch> {
+    let mut conn = pool.acquire().await?;
+
+    Ok(db_switch::find_by_id(&mut conn, switch_id)
+        .await?
+        .expect("switch should exist"))
+}
+
+async fn operation_state(
+    pool: &sqlx::PgPool,
+    bmc_mac_address: mac_address::MacAddress,
+) -> TestResult<db::credential_rotation::DeviceRotationOperationState> {
+    let mut conn = pool.acquire().await?;
+
+    Ok(db::credential_rotation::device_rotation_operation_state(
+        &mut *conn,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        bmc_mac_address,
+    )
+    .await?
+    .expect("NVOS operation state should exist"))
+}
+
+async fn reconcile(
+    env: &common::api_fixtures::TestEnv,
+    pool: &sqlx::PgPool,
+    switch_id: &carbide_uuid::switch::SwitchId,
+    manager: MockNvSwitchManager,
+) -> TestResult<NvosPasswordRotationOutcome> {
+    let switch = load_switch(pool, switch_id).await?;
+
+    let mut services = switch_services(env, pool, manager);
+
+    let mut metrics = SwitchMetrics::default();
+    let mut pending_db_writes = DbWriteBatch::new();
+
+    let mut ctx = StateHandlerContext::<SwitchStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut pending_db_writes,
+    };
+
+    Ok(reconcile_nvos_password_rotation(switch_id, &switch, &mut ctx).await?)
+}
+
+fn switch_services(
+    env: &common::api_fixtures::TestEnv,
+    pool: &sqlx::PgPool,
+    manager: MockNvSwitchManager,
+) -> SwitchStateHandlerServices {
+    SwitchStateHandlerServices {
+        db_pool: pool.clone(),
+        component_manager: Some(mock_component_manager(Arc::new(manager))),
+        credential_manager: env.test_credential_manager.clone(),
+        switch_mtls_services: default_switch_mtls_services(),
+        per_object_metrics_registry: env.per_object_metrics_registry(),
+    }
+}
+
+async fn run_controller(
+    env: &common::api_fixtures::TestEnv,
+    pool: &sqlx::PgPool,
+    manager: MockNvSwitchManager,
+    passes: usize,
+) {
+    for _ in 0..passes {
+        run_switch_controller_with_services(
+            pool.clone(),
+            env.api.work_lock_manager_handle.clone(),
+            switch_services(env, pool, manager.clone()),
+        )
+        .await;
+    }
+}
+
+async fn prepare_version_one_rotation(
+    env: &common::api_fixtures::TestEnv,
+    pool: &sqlx::PgPool,
+) -> TestResult<(carbide_uuid::switch::SwitchId, mac_address::MacAddress)> {
+    publish_target(env, pool, None, CURRENT_PASSWORD).await?;
+    let (switch_id, bmc_mac_address) = create_switch(env, pool, None).await?;
+
+    insert_current_version(pool, bmc_mac_address, 0).await?;
+    publish_target(env, pool, Some(0), TARGET_PASSWORD).await?;
+    Ok((switch_id, bmc_mac_address))
+}
+
+#[crate::sqlx_test]
+async fn configuring_skips_credentials_when_rotation_is_not_actionable(
+    pool: sqlx::PgPool,
+) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+
+    let cases = [
+        (
+            "uninitialized target",
+            false,
+            true,
+            MockNvSwitchManager::default().with_password_rotation_enabled(),
+        ),
+        (
+            "unsupported backend",
+            true,
+            false,
+            MockNvSwitchManager::default(),
+        ),
+    ];
+
+    for (index, (case, publish, clear_bmc, manager)) in cases.into_iter().enumerate() {
+        if publish {
+            publish_target(&env, &pool, None, TARGET_PASSWORD).await?;
+        }
+
+        let (switch_id, bmc_mac_address) =
+            create_switch(&env, &pool, Some(format!("Switch{}", index + 1))).await?;
+
+        sqlx::query(
+            "UPDATE expected_switches \
+             SET nvos_username = 'nvos-admin', nvos_password = NULL \
+             WHERE bmc_mac_address = $1",
+        )
+        .bind(bmc_mac_address)
+        .execute(&pool)
+        .await?;
+
+        if clear_bmc {
+            sqlx::query("UPDATE switches SET bmc_mac_address = NULL WHERE id = $1")
+                .bind(switch_id)
+                .execute(&pool)
+                .await?;
+        }
+
+        env.test_credential_manager
+            .delete_credentials(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+            .await
+            .expect("failed to remove the per-switch NVOS credential");
+
+        let mut txn = pool.begin().await?;
+
+        transition_switch_controller_state(
+            txn.as_mut(),
+            &switch_id,
+            SwitchControllerState::Configuring {
+                config_state: ConfiguringState::RotateOsPassword,
+            },
+        )
+        .await?;
+
+        txn.commit().await?;
+
+        run_controller(&env, &pool, manager, 1).await;
+
+        let switch = load_switch(&pool, &switch_id).await?;
+
+        assert!(
+            matches!(
+                switch.controller_state.value,
+                SwitchControllerState::FetchInfo
+            ),
+            "{case} should bypass malformed credential data"
+        );
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn ready_switch_submits_version_zero_target(pool: sqlx::PgPool) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+
+    publish_target(&env, &pool, None, TARGET_PASSWORD).await?;
+    let (switch_id, bmc_mac_address) = create_switch(&env, &pool, None).await?;
+
+    sqlx::query(
+        "UPDATE expected_switches \
+         SET nvos_username = 'corrected-admin', \
+             nvos_password = 'Corrected-Nvos-Password-0!' \
+         WHERE bmc_mac_address = $1",
+    )
+    .bind(bmc_mac_address)
+    .execute(&pool)
+    .await?;
+
+    let mut txn = pool.begin().await?;
+
+    transition_switch_controller_state(txn.as_mut(), &switch_id, SwitchControllerState::Ready)
+        .await?;
+
+    txn.commit().await?;
+
+    let manager = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_expected_password_rotation_password(TARGET_PASSWORD)
+        .with_password_rotation_outcome_unknown("lost response");
+
+    run_controller(&env, &pool, manager, 2).await;
+
+    let first = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(first.current_version, None);
+    assert_eq!(first.rotating_to_version, Some(0));
+    assert_eq!(first.rotate_job_id, None);
+    assert_eq!(first.rotate_attempts, 1);
+
+    sqlx::query(
+        "UPDATE expected_switches SET nvos_password = 'Replacement-Nvos-Password-0!' \
+         WHERE bmc_mac_address = $1",
+    )
+    .bind(bmc_mac_address)
+    .execute(&pool)
+    .await?;
+
+    let retry = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_expected_password_rotation_password(TARGET_PASSWORD)
+        .with_password_rotation_job("retry-job");
+
+    reconcile(&env, &pool, &switch_id, retry).await?;
+
+    let current = env
+        .test_credential_manager
+        .get_credentials_from_writer(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+        .await
+        .expect("staged rotation should be `Ok`")
+        .expect("staged rotation should retain the captured current credential");
+
+    assert_eq!(
+        current,
+        Credentials::UsernamePassword {
+            username: "corrected-admin".to_string(),
+            password: "Corrected-Nvos-Password-0!".to_string(),
+        }
+    );
+
+    let second = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(second.current_version, None);
+    assert_eq!(second.rotating_to_version, Some(0));
+    assert_eq!(second.rotate_job_id.as_deref(), Some("retry-job"));
+    assert_eq!(second.rotate_attempts, 2);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn lost_submission_response_retries_original_target_after_later_publication(
+    pool: sqlx::PgPool,
+) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+    let (switch_id, bmc_mac_address) = prepare_version_one_rotation(&env, &pool).await?;
+
+    let unknown = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_expected_password_rotation_password(TARGET_PASSWORD)
+        .with_password_rotation_outcome_unknown("lost response");
+
+    assert!(matches!(
+        reconcile(&env, &pool, &switch_id, unknown).await?,
+        NvosPasswordRotationOutcome::Waiting(_)
+    ));
+
+    let first = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(first.rotating_to_version, Some(1));
+    assert_eq!(first.rotate_job_id, None);
+    assert_eq!(first.rotate_attempts, 1);
+
+    assert_eq!(first.rotate_last_error_redacted, None);
+
+    publish_target(&env, &pool, Some(1), "Recovered-Nvos-Password-2!").await?;
+
+    reconcile(
+        &env,
+        &pool,
+        &switch_id,
+        MockNvSwitchManager::default()
+            .with_password_rotation_enabled()
+            .with_expected_password_rotation_password(TARGET_PASSWORD)
+            .with_password_rotation_job("recovered-job"),
+    )
+    .await?;
+
+    let second = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(second.rotating_to_version, Some(1));
+    assert_eq!(second.rotate_job_id.as_deref(), Some("recovered-job"));
+    assert_eq!(second.rotate_attempts, 2);
+    assert_eq!(second.rotate_last_error_redacted, None);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn job_observations_preserve_or_retry_staged_target(pool: sqlx::PgPool) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+
+    publish_target(&env, &pool, None, CURRENT_PASSWORD).await?;
+    publish_target(&env, &pool, Some(0), TARGET_PASSWORD).await?;
+
+    let retry = |status| {
+        MockNvSwitchManager::default()
+            .with_password_rotation_enabled()
+            .with_expected_password_rotation_password(TARGET_PASSWORD)
+            .with_password_rotation_job("retry-job")
+            .with_password_rotation_job_status(status)
+    };
+
+    let cases = [
+        ("failed", retry(SwitchPasswordRotationState::Failed), true),
+        (
+            "not-found",
+            retry(SwitchPasswordRotationState::NotFound),
+            true,
+        ),
+        ("unknown", retry(SwitchPasswordRotationState::Unknown), true),
+        (
+            "poll-unavailable",
+            MockNvSwitchManager::default()
+                .with_password_rotation_enabled()
+                .with_expected_password_rotation_password(TARGET_PASSWORD)
+                .with_password_rotation_job("retry-job")
+                .with_password_rotation_job_status_unavailable("temporary polling failure"),
+            false,
+        ),
+        (
+            "pending",
+            retry(SwitchPasswordRotationState::Pending),
+            false,
+        ),
+    ];
+
+    for (index, (case, manager, should_replay)) in cases.into_iter().enumerate() {
+        let (switch_id, bmc_mac_address) =
+            create_switch(&env, &pool, Some(format!("Switch{}", index + 1))).await?;
+
+        insert_current_version(&pool, bmc_mac_address, 0).await?;
+        let old_job = format!("old-job-{case}");
+        stage_submitted_rotation(&pool, bmc_mac_address, 1, &old_job).await?;
+
+        assert!(matches!(
+            reconcile(&env, &pool, &switch_id, manager).await?,
+            NvosPasswordRotationOutcome::Waiting(_)
+        ));
+
+        let retried = operation_state(&pool, bmc_mac_address).await?;
+
+        let expected_job_id = if should_replay {
+            "retry-job"
+        } else {
+            old_job.as_str()
+        };
+
+        let expected_attempts = if should_replay { 2 } else { 1 };
+
+        assert_eq!(retried.current_version, Some(0));
+        assert_eq!(retried.rotating_to_version, Some(1));
+        assert_eq!(retried.rotate_job_id.as_deref(), Some(expected_job_id));
+        assert_eq!(retried.rotate_attempts, expected_attempts);
+        assert_eq!(retried.rotate_last_error_redacted, None);
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn corrected_target_supersedes_rejected_submission(pool: sqlx::PgPool) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+    let (switch_id, bmc_mac_address) = prepare_version_one_rotation(&env, &pool).await?;
+
+    let rejected = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_expected_password_rotation_password("Different-Nvos-Password-1!");
+
+    assert!(matches!(
+        reconcile(&env, &pool, &switch_id, rejected).await?,
+        NvosPasswordRotationOutcome::Waiting(_)
+    ));
+
+    let rejected = operation_state(&pool, bmc_mac_address).await?;
+    assert_eq!(rejected.rotating_to_version, Some(1));
+    assert_eq!(rejected.rotate_job_id, None);
+    assert!(rejected.rotate_last_error_redacted.is_some());
+
+    let corrected_password = "Recovered-Nvos-Password-2!";
+    publish_target(&env, &pool, Some(1), corrected_password).await?;
+
+    let recovered = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_expected_password_rotation_password(corrected_password)
+        .with_password_rotation_job("recovered-job");
+
+    assert!(matches!(
+        reconcile(&env, &pool, &switch_id, recovered).await?,
+        NvosPasswordRotationOutcome::Waiting(_)
+    ));
+
+    let recovered = operation_state(&pool, bmc_mac_address).await?;
+    assert_eq!(recovered.current_version, Some(0));
+    assert_eq!(recovered.rotating_to_version, Some(2));
+    assert_eq!(recovered.rotate_job_id.as_deref(), Some("recovered-job"));
+    assert_eq!(recovered.rotate_attempts, 2);
+    assert_eq!(recovered.rotate_last_error_redacted, None);
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn controller_converges_directly_to_latest_revision(pool: sqlx::PgPool) -> TestResult {
+    let env = create_test_env(pool.clone()).await;
+
+    publish_target(&env, &pool, None, CURRENT_PASSWORD).await?;
+    let (switch_id, bmc_mac_address) = create_switch(&env, &pool, None).await?;
+
+    insert_current_version(&pool, bmc_mac_address, 0).await?;
+    publish_target(&env, &pool, Some(0), "Nvos-Target-1!").await?;
+    publish_target(&env, &pool, Some(1), "Nvos-Target-2!").await?;
+    publish_target(&env, &pool, Some(2), "Nvos-Target-3!").await?;
+
+    let manager = MockNvSwitchManager::default()
+        .with_password_rotation_enabled()
+        .with_expected_password_rotation_password("Nvos-Target-3!")
+        .with_password_rotation_job("revision-3-job")
+        .with_password_rotation_job_status(SwitchPasswordRotationState::Completed);
+
+    reconcile(&env, &pool, &switch_id, manager.clone()).await?;
+
+    let staged = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(staged.rotating_to_version, Some(3));
+    assert_eq!(staged.rotate_attempts, 1);
+
+    reconcile(&env, &pool, &switch_id, manager.clone()).await?;
+
+    let converged = operation_state(&pool, bmc_mac_address).await?;
+
+    assert_eq!(converged.current_version, Some(3));
+    assert_eq!(converged.rotating_to_version, None);
+
+    let stored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+        .await
+        .expect("read completed per-device NVOS credential")
+        .expect("completed per-device credential");
+
+    assert_eq!(
+        stored,
+        Credentials::UsernamePassword {
+            username: "nvos-admin".to_string(),
+            password: "Nvos-Target-3!".to_string(),
+        }
+    );
+
+    env.test_credential_manager
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin { bmc_mac_address },
+            &Credentials::UsernamePassword {
+                username: "nvos-admin".to_string(),
+                password: "Stale-Nvos-Password!".to_string(),
+            },
+        )
+        .await
+        .expect("replace per-device NVOS credential with a stale password");
+
+    let mut txn = pool.begin().await?;
+
+    transition_switch_controller_state(txn.as_mut(), &switch_id, SwitchControllerState::Ready)
+        .await?;
+
+    txn.commit().await?;
+
+    run_controller(&env, &pool, manager, 2).await;
+
+    let restored = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+        .await
+        .expect("read restored per-device NVOS credential")
+        .expect("confirmed NVOS credential should be restored");
+
+    assert_eq!(restored, stored);
+
+    Ok(())
+}

--- a/crates/api-core/tests/integration/credential_rotation.rs
+++ b/crates/api-core/tests/integration/credential_rotation.rs
@@ -15,11 +15,15 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialReader, CredentialType, CredentialWriter,
     Credentials, NicLockdownIkm,
 };
 use carbide_test_harness::prelude::*;
+use component_manager::component_manager::ComponentManager;
+use component_manager::mock::{MockComputeTrayManager, MockNvSwitchManager, MockPowerShelfManager};
 use rpc::forge::{
     CredentialRotationStatusRequest, RotateCredentialRequest, RotationCredentialType,
 };
@@ -27,6 +31,32 @@ use tonic::Code;
 
 async fn init(pool: PgPool) -> TestHarness {
     TestHarness::builder(pool).build().await
+}
+
+fn component_manager_with_nvos_rotation(supported: bool) -> Arc<ComponentManager> {
+    let nv_switch = if supported {
+        MockNvSwitchManager::default().with_password_rotation_enabled()
+    } else {
+        MockNvSwitchManager::default()
+    };
+
+    Arc::new(ComponentManager::new(
+        Arc::new(nv_switch),
+        Arc::new(MockPowerShelfManager),
+        Arc::new(MockComputeTrayManager),
+        false,
+        false,
+        false,
+    ))
+}
+
+async fn init_with_nvos_rotation(pool: PgPool) -> TestHarness {
+    TestHarness::builder(pool)
+        .with_api_builder_fn(|builder| {
+            builder.with_component_manager(component_manager_with_nvos_rotation(true))
+        })
+        .build()
+        .await
 }
 
 /// Pulls the password out of a stored credential, failing the test if the key
@@ -192,29 +222,144 @@ async fn rotate_rejects_weak_explicit_password(pool: sqlx::PgPool) {
 }
 
 #[sqlx_test]
-async fn rotate_and_status_reject_nvos(pool: sqlx::PgPool) {
-    let env = init(pool).await;
+async fn first_nvos_rotation_publishes_verified_version_zero_target(pool: sqlx::PgPool) {
+    let env = init_with_nvos_rotation(pool).await;
 
-    let rotate_err = env
+    let password = "Nvos-Site-Target-0!";
+
+    let result = env
         .api()
         .rotate_credential(tonic::Request::new(RotateCredentialRequest {
             credential_type: RotationCredentialType::RotationNvos.into(),
-            password: None,
+            password: Some(password.to_string()),
             reason: None,
         }))
         .await
-        .expect_err("nvos rotation is unsupported in v1");
-    assert_eq!(rotate_err.code(), Code::FailedPrecondition);
+        .expect("nvos target staging should succeed")
+        .into_inner();
 
-    let status_err = env
+    assert_eq!(result.target_version, 0);
+
+    let versioned = stored_password(
+        env.api().credential_manager(),
+        &CredentialKey::switch_nvos_site_admin(0),
+    )
+    .await
+    .expect("v0 nvos site target must be written");
+
+    assert_eq!(versioned, password);
+
+    let per_device = stored_password(
+        env.api().credential_manager(),
+        &CredentialKey::SwitchNvosAdmin {
+            bmc_mac_address: "02:00:00:00:00:01".parse().unwrap(),
+        },
+    )
+    .await;
+
+    assert!(
+        per_device.is_none(),
+        "staging an nvos target must not overwrite per-device switch credentials"
+    );
+
+    let status = env
         .api()
         .get_credential_rotation_status(tonic::Request::new(CredentialRotationStatusRequest {
             credential_type: RotationCredentialType::RotationNvos.into(),
             device_mac: None,
         }))
         .await
-        .expect_err("nvos status is unsupported in v1");
-    assert_eq!(status_err.code(), Code::FailedPrecondition);
+        .expect("nvos status should succeed")
+        .into_inner();
+
+    assert_eq!(status.target_version, 0);
+    assert_eq!(status.converged, 0);
+    assert_eq!(status.pending, 0);
+    assert_eq!(status.quarantined, 0);
+    assert!(status.complete);
+}
+
+#[sqlx_test]
+async fn nvos_rotation_requires_supporting_component_manager(pool: sqlx::PgPool) {
+    let env = TestHarness::builder(pool)
+        .with_api_builder_fn(|builder| {
+            builder.with_component_manager(component_manager_with_nvos_rotation(false))
+        })
+        .build()
+        .await;
+
+    let err = env
+        .api()
+        .rotate_credential(tonic::Request::new(RotateCredentialRequest {
+            credential_type: RotationCredentialType::RotationNvos.into(),
+            password: Some("Nvos-Site-Target-0!".to_string()),
+            reason: None,
+        }))
+        .await
+        .expect_err("unsupported component-manager backend must block NVOS rotation");
+
+    assert_eq!(err.code(), Code::FailedPrecondition);
+
+    assert_eq!(
+        err.message(),
+        "NVOS rotation requires a component-manager switch backend that supports password rotation"
+    );
+}
+
+#[sqlx_test]
+async fn nvos_status_before_first_target_is_failed_precondition(pool: sqlx::PgPool) {
+    let env = init(pool).await;
+    let switch = env.create_switch(1, 1).await;
+    let bmc_mac = "02:00:00:00:00:41";
+    let mut txn = env.db_txn().await;
+
+    sqlx::query(
+        "INSERT INTO expected_switches \
+             (serial_number, bmc_mac_address, bmc_username, bmc_password) \
+         VALUES ('nvos-status-before-target', $1::macaddr, 'admin', 'password')",
+    )
+    .bind(bmc_mac)
+    .execute(&mut *txn)
+    .await
+    .unwrap();
+
+    sqlx::query("UPDATE switches SET bmc_mac_address = $1::macaddr WHERE id = $2")
+        .bind(bmc_mac)
+        .bind(switch.id)
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+
+    txn.commit().await.unwrap();
+
+    for device_mac in [None, Some(bmc_mac.to_string())] {
+        let error = env
+            .api()
+            .get_credential_rotation_status(tonic::Request::new(CredentialRotationStatusRequest {
+                credential_type: RotationCredentialType::RotationNvos.into(),
+                device_mac,
+            }))
+            .await
+            .expect_err("unpublished NVOS status must report a precondition");
+
+        assert_eq!(error.code(), Code::FailedPrecondition);
+
+        assert_eq!(
+            error.message(),
+            "no site-wide NVOS credential rotation target has been published"
+        );
+    }
+
+    let unknown = env
+        .api()
+        .get_credential_rotation_status(tonic::Request::new(CredentialRotationStatusRequest {
+            credential_type: RotationCredentialType::RotationNvos.into(),
+            device_mac: Some("02:00:00:00:00:42".to_string()),
+        }))
+        .await
+        .expect_err("unknown switch must remain not found");
+
+    assert_eq!(unknown.code(), Code::NotFound);
 }
 
 #[sqlx_test]

--- a/crates/api-core/tests/integration/credential_rotation.rs
+++ b/crates/api-core/tests/integration/credential_rotation.rs
@@ -24,6 +24,7 @@ use carbide_secrets::credentials::{
 use carbide_test_harness::prelude::*;
 use component_manager::component_manager::ComponentManager;
 use component_manager::mock::{MockComputeTrayManager, MockNvSwitchManager, MockPowerShelfManager};
+use mac_address::MacAddress;
 use rpc::forge::{
     CredentialRotationStatusRequest, RotateCredentialRequest, RotationCredentialType,
 };
@@ -75,6 +76,42 @@ fn site_creds(password: &str) -> Credentials {
         username: String::new(),
         password: password.to_string(),
     }
+}
+
+async fn add_live_nvos_switch(
+    env: &TestHarness,
+    index: i32,
+    bmc_mac: &str,
+    nvos_username: Option<&str>,
+    nvos_password: Option<&str>,
+) -> MacAddress {
+    let switch = env.create_switch(index, index).await;
+    let mut txn = env.db_txn().await;
+
+    sqlx::query(
+        "INSERT INTO expected_switches \
+             (serial_number, bmc_mac_address, bmc_username, bmc_password, \
+              nvos_username, nvos_password) \
+         VALUES ($1, $2::macaddr, 'admin', 'password', $3, $4)",
+    )
+    .bind(format!("nvos-preflight-{index}"))
+    .bind(bmc_mac)
+    .bind(nvos_username)
+    .bind(nvos_password)
+    .execute(&mut *txn)
+    .await
+    .unwrap();
+
+    sqlx::query("UPDATE switches SET bmc_mac_address = $1::macaddr WHERE id = $2")
+        .bind(bmc_mac)
+        .bind(switch.id)
+        .execute(&mut *txn)
+        .await
+        .unwrap();
+
+    txn.commit().await.unwrap();
+
+    bmc_mac.parse().unwrap()
 }
 
 #[sqlx_test]
@@ -277,6 +314,91 @@ async fn first_nvos_rotation_publishes_verified_version_zero_target(pool: sqlx::
     assert_eq!(status.pending, 0);
     assert_eq!(status.quarantined, 0);
     assert!(status.complete);
+}
+
+#[sqlx_test]
+async fn nvos_rotation_rejects_malformed_expected_credentials(pool: sqlx::PgPool) {
+    let env = init_with_nvos_rotation(pool).await;
+    let bmc_mac = "02:00:00:00:00:51";
+
+    let stored_mac = add_live_nvos_switch(&env, 1, bmc_mac, Some("admin"), None).await;
+    env.api()
+        .credential_manager()
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin {
+                bmc_mac_address: stored_mac,
+            },
+            &Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "stored-password".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let error = env
+        .api()
+        .rotate_credential(tonic::Request::new(RotateCredentialRequest {
+            credential_type: RotationCredentialType::RotationNvos.into(),
+            password: Some("Nvos-Site-Target-0!".to_string()),
+            reason: None,
+        }))
+        .await
+        .expect_err("malformed expected credentials must block target publication");
+
+    assert_eq!(error.code(), Code::FailedPrecondition);
+    assert!(error.message().contains(bmc_mac));
+
+    assert!(
+        stored_password(
+            env.api().credential_manager(),
+            &CredentialKey::switch_nvos_site_admin(0),
+        )
+        .await
+        .is_none()
+    );
+}
+
+#[sqlx_test]
+async fn nvos_rotation_accepts_expected_or_stored_current_credentials(pool: sqlx::PgPool) {
+    let env = init_with_nvos_rotation(pool).await;
+
+    add_live_nvos_switch(
+        &env,
+        1,
+        "02:00:00:00:00:52",
+        Some("admin"),
+        Some("expected-password"),
+    )
+    .await;
+
+    let stored_mac = add_live_nvos_switch(&env, 2, "02:00:00:00:00:53", None, None).await;
+    env.api()
+        .credential_manager()
+        .set_credentials(
+            &CredentialKey::SwitchNvosAdmin {
+                bmc_mac_address: stored_mac,
+            },
+            &Credentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "stored-password".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let result = env
+        .api()
+        .rotate_credential(tonic::Request::new(RotateCredentialRequest {
+            credential_type: RotationCredentialType::RotationNvos.into(),
+            password: Some("Nvos-Site-Target-0!".to_string()),
+            reason: None,
+        }))
+        .await
+        .expect("either current credential source should allow rotation")
+        .into_inner();
+
+    assert_eq!(result.target_version, 0);
 }
 
 #[sqlx_test]

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -64,6 +64,7 @@
 //! join `device_credential_rotation` to the live device tables when selecting
 //! work so a row orphaned by device deletion is never acted on.
 
+use carbide_uuid::switch::SwitchId;
 use chrono::{DateTime, Duration, Utc};
 use mac_address::MacAddress;
 use sqlx::PgConnection;
@@ -671,6 +672,27 @@ struct RotationCounts {
     pending: i64,
     quarantined: i64,
     started_at: DateTime<Utc>,
+}
+
+/// Live switches that cannot bootstrap from complete expected-switch credentials.
+pub async fn nvos_credential_source_gaps(
+    conn: impl DbReader<'_>,
+) -> Result<Vec<(SwitchId, Option<MacAddress>, bool)>, DatabaseError> {
+    let query = "SELECT s.id AS switch_id, s.bmc_mac_address, \
+                        es.nvos_username IS NOT NULL \
+                            OR es.nvos_password IS NOT NULL AS malformed_expected_credentials \
+                 FROM switches s \
+                 LEFT JOIN expected_switches es \
+                   ON es.bmc_mac_address = s.bmc_mac_address \
+                 WHERE s.deleted IS NULL \
+                   AND (NULLIF(es.nvos_username, '') IS NULL \
+                        OR NULLIF(es.nvos_password, '') IS NULL) \
+                 ORDER BY s.id";
+
+    sqlx::query_as::<_, (SwitchId, Option<MacAddress>, bool)>(query)
+        .fetch_all(conn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))
 }
 
 /// Convergence status for `credential_type`'s current site-wide target.

--- a/crates/api-db/src/credential_rotation.rs
+++ b/crates/api-db/src/credential_rotation.rs
@@ -44,18 +44,10 @@
 //!   mid-flight advance from mis-recording a card as converged to a version it
 //!   was never locked under.
 //!
-//! NVOS password rotation requires durable progress across process restarts.
-//! The controller stages a published target with
-//! [`record_device_rotation_started`], attaches its backend job ID with
-//! [`record_device_rotation_submitted`], and recovers progress through
-//! [`device_rotation_operation_state`]. A lost response, missing job, unknown
-//! job, or failed job claims another attempt through
-//! [`record_device_rotation_retry_started`] before redispatching the same
-//! resumable RMS mutation. A matching completed job is promoted through
-//! [`record_device_rotation_succeeded`] only after the per-device target
-//! credential has been written and read back. Each transition compares the
-//! durable attempt number so a stale worker or late backend response cannot
-//! overwrite a retry.
+//! NVOS stages its target before dispatch and records an optional backend job.
+//! Missing or terminal job observations retry that exact target. Completion is
+//! promoted only after per-device credential readback, with target, attempt, and
+//! job comparisons fencing stale responses.
 //!
 //! Teardown hooks (calling [`delete_device_converged`]) remove a marker when the
 //! credential it tracks is torn down, keeping the table honest:
@@ -277,7 +269,7 @@ pub async fn promote_rotating_to_current(
 /// `rotate_quarantined_until` so the engine skips this device until it expires.
 ///
 /// This is the BMC engine's synchronous failure recorder, distinct from the
-/// NVOS job-based [`record_device_rotation_rejected`] (which marks a *terminal*
+/// NVOS job-based [`record_device_rotation_failed`] (which marks a *terminal*
 /// backend rejection under attempt CAS). The in-flight `rotating_to_version`
 /// crash marker is deliberately left in place: once the window passes the engine
 /// re-enters and its two-candidate recovery reconciles the hardware.
@@ -322,18 +314,9 @@ pub async fn increment_rotate_attempt(
 
 /// Stages a target before dispatching a password mutation.
 ///
-/// This is the durable pre-dispatch boundary. It must commit before dispatch so
-/// a restarted worker can see that mutation work was staged and avoid replacing
-/// or blindly repeating an unresolved operation.
-///
-/// Returns the new positive attempt number when work was staged. Returns `None`
-/// when the site-wide target no longer matches, the device has already converged
-/// to that revision, unresolved work is staged, the requested target does not
-/// supersede a definitive failed attempt, or an active quarantine window
-/// prevents work from being claimed. A later target may replace a staged
-/// definitive failure, which makes publishing that target the operator retry
-/// signal. Callers must pass the attempt number to every later transition so
-/// stale responses from an earlier retry cannot mutate current state.
+/// Returns the new attempt number. `None` means the target changed, the device
+/// converged, or unresolved work cannot be replaced. Only a later target may
+/// replace a pre-dispatch rejection without a backend job.
 pub async fn record_device_rotation_started(
     conn: &mut PgConnection,
     device_mac: MacAddress,
@@ -369,7 +352,8 @@ pub async fn record_device_rotation_started(
                             AND device_credential_rotation.rotate_last_error_redacted IS NULL \
                         OR device_credential_rotation.rotating_to_version \
                                < EXCLUDED.rotating_to_version \
-                            AND device_credential_rotation.rotate_last_error_redacted IS NOT NULL) \
+                            AND device_credential_rotation.rotate_last_error_redacted IS NOT NULL \
+                            AND device_credential_rotation.rotate_job_id IS NULL) \
                        AND (device_credential_rotation.current_version IS NULL \
                             OR device_credential_rotation.current_version \
                                < EXCLUDED.rotating_to_version) \
@@ -388,13 +372,8 @@ pub async fn record_device_rotation_started(
 
 /// Records the opaque backend job ID returned for a staged target.
 ///
-/// This is the durable handoff from mutation dispatch to job reconciliation.
-/// Persisting the backend handle allows polling to resume after process restart,
-/// while matching the staged target and attempt number prevents a late response
-/// from attaching to a newer operation.
-///
-/// Returns `false` if the row no longer has the expected target, already has a
-/// different job ID, or has already reached a terminal failure.
+/// Target and attempt comparisons prevent a late response from attaching to a
+/// newer operation. Returns `false` when that operation is no longer active.
 pub async fn record_device_rotation_submitted(
     conn: &mut PgConnection,
     device_mac: MacAddress,
@@ -430,18 +409,9 @@ pub async fn record_device_rotation_submitted(
     Ok(result.rows_affected() > 0)
 }
 
-/// Claims another dispatch attempt for the same unresolved staged target.
+/// Starts another observation attempt for the same unresolved target.
 ///
-/// RMS password updates are resumable: the backend can continue with either the
-/// previous endpoint credential or the requested target credential after a
-/// partial success. This transition clears the old job handle and increments
-/// the attempt CAS before that mutation is dispatched again. `expected_job_id`
-/// is `None` after a lost submission response and `Some` after a failed,
-/// missing, or unknown job observation.
-///
-/// Returns the new attempt number on success. Returns `None` if operation state
-/// changed, an error already marked the request as non-retryable, or active
-/// quarantine blocks work.
+/// The target never changes. Attempt and job comparisons fence late results.
 pub async fn record_device_rotation_retry_started(
     conn: &mut PgConnection,
     device_mac: MacAddress,
@@ -476,14 +446,11 @@ pub async fn record_device_rotation_retry_started(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-/// Marks a staged mutation that the backend definitively did not accept.
+/// Marks a definitive staged backend rejection without changing its target.
 ///
-/// The last confirmed credential and exact staged target remain unchanged. The
-/// terminal marker blocks unchanged redispatch; a later corrected target may
-/// supersede it. Matching the attempt number and requiring no job ID prevents a
-/// late dispatch error from terminating newer or accepted work. Returns `false`
-/// when that exact pre-submission attempt is no longer active.
-pub async fn record_device_rotation_rejected(
+/// Use only when no mutation was accepted. A row with a backend job is retained
+/// because its password outcome may be unknown.
+pub async fn record_device_rotation_failed(
     conn: &mut PgConnection,
     device_mac: MacAddress,
     credential_type: CredentialRotationType,
@@ -512,22 +479,19 @@ pub async fn record_device_rotation_rejected(
     Ok(result.rows_affected() > 0)
 }
 
-/// Promotes a target after its matching backend job completed.
+/// Promotes a target after its matching backend operation confirmed convergence.
 ///
-/// Call this only after the backend reported `Completed` and the caller wrote
-/// and read back the target under the per-device credential key. Matching the
-/// staged target, attempt number, and job ID prevents stale completion from
-/// promoting a newer retry. Returns `false` when that exact operation is no
-/// longer active.
+/// The caller must first write and read back the per-device target. Target,
+/// attempt, and job comparisons fence stale completion.
 pub async fn record_device_rotation_succeeded(
     conn: &mut PgConnection,
     device_mac: MacAddress,
     credential_type: CredentialRotationType,
     rotating_to_version: i32,
     expected_attempt: i32,
-    job_id: &str,
+    expected_job_id: &str,
 ) -> Result<bool, DatabaseError> {
-    if job_id.is_empty() {
+    if expected_job_id.is_empty() {
         return Err(DatabaseError::InvalidArgument(
             "rotation job ID must not be empty".to_string(),
         ));
@@ -542,14 +506,15 @@ pub async fn record_device_rotation_succeeded(
                  WHERE device_mac = $1 AND credential_type = $2 \
                        AND rotating_to_version = $3 \
                        AND rotate_attempts = $4 \
-                       AND rotate_job_id = $5";
+                       AND rotate_job_id = $5 \
+                       AND rotate_last_error_redacted IS NULL";
 
     let result = sqlx::query(query)
         .bind(device_mac)
         .bind(credential_type)
         .bind(rotating_to_version)
         .bind(expected_attempt)
-        .bind(job_id)
+        .bind(expected_job_id)
         .execute(&mut *conn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
@@ -771,24 +736,28 @@ pub async fn rotation_status(
     })
 }
 
-/// NVOS convergence uses live switches as its device universe because rows are
-/// created lazily when the switch controller first stages a target.
+/// NVOS convergence is reported over live switches.
+///
+/// The database cannot see credential-store-only per-device NVOS secrets, so
+/// filtering by expected-switch credential columns could report false
+/// convergence. Every live switch counts once; a switch without a BMC MAC or
+/// actionable credential remains pending until its inventory is corrected or it
+/// is removed from the live set.
 async fn nvos_rotation_status(conn: &mut PgConnection) -> Result<RotationStatus, DatabaseError> {
     let counts_query = "WITH live_devices AS ( \
-                            SELECT DISTINCT bmc_mac_address AS device_mac \
+                            SELECT id AS switch_id, bmc_mac_address AS device_mac \
                             FROM switches \
                             WHERE deleted IS NULL \
-                              AND bmc_mac_address IS NOT NULL \
                         ) \
                         SELECT s.target_version, \
-                            count(ld.device_mac) FILTER ( \
+                            count(ld.switch_id) FILTER ( \
                                 WHERE d.current_version >= s.target_version) AS converged, \
-                            count(ld.device_mac) FILTER ( \
+                            count(ld.switch_id) FILTER ( \
                                 WHERE (d.current_version IS NULL \
                                        OR d.current_version < s.target_version) \
                                   AND (d.rotate_quarantined_until IS NULL \
                                        OR d.rotate_quarantined_until <= now())) AS pending, \
-                            count(ld.device_mac) FILTER ( \
+                            count(ld.switch_id) FILTER ( \
                                 WHERE d.rotate_quarantined_until > now()) AS quarantined, \
                             s.started_at \
                         FROM sitewide_credential_rotation s \
@@ -876,9 +845,7 @@ pub struct DeviceRotationStatus {
 /// Query row for NVOS status while the site-wide target may be unpublished.
 ///
 /// The query starts from the live switch and left-joins the target, so these
-/// target fields must be nullable. The helper converts a complete row into
-/// [`DeviceRotationStatus`] and maps a missing target to
-/// [`DatabaseError::MissingSitewideRotationTarget`].
+/// target fields must be nullable.
 #[derive(sqlx::FromRow)]
 struct NvosDeviceRotationStatusRow {
     target_version: Option<i32>,
@@ -915,6 +882,9 @@ pub struct DeviceRotationOperationState {
     /// so the non-negative `integer` column maps directly to `i32`.
     pub rotate_attempts: i32,
 
+    /// Database time when the current attempt was staged.
+    pub rotate_last_attempt_at: Option<DateTime<Utc>>,
+
     /// Redacted reason a definitive failed attempt is blocked.
     pub rotate_last_error_redacted: Option<String>,
 }
@@ -933,6 +903,7 @@ pub async fn device_rotation_operation_state(
                         rotating_to_version, \
                         rotate_job_id, \
                         rotate_attempts, \
+                        rotate_last_attempt_at, \
                         rotate_last_error_redacted \
                  FROM device_credential_rotation \
                  WHERE credential_type = $1 AND device_mac = $2";
@@ -1064,7 +1035,7 @@ mod tests {
         BACKOFF_CAP_SECS, CredentialRotationType, backoff_until, current_target_version,
         delete_device_converged, device_rotation_operation_state, device_rotation_status,
         increment_rotate_attempt, mark_device_rotating_to_version, promote_rotating_to_current,
-        record_device_converged, record_device_rotation_rejected,
+        record_device_converged, record_device_rotation_failed,
         record_device_rotation_retry_started, record_device_rotation_started,
         record_device_rotation_submitted, record_device_rotation_succeeded, rotation_status,
         set_initial_target_version, set_next_target_version,
@@ -1086,14 +1057,23 @@ mod tests {
         .unwrap();
     }
 
-    async fn insert_switch(conn: &mut PgConnection, id: &str, bmc_mac: &str, deleted: bool) {
+    async fn insert_switch_with_nvos_credentials(
+        conn: &mut PgConnection,
+        id: &str,
+        bmc_mac: &str,
+        deleted: bool,
+        has_nvos_credentials: bool,
+    ) {
         sqlx::query(
             "INSERT INTO expected_switches \
-                 (serial_number, bmc_mac_address, bmc_username, bmc_password) \
-             VALUES ($1, $2::macaddr, 'admin', 'pw')",
+                 (serial_number, bmc_mac_address, bmc_username, bmc_password, \
+                  nvos_username, nvos_password) \
+             VALUES ($1, $2::macaddr, 'admin', 'pw', $3, $4)",
         )
         .bind(format!("sn-{id}"))
         .bind(bmc_mac)
+        .bind(has_nvos_credentials.then_some("nvos-admin"))
+        .bind(has_nvos_credentials.then_some("nvos-password"))
         .execute(&mut *conn)
         .await
         .unwrap();
@@ -1109,6 +1089,19 @@ mod tests {
         .execute(&mut *conn)
         .await
         .unwrap();
+    }
+
+    async fn insert_switch(conn: &mut PgConnection, id: &str, bmc_mac: &str, deleted: bool) {
+        insert_switch_with_nvos_credentials(conn, id, bmc_mac, deleted, true).await;
+    }
+
+    async fn insert_credentialless_switch(
+        conn: &mut PgConnection,
+        id: &str,
+        bmc_mac: &str,
+        deleted: bool,
+    ) {
+        insert_switch_with_nvos_credentials(conn, id, bmc_mac, deleted, false).await;
     }
 
     // current_version for a (mac, type) row, or None if no row exists. Takes the
@@ -1444,7 +1437,7 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn definitive_rejection_requires_a_later_target_for_retry(pool: PgPool) {
+    async fn corrected_target_supersedes_pre_dispatch_rejection(pool: PgPool) {
         let mac: MacAddress = "02:00:00:00:00:0c".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
@@ -1457,7 +1450,7 @@ mod tests {
                 .expect("the first attempt should be staged");
 
         assert!(
-            record_device_rotation_rejected(
+            record_device_rotation_failed(
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,
@@ -1486,15 +1479,14 @@ mod tests {
         .unwrap()
         .expect("operator should publish a later target");
 
-        let retry_attempt =
+        let next_attempt =
             record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 2)
                 .await
-                .unwrap()
-                .expect("a later target should reopen rejected work");
+                .unwrap();
 
-        assert_eq!(retry_attempt, attempt + 1);
+        let next_attempt = next_attempt.expect("a corrected target should replace a rejection");
 
-        let stale_release = record_device_rotation_rejected(
+        let stale_release = record_device_rotation_failed(
             &mut conn,
             mac,
             CredentialRotationType::Nvos,
@@ -1515,43 +1507,36 @@ mod tests {
         assert_eq!(state.current_version, None);
         assert_eq!(state.rotating_to_version, Some(2));
         assert_eq!(state.rotate_job_id, None);
-        assert_eq!(state.rotate_attempts, retry_attempt);
+        assert_eq!(state.rotate_attempts, next_attempt);
+
         assert_eq!(state.rotate_last_error_redacted, None);
     }
 
     #[crate::sqlx_test]
-    async fn new_target_does_not_bypass_active_quarantine(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
+    async fn retry_retains_original_target_after_later_publication(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:1a".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
         publish_nvos_target(&mut conn, 1).await;
 
-        let attempt =
+        let first_attempt =
             record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
                 .await
                 .unwrap()
                 .expect("the first attempt should be staged");
 
-        record_device_rotation_rejected(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            "backend did not accept password rotation",
-        )
-        .await
-        .unwrap();
-
-        sqlx::query(
-            "UPDATE device_credential_rotation \
-             SET rotate_quarantined_until = now() + interval '1 hour' \
-             WHERE device_mac = $1 AND credential_type = 'nvos'",
-        )
-        .bind(mac)
-        .execute(&mut *conn)
-        .await
-        .unwrap();
+        assert!(
+            record_device_rotation_submitted(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                first_attempt,
+                "first-job",
+            )
+            .await
+            .unwrap()
+        );
 
         set_next_target_version(
             &mut conn,
@@ -1561,15 +1546,84 @@ mod tests {
         )
         .await
         .unwrap()
-        .expect("operator should publish the next target");
+        .expect("operator should publish a later target");
+
+        let retry_attempt = record_device_rotation_retry_started(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            first_attempt,
+            Some("first-job"),
+        )
+        .await
+        .unwrap()
+        .expect("the original target should be retried");
+
+        assert_eq!(retry_attempt, first_attempt + 1);
 
         let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
             .expect("operation state should exist");
 
+        assert_eq!(state.current_version, None);
         assert_eq!(state.rotating_to_version, Some(1));
-        assert!(state.rotate_last_error_redacted.is_some());
+        assert_eq!(state.rotate_job_id, None);
+        assert_eq!(state.rotate_attempts, retry_attempt);
+
+        assert!(
+            record_device_rotation_submitted(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                retry_attempt,
+                "retry-job",
+            )
+            .await
+            .unwrap()
+        );
+
+        assert!(
+            record_device_rotation_succeeded(
+                &mut conn,
+                mac,
+                CredentialRotationType::Nvos,
+                1,
+                retry_attempt,
+                "retry-job",
+            )
+            .await
+            .unwrap()
+        );
+
+        let converged =
+            device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
+                .await
+                .unwrap()
+                .expect("operation state should exist");
+
+        assert_eq!(converged.current_version, Some(1));
+        assert_eq!(converged.rotating_to_version, None);
+    }
+
+    #[crate::sqlx_test]
+    async fn active_quarantine_blocks_then_allows_initial_work_claim(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        publish_nvos_target(&mut conn, 1).await;
+
+        sqlx::query(
+            "INSERT INTO device_credential_rotation \
+             (device_mac, credential_type, current_version, rotate_quarantined_until) \
+             VALUES ($1, 'nvos', 0, now() + interval '1 hour')",
+        )
+        .bind(mac)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
 
         let quarantine_active: bool = sqlx::query_scalar(
             "SELECT rotate_quarantined_until > now() \
@@ -1583,51 +1637,14 @@ mod tests {
 
         assert!(quarantine_active);
 
-        let blocked =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 2)
-                .await
-                .unwrap();
-
-        assert_eq!(blocked, None, "active quarantine must still block retry");
-    }
-
-    #[crate::sqlx_test]
-    async fn active_quarantine_prevents_rotation_claim(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:10".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        publish_nvos_target(&mut conn, 1).await;
-
-        sqlx::query(
-            "INSERT INTO device_credential_rotation \
-                 (device_mac, credential_type, current_version, rotate_quarantined_until) \
-             VALUES ($1, 'nvos', 0, now() + interval '1 hour')",
-        )
-        .bind(mac)
-        .execute(&mut *conn)
-        .await
-        .unwrap();
-
-        let blocked =
+        let blocked_attempt =
             record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
                 .await
                 .unwrap();
 
-        assert_eq!(blocked, None, "active quarantine must prevent work claim");
-
-        let quarantine_active: bool = sqlx::query_scalar(
-            "SELECT rotate_quarantined_until > now() \
-             FROM device_credential_rotation \
-             WHERE device_mac = $1 AND credential_type = 'nvos'",
-        )
-        .bind(mac)
-        .fetch_one(&mut *conn)
-        .await
-        .unwrap();
-
-        assert!(
-            quarantine_active,
-            "a blocked claim must preserve quarantine"
+        assert_eq!(
+            blocked_attempt, None,
+            "active quarantine must still block retry"
         );
 
         sqlx::query(
@@ -1640,13 +1657,13 @@ mod tests {
         .await
         .unwrap();
 
-        let attempt =
+        let next_attempt =
             record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
                 .await
                 .unwrap();
 
         assert_eq!(
-            attempt,
+            next_attempt,
             Some(1),
             "expired quarantine must permit work claim"
         );
@@ -1665,129 +1682,6 @@ mod tests {
             quarantine_cleared,
             "successful claim must clear expired quarantine"
         );
-    }
-
-    #[crate::sqlx_test]
-    async fn unresolved_dispatch_retries_exact_staged_target(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0d".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        publish_nvos_target(&mut conn, 1).await;
-
-        let attempt =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
-                .await
-                .unwrap()
-                .expect("the first attempt should be staged");
-
-        set_next_target_version(
-            &mut conn,
-            CredentialRotationType::Nvos,
-            1,
-            serde_json::json!({}),
-        )
-        .await
-        .unwrap()
-        .expect("operator should publish a later target");
-
-        let retry = record_device_rotation_retry_started(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            None,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(retry, Some(attempt + 1));
-
-        let stale_retry = record_device_rotation_retry_started(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            None,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(stale_retry, None);
-
-        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
-            .await
-            .unwrap()
-            .expect("operation state should exist");
-
-        assert_eq!(state.current_version, None);
-        assert_eq!(state.rotating_to_version, Some(1));
-        assert_eq!(state.rotate_job_id, None);
-        assert_eq!(state.rotate_attempts, attempt + 1);
-        assert_eq!(state.rotate_last_error_redacted, None);
-    }
-
-    #[crate::sqlx_test]
-    async fn failed_or_missing_job_retries_only_matching_operation(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:11".parse().unwrap();
-        let mut conn = pool.acquire().await.unwrap();
-
-        publish_nvos_target(&mut conn, 1).await;
-
-        let attempt =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
-                .await
-                .unwrap()
-                .expect("the first attempt should be staged");
-
-        assert!(
-            record_device_rotation_submitted(
-                &mut conn,
-                mac,
-                CredentialRotationType::Nvos,
-                1,
-                attempt,
-                "old-job",
-            )
-            .await
-            .unwrap()
-        );
-
-        let wrong_job = record_device_rotation_retry_started(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            Some("other-job"),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(wrong_job, None);
-
-        let retry = record_device_rotation_retry_started(
-            &mut conn,
-            mac,
-            CredentialRotationType::Nvos,
-            1,
-            attempt,
-            Some("old-job"),
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(retry, Some(attempt + 1));
-
-        let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
-            .await
-            .unwrap()
-            .expect("operation state should exist");
-
-        assert_eq!(state.rotating_to_version, Some(1));
-        assert_eq!(state.rotate_job_id, None);
-        assert_eq!(state.rotate_attempts, attempt + 1);
     }
 
     #[crate::sqlx_test]
@@ -1899,6 +1793,16 @@ mod tests {
 
         assert!(!promoted_again);
 
+        let restarted_same =
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 7)
+                .await
+                .unwrap();
+
+        assert_eq!(
+            restarted_same, None,
+            "a converged revision must not be staged again"
+        );
+
         let next_started =
             record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 8)
                 .await
@@ -1917,14 +1821,14 @@ mod tests {
     }
 
     #[crate::sqlx_test]
-    async fn completed_revision_cannot_be_restarted(pool: PgPool) {
-        let mac: MacAddress = "02:00:00:00:00:0f".parse().unwrap();
+    async fn accepted_job_cannot_be_marked_as_pre_dispatch_failure(pool: PgPool) {
+        let mac: MacAddress = "02:00:00:00:00:12".parse().unwrap();
         let mut conn = pool.acquire().await.unwrap();
 
-        publish_nvos_target(&mut conn, 0).await;
+        publish_nvos_target(&mut conn, 1).await;
 
         let attempt =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 0)
+            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 1)
                 .await
                 .unwrap()
                 .expect("the first attempt should be staged");
@@ -1934,44 +1838,49 @@ mod tests {
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,
-                0,
+                1,
                 attempt,
-                "job-0",
+                "job-1",
             )
             .await
             .unwrap()
         );
 
         assert!(
-            record_device_rotation_succeeded(
+            !record_device_rotation_failed(
                 &mut conn,
                 mac,
                 CredentialRotationType::Nvos,
-                0,
+                1,
                 attempt,
-                "job-0",
+                "backend reported failure",
             )
             .await
             .unwrap()
         );
 
-        let restarted =
-            record_device_rotation_started(&mut conn, mac, CredentialRotationType::Nvos, 0)
-                .await
-                .unwrap();
+        let promoted = record_device_rotation_succeeded(
+            &mut conn,
+            mac,
+            CredentialRotationType::Nvos,
+            1,
+            attempt,
+            "job-1",
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(
-            restarted, None,
-            "a converged revision must not be staged again"
-        );
+        assert!(promoted);
 
         let state = device_rotation_operation_state(&mut *conn, CredentialRotationType::Nvos, mac)
             .await
             .unwrap()
-            .expect("operation state should exist");
+            .expect("failed operation state should remain");
 
-        assert_eq!(state.current_version, Some(0));
+        assert_eq!(state.current_version, Some(1));
         assert_eq!(state.rotating_to_version, None);
+        assert_eq!(state.rotate_job_id, None);
+        assert_eq!(state.rotate_last_error_redacted, None);
     }
 
     #[crate::sqlx_test]
@@ -2123,8 +2032,9 @@ mod tests {
         insert_device(&mut conn, "02:00:00:00:00:02", "host_uefi", Some(0)).await;
         // pending: not yet established (NULL current_version).
         insert_device(&mut conn, "02:00:00:00:00:03", "host_uefi", None).await;
+
         // quarantined: behind the target but with a future backoff window, so it
-        // is counted as quarantined rather than pending.
+        // counted as quarantined rather than pending.
         sqlx::query(
             "INSERT INTO device_credential_rotation \
                  (device_mac, credential_type, current_version, rotate_quarantined_until) \
@@ -2177,8 +2087,17 @@ mod tests {
 
         publish_nvos_target(&mut conn, 1).await;
         insert_switch(&mut conn, "nvos-sw-1", "02:00:00:00:40:01", false).await;
-        insert_switch(&mut conn, "nvos-sw-2", "02:00:00:00:40:02", false).await;
+        insert_credentialless_switch(&mut conn, "nvos-sw-2", "02:00:00:00:40:02", false).await;
         insert_switch(&mut conn, "nvos-sw-deleted", "02:00:00:00:40:03", true).await;
+
+        sqlx::query(
+            "INSERT INTO switches (id, name, config) \
+             VALUES ('nvos-sw-no-bmc', 'nvos-sw-no-bmc', '{}'::jsonb)",
+        )
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+
         insert_device(&mut conn, "02:00:00:00:40:01", "nvos", Some(1)).await;
         insert_device(&mut conn, "02:00:00:00:40:03", "nvos", Some(0)).await;
 
@@ -2188,8 +2107,18 @@ mod tests {
 
         assert_eq!(status.target_version, 1);
         assert_eq!(status.converged, 1);
-        assert_eq!(status.pending, 1);
+        assert_eq!(status.pending, 2);
         assert_eq!(status.quarantined, 0);
+
+        insert_device(&mut conn, "02:00:00:00:40:02", "nvos", Some(1)).await;
+
+        let complete = rotation_status(&mut conn, CredentialRotationType::Nvos)
+            .await
+            .unwrap();
+
+        assert_eq!(complete.converged, 2);
+        assert_eq!(complete.pending, 1);
+        assert_eq!(complete.quarantined, 0);
     }
 
     #[crate::sqlx_test]
@@ -2198,15 +2127,35 @@ mod tests {
         let live_mac: MacAddress = "02:00:00:00:50:01".parse().unwrap();
         let deleted_mac: MacAddress = "02:00:00:00:50:02".parse().unwrap();
         let unknown_mac: MacAddress = "02:00:00:00:50:ff".parse().unwrap();
+        let credentialless_mac: MacAddress = "02:00:00:00:50:10".parse().unwrap();
 
         insert_switch(&mut conn, "nvos-device-live", "02:00:00:00:50:01", false).await;
         insert_switch(&mut conn, "nvos-device-deleted", "02:00:00:00:50:02", true).await;
 
+        insert_credentialless_switch(
+            &mut conn,
+            "nvos-device-credentialless",
+            "02:00:00:00:50:10",
+            false,
+        )
+        .await;
+
         let before_publish =
             device_rotation_status(&mut conn, CredentialRotationType::Nvos, live_mac).await;
 
+        let credentialless_before_publish =
+            device_rotation_status(&mut conn, CredentialRotationType::Nvos, credentialless_mac)
+                .await;
+
         assert!(matches!(
             before_publish,
+            Err(crate::DatabaseError::MissingSitewideRotationTarget(
+                CredentialRotationType::Nvos
+            ))
+        ));
+
+        assert!(matches!(
+            credentialless_before_publish,
             Err(crate::DatabaseError::MissingSitewideRotationTarget(
                 CredentialRotationType::Nvos
             ))
@@ -2231,6 +2180,15 @@ mod tests {
         assert_eq!(pending.rotating_to_version, None);
         assert!(!pending.converged);
         assert_eq!(pending.rotate_attempts, 0);
+
+        let credentialless_pending =
+            device_rotation_status(&mut conn, CredentialRotationType::Nvos, credentialless_mac)
+                .await
+                .unwrap()
+                .expect("live credentialless switch should remain visible as pending");
+
+        assert!(!credentialless_pending.converged);
+        assert_eq!(credentialless_pending.rotate_attempts, 0);
 
         assert!(
             device_rotation_status(&mut conn, CredentialRotationType::Nvos, deleted_mac)

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -320,6 +320,36 @@ pub async fn find(
     }
 }
 
+/// Locks the expected-switch write domain and returns the selected row for update.
+pub async fn find_for_update(
+    txn: &mut PgConnection,
+    req: &ExpectedSwitchRequest,
+) -> DatabaseResult<Option<ExpectedSwitch>> {
+    lock_expected_switch_writes(&mut *txn).await?;
+
+    let (query, key) = if let Some(id) = req.expected_switch_id {
+        (
+            "SELECT * FROM expected_switches WHERE expected_switch_id=$1::uuid FOR UPDATE",
+            id.to_string(),
+        )
+    } else if let Some(mac) = req.bmc_mac_address {
+        (
+            "SELECT * FROM expected_switches WHERE bmc_mac_address=$1::macaddr FOR UPDATE",
+            mac.to_string(),
+        )
+    } else {
+        return Err(DatabaseError::InvalidArgument(
+            "either expected_switch_id or bmc_mac_address must be provided".into(),
+        ));
+    };
+
+    sqlx::query_as(query)
+        .bind(key)
+        .fetch_optional(txn)
+        .await
+        .map_err(|err| DatabaseError::query(query, err))
+}
+
 /// delete deletes an expected switch by expected_switch_id if provided,
 /// otherwise by bmc_mac_address.
 pub async fn delete(txn: &mut PgConnection, req: &ExpectedSwitchRequest) -> DatabaseResult<()> {

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -465,14 +465,14 @@ impl ComponentManager {
             .await
     }
 
-    /// Starts an NVOS password rotation through the configured switch backend.
-    pub async fn start_switch_password_rotation(
+    /// Converges an NVOS password through the configured switch backend.
+    pub async fn ensure_switch_password_rotation(
         &self,
         endpoint: &SwitchEndpoint,
         next_password: &str,
     ) -> Result<String, ComponentManagerError> {
         self.nv_switch
-            .start_password_rotation(endpoint, next_password)
+            .ensure_password_rotation(endpoint, next_password)
             .await
     }
 

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -671,6 +671,13 @@ mod tests {
 
     #[async_trait]
     impl CredentialWriter for FailingCredentialManager {
+        async fn get_credentials_from_writer(
+            &self,
+            _key: &CredentialKey,
+        ) -> Result<Option<Credentials>, SecretsError> {
+            Ok(None)
+        }
+
         async fn set_credentials(
             &self,
             _key: &CredentialKey,

--- a/crates/component-manager/src/config.rs
+++ b/crates/component-manager/src/config.rs
@@ -51,8 +51,8 @@ pub struct ComponentManagerConfig {
 
     /// Enables the NVOS password-rotation backend capability.
     ///
-    /// End-to-end rotation remains unavailable until orchestration is implemented.
-    /// TODO: Remove this gate once end-to-end rotation is enabled by default.
+    /// Keep this rollout gate until every reachable RMS supports repeat-safe
+    /// current-to-target password convergence.
     #[serde(default)]
     pub nvos_password_rotation_enabled: bool,
 }

--- a/crates/component-manager/src/error.rs
+++ b/crates/component-manager/src/error.rs
@@ -16,13 +16,16 @@ pub enum ComponentManagerError {
     #[error("unsupported operation: {0}")]
     Unsupported(String),
 
+    /// The backend rejected a mutating request before accepting any work.
+    #[error("operation rejected before dispatch: {0}")]
+    RejectedBeforeDispatch(String),
+
     /// A mutating request may have reached the backend, but no job handle is
-    /// available. Callers must reconcile observed credential state
-    /// instead of retrying the mutation directly.
+    /// available. Callers must preserve the staged target until their
+    /// reconciliation policy decides whether it is safe to retry.
     ///
-    /// For [`crate::nv_switch_manager::NvSwitchManager::start_password_rotation`],
-    /// every other error guarantees that the backend did not accept the password
-    /// mutation and the caller may release any staged submission marker.
+    /// For [`crate::nv_switch_manager::NvSwitchManager::ensure_password_rotation`],
+    /// callers retain the exact current-to-target request and retry it later.
     #[error("operation outcome unknown: {0}")]
     OperationOutcomeUnknown(String),
 

--- a/crates/component-manager/src/mock.rs
+++ b/crates/component-manager/src/mock.rs
@@ -13,7 +13,8 @@ use crate::compute_tray_manager::{
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     ConfigureSwitchCertificateJobStatus, NvSwitchManager, SwitchComponentResult, SwitchEndpoint,
-    SwitchFirmwareUpdateStatus, SwitchPowerStateResult, SwitchSlotAndTrayResult,
+    SwitchFirmwareUpdateStatus, SwitchPasswordRotationState, SwitchPowerStateResult,
+    SwitchSlotAndTrayResult,
 };
 use crate::power_shelf_manager::{
     PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
@@ -21,12 +22,18 @@ use crate::power_shelf_manager::{
 };
 use crate::types::FirmwareUpdateOptions;
 
+/// Configurable switch backend used by component-manager and controller tests.
 #[derive(Debug, Clone, Default)]
 pub struct MockNvSwitchManager {
     certificate_job_status: Option<ConfigureSwitchCertificateJobStatus>,
+    password_rotation_enabled: bool,
+    password_rotation_start_result: Option<MockPasswordRotationStartResult>,
+    password_rotation_job_status_result: Option<MockPasswordRotationJobStatusResult>,
+    expected_password_rotation_password: Option<String>,
 }
 
 impl MockNvSwitchManager {
+    /// Returns a mock configured with a certificate job status.
     pub fn with_certificate_job_status(
         mut self,
         status: ConfigureSwitchCertificateJobStatus,
@@ -34,12 +41,80 @@ impl MockNvSwitchManager {
         self.certificate_job_status = Some(status);
         self
     }
+
+    /// Enables the mock's password-rotation capability.
+    pub fn with_password_rotation_enabled(mut self) -> Self {
+        self.password_rotation_enabled = true;
+        self
+    }
+
+    /// Makes password-rotation submission return `job_id`.
+    pub fn with_password_rotation_job(mut self, job_id: impl Into<String>) -> Self {
+        self.password_rotation_start_result =
+            Some(MockPasswordRotationStartResult::Job(job_id.into()));
+
+        self
+    }
+
+    /// Makes password-rotation submission report an ambiguous outcome.
+    pub fn with_password_rotation_outcome_unknown(mut self, message: impl Into<String>) -> Self {
+        self.password_rotation_start_result = Some(
+            MockPasswordRotationStartResult::OutcomeUnknown(message.into()),
+        );
+
+        self
+    }
+
+    /// Sets the status returned when a password-rotation job is polled.
+    pub fn with_password_rotation_job_status(
+        mut self,
+        status: SwitchPasswordRotationState,
+    ) -> Self {
+        self.password_rotation_job_status_result =
+            Some(MockPasswordRotationJobStatusResult::Status(status));
+
+        self
+    }
+
+    /// Makes password-rotation polling fail without observing the job.
+    pub fn with_password_rotation_job_status_unavailable(
+        mut self,
+        message: impl Into<String>,
+    ) -> Self {
+        self.password_rotation_job_status_result = Some(
+            MockPasswordRotationJobStatusResult::Unavailable(message.into()),
+        );
+
+        self
+    }
+
+    /// Requires submissions to carry the supplied target password.
+    pub fn with_expected_password_rotation_password(mut self, password: impl Into<String>) -> Self {
+        self.expected_password_rotation_password = Some(password.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MockPasswordRotationStartResult {
+    Job(String),
+    OutcomeUnknown(String),
+}
+
+#[derive(Debug, Clone)]
+enum MockPasswordRotationJobStatusResult {
+    Status(SwitchPasswordRotationState),
+    Unavailable(String),
 }
 
 #[async_trait::async_trait]
 impl NvSwitchManager for MockNvSwitchManager {
     fn name(&self) -> &str {
         "mock-nsm"
+    }
+
+    fn supports_password_rotation(&self) -> bool {
+        self.password_rotation_enabled
     }
 
     async fn power_control(
@@ -121,6 +196,7 @@ impl NvSwitchManager for MockNvSwitchManager {
             })
             .collect())
     }
+
     async fn configure_switch_certificate(
         &self,
         _endpoint: &SwitchEndpoint,
@@ -141,6 +217,47 @@ impl NvSwitchManager for MockNvSwitchManager {
                 state: ConfigureSwitchCertificateState::Completed,
                 error: None,
             }))
+    }
+
+    async fn ensure_password_rotation(
+        &self,
+        _endpoint: &SwitchEndpoint,
+        next_password: &str,
+    ) -> Result<String, ComponentManagerError> {
+        if !self.password_rotation_enabled {
+            return Err(ComponentManagerError::Unsupported(
+                "mock switch password rotation is disabled".to_string(),
+            ));
+        }
+
+        if let Some(expected) = &self.expected_password_rotation_password
+            && next_password != expected
+        {
+            return Err(ComponentManagerError::RejectedBeforeDispatch(
+                "mock switch password rotation received unexpected target password".to_string(),
+            ));
+        }
+
+        match self.password_rotation_start_result.as_ref() {
+            Some(MockPasswordRotationStartResult::Job(job_id)) => Ok(job_id.clone()),
+            Some(MockPasswordRotationStartResult::OutcomeUnknown(message)) => Err(
+                ComponentManagerError::OperationOutcomeUnknown(message.clone()),
+            ),
+            None => Ok("mock-switch-password-job".to_string()),
+        }
+    }
+
+    async fn get_password_rotation_job_status(
+        &self,
+        _job_id: &str,
+    ) -> Result<SwitchPasswordRotationState, ComponentManagerError> {
+        match self.password_rotation_job_status_result.as_ref() {
+            Some(MockPasswordRotationJobStatusResult::Status(status)) => Ok(*status),
+            Some(MockPasswordRotationJobStatusResult::Unavailable(message)) => {
+                Err(ComponentManagerError::Unavailable(message.clone()))
+            }
+            None => Ok(SwitchPasswordRotationState::Completed),
+        }
     }
 }
 

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -33,37 +33,6 @@ impl std::fmt::Display for Backend {
     }
 }
 
-/// Backend-neutral classification of a terminal password-rotation failure.
-///
-/// This classification supplies reconciliation context; it does not by itself
-/// determine whether retrying the password mutation is safe.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SwitchPasswordRotationFailure {
-    /// The switch rejected the current credential.
-    Unauthenticated,
-
-    /// The backend rejected the request parameters.
-    InvalidArgument,
-
-    /// Another update prevented the password mutation from running.
-    UpdateInProgress,
-
-    /// Communication with the switch failed or returned an invalid response.
-    Communication,
-
-    /// The backend could not locate the target switch.
-    TargetNotFound,
-
-    /// The backend timed out while waiting for the password mutation.
-    TimedOut,
-
-    /// The backend reported an internal or otherwise unclassified failure.
-    Backend,
-
-    /// The backend returned an unset or unrecognized failure code.
-    Unknown,
-}
-
 /// Backend observation of a switch OS password-rotation job.
 ///
 /// This describes the backend job, not the credential state observed on the
@@ -72,7 +41,8 @@ pub enum SwitchPasswordRotationFailure {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SwitchPasswordRotationState {
     /// The backend cannot currently resolve the job. This does not establish
-    /// the mutation outcome and requires credential-state reconciliation.
+    /// the mutation outcome; callers must retain or fail the staged target
+    /// according to their recovery policy.
     NotFound,
 
     /// The backend returned a job state that cannot be classified.
@@ -85,10 +55,8 @@ pub enum SwitchPasswordRotationState {
     /// Callers may still need to promote and verify the staged credential.
     Completed,
 
-    /// The backend reports that the job terminated unsuccessfully. The failure
-    /// class does not by itself identify which credential currently
-    /// authenticates.
-    Failed(SwitchPasswordRotationFailure),
+    /// The backend reports that the job terminated unsuccessfully.
+    Failed,
 }
 
 /// Physical network identifiers for an NV-Switch, used to register with and
@@ -160,17 +128,18 @@ pub struct ConfigureSwitchCertificateJobStatus {
 ///
 /// Password rotation is split into capability discovery, submission, and
 /// observation. This keeps backend-specific job handling here while leaving
-/// retry safety and credential reconciliation to the orchestration layer.
+/// convergence persistence to the orchestration layer.
 #[async_trait::async_trait]
 pub trait NvSwitchManager: Send + Sync + Debug + 'static {
     fn name(&self) -> &str;
 
-    /// Reports whether this backend is configured to support OS password
-    /// rotation.
+    /// Reports whether this backend supports OS password rotation.
     ///
-    /// `false` means callers must not submit rotation work. `true` reports
-    /// configured capability, not current backend or switch health. The default
-    /// keeps existing backends disabled until they implement the full contract.
+    /// `false` means callers must not submit rotation work. `true` means an
+    /// unchanged request from the current password to the target password is
+    /// safe to repeat: a backend must either apply the target or recognize that
+    /// the target is already active. The default keeps existing backends
+    /// disabled until they implement this contract.
     fn supports_password_rotation(&self) -> bool {
         false
     }
@@ -221,22 +190,29 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
         job_id: &str,
     ) -> Result<ConfigureSwitchCertificateJobStatus, ComponentManagerError>;
 
-    /// Starts a rotation from the endpoint's current NVOS credential to
+    /// Converges the endpoint from its current NVOS credential to
     /// `next_password`.
     ///
-    /// On accepted submission, returns a backend job ID that can be passed to
-    /// [`Self::get_password_rotation_job_status`].
-    /// Job IDs are opaque: callers must preserve the exact value and must not
-    /// infer backend state from its contents. Implementations must not log
-    /// `next_password` or otherwise expose it outside the backend request.
+    /// Implementations must make repeated identical requests safe after a
+    /// controller or backend restart, including overlapping requests through
+    /// different backend replicas. If the endpoint authenticates with the current
+    /// password, apply the target. If it authenticates with the target, recognize
+    /// convergence without applying another password change.
+    ///
+    /// The returned job ID can be passed to
+    /// [`Self::get_password_rotation_job_status`] for an early completion
+    /// observation. It is opaque and transient: callers must not derive
+    /// credential state from it. Implementations must not log `next_password`
+    /// or otherwise expose it outside the backend request.
     ///
     /// If dispatch may have reached the backend but no job ID is available, the
     /// implementation returns [`ComponentManagerError::OperationOutcomeUnknown`].
-    /// Every other error guarantees that no password mutation was accepted.
-    /// Callers that cancel or time out this future before it returns must treat
-    /// the outcome as unknown unless they can prove dispatch did not occur. The
-    /// default implementation returns [`ComponentManagerError::Unsupported`].
-    async fn start_password_rotation(
+    /// Callers retain the exact staged current-to-target transition and retry it
+    /// later. [`ComponentManagerError::RejectedBeforeDispatch`] is reserved for
+    /// rejection that proves no mutation or job was accepted. The default
+    /// implementation returns
+    /// [`ComponentManagerError::Unsupported`].
+    async fn ensure_password_rotation(
         &self,
         _endpoint: &SwitchEndpoint,
         _next_password: &str,

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -47,9 +47,8 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     Backend as NvSwitchBackend, ConfigureSwitchCertificateJobStatus, NvSwitchManager,
-    SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus,
-    SwitchPasswordRotationFailure, SwitchPasswordRotationState, SwitchPowerStateResult,
-    SwitchSlotAndTrayResult,
+    SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus, SwitchPasswordRotationState,
+    SwitchPowerStateResult, SwitchSlotAndTrayResult,
 };
 use crate::power_shelf_manager::{
     Backend as PowerShelfBackend, PowerShelfComponentResult, PowerShelfEndpoint,
@@ -1910,7 +1909,7 @@ impl NvSwitchManager for RmsBackend {
     }
 
     #[instrument(skip(self, endpoint, next_password), fields(backend = "rms", bmc_mac = %endpoint.bmc_mac))]
-    async fn start_password_rotation(
+    async fn ensure_password_rotation(
         &self,
         endpoint: &SwitchEndpoint,
         next_password: &str,
@@ -1943,7 +1942,7 @@ impl NvSwitchManager for RmsBackend {
             hostnames.get(&endpoint.nvos_mac).cloned(),
         );
 
-        rms_start_switch_password_rotation(
+        rms_ensure_switch_password_rotation(
             self.client.as_ref(),
             device,
             &endpoint.nvos_credentials,
@@ -1961,12 +1960,12 @@ impl NvSwitchManager for RmsBackend {
     }
 }
 
-/// Submits a password rotation and preserves ambiguous dispatch outcomes.
+/// Submits one resumable password-convergence attempt.
 ///
-/// A returned job ID is the handle for later reconciliation. If submission may
-/// have reached the backend without one, this returns an unknown outcome rather
-/// than allowing a blind retry.
-async fn rms_start_switch_password_rotation(
+/// A returned job ID is the handle for later reconciliation. A successful RMS
+/// response without a job ID is not accepted as convergence evidence because
+/// older RMS builds used that shape for non-resumable synchronous work.
+async fn rms_ensure_switch_password_rotation(
     client: &dyn RmsApi,
     device: rms::NodeInfo,
     current_credentials: &Credentials,
@@ -1978,7 +1977,7 @@ async fn rms_start_switch_password_rotation(
     } = current_credentials;
 
     if username.is_empty() || current_password.is_empty() || next_password.is_empty() {
-        return Err(ComponentManagerError::InvalidArgument(
+        return Err(ComponentManagerError::RejectedBeforeDispatch(
             "switch password rotation requires non-empty username, current password, and next password"
                 .to_string(),
         ));
@@ -2002,7 +2001,7 @@ async fn rms_start_switch_password_rotation(
         RackManagerError::ApiInvocationError(status)
             if status.code() == tonic::Code::InvalidArgument =>
         {
-            ComponentManagerError::InvalidArgument(
+            ComponentManagerError::RejectedBeforeDispatch(
                 "RMS rejected the switch password rotation request".to_string(),
             )
         }
@@ -2024,34 +2023,17 @@ async fn rms_start_switch_password_rotation(
         )
     })?;
 
-    // A job ID is durable reconciliation evidence. Preserve it even when the
-    // aggregate admission status is pessimistic, then poll the exact job.
+    // A job ID enables early completion observation. NICo retains the exact
+    // current-to-target credential transition because RMS can lose this handle
+    // after a restart and safely resume the same request.
     if !batch.job_id.is_empty() {
         return Ok(batch.job_id);
     }
 
     Err(ComponentManagerError::OperationOutcomeUnknown(format!(
-        "RMS switch password rotation returned no job ID (status {}); reconcile credential state before retrying",
+        "RMS switch password rotation returned no job ID (status {}); the operation outcome is unknown",
         batch.status
     )))
-}
-
-/// Maps a backend terminal failure code to the backend-neutral failure class.
-fn map_rms_password_rotation_failure(error: i32) -> SwitchPasswordRotationFailure {
-    match rms::JobError::try_from(error) {
-        Ok(rms::JobError::Unauthenticated) => SwitchPasswordRotationFailure::Unauthenticated,
-        Ok(rms::JobError::InvalidArgument) => SwitchPasswordRotationFailure::InvalidArgument,
-        Ok(rms::JobError::UpdateInProgress) => SwitchPasswordRotationFailure::UpdateInProgress,
-        Ok(rms::JobError::ClientError)
-        | Ok(rms::JobError::ServerError)
-        | Ok(rms::JobError::InvalidResponse) => SwitchPasswordRotationFailure::Communication,
-        Ok(rms::JobError::Timeout) => SwitchPasswordRotationFailure::TimedOut,
-        Ok(rms::JobError::TargetNotFound) => SwitchPasswordRotationFailure::TargetNotFound,
-        Ok(rms::JobError::Internal)
-        | Ok(rms::JobError::Other)
-        | Ok(rms::JobError::FileNotFound) => SwitchPasswordRotationFailure::Backend,
-        Ok(rms::JobError::Unspecified) | Err(_) => SwitchPasswordRotationFailure::Unknown,
-    }
 }
 
 /// Maps a backend job record to the backend-neutral rotation state.
@@ -2061,9 +2043,7 @@ fn map_rms_password_rotation_state(job: &rms::JobStatus) -> SwitchPasswordRotati
             SwitchPasswordRotationState::Pending
         }
         Ok(rms::JobExecutionState::Completed) => SwitchPasswordRotationState::Completed,
-        Ok(rms::JobExecutionState::Failed) => {
-            SwitchPasswordRotationState::Failed(map_rms_password_rotation_failure(job.error_code))
-        }
+        Ok(rms::JobExecutionState::Failed) => SwitchPasswordRotationState::Failed,
         Ok(rms::JobExecutionState::Unspecified) | Err(_) => SwitchPasswordRotationState::Unknown,
     }
 }
@@ -2091,7 +2071,7 @@ fn summarize_password_rotation_jobs(
         job.parent_job_id.as_deref() == Some(job_id)
             && matches!(
                 map_rms_password_rotation_state(job),
-                SwitchPasswordRotationState::Failed(_)
+                SwitchPasswordRotationState::Failed
             )
     }) {
         return map_rms_password_rotation_state(failed);
@@ -2101,7 +2081,7 @@ fn summarize_password_rotation_jobs(
         job.job_id == job_id
             && matches!(
                 map_rms_password_rotation_state(job),
-                SwitchPasswordRotationState::Failed(_)
+                SwitchPasswordRotationState::Failed
             )
     }) {
         return map_rms_password_rotation_state(failed);
@@ -2729,36 +2709,8 @@ mod tests {
                 rms::JobExecutionState::Queued => SwitchPasswordRotationState::Pending,
                 rms::JobExecutionState::Running => SwitchPasswordRotationState::Pending,
                 rms::JobExecutionState::Completed => SwitchPasswordRotationState::Completed,
-                rms::JobExecutionState::Failed => SwitchPasswordRotationState::Failed(
-                    SwitchPasswordRotationFailure::Unknown,
-                ),
+                rms::JobExecutionState::Failed => SwitchPasswordRotationState::Failed,
             }
-        );
-    }
-
-    #[test]
-    fn password_rotation_failure_maps_each_rms_class() {
-        value_scenarios!(run = |error: rms::JobError| map_rms_password_rotation_failure(error as i32);
-            "failures" {
-                rms::JobError::Unauthenticated => SwitchPasswordRotationFailure::Unauthenticated,
-                rms::JobError::InvalidArgument => SwitchPasswordRotationFailure::InvalidArgument,
-                rms::JobError::UpdateInProgress => SwitchPasswordRotationFailure::UpdateInProgress,
-                rms::JobError::ClientError => SwitchPasswordRotationFailure::Communication,
-                rms::JobError::ServerError => SwitchPasswordRotationFailure::Communication,
-                rms::JobError::InvalidResponse => SwitchPasswordRotationFailure::Communication,
-                rms::JobError::Timeout => SwitchPasswordRotationFailure::TimedOut,
-                rms::JobError::TargetNotFound => SwitchPasswordRotationFailure::TargetNotFound,
-                rms::JobError::Internal => SwitchPasswordRotationFailure::Backend,
-                rms::JobError::Other => SwitchPasswordRotationFailure::Backend,
-                rms::JobError::FileNotFound => SwitchPasswordRotationFailure::Backend,
-                rms::JobError::Unspecified => SwitchPasswordRotationFailure::Unknown,
-            }
-        );
-
-        assert_eq!(
-            map_rms_password_rotation_failure(i32::MAX),
-            SwitchPasswordRotationFailure::Unknown,
-            "future protobuf value"
         );
     }
 
@@ -2820,7 +2772,7 @@ mod tests {
                 SwitchPasswordRotationState::Pending,
             ),
             (
-                "specific child failure overrides generic parent",
+                "child failure overrides generic parent",
                 vec![
                     job(
                         "password-job",
@@ -2835,7 +2787,7 @@ mod tests {
                         rms::JobError::Unauthenticated,
                     ),
                 ],
-                SwitchPasswordRotationState::Failed(SwitchPasswordRotationFailure::Unauthenticated),
+                SwitchPasswordRotationState::Failed,
             ),
         ];
 
@@ -3971,11 +3923,12 @@ mod tests {
 
         let endpoint = make_sw_endpoint(SW_MAC_1);
 
-        let job_id = NvSwitchManager::start_password_rotation(&backend, &endpoint, "next-password")
-            .await
-            .expect("password rotation should start");
+        let started =
+            NvSwitchManager::ensure_password_rotation(&backend, &endpoint, "next-password")
+                .await
+                .expect("password rotation should start");
 
-        assert_eq!(job_id, "password-job-1");
+        assert_eq!(started, "password-job-1");
 
         let calls = mock.update_switch_system_password_calls().await;
 
@@ -4008,39 +3961,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sw_password_rotation_disabled_gate_sends_no_rms_request() {
-        let mock = Arc::new(MockRmsApi::new());
-
-        let pool = sqlx::postgres::PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/password-rotation-gate-test")
-            .expect("static test database URL should parse");
-
-        let backend = RmsBackend::new(
-            mock.clone(),
-            Some(mock.clone()),
-            pool,
-            Arc::new(rack_profile_config()),
-            false,
-        );
-
-        let endpoint = make_sw_endpoint(SW_MAC_1);
-
-        let result =
-            NvSwitchManager::start_password_rotation(&backend, &endpoint, "next-password").await;
-
-        assert!(!backend.supports_password_rotation());
-
-        assert!(matches!(
-            result,
-            Err(ComponentManagerError::Unsupported(message))
-                if message.contains("password rotation is disabled")
-        ));
-
-        assert!(mock.update_switch_system_password_calls().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn sw_password_rotation_missing_parent_job_has_unknown_outcome() {
+    async fn sw_password_rotation_success_without_job_has_unknown_outcome() {
         let mock = MockRmsApi::new();
 
         mock.enqueue_update_switch_system_password(Ok(rms::UpdateSwitchSystemPasswordResponse {
@@ -4056,7 +3977,35 @@ mod tests {
             password: "current-password".to_string(),
         };
 
-        let result = rms_start_switch_password_rotation(
+        let result = rms_ensure_switch_password_rotation(
+            &mock,
+            rms::NodeInfo::default(),
+            &credentials,
+            "next-password",
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ComponentManagerError::OperationOutcomeUnknown(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn sw_password_rotation_unspecified_without_job_has_unknown_outcome() {
+        let mock = MockRmsApi::new();
+
+        mock.enqueue_update_switch_system_password(Ok(rms::UpdateSwitchSystemPasswordResponse {
+            response: Some(rms::NodeBatchResponse::default()),
+        }))
+        .await;
+
+        let credentials = Credentials::UsernamePassword {
+            username: "admin".to_string(),
+            password: "current-password".to_string(),
+        };
+
+        let result = rms_ensure_switch_password_rotation(
             &mock,
             rms::NodeInfo::default(),
             &credentials,
@@ -4089,7 +4038,7 @@ mod tests {
             password: "current-password".to_string(),
         };
 
-        let job_id = rms_start_switch_password_rotation(
+        let started = rms_ensure_switch_password_rotation(
             &mock,
             rms::NodeInfo::default(),
             &credentials,
@@ -4098,7 +4047,7 @@ mod tests {
         .await
         .expect("durable job ID should permit reconciliation");
 
-        assert_eq!(job_id, "password-job-1");
+        assert_eq!(started, "password-job-1");
 
         let calls = mock.update_switch_system_password_calls().await;
 
@@ -4121,7 +4070,7 @@ mod tests {
             password: "current-password".to_string(),
         };
 
-        let result = rms_start_switch_password_rotation(
+        let result = rms_ensure_switch_password_rotation(
             &mock,
             rms::NodeInfo::default(),
             &credentials,
@@ -4137,7 +4086,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sw_password_rotation_invalid_request_is_safe_to_retry() {
+    async fn sw_password_rotation_invalid_request_is_rejected_before_dispatch() {
         let mock = MockRmsApi::new();
 
         mock.enqueue_update_switch_system_password(Err(RackManagerError::ApiInvocationError(
@@ -4150,7 +4099,7 @@ mod tests {
             password: "current-password".to_string(),
         };
 
-        let result = rms_start_switch_password_rotation(
+        let result = rms_ensure_switch_password_rotation(
             &mock,
             rms::NodeInfo::default(),
             &credentials,
@@ -4160,8 +4109,37 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ComponentManagerError::InvalidArgument(message))
+            Err(ComponentManagerError::RejectedBeforeDispatch(message))
                 if message == "RMS rejected the switch password rotation request"
+        ));
+    }
+
+    #[tokio::test]
+    async fn sw_password_rotation_unimplemented_is_unsupported() {
+        let mock = MockRmsApi::new();
+
+        mock.enqueue_update_switch_system_password(Err(RackManagerError::ApiInvocationError(
+            tonic::Status::unimplemented("upgrade RMS"),
+        )))
+        .await;
+
+        let credentials = Credentials::UsernamePassword {
+            username: "admin".to_string(),
+            password: "current-password".to_string(),
+        };
+
+        let result = rms_ensure_switch_password_rotation(
+            &mock,
+            rms::NodeInfo::default(),
+            &credentials,
+            "next-password",
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ComponentManagerError::Unsupported(message))
+                if message == "RMS does not support switch password rotation"
         ));
     }
 

--- a/crates/rpc/src/forge_api_client.rs
+++ b/crates/rpc/src/forge_api_client.rs
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::fmt::{self, Display};
 use std::fs;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::SystemTime;
 
@@ -29,91 +31,151 @@ pub use crate::protos::forge_api_client::ForgeApiClient;
 
 pub const EXPECTED_SWITCH_UPDATE_MASK_HEADER: &str = "x-nico-expected-switch-update-mask";
 
-pub mod expected_switch_update_field {
-    pub const BMC_USERNAME: &str = "bmc_username";
-    pub const BMC_PASSWORD: &str = "bmc_password";
-    pub const SWITCH_SERIAL_NUMBER: &str = "switch_serial_number";
-    pub const NVOS_MAC_ADDRESSES: &str = "nvos_mac_addresses";
-    pub const NVOS_USERNAME: &str = "nvos_username";
-    pub const NVOS_PASSWORD: &str = "nvos_password";
-    pub const METADATA_NAME: &str = "metadata.name";
-    pub const METADATA_DESCRIPTION: &str = "metadata.description";
-    pub const METADATA_LABELS: &str = "metadata.labels";
-    pub const RACK_ID: &str = "rack_id";
-    pub const BMC_IP_ADDRESS: &str = "bmc_ip_address";
-    pub const NVOS_IP_ADDRESS: &str = "nvos_ip_address";
-    pub const BMC_RETAIN_CREDENTIALS: &str = "bmc_retain_credentials";
+/// Field accepted by the sparse expected-switch update contract.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ExpectedSwitchUpdateField {
+    /// BMC username.
+    BmcUsername,
 
-    pub const ALL: &[&str] = &[
-        BMC_USERNAME,
-        BMC_PASSWORD,
-        SWITCH_SERIAL_NUMBER,
-        NVOS_MAC_ADDRESSES,
-        NVOS_USERNAME,
-        NVOS_PASSWORD,
-        METADATA_NAME,
-        METADATA_DESCRIPTION,
-        METADATA_LABELS,
-        RACK_ID,
-        BMC_IP_ADDRESS,
-        NVOS_IP_ADDRESS,
-        BMC_RETAIN_CREDENTIALS,
-    ];
+    /// BMC password.
+    BmcPassword,
+
+    /// Switch serial number.
+    SwitchSerialNumber,
+
+    /// NVOS MAC addresses.
+    NvosMacAddresses,
+
+    /// NVOS username.
+    NvosUsername,
+
+    /// NVOS password.
+    NvosPassword,
+
+    /// Metadata name.
+    MetadataName,
+
+    /// Metadata description.
+    MetadataDescription,
+
+    /// Metadata labels.
+    MetadataLabels,
+
+    /// Rack ID.
+    RackId,
+
+    /// BMC IP address.
+    BmcIpAddress,
+
+    /// NVOS IP address.
+    NvosIpAddress,
+
+    /// BMC credential-retention setting.
+    BmcRetainCredentials,
+}
+
+impl Display for ExpectedSwitchUpdateField {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::BmcUsername => "bmc_username",
+            Self::BmcPassword => "bmc_password",
+            Self::SwitchSerialNumber => "switch_serial_number",
+            Self::NvosMacAddresses => "nvos_mac_addresses",
+            Self::NvosUsername => "nvos_username",
+            Self::NvosPassword => "nvos_password",
+            Self::MetadataName => "metadata.name",
+            Self::MetadataDescription => "metadata.description",
+            Self::MetadataLabels => "metadata.labels",
+            Self::RackId => "rack_id",
+            Self::BmcIpAddress => "bmc_ip_address",
+            Self::NvosIpAddress => "nvos_ip_address",
+            Self::BmcRetainCredentials => "bmc_retain_credentials",
+        })
+    }
+}
+
+impl FromStr for ExpectedSwitchUpdateField {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "bmc_username" => Ok(Self::BmcUsername),
+            "bmc_password" => Ok(Self::BmcPassword),
+            "switch_serial_number" => Ok(Self::SwitchSerialNumber),
+            "nvos_mac_addresses" => Ok(Self::NvosMacAddresses),
+            "nvos_username" => Ok(Self::NvosUsername),
+            "nvos_password" => Ok(Self::NvosPassword),
+            "metadata.name" => Ok(Self::MetadataName),
+            "metadata.description" => Ok(Self::MetadataDescription),
+            "metadata.labels" => Ok(Self::MetadataLabels),
+            "rack_id" => Ok(Self::RackId),
+            "bmc_ip_address" => Ok(Self::BmcIpAddress),
+            "nvos_ip_address" => Ok(Self::NvosIpAddress),
+            "bmc_retain_credentials" => Ok(Self::BmcRetainCredentials),
+            _ => Err(format!("unknown expected-switch update field: {value}")),
+        }
+    }
 }
 
 /// Builds the sparse-update field mask represented by `switch`.
-pub fn expected_switch_update_mask(switch: &crate::protos::forge::ExpectedSwitch) -> String {
-    use expected_switch_update_field as field;
-
+pub fn expected_switch_update_mask(
+    switch: &crate::protos::forge::ExpectedSwitch,
+) -> Vec<ExpectedSwitchUpdateField> {
     let mut fields = Vec::new();
 
     if !switch.bmc_username.is_empty() || !switch.bmc_password.is_empty() {
-        fields.extend([field::BMC_USERNAME, field::BMC_PASSWORD]);
+        fields.extend([
+            ExpectedSwitchUpdateField::BmcUsername,
+            ExpectedSwitchUpdateField::BmcPassword,
+        ]);
     }
 
     if !switch.switch_serial_number.is_empty() {
-        fields.push(field::SWITCH_SERIAL_NUMBER);
+        fields.push(ExpectedSwitchUpdateField::SwitchSerialNumber);
     }
 
     if !switch.nvos_mac_addresses.is_empty() {
-        fields.push(field::NVOS_MAC_ADDRESSES);
+        fields.push(ExpectedSwitchUpdateField::NvosMacAddresses);
     }
 
     if switch.nvos_username.is_some() || switch.nvos_password.is_some() {
-        fields.extend([field::NVOS_USERNAME, field::NVOS_PASSWORD]);
+        fields.extend([
+            ExpectedSwitchUpdateField::NvosUsername,
+            ExpectedSwitchUpdateField::NvosPassword,
+        ]);
     }
 
     if let Some(metadata) = &switch.metadata {
         if !metadata.name.is_empty() {
-            fields.push(field::METADATA_NAME);
+            fields.push(ExpectedSwitchUpdateField::MetadataName);
         }
 
         if !metadata.description.is_empty() {
-            fields.push(field::METADATA_DESCRIPTION);
+            fields.push(ExpectedSwitchUpdateField::MetadataDescription);
         }
 
         if !metadata.labels.is_empty() {
-            fields.push(field::METADATA_LABELS);
+            fields.push(ExpectedSwitchUpdateField::MetadataLabels);
         }
     }
 
     if switch.rack_id.is_some() {
-        fields.push(field::RACK_ID);
+        fields.push(ExpectedSwitchUpdateField::RackId);
     }
 
     if !switch.bmc_ip_address.is_empty() {
-        fields.push(field::BMC_IP_ADDRESS);
+        fields.push(ExpectedSwitchUpdateField::BmcIpAddress);
     }
 
     if switch.nvos_ip_address.is_some() {
-        fields.push(field::NVOS_IP_ADDRESS);
+        fields.push(ExpectedSwitchUpdateField::NvosIpAddress);
     }
 
     if switch.bmc_retain_credentials.is_some() {
-        fields.push(field::BMC_RETAIN_CREDENTIALS);
+        fields.push(ExpectedSwitchUpdateField::BmcRetainCredentials);
     }
 
-    fields.join(",")
+    fields
 }
 
 impl ForgeApiClient {
@@ -150,9 +212,13 @@ impl ForgeApiClient {
     pub async fn patch_expected_switch(
         &self,
         switch: crate::protos::forge::ExpectedSwitch,
-        update_mask: &str,
+        update_mask: &[ExpectedSwitchUpdateField],
     ) -> Result<(), Status> {
         let update_mask = update_mask
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
             .parse()
             .map_err(|error| Status::invalid_argument(format!("invalid update mask: {error}")))?;
 
@@ -308,13 +374,24 @@ mod tests {
     use crate::protos::forge::ExpectedSwitch;
 
     #[test]
+    fn expected_switch_update_field_round_trips() {
+        let field = ExpectedSwitchUpdateField::NvosUsername;
+
+        assert_eq!(field.to_string(), "nvos_username");
+        assert_eq!("nvos_username".parse(), Ok(field));
+        assert!("unknown".parse::<ExpectedSwitchUpdateField>().is_err());
+    }
+
+    #[test]
     fn expected_switch_update_mask_contains_only_provided_fields() {
+        use ExpectedSwitchUpdateField as Field;
+
         check_values(
             [
                 Check {
                     scenario: "empty patch",
                     input: ExpectedSwitch::default(),
-                    expect: String::new(),
+                    expect: Vec::new(),
                 },
                 Check {
                     scenario: "paired credentials",
@@ -325,7 +402,12 @@ mod tests {
                         nvos_password: Some("nvos-password".to_string()),
                         ..Default::default()
                     },
-                    expect: "bmc_username,bmc_password,nvos_username,nvos_password".to_string(),
+                    expect: vec![
+                        Field::BmcUsername,
+                        Field::BmcPassword,
+                        Field::NvosUsername,
+                        Field::NvosPassword,
+                    ],
                 },
                 Check {
                     scenario: "switch endpoint fields",
@@ -337,7 +419,13 @@ mod tests {
                         bmc_retain_credentials: Some(true),
                         ..Default::default()
                     },
-                    expect: "switch_serial_number,nvos_mac_addresses,bmc_ip_address,nvos_ip_address,bmc_retain_credentials".to_string(),
+                    expect: vec![
+                        Field::SwitchSerialNumber,
+                        Field::NvosMacAddresses,
+                        Field::BmcIpAddress,
+                        Field::NvosIpAddress,
+                        Field::BmcRetainCredentials,
+                    ],
                 },
             ],
             |switch| expected_switch_update_mask(&switch),

--- a/crates/rpc/src/forge_api_client.rs
+++ b/crates/rpc/src/forge_api_client.rs
@@ -27,6 +27,95 @@ use crate::forge_tls_client::{
 };
 pub use crate::protos::forge_api_client::ForgeApiClient;
 
+pub const EXPECTED_SWITCH_UPDATE_MASK_HEADER: &str = "x-nico-expected-switch-update-mask";
+
+pub mod expected_switch_update_field {
+    pub const BMC_USERNAME: &str = "bmc_username";
+    pub const BMC_PASSWORD: &str = "bmc_password";
+    pub const SWITCH_SERIAL_NUMBER: &str = "switch_serial_number";
+    pub const NVOS_MAC_ADDRESSES: &str = "nvos_mac_addresses";
+    pub const NVOS_USERNAME: &str = "nvos_username";
+    pub const NVOS_PASSWORD: &str = "nvos_password";
+    pub const METADATA_NAME: &str = "metadata.name";
+    pub const METADATA_DESCRIPTION: &str = "metadata.description";
+    pub const METADATA_LABELS: &str = "metadata.labels";
+    pub const RACK_ID: &str = "rack_id";
+    pub const BMC_IP_ADDRESS: &str = "bmc_ip_address";
+    pub const NVOS_IP_ADDRESS: &str = "nvos_ip_address";
+    pub const BMC_RETAIN_CREDENTIALS: &str = "bmc_retain_credentials";
+
+    pub const ALL: &[&str] = &[
+        BMC_USERNAME,
+        BMC_PASSWORD,
+        SWITCH_SERIAL_NUMBER,
+        NVOS_MAC_ADDRESSES,
+        NVOS_USERNAME,
+        NVOS_PASSWORD,
+        METADATA_NAME,
+        METADATA_DESCRIPTION,
+        METADATA_LABELS,
+        RACK_ID,
+        BMC_IP_ADDRESS,
+        NVOS_IP_ADDRESS,
+        BMC_RETAIN_CREDENTIALS,
+    ];
+}
+
+/// Builds the sparse-update field mask represented by `switch`.
+pub fn expected_switch_update_mask(switch: &crate::protos::forge::ExpectedSwitch) -> String {
+    use expected_switch_update_field as field;
+
+    let mut fields = Vec::new();
+
+    if !switch.bmc_username.is_empty() || !switch.bmc_password.is_empty() {
+        fields.extend([field::BMC_USERNAME, field::BMC_PASSWORD]);
+    }
+
+    if !switch.switch_serial_number.is_empty() {
+        fields.push(field::SWITCH_SERIAL_NUMBER);
+    }
+
+    if !switch.nvos_mac_addresses.is_empty() {
+        fields.push(field::NVOS_MAC_ADDRESSES);
+    }
+
+    if switch.nvos_username.is_some() || switch.nvos_password.is_some() {
+        fields.extend([field::NVOS_USERNAME, field::NVOS_PASSWORD]);
+    }
+
+    if let Some(metadata) = &switch.metadata {
+        if !metadata.name.is_empty() {
+            fields.push(field::METADATA_NAME);
+        }
+
+        if !metadata.description.is_empty() {
+            fields.push(field::METADATA_DESCRIPTION);
+        }
+
+        if !metadata.labels.is_empty() {
+            fields.push(field::METADATA_LABELS);
+        }
+    }
+
+    if switch.rack_id.is_some() {
+        fields.push(field::RACK_ID);
+    }
+
+    if !switch.bmc_ip_address.is_empty() {
+        fields.push(field::BMC_IP_ADDRESS);
+    }
+
+    if switch.nvos_ip_address.is_some() {
+        fields.push(field::NVOS_IP_ADDRESS);
+    }
+
+    if switch.bmc_retain_credentials.is_some() {
+        fields.push(field::BMC_RETAIN_CREDENTIALS);
+    }
+
+    fields.join(",")
+}
+
 impl ForgeApiClient {
     pub fn new(api_config: &ApiConfig<'_>) -> Self {
         Self::build(ForgeTlsConnectionProvider {
@@ -55,6 +144,29 @@ impl ForgeApiClient {
             last_connection_index: 0.into(),
             fail_over_on,
         })
+    }
+
+    /// Applies the named `ExpectedSwitch` fields without replacing omitted fields.
+    pub async fn patch_expected_switch(
+        &self,
+        switch: crate::protos::forge::ExpectedSwitch,
+        update_mask: &str,
+    ) -> Result<(), Status> {
+        let update_mask = update_mask
+            .parse()
+            .map_err(|error| Status::invalid_argument(format!("invalid update mask: {error}")))?;
+
+        let mut request = tonic::Request::new(switch);
+        request
+            .metadata_mut()
+            .insert(EXPECTED_SWITCH_UPDATE_MASK_HEADER, update_mask);
+
+        self.connection()
+            .await?
+            .update_expected_switch(request)
+            .await?;
+
+        Ok(())
     }
 }
 
@@ -185,5 +297,50 @@ impl tonic_client_wrapper::ConnectionProvider<ForgeClientT> for ForgeTlsConnecti
 
     fn connection_url(&self) -> &str {
         self.current_endpoint_url()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+    use crate::protos::forge::ExpectedSwitch;
+
+    #[test]
+    fn expected_switch_update_mask_contains_only_provided_fields() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty patch",
+                    input: ExpectedSwitch::default(),
+                    expect: String::new(),
+                },
+                Check {
+                    scenario: "paired credentials",
+                    input: ExpectedSwitch {
+                        bmc_username: "bmc-admin".to_string(),
+                        bmc_password: "bmc-password".to_string(),
+                        nvos_username: Some("nvos-admin".to_string()),
+                        nvos_password: Some("nvos-password".to_string()),
+                        ..Default::default()
+                    },
+                    expect: "bmc_username,bmc_password,nvos_username,nvos_password".to_string(),
+                },
+                Check {
+                    scenario: "switch endpoint fields",
+                    input: ExpectedSwitch {
+                        switch_serial_number: "serial".to_string(),
+                        nvos_mac_addresses: vec!["00:11:22:33:44:55".to_string()],
+                        bmc_ip_address: "192.0.2.1".to_string(),
+                        nvos_ip_address: Some("192.0.2.2".to_string()),
+                        bmc_retain_credentials: Some(true),
+                        ..Default::default()
+                    },
+                    expect: "switch_serial_number,nvos_mac_addresses,bmc_ip_address,nvos_ip_address,bmc_retain_credentials".to_string(),
+                },
+            ],
+            |switch| expected_switch_update_mask(&switch),
+        );
     }
 }

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -182,6 +182,16 @@ impl<T: CredentialReader + ?Sized> CredentialReader for Arc<T> {
 
 #[async_trait]
 pub trait CredentialWriter: Send + Sync {
+    /// Reads the value persisted by this writer, bypassing any composite reader
+    /// precedence or local overrides.
+    ///
+    /// Callers use this after a security-sensitive write when publishing state
+    /// requires proof that the configured write target contains the value.
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError>;
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -199,6 +209,13 @@ pub trait CredentialWriter: Send + Sync {
 
 #[async_trait]
 impl<T: CredentialWriter + ?Sized> CredentialWriter for Arc<T> {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        (**self).get_credentials_from_writer(key).await
+    }
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -249,6 +266,13 @@ impl<R: CredentialReader, W: CredentialWriter> CredentialReader
 impl<R: CredentialReader, W: CredentialWriter> CredentialWriter
     for CompositeCredentialManager<R, W>
 {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        self.writer.get_credentials_from_writer(key).await
+    }
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -941,6 +965,13 @@ mod tests {
                 password: "read-pass".to_string(),
             })
         );
+
+        let writer_readback = composite
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("writer readback");
+
+        assert_eq!(writer_readback, Some(write_cred));
     }
 
     #[tokio::test]

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -978,6 +978,13 @@ impl CredentialReader for ForgeVaultClient {
 
 #[async_trait]
 impl CredentialWriter for ForgeVaultClient {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        CredentialReader::get_credentials(self, key).await
+    }
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,

--- a/crates/secrets/src/memory_credentials.rs
+++ b/crates/secrets/src/memory_credentials.rs
@@ -46,6 +46,13 @@ impl CredentialReader for MemoryCredentialStore {
 
 #[async_trait]
 impl CredentialWriter for MemoryCredentialStore {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        CredentialReader::get_credentials(self, key).await
+    }
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,

--- a/crates/secrets/src/test_support/credentials.rs
+++ b/crates/secrets/src/test_support/credentials.rs
@@ -70,6 +70,14 @@ impl CredentialReader for TestCredentialManager {
 
 #[async_trait]
 impl CredentialWriter for TestCredentialManager {
+    async fn get_credentials_from_writer(
+        &self,
+        key: &CredentialKey,
+    ) -> Result<Option<Credentials>, SecretsError> {
+        let credentials = self.credentials.lock().await;
+        Ok(credentials.get(key.to_key_str().as_ref()).cloned())
+    }
+
     async fn set_credentials(
         &self,
         key: &CredentialKey,
@@ -127,3 +135,36 @@ impl CredentialWriter for TestCredentialManager {
 }
 
 impl CredentialManager for TestCredentialManager {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn writer_readback_ignores_reader_fallback() {
+        let fallback = Credentials::UsernamePassword {
+            username: "fallback".to_string(),
+            password: "fallback-password".to_string(),
+        };
+
+        let manager = TestCredentialManager::new(fallback);
+        let key = CredentialKey::switch_nvos_site_admin(1);
+
+        assert_eq!(
+            manager.get_credentials_from_writer(&key).await.unwrap(),
+            None
+        );
+
+        let persisted = Credentials::UsernamePassword {
+            username: "nvos-admin".to_string(),
+            password: "target-password".to_string(),
+        };
+
+        manager.set_credentials(&key, &persisted).await.unwrap();
+
+        assert_eq!(
+            manager.get_credentials_from_writer(&key).await.unwrap(),
+            Some(persisted)
+        );
+    }
+}

--- a/crates/switch-controller/src/configuring.rs
+++ b/crates/switch-controller/src/configuring.rs
@@ -177,19 +177,42 @@ pub(crate) async fn ensure_nvos_admin_credentials(
 
     txn.commit().await?;
 
-    if operation.as_ref().is_some_and(|operation| {
-        operation.current_version.is_none() && operation.rotating_to_version.is_some()
-    }) {
-        return Ok(match existing.as_ref() {
+    if let Some(operation) = operation.as_ref()
+        && let Some(staged_version) = operation.rotating_to_version
+    {
+        let existing_password = match existing.as_ref() {
             Some(Credentials::UsernamePassword { username, password })
                 if !username.is_empty() && !password.is_empty() =>
             {
-                NvosAdminCredentialStatus::Available
+                Some(password.as_str())
             }
-            _ => NvosAdminCredentialStatus::Error(
-                "Staged NVOS rotation has no valid current per-switch credential".to_string(),
-            ),
-        });
+            _ => None,
+        };
+
+        if operation.current_version.is_none() {
+            return Ok(if existing_password.is_some() {
+                NvosAdminCredentialStatus::Available
+            } else {
+                NvosAdminCredentialStatus::Error(
+                    "Staged NVOS rotation has no valid current per-switch credential".to_string(),
+                )
+            });
+        }
+
+        if let Some(existing_password) = existing_password
+            && let Some(Credentials::UsernamePassword {
+                password: staged_password,
+                ..
+            }) = read_nvos_site_credentials(
+                switch_id,
+                staged_version,
+                ctx.services.credential_manager.as_ref(),
+            )
+            .await?
+            && existing_password == staged_password
+        {
+            return Ok(NvosAdminCredentialStatus::Available);
+        }
     }
 
     let Some(expected_switch) = expected_switch else {
@@ -207,7 +230,9 @@ pub(crate) async fn ensure_nvos_admin_credentials(
         Err(error) => return Ok(NvosAdminCredentialStatus::Error(error.to_string())),
     };
 
-    let current_version = operation.and_then(|operation| operation.current_version);
+    let current_version = operation
+        .as_ref()
+        .and_then(|operation| operation.current_version);
 
     let (credentials, source) = match current_version {
         Some(current_version) => {

--- a/crates/switch-controller/src/configuring.rs
+++ b/crates/switch-controller/src/configuring.rs
@@ -152,6 +152,8 @@ pub(crate) async fn ensure_nvos_admin_credentials(
 ) -> Result<NvosAdminCredentialStatus, StateHandlerError> {
     let key = CredentialKey::SwitchNvosAdmin { bmc_mac_address };
 
+    // This effective value may be the bootstrap credential, the confirmed
+    // credential, or a target persisted immediately before DB promotion.
     let existing = ctx
         .services
         .credential_manager
@@ -177,6 +179,9 @@ pub(crate) async fn ensure_nvos_admin_credentials(
 
     txn.commit().await?;
 
+    // Rotation may resume after a restart. Before initial confirmation, retain
+    // any valid per-switch credential. Also retain a staged target that was
+    // persisted before its matching DB promotion completed.
     if let Some(operation) = operation.as_ref()
         && let Some(staged_version) = operation.rotating_to_version
     {
@@ -190,6 +195,9 @@ pub(crate) async fn ensure_nvos_admin_credentials(
         };
 
         if operation.current_version.is_none() {
+            // During initial rotation, no versioned credential is confirmed.
+            // Preserve any valid per-switch credential so retries keep a
+            // usable password.
             return Ok(if existing_password.is_some() {
                 NvosAdminCredentialStatus::Available
             } else {
@@ -211,10 +219,14 @@ pub(crate) async fn ensure_nvos_admin_credentials(
             .await?
             && existing_password == staged_password
         {
+            // Completion persists the target before promoting its DB version.
+            // Preserve that target when recovering between those two steps.
             return Ok(NvosAdminCredentialStatus::Available);
         }
     }
 
+    // Expected-switch data provides bootstrap credentials and the fallback
+    // username because site-wide rotation targets contain only a password.
     let Some(expected_switch) = expected_switch else {
         return Ok(NvosAdminCredentialStatus::Error(format!(
             "No expected switch found for BMC MAC {bmc_mac_address}"
@@ -236,6 +248,8 @@ pub(crate) async fn ensure_nvos_admin_credentials(
 
     let (credentials, source) = match current_version {
         Some(current_version) => {
+            // A confirmed version is authoritative. Repair its password from
+            // the immutable site credential instead of stale bootstrap data.
             let versioned = read_nvos_site_credentials(
                 switch_id,
                 current_version,
@@ -257,6 +271,8 @@ pub(crate) async fn ensure_nvos_admin_credentials(
                 )));
             }
 
+            // Rotation changes only the password. Preserve the established
+            // per-switch username, or recover it from expected-switch data.
             let username = match existing.as_ref() {
                 Some(Credentials::UsernamePassword { username, .. }) if !username.is_empty() => {
                     username.clone()
@@ -277,7 +293,11 @@ pub(crate) async fn ensure_nvos_admin_credentials(
             (credentials, "confirmed rotation version")
         }
         None => {
+            // Before first convergence, expected-switch credentials bootstrap
+            // the per-switch key.
             let Some((username, password)) = expected_credentials else {
+                // Preserve an existing credential when bootstrap input is
+                // absent so rotation can use it as the current credential.
                 let Some(credentials) = existing else {
                     tracing::info!(
                         switch_id = ?switch_id,
@@ -304,6 +324,7 @@ pub(crate) async fn ensure_nvos_admin_credentials(
         }
     };
 
+    // Availability is reported only after writer and effective readback agree.
     persist_nvos_admin_credentials(switch_id, bmc_mac_address, &credentials, ctx).await?;
 
     tracing::info!(

--- a/crates/switch-controller/src/configuring.rs
+++ b/crates/switch-controller/src/configuring.rs
@@ -29,6 +29,22 @@ use crate::certificate::{
     poll_configure_switch_certificate_job, start_configure_switch_certificate,
 };
 use crate::context::SwitchStateHandlerContextObjects;
+use crate::nvos_password_rotation::{
+    NvosPasswordRotationOutcome, expected_nvos_credential_pair, read_nvos_site_credentials,
+    reconcile_nvos_password_rotation,
+};
+
+/// Result of resolving the current per-switch NVOS credential.
+pub(crate) enum NvosAdminCredentialStatus {
+    /// A credential is available to resolve the component-manager endpoint.
+    Available,
+
+    /// No credential source exists, so rotation is not actionable yet.
+    Skip,
+
+    /// Expected-switch data required to resolve a credential is inconsistent.
+    Error(String),
+}
 
 /// Handles the Configuring state for a switch.
 pub async fn handle_configuring(
@@ -56,103 +72,223 @@ async fn handle_rotate_os_password(
     state: &mut Switch,
     ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
-    let Some(bmc_mac_address) = state.bmc_mac_address else {
-        return Ok(StateHandlerOutcome::transition(
-            SwitchControllerState::Error {
-                cause: "No BMC MAC address on switch".to_string(),
-            },
-        ));
-    };
+    match reconcile_nvos_password_rotation(switch_id, state, ctx).await? {
+        NvosPasswordRotationOutcome::UpToDate => Ok(StateHandlerOutcome::transition(
+            SwitchControllerState::FetchInfo,
+        )),
+        NvosPasswordRotationOutcome::Waiting(reason) => Ok(StateHandlerOutcome::wait(reason)),
+        NvosPasswordRotationOutcome::CredentialError(cause) => Ok(StateHandlerOutcome::transition(
+            SwitchControllerState::Error { cause },
+        )),
+    }
+}
 
+/// Persists and verifies the effective per-switch NVOS credential.
+pub(crate) async fn persist_nvos_admin_credentials(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    credentials: &Credentials,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<(), StateHandlerError> {
     let key = CredentialKey::SwitchNvosAdmin { bmc_mac_address };
 
-    if let Ok(Some(Credentials::UsernamePassword { .. })) =
-        ctx.services.credential_manager.get_credentials(&key).await
-    {
-        tracing::info!(
-            switch_id = ?switch_id,
-            bmc_mac_address = %bmc_mac_address,
-            "Switch: NVOS admin credentials already exist in vault",
-        );
-        return Ok(StateHandlerOutcome::transition(
-            SwitchControllerState::FetchInfo,
-        ));
+    ctx.services
+        .credential_manager
+        .set_credentials(&key, credentials)
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: failed to persist NVOS credentials: {error}"
+            ))
+        })?;
+
+    let persisted = ctx
+        .services
+        .credential_manager
+        .get_credentials_from_writer(&key)
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: failed to read back NVOS credentials: {error}"
+            ))
+        })?;
+
+    if persisted.as_ref() != Some(credentials) {
+        return Err(StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: NVOS credential writer readback did not match"
+        )));
     }
 
-    let outcome = StateHandlerOutcome::transition(SwitchControllerState::FetchInfo);
+    let effective = ctx
+        .services
+        .credential_manager
+        .get_credentials(&key)
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: failed to read effective NVOS credentials: {error}"
+            ))
+        })?;
 
-    // REQ-6 (set NVOS from factory) is not implemented yet, so this is gated off.
-    // Today NICo only stores the operator-provided credential so the rest of
-    // NICo can authenticate. The first NVOS rotation target is published only
-    // after its credential has been stored and verified; password mutation and
-    // convergence recording remain disabled until that path is activated.
-    let update_device_password = false;
+    if effective.as_ref() != Some(credentials) {
+        return Err(StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: NVOS credential is shadowed in the effective read chain"
+        )));
+    }
 
-    if update_device_password {
-        // Activation must stage an exact target before dispatch, then persist
-        // and read back the per-device credential before promoting the matching
-        // target, attempt, and backend job. Fail closed until that complete
-        // sequence is implemented.
-        Ok(StateHandlerOutcome::transition(
-            SwitchControllerState::Error {
-                cause: "NVOS password rotation is not implemented".to_string(),
-            },
-        ))
-    } else {
-        // Copy the operator-provided NVOS admin credential from the expected
-        // switch into Vault. This does not touch the switch, so no convergence is
-        // recorded.
-        let mut txn = ctx.services.db_pool.begin().await?;
-        let expected_switch =
-            db::expected_switch::find_by_bmc_mac_address(&mut txn, bmc_mac_address).await?;
-        txn.commit().await?;
+    Ok(())
+}
 
-        let expected_switch = match expected_switch {
-            Some(es) => es,
-            None => {
-                return Ok(StateHandlerOutcome::transition(
-                    SwitchControllerState::Error {
-                        cause: format!("No expected switch found for BMC MAC {}", bmc_mac_address),
-                    },
-                ));
+/// Ensures the credential manager contains the switch's current NVOS credential.
+///
+/// Expected-switch credentials seed the initial value before rotation starts.
+/// While the initial rotation is staged, the captured per-switch credential is
+/// preserved. After convergence, it is repaired from the immutable confirmed
+/// site credential.
+pub(crate) async fn ensure_nvos_admin_credentials(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosAdminCredentialStatus, StateHandlerError> {
+    let key = CredentialKey::SwitchNvosAdmin { bmc_mac_address };
+
+    let existing = ctx
+        .services
+        .credential_manager
+        .get_credentials(&key)
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: failed to read NVOS credentials from credential store: {error}"
+            ))
+        })?;
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    let expected_switch =
+        db::expected_switch::find_by_bmc_mac_address(&mut txn, bmc_mac_address).await?;
+
+    let operation = db::credential_rotation::device_rotation_operation_state(
+        &mut *txn,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        bmc_mac_address,
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    if operation.as_ref().is_some_and(|operation| {
+        operation.current_version.is_none() && operation.rotating_to_version.is_some()
+    }) {
+        return Ok(match existing.as_ref() {
+            Some(Credentials::UsernamePassword { username, password })
+                if !username.is_empty() && !password.is_empty() =>
+            {
+                NvosAdminCredentialStatus::Available
             }
-        };
+            _ => NvosAdminCredentialStatus::Error(
+                "Staged NVOS rotation has no valid current per-switch credential".to_string(),
+            ),
+        });
+    }
 
-        let (username, password) =
-            match (expected_switch.nvos_username, expected_switch.nvos_password) {
-                (Some(username), Some(password)) => (username, password),
-                _ => {
-                    tracing::info!(
-                        switch_id = ?switch_id,
-                        bmc_mac_address = %bmc_mac_address,
-                        "Switch: no NVOS credentials in vault or expected switch; skipping",
-                    );
-                    return Ok(outcome);
-                }
-            };
+    let Some(expected_switch) = expected_switch else {
+        return Ok(NvosAdminCredentialStatus::Error(format!(
+            "No expected switch found for BMC MAC {bmc_mac_address}"
+        )));
+    };
 
-        let credentials = Credentials::UsernamePassword { username, password };
+    let expected_credentials = match expected_nvos_credential_pair(
+        expected_switch.nvos_username.as_deref(),
+        expected_switch.nvos_password.as_deref(),
+    ) {
+        Ok(None) => None,
+        Ok(Some(credentials)) => Some(credentials),
+        Err(error) => return Ok(NvosAdminCredentialStatus::Error(error.to_string())),
+    };
 
-        ctx.services
-            .credential_manager
-            .set_credentials(&key, &credentials)
-            .await
-            .map_err(|e| {
+    let current_version = operation.and_then(|operation| operation.current_version);
+
+    let (credentials, source) = match current_version {
+        Some(current_version) => {
+            let versioned = read_nvos_site_credentials(
+                switch_id,
+                current_version,
+                ctx.services.credential_manager.as_ref(),
+            )
+            .await?
+            .ok_or_else(|| {
                 StateHandlerError::GenericError(eyre::eyre!(
-                    "switch {:?}: failed to store NVOS credentials in vault: {}",
-                    switch_id,
-                    e
+                    "switch {switch_id}: confirmed NVOS credential version {current_version} \
+                     is missing"
                 ))
             })?;
 
-        tracing::info!(
-            switch_id = ?switch_id,
-            bmc_mac_address = %bmc_mac_address,
-            "Switch: stored NVOS admin credentials from expected switch into vault",
-        );
+            let Credentials::UsernamePassword { password, .. } = versioned;
 
-        Ok(outcome)
-    }
+            if password.is_empty() {
+                return Ok(NvosAdminCredentialStatus::Error(format!(
+                    "Confirmed NVOS credential version {current_version} has an empty password"
+                )));
+            }
+
+            let username = match existing.as_ref() {
+                Some(Credentials::UsernamePassword { username, .. }) if !username.is_empty() => {
+                    username.clone()
+                }
+                _ => {
+                    let Some((username, _)) = expected_credentials else {
+                        return Ok(NvosAdminCredentialStatus::Error(format!(
+                            "Cannot restore confirmed NVOS credential version {current_version} \
+                             without an expected-switch username"
+                        )));
+                    };
+
+                    username.to_string()
+                }
+            };
+
+            let credentials = Credentials::UsernamePassword { username, password };
+            (credentials, "confirmed rotation version")
+        }
+        None => {
+            let Some((username, password)) = expected_credentials else {
+                let Some(credentials) = existing else {
+                    tracing::info!(
+                        switch_id = ?switch_id,
+                        bmc_mac_address = %bmc_mac_address,
+                        "Switch: no NVOS credentials in credential store or expected switch; skipping",
+                    );
+
+                    return Ok(NvosAdminCredentialStatus::Skip);
+                };
+
+                persist_nvos_admin_credentials(switch_id, bmc_mac_address, &credentials, ctx)
+                    .await?;
+
+                return Ok(NvosAdminCredentialStatus::Available);
+            };
+
+            (
+                Credentials::UsernamePassword {
+                    username: username.to_string(),
+                    password: password.to_string(),
+                },
+                "expected switch",
+            )
+        }
+    };
+
+    persist_nvos_admin_credentials(switch_id, bmc_mac_address, &credentials, ctx).await?;
+
+    tracing::info!(
+        switch_id = ?switch_id,
+        bmc_mac_address = %bmc_mac_address,
+        source,
+        "Switch: restored NVOS admin credentials",
+    );
+
+    Ok(NvosAdminCredentialStatus::Available)
 }
 
 async fn handle_configure_certificate(

--- a/crates/switch-controller/src/lib.rs
+++ b/crates/switch-controller/src/lib.rs
@@ -31,6 +31,7 @@ pub mod initializing;
 pub mod io;
 pub mod maintenance;
 pub mod metrics;
+pub mod nvos_password_rotation;
 pub mod ready;
 pub mod reprovisioning;
 pub mod validating;

--- a/crates/switch-controller/src/nvos_password_rotation.rs
+++ b/crates/switch-controller/src/nvos_password_rotation.rs
@@ -49,7 +49,6 @@ pub enum NvosPasswordRotationOutcome {
 /// Inputs shared by initial dispatch and completion persistence.
 struct RotationInputs {
     endpoint: SwitchEndpoint,
-    target_password: String,
     target_credentials: Credentials,
 }
 
@@ -128,12 +127,11 @@ async fn rotation_inputs(
 
     let target_credentials = Credentials::UsernamePassword {
         username: username.clone(),
-        password: target_password.clone(),
+        password: target_password,
     };
 
     Ok(RotationInputs {
         endpoint,
-        target_password,
         target_credentials,
     })
 }
@@ -203,11 +201,11 @@ async fn ensure_staged_rotation(
     expected_attempt: i32,
     ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
-    let Some(component_manager) = ctx.services.component_manager.clone() else {
-        return Ok(NvosPasswordRotationOutcome::Waiting(
-            "component manager is unavailable for NVOS password submission".to_string(),
-        ));
-    };
+    let component_manager = ctx.services.component_manager.clone().ok_or_else(|| {
+        StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: component manager is unavailable for NVOS password submission"
+        ))
+    })?;
 
     let inputs = match rotation_inputs(
         switch_id,
@@ -225,8 +223,13 @@ async fn ensure_staged_rotation(
         }
     };
 
+    let Credentials::UsernamePassword {
+        password: target_password,
+        ..
+    } = &inputs.target_credentials;
+
     match component_manager
-        .ensure_switch_password_rotation(&inputs.endpoint, &inputs.target_password)
+        .ensure_switch_password_rotation(&inputs.endpoint, target_password)
         .await
     {
         Ok(job_id) => {
@@ -275,8 +278,9 @@ async fn ensure_staged_rotation(
             txn.commit().await?;
 
             if failed {
-                Ok(NvosPasswordRotationOutcome::Waiting(format!(
-                    "NVOS submission is not retryable without correction: {error}"
+                Err(StateHandlerError::GenericError(eyre::eyre!(
+                    "switch {switch_id}: NVOS submission is not retryable without correction: \
+                     {error}"
                 )))
             } else {
                 Ok(NvosPasswordRotationOutcome::Waiting(
@@ -284,8 +288,8 @@ async fn ensure_staged_rotation(
                 ))
             }
         }
-        Err(error) => Ok(NvosPasswordRotationOutcome::Waiting(format!(
-            "NVOS submission could not be attempted: {error}"
+        Err(error) => Err(StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: NVOS submission could not be attempted: {error}"
         ))),
     }
 }
@@ -592,6 +596,10 @@ pub async fn reconcile_nvos_password_rotation(
     state: &Switch,
     ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    // Component-manager availability and password-rotation support are rollout
+    // gates. The API cannot publish an NVOS target while either is absent, so
+    // treat disabled rotation as a no-op and continue the switch lifecycle.
+    // Durable rotation state remains unchanged and resumes when support returns.
     let Some(component_manager) = ctx.services.component_manager.as_ref() else {
         return Ok(NvosPasswordRotationOutcome::UpToDate);
     };

--- a/crates/switch-controller/src/nvos_password_rotation.rs
+++ b/crates/switch-controller/src/nvos_password_rotation.rs
@@ -1,0 +1,703 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Restart-safe NVOS password rotation through component-manager.
+//!
+//! NICo stages each target and attempt before dispatch. A missing backend job
+//! retries the same current-to-target transition. Completion writes and verifies
+//! the per-device credential before promoting the matching attempt.
+
+use std::sync::Arc;
+
+use carbide_secrets::credentials::{CredentialKey, CredentialManager, Credentials};
+use carbide_uuid::switch::SwitchId;
+use component_manager::error::ComponentManagerError;
+use component_manager::nv_switch_manager::{SwitchEndpoint, SwitchPasswordRotationState};
+use model::switch::Switch;
+use state_controller::state_handler::{StateHandlerContext, StateHandlerError};
+
+use crate::context::SwitchStateHandlerContextObjects;
+use crate::endpoint;
+
+/// Result of reconciling one switch against the current NVOS target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NvosPasswordRotationOutcome {
+    /// No actionable controller work remains for this pass.
+    UpToDate,
+
+    /// Work remains blocked or in progress.
+    Waiting(String),
+
+    /// Expected-switch credential data prevents safe rotation.
+    CredentialError(String),
+}
+
+/// Inputs shared by initial dispatch and completion persistence.
+struct RotationInputs {
+    endpoint: SwitchEndpoint,
+    target_password: String,
+    target_credentials: Credentials,
+}
+
+/// Classifies expected-switch NVOS credential fields without treating partial
+/// or empty legacy rows as absent.
+pub(crate) fn expected_nvos_credential_pair<'a>(
+    username: Option<&'a str>,
+    password: Option<&'a str>,
+) -> Result<Option<(&'a str, &'a str)>, &'static str> {
+    match (username, password) {
+        (None, None) => Ok(None),
+        (Some(""), Some(_)) => Err("Expected switch nvos_username must not be empty"),
+        (Some(_), Some("")) => Err("Expected switch nvos_password must not be empty"),
+        (Some(username), Some(password)) => Ok(Some((username, password))),
+        _ => Err("Expected switch nvos_username and nvos_password must be set together"),
+    }
+}
+
+/// Reads an immutable site credential directly from the configured writer.
+pub(crate) async fn read_nvos_site_credentials(
+    switch_id: &SwitchId,
+    version: i32,
+    credential_manager: &dyn CredentialManager,
+) -> Result<Option<Credentials>, StateHandlerError> {
+    let version = u32::try_from(version).map_err(|error| {
+        StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: invalid NVOS credential version {version}: {error}"
+        ))
+    })?;
+
+    credential_manager
+        .get_credentials_from_writer(&CredentialKey::switch_nvos_site_admin(version))
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: failed to read NVOS credential version {version}: {error}"
+            ))
+        })
+}
+
+/// Resolves current endpoint credentials and the exact staged target password.
+async fn rotation_inputs(
+    switch_id: &SwitchId,
+    target_version: i32,
+    db_pool: &sqlx::PgPool,
+    credential_manager: Arc<dyn CredentialManager>,
+) -> Result<RotationInputs, StateHandlerError> {
+    let endpoint = endpoint::resolve_switch_endpoint(switch_id, db_pool, &credential_manager)
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: could not resolve switch endpoint: {error}"
+            ))
+        })?;
+
+    let target = read_nvos_site_credentials(switch_id, target_version, credential_manager.as_ref())
+        .await?
+        .ok_or_else(|| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: missing NVOS target version {target_version}"
+            ))
+        })?;
+
+    let Credentials::UsernamePassword {
+        password: target_password,
+        ..
+    } = target;
+
+    let Credentials::UsernamePassword { username, .. } = &endpoint.nvos_credentials;
+
+    if username.is_empty() || target_password.is_empty() {
+        return Err(StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: NVOS rotation requires a non-empty username and target password"
+        )));
+    }
+
+    let target_credentials = Credentials::UsernamePassword {
+        username: username.clone(),
+        password: target_password.clone(),
+    };
+
+    Ok(RotationInputs {
+        endpoint,
+        target_password,
+        target_credentials,
+    })
+}
+
+/// Stores a completed target and promotes only its matching operation attempt.
+///
+/// Promotion requires both the configured writer and NICo's effective read
+/// chain to return the target. This prevents a higher-priority secrets backend
+/// from shadowing the new credential after the database records convergence.
+async fn complete_staged_rotation(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    target_version: i32,
+    expected_attempt: i32,
+    expected_job_id: &str,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    let credential_manager = ctx.services.credential_manager.clone();
+
+    let inputs = rotation_inputs(
+        switch_id,
+        target_version,
+        &ctx.services.db_pool,
+        credential_manager.clone(),
+    )
+    .await?;
+
+    // The state controller serializes handlers for a switch. Complete credential
+    // store I/O before opening the short transaction; the final attempt CAS still
+    // rejects promotion if another worker changed the operation state.
+    crate::configuring::persist_nvos_admin_credentials(
+        switch_id,
+        bmc_mac_address,
+        &inputs.target_credentials,
+        ctx,
+    )
+    .await?;
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    let succeeded = db::credential_rotation::record_device_rotation_succeeded(
+        &mut txn,
+        bmc_mac_address,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        target_version,
+        expected_attempt,
+        expected_job_id,
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    Ok(if succeeded {
+        NvosPasswordRotationOutcome::UpToDate
+    } else {
+        NvosPasswordRotationOutcome::Waiting(
+            "NVOS operation changed while recording backend completion".to_string(),
+        )
+    })
+}
+
+/// Asks component-manager to converge one already-claimed target attempt.
+async fn ensure_staged_rotation(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    target_version: i32,
+    expected_attempt: i32,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    let Some(component_manager) = ctx.services.component_manager.clone() else {
+        return Ok(NvosPasswordRotationOutcome::Waiting(
+            "component manager is unavailable for NVOS password submission".to_string(),
+        ));
+    };
+
+    let inputs = match rotation_inputs(
+        switch_id,
+        target_version,
+        &ctx.services.db_pool,
+        ctx.services.credential_manager.clone(),
+    )
+    .await
+    {
+        Ok(inputs) => inputs,
+        Err(error) => {
+            return Ok(NvosPasswordRotationOutcome::Waiting(format!(
+                "NVOS password rotation inputs are not ready: {error}"
+            )));
+        }
+    };
+
+    match component_manager
+        .ensure_switch_password_rotation(&inputs.endpoint, &inputs.target_password)
+        .await
+    {
+        Ok(job_id) => {
+            let mut txn = ctx.services.db_pool.begin().await?;
+
+            let recorded = db::credential_rotation::record_device_rotation_submitted(
+                &mut txn,
+                bmc_mac_address,
+                db::credential_rotation::CredentialRotationType::Nvos,
+                target_version,
+                expected_attempt,
+                &job_id,
+            )
+            .await?;
+
+            txn.commit().await?;
+
+            if !recorded {
+                return Err(StateHandlerError::GenericError(eyre::eyre!(
+                    "switch {switch_id}: NVOS job returned after its staged attempt changed"
+                )));
+            }
+
+            Ok(NvosPasswordRotationOutcome::Waiting(format!(
+                "NVOS job {job_id} was submitted"
+            )))
+        }
+        Err(ComponentManagerError::OperationOutcomeUnknown(error)) => {
+            Ok(NvosPasswordRotationOutcome::Waiting(format!(
+                "NVOS submission outcome is unknown and will be retried: {error}"
+            )))
+        }
+        Err(ComponentManagerError::RejectedBeforeDispatch(error)) => {
+            let mut txn = ctx.services.db_pool.begin().await?;
+
+            let failed = db::credential_rotation::record_device_rotation_failed(
+                &mut txn,
+                bmc_mac_address,
+                db::credential_rotation::CredentialRotationType::Nvos,
+                target_version,
+                expected_attempt,
+                "component-manager rejected the NVOS password request",
+            )
+            .await?;
+
+            txn.commit().await?;
+
+            if failed {
+                Ok(NvosPasswordRotationOutcome::Waiting(format!(
+                    "NVOS submission is not retryable without correction: {error}"
+                )))
+            } else {
+                Ok(NvosPasswordRotationOutcome::Waiting(
+                    "NVOS operation changed while recording failure".to_string(),
+                ))
+            }
+        }
+        Err(error) => Ok(NvosPasswordRotationOutcome::Waiting(format!(
+            "NVOS submission could not be attempted: {error}"
+        ))),
+    }
+}
+
+/// Starts another observation attempt for the same staged current-to-target
+/// transition, then asks component-manager to converge it again.
+async fn retry_staged_rotation(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    target_version: i32,
+    expected_attempt: i32,
+    expected_job_id: Option<&str>,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    let attempt = db::credential_rotation::record_device_rotation_retry_started(
+        &mut txn,
+        bmc_mac_address,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        target_version,
+        expected_attempt,
+        expected_job_id,
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    let Some(attempt) = attempt else {
+        return Ok(NvosPasswordRotationOutcome::Waiting(
+            "NVOS operation changed while retrying backend observation".to_string(),
+        ));
+    };
+
+    ensure_staged_rotation(switch_id, bmc_mac_address, target_version, attempt, ctx).await
+}
+
+/// Polls work already staged before a prior dispatch.
+async fn reconcile_staged_rotation(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    operation: &db::credential_rotation::DeviceRotationOperationState,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    let target_version = operation.rotating_to_version.ok_or_else(|| {
+        StateHandlerError::GenericError(eyre::eyre!(
+            "switch {switch_id}: staged NVOS operation has no target version"
+        ))
+    })?;
+
+    if let Some(error) = &operation.rotate_last_error_redacted {
+        return Ok(NvosPasswordRotationOutcome::Waiting(error.clone()));
+    }
+
+    let Some(job_id) = operation.rotate_job_id.as_deref() else {
+        return retry_staged_rotation(
+            switch_id,
+            bmc_mac_address,
+            target_version,
+            operation.rotate_attempts,
+            None,
+            ctx,
+        )
+        .await;
+    };
+
+    let Some(component_manager) = ctx.services.component_manager.clone() else {
+        return Ok(NvosPasswordRotationOutcome::Waiting(
+            "component manager is unavailable while polling NVOS rotation".to_string(),
+        ));
+    };
+
+    let status = match component_manager
+        .get_switch_password_rotation_job_status(job_id)
+        .await
+    {
+        Ok(status) => status,
+        Err(error) => {
+            return Ok(NvosPasswordRotationOutcome::Waiting(format!(
+                "NVOS job {job_id} could not be observed and remains attached: {error}"
+            )));
+        }
+    };
+
+    match status {
+        SwitchPasswordRotationState::Pending => Ok(NvosPasswordRotationOutcome::Waiting(format!(
+            "NVOS job {job_id} is still in progress"
+        ))),
+        SwitchPasswordRotationState::Completed => {
+            complete_staged_rotation(
+                switch_id,
+                bmc_mac_address,
+                target_version,
+                operation.rotate_attempts,
+                job_id,
+                ctx,
+            )
+            .await
+        }
+        SwitchPasswordRotationState::Failed
+        | SwitchPasswordRotationState::NotFound
+        | SwitchPasswordRotationState::Unknown => {
+            retry_staged_rotation(
+                switch_id,
+                bmc_mac_address,
+                target_version,
+                operation.rotate_attempts,
+                Some(job_id),
+                ctx,
+            )
+            .await
+        }
+    }
+}
+
+/// Claims a published target before its first component-manager dispatch.
+async fn stage_rotation(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    target_version: i32,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    rotation_inputs(
+        switch_id,
+        target_version,
+        &ctx.services.db_pool,
+        ctx.services.credential_manager.clone(),
+    )
+    .await?;
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    let attempt = db::credential_rotation::record_device_rotation_started(
+        &mut txn,
+        bmc_mac_address,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        target_version,
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    let Some(attempt) = attempt else {
+        return Ok(NvosPasswordRotationOutcome::Waiting(
+            "NVOS rotation could not be claimed because target or device state changed".to_string(),
+        ));
+    };
+
+    ensure_staged_rotation(switch_id, bmc_mac_address, target_version, attempt, ctx).await
+}
+
+/// Checks that the per-device credential uses the confirmed password, when known.
+async fn has_nvos_admin_credential(
+    switch_id: &SwitchId,
+    bmc_mac_address: mac_address::MacAddress,
+    confirmed_version: Option<i32>,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<bool, StateHandlerError> {
+    let current = ctx
+        .services
+        .credential_manager
+        .get_credentials(&CredentialKey::SwitchNvosAdmin { bmc_mac_address })
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre::eyre!(
+                "switch {switch_id}: failed to read NVOS credentials for BMC MAC \
+                 {bmc_mac_address}: {error}"
+            ))
+        })?;
+
+    let Some(Credentials::UsernamePassword {
+        username,
+        password: current_password,
+    }) = current
+    else {
+        return Ok(false);
+    };
+
+    if username.is_empty() || current_password.is_empty() {
+        return Ok(false);
+    }
+
+    let Some(confirmed_version) = confirmed_version else {
+        return Ok(true);
+    };
+
+    let Some(Credentials::UsernamePassword {
+        password: confirmed_password,
+        ..
+    }) = read_nvos_site_credentials(
+        switch_id,
+        confirmed_version,
+        ctx.services.credential_manager.as_ref(),
+    )
+    .await?
+    else {
+        return Ok(false);
+    };
+
+    Ok(current_password == confirmed_password)
+}
+
+/// Returns whether Ready should schedule an authoritative reconciliation pass.
+///
+/// This is only a preflight. Reconciliation reloads target and operation state
+/// before changing credentials or dispatching a backend operation.
+pub(crate) async fn needs_nvos_password_reconciliation(
+    switch_id: &SwitchId,
+    state: &Switch,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<bool, StateHandlerError> {
+    let Some(component_manager) = ctx.services.component_manager.as_ref() else {
+        return Ok(false);
+    };
+
+    if !component_manager.nv_switch.supports_password_rotation() {
+        return Ok(false);
+    }
+
+    let Some(bmc_mac_address) = state.bmc_mac_address else {
+        return Ok(false);
+    };
+
+    let mut conn = ctx.services.db_pool.acquire().await?;
+
+    let Some(target_version) = db::credential_rotation::current_target_version(
+        &mut conn,
+        db::credential_rotation::CredentialRotationType::Nvos,
+    )
+    .await?
+    else {
+        return Ok(false);
+    };
+
+    let operation = db::credential_rotation::device_rotation_operation_state(
+        &mut *conn,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        bmc_mac_address,
+    )
+    .await?;
+
+    // Credential reads may call an external store.
+    drop(conn);
+
+    if let Some(operation) = operation {
+        if operation.rotate_last_error_redacted.is_some() && operation.rotate_job_id.is_none() {
+            if matches!(
+                operation.rotating_to_version,
+                Some(staged_target) if staged_target < target_version
+            ) {
+                return Ok(true);
+            }
+
+            return Ok(!has_nvos_admin_credential(switch_id, bmc_mac_address, None, ctx).await?);
+        }
+
+        if operation.rotating_to_version.is_some() {
+            return Ok(true);
+        }
+
+        let Some(current_version) = operation.current_version else {
+            return Ok(true);
+        };
+
+        if current_version < target_version {
+            return Ok(true);
+        }
+
+        return Ok(!has_nvos_admin_credential(
+            switch_id,
+            bmc_mac_address,
+            Some(current_version),
+            ctx,
+        )
+        .await?);
+    }
+
+    // Avoid cycling switches that have no known credential source.
+    if has_nvos_admin_credential(switch_id, bmc_mac_address, None, ctx).await? {
+        return Ok(true);
+    }
+
+    let mut conn = ctx.services.db_pool.acquire().await?;
+
+    let expected_switch =
+        db::expected_switch::find_by_bmc_mac_address(&mut conn, bmc_mac_address).await?;
+
+    let Some(expected_switch) = expected_switch else {
+        return Ok(false);
+    };
+
+    Ok(!matches!(
+        expected_nvos_credential_pair(
+            expected_switch.nvos_username.as_deref(),
+            expected_switch.nvos_password.as_deref(),
+        ),
+        Ok(None)
+    ))
+}
+
+/// Reconciles or submits NVOS password rotation work for one switch.
+pub async fn reconcile_nvos_password_rotation(
+    switch_id: &SwitchId,
+    state: &Switch,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<NvosPasswordRotationOutcome, StateHandlerError> {
+    let Some(component_manager) = ctx.services.component_manager.as_ref() else {
+        return Ok(NvosPasswordRotationOutcome::UpToDate);
+    };
+
+    if !component_manager.nv_switch.supports_password_rotation() {
+        return Ok(NvosPasswordRotationOutcome::UpToDate);
+    }
+
+    let mut conn = ctx.services.db_pool.acquire().await?;
+
+    let Some(target_version) = db::credential_rotation::current_target_version(
+        &mut conn,
+        db::credential_rotation::CredentialRotationType::Nvos,
+    )
+    .await?
+    else {
+        return Ok(NvosPasswordRotationOutcome::UpToDate);
+    };
+
+    let Some(bmc_mac_address) = state.bmc_mac_address else {
+        return Ok(NvosPasswordRotationOutcome::CredentialError(
+            "No BMC MAC address on switch".to_string(),
+        ));
+    };
+
+    // Credential resolution may call an external store. Release the database
+    // connection before crossing that boundary.
+    drop(conn);
+
+    match crate::configuring::ensure_nvos_admin_credentials(switch_id, bmc_mac_address, ctx).await?
+    {
+        crate::configuring::NvosAdminCredentialStatus::Available => {}
+        crate::configuring::NvosAdminCredentialStatus::Skip => {
+            return Ok(NvosPasswordRotationOutcome::UpToDate);
+        }
+        crate::configuring::NvosAdminCredentialStatus::Error(cause) => {
+            return Ok(NvosPasswordRotationOutcome::CredentialError(cause));
+        }
+    }
+
+    let mut conn = ctx.services.db_pool.acquire().await?;
+
+    let operation = db::credential_rotation::device_rotation_operation_state(
+        &mut *conn,
+        db::credential_rotation::CredentialRotationType::Nvos,
+        bmc_mac_address,
+    )
+    .await?;
+
+    drop(conn);
+
+    if let Some(operation) = &operation
+        && let Some(staged_target) = operation.rotating_to_version
+    {
+        if operation.rotate_last_error_redacted.is_some()
+            && operation.rotate_job_id.is_none()
+            && staged_target < target_version
+        {
+            return stage_rotation(switch_id, bmc_mac_address, target_version, ctx).await;
+        }
+
+        return reconcile_staged_rotation(switch_id, bmc_mac_address, operation, ctx).await;
+    }
+
+    if matches!(
+        operation.as_ref().and_then(|state| state.current_version),
+        Some(current_version) if current_version >= target_version
+    ) {
+        return Ok(NvosPasswordRotationOutcome::UpToDate);
+    }
+
+    stage_rotation(switch_id, bmc_mac_address, target_version, ctx).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_nvos_credential_pair_distinguishes_absent_valid_and_invalid_rows() {
+        let cases = [
+            ((None, None), Ok(None)),
+            (
+                (Some("admin"), Some("password")),
+                Ok(Some(("admin", "password"))),
+            ),
+            (
+                (Some("admin"), None),
+                Err("Expected switch nvos_username and nvos_password must be set together"),
+            ),
+            (
+                (None, Some("password")),
+                Err("Expected switch nvos_username and nvos_password must be set together"),
+            ),
+            (
+                (Some(""), Some("password")),
+                Err("Expected switch nvos_username must not be empty"),
+            ),
+            (
+                (Some("admin"), Some("")),
+                Err("Expected switch nvos_password must not be empty"),
+            ),
+        ];
+
+        for ((username, password), expected) in cases {
+            assert_eq!(expected_nvos_credential_pair(username, password), expected);
+        }
+    }
+}

--- a/crates/switch-controller/src/ready.rs
+++ b/crates/switch-controller/src/ready.rs
@@ -18,12 +18,13 @@
 //! Handler for SwitchControllerState::Ready.
 
 use carbide_uuid::switch::SwitchId;
-use model::switch::{ReProvisioningState, Switch, SwitchControllerState};
+use model::switch::{ConfiguringState, ReProvisioningState, Switch, SwitchControllerState};
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
 use crate::context::SwitchStateHandlerContextObjects;
+use crate::nvos_password_rotation::needs_nvos_password_reconciliation;
 
 /// Handles the Ready state for a switch.
 ///
@@ -31,11 +32,11 @@ use crate::context::SwitchStateHandlerContextObjects;
 /// If a maintenance request has been posted via `switch_maintenance_requested`,
 /// transitions to `Maintenance` with the requested operation. If rack-level
 /// reprovisioning has been requested, transitions to `ReProvisioning`.
-/// Otherwise idles.
+/// Otherwise, actionable NVOS convergence work transitions back to `Configuring`.
 pub async fn handle_ready(
-    _switch_id: &SwitchId,
+    switch_id: &SwitchId,
     state: &mut Switch,
-    _ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
 ) -> Result<StateHandlerOutcome<SwitchControllerState>, StateHandlerError> {
     if state.is_marked_as_deleted() {
         return Ok(StateHandlerOutcome::transition(
@@ -76,6 +77,19 @@ pub async fn handle_ready(
                     "unknown initiator for switch reprovisioning request: {}",
                     req.initiator
                 ),
+            },
+        ));
+    }
+
+    if needs_nvos_password_reconciliation(switch_id, state, ctx).await? {
+        tracing::info!(
+            switch_id = ?switch_id,
+            "Switch: NVOS password reconciliation pending; transitioning to Configuring",
+        );
+
+        return Ok(StateHandlerOutcome::transition(
+            SwitchControllerState::Configuring {
+                config_state: ConfiguringState::RotateOsPassword,
             },
         ));
     }

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -162,6 +162,8 @@ navigation:
               path: dpu-management/dpu-operations.md
         - page: Firmware Updates
           path: operations/firmware-updates.md
+        - page: NVOS Password Rotation
+          path: operations/nvos-password-rotation.md
         - page: Monitoring and Health
           path: operations/monitoring-health.md
         - page: NICo MCP Server

--- a/docs/operations/nvos-password-rotation.md
+++ b/docs/operations/nvos-password-rotation.md
@@ -1,45 +1,30 @@
 # NVOS Password Rotation
 
-Use this workflow to rotate the NVOS admin password across managed NVLink
-switches, monitor site-wide convergence, and recover switches that do not reach
-the published target.
+Use this workflow to rotate the NVOS admin password across managed NVLink switches, monitor site-wide convergence, and recover switches that do not reach the published target.
 
-For related configuration and command guidance, see:
+Related guidance:
 
 - [Component Manager RMS Backends](../configuration/component-manager-rms.md)
 - [NICo Admin CLI](../manuals/nico-admin-cli.md)
 
 ## Workflow Boundaries
 
-NVOS password rotation is a site-wide, asynchronous operation. NICo publishes
-one versioned password target and reconciles each managed switch that has not
-been deleted.
+NVOS password rotation is a site-wide, asynchronous operation. NICo publishes one versioned password target and reconciles each managed switch that has not been deleted.
 
-- Rotation applies to managed NVLink switches that use the Rack Manager Service
-  (RMS) component-manager backend.
-- A published target cannot be canceled. Routine rotations should remain
-  serialized: wait for `Complete=true` prior to publishing another target.
-- Expected-switch credentials provide bootstrap authentication. They do not
-  replace credentials associated with a confirmed rotation version.
-- The rotation command reports the target version, not the generated password.
-  NICo keeps generated passwords in its configured credential store.
+- **Scope:** Rotation applies to managed NVLink switches that use the Rack Manager Service (RMS) component-manager backend.
+- **Serialization:** A published target cannot be canceled. Keep routine rotations serialized: wait for `Complete=true` before publishing another target.
+- **Bootstrap credentials:** Expected-switch credentials provide bootstrap authentication. They do not replace credentials associated with a confirmed rotation version.
+- **Password storage:** The rotation command reports the target version, not the generated password. NICo keeps generated passwords in its configured credential store.
 
 ## Prerequisites
 
-- Configure `nico-admin-cli` with the NICo Core API URL and an identity
-  authorized for Forge Admin CLI operations. See
-  [Connecting to nico-api](../manuals/nico-admin-cli.md#connecting-to-nico-api).
-- Configure RMS connectivity, rack profiles, and switch vendor data as described
-  in [Component Manager RMS Backends](../configuration/component-manager-rms.md).
+- Configure `nico-admin-cli` with the NICo Core API URL and an identity authorized for Forge Admin CLI operations. Refer to [Connecting to nico-api](../manuals/nico-admin-cli.md#connecting-to-nico-api).
+- Configure RMS connectivity, rack profiles, and switch vendor data as described in [Component Manager RMS Backends](../configuration/component-manager-rms.md).
 - Ensure each managed switch has a BMC MAC address.
-- Ensure each managed switch has an NVOS credential that authenticates to the
-  switch. The credential must be available from the expected-switch record or
-  the NICo credential store.
-- Set expected-switch NVOS username and password fields together. Both values
-  must be non-empty, or both fields must be unset.
+- Ensure each managed switch has an NVOS credential that authenticates to the switch. The credential must be available from the expected-switch record or the NICo credential store.
+- Set expected-switch NVOS username and password fields together. Both values must be non-empty, or both fields must be unset.
 
-Enable the RMS switch backend and password-rotation gate in the `nico-api` site
-configuration. The gate defaults to `false`.
+Enable the RMS switch backend and password-rotation gate in the `nico-api` site configuration. The gate defaults to `false`.
 
 ```toml
 [component_manager]
@@ -47,21 +32,18 @@ nv_switch_backend = "rms"
 nvos_password_rotation_enabled = true
 ```
 
-The gate is a deployment assertion, not a runtime capability negotiation.
-Enable it only through a coordinated NICo and RMS rollout that qualifies every
-reachable RMS instance, including every replica behind a load balancer.
+The gate is a deployment assertion, not a runtime capability negotiation. Enable it only through a coordinated NICo and RMS rollout that qualifies every reachable RMS instance, including every replica behind a load balancer.
 
-RPC availability alone does not establish compatibility. Each RMS instance must:
+RPC availability alone does not establish compatibility. Each RMS instance must meet these requirements:
 
 - Return a job ID for an accepted request.
 - Support job-status lookup.
 - Safely repeat the same active-to-target transition.
 - Recognize that a switch already using the target password is converged.
 
-When the gate is `false`, an NVOS rotation request returns
-`FailedPrecondition`.
+When the gate is `false`, an NVOS rotation request returns `FailedPrecondition`.
 
-## Establish Switch Credentials
+## Configure Switch Credentials
 
 Set a missing expected-switch credential pair:
 
@@ -72,22 +54,15 @@ nico-admin-cli -a <core-api-url> expected-switch update \
   --nvos-password='<active-password>'
 ```
 
-> **Warning:** `--nvos-password` and `credential rotate --password` place secret
-> values in process arguments. Shell history, command auditing, or process
-> inspection can expose them. The CLI does not support protected file or
-> standard-input password entry. Do not use these options where site policy
-> prohibits process-argument exposure. Prefer NICo-generated rotation
-> passwords.
+<Warning>
+`--nvos-password` and `credential rotate --password` place secret values in process arguments. Shell history, command auditing, or process inspection can expose them. The CLI does not support protected file or standard-input password entry. Do not use these options where site policy prohibits process-argument exposure. Prefer NICo-generated rotation passwords.
+</Warning>
 
-When an operator requests a target, NICo checks that every managed switch has a
-well-formed credential source. A missing or malformed source returns
-`FailedPrecondition`, and NICo does not publish the target. This admission check
-does not authenticate to each switch.
+When an operator requests a target, NICo checks that every managed switch has a well-formed credential source. A missing or malformed source returns `FailedPrecondition`, and NICo does not publish the target. This admission check does not authenticate to each switch.
 
-## Rotate the Password
+## Start the Rotation
 
-Confirm the prerequisites and verify that any prior target reports
-`Complete=true`.
+Confirm the prerequisites and verify that any prior target reports `Complete=true`.
 
 Let NICo generate a password that satisfies its password policy:
 
@@ -95,8 +70,7 @@ Let NICo generate a password that satisfies its password policy:
 nico-admin-cli -a <core-api-url> credential rotate --type=nvos
 ```
 
-The command returns the target version. Switch convergence continues
-asynchronously, and the generated password is not printed.
+The command returns the target version. Switch convergence continues asynchronously, and the generated password is not printed.
 
 To supply a password required by site policy:
 
@@ -107,9 +81,7 @@ nico-admin-cli -a <core-api-url> credential rotate \
   --reason='credential rotation ticket'
 ```
 
-NICo requires at least 16 bytes, including an ASCII uppercase letter, lowercase
-letter, digit, and punctuation character. Switches can enforce additional
-restrictions. Do not place secrets in `--reason`.
+NICo requires at least 16 bytes, including an ASCII uppercase letter, lowercase letter, digit, and punctuation character. Switches can enforce additional restrictions. Do not place secrets in `--reason`.
 
 ## Monitor Convergence
 
@@ -127,47 +99,44 @@ nico-admin-cli -a <core-api-url> credential rotation-status \
   --mac-address <bmc-mac>
 ```
 
-| Status field | Meaning |
-| --- | --- |
+### Rotation status fields
+
+| Status Field | Meaning |
+| ------------ | ------- |
 | `Target` | Site-wide credential version selected for convergence. |
 | `Converged` | Managed switches confirmed at the target version. |
 | `Pending` | Managed switches that have not confirmed the target version. |
 | `Quarantined` | Shared retry-deferral count. NVOS rotation does not create retry delays, so this value is normally `0`. |
 | `Complete` | `true` when every managed switch is converged. |
 
-Device status also includes the confirmed version, staged version, attempt
-count, last-attempt time, and redacted error.
+Device status also includes the confirmed version, staged version, attempt count, last-attempt time, and redacted error.
 
-## Convergence and Recovery
+## Recover from Rotation Failures
 
-NICo stores and verifies the versioned target credential prior to publishing
-its version. During reconciliation, component-manager supplies the active and
-target passwords to RMS.
-
-- A recorded RMS job is polled until it reaches a terminal state.
-- A failed, missing, or unknown job causes NICo to repeat the same staged
-  transition.
-- An ambiguous submission retains the staged target for another reconciliation
-  pass.
-- A switch that already accepts the target can converge through a repeated RMS
-  request.
-- NICo records convergence only when RMS reports completion and the matching
-  per-switch credential is stored and verified.
-- Switches ingested during an incomplete rotation reconcile to the published
-  target independently.
+### Recovery actions
 
 | Symptom | Action |
-| --- | --- |
+| ------- | ------ |
 | Rotation request returns `FailedPrecondition` | Follow the error details: enable the gate, use a supported backend, or supply valid credentials for the listed switches. |
-| Site status shows pending switches | Query each switch with `--mac-address`; inspect its staged version, attempt count, and redacted error. |
+| Site status shows pending switches | Query each switch with `--mac-address` and inspect its staged version, attempt count, and redacted error. |
 | Component-manager reports a non-retryable rejection | Correct the backend, endpoint, or credential issue, then issue another rotation request. |
 | Reconciliation remains unresolved | Verify RMS reachability and job handling. Inspect NICo and RMS logs without removing versioned credentials. |
 
-An accepted or ambiguous operation retains its target. If RMS rejects a request
-without starting work, a higher target can replace that rejected operation once
-the cause is corrected.
+An accepted or ambiguous operation retains its target. If RMS rejects a request without starting work, a higher target can replace that rejected operation after the operator corrects the cause.
 
-## Credential Retention
+### How reconciliation works
 
-NICo does not automatically delete versioned credentials. Treat them as
-NICo-managed state and do not delete them manually.
+NICo stores and verifies the versioned target credential before publishing its version. During reconciliation, component-manager supplies the active and target passwords to RMS.
+
+Reconciliation follows these rules:
+
+- NICo polls a recorded RMS job until it reaches a terminal state.
+- A failed, missing, or unknown job causes NICo to repeat the same staged transition.
+- An ambiguous submission retains the staged target for another reconciliation pass.
+- A switch that already accepts the target can converge through a repeated RMS request.
+- NICo records convergence only when RMS reports completion and NICo stores and verifies the matching per-switch credential.
+- Switches ingested during an incomplete rotation reconcile to the published target independently.
+
+## Preserve Credential History
+
+NICo does not automatically delete versioned credentials. Treat them as NICo-managed state and do not delete them manually.

--- a/docs/operations/nvos-password-rotation.md
+++ b/docs/operations/nvos-password-rotation.md
@@ -1,0 +1,173 @@
+# NVOS Password Rotation
+
+Use this workflow to rotate the NVOS admin password across managed NVLink
+switches, monitor site-wide convergence, and recover switches that do not reach
+the published target.
+
+For related configuration and command guidance, see:
+
+- [Component Manager RMS Backends](../configuration/component-manager-rms.md)
+- [NICo Admin CLI](../manuals/nico-admin-cli.md)
+
+## Workflow Boundaries
+
+NVOS password rotation is a site-wide, asynchronous operation. NICo publishes
+one versioned password target and reconciles each managed switch that has not
+been deleted.
+
+- Rotation applies to managed NVLink switches that use the Rack Manager Service
+  (RMS) component-manager backend.
+- A published target cannot be canceled. Routine rotations should remain
+  serialized: wait for `Complete=true` prior to publishing another target.
+- Expected-switch credentials provide bootstrap authentication. They do not
+  replace credentials associated with a confirmed rotation version.
+- The rotation command reports the target version, not the generated password.
+  NICo keeps generated passwords in its configured credential store.
+
+## Prerequisites
+
+- Configure `nico-admin-cli` with the NICo Core API URL and an identity
+  authorized for Forge Admin CLI operations. See
+  [Connecting to nico-api](../manuals/nico-admin-cli.md#connecting-to-nico-api).
+- Configure RMS connectivity, rack profiles, and switch vendor data as described
+  in [Component Manager RMS Backends](../configuration/component-manager-rms.md).
+- Ensure each managed switch has a BMC MAC address.
+- Ensure each managed switch has an NVOS credential that authenticates to the
+  switch. The credential must be available from the expected-switch record or
+  the NICo credential store.
+- Set expected-switch NVOS username and password fields together. Both values
+  must be non-empty, or both fields must be unset.
+
+Enable the RMS switch backend and password-rotation gate in the `nico-api` site
+configuration. The gate defaults to `false`.
+
+```toml
+[component_manager]
+nv_switch_backend = "rms"
+nvos_password_rotation_enabled = true
+```
+
+The gate is a deployment assertion, not a runtime capability negotiation.
+Enable it only through a coordinated NICo and RMS rollout that qualifies every
+reachable RMS instance, including every replica behind a load balancer.
+
+RPC availability alone does not establish compatibility. Each RMS instance must:
+
+- Return a job ID for an accepted request.
+- Support job-status lookup.
+- Safely repeat the same active-to-target transition.
+- Recognize that a switch already using the target password is converged.
+
+When the gate is `false`, an NVOS rotation request returns
+`FailedPrecondition`.
+
+## Establish Switch Credentials
+
+Set a missing expected-switch credential pair:
+
+```bash
+nico-admin-cli -a <core-api-url> expected-switch update \
+  --bmc-mac-address <bmc-mac> \
+  --nvos-username <username> \
+  --nvos-password='<active-password>'
+```
+
+> **Warning:** `--nvos-password` and `credential rotate --password` place secret
+> values in process arguments. Shell history, command auditing, or process
+> inspection can expose them. The CLI does not support protected file or
+> standard-input password entry. Do not use these options where site policy
+> prohibits process-argument exposure. Prefer NICo-generated rotation
+> passwords.
+
+When an operator requests a target, NICo checks that every managed switch has a
+well-formed credential source. A missing or malformed source returns
+`FailedPrecondition`, and NICo does not publish the target. This admission check
+does not authenticate to each switch.
+
+## Rotate the Password
+
+Confirm the prerequisites and verify that any prior target reports
+`Complete=true`.
+
+Let NICo generate a password that satisfies its password policy:
+
+```bash
+nico-admin-cli -a <core-api-url> credential rotate --type=nvos
+```
+
+The command returns the target version. Switch convergence continues
+asynchronously, and the generated password is not printed.
+
+To supply a password required by site policy:
+
+```bash
+nico-admin-cli -a <core-api-url> credential rotate \
+  --type=nvos \
+  --password='<strong-password>' \
+  --reason='credential rotation ticket'
+```
+
+NICo requires at least 16 bytes, including an ASCII uppercase letter, lowercase
+letter, digit, and punctuation character. Switches can enforce additional
+restrictions. Do not place secrets in `--reason`.
+
+## Monitor Convergence
+
+Show site-wide status:
+
+```bash
+nico-admin-cli -a <core-api-url> credential rotation-status --type=nvos
+```
+
+Show one switch by BMC MAC address:
+
+```bash
+nico-admin-cli -a <core-api-url> credential rotation-status \
+  --type=nvos \
+  --mac-address <bmc-mac>
+```
+
+| Status field | Meaning |
+| --- | --- |
+| `Target` | Site-wide credential version selected for convergence. |
+| `Converged` | Managed switches confirmed at the target version. |
+| `Pending` | Managed switches that have not confirmed the target version. |
+| `Quarantined` | Shared retry-deferral count. NVOS rotation does not create retry delays, so this value is normally `0`. |
+| `Complete` | `true` when every managed switch is converged. |
+
+Device status also includes the confirmed version, staged version, attempt
+count, last-attempt time, and redacted error.
+
+## Convergence and Recovery
+
+NICo stores and verifies the versioned target credential prior to publishing
+its version. During reconciliation, component-manager supplies the active and
+target passwords to RMS.
+
+- A recorded RMS job is polled until it reaches a terminal state.
+- A failed, missing, or unknown job causes NICo to repeat the same staged
+  transition.
+- An ambiguous submission retains the staged target for another reconciliation
+  pass.
+- A switch that already accepts the target can converge through a repeated RMS
+  request.
+- NICo records convergence only when RMS reports completion and the matching
+  per-switch credential is stored and verified.
+- Switches ingested during an incomplete rotation reconcile to the published
+  target independently.
+
+| Symptom | Action |
+| --- | --- |
+| Rotation request returns `FailedPrecondition` | Follow the error details: enable the gate, use a supported backend, or supply valid credentials for the listed switches. |
+| Site status shows pending switches | Query each switch with `--mac-address`; inspect its staged version, attempt count, and redacted error. |
+| Component-manager reports a non-retryable rejection | Correct the backend, endpoint, or credential issue, then issue another rotation request. |
+| Reconciliation remains unresolved | Verify RMS reachability and job handling. Inspect NICo and RMS logs without removing versioned credentials. |
+
+An accepted or ambiguous operation retains its target. If RMS rejects a request
+without starting work, a higher target can replace that rejected operation once
+the cause is corrected.
+
+## Credential Retention
+
+NICo does not automatically delete versioned credentials. Treat them as
+NICo-managed state and do not delete them manually.


### PR DESCRIPTION
This continues #3409 and completes end-to-end NVOS password rotation support.

The main flow is:

- Store each site-wide switch target as an immutable, versioned secret.
- Verify both writer and effective credential readback before publishing the target.
- Atomically publish the target and enqueue live switches for reconciliation.
- Stage each per-switch target and attempt before calling component-manager.
- Use RMS job IDs as transient observation handles.
- Retry the same current-to-target request after unknown, failed, or missing jobs.
- Persist and verify the new per-switch credential before promoting the exact target and attempt.

Passwords remain in the configured credential backend. The database stores versions, attempt metadata, transient job IDs, and redacted failure information.

Expected-switch validates NVOS credential pairs and supports updating the current credential used for reconciliation. If a confirmed per-switch credential is missing, the controller restores it from the last confirmed versioned target instead of falling back to a stale bootstrap password. Support for `admin-cli` is included for NVOS password rotation and credential-only expected-switch updates.

## Related issues

Supports #2041 and #3522.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required

### Manual validation with real switches

Validated NVOS password rotation against two real GB200 NVLink switches. Device identities, addresses, usernames, passwords, fingerprints, and rack IDs are removed.

#### Scenarios

1. **Single-switch rotation:** Ingested Switch A, established target version 0, then completed 10 sequential rotations through version 10. Direct credential authentication succeeded after every convergence.
2. **Late join with a different password:** Added Switch B after version 10 existed and verified its distinct bootstrap credential before ingestion. NICo and RMS converged only Switch B to version 10 while Switch A remained converged. Both accepted the target; Switch B's old password returned HTTP 401, proving device mutation.
3. **Controller recovery:** Stopped NICo while Switch B held a queued controller claim. NICo reclaimed it after normal stale-claim expiry and completed convergence. This covered recovery before mutation dispatch, not restart during an active RMS job.
4. **Two-switch soak:** Completed 20 more site-wide rotations across both switches, versions 11 through 30, without skipping or superseding a target. Runtime was 8 minutes (`2026-07-19T19:03:59Z` to `2026-07-19T19:11:59Z`).

For each soak iteration, the test recorded the exact target before publication, published it through admin CLI, waited for aggregate convergence, authenticated it directly on both switches, promoted the tracked current credential while retaining the previous password, then authenticated the current credential on both switches.

#### Results

| Scenario | Result |
| --- | --- |
| Single-switch sequence | 10/10 rotations converged through version 10 |
| Late-joining switch | Caught up to version 10; old password rejected with HTTP 401 |
| Controller stale-claim recovery | Reclaimed and converged successfully |
| Two-switch soak | 20/20 targets converged, versions 11 through 30 |

| Soak evidence | Result |
| --- | ---: |
| Admin CLI rotation RPCs | 20/20 successful |
| NICo controller reconciliation transitions | 40 |
| RMS per-switch requests and completed jobs | 40/40 |
| Direct target-credential authentication | 40/40 HTTP 200 |
| Direct current-credential authentication | 42/42 HTTP 200 (2 preflight, 40 post-convergence) |
| BMC authentication checks | 82/82 HTTP 200 |
| Recovery-journal failures | 0 |
| Rotation failures / process panics | 0 / 0 |
| Runtime | 8 minutes |

Final state was target version 30 with both switches converged at version 30, `pending=0`, `quarantined=0`, and `complete=true`. No staged target, job ID, or rotation error remained. Both switches accepted the final current credential; NICo's current and target records matched, while the previous record remained distinct for recovery.

#### Sanitized logs

NICo final-target publication and reconciliation:

```text
time=2026-07-19T19:11:38.410991215Z component=nico-api rpc=RotateCredential grpc_status=0
component=switch_controller switch=[REDACTED] message="NVOS password reconciliation pending; transitioning to Configuring"
component=switch_controller switch=[REDACTED] message="NVOS password reconciliation pending; transitioning to Configuring"
time=2026-07-19T19:12:01.781432629Z component=nico-api rpc=GetCredentialRotationStatus grpc_status=0
```

RMS final-target processing for both switches:

```text
time=2026-07-19T19:11:41.384222Z message="processing switch password rotation request" switch=[REDACTED]
time=2026-07-19T19:11:42.438184Z message="processing switch password rotation request" switch=[REDACTED]
time=2026-07-19T19:11:43.241833Z message="started NVUE revision apply for switch password rotation" switch=[REDACTED]
time=2026-07-19T19:11:44.252225Z message="started NVUE revision apply for switch password rotation" switch=[REDACTED]
time=2026-07-19T19:11:47.716380Z message="saved applied switch password revision for reboot persistence" switch=[REDACTED]
time=2026-07-19T19:11:47.716459Z message="switch password update job completed" switch=[REDACTED]
time=2026-07-19T19:11:52.969675Z message="saved applied switch password revision for reboot persistence" switch=[REDACTED]
time=2026-07-19T19:11:52.969784Z message="switch password update job completed" switch=[REDACTED]
```

Recovery journal completion:

```text
timestamp=2026-07-19T19:11:38Z iteration=20 state=published target_version=30
timestamp=2026-07-19T19:11:59Z iteration=20 state=converged target_version=30
timestamp=2026-07-19T19:11:59Z state=complete iterations=20
```

### Automated validation with simulation

Ran CLI-driven NVOS password rotation through NICo, component-manager, RMS, and nine simulated switches.

Tested scenarios:

- Initial target publication and fleet convergence at version 0.
- Normal fleet rotation to a new target.
- Partial authentication failure: 8 of 9 switches converged while one rejected both known passwords. NICo retained its staged target; restoring a known password allowed 9 of 9 convergence.
- Total authentication failure: all 9 switches rejected both known passwords. NICo retained every staged target; restoring known passwords allowed full convergence.
- Lost submission response without mutation: NICo retained the target without a job ID, retried the same transition, and converged.
- Lost RMS job record: NICo observed the missing job, re-dispatched the same staged transition, and converged.
- Password changed but response lost: the switch already accepted the target while NICo still recorded the prior version. RMS recognized the target on retry, and NICo converged without losing either known credential.
- Paused RMS job: The operation remained pending across reconciliation passes without losing credential state. Removing the pause allowed convergence to complete.
- Multiple sequential targets: versions 0 through 7 converged without losing staged or confirmed credential state.
- Concurrent admin requests: two simultaneous rotations published distinct versions through CAS; the fleet converged directly to the latest target without overwriting either versioned secret.
- NICo and RMS restart recovery: mixed per-switch password states survived service restart and converged to the published target.
- Mixed-version recovery: one switch lagging the rest of the fleet converged to the next published target.
- Public status reporting: partial failure, total failure, pending recovery, and final completion counts matched simulated hardware state.
- Direct verification: RMS authenticated the final target credential against all 9 simulated switches.

Final result:

- `target_version=7`
- `converged=9`
- `pending=0`
- `quarantined=0`
- `complete=true`
- Final target credential accepted by all simulated switches.

Restart testing covered recovery between reconciliation passes and explicit lost-job state. It did not kill RMS at the exact instant of an active NVUE password apply.