### PR TITLE
docs(observability): document message = dynamic in the instrumentation guide

### DIFF
--- a/docs/observability/instrumentation.md
+++ b/docs/observability/instrumentation.md
@@ -139,6 +139,24 @@ impl DynamicLog for CallFinished {
 }
 ```
 
+When the per-case *wording* matters, not just the level, declare `message = dynamic`
+and implement `DynamicMessage`; the derive routes `Event::message()` through it:
+
+```rust
+impl DynamicMessage for CallFinished {
+    fn message(&self) -> &'static str {
+        match self.outcome {
+            Outcome::Error => "outbound call failed",
+            Outcome::Ok => "outbound call finished",
+        }
+    }
+}
+```
+
+The level and the message are independent: an event can pair a dynamic level with a static
+message, or the reverse. Prefer a static `message` plus a `#[label]` where the label already
+names the case. Use `message = dynamic` only when the wording says something the label does not.
+
 ## Outbound calls
 
 Every generated gRPC client method is already wrapped: it records


### PR DESCRIPTION
Documents the `message = dynamic` knob added in #3705, next to the existing `log = dynamic` section in the instrumentation guide.

`message = dynamic` lets an event choose its log message per instance (typically a match on a `#[label]` enum) by implementing the new `DynamicMessage` trait. The entry shows the pattern and adds the guidance to prefer a static `message` plus a label where the label already names the case.

Split from the code PR (#3705) so the documentation can be reviewed on its own timeline. Part of the instrumentation-coherency initiative (#3169).
