### PR TITLE
feat(sku): validate v5 storage by drive size and PCI location

### DIFF
--- a/crates/admin-cli/src/sku/show/cmd.rs
+++ b/crates/admin-cli/src/sku/show/cmd.rs
@@ -148,11 +148,39 @@ fn storage_table(storage: Vec<::rpc::forge::SkuComponentStorage>) -> Table {
     let table_format = table.get_format();
     table_format.indent(10);
 
-    table.set_titles(Row::from(vec!["Model", "Count"]));
+    // Size (MB) and PCI Patterns carry the per-drive constraints introduced in
+    // schema version 5; they render empty for older SKUs that don't set them.
+    table.set_titles(Row::from(vec![
+        "Model",
+        "Count",
+        "Size (MB)",
+        "PCI Patterns",
+    ]));
     for s in storage {
-        table.add_row(Row::from(vec![s.model, s.count.to_string()]));
+        table.add_row(Row::from(vec![
+            s.model,
+            s.count.to_string(),
+            format_size_range(s.min_size_mb, s.max_size_mb),
+            if s.pci_patterns.is_empty() {
+                String::new()
+            } else {
+                s.pci_patterns.join("\n")
+            },
+        ]));
     }
     table
+}
+
+// Render a storage size bound as "min-max" (matching SkuComponentStorage's
+// Display), using "*" for an open bound and an empty string when neither is set.
+fn format_size_range(min_size_mb: Option<u32>, max_size_mb: Option<u32>) -> String {
+    match (min_size_mb, max_size_mb) {
+        (None, None) => String::new(),
+        (min, max) => {
+            let bound = |v: Option<u32>| v.map_or_else(|| "*".to_string(), |n| n.to_string());
+            format!("{}-{}", bound(min), bound(max))
+        }
+    }
 }
 
 pub async fn show_skus_table(

--- a/crates/admin-cli/src/sku/show/cmd.rs
+++ b/crates/admin-cli/src/sku/show/cmd.rs
@@ -148,12 +148,14 @@ fn storage_table(storage: Vec<::rpc::forge::SkuComponentStorage>) -> Table {
     let table_format = table.get_format();
     table_format.indent(10);
 
-    // Size (MB) and PCI Patterns carry the per-drive constraints introduced in
+    // Size (MiB) and PCI Patterns carry the per-drive constraints introduced in
     // schema version 5; they render empty for older SKUs that don't set them.
+    // The size field is labeled MB in the API but is computed as MiB (1 unit =
+    // 2048 * 512-byte sectors); label the column MiB so the value reads true.
     table.set_titles(Row::from(vec![
         "Model",
         "Count",
-        "Size (MB)",
+        "Size (MiB)",
         "PCI Patterns",
     ]));
     for s in storage {

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -161,7 +161,7 @@ pub mod tests {
               "version": "2.0"
             }
         },
-        "schema_version": 4
+        "schema_version": 5
     }"#;
 
     const SKU_DATA: &str = r#"
@@ -210,7 +210,10 @@ pub mod tests {
     "storage": [
       {
         "model": "Dell Ent NVMe CM6 RI 1.92TB",
-        "count": 1
+        "count": 1,
+        "min_size_mb": 1831420,
+        "max_size_mb": 1831420,
+        "pci_patterns": ["/devices/pci0000:00/0000:64:00.0/0000:65:00.0/nvme/nvme0/nvme0n1"]
       }
     ],
     "memory": [
@@ -228,7 +231,7 @@ pub mod tests {
         "version": "2.0"
       }
   },
-  "schema_version": 4
+  "schema_version": 5
 }"#;
 
     pub async fn handle_inventory_update(pool: &sqlx::PgPool, env: &TestEnv, mh: &TestManagedHost) {

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -775,17 +775,30 @@ pub async fn generate_sku_from_machine_at_version_5(
     // sysfs/PCI path is stored as the drive's single "pattern". An expected SKU
     // authored from this can then widen the size range or replace the literal
     // path with a regex. Drives are ordered by path for deterministic output.
+    //
+    // Both fields are required: a missing size or PCI path would produce an
+    // unconstrained storage entry that validates any drive at any location or
+    // capacity. Since a generated SKU can be persisted as an expected SKU,
+    // reject generation rather than silently authoring a permissive v5 SKU.
     let mut storage: Vec<SkuComponentStorage> = hardware_info
         .nvme_devices
         .iter()
-        .map(|nvme| SkuComponentStorage {
-            model: nvme.model.clone(),
-            count: 1,
-            min_size_mb: nvme.size_mb,
-            max_size_mb: nvme.size_mb,
-            pci_patterns: nvme.pci_path.iter().cloned().collect(),
+        .map(|nvme| {
+            let (Some(size_mb), Some(pci_path)) = (nvme.size_mb, nvme.pci_path.as_ref()) else {
+                return Err(DatabaseError::InvalidArgument(format!(
+                    "generate sku (v5): nvme drive (model {:?}, serial {:?}) is missing size or PCI path",
+                    nvme.model, nvme.serial
+                )));
+            };
+            Ok(SkuComponentStorage {
+                model: nvme.model.clone(),
+                count: 1,
+                min_size_mb: Some(size_mb),
+                max_size_mb: Some(size_mb),
+                pci_patterns: vec![pci_path.clone()],
+            })
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
     storage.sort();
     sku.components.storage = storage;
 

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -760,7 +760,7 @@ pub async fn generate_sku_from_machine_at_version_5(
         ));
     };
 
-    let Some(hardware_info) = machine.hardware_info.as_ref() else {
+    let Some(hardware_info) = machine.status.hardware_info.as_ref() else {
         return Err(DatabaseError::new(
             "generate sku: load hardware info (v5)",
             sqlx::Error::RowNotFound,

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -88,7 +88,7 @@ fn validate_storage_pci_patterns(sku: &Sku) -> Result<(), DatabaseError> {
         for pattern in &storage.pci_patterns {
             regex::Regex::new(pattern).map_err(|err| {
                 DatabaseError::InvalidArgument(format!(
-                    "Invalid storage PCI pattern \"{pattern}\": {err}"
+                    "invalid storage PCI pattern \"{pattern}\": {err}"
                 ))
             })?;
         }

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -37,7 +37,7 @@ use crate::{DatabaseError, ObjectFilter, Transaction, machine};
 /// The current version of the SKU format.  The state machine will create older
 /// versions from hardware using the currently assigned sku's version so that
 /// SKUs can maintain backward compatibility
-pub const CURRENT_SKU_VERSION: u32 = 4;
+pub const CURRENT_SKU_VERSION: u32 = 5;
 
 /// Find a SKU that matches the specified SKU using the same comparison that
 /// the SKU validation code uses. (i.e. the description, id and others are not compared)
@@ -80,6 +80,23 @@ pub async fn find_matching_with_exclusion(
     Ok(None)
 }
 
+/// Reject a SKU whose storage components carry an uncompilable PCI location
+/// pattern, so an invalid regex is caught at authoring time rather than at
+/// validation time.
+fn validate_storage_pci_patterns(sku: &Sku) -> Result<(), DatabaseError> {
+    for storage in &sku.components.storage {
+        for pattern in &storage.pci_patterns {
+            regex::Regex::new(pattern).map_err(|err| {
+                DatabaseError::InvalidArgument(format!(
+                    "Invalid storage PCI pattern \"{pattern}\": {err}"
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+#[allow(txn_held_across_await)]
 pub async fn create(txn: &mut PgConnection, sku: &Sku) -> Result<(), DatabaseError> {
     if sku.schema_version != CURRENT_SKU_VERSION {
         return Err(DatabaseError::InvalidArgument(
@@ -92,6 +109,8 @@ pub async fn create(txn: &mut PgConnection, sku: &Sku) -> Result<(), DatabaseErr
             "SKU ID must not be empty".to_string(),
         ));
     }
+
+    validate_storage_pci_patterns(sku)?;
 
     let mut inner_txn = Transaction::begin_inner(txn).await?;
 
@@ -222,6 +241,8 @@ pub async fn replace(txn: &mut PgConnection, sku: &Sku) -> Result<Sku, DatabaseE
         ));
     }
 
+    validate_storage_pci_patterns(sku)?;
+
     let mut inner_txn = Transaction::begin_inner(txn).await?;
 
     let query = "LOCK TABLE machine_skus IN ACCESS EXCLUSIVE MODE";
@@ -281,6 +302,7 @@ pub async fn generate_sku_from_machine_at_version(
         2 => generate_sku_from_machine_at_version_2(txn, machine_id).await,
         3 => generate_sku_from_machine_at_version_3(txn, machine_id).await,
         4 => generate_sku_from_machine_at_version_4(txn, machine_id).await,
+        5 => generate_sku_from_machine_at_version_5(txn, machine_id).await,
         _ => Err(DatabaseError::new(
             "generate_sku_from_machine_at_version",
             sqlx::Error::RowNotFound,
@@ -404,6 +426,9 @@ pub async fn generate_sku_from_machine_at_version_0_or_1(
                 .or_insert(SkuComponentStorage {
                     model: block_device.model.clone(),
                     count: 1,
+                    min_size_mb: None,
+                    max_size_mb: None,
+                    pci_patterns: Vec::new(),
                 });
         }
         storage
@@ -589,6 +614,9 @@ pub async fn generate_sku_from_machine_at_version_2(
             .or_insert(SkuComponentStorage {
                 model: s.model.clone(),
                 count: 1,
+                min_size_mb: None,
+                max_size_mb: None,
+                pci_patterns: Vec::new(),
             });
     }
 
@@ -639,6 +667,9 @@ pub async fn generate_sku_from_machine_at_version_3(
             .or_insert(SkuComponentStorage {
                 model: nvme.model.clone(),
                 count: 1,
+                min_size_mb: None,
+                max_size_mb: None,
+                pci_patterns: Vec::new(),
             });
     });
     sku.components.storage = storage.into_values().collect();
@@ -688,9 +719,75 @@ pub async fn generate_sku_from_machine_at_version_4(
             .or_insert(SkuComponentStorage {
                 model: nvme.model.clone(),
                 count: 1,
+                min_size_mb: None,
+                max_size_mb: None,
+                pci_patterns: Vec::new(),
             });
     });
     sku.components.storage = storage.into_values().collect();
+
+    // Vendor and Model fields do not contain useful information.  They seem limited and encoded somehow.
+    // We really only care about the spec version supported and that a TPM exists.
+    sku.components.tpm = hardware_info
+        .tpm_description
+        .as_ref()
+        .map(|tpm| SkuComponentTpm {
+            vendor: tpm.vendor.clone(),
+            version: tpm.tpm_spec.clone(),
+        });
+
+    Ok(sku)
+}
+
+pub async fn generate_sku_from_machine_at_version_5(
+    txn: impl DbReader<'_>,
+    machine_id: &MachineId,
+) -> Result<Sku, DatabaseError> {
+    let Some(machine) = machine::find(
+        txn,
+        ObjectFilter::One(*machine_id),
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..Default::default()
+        },
+    )
+    .await?
+    .into_iter()
+    .next() else {
+        return Err(DatabaseError::new(
+            "generate sku: find machine (v5)",
+            sqlx::Error::RowNotFound,
+        ));
+    };
+
+    let Some(hardware_info) = machine.hardware_info.as_ref() else {
+        return Err(DatabaseError::new(
+            "generate sku: load hardware info (v5)",
+            sqlx::Error::RowNotFound,
+        ));
+    };
+
+    let mut sku = generate_base_sku_from_hardware(&machine, 5, hardware_info);
+
+    // Unlike earlier versions, v5 records one storage entry per NVMe drive so
+    // each drive's size and PCI location can be validated individually. The
+    // discovered size is stored as an exact point (min == max) and the concrete
+    // sysfs/PCI path is stored as the drive's single "pattern". An expected SKU
+    // authored from this can then widen the size range or replace the literal
+    // path with a regex. Drives are ordered by path for deterministic output.
+    let mut storage: Vec<SkuComponentStorage> = hardware_info
+        .nvme_devices
+        .iter()
+        .map(|nvme| SkuComponentStorage {
+            model: nvme.model.clone(),
+            count: 1,
+            min_size_mb: nvme.size_mb,
+            max_size_mb: nvme.size_mb,
+            pci_patterns: nvme.pci_path.iter().cloned().collect(),
+        })
+        .collect();
+    storage.sort();
+    sku.components.storage = storage;
 
     // Vendor and Model fields do not contain useful information.  They seem limited and encoded somehow.
     // We really only care about the spec version supported and that a TPM exists.

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -107,6 +107,12 @@ pub struct NvmeDevice {
     pub firmware_rev: String,
     #[serde(default)]
     pub serial: String,
+    /// Total capacity of the drive in MB, when discoverable.
+    #[serde(default)]
+    pub size_mb: Option<u32>,
+    /// Full sysfs device path (DEVPATH), used for SKU PCI-location validation.
+    #[serde(default)]
+    pub pci_path: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/api-model/src/hardware_info/test_data/x86_info.json
+++ b/crates/api-model/src/hardware_info/test_data/x86_info.json
@@ -13,7 +13,9 @@
     {
       "model": "Dell Ent NVMe CM6 RI 1.92TB",
       "serial": "61M0A0D2TCD8",
-      "firmware_rev": "2.1.3"
+      "firmware_rev": "2.1.3",
+      "size_mb": 1831420,
+      "pci_path": "/devices/pci0000:00/0000:64:00.0/0000:65:00.0/nvme/nvme0/nvme0n1"
     }
   ],
   "dmi_data": {

--- a/crates/api-model/src/sku.rs
+++ b/crates/api-model/src/sku.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Write};
 
 use chrono::{DateTime, Utc};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
@@ -138,11 +139,40 @@ pub struct SkuComponentInfinibandDevices {
 pub struct SkuComponentStorage {
     pub model: String,
     pub count: u32,
+    /// Inclusive lower bound (MB) each drive in this group must meet. `None`
+    /// means no lower bound. Only consulted for schema version >= 5.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_size_mb: Option<u32>,
+    /// Inclusive upper bound (MB) each drive in this group must meet. `None`
+    /// means no upper bound. Only consulted for schema version >= 5.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_size_mb: Option<u32>,
+    /// Regex patterns matched against a drive's sysfs/PCI path to validate its
+    /// physical location. Empty means the drive location is not checked. On a
+    /// discovered (actual) SKU this holds the concrete path of each drive.
+    /// Only consulted for schema version >= 5.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pci_patterns: Vec<String>,
 }
 
 impl Display for SkuComponentStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "model: {} count {}", self.model, self.count)
+        write!(f, "model: {} count {}", self.model, self.count)?;
+        match (self.min_size_mb, self.max_size_mb) {
+            (None, None) => {}
+            (min, max) => write!(
+                f,
+                " size {}-{} MB",
+                min.map(|v| v.to_string())
+                    .unwrap_or_else(|| "*".to_string()),
+                max.map(|v| v.to_string())
+                    .unwrap_or_else(|| "*".to_string()),
+            )?,
+        }
+        if !self.pci_patterns.is_empty() {
+            write!(f, " pci {:?}", self.pci_patterns)?;
+        }
+        Ok(())
     }
 }
 
@@ -180,6 +210,11 @@ pub struct SkuStatus {
     // expected machine.
     pub last_generate_attempt: Option<DateTime<Utc>>,
 }
+
+/// First SKU schema version that validates storage by drive size range and
+/// PCI location instead of by model. Versions below this keep the legacy
+/// model + count storage comparison.
+pub const SKU_VERSION_WITH_DRIVE_LOCATION: u32 = 5;
 
 /// diff an actual sku against an expected sku and return the differences.
 ///
@@ -335,27 +370,10 @@ pub fn diff_skus(actual_sku: &Sku, expected_sku: &Sku) -> Vec<String> {
         ));
     }
 
-    let mut actual_storage: HashMap<String, SkuComponentStorage> = actual_sku
-        .components
-        .storage
-        .iter()
-        .map(|s| (s.model.clone(), s.clone()))
-        .collect();
-
-    for es in &expected_sku.components.storage {
-        if let Some(actual_storage) = actual_storage.remove(&es.model) {
-            if actual_storage.count != es.count {
-                diffs.push(format!(
-                    "Expected device count ({}) does not match actual ({}) for storage model ({})",
-                    es.count, actual_storage.count, actual_storage.model,
-                ));
-            }
-        } else {
-            diffs.push(format!("Missing storage config: {es}"));
-        };
-    }
-    for s in actual_storage.values() {
-        diffs.push(format!("Found unexpected storage config: {s}"));
+    if expected_sku.schema_version >= SKU_VERSION_WITH_DRIVE_LOCATION {
+        diff_storage_by_location(actual_sku, expected_sku, &mut diffs);
+    } else {
+        diff_storage_by_model(actual_sku, expected_sku, &mut diffs);
     }
 
     // Vendor and Model fields do not contain useful information.  They seem limited and encoded somehow.
@@ -380,4 +398,375 @@ pub fn diff_skus(actual_sku: &Sku, expected_sku: &Sku) -> Vec<String> {
         }
     }
     diffs
+}
+
+/// Legacy (schema version < 5) storage comparison: match discovered storage to
+/// expected storage by model and compare counts.
+fn diff_storage_by_model(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Vec<String>) {
+    let mut actual_storage: HashMap<String, SkuComponentStorage> = actual_sku
+        .components
+        .storage
+        .iter()
+        .map(|s| (s.model.clone(), s.clone()))
+        .collect();
+
+    for es in &expected_sku.components.storage {
+        if let Some(actual_storage) = actual_storage.remove(&es.model) {
+            if actual_storage.count != es.count {
+                diffs.push(format!(
+                    "Expected device count ({}) does not match actual ({}) for storage model ({})",
+                    es.count, actual_storage.count, actual_storage.model,
+                ));
+            }
+        } else {
+            diffs.push(format!("Missing storage config: {es}"));
+        };
+    }
+    for s in actual_storage.values() {
+        diffs.push(format!("Found unexpected storage config: {s}"));
+    }
+}
+
+/// A single discovered drive, projected out of an actual (generated) SKU where
+/// each storage entry represents one drive: `pci_patterns[0]` is its concrete
+/// path and `min_size_mb == max_size_mb` is its capacity.
+struct DiscoveredDrive<'a> {
+    path: Option<&'a str>,
+    size_mb: Option<u32>,
+}
+
+impl DiscoveredDrive<'_> {
+    fn describe(&self) -> String {
+        format!(
+            "path {}, size {}",
+            self.path.unwrap_or("<unknown>"),
+            self.size_mb
+                .map(|v| format!("{v} MB"))
+                .unwrap_or_else(|| "<unknown>".to_string()),
+        )
+    }
+
+    fn size_in_range(&self, min: Option<u32>, max: Option<u32>) -> bool {
+        // Unknown size cannot be shown to violate a bound.
+        let Some(size) = self.size_mb else {
+            return true;
+        };
+        min.is_none_or(|m| size >= m) && max.is_none_or(|m| size <= m)
+    }
+}
+
+/// Storage comparison for schema version >= 5. Model is intentionally ignored;
+/// each expected storage group is validated by drive size range, count, and PCI
+/// location patterns. Fails safely (emits a diff) when an expected drive is
+/// missing, when a location is ambiguous, when a drive is the wrong size, or
+/// when a discovered drive is not expected anywhere.
+fn diff_storage_by_location(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Vec<String>) {
+    let drives: Vec<DiscoveredDrive> = actual_sku
+        .components
+        .storage
+        .iter()
+        .map(|s| DiscoveredDrive {
+            path: s.pci_patterns.first().map(|p| p.as_str()),
+            size_mb: s.min_size_mb,
+        })
+        .collect();
+
+    // Track which discovered drives have been claimed by an expected group so
+    // that leftovers can be reported as unexpected.
+    let mut claimed = vec![false; drives.len()];
+
+    for es in &expected_sku.components.storage {
+        if es.pci_patterns.is_empty() {
+            // No location constraint: claim up to `count` unclaimed drives that
+            // fall within the size range.
+            let mut matched = 0u32;
+            for (i, drive) in drives.iter().enumerate() {
+                if matched >= es.count {
+                    break;
+                }
+                if !claimed[i] && drive.size_in_range(es.min_size_mb, es.max_size_mb) {
+                    claimed[i] = true;
+                    matched += 1;
+                }
+            }
+            if matched != es.count {
+                diffs.push(format!(
+                    "Expected {} storage drive(s) ({es}) but found {matched} matching the size range",
+                    es.count,
+                ));
+            }
+            continue;
+        }
+
+        // Location-constrained group: every pattern must match at least one
+        // drive, the group must claim exactly `count` drives, and each claimed
+        // drive must be within the size range.
+        let mut group_claimed: Vec<usize> = Vec::new();
+        for pattern in &es.pci_patterns {
+            let re = match Regex::new(pattern) {
+                Ok(re) => re,
+                Err(err) => {
+                    diffs.push(format!("Invalid storage PCI pattern \"{pattern}\": {err}"));
+                    continue;
+                }
+            };
+            let hits: Vec<usize> = drives
+                .iter()
+                .enumerate()
+                .filter(|(i, drive)| !claimed[*i] && drive.path.is_some_and(|p| re.is_match(p)))
+                .map(|(i, _)| i)
+                .collect();
+
+            if hits.is_empty() {
+                diffs.push(format!(
+                    "Expected storage drive at PCI location /{pattern}/ not found"
+                ));
+                continue;
+            }
+            for i in hits {
+                if !claimed[i] {
+                    claimed[i] = true;
+                    group_claimed.push(i);
+                }
+            }
+        }
+
+        if group_claimed.len() as u32 != es.count {
+            diffs.push(format!(
+                "Expected {} storage drive(s) ({es}) but matched {} at those PCI locations",
+                es.count,
+                group_claimed.len(),
+            ));
+        }
+
+        for i in group_claimed {
+            if !drives[i].size_in_range(es.min_size_mb, es.max_size_mb) {
+                diffs.push(format!(
+                    "Storage drive ({}) is outside expected size range {}-{} MB",
+                    drives[i].describe(),
+                    es.min_size_mb
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "*".to_string()),
+                    es.max_size_mb
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "*".to_string()),
+                ));
+            }
+        }
+    }
+
+    for (i, drive) in drives.iter().enumerate() {
+        if !claimed[i] {
+            diffs.push(format!(
+                "Found unexpected storage drive ({})",
+                drive.describe()
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sku(schema_version: u32, storage: Vec<SkuComponentStorage>) -> Sku {
+        Sku {
+            schema_version,
+            id: "test".to_string(),
+            description: String::new(),
+            created: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+            components: SkuComponents {
+                chassis: SkuComponentChassis::default(),
+                cpus: Vec::new(),
+                gpus: Vec::new(),
+                memory: Vec::new(),
+                infiniband_devices: Vec::new(),
+                storage,
+                tpm: None,
+            },
+            device_type: None,
+        }
+    }
+
+    /// A discovered drive as an actual (generated) v5 storage entry.
+    fn drive(path: &str, size_mb: u32) -> SkuComponentStorage {
+        SkuComponentStorage {
+            model: "nvme".to_string(),
+            count: 1,
+            min_size_mb: Some(size_mb),
+            max_size_mb: Some(size_mb),
+            pci_patterns: vec![path.to_string()],
+        }
+    }
+
+    /// An expected v5 storage group.
+    fn expected(
+        count: u32,
+        min: Option<u32>,
+        max: Option<u32>,
+        patterns: &[&str],
+    ) -> SkuComponentStorage {
+        SkuComponentStorage {
+            model: String::new(),
+            count,
+            min_size_mb: min,
+            max_size_mb: max,
+            pci_patterns: patterns.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    const PATH_A: &str = "/devices/pci0000:00/0000:04:00.0/nvme/nvme0/nvme0n1";
+    const PATH_B: &str = "/devices/pci0000:00/0000:05:00.0/nvme/nvme1/nvme1n1";
+
+    fn v5_storage_diffs(
+        actual: Vec<SkuComponentStorage>,
+        expected: Vec<SkuComponentStorage>,
+    ) -> Vec<String> {
+        diff_skus(&sku(5, actual), &sku(5, expected))
+    }
+
+    #[test]
+    fn v5_exact_location_and_size_match() {
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![
+                expected(1, Some(3_800_000), Some(4_000_000), &[r"0000:04:00\.0"]),
+                expected(1, Some(3_800_000), Some(4_000_000), &[r"0000:05:00\.0"]),
+            ],
+        );
+        assert!(diffs.is_empty(), "expected no diffs, got {diffs:?}");
+    }
+
+    #[test]
+    fn v5_missing_expected_location() {
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000)],
+            vec![expected(1, None, None, &[r"0000:09:00\.0"])],
+        );
+        assert!(
+            diffs.iter().any(|d| d.contains("not found")),
+            "got {diffs:?}"
+        );
+        // The unmatched discovered drive is reported as unexpected.
+        assert!(
+            diffs.iter().any(|d| d.contains("unexpected storage drive")),
+            "got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_unexpected_extra_drive() {
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![expected(1, None, None, &[r"0000:04:00\.0"])],
+        );
+        assert!(
+            diffs
+                .iter()
+                .any(|d| d.contains("unexpected storage drive") && d.contains("0000:05:00.0")),
+            "got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_drive_size_out_of_range() {
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 1_920_000)],
+            vec![expected(
+                1,
+                Some(3_800_000),
+                Some(4_000_000),
+                &[r"0000:04:00\.0"],
+            )],
+        );
+        assert!(
+            diffs
+                .iter()
+                .any(|d| d.contains("outside expected size range")),
+            "got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_broad_pattern_count_mismatch() {
+        // One pattern matches both drives but only one is expected.
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![expected(1, None, None, &[r"nvme"])],
+        );
+        assert!(
+            diffs.iter().any(|d| d.contains("but matched 2")),
+            "got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_broad_pattern_count_match() {
+        // One pattern matching all drives, count set to match, is accepted.
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![expected(2, None, None, &[r"/nvme/"])],
+        );
+        assert!(diffs.is_empty(), "expected no diffs, got {diffs:?}");
+    }
+
+    #[test]
+    fn v5_invalid_pattern_fails_soft() {
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000)],
+            vec![expected(1, None, None, &["0000:04:00(.0"])],
+        );
+        assert!(
+            diffs
+                .iter()
+                .any(|d| d.contains("Invalid storage PCI pattern")),
+            "got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_size_only_no_location() {
+        // Empty patterns: validate by size range and count only.
+        let ok = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![expected(2, Some(3_800_000), Some(4_000_000), &[])],
+        );
+        assert!(ok.is_empty(), "expected no diffs, got {ok:?}");
+
+        let bad = v5_storage_diffs(
+            vec![drive(PATH_A, 1_920_000)],
+            vec![expected(1, Some(3_800_000), Some(4_000_000), &[])],
+        );
+        assert!(
+            bad.iter().any(|d| d.contains("matching the size range")),
+            "got {bad:?}"
+        );
+    }
+
+    #[test]
+    fn legacy_v4_still_matches_by_model() {
+        // Under v4 the model is compared and size/pci fields are ignored.
+        let actual = vec![SkuComponentStorage {
+            model: "MODEL_X".to_string(),
+            count: 4,
+            min_size_mb: None,
+            max_size_mb: None,
+            pci_patterns: Vec::new(),
+        }];
+        let expected_match = actual.clone();
+        assert!(diff_skus(&sku(4, actual.clone()), &sku(4, expected_match)).is_empty());
+
+        let expected_wrong = vec![SkuComponentStorage {
+            model: "MODEL_Y".to_string(),
+            count: 4,
+            min_size_mb: None,
+            max_size_mb: None,
+            pci_patterns: Vec::new(),
+        }];
+        let diffs = diff_skus(&sku(4, actual), &sku(4, expected_wrong));
+        assert!(
+            diffs.iter().any(|d| d.contains("Missing storage config")),
+            "got {diffs:?}"
+        );
+    }
 }

--- a/crates/api-model/src/sku.rs
+++ b/crates/api-model/src/sku.rs
@@ -447,9 +447,10 @@ impl DiscoveredDrive<'_> {
     }
 
     fn size_in_range(&self, min: Option<u32>, max: Option<u32>) -> bool {
-        // Unknown size cannot be shown to violate a bound.
+        // Fail safe: an unknown size can only satisfy a group that configures no
+        // size bounds. Against an explicit min/max it is treated as a mismatch.
         let Some(size) = self.size_mb else {
-            return true;
+            return min.is_none() && max.is_none();
         };
         min.is_none_or(|m| size >= m) && max.is_none_or(|m| size <= m)
     }
@@ -475,7 +476,17 @@ fn diff_storage_by_location(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Ve
     // that leftovers can be reported as unexpected.
     let mut claimed = vec![false; drives.len()];
 
-    for es in &expected_sku.components.storage {
+    // Process location-constrained groups before generic (size-only) ones. A
+    // generic group is greedy and would otherwise claim a drive that only a
+    // constrained group can match, producing a false mismatch even when a valid
+    // overall assignment exists.
+    let (constrained, generic): (Vec<_>, Vec<_>) = expected_sku
+        .components
+        .storage
+        .iter()
+        .partition(|es| !es.pci_patterns.is_empty());
+
+    for es in constrained.into_iter().chain(generic) {
         if es.pci_patterns.is_empty() {
             // No location constraint: claim up to `count` unclaimed drives that
             // fall within the size range.
@@ -741,6 +752,55 @@ mod tests {
             bad.iter().any(|d| d.contains("matching the size range")),
             "got {bad:?}"
         );
+    }
+
+    #[test]
+    fn v5_generic_group_does_not_starve_constrained_group() {
+        // A generic (size-only) group is listed before a location-constrained
+        // group and both match PATH_A by size. If groups were processed in list
+        // order the generic group would greedily claim PATH_A, leaving the
+        // constrained group unable to match its required location. Constrained
+        // groups must be resolved first so a valid overall assignment is found.
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![
+                expected(1, Some(3_800_000), Some(4_000_000), &[]),
+                expected(1, Some(3_800_000), Some(4_000_000), &[r"0000:04:00\.0"]),
+            ],
+        );
+        assert!(diffs.is_empty(), "expected no diffs, got {diffs:?}");
+    }
+
+    #[test]
+    fn v5_unknown_size_fails_explicit_bounds() {
+        // A discovered drive whose capacity could not be read (min_size_mb None)
+        // must not silently satisfy a group that configures a size range.
+        let mut unknown = drive(PATH_A, 0);
+        unknown.min_size_mb = None;
+        unknown.max_size_mb = None;
+
+        let diffs = v5_storage_diffs(
+            vec![unknown.clone()],
+            vec![expected(
+                1,
+                Some(3_800_000),
+                Some(4_000_000),
+                &[r"0000:04:00\.0"],
+            )],
+        );
+        assert!(
+            diffs
+                .iter()
+                .any(|d| d.contains("outside expected size range")),
+            "got {diffs:?}"
+        );
+
+        // With no bounds configured, unknown size is accepted.
+        let ok = v5_storage_diffs(
+            vec![unknown],
+            vec![expected(1, None, None, &[r"0000:04:00\.0"])],
+        );
+        assert!(ok.is_empty(), "expected no diffs, got {ok:?}");
     }
 
     #[test]

--- a/crates/api-model/src/sku.rs
+++ b/crates/api-model/src/sku.rs
@@ -617,7 +617,12 @@ fn diff_storage_by_location(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Ve
                 "Expected {} storage drive(s) ({es}) but found {} matching the size range",
                 es.count, assigned_per_group[g],
             ));
-        } else {
+        } else if !eligibility[g].is_empty() {
+            // Only report the count shortfall when at least one drive matched a
+            // pattern. When none did, every pattern already emitted its own
+            // "Expected storage drive at PCI location /.../ not found" diff
+            // above, so a group-level "matched 0" diff would double-report the
+            // same root cause.
             diffs.push(format!(
                 "Expected {} storage drive(s) ({es}) but matched {} at those PCI locations",
                 es.count, assigned_per_group[g],
@@ -740,6 +745,49 @@ mod tests {
         assert!(
             diffs.iter().any(|d| d.contains("unexpected storage drive")),
             "got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_missing_location_reported_once() {
+        // A constrained group whose only pattern matches no drive reports the
+        // missing location once (the per-pattern "not found"), not also a
+        // redundant group-level "at those PCI locations" count diff.
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000)],
+            vec![expected(1, None, None, &[r"0000:09:00\.0"])],
+        );
+        assert!(
+            diffs.iter().any(|d| d.contains("not found")),
+            "got {diffs:?}"
+        );
+        assert!(
+            !diffs.iter().any(|d| d.contains("at those PCI locations")),
+            "missing location should not be double-reported, got {diffs:?}"
+        );
+    }
+
+    #[test]
+    fn v5_partial_location_match_reports_count() {
+        // When at least one pattern matches a drive but the group is still
+        // short, the group-level count diff is not redundant with a per-pattern
+        // "not found", so both are reported.
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000)],
+            vec![expected(
+                2,
+                None,
+                None,
+                &[r"0000:04:00\.0", r"0000:09:00\.0"],
+            )],
+        );
+        assert!(
+            diffs.iter().any(|d| d.contains("at those PCI locations")),
+            "expected count-shortfall diff, got {diffs:?}"
+        );
+        assert!(
+            diffs.iter().any(|d| d.contains("not found")),
+            "expected missing-location diff, got {diffs:?}"
         );
     }
 

