### PR TITLE
refactor(scout): pair action and reconnect records with their counters

### DIFF
--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -264,22 +264,20 @@ async fn run_as_service(config: &Options) -> Result<(), eyre::Report> {
             }
         };
         if let Some(action) = controller_response.action {
-            let action_str = action.as_str_name().to_owned();
+            let action_name = action.as_str_name();
             // Capture the action label before handle_action consumes `action`.
             let scout_action = metrics::ScoutAction::from(&action);
             let result = handle_action(action, &machine_id, machine_interface_id, config).await;
+            let outcome = Outcome::from(&result);
+            let error = result
+                .err()
+                .map_or_else(String::new, |error| error.to_string());
             emit(metrics::ScoutActionHandled {
                 action: scout_action,
-                outcome: Outcome::from(&result),
+                outcome,
+                action_name,
+                error,
             });
-            match result {
-                Ok(_) => tracing::info!(action = %action_str, "Successfully served action"),
-                Err(e) => tracing::info!(
-                    action = %action_str,
-                    error = %e,
-                    "Failed to serve action",
-                ),
-            };
         } else {
             tracing::warn!("API response did not contain an action, skipping.");
         }

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -15,14 +15,15 @@
  * limitations under the License.
  */
 
-//! Control-loop and stream counters for scout. Every event here is metric-only
-//! (`log = off`): the human-readable side is already carried by the existing
-//! `tracing` lines at each site, and the process-wide log rate rides on
-//! `carbide_log_events_total{level, component}` once `log_events::register`
-//! runs. These counters add the per-action and per-stream-outcome rates that a
-//! log line alone can't total.
+//! Scout control-loop and stream events.
+//!
+//! `ScoutActionHandled` and `ScoutStreamReconnect` pair their counters with
+//! the records operators use to diagnose those outcomes.
+//! `ScoutStreamConnection` remains metric-only because the surrounding stream
+//! lifecycle logs already carry the endpoint and machine context.
 
-use carbide_instrument::{Event, LabelValue, Outcome};
+use carbide_instrument::{DynamicMessage, Event, LabelValue, Outcome};
+use carbide_uuid::machine::MachineId;
 use rpc::forge_agent_control_response as fac;
 
 /// Which control-loop action scout handled, as a bounded metric label: one
@@ -58,14 +59,16 @@ impl From<&fac::Action> for ScoutAction {
     }
 }
 
-/// Scout finished handling one control-loop action, whatever the result.
+/// `ScoutActionHandled` records a completed control-loop action and keeps its
+/// outcome counter paired with the corresponding success or failure record.
 #[derive(Event)]
 #[event(
     event_name = "scout_action_handled",
     metric_name = "carbide_scout_actions_total",
     component = "nico-scout",
-    log = off,
+    log = info,
     metric = counter,
+    message = dynamic,
     describe = "Number of scout control-loop actions handled, by action and outcome."
 )]
 pub struct ScoutActionHandled {
@@ -73,10 +76,29 @@ pub struct ScoutActionHandled {
     pub action: ScoutAction,
     #[label]
     pub outcome: Outcome,
+    /// `action_name` retains the protobuf's uppercase spelling from the
+    /// original log. The existing `action` metric label also renders its
+    /// bounded `snake_case` value into the record, so both values are
+    /// intentional.
+    #[context]
+    pub action_name: &'static str,
+    /// `error` carries failure detail. Successful actions use `""` because
+    /// Event context fields are present on every generated record.
+    #[context]
+    pub error: String,
 }
 
-/// A scout stream connection attempt resolved -- `ok` once the bidirectional
-/// stream is established, `error` when the client could not be built.
+impl DynamicMessage for ScoutActionHandled {
+    fn message(&self) -> &'static str {
+        match self.outcome {
+            Outcome::Ok => "Successfully served action",
+            Outcome::Error => "Failed to serve action",
+        }
+    }
+}
+
+/// `ScoutStreamConnection` records whether scout established its bidirectional
+/// stream. `error` covers both client construction and the opening stream RPC.
 #[derive(Event)]
 #[event(
     event_name = "scout_stream_connection",
@@ -91,23 +113,32 @@ pub struct ScoutStreamConnection {
     pub outcome: Outcome,
 }
 
-/// The scout stream closed or errored and the loop looped back to re-establish
-/// it after the reconnect delay.
+/// `ScoutStreamReconnect` records the retry boundary after a stream closes or
+/// errors. Endpoint and machine context stay on the warning, while the counter
+/// tracks how often scout reaches the fixed reconnect delay.
 #[derive(Event)]
 #[event(
     event_name = "scout_stream_reconnect",
     metric_name = "carbide_scout_stream_reconnects_total",
     component = "nico-scout",
-    log = off,
+    log = warn,
     metric = counter,
+    message = "scout stream reconnecting after 10s delay",
     describe = "Number of scout stream reconnect cycles after a stream closed or errored."
 )]
-pub struct ScoutStreamReconnect {}
+pub struct ScoutStreamReconnect {
+    #[context]
+    pub api_endpoint: String,
+    #[context]
+    pub machine_id: MachineId,
+}
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr as _;
+
     use carbide_instrument::emit;
-    use carbide_instrument::testing::MetricsCapture;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
     use super::*;
@@ -172,37 +203,229 @@ mod tests {
     }
 
     #[test]
-    fn scout_counters_move_per_label() {
+    fn scout_action_outcomes_log_and_count() {
+        struct ActionCase {
+            action: ScoutAction,
+            outcome: Outcome,
+            action_name: &'static str,
+            error: &'static str,
+            action_label: &'static str,
+            outcome_label: &'static str,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct LogObservation {
+            metadata_name: String,
+            level: tracing::Level,
+            message: String,
+            event_name: Option<String>,
+            metric_name: Option<String>,
+            action: Option<String>,
+            outcome: Option<String>,
+            action_name: Option<String>,
+            error: Option<String>,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            log_count: usize,
+            log: Option<LogObservation>,
+            counter_delta: f64,
+        }
+
+        fn expected_log(
+            message: &str,
+            action: &str,
+            outcome: &str,
+            action_name: &str,
+            error: &str,
+        ) -> Option<LogObservation> {
+            Some(LogObservation {
+                metadata_name: "scout_action_handled".to_string(),
+                level: tracing::Level::INFO,
+                message: message.to_string(),
+                event_name: Some("scout_action_handled".to_string()),
+                metric_name: Some("carbide_scout_actions_total".to_string()),
+                action: Some(action.to_string()),
+                outcome: Some(outcome.to_string()),
+                action_name: Some(action_name.to_string()),
+                error: Some(error.to_string()),
+            })
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "successful firmware upgrade action",
+                    input: ActionCase {
+                        action: ScoutAction::FirmwareUpgrade,
+                        outcome: Outcome::Ok,
+                        action_name: "FIRMWARE_UPGRADE",
+                        error: "",
+                        action_label: "firmware_upgrade",
+                        outcome_label: "ok",
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: expected_log(
+                            "Successfully served action",
+                            "firmware_upgrade",
+                            "ok",
+                            "FIRMWARE_UPGRADE",
+                            "",
+                        ),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "failed machine validation action",
+                    input: ActionCase {
+                        action: ScoutAction::MachineValidation,
+                        outcome: Outcome::Error,
+                        action_name: "MACHINE_VALIDATION",
+                        error: "validation command failed",
+                        action_label: "machine_validation",
+                        outcome_label: "error",
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: expected_log(
+                            "Failed to serve action",
+                            "machine_validation",
+                            "error",
+                            "MACHINE_VALIDATION",
+                            "validation command failed",
+                        ),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |case| {
+                let ActionCase {
+                    action,
+                    outcome,
+                    action_name,
+                    error,
+                    action_label,
+                    outcome_label,
+                } = case;
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| {
+                    emit(ScoutActionHandled {
+                        action,
+                        outcome,
+                        action_name,
+                        error: error.to_string(),
+                    });
+                });
+                let log = logs.first().map(|log| LogObservation {
+                    metadata_name: log.metadata_name.clone(),
+                    level: log.level,
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    action: log.field("action").map(str::to_string),
+                    outcome: log.field("outcome").map(str::to_string),
+                    action_name: log.field("action_name").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                });
+
+                Observation {
+                    log_count: logs.len(),
+                    log,
+                    counter_delta: metrics.counter_delta(
+                        "carbide_scout_actions_total",
+                        &[("action", action_label), ("outcome", outcome_label)],
+                    ),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn scout_stream_connection_counter_moves_per_outcome() {
+        struct ConnectionCase {
+            outcome: Outcome,
+            outcome_label: &'static str,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            log_count: usize,
+            counter_delta: f64,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "stream connected",
+                    input: ConnectionCase {
+                        outcome: Outcome::Ok,
+                        outcome_label: "ok",
+                    },
+                    expect: Observation {
+                        log_count: 0,
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "stream connection failed",
+                    input: ConnectionCase {
+                        outcome: Outcome::Error,
+                        outcome_label: "error",
+                    },
+                    expect: Observation {
+                        log_count: 0,
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |ConnectionCase {
+                 outcome,
+                 outcome_label,
+             }| {
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| emit(ScoutStreamConnection { outcome }));
+                Observation {
+                    log_count: logs.len(),
+                    counter_delta: metrics.counter_delta(
+                        "carbide_scout_stream_connections_total",
+                        &[("outcome", outcome_label)],
+                    ),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn scout_stream_reconnect_logs_and_counts() {
         let metrics = MetricsCapture::start();
-
-        // Labels chosen so no other test in this binary shares them.
-        emit(ScoutActionHandled {
-            action: ScoutAction::FirmwareUpgrade,
-            outcome: Outcome::Error,
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
+                .expect("valid machine id");
+        let logs = capture_logs(|| {
+            emit(ScoutStreamReconnect {
+                api_endpoint: "https://[::1]:1079".to_string(),
+                machine_id,
+            });
         });
-        emit(ScoutStreamConnection {
-            outcome: Outcome::Ok,
-        });
-        emit(ScoutStreamReconnect {});
-        emit(ScoutStreamReconnect {});
 
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].metadata_name, "scout_stream_reconnect");
+        assert_eq!(logs[0].level, tracing::Level::WARN);
+        assert_eq!(logs[0].message, "scout stream reconnecting after 10s delay");
+        assert_eq!(logs[0].field("event_name"), Some("scout_stream_reconnect"));
         assert_eq!(
-            metrics.counter_delta(
-                "carbide_scout_actions_total",
-                &[("action", "firmware_upgrade"), ("outcome", "error")],
-            ),
-            1.0
+            logs[0].field("metric_name"),
+            Some("carbide_scout_stream_reconnects_total")
         );
-        assert_eq!(
-            metrics.counter_delta(
-                "carbide_scout_stream_connections_total",
-                &[("outcome", "ok")],
-            ),
-            1.0
-        );
+        assert_eq!(logs[0].field("api_endpoint"), Some("https://[::1]:1079"));
+        let machine_id = machine_id.to_string();
+        assert_eq!(logs[0].field("machine_id"), Some(machine_id.as_str()));
+
         assert_eq!(
             metrics.counter_delta("carbide_scout_stream_reconnects_total", &[]),
-            2.0
+            1.0
         );
     }
 }

--- a/crates/scout/src/stream.rs
+++ b/crates/scout/src/stream.rs
@@ -77,12 +77,10 @@ pub fn start_scout_stream(machine_id: MachineId, options: &Options) -> tokio::ta
                     );
                 }
             }
-            emit(ScoutStreamReconnect {});
-            tracing::warn!(
-                api_endpoint = %options.api,
-                %machine_id,
-                "scout stream reconnecting after 10s delay",
-            );
+            emit(ScoutStreamReconnect {
+                api_endpoint: options.api.clone(),
+                machine_id,
+            });
             tokio::time::sleep(Duration::from_secs(10)).await;
         }
     })


### PR DESCRIPTION
Scout action outcomes and stream reconnects each described one occurrence with two calls: a counter update followed by its operator record.

Typed sibling `Event`s now own both sides while preserving the existing metric names, labels, log levels, messages, and log-only context. Stream connection outcomes remain metric-only because their surrounding lifecycle records describe a broader boundary.

Table-driven tests cover each paired emission and the deliberately silent connection outcome.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3730
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The action and stream-connection outcome matrices use named `check_values` rows, while the reconnect contract remains a focused test.

Verified with:

- `cargo test -p carbide-scout`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`

## Additional Notes

`Event` labels are also written into the log record, so action records now carry `action=firmware_upgrade` (the bounded metric spelling) alongside `action_name=FIRMWARE_UPGRADE` (the historical protobuf spelling). This keeps the existing metric contract and retains the original action value.

Closes #3730
