### PR TITLE
fix(site-explorer): skip chassis missing ChassisType instead of aborting host

### DIFF
--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -78,14 +78,58 @@ impl<B: Bmc> ExploredChassisCollection<B> {
             }
             Ok(result)
         } else {
-            root.chassis()
+            let collection = root
+                .chassis()
                 .await
                 .map_err(Error::nv_redfish("chassis collection"))?
-                .ok_or_else(Error::bmc_not_provided("chassis collection"))?
-                .members()
-                .await
-                .map_err(Error::nv_redfish("chassis collection members"))
+                .ok_or_else(Error::bmc_not_provided("chassis collection"))?;
+            match collection.members().await {
+                Ok(members) => Ok(members),
+                // A single malformed chassis fails the batch `members()` call
+                // and would otherwise abort the whole host exploration. This
+                // happens on some Supermicro BMCs, whose `SmartNIC` chassis
+                // omits the Redfish-required `ChassisType` field. Fall back to
+                // fetching each member individually so the healthy chassis
+                // still ingest, skipping (with a warning) only the ones that
+                // fail to parse.
+                Err(err) => {
+                    tracing::warn!(
+                        error = ?err,
+                        "Chassis collection failed to parse as a batch; retrying \
+                         members individually and skipping malformed ones",
+                    );
+                    Self::fetch_members_skipping_malformed(root).await
+                }
+            }
         }