--- a/crates/api-model/src/sku.rs
+++ b/crates/api-model/src/sku.rs
@@ -456,11 +456,47 @@ impl DiscoveredDrive<'_> {
     }
 }
 
+/// Attempt to place `drive` into an eligible, unfilled slot using Kuhn's
+/// augmenting-path algorithm, displacing already-placed drives when doing so
+/// frees a slot for them elsewhere. `slot_group[s]` is the expected-group index
+/// that owns slot `s`; `eligibility[g]` lists the drive indices group `g` can
+/// legally claim. Returns whether `drive` was placed.
+fn augment_drive(
+    drive: usize,
+    slot_group: &[usize],
+    eligibility: &[Vec<usize>],
+    slot_to_drive: &mut [Option<usize>],
+    visited: &mut [bool],
+) -> bool {
+    for s in 0..slot_group.len() {
+        if visited[s] || !eligibility[slot_group[s]].contains(&drive) {
+            continue;
+        }
+        visited[s] = true;
+        let freed = match slot_to_drive[s] {
+            None => true,
+            Some(occupant) => {
+                augment_drive(occupant, slot_group, eligibility, slot_to_drive, visited)
+            }
+        };
+        if freed {
+            slot_to_drive[s] = Some(drive);
+            return true;
+        }
+    }
+    false
+}
+
 /// Storage comparison for schema version >= 5. Model is intentionally ignored;
 /// each expected storage group is validated by drive size range, count, and PCI
 /// location patterns. Fails safely (emits a diff) when an expected drive is
 /// missing, when a location is ambiguous, when a drive is the wrong size, or
 /// when a discovered drive is not expected anywhere.
