### PR TITLE
Disable flaky dpu-to-nic-mode test until it's fixed

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -228,14 +228,11 @@ async fn test_integration() -> eyre::Result<()> {
             &host_inband_segment_id,
         )
         .boxed(),
-        test_machine_a_tron_dpu_to_nic_mode_reregistration(
-            HostHardwareType::DellPowerEdgeR750,
-            &test_env,
-            &bmc_address_registry,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
-        )
-        .boxed(),
+        // TODO: https://github.com/NVIDIA/infra-controller/issues/3709
+        // Re-enable `test_machine_a_tron_dpu_to_nic_mode_reregistration` after the
+        // Admin-to-HostInband re-ingestion race is fixed. The scenario currently flakes in CI when
+        // the host-facing DPU MAC is re-created on the Admin segment before the NIC-mode
+        // transition completes.
         test_machine_a_tron_dual_stack(
             HostHardwareType::DellPowerEdgeR750,
             &test_env,
@@ -1048,6 +1045,7 @@ async fn assert_auto_instance_network(
 /// Asserts the re-ingest milestone directly against the database -- the host's
 /// (stable, TPM-derived) machine row returns with its data-plane NIC and no
 /// managed DPU -- then drives the re-ingested NIC-mode host all the way to Ready.
+#[expect(dead_code, reason = "temporarily disabled due to a CI race")]
 async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
     hw_type: HostHardwareType,
     test_env: &IntegrationTestEnvironment,


### PR DESCRIPTION
See comments: there seems to be a race condition where the same MAC address is re-created and re-ingested before we complete the dpu-to-nic-mode transition, causing errors like these:

```
2026-07-18T17:03:56.4530969Z 2026-07-18T17:03:51.315785Z  WARN
run_iteration: carbide_instrument::red: external call failed
backend="forge" operation="discover_dhcp" error=code: 'Internal error',
message: "internal error: Network segment mismatch for existing MAC
address: 02:00:00:00:00:BB expected:
3f1df169-bcf3-4c6e-92a1-4ce30b0679ad actual from network switch:
04605172-a453-4df4-9cb9-54bd4e7f5c2b"
mat_host_id=7a04a9be-65a9-4f11-bd69-dbe2f2e757c6 api_state=Ready
state=MachineDown booted_os=<None>
```

The tests ultimately fail with a timeout error:

```
host with BMC MAC 02:00:00:00:00:BD did not re-ingest as a
zero-managed-DPU NicMode machine within the timeout
```

(Example failure: https://github.com/NVIDIA/infra-controller/actions/runs/29616669626/job/88121119589?pr=3695)

I put up a separate GitHub issue to track the fix, but it may be slightly non-trivial, and CI is broken on so many PR's right now it's more prudent to disable the test for now until we get a proper fix.

## Related issues
(Issue 3709, but not I'm not linking to it because I don't want confusion thinking this PR fixes that issue... we need a followup to actually fix it.)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

