### PR TITLE
fix(api): guard against nil NVLink LogicalPartitionId in inventory sync

### DIFF
--- a/rest-api/workflow/pkg/activity/instance/instance.go
+++ b/rest-api/workflow/pkg/activity/instance/instance.go
@@ -715,7 +715,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 					continue
 				}
 
-				nvlifcKey := fmt.Sprintf("%s-%d", nvLinkGpuConfig.LogicalPartitionId.Value, nvLinkGpuConfig.DeviceInstance)
+				nvlifcKey := fmt.Sprintf("%s-%d", nvLinkGpuConfig.LogicalPartitionId.GetValue(), nvLinkGpuConfig.DeviceInstance)
 				nvlifc, ok := nvLinkInterfaceMap[nvlifcKey]
 				if !ok {
 					continue


### PR DESCRIPTION
The inventory-sync activity read `nvLinkGpuConfig.LogicalPartitionId.Value` directly (rest-api/workflow/pkg/activity/instance/instance.go:708). If the site reports a GPU config with the partition ID left empty, that field is nil and the read panics. That panic crashes the whole inventory-sync job.

Switch to the nil-safe generated accessor .GetValue(), which returns "" on a nil wrapper. This matches the existing safe read of the same field ~26 lines below (line 744).

## Related issues


## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes


