### PR TITLE
Add code to debug verify astra attachment revisions are same

### DIFF
--- a/crates/agent/src/astra_weave.rs
+++ b/crates/agent/src/astra_weave.rs
@@ -390,6 +390,10 @@ async fn update_weave_ew_vpc_astra_attachments(
         weave_ew_vpc_list_virtual_network_attachments(socket_path, list_vni_attachments_req)
             .await?;
 
+    debug_check_weave_ew_vpc_attachment_revisions(
+        &list_vni_attachments_rsp.virtual_network_attachments,
+    );
+
     log_virtual_network_attachments(&list_vni_attachments_rsp.virtual_network_attachments);
 
     // Track attachments we delete during reconcile so the stale-attachment
@@ -742,6 +746,8 @@ async fn update_weave_ew_vpc_astra_config_uds(
         });
     };
 
+    debug_check_astra_config_attachment_revisions(astra_config);
+
     // There is a revision string associated with the AstraConfig that
     // is used to track changes to the AstraConfig. The configs don't change
     // if the revision string is unchanged. So at the onset of the routine
@@ -808,6 +814,10 @@ async fn build_synced_astra_config_status_if_version_unchanged(
     let list_vni_attachments_rsp =
         weave_ew_vpc_list_virtual_network_attachments(socket_path, list_vni_attachments_req)
             .await?;
+
+    debug_check_weave_ew_vpc_attachment_revisions(
+        &list_vni_attachments_rsp.virtual_network_attachments,
+    );
 
     let weave_spx_version = list_vni_attachments_rsp
         .virtual_network_attachments
@@ -926,6 +936,90 @@ fn astra_attachment_revision(
     }
 
     Ok(astra_attachment.revision.as_str())
+}
+
+fn weave_ew_vpc_attachment_revision(
+    virtual_network_attachment: &VirtualNetworkAttachment,
+) -> Option<&str> {
+    virtual_network_attachment
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.user_data.get(WEAVE_EW_VPC_REVISION_USER_DATA_KEY))
+        .map(String::as_str)
+}
+
+fn weave_ew_vpc_attachment_id(virtual_network_attachment: &VirtualNetworkAttachment) -> &str {
+    virtual_network_attachment
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.id.as_deref())
+        .filter(|id| !id.is_empty())
+        .unwrap_or("unknown")
+}
+
+// Debug-only consistency checks. These log errors but do not fail reconcile.
+fn debug_check_astra_config_attachment_revisions(astra_config: &AstraConfig) {
+    let attachments = &astra_config.astra_attachments;
+    if attachments.len() <= 1 {
+        return;
+    }
+
+    let Some(first_attachment) = attachments.first() else {
+        return;
+    };
+
+    if first_attachment.revision.is_empty() {
+        tracing::error!(
+            mac_address = %first_attachment.mac_address,
+            "AstraConfig attachment has missing revision"
+        );
+    }
+
+    let first_revision = first_attachment.revision.as_str();
+    for attachment in attachments.iter().skip(1) {
+        if attachment.revision.is_empty() {
+            tracing::error!(
+                mac_address = %attachment.mac_address,
+                "AstraConfig attachment has missing revision"
+            );
+            continue;
+        }
+
+        if attachment.revision != first_revision {
+            tracing::error!(
+                first_mac_address = %first_attachment.mac_address,
+                first_revision,
+                mac_address = %attachment.mac_address,
+                revision = %attachment.revision,
+                "AstraConfig attachment revisions are inconsistent"
+            );
+        }
+    }
+}
+
+fn debug_check_weave_ew_vpc_attachment_revisions(
+    virtual_network_attachments: &[VirtualNetworkAttachment],
+) {
+    if virtual_network_attachments.len() <= 1 {
+        return;
+    }
+
+    let first_attachment = &virtual_network_attachments[0];
+    let first_revision = weave_ew_vpc_attachment_revision(first_attachment);
+    let first_attachment_id = weave_ew_vpc_attachment_id(first_attachment);
+
+    for attachment in virtual_network_attachments.iter().skip(1) {
+        let revision = weave_ew_vpc_attachment_revision(attachment);
+        if revision != first_revision {
+            tracing::error!(
+                first_attachment_id,
+                first_revision = first_revision.unwrap_or("none"),
+                attachment_id = weave_ew_vpc_attachment_id(attachment),
+                revision = revision.unwrap_or("none"),
+                "DOCA Weave virtual network attachment revisions are inconsistent"
+            );
+        }
+    }
 }
 
 pub fn set_astra_attachment_status_with_weave_ew_vpc_status(

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -998,7 +998,9 @@ impl MainLoop {
                         Ok((has_changed, astra_config_status)) => {
                             self.current_network_version.update_from(&conf);
                             has_changed_configs = has_changed;
-                            status_out.astra_config_status = Some(astra_config_status);
+                            if conf.astra_config.is_some() {
+                                status_out.astra_config_status = Some(astra_config_status);
+                            }
                             if self.options.agent_platform_type.is_dpu_os()
                                 && let Err(err) = mtu::ensure().await
                             {


### PR DESCRIPTION
This supports #3786.

1. This PR adds debug code to walk and verify astra configs and astra attachments all have the same revision
2. Also made a fix to main loop to not return an empty astra config status vector if no astra config was proviced

## Related issues


## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x ] No testing required (docs, internal refactor, etc.)

## Additional Notes