+    }
+
+    /// Fetches chassis members one at a time, skipping any that fail to parse.
+    ///
+    /// Used as a fallback when the batch `members()` fetch fails on a single
+    /// malformed chassis. Each skipped chassis is logged at `WARN` with its
+    /// `@odata.id` and the parse error, so dropped components are visible in
+    /// the carbide-api logs rather than silently discarded.
+    async fn fetch_members_skipping_malformed(
+        root: &ServiceRoot<B>,
+    ) -> Result<Vec<NvChassis<B>>, Error<B>> {
+        let links = root
+            .chassis_links()
+            .await
+            .map_err(Error::nv_redfish("chassis collection"))?
+            .ok_or_else(Error::bmc_not_provided("chassis collection"))?;
+        let mut result = Vec::with_capacity(links.len());
+        for l in links {
+            match l.upgrade().await {
+                Ok(chassis) => result.push(chassis),
+                Err(err) => tracing::warn!(
+                    chassis = %l.odata_id(),
+                    error = ?err,
+                    "Skipping malformed chassis that failed to parse",
+                ),
+            }
+        }
+        Ok(result)
     }
 
     pub fn to_model(&self) -> Vec<Chassis> {

--- a/crates/bmc-explorer/src/test_support.rs
+++ b/crates/bmc-explorer/src/test_support.rs
@@ -47,6 +47,18 @@ use crate::{
 ///
 /// Not part of the production API: it re-runs the chassis/system exploration and
 /// is only meaningful against a mock BMC.
+/// Runs only chassis exploration and returns the explored chassis ids.
+///
+/// Lets tests assert which chassis survive exploration without running a full
+/// report, which for some platforms (e.g. Supermicro) also requires
+/// manager/system OEM data that minimal mock profiles do not serve. Not part of
+/// the production API; only meaningful against a mock BMC.
+pub async fn explore_chassis_ids<B: Bmc>(root: &ServiceRoot<B>) -> Result<Vec<String>, Error<B>> {
+    let config = build_chassis_explore_config(root);
+    let explored = ExploredChassisCollection::explore(root, &config).await?;
+    Ok(explored.to_model().into_iter().map(|c| c.id).collect())
+}
+
 pub async fn detect_hw_type<B: Bmc>(
     mut root: Arc<ServiceRoot<B>>,
     config: &Config<'_, B>,

--- a/crates/bmc-explorer/tests/integration/generic_supermicro_explore.rs
+++ b/crates/bmc-explorer/tests/integration/generic_supermicro_explore.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use bmc_explorer::hw::HwType;
-use bmc_explorer::test_support::detect_hw_type;
+use bmc_explorer::test_support::{detect_hw_type, explore_chassis_ids};
 use bmc_mock::test_support;
 use tokio::test;
 
@@ -34,5 +34,27 @@ async fn generic_supermicro_is_not_gb300() {
             .unwrap(),
         Some(HwType::Supermicro),
         "a non-GB300 Supermicro must not be detected as SupermicroGb300",
+    );
+}
+
+/// Regression test for issue #3715: a Supermicro chassis collection containing a
+/// member that omits the Redfish-required `ChassisType` (the `SmartNIC` chassis)
+/// must not abort exploration. The malformed chassis is skipped with a warning
+/// while the healthy chassis still ingests.
+#[test]
+async fn explore_supermicro_skips_chassis_missing_chassis_type() {
+    let h = test_support::generic_supermicro_bmc_with_malformed_chassis().await;
+
+    let chassis_ids = explore_chassis_ids(&h.service_root)
+        .await
+        .expect("chassis exploration must succeed despite one malformed chassis");
+
+    assert!(
+        chassis_ids.iter().any(|id| id == "Self"),
+        "the healthy chassis must still be explored, got {chassis_ids:?}",
+    );
+    assert!(
+        !chassis_ids.iter().any(|id| id == "SmartNIC_1"),
+        "the malformed chassis must be skipped, got {chassis_ids:?}",
     );
 }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -47,7 +47,7 @@ pub use machine_info::{
 };
 pub use mock_machine_router::{
     BmcCommand, SetSystemPowerError, SetSystemPowerResult, machine_router,
-    machine_router_with_injection_store,
+    machine_router_with_extra_chassis, machine_router_with_injection_store,
 };
 
 pub const DUMMY_FACTORY_USERNAME: &str = "root";

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -84,8 +84,48 @@ pub fn machine_router_with_injection_store(
     redfish_auth: bool,
     injection: Arc<InjectionStore>,
 ) -> (Router, BmcState) {
+    machine_router_impl(
+        machine_info,
+        callbacks,
+        mat_host_id,
+        redfish_auth,
+        injection,
+        Vec::new(),
+    )
+}
+
+/// Like [`machine_router`] but appends extra chassis to the served chassis
+/// collection. Test-only: lets exploration tests model a BMC whose chassis
+/// collection contains additional (possibly malformed) members, e.g. the
+/// Supermicro `SmartNIC` chassis that omits `ChassisType` in issue #3715.
+pub fn machine_router_with_extra_chassis(
+    machine_info: &MachineInfo,
+    callbacks: Arc<dyn Callbacks>,
+    mat_host_id: String,
+    redfish_auth: bool,
+    extra_chassis: Vec<crate::redfish::chassis::SingleChassisConfig>,
+) -> (Router, BmcState) {
+    machine_router_impl(
+        machine_info,
+        callbacks,
+        mat_host_id,
+        redfish_auth,
+        Arc::new(InjectionStore::new()),
+        extra_chassis,
+    )
+}
+
+fn machine_router_impl(
+    machine_info: &MachineInfo,
+    callbacks: Arc<dyn Callbacks>,
+    mat_host_id: String,
+    redfish_auth: bool,
+    injection: Arc<InjectionStore>,
+    extra_chassis: Vec<crate::redfish::chassis::SingleChassisConfig>,
+) -> (Router, BmcState) {
     let system_config = machine_info.system_config(callbacks.clone());
-    let chassis_config = machine_info.chassis_config();
+    let mut chassis_config = machine_info.chassis_config();
+    chassis_config.chassis.extend(extra_chassis);
     let update_service_config = machine_info.update_service_config();
     let bmc_vendor = machine_info.bmc_vendor();
     let bmc_product = machine_info.bmc_product();

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -145,6 +145,10 @@ pub struct SingleChassisConfig {
     pub sensors: Option<Vec<redfish::sensor::Sensor>>,
     pub leak_detectors: Option<Vec<redfish::leak_detector::LeakDetector>>,
     pub chassis_type: Cow<'static, str>,
+    /// When true, the `ChassisType` field is left out of the rendered chassis
+    /// entirely (not merely empty). Models BMCs that omit this Redfish-required
+    /// field, e.g. the Supermicro `SmartNIC` chassis in issue #3715.
+    pub omit_chassis_type: bool,
     pub assembly: Option<serde_json::Value>,
     pub power_supplies: Option<Vec<redfish::power_supply::PowerSupply>>,
     pub oem: Option<serde_json::Value>,
@@ -157,6 +161,7 @@ impl SingleChassisConfig {
         Self {
             id: "".into(),
             chassis_type: "".into(),
+            omit_chassis_type: false,
             serial_number: None,
             manufacturer: None,
             model: None,
@@ -308,8 +313,11 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .is_some()
         .then_some(redfish::thermal_subsystem::resource(&chassis_id));
 
-    let mut b = builder(&resource(&chassis_id))
-        .chassis_type(&config.chassis_type)
+    let mut b = builder(&resource(&chassis_id));
+    if !config.omit_chassis_type {
+        b = b.chassis_type(&config.chassis_type);
+    }
+    b = b
         .maybe_with(ChassisBuilder::assembly, &assembly)
         .maybe_with(ChassisBuilder::pcie_devices, &pcie_devices)
         .maybe_with(ChassisBuilder::network_adapters, &network_adapters)

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -30,6 +30,7 @@ use crate::machine_info::DpuSettings;
 use crate::{
     BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
     MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
+    machine_router_with_extra_chassis,
 };
 
 pub mod axum_http_client;
@@ -176,6 +177,26 @@ pub async fn generic_supermicro_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+    ))
+    .await
+}
+
+/// A Supermicro BMC whose chassis collection contains one healthy chassis plus
+/// an extra chassis that omits the Redfish-required `ChassisType` field. Models
+/// issue #3715, where a malformed `SmartNIC` chassis aborted exploration of the
+/// whole host; used to verify the malformed member is skipped, not fatal.
+pub async fn generic_supermicro_bmc_with_malformed_chassis() -> TestBmcHandle {
+    let malformed_chassis = crate::redfish::chassis::SingleChassisConfig {
+        id: "SmartNIC_1".into(),
+        omit_chassis_type: true,
+        ..crate::redfish::chassis::SingleChassisConfig::defaults()
+    };
+    test_bmc(machine_router_with_extra_chassis(
+        &host_info(HostHardwareType::GenericSupermicro),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+        false,
+        vec![malformed_chassis],
     ))
     .await
 }


### PR DESCRIPTION
## Summary
Ingesting a Supermicro GB200 host fails in site-explorer with `missing field \`ChassisType\``. The Supermicro BMC exposes a `SmartNIC` chassis that omits the Redfish-required `ChassisType`; nv-redfish's batch `chassis members()` fetch fails on it and aborts exploration of the whole host.

## Fix
`bmc-explorer` chassis exploration keeps the fast batch path, and on a parse failure falls back to fetching each chassis link individually — skipping (with a `WARN` log naming the chassis `@odata.id` + error) any member that won't deserialize. Healthy chassis still ingest; the malformed one is dropped visibly rather than fatally.

## Tests
- `bmc-mock` gains an additive `omit_chassis_type` flag + a Supermicro fixture with one `ChassisType`-less chassis.
- New regression test `explore_supermicro_skips_chassis_missing_chassis_type` asserts the healthy chassis survives and the malformed one is skipped.
- Full `bmc-explorer` suite passes (26 integration + 5 unit); `clippy` clean.

Fixes #3715