### PR TITLE
ci: add floating latest tag for each release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ env:
   FF_USE_FASTZIP: "true"
   GIT_SUBMODULE_STRATEGY: recursive
 
+
 jobs:
   changes:
     name: Detect Core CI Gate
@@ -1083,7 +1084,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
-      download_artifacts: true # Download boot and ephemeral artifacts for packaging
+      download_artifacts: true  # Download boot and ephemeral artifacts for packaging
       build_args: |
         {
           "VERSION": "${{ needs.prepare.outputs.version }}",
@@ -1117,7 +1118,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
-      download_artifacts: true # Download boot and ephemeral artifacts for packaging
+      download_artifacts: true  # Download boot and ephemeral artifacts for packaging
       build_args: |
         {
           "VERSION": "${{ needs.prepare.outputs.version }}",
@@ -1144,14 +1145,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0 # Full history for secret scanning
+          fetch-depth: 0  # Full history for secret scanning
 
       - name: Run TruffleHog Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
-          extra-args: "--results=verified,unknown --only-verified"
-          post-pr-comment: "false"
-          fail-on-findings: "true"
+          extra-args: '--results=verified,unknown --only-verified'
+          post-pr-comment: 'false'
+          fail-on-findings: 'true'
 
   security-codeql-scan:
     name: CodeQL Security Analysis
@@ -1173,17 +1174,19 @@ jobs:
       - name: Run CodeQL Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
         with:
-          languages: "rust"
-          build-mode: "none"
-          category: "/language:rust"
-          upload-sarif: "false" # Disable upload until GHAS is enabled, such as the repo be public
-          post-pr-comment: "false"
-          fail-on-findings: "true" # Enforce quality gate
-          fail-on-severity: "error" # Only fail on critical/high severity issues
+          languages: 'rust'
+          build-mode: 'none'
+          category: '/language:rust'
+          upload-sarif: 'false'  # Disable upload until GHAS is enabled, such as the repo be public
+          post-pr-comment: 'false'
+          fail-on-findings: 'true'  # Enforce quality gate
+          fail-on-severity: 'error' # Only fail on critical/high severity issues
+
 
   # ============================================================================
   # BUILD STAGE - Machine Validation
   # ============================================================================
+
 
   build-release-machine-validation-runner:
     needs:
@@ -1450,8 +1453,8 @@ jobs:
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm
-          lint: "true"
-          template: "true"
+          lint: 'true'
+          template: 'true'
 
   build-push-helm-chart:
     needs:
@@ -1472,7 +1475,7 @@ jobs:
           chart-path: helm
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: "false"
+          lint: 'false'
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1492,8 +1495,8 @@ jobs:
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm-prereqs
-          lint: "true"
-          template: "true"
+          lint: 'true'
+          template: 'true'
 
   build-push-helm-prereqs-chart:
     needs:
@@ -1514,7 +1517,7 @@ jobs:
           chart-path: helm-prereqs
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: "false"
+          lint: 'false'
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1588,7 +1591,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ""
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/otelcol-contrib/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib
@@ -1607,7 +1610,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ""
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/transceiver-exporter/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter
@@ -1645,7 +1648,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ""
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1665,7 +1668,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ""
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1685,7 +1688,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ""
+      source_registry_host: ''
       dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1716,29 +1719,29 @@ jobs:
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-otelcol
-          lint: "true"
-          template: "true"
+          lint: 'true'
+          template: 'true'
 
       - name: Validate nico-dpu-agent chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dpu-agent
-          lint: "true"
-          template: "true"
+          lint: 'true'
+          template: 'true'
 
       - name: Validate nico-dhcp-server chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dhcp-server
-          lint: "true"
-          template: "true"
+          lint: 'true'
+          template: 'true'
 
       - name: Validate nico-fmds chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-fmds
-          lint: "true"
-          template: "true"
+          lint: 'true'
+          template: 'true'
 
   build-push-bluefield-helm-charts:
     needs:
@@ -1759,7 +1762,7 @@ jobs:
           chart-path: bluefield/charts/nico-otelcol
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: "false"
+          lint: 'false'
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1771,7 +1774,7 @@ jobs:
           chart-path: bluefield/charts/nico-dpu-agent
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: "false"
+          lint: 'false'
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1783,7 +1786,7 @@ jobs:
           chart-path: bluefield/charts/nico-dhcp-server
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: "false"
+          lint: 'false'
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1795,7 +1798,7 @@ jobs:
           chart-path: bluefield/charts/nico-fmds
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: "false"
+          lint: 'false'
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ env:
   FF_USE_FASTZIP: "true"
   GIT_SUBMODULE_STRATEGY: recursive
 
-
 jobs:
   changes:
     name: Detect Core CI Gate
@@ -108,6 +107,7 @@ jobs:
       extras_container_ref: ${{ steps.resolve-extras.outputs.extras_container_ref }}
       build_container_x86_64_run: ${{ steps.base-container-gate.outputs.build_container_x86_64_run }}
       build_container_x86_64_version: ${{ steps.base-container-gate.outputs.build_container_x86_64_version }}
+      build_container_x86_64_version_latest: ${{ steps.base-container-gate.outputs.build_container_x86_64_version_latest }}
       build_container_x86_64_ref: ${{ steps.base-container-gate.outputs.build_container_x86_64_ref }}
       runtime_container_x86_64_ref: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_ref }}
       build_container_aarch64_ref: ${{ steps.base-container-gate.outputs.build_container_aarch64_ref }}
@@ -116,14 +116,19 @@ jobs:
       build_artifacts_container_aarch64_ref: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_ref }}
       runtime_container_x86_64_run: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_run }}
       runtime_container_x86_64_version: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_version }}
+      runtime_container_x86_64_version_latest: ${{ steps.base-container-gate.outputs.runtime_container_x86_64_version_latest }}
       build_container_aarch64_run: ${{ steps.base-container-gate.outputs.build_container_aarch64_run }}
       build_container_aarch64_version: ${{ steps.base-container-gate.outputs.build_container_aarch64_version }}
+      build_container_aarch64_version_latest: ${{ steps.base-container-gate.outputs.build_container_aarch64_version_latest }}
       build_artifacts_container_x86_64_run: ${{ steps.base-container-gate.outputs.build_artifacts_container_x86_64_run }}
       build_artifacts_container_x86_64_version: ${{ steps.base-container-gate.outputs.build_artifacts_container_x86_64_version }}
+      build_artifacts_container_x86_64_version_latest: ${{ steps.base-container-gate.outputs.build_artifacts_container_x86_64_version_latest }}
       build_artifacts_container_aarch64_run: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_run }}
       build_artifacts_container_aarch64_version: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_version }}
+      build_artifacts_container_aarch64_version_latest: ${{ steps.base-container-gate.outputs.build_artifacts_container_aarch64_version_latest }}
       runtime_container_aarch64_run: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_run }}
       runtime_container_aarch64_version: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_version }}
+      runtime_container_aarch64_version_latest: ${{ steps.base-container-gate.outputs.runtime_container_aarch64_version_latest }}
       proto_files_changed: ${{ steps.base-container-gate.outputs.proto_files_changed }}
       core_rpc_proto_files_changed: ${{ steps.base-container-gate.outputs.core_rpc_proto_files_changed }}
       source_files_changed: ${{ steps.base-container-gate.outputs.source_files_changed }}
@@ -418,49 +423,61 @@ jobs:
           if [[ "$build_container_x86_64_run" == "true" ]]; then
             echo "build_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_ref=${TARGET_REGISTRY}/build-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_version_latest=${TARGET_REGISTRY}/build-container-x86_64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$runtime_container_x86_64_run" == "true" ]]; then
             echo "runtime_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "runtime_container_x86_64_ref=${TARGET_REGISTRY}/runtime-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_x86_64_version_latest=${TARGET_REGISTRY}/runtime-container-x86_64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
             echo "runtime_container_x86_64_ref=${SOURCE_REGISTRY}/runtime-container-x86_64:latest" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$build_container_aarch64_run" == "true" ]]; then
             echo "build_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_aarch64_ref=${TARGET_REGISTRY}/build-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_version_latest=${TARGET_REGISTRY}/build-container-aarch64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_container_aarch64_ref=${SOURCE_REGISTRY}/build-container-aarch64:latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$runtime_container_aarch64_run" == "true" ]]; then
             echo "runtime_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "runtime_container_aarch64_ref=${TARGET_REGISTRY}/runtime-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_aarch64_version_latest=${TARGET_REGISTRY}/runtime-container-aarch64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "runtime_container_aarch64_ref=${SOURCE_REGISTRY}/runtime-container-aarch64:latest" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$build_artifacts_container_x86_64_run" == "true" ]]; then
             echo "build_artifacts_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_x86_64_ref=${TARGET_REGISTRY}/build-artifacts-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_x86_64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-x86_64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_artifacts_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_x86_64_ref=${SOURCE_REGISTRY}/build-artifacts-container-x86_64:latest" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_x86_64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
           if [[ "$build_artifacts_container_aarch64_run" == "true" ]]; then
             echo "build_artifacts_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_aarch64_ref=${TARGET_REGISTRY}/build-artifacts-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_aarch64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-aarch64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_artifacts_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_aarch64_ref=${SOURCE_REGISTRY}/build-artifacts-container-aarch64:latest" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_aarch64_version_latest=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Decide release container publish strategy
@@ -550,6 +567,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.build-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_container_x86_64_version }}
+      additional_tags: ${{ needs.prepare.outputs.build_container_x86_64_version_latest }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -567,6 +585,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.build-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_container_aarch64_version }}
+      additional_tags: ${{ needs.prepare.outputs.build_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -584,6 +603,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.runtime-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-x86_64
       image_tag: ${{ needs.prepare.outputs.runtime_container_x86_64_version }}
+      additional_tags: ${{ needs.prepare.outputs.runtime_container_x86_64_version_latest }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -601,6 +621,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.runtime-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/runtime-container-aarch64
       image_tag: ${{ needs.prepare.outputs.runtime_container_aarch64_version }}
+      additional_tags: ${{ needs.prepare.outputs.runtime_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -618,6 +639,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-x86_64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_x86_64_version }}
+      additional_tags: ${{needs.prepare.outputs.build_artifacts_container_x86_64_version_latest }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -635,6 +657,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.build-artifacts-container-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/build-artifacts-container-aarch64
       image_tag: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version }}
+      additional_tags: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
@@ -1052,7 +1075,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
-      download_artifacts: true  # Download boot and ephemeral artifacts for packaging
+      download_artifacts: true # Download boot and ephemeral artifacts for packaging
       build_args: |
         {
           "VERSION": "${{ needs.prepare.outputs.version }}",
@@ -1085,7 +1108,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: true
       scan: true
-      download_artifacts: true  # Download boot and ephemeral artifacts for packaging
+      download_artifacts: true # Download boot and ephemeral artifacts for packaging
       build_args: |
         {
           "VERSION": "${{ needs.prepare.outputs.version }}",
@@ -1112,14 +1135,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0  # Full history for secret scanning
+          fetch-depth: 0 # Full history for secret scanning
 
       - name: Run TruffleHog Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
-          extra-args: '--results=verified,unknown --only-verified'
-          post-pr-comment: 'false'
-          fail-on-findings: 'true'
+          extra-args: "--results=verified,unknown --only-verified"
+          post-pr-comment: "false"
+          fail-on-findings: "true"
 
   security-codeql-scan:
     name: CodeQL Security Analysis
@@ -1141,19 +1164,17 @@ jobs:
       - name: Run CodeQL Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
         with:
-          languages: 'rust'
-          build-mode: 'none'
-          category: '/language:rust'
-          upload-sarif: 'false'  # Disable upload until GHAS is enabled, such as the repo be public
-          post-pr-comment: 'false'
-          fail-on-findings: 'true'  # Enforce quality gate
-          fail-on-severity: 'error' # Only fail on critical/high severity issues
-
+          languages: "rust"
+          build-mode: "none"
+          category: "/language:rust"
+          upload-sarif: "false" # Disable upload until GHAS is enabled, such as the repo be public
+          post-pr-comment: "false"
+          fail-on-findings: "true" # Enforce quality gate
+          fail-on-severity: "error" # Only fail on critical/high severity issues
 
   # ============================================================================
   # BUILD STAGE - Machine Validation
   # ============================================================================
-
 
   build-release-machine-validation-runner:
     needs:
@@ -1417,8 +1438,8 @@ jobs:
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm
-          lint: 'true'
-          template: 'true'
+          lint: "true"
+          template: "true"
 
   build-push-helm-chart:
     needs:
@@ -1439,7 +1460,7 @@ jobs:
           chart-path: helm
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: 'false'
+          lint: "false"
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1459,8 +1480,8 @@ jobs:
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: helm-prereqs
-          lint: 'true'
-          template: 'true'
+          lint: "true"
+          template: "true"
 
   build-push-helm-prereqs-chart:
     needs:
@@ -1481,7 +1502,7 @@ jobs:
           chart-path: helm-prereqs
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: 'false'
+          lint: "false"
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1555,7 +1576,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ''
+      source_registry_host: ""
       dockerfile_path: bluefield/containers/otelcol-contrib/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib
@@ -1573,7 +1594,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ''
+      source_registry_host: ""
       dockerfile_path: bluefield/containers/transceiver-exporter/Dockerfile
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter
@@ -1610,7 +1631,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ''
+      source_registry_host: ""
       dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1629,7 +1650,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ''
+      source_registry_host: ""
       dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1648,7 +1669,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yml
     with:
       # public bases only: skip source login so anonymous nvcr pulls keep working
-      source_registry_host: ''
+      source_registry_host: ""
       dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1678,29 +1699,29 @@ jobs:
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-otelcol
-          lint: 'true'
-          template: 'true'
+          lint: "true"
+          template: "true"
 
       - name: Validate nico-dpu-agent chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dpu-agent
-          lint: 'true'
-          template: 'true'
+          lint: "true"
+          template: "true"
 
       - name: Validate nico-dhcp-server chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-dhcp-server
-          lint: 'true'
-          template: 'true'
+          lint: "true"
+          template: "true"
 
       - name: Validate nico-fmds chart
         uses: NVIDIA/dsx-github-actions/.github/actions/helm-validate@94bde998f5d7965576b0c663db7d5d709c918167
         with:
           chart-path: bluefield/charts/nico-fmds
-          lint: 'true'
-          template: 'true'
+          lint: "true"
+          template: "true"
 
   build-push-bluefield-helm-charts:
     needs:
@@ -1721,7 +1742,7 @@ jobs:
           chart-path: bluefield/charts/nico-otelcol
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: 'false'
+          lint: "false"
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1733,7 +1754,7 @@ jobs:
           chart-path: bluefield/charts/nico-dpu-agent
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: 'false'
+          lint: "false"
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1745,7 +1766,7 @@ jobs:
           chart-path: bluefield/charts/nico-dhcp-server
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: 'false'
+          lint: "false"
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail
@@ -1757,7 +1778,7 @@ jobs:
           chart-path: bluefield/charts/nico-fmds
           chart-version: ${{ needs.prepare.outputs.helm_version }}
           app-version: ${{ needs.prepare.outputs.version }}
-          lint: 'false'
+          lint: "false"
           ngc-key: ${{ secrets.NICO_NGC_TOKEN || secrets.NVCR_TOKEN }}
           ngc-path: ${{ needs.prepare.outputs.target_ngc_path }}
           ngc-duplicate: fail

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
       prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
       helm_version: ${{ steps.version.outputs.helm_version }}
       short_sha: ${{ steps.version.outputs.short_sha }}
-      major_minor_version: ${{ steps.version.outputs.major_minor_version }}
+      major_minor_version: ${{ steps.base-container-gate.outputs.major_minor_version }}
       extras_container_ref: ${{ steps.resolve-extras.outputs.extras_container_ref }}
       build_container_x86_64_run: ${{ steps.base-container-gate.outputs.build_container_x86_64_run }}
       build_container_x86_64_version: ${{ steps.base-container-gate.outputs.build_container_x86_64_version }}
@@ -212,7 +212,6 @@ jobs:
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "helm_version=${HELM_VERSION}" >> $GITHUB_OUTPUT
-          echo "major_minor_version=$(echo "${VERSION}" | cut -d. -f1,2)" >> $GITHUB_OUTPUT
           echo "Calculated VERSION: ${VERSION}"
           echo "Calculated HELM_VERSION: ${HELM_VERSION}"
 
@@ -423,10 +422,13 @@ jobs:
           echo "core_rpc_proto_files_changed=${core_rpc_proto_files_changed}" >> "$GITHUB_OUTPUT"
           echo "source_files_changed=${source_files_changed}" >> "$GITHUB_OUTPUT"
 
+          MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
+          echo "major_minor_version=${MAJOR_MINOR}" >> "$GITHUB_OUTPUT"
+
           if [[ "$build_container_x86_64_run" == "true" ]]; then
             echo "build_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_ref=${TARGET_REGISTRY}/build-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_container_x86_64_version_latest=${TARGET_REGISTRY}/build-container-x86_64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_x86_64_version_latest=${TARGET_REGISTRY}/build-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_container_x86_64_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
@@ -436,7 +438,7 @@ jobs:
           if [[ "$runtime_container_x86_64_run" == "true" ]]; then
             echo "runtime_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "runtime_container_x86_64_ref=${TARGET_REGISTRY}/runtime-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_x86_64_version_latest=${TARGET_REGISTRY}/runtime-container-x86_64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_x86_64_version_latest=${TARGET_REGISTRY}/runtime-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
             echo "runtime_container_x86_64_ref=${SOURCE_REGISTRY}/runtime-container-x86_64:latest" >> "$GITHUB_OUTPUT"
@@ -446,7 +448,7 @@ jobs:
           if [[ "$build_container_aarch64_run" == "true" ]]; then
             echo "build_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_container_aarch64_ref=${TARGET_REGISTRY}/build-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_container_aarch64_version_latest=${TARGET_REGISTRY}/build-container-aarch64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
+            echo "build_container_aarch64_version_latest=${TARGET_REGISTRY}/build-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_container_aarch64_ref=${SOURCE_REGISTRY}/build-container-aarch64:latest" >> "$GITHUB_OUTPUT"
@@ -456,7 +458,7 @@ jobs:
           if [[ "$runtime_container_aarch64_run" == "true" ]]; then
             echo "runtime_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "runtime_container_aarch64_ref=${TARGET_REGISTRY}/runtime-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "runtime_container_aarch64_version_latest=${TARGET_REGISTRY}/runtime-container-aarch64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
+            echo "runtime_container_aarch64_version_latest=${TARGET_REGISTRY}/runtime-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
             echo "runtime_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "runtime_container_aarch64_ref=${SOURCE_REGISTRY}/runtime-container-aarch64:latest" >> "$GITHUB_OUTPUT"
@@ -466,7 +468,7 @@ jobs:
           if [[ "$build_artifacts_container_x86_64_run" == "true" ]]; then
             echo "build_artifacts_container_x86_64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_x86_64_ref=${TARGET_REGISTRY}/build-artifacts-container-x86_64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_x86_64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-x86_64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_x86_64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-x86_64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_artifacts_container_x86_64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_x86_64_ref=${SOURCE_REGISTRY}/build-artifacts-container-x86_64:latest" >> "$GITHUB_OUTPUT"
@@ -476,7 +478,7 @@ jobs:
           if [[ "$build_artifacts_container_aarch64_run" == "true" ]]; then
             echo "build_artifacts_container_aarch64_version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_aarch64_ref=${TARGET_REGISTRY}/build-artifacts-container-aarch64:${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "build_artifacts_container_aarch64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-aarch64:$(echo "${VERSION}" | cut -d. -f1,2)-latest" >> "$GITHUB_OUTPUT"
+            echo "build_artifacts_container_aarch64_version_latest=${TARGET_REGISTRY}/build-artifacts-container-aarch64:${MAJOR_MINOR}-latest" >> "$GITHUB_OUTPUT"
           else
             echo "build_artifacts_container_aarch64_version=latest" >> "$GITHUB_OUTPUT"
             echo "build_artifacts_container_aarch64_ref=${SOURCE_REGISTRY}/build-artifacts-container-aarch64:latest" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -781,6 +781,11 @@ jobs:
               ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide@${{ needs.build-release-container-x86_64.outputs.image_digest }} \
               ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64@${{ needs.build-release-container-aarch64.outputs.image_digest }}
 
+            docker buildx imagetools create -t \
+              ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide:${{ needs.prepare.outputs.major_minor_version }}-latest \
+              ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide@${{ needs.build-release-container-x86_64.outputs.image_digest }} \
+              ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64@${{ needs.build-release-container-aarch64.outputs.image_digest }}
+
   build-machine-a-tron:
     if: >-
       ${{
@@ -967,6 +972,11 @@ jobs:
 
             docker buildx imagetools create -t \
               ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli:latest \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.version }}
+
+            docker buildx imagetools create -t \
+              ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli:${{ needs.prepare.outputs.major_minor_version }}-latest \
               ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.version }} \
               ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.version }}
 
@@ -1294,6 +1304,11 @@ jobs:
           command: |
             docker buildx imagetools create -t \
               ${{ needs.prepare.outputs.image_registry }}/machine_validation:${{ needs.prepare.outputs.version }} \
+              ${{ needs.prepare.outputs.image_registry }}/machine_validation@${{ needs.build-release-machine-validation-artifacts-x86-host.outputs.image_digest }} \
+              ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64@${{ needs.build-release-machine-validation-artifacts-arm-host.outputs.image_digest }}
+
+            docker buildx imagetools create -t \
+              ${{ needs.prepare.outputs.image_registry }}/machine_validation:${{ needs.prepare.outputs.major_minor_version }}-latest \
               ${{ needs.prepare.outputs.image_registry }}/machine_validation@${{ needs.build-release-machine-validation-artifacts-x86-host.outputs.image_digest }} \
               ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64@${{ needs.build-release-machine-validation-artifacts-arm-host.outputs.image_digest }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,7 @@ jobs:
       prod_image_registry: ${{ steps.registry.outputs.prod_registry }}
       helm_version: ${{ steps.version.outputs.helm_version }}
       short_sha: ${{ steps.version.outputs.short_sha }}
+      major_minor_version: ${{ steps.version.outputs.major_minor_version }}
       extras_container_ref: ${{ steps.resolve-extras.outputs.extras_container_ref }}
       build_container_x86_64_run: ${{ steps.base-container-gate.outputs.build_container_x86_64_run }}
       build_container_x86_64_version: ${{ steps.base-container-gate.outputs.build_container_x86_64_version }}
@@ -210,6 +211,7 @@ jobs:
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "helm_version=${HELM_VERSION}" >> $GITHUB_OUTPUT
+          echo "major_minor_version=$(echo "${VERSION}" | cut -d. -f1,2)" >> $GITHUB_OUTPUT
           echo "Calculated VERSION: ${VERSION}"
           echo "Calculated HELM_VERSION: ${HELM_VERSION}"
 
@@ -694,6 +696,7 @@ jobs:
       build_args: ${{ needs.prepare.outputs.release_build_args }}
       image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/amd64
       runner: linux-amd64-cpu16
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -727,6 +730,7 @@ jobs:
       build_args: ${{ needs.prepare.outputs.release_build_args_aarch64 }}
       image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
       runner: linux-arm64-cpu16
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -794,6 +798,7 @@ jobs:
           needs.prepare.outputs.short_sha) }}
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine-a-tron
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/machine-a-tron:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/amd64
       runner: linux-amd64-cpu16
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -893,6 +898,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.build_artifacts_container_x86_64_ref }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
@@ -913,6 +919,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_BUILD":"${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}"}'
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1065,6 +1072,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64:${{ needs.prepare.outputs.major_minor_version }}-latest
       # Multi-arch on push so this x86_64 boot-artifacts carrier can run as an
       # init container on both amd64 and arm64 control-plane nodes; the payload
       # it ships is unchanged (x86_64 boot blobs). The Dockerfile has no RUN
@@ -1098,6 +1106,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest
       # Container arch is independent of the payload: this carrier always ships
       # the aarch64 boot blobs as files. Build it multi-arch on push so it can
       # run as an init container on both amd64 and arm64 control-plane nodes. The
@@ -1188,6 +1197,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.machine-validation-runner
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine-validation-runner
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/machine-validation-runner:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.runtime_container_x86_64_ref }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
@@ -1208,6 +1218,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/machine_validation:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_X86_64":"${{ needs.prepare.outputs.runtime_container_x86_64_ref }}"}'
       platforms: linux/amd64
       runner: linux-amd64-cpu4
@@ -1234,6 +1245,7 @@ jobs:
       dockerfile_path: dev/docker/Dockerfile.machine-validation-config-aarch64
       image_name: ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/machine_validation-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest
       build_args: '{"CI_COMMIT_SHORT_SHA":"${{ needs.prepare.outputs.short_sha }}","CONTAINER_RUNTIME_AARCH64":"${{ needs.prepare.outputs.runtime_container_aarch64_ref }}"}'
       platforms: linux/arm64
       runner: linux-arm64-cpu4
@@ -1581,6 +1593,7 @@ jobs:
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/otelcol-contrib:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1599,6 +1612,7 @@ jobs:
       context_path: .
       image_name: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/transceiver-exporter:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1635,6 +1649,7 @@ jobs:
       dockerfile_path: bluefield/containers/forge-dpu-agent/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-dpu-agent:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1654,6 +1669,7 @@ jobs:
       dockerfile_path: bluefield/containers/forge-dhcp-server/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-dhcp-server:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1673,6 +1689,7 @@ jobs:
       dockerfile_path: bluefield/containers/carbide-fmds/Dockerfile
       image_name: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds
       image_tag: ${{ needs.prepare.outputs.version }}
+      additional_tags: ${{ needs.prepare.outputs.image_registry }}/carbide-fmds:${{ needs.prepare.outputs.major_minor_version }}-latest
       platforms: linux/arm64
       runner: linux-arm64-cpu4
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}


### PR DESCRIPTION
This adds a floating `-latest` tag for each release to make it easier to automate security scanning. Since this tag points to the latest of a given release, we can use the `major` and `minor` of the given version to get the floating tag to update (ex: `v2.0.0-rc.16` -> `v2.0`). 

This utilizes the `addtional_tags` input for the `docker-build` workflow call which can be used to add additional tags to upload a given container to the registry. For some of the build jobs we already publish a `latest` which is accounted for by setting the appropriate var to empty `build_container_x86_64_version_latest=` which `docker-build` handles to not adding any additional tags. For other jobs, just `version` is used to upload which we can reuse the same `<major>.<minor>-later`.

| version | tags |
| - | - |
| v2.0.0 | v2.0-latest, v2.0.0  |
| v2.0.0-pr | v2.0-latest, v2.0.0-pr|
| v2.0.0-rc.1 | v2.0-latest, v2.0.0-rc.1 |
| v2.1.0-pr-0-g12435a |   v2.1-latest, v2.1.0-pr-0-g12435a |


## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