+///
+/// Drives are assigned to expected groups with a global maximum matching rather
+/// than greedily, so a broad group (e.g. `/nvme/`) never claims a drive that
+/// only a more specific group (e.g. `0000:04:00\.0`) can satisfy when a valid
+/// overall assignment exists.
 fn diff_storage_by_location(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Vec<String>) {
     let drives: Vec<DiscoveredDrive> = actual_sku
         .components
@@ -472,102 +508,144 @@ fn diff_storage_by_location(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Ve
         })
         .collect();
 
-    // Track which discovered drives have been claimed by an expected group so
-    // that leftovers can be reported as unexpected.
-    let mut claimed = vec![false; drives.len()];
-
-    // Process location-constrained groups before generic (size-only) ones. A
-    // generic group is greedy and would otherwise claim a drive that only a
-    // constrained group can match, producing a false mismatch even when a valid
-    // overall assignment exists.
+    // Order location-constrained groups before generic (size-only) ones. The
+    // assignment below is global, so this ordering does not affect whether a
+    // valid assignment is found; it only biases which of several equivalent
+    // assignments is chosen so a drive prefers the group naming its PCI
+    // location, keeping diagnostics deterministic.
     let (constrained, generic): (Vec<_>, Vec<_>) = expected_sku
         .components
         .storage
         .iter()
         .partition(|es| !es.pci_patterns.is_empty());
+    let groups: Vec<&SkuComponentStorage> = constrained.into_iter().chain(generic).collect();
 
-    for es in constrained.into_iter().chain(generic) {
+    // Compute, per expected group, the drives it may legally claim. A generic
+    // group (no patterns) accepts any drive within its size range. A
+    // location-constrained group accepts any drive matching at least one of its
+    // patterns; size is validated after assignment (as a diagnostic) so a drive
+    // at the right location but wrong size is reported as out-of-range rather
+    // than silently left unclaimed. Invalid patterns are reported and match
+    // nothing, and a pattern that matches no drive at all is reported here since
+    // it is unsatisfiable regardless of the final assignment.
+    let mut eligibility: Vec<Vec<usize>> = Vec::with_capacity(groups.len());
+    for es in &groups {
+        let mut eligible = Vec::new();
         if es.pci_patterns.is_empty() {
-            // No location constraint: claim up to `count` unclaimed drives that
-            // fall within the size range.
-            let mut matched = 0u32;
             for (i, drive) in drives.iter().enumerate() {
-                if matched >= es.count {
-                    break;
-                }
-                if !claimed[i] && drive.size_in_range(es.min_size_mb, es.max_size_mb) {
-                    claimed[i] = true;
-                    matched += 1;
+                if drive.size_in_range(es.min_size_mb, es.max_size_mb) {
+                    eligible.push(i);
                 }
             }
-            if matched != es.count {
-                diffs.push(format!(
-                    "Expected {} storage drive(s) ({es}) but found {matched} matching the size range",
-                    es.count,
-                ));
-            }
-            continue;
-        }
-
-        // Location-constrained group: every pattern must match at least one
-        // drive, the group must claim exactly `count` drives, and each claimed
-        // drive must be within the size range.
-        let mut group_claimed: Vec<usize> = Vec::new();
-        for pattern in &es.pci_patterns {
-            let re = match Regex::new(pattern) {
-                Ok(re) => re,
-                Err(err) => {
-                    diffs.push(format!("Invalid storage PCI pattern \"{pattern}\": {err}"));
-                    continue;
-                }
-            };
-            let hits: Vec<usize> = drives
+        } else {
+            let compiled: Vec<(&String, Option<Regex>)> = es
+                .pci_patterns
                 .iter()
-                .enumerate()
-                .filter(|(i, drive)| !claimed[*i] && drive.path.is_some_and(|p| re.is_match(p)))
-                .map(|(i, _)| i)
+                .map(|pattern| match Regex::new(pattern) {
+                    Ok(re) => (pattern, Some(re)),
+                    Err(err) => {
+                        diffs.push(format!("Invalid storage PCI pattern \"{pattern}\": {err}"));
+                        (pattern, None)
+                    }
+                })
                 .collect();
 
-            if hits.is_empty() {
-                diffs.push(format!(
-                    "Expected storage drive at PCI location /{pattern}/ not found"
-                ));
-                continue;
+            for (i, drive) in drives.iter().enumerate() {
+                let matches = drive.path.is_some_and(|p| {
+                    compiled
+                        .iter()
+                        .any(|(_, re)| re.as_ref().is_some_and(|re| re.is_match(p)))
+                });
+                if matches {
+                    eligible.push(i);
+                }
             }
-            for i in hits {
-                if !claimed[i] {
-                    claimed[i] = true;
-                    group_claimed.push(i);
+
+            for (pattern, re) in &compiled {
+                if let Some(re) = re {
+                    let found = drives
+                        .iter()
+                        .any(|d| d.path.is_some_and(|p| re.is_match(p)));
+                    if !found {
+                        diffs.push(format!(
+                            "Expected storage drive at PCI location /{pattern}/ not found"
+                        ));
+                    }
                 }
             }
         }
+        eligibility.push(eligible);
+    }
 
-        if group_claimed.len() as u32 != es.count {
-            diffs.push(format!(
-                "Expected {} storage drive(s) ({es}) but matched {} at those PCI locations",
-                es.count,
-                group_claimed.len(),
-            ));
+    // Expand each group into `count` interchangeable slots, then find a global
+    // maximum matching of drives to slots. Maximising the number of matched
+    // drives yields a saturating assignment whenever one exists.
+    let mut slot_group: Vec<usize> = Vec::new();
+    for (g, es) in groups.iter().enumerate() {
+        for _ in 0..es.count {
+            slot_group.push(g);
         }
+    }
+    let mut slot_to_drive: Vec<Option<usize>> = vec![None; slot_group.len()];
+    for drive in 0..drives.len() {
+        let mut visited = vec![false; slot_group.len()];
+        augment_drive(
+            drive,
+            &slot_group,
+            &eligibility,
+            &mut slot_to_drive,
+            &mut visited,
+        );
+    }
 
-        for i in group_claimed {
-            if !drives[i].size_in_range(es.min_size_mb, es.max_size_mb) {
-                diffs.push(format!(
-                    "Storage drive ({}) is outside expected size range {}-{} MB",
-                    drives[i].describe(),
-                    es.min_size_mb
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "*".to_string()),
-                    es.max_size_mb
-                        .map(|v| v.to_string())
-                        .unwrap_or_else(|| "*".to_string()),
-                ));
-            }
+    let mut drive_to_group: Vec<Option<usize>> = vec![None; drives.len()];
+    let mut assigned_per_group = vec![0u32; groups.len()];
+    for (s, occupant) in slot_to_drive.iter().enumerate() {
+        if let Some(drive) = occupant {
+            drive_to_group[*drive] = Some(slot_group[s]);
+            assigned_per_group[slot_group[s]] += 1;
         }
     }
 
+    // Report groups that could not be fully satisfied.
+    for (g, es) in groups.iter().enumerate() {
+        if assigned_per_group[g] == es.count {
+            continue;
+        }
+        if es.pci_patterns.is_empty() {
+            diffs.push(format!(
+                "Expected {} storage drive(s) ({es}) but found {} matching the size range",
+                es.count, assigned_per_group[g],
+            ));
+        } else {
+            diffs.push(format!(
+                "Expected {} storage drive(s) ({es}) but matched {} at those PCI locations",
+                es.count, assigned_per_group[g],
+            ));
+        }
+    }
+
+    // Report size mismatches for drives claimed by a location-constrained group.
     for (i, drive) in drives.iter().enumerate() {
-        if !claimed[i] {
+        let Some(g) = drive_to_group[i] else { continue };
+        let es = groups[g];
+        if !es.pci_patterns.is_empty() && !drive.size_in_range(es.min_size_mb, es.max_size_mb) {
+            diffs.push(format!(
+                "Storage drive ({}) is outside expected size range {}-{} MB",
+                drive.describe(),
+                es.min_size_mb
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "*".to_string()),
+                es.max_size_mb
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "*".to_string()),
+            ));
+        }
+    }
+
+    // Any drive not claimed by a group is unexpected.
+    for (i, drive) in drives.iter().enumerate() {
+        if drive_to_group[i].is_none() {
             diffs.push(format!(
                 "Found unexpected storage drive ({})",
                 drive.describe()
@@ -699,16 +777,34 @@ mod tests {
     }
 
     #[test]
-    fn v5_broad_pattern_count_mismatch() {
-        // One pattern matches both drives but only one is expected.
+    fn v5_broad_pattern_over_matches_reported_as_unexpected() {
+        // One pattern matches both drives but only one is expected. Global
+        // assignment claims a single drive for the group and reports the
+        // leftover as unexpected rather than inflating the group's match count.
         let diffs = v5_storage_diffs(
             vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
             vec![expected(1, None, None, &[r"nvme"])],
         );
         assert!(
-            diffs.iter().any(|d| d.contains("but matched 2")),
+            diffs.iter().any(|d| d.contains("unexpected storage drive")),
             "got {diffs:?}"
         );
+    }
+
+    #[test]
+    fn v5_broad_constrained_group_does_not_starve_specific_group() {
+        // A broad constrained group (/nvme/) and a specific one (0000:04:00.0)
+        // each expect one of two drives. A valid assignment exists
+        // (/nvme/ -> PATH_B, 0000:04:00.0 -> PATH_A), so global matching must
+        // find it instead of letting the broad group claim both drives.
+        let diffs = v5_storage_diffs(
+            vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)],
+            vec![
+                expected(1, None, None, &[r"/nvme/"]),
+                expected(1, None, None, &[r"0000:04:00\.0"]),
+            ],
+        );
+        assert!(diffs.is_empty(), "expected no diffs, got {diffs:?}");
     }
 
     #[test]

--- a/crates/api-model/src/test_support/machine_snapshot.rs
+++ b/crates/api-model/src/test_support/machine_snapshot.rs
@@ -172,6 +172,8 @@ pub fn host_hardware_info() -> HardwareInfo {
                 model: "Dell Ent NVMe CM6 RI 3.84TB".to_string(),
                 firmware_rev: "2.2.0".to_string(),
                 serial: format!("Y2Q0A05DT2Q{i}"),
+                size_mb: None,
+                pci_path: None,
             })
             .collect(),
         dmi_data: Some(DmiData {

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1852,7 +1852,7 @@ mod tests {
 
     fn static_machine() -> StaticMachineEndpoint {
         StaticMachineEndpoint {
-            id: "machine-id".to_string(),
+            id: Some("machine-id".to_string()),
             serial: None,
             driver_version: None,
             slot_number: None,

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -237,6 +237,13 @@ fn get_nvme_size_mb(context: &libudev::Context, controller: &Device) -> Option<u
     let total_sectors: u64 = enumerator
         .scan_devices()
         .ok()?
+        .filter(|ns| {
+            // Only whole-namespace disks. `match_parent` walks the full block
+            // subtree, so without this a partitioned drive would have its
+            // partition sizes summed on top of the namespace size, inflating
+            // the reported capacity.
+            ns.property_value("DEVTYPE").and_then(|v| v.to_str()) == Some("disk")
+        })
         .filter_map(|ns| {
             ns.attribute_value("size")
                 .and_then(|v| v.to_str())

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -234,24 +234,24 @@ fn get_nvme_size_mb(context: &libudev::Context, controller: &Device) -> Option<u
     enumerator.match_subsystem("block").ok()?;
     enumerator.match_parent(controller).ok()?;
 
-    let total_sectors: u64 = enumerator
-        .scan_devices()
-        .ok()?
-        .filter(|ns| {
-            // Only whole-namespace disks. `match_parent` walks the full block
-            // subtree, so without this a partitioned drive would have its
-            // partition sizes summed on top of the namespace size, inflating
-            // the reported capacity.
-            ns.property_value("DEVTYPE").and_then(|v| v.to_str()) == Some("disk")
-        })
-        .filter_map(|ns| {
-            ns.attribute_value("size")
-                .and_then(|v| v.to_str())
-                .and_then(|v| v.trim().parse::<u64>().ok())
-        })
-        .sum();
-
-    if total_sectors == 0 {
+    let mut total_sectors = 0_u64;
+    let mut found_namespace = false;
+    for ns in enumerator.scan_devices().ok()? {
+        // Only whole-namespace disks. `match_parent` walks the full block
+        // subtree, so without this a partitioned drive would have its
+        // partition sizes summed on top of the namespace size, inflating
+        // the reported capacity.
+        if ns.property_value("DEVTYPE").and_then(|v| v.to_str()) != Some("disk") {
+            continue;
+        }
+        found_namespace = true;
+        let sectors = ns
+            .attribute_value("size")
+            .and_then(|v| v.to_str())
+            .and_then(|v| v.trim().parse::<u64>().ok())?;
+        total_sectors = total_sectors.checked_add(sectors)?;
+    }
+    if !found_namespace {
         return None;
     }
     u32::try_from(total_sectors / 2048).ok()

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -225,6 +225,31 @@ fn get_numa_node_from_syspath(syspath: Option<&Path>) -> Result<i32, HardwareEnu
     })
 }
 
+// Total capacity of an NVMe controller in MB, summed across its block
+// namespaces. The `size` sysattr on a block device is a count of 512-byte
+// sectors (1 MB == 2048 sectors). Returns None when no namespace size can be
+// read, so callers can treat size as "unknown" rather than zero.
+fn get_nvme_size_mb(context: &libudev::Context, controller: &Device) -> Option<u32> {
+    let mut enumerator = libudev::Enumerator::new(context).ok()?;
+    enumerator.match_subsystem("block").ok()?;
+    enumerator.match_parent(controller).ok()?;
+
+    let total_sectors: u64 = enumerator
+        .scan_devices()
+        .ok()?
+        .filter_map(|ns| {
+            ns.attribute_value("size")
+                .and_then(|v| v.to_str())
+                .and_then(|v| v.trim().parse::<u64>().ok())
+        })
+        .sum();
+
+    if total_sectors == 0 {
+        return None;
+    }
+    u32::try_from(total_sectors / 2048).ok()
+}
+
 // discovery all the non-DPU IB devices
 pub fn discovery_ibs() -> HardwareEnumerationResult<Vec<rpc_discovery::InfinibandInterface>> {
     let device_debug_log = |device: &Device| {
@@ -679,12 +704,17 @@ fn enumerate_hardware_inner(
             .filter(|v| !v.contains("virtual"))
             .is_some()
         {
+            let pci_path = convert_property_to_string(PCI_DEV_PATH, "", &device)
+                .ok()
+                .map(|v| v.to_string());
             nvmes.push(rpc_discovery::NvmeDevice {
                 model: convert_sysattr_to_string("model", &device)?.to_string(),
                 firmware_rev: convert_sysattr_to_string("firmware_rev", &device)?.to_string(),
                 serial: convert_sysattr_to_string("serial", &device)?
                     .trim()
                     .to_string(),
+                size_mb: get_nvme_size_mb(&context, &device),
+                pci_path,
             });
         }
     }

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -266,6 +266,8 @@ fn hpe_proliant(host: &HostMachineInfo) -> DiscoveryInfo {
                 model: "VO001920KXPTN".into(),
                 firmware_rev: "HPK0".into(),
                 serial,
+                size_mb: None,
+                pci_path: None,
             })
             .collect(),
         dmi_data: Some(DmiData {
@@ -328,6 +330,8 @@ fn wiwynn_gb200(host: &HostMachineInfo) -> DiscoveryInfo {
                 model: "SAMSUNG MZTL63T8HFLT-00AW7".into(),
                 firmware_rev: "LDDL4U2Q".into(),
                 serial: format!("BDFAKESERNUM{index}"),
+                size_mb: None,
+                pci_path: None,
             })
             .collect(),
         dmi_data: Some(DmiData {
@@ -383,6 +387,8 @@ fn lenovo_gb300(host: &HostMachineInfo) -> DiscoveryInfo {
                 model: (*model).into(),
                 firmware_rev: (*firmware_rev).into(),
                 serial: (*serial).into(),
+                size_mb: None,
+                pci_path: None,
             })
             .collect(),
         dmi_data: Some(DmiData {
@@ -514,11 +520,15 @@ fn nvidia_dgx_h100(host: &HostMachineInfo) -> DiscoveryInfo {
                 model: "Micron_7450_MTFDKBG1T9TFR".into(),
                 firmware_rev: "E2MU200".into(),
                 serial: format!("MicronFAKESERNUM{index}"),
+                size_mb: None,
+                pci_path: None,
             })
             .chain((0..8).map(|index| NvmeDevice {
                 model: "KCM6DRUL3T84".into(),
                 firmware_rev: "0107".into(),
                 serial: format!("KCMFAKESERNUM{index}"),
+                size_mb: None,
+                pci_path: None,
             }))
             .collect(),
         dmi_data: Some(DmiData {

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -685,7 +685,10 @@ fn nvme_size_mb(model: &str) -> u32 {
 /// needs a unique PCI path so v5 SKU generation records one storage entry per
 /// drive.
 fn nvme_pci_path(index: usize) -> String {
-    format!("/devices/pci0000:00/0000:64:00.0/0000:{:02x}:00.0/nvme/nvme{index}/nvme{index}n1", 0x65 + index)
+    format!(
+        "/devices/pci0000:00/0000:64:00.0/0000:{:02x}:00.0/nvme/nvme{index}/nvme{index}n1",
+        0x65 + index
+    )
 }
 
 fn gb200_gpus() -> Vec<Gpu> {

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -262,12 +262,13 @@ fn hpe_proliant(host: &HostMachineInfo) -> DiscoveryInfo {
         machine_arch,
         nvme_devices: serials
             .into_iter()
-            .map(|serial| NvmeDevice {
+            .enumerate()
+            .map(|(index, serial)| NvmeDevice {
                 model: "VO001920KXPTN".into(),
                 firmware_rev: "HPK0".into(),
                 serial,
-                size_mb: None,
-                pci_path: None,
+                size_mb: Some(nvme_size_mb("VO001920KXPTN")),
+                pci_path: Some(nvme_pci_path(index)),
             })
             .collect(),
         dmi_data: Some(DmiData {
@@ -330,8 +331,8 @@ fn wiwynn_gb200(host: &HostMachineInfo) -> DiscoveryInfo {
                 model: "SAMSUNG MZTL63T8HFLT-00AW7".into(),
                 firmware_rev: "LDDL4U2Q".into(),
                 serial: format!("BDFAKESERNUM{index}"),
-                size_mb: None,
-                pci_path: None,
+                size_mb: Some(nvme_size_mb("SAMSUNG MZTL63T8HFLT-00AW7")),
+                pci_path: Some(nvme_pci_path(index)),
             })
             .collect(),
         dmi_data: Some(DmiData {
@@ -383,12 +384,13 @@ fn lenovo_gb300(host: &HostMachineInfo) -> DiscoveryInfo {
         machine_arch,
         nvme_devices: storage
             .iter()
-            .map(|(model, firmware_rev, serial)| NvmeDevice {
+            .enumerate()
+            .map(|(index, (model, firmware_rev, serial))| NvmeDevice {
                 model: (*model).into(),
                 firmware_rev: (*firmware_rev).into(),
                 serial: (*serial).into(),
-                size_mb: None,
-                pci_path: None,
+                size_mb: Some(nvme_size_mb(model)),
+                pci_path: Some(nvme_pci_path(index)),
             })
             .collect(),
         dmi_data: Some(DmiData {
@@ -520,15 +522,15 @@ fn nvidia_dgx_h100(host: &HostMachineInfo) -> DiscoveryInfo {
                 model: "Micron_7450_MTFDKBG1T9TFR".into(),
                 firmware_rev: "E2MU200".into(),
                 serial: format!("MicronFAKESERNUM{index}"),
-                size_mb: None,
-                pci_path: None,
+                size_mb: Some(nvme_size_mb("Micron_7450_MTFDKBG1T9TFR")),
+                pci_path: Some(nvme_pci_path(index)),
             })
             .chain((0..8).map(|index| NvmeDevice {
                 model: "KCM6DRUL3T84".into(),
                 firmware_rev: "0107".into(),
                 serial: format!("KCMFAKESERNUM{index}"),
-                size_mb: None,
-                pci_path: None,
+                size_mb: Some(nvme_size_mb("KCM6DRUL3T84")),
+                pci_path: Some(nvme_pci_path(index + 2)),
             }))
             .collect(),
         dmi_data: Some(DmiData {
@@ -664,6 +666,26 @@ fn memory_devices(count: usize, size_mb: u32, memory_type: &str) -> Vec<MemoryDe
             mem_type: Some(memory_type.into()),
         })
         .collect()
+}
+
+/// Mock NVMe capacity in MiB (matching what the real host enumeration reports),
+/// inferred from the capacity encoded in the model string (e.g. `…3T8…` = 3.84
+/// TB, otherwise 1.92 TB). Mock hosts must report a size so v5 SKU generation,
+/// which rejects drives with unknown size, can run against them.
+fn nvme_size_mb(model: &str) -> u32 {
+    if model.contains("3T8") {
+        3_662_840
+    } else {
+        1_831_420
+    }
+}
+
+/// Distinct fake sysfs DEVPATH for the Nth mock NVMe controller, mirroring the
+/// shape the real host enumeration reports (`…/nvme/nvmeN/nvmeNn1`). Each drive
+/// needs a unique PCI path so v5 SKU generation records one storage entry per
+/// drive.
+fn nvme_pci_path(index: usize) -> String {
+    format!("/devices/pci0000:00/0000:64:00.0/0000:{:02x}:00.0/nvme/nvme{index}/nvme{index}n1", 0x65 + index)
 }
 
 fn gb200_gpus() -> Vec<Gpu> {

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -798,6 +798,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .field_attribute("SkuComponentStorage.vendor", "#[serde(default)]")
         .field_attribute("SkuComponentStorage.capacity_mb", "#[serde(default)]")
+        .field_attribute("SkuComponentStorage.min_size_mb", "#[serde(default)]")
+        .field_attribute("SkuComponentStorage.max_size_mb", "#[serde(default)]")
+        .field_attribute("SkuComponentStorage.pci_patterns", "#[serde(default)]")
         .type_attribute(
             "SkuComponentTpm",
             "#[derive(serde::Serialize, serde::Deserialize)]",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -7376,6 +7376,9 @@ message SkuComponentStorage {
   string model = 2;
   uint32 count = 3;
   uint32 capacity_mb = 4;
+  optional uint32 min_size_mb = 5;
+  optional uint32 max_size_mb = 6;
+  repeated string pci_patterns = 7;
 }
 
 message SkuComponentStorageController {

--- a/crates/rpc/proto/machine_discovery.proto
+++ b/crates/rpc/proto/machine_discovery.proto
@@ -111,6 +111,8 @@ message NvmeDevice {
   string model = 1;
   string firmware_rev = 2;
   string serial = 3;
+  optional uint32 size_mb = 4;
+  optional string pci_path = 5;
 }
 
 message DmiData {

--- a/crates/rpc/src/model/hardware_info.rs
+++ b/crates/rpc/src/model/hardware_info.rs
@@ -122,6 +122,8 @@ impl TryFrom<rpc::machine_discovery::NvmeDevice> for NvmeDevice {
             model: dev.model,
             firmware_rev: dev.firmware_rev,
             serial: dev.serial,
+            size_mb: dev.size_mb,
+            pci_path: dev.pci_path,
         })
     }
 }
@@ -134,6 +136,8 @@ impl TryFrom<NvmeDevice> for rpc::machine_discovery::NvmeDevice {
             model: dev.model,
             firmware_rev: dev.firmware_rev,
             serial: dev.serial,
+            size_mb: dev.size_mb,
+            pci_path: dev.pci_path,
         })
     }
 }

--- a/crates/rpc/src/model/sku.rs
+++ b/crates/rpc/src/model/sku.rs
@@ -235,6 +235,9 @@ impl From<rpc::forge::SkuComponentStorage> for SkuComponentStorage {
         SkuComponentStorage {
             model: value.model,
             count: value.count,
+            min_size_mb: value.min_size_mb,
+            max_size_mb: value.max_size_mb,
+            pci_patterns: value.pci_patterns,
         }
     }
 }
@@ -246,6 +249,9 @@ impl From<SkuComponentStorage> for rpc::forge::SkuComponentStorage {
             model: value.model,
             capacity_mb: 0u32,
             count: value.count,
+            min_size_mb: value.min_size_mb,
+            max_size_mb: value.max_size_mb,
+            pci_patterns: value.pci_patterns,
         }
     }
 }

--- a/rest-api/proto/core/gen/v1/machine_discovery_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/machine_discovery_nico.pb.go
@@ -704,6 +704,8 @@ type NvmeDevice struct {
 	Model         string                 `protobuf:"bytes,1,opt,name=model,proto3" json:"model,omitempty"`
 	FirmwareRev   string                 `protobuf:"bytes,2,opt,name=firmware_rev,json=firmwareRev,proto3" json:"firmware_rev,omitempty"`
 	Serial        string                 `protobuf:"bytes,3,opt,name=serial,proto3" json:"serial,omitempty"`
+	SizeMb        *uint32                `protobuf:"varint,4,opt,name=size_mb,json=sizeMb,proto3,oneof" json:"size_mb,omitempty"`
+	PciPath       *string                `protobuf:"bytes,5,opt,name=pci_path,json=pciPath,proto3,oneof" json:"pci_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -755,6 +757,20 @@ func (x *NvmeDevice) GetFirmwareRev() string {
 func (x *NvmeDevice) GetSerial() string {
 	if x != nil {
 		return x.Serial
+	}
+	return ""
+}
+
+func (x *NvmeDevice) GetSizeMb() uint32 {
+	if x != nil && x.SizeMb != nil {
+		return *x.SizeMb
+	}
+	return 0
+}
+
+func (x *NvmeDevice) GetPciPath() string {
+	if x != nil && x.PciPath != nil {
+		return *x.PciPath
 	}
 	return ""
 }
@@ -1544,12 +1560,17 @@ const file_machine_discovery_nico_proto_rawDesc = "" +
 	"\brevision\x18\x02 \x01(\tR\brevision\x12\x16\n" +
 	"\x06serial\x18\x03 \x01(\tR\x06serial\x12\x1f\n" +
 	"\vdevice_type\x18\x04 \x01(\tR\n" +
-	"deviceType\"]\n" +
+	"deviceType\"\xb4\x01\n" +
 	"\n" +
 	"NvmeDevice\x12\x14\n" +
 	"\x05model\x18\x01 \x01(\tR\x05model\x12!\n" +
 	"\ffirmware_rev\x18\x02 \x01(\tR\vfirmwareRev\x12\x16\n" +
-	"\x06serial\x18\x03 \x01(\tR\x06serial\"\xc0\x02\n" +
+	"\x06serial\x18\x03 \x01(\tR\x06serial\x12\x1c\n" +
+	"\asize_mb\x18\x04 \x01(\rH\x00R\x06sizeMb\x88\x01\x01\x12\x1e\n" +
+	"\bpci_path\x18\x05 \x01(\tH\x01R\apciPath\x88\x01\x01B\n" +
+	"\n" +
+	"\b_size_mbB\v\n" +
+	"\t_pci_path\"\xc0\x02\n" +
 	"\aDmiData\x12\x1d\n" +
 	"\n" +
 	"board_name\x18\x01 \x01(\tR\tboardName\x12#\n" +
@@ -1702,6 +1723,7 @@ func file_machine_discovery_nico_proto_init() {
 		return
 	}
 	file_machine_discovery_nico_proto_msgTypes[0].OneofWrappers = []any{}
+	file_machine_discovery_nico_proto_msgTypes[8].OneofWrappers = []any{}
 	file_machine_discovery_nico_proto_msgTypes[10].OneofWrappers = []any{}
 	file_machine_discovery_nico_proto_msgTypes[11].OneofWrappers = []any{}
 	file_machine_discovery_nico_proto_msgTypes[12].OneofWrappers = []any{}

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -59650,8 +59650,8 @@ func (x *GetMachineBootInterfacesResponse) GetPredictedBootInterface() *MachineB
 
 type DNSMessage_DNSQuestion struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	QName         *string                `protobuf:"bytes,1,opt,name=q_name,json=qName,proto3,oneof" json:"q_name,omitempty"`     // FQDN including trailing dot
-	QType         *uint32                `protobuf:"varint,2,opt,name=q_type,json=qType,proto3,oneof" json:"q_type,omitempty"`    //
+	QName         *string                `protobuf:"bytes,1,opt,name=q_name,json=qName,proto3,oneof" json:"q_name,omitempty"` // FQDN including trailing dot
+	QType         *uint32                `protobuf:"varint,2,opt,name=q_type,json=qType,proto3,oneof" json:"q_type,omitempty"`
 	QClass        *uint32                `protobuf:"varint,3,opt,name=q_class,json=qClass,proto3,oneof" json:"q_class,omitempty"` // Usually 1 (IN)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -44238,6 +44238,9 @@ type SkuComponentStorage struct {
 	Model         string                 `protobuf:"bytes,2,opt,name=model,proto3" json:"model,omitempty"`
 	Count         uint32                 `protobuf:"varint,3,opt,name=count,proto3" json:"count,omitempty"`
 	CapacityMb    uint32                 `protobuf:"varint,4,opt,name=capacity_mb,json=capacityMb,proto3" json:"capacity_mb,omitempty"`
+	MinSizeMb     *uint32                `protobuf:"varint,5,opt,name=min_size_mb,json=minSizeMb,proto3,oneof" json:"min_size_mb,omitempty"`
+	MaxSizeMb     *uint32                `protobuf:"varint,6,opt,name=max_size_mb,json=maxSizeMb,proto3,oneof" json:"max_size_mb,omitempty"`
+	PciPatterns   []string               `protobuf:"bytes,7,rep,name=pci_patterns,json=pciPatterns,proto3" json:"pci_patterns,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -44298,6 +44301,27 @@ func (x *SkuComponentStorage) GetCapacityMb() uint32 {
 		return x.CapacityMb
 	}
 	return 0
+}
+
+func (x *SkuComponentStorage) GetMinSizeMb() uint32 {
+	if x != nil && x.MinSizeMb != nil {
+		return *x.MinSizeMb
+	}
+	return 0
+}
+
+func (x *SkuComponentStorage) GetMaxSizeMb() uint32 {
+	if x != nil && x.MaxSizeMb != nil {
+		return *x.MaxSizeMb
+	}
+	return 0
+}
+
+func (x *SkuComponentStorage) GetPciPatterns() []string {
+	if x != nil {
+		return x.PciPatterns
+	}
+	return nil
 }
 
 type SkuComponentStorageController struct {
@@ -59626,8 +59650,8 @@ func (x *GetMachineBootInterfacesResponse) GetPredictedBootInterface() *MachineB
 
 type DNSMessage_DNSQuestion struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	QName         *string                `protobuf:"bytes,1,opt,name=q_name,json=qName,proto3,oneof" json:"q_name,omitempty"` // FQDN including trailing dot
-	QType         *uint32                `protobuf:"varint,2,opt,name=q_type,json=qType,proto3,oneof" json:"q_type,omitempty"`
+	QName         *string                `protobuf:"bytes,1,opt,name=q_name,json=qName,proto3,oneof" json:"q_name,omitempty"`     // FQDN including trailing dot
+	QType         *uint32                `protobuf:"varint,2,opt,name=q_type,json=qType,proto3,oneof" json:"q_type,omitempty"`    //
 	QClass        *uint32                `protobuf:"varint,3,opt,name=q_class,json=qClass,proto3,oneof" json:"q_class,omitempty"` // Usually 1 (IN)
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -65014,13 +65038,18 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x06vendor\x18\x01 \x01(\tR\x06vendor\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x14\n" +
 	"\x05count\x18\x03 \x01(\rR\x05count\x12)\n" +
-	"\x10inactive_devices\x18\x04 \x03(\rR\x0finactiveDevices\"z\n" +
+	"\x10inactive_devices\x18\x04 \x03(\rR\x0finactiveDevices\"\x87\x02\n" +
 	"\x13SkuComponentStorage\x12\x16\n" +
 	"\x06vendor\x18\x01 \x01(\tR\x06vendor\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x14\n" +
 	"\x05count\x18\x03 \x01(\rR\x05count\x12\x1f\n" +
 	"\vcapacity_mb\x18\x04 \x01(\rR\n" +
-	"capacityMb\"c\n" +
+	"capacityMb\x12#\n" +
+	"\vmin_size_mb\x18\x05 \x01(\rH\x00R\tminSizeMb\x88\x01\x01\x12#\n" +
+	"\vmax_size_mb\x18\x06 \x01(\rH\x01R\tmaxSizeMb\x88\x01\x01\x12!\n" +
+	"\fpci_patterns\x18\a \x03(\tR\vpciPatternsB\x0e\n" +
+	"\f_min_size_mbB\x0e\n" +
+	"\f_max_size_mb\"c\n" +
 	"\x1dSkuComponentStorageController\x12\x16\n" +
 	"\x06vendor\x18\x01 \x01(\tR\x06vendor\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x14\n" +
@@ -70815,6 +70844,7 @@ func file_nico_nico_proto_init() {
 		(*NetworkSecurityGroupRuleAttributes_SrcPrefix)(nil),
 		(*NetworkSecurityGroupRuleAttributes_DstPrefix)(nil),
 	}
+	file_nico_nico_proto_msgTypes[606].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[610].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[611].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[616].OneofWrappers = []any{}

--- a/rest-api/proto/core/src/v1/machine_discovery_nico.proto
+++ b/rest-api/proto/core/src/v1/machine_discovery_nico.proto
@@ -116,6 +116,8 @@ message NvmeDevice {
   string model = 1;
   string firmware_rev = 2;
   string serial = 3;
+  optional uint32 size_mb = 4;
+  optional string pci_path = 5;
 }
 
 message DmiData {

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -7393,6 +7393,9 @@ message SkuComponentStorage {
   string model = 2;
   uint32 count = 3;
   uint32 capacity_mb = 4;
+  optional uint32 min_size_mb = 5;
+  optional uint32 max_size_mb = 6;
+  repeated string pci_patterns = 7;
 }
 
 message SkuComponentStorageController {


### PR DESCRIPTION
## Description

SKU verification previously compared storage only by drive **model** and count. That is too coarse for fleets where a chassis can be populated with drives of the same model but different capacities, or where a specific NVMe must sit at a specific PCI location. This PR introduces SKU schema **v5**, which records one storage entry per NVMe drive carrying its capacity (`size_mb`) and concrete sysfs/PCI path (`pci_path`), and validates an expected SKU against discovered hardware by **drive size range and PCI location** rather than model.

The comparison fails safe: it emits a diff (rather than silently matching) when an expected drive is missing, a location is ambiguous, a drive is the wrong size, a discovered drive is unexpected, or a drive's size could not be read. Expected drives are assigned to expected groups with a **global maximum matching** so a broad location group (e.g. `/nvme/`) never starves a more specific one (e.g. `0000:04:00\.0`) when a valid overall assignment exists. Uncompilable PCI patterns are rejected at SKU authoring time.

## Related issues

Closes #2795

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

Older SKU schema versions remain supported and are still compared by model; v5 is generated only for new SKUs at `CURRENT_SKU_VERSION`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Unit tests in `crates/api-model/src/sku.rs` cover exact location+size match, missing/extra/wrong-size drives, invalid patterns, size-only groups, unknown drive size, and the broad-vs-specific group assignment (regression for the global-matching fix).
- sqlx-backed suite in `crates/api-core` (SKU create/replace/verify/generate, version compatibility) passes.
- Manually verified against a local env via `nico-admin-cli`: v5 generation, create-time duplicate detection driving the new matching (a broad `/nvme/` + specific `0000:04:00\.0` expected SKU correctly matches the two-drive discovered layout), a genuinely non-matching layout accepted as distinct, and invalid-regex patterns rejected at create time.

## Additional Notes

Reviewer guidance: the core comparison logic is `diff_storage_by_location` in `crates/api-model/src/sku.rs` (global bipartite matching via Kuhn's algorithm over expected-group slots). v5 generation is `generate_sku_from_machine_at_version_5` in `crates/api-db/src/sku.rs`; `NvmeDevice` gains `size_mb`/`pci_path` sourced from host hardware enumeration.
