### PR TITLE
feat(machine-a-tron): expose IPMI ports in machine status

### DIFF
--- a/crates/bmc-mock/src/ipmi_sim.rs
+++ b/crates/bmc-mock/src/ipmi_sim.rs
@@ -36,12 +36,31 @@ const START_ATTEMPTS: usize = 5;
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const PASSWORD_UPDATE_TIMEOUT: Duration = Duration::from_secs(10);
+pub const STANDARD_IPMI_PORT: u16 = 623;
 
 #[derive(Debug, Clone)]
 pub struct IpmiSimConfig {
     pub bind_ip: IpAddr,
+    /// Client-facing port advertised through Redfish. When absent, clients connect directly to
+    /// the dynamically allocated simulator port.
+    pub reachable_port: Option<u16>,
     pub stable_id: String,
     pub console_prompt: String,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct IpmiEndpoint {
+    pub reachable_port: u16,
+    pub listen_port: u16,
+}
+
+impl IpmiEndpoint {
+    fn new(listen_port: u16, reachable_port: Option<u16>) -> Self {
+        Self {
+            reachable_port: reachable_port.unwrap_or(listen_port),
+            listen_port,
+        }
+    }
 }
 
 pub struct IpmiSimHandle {
@@ -50,14 +69,14 @@ pub struct IpmiSimHandle {
     _console: MockConsole,
     manager: Arc<ManagerState>,
     _password_updater: Arc<dyn PasswordUpdater>,
-    pub ipmi_sim_lan_port: u16,
+    pub endpoint: IpmiEndpoint,
 }
 
 impl std::fmt::Debug for IpmiSimHandle {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("IpmiSimHandle")
-            .field("ipmi_sim_lan_port", &self.ipmi_sim_lan_port)
+            .field("endpoint", &self.endpoint)
             .finish_non_exhaustive()
     }
 }
@@ -167,6 +186,7 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
         .await
         {
             Ok(()) => {
+                let endpoint = IpmiEndpoint::new(ipmi_sim_lan_port, config.reachable_port);
                 let connect_ip = if config.bind_ip.is_unspecified() {
                     IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
                 } else {
@@ -179,14 +199,16 @@ pub async fn start(state: &BmcState, config: IpmiSimConfig) -> Result<IpmiSimHan
                 state
                     .account_service_state
                     .set_password_updater(&password_updater);
-                state.manager.set_ipmi_endpoint(Some(ipmi_sim_lan_port));
+                state
+                    .manager
+                    .set_ipmi_endpoint(Some(endpoint.reachable_port));
                 return Ok(IpmiSimHandle {
                     child,
                     _temp_dir: temp_dir,
                     _console: console,
                     manager: state.manager.clone(),
                     _password_updater: password_updater,
-                    ipmi_sim_lan_port,
+                    endpoint,
                 });
             }
             Err(error) => {
@@ -438,7 +460,37 @@ async fn serve_console(mut stream: TcpStream, prompt: &str) -> Result<(), std::i
 
 #[cfg(test)]
 mod tests {
-    use super::{Error, MockConsole, stable_guid, validate_credential};
+    use super::{Error, IpmiEndpoint, MockConsole, stable_guid, validate_credential};
+
+    #[test]
+    fn endpoint_uses_configured_reachable_port_or_listen_port() {
+        for (name, listen_port, reachable_port, expected) in [
+            (
+                "direct",
+                16_020,
+                None,
+                IpmiEndpoint {
+                    reachable_port: 16_020,
+                    listen_port: 16_020,
+                },
+            ),
+            (
+                "forwarded",
+                16_020,
+                Some(623),
+                IpmiEndpoint {
+                    reachable_port: 623,
+                    listen_port: 16_020,
+                },
+            ),
+        ] {
+            assert_eq!(
+                IpmiEndpoint::new(listen_port, reachable_port),
+                expected,
+                "{name}",
+            );
+        }
+    }
 
     #[test]
     fn stable_guid_is_stable_and_has_ipmi_length() {

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -116,6 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 state,
                 bmc_mock::ipmi_sim::IpmiSimConfig {
                     bind_ip: "0.0.0.0".parse().unwrap(),
+                    reachable_port: None,
                     stable_id: "standalone-bmc-mock".to_string(),
                     console_prompt: "root@bmc-mock # ".to_string(),
                 },

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use bmc_mock::injection::InjectionStore;
-use bmc_mock::ipmi_sim::{IpmiSimConfig, IpmiSimHandle};
+use bmc_mock::ipmi_sim::{IpmiEndpoint, IpmiSimConfig, IpmiSimHandle, STANDARD_IPMI_PORT};
 use bmc_mock::{
     BmcState, Callbacks, CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo,
 };
@@ -156,7 +156,7 @@ impl BmcMockWrapper {
         } else {
             None
         };
-        let ipmi_sim_handle = self.start_ipmi_sim(address.ip()).await?;
+        let ipmi_sim_handle = self.start_ipmi_sim(address.ip(), None).await?;
 
         tracing::info!(
             listen_address = ?address,
@@ -187,7 +187,7 @@ impl BmcMockWrapper {
         bind_ip: std::net::IpAddr,
     ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
         Ok(self
-            .start_ipmi_sim(bind_ip)
+            .start_ipmi_sim(bind_ip, Some(STANDARD_IPMI_PORT))
             .await?
             .map(|ipmi_sim_handle| BmcMockWrapperHandle {
                 _bmc_mock: None,
@@ -199,6 +199,7 @@ impl BmcMockWrapper {
     async fn start_ipmi_sim(
         &self,
         bind_ip: std::net::IpAddr,
+        reachable_port: Option<u16>,
     ) -> Result<Option<IpmiSimHandle>, MachineStateError> {
         if !self.app_context.app_config.enable_ipmi_simulation || !self.supports_ipmi_console {
             return Ok(None);
@@ -209,6 +210,7 @@ impl BmcMockWrapper {
             &self.bmc_mock_state,
             IpmiSimConfig {
                 bind_ip,
+                reachable_port,
                 stable_id: self.stable_id.clone(),
                 console_prompt,
             },
@@ -232,6 +234,12 @@ pub struct BmcMockWrapperHandle {
     pub _bmc_mock: Option<CombinedServer>,
     pub ssh_handle: Option<MockSshServerHandle>,
     _ipmi_sim_handle: Option<IpmiSimHandle>,
+}
+
+impl BmcMockWrapperHandle {
+    pub fn ipmi_endpoint(&self) -> Option<IpmiEndpoint> {
+        self._ipmi_sim_handle.as_ref().map(|handle| handle.endpoint)
+    }
 }
 
 /// BmcMockRegistry is shared state that MachineATron's mock hosts can use to register their BMC

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -191,6 +191,7 @@ mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request, StatusCode};
     use axum::routing::get;
+    use bmc_mock::ipmi_sim::IpmiEndpoint;
     use tower::ServiceExt;
     use uuid::Uuid;
 
@@ -236,6 +237,51 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert!(String::from_utf8_lossy(&body).contains("machine-a-tron machines"));
+    }
+
+    #[tokio::test]
+    async fn machines_status_reports_each_bmc_ipmi_endpoint() {
+        let first = HostMachineHandle::for_control_test(
+            Vec::new(),
+            Some(IpmiEndpoint {
+                reachable_port: 623,
+                listen_port: 16_020,
+            }),
+        );
+        let second = HostMachineHandle::for_control_test(
+            Vec::new(),
+            Some(IpmiEndpoint {
+                reachable_port: 623,
+                listen_port: 16_021,
+            }),
+        );
+        let without_ipmi = HostMachineHandle::for_control_test(Vec::new(), None);
+        let router = append(
+            Router::new(),
+            ControlState::new(
+                vec![first, second, without_ipmi],
+                MachineStatusConfig::new(1266),
+            ),
+        );
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/machines/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let status: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let machines = status["machines"].as_array().unwrap();
+
+        assert_eq!(machines[0]["bmc"]["ipmi"]["reachable_port"], 623);
+        assert_eq!(machines[0]["bmc"]["ipmi"]["listen_port"], 16_020);
+        assert_eq!(machines[1]["bmc"]["ipmi"]["reachable_port"], 623);
+        assert_eq!(machines[1]["bmc"]["ipmi"]["listen_port"], 16_021);
+        assert!(machines[2]["bmc"].get("ipmi").is_none());
     }
 
     #[tokio::test]
@@ -298,7 +344,7 @@ mod tests {
             .parse()
             .unwrap();
         let dpu = DpuMachineHandle::for_control_test(dpu_id, Some(observed_dpu_id));
-        let host = HostMachineHandle::for_control_test(vec![dpu]);
+        let host = HostMachineHandle::for_control_test(vec![dpu], None);
         let router = append(
             Router::new(),
             ControlState::new(vec![host.clone()], MachineStatusConfig::new(1266)),

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -474,6 +474,7 @@ impl DpuMachineHandle {
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
+                ipmi: live_state.ipmi_endpoint.map(Into::into),
             },
             dpus: Vec::new(),
         }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -546,13 +546,20 @@ pub struct HostMachineHandle(Arc<HostMachineActor>);
 
 impl HostMachineHandle {
     #[cfg(test)]
-    pub(crate) fn for_control_test(dpus: Vec<DpuMachineHandle>) -> Self {
+    pub(crate) fn for_control_test(
+        dpus: Vec<DpuMachineHandle>,
+        ipmi_endpoint: Option<bmc_mock::ipmi_sim::IpmiEndpoint>,
+    ) -> Self {
         let (message_tx, _message_rx) = mpsc::unbounded_channel();
         let mac = mac_address::MacAddress::new([2, 0, 0, 0, 0, 2]);
+        let live_state = LiveState {
+            ipmi_endpoint,
+            ..LiveState::default()
+        };
         Self(Arc::new(HostMachineActor {
             message_tx,
             join_handle: Mutex::new(None),
-            live_state: Arc::new(RwLock::new(LiveState::default())),
+            live_state: Arc::new(RwLock::new(live_state)),
             mat_id: Uuid::new_v4(),
             host_info: HostMachineInfo {
                 hw_type: Default::default(),
@@ -659,6 +666,7 @@ impl HostMachineHandle {
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),
+                ipmi: live_state.ipmi_endpoint.map(Into::into),
             },
             dpus: self.0.dpus.iter().map(|dpu| dpu.status(config)).collect(),
         }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::injection::InjectionStore;
+use bmc_mock::ipmi_sim::IpmiEndpoint;
 use bmc_mock::{
     BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostnameQuerying,
     MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
@@ -158,6 +159,7 @@ pub struct LiveState {
     pub observed_machine_id: Option<MachineId>,
     pub machine_ip: Option<Ipv4Addr>,
     pub bmc_ip: Option<Ipv4Addr>,
+    pub ipmi_endpoint: Option<IpmiEndpoint>,
     pub booted_os: MaybeOsImage,
     pub next_boot_kind: Option<BootOptionKind>,
     pub installed_os: OsImage,
@@ -180,6 +182,7 @@ impl Default for LiveState {
             observed_machine_id: None,
             machine_ip: None,
             bmc_ip: None,
+            ipmi_endpoint: None,
             booted_os: Default::default(),
             next_boot_kind: None,
             installed_os: Default::default(),
@@ -819,6 +822,10 @@ impl MachineStateMachine {
         live_state.is_up = self.fsm.is_up();
         live_state.machine_ip = self.machine_ip();
         live_state.bmc_ip = self.bmc_ip();
+        live_state.ipmi_endpoint = self
+            .bmc_mock
+            .as_ref()
+            .and_then(|bmc_mock| bmc_mock.ipmi_endpoint());
         live_state.installed_os = self.installed_os;
         if let Some(machine_id) = self.machine_id()
             && live_state.observed_machine_id != Some(machine_id)

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use bmc_mock::HostHardwareType;
+use bmc_mock::ipmi_sim::IpmiEndpoint;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy)]
@@ -59,6 +60,8 @@ pub struct BmcStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip: Option<String>,
     pub redfish: EndpointStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ipmi: Option<EndpointStatus>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -72,6 +75,15 @@ impl EndpointStatus {
         Self {
             reachable_port: config.redfish_reachable_port,
             listen_port: config.redfish_listen_port,
+        }
+    }
+}
+
+impl From<IpmiEndpoint> for EndpointStatus {
+    fn from(endpoint: IpmiEndpoint) -> Self {
+        Self {
+            reachable_port: endpoint.reachable_port,
+            listen_port: endpoint.listen_port,
         }
     }
 }

--- a/crates/ssh-console/tests/util/ipmi_sim.rs
+++ b/crates/ssh-console/tests/util/ipmi_sim.rs
@@ -183,6 +183,7 @@ pub async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
         &bmc.state,
         bmc_mock::ipmi_sim::IpmiSimConfig {
             bind_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            reachable_port: None,
             stable_id: prompt.clone(),
             console_prompt: prompt,
         },

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -158,7 +158,7 @@ pub async fn run_baseline_test_environment(
                 },
                 ipmi_port: match &bmc_handle {
                     MockBmcHandle::Ssh(_) => None,
-                    MockBmcHandle::Ipmi(i) => Some(i.ipmi_sim_lan_port),
+                    MockBmcHandle::Ipmi(i) => Some(i.endpoint.listen_port),
                 },
                 bmc_user: "root".to_string(),
                 bmc_password: "password".to_string(),


### PR DESCRIPTION
Expose each simulated BMC's IPMI endpoint through machine-a-tron's `/machines/status` response.

IPMI simulators bind to dynamically allocated local ports, while clients may reach them through the standard IPMI port exposed by the deployment. Reporting both ports lets external orchestration create the correct per-BMC forwarding:

- `reachable_port` is the client-facing port advertised through Redfish.
- `listen_port` is the dynamically allocated simulator port.
- In direct mode, both values are the simulator port.
- Machines without an IPMI simulator omit the `ipmi` endpoint.

This also keeps the port advertised by Redfish `ManagerNetworkProtocol.IPMI.Port` consistent with the reported reachable port. The Kubernetes controller can use this status in follow-up work to create services that map port 623 to each simulator's dynamic port.

## Related issues

- Closes #3379
- Related to #3380

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This PR only exposes the endpoint information. Kubernetes service creation and port forwarding remain part of #3380.