### PR TITLE
refactor(api,bmc-proxy): pair TLS failure records with their counters

### DIFF
--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -222,22 +222,46 @@ enum ConnectionFailReason {
     TlsConnectionFailure,
 }
 
-/// An inbound connection failed before it could be served -- the TCP accept or
-/// the TLS handshake errored. Metric-only: the `tracing::error!` beside each
-/// emit stays the log, byte-for-byte as before; the `reason` label
-/// distinguishes which leg failed.
+/// `TcpAcceptFailed` records a listener error before a peer connection exists.
+/// It increments the existing `tcp_connection_failure` series while keeping
+/// the per-attempt error in log-only context.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "api_tcp_accept_failed",
+    metric_name = "carbide_api_tls_connection_fail_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "Error accepting connection",
+    describe = "Number of failed inbound TLS connection attempts"
+)]
+struct TcpAcceptFailed {
+    #[label]
+    reason: ConnectionFailReason,
+    #[context]
+    error: String,
+}
+
+/// `TlsConnectionFailed` records a handshake error after the listener knows
+/// the peer. It shares the failure counter with [`TcpAcceptFailed`], while
+/// `peer_address` and `error` remain available only on the diagnostic record.
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "api_tls_connection_failed",
     metric_name = "carbide_api_tls_connection_fail_total",
     component = "nico-api",
-    log = off,
+    log = error,
     metric = counter,
+    message = "error accepting tls connection",
     describe = "Number of failed inbound TLS connection attempts"
 )]
 struct TlsConnectionFailed {
     #[label]
     reason: ConnectionFailReason,
+    #[context]
+    error: String,
+    #[context]
+    peer_address: SocketAddr,
 }
 
 /// Start listening for requests, spawning the listener task into `join_set`.
@@ -368,9 +392,9 @@ pub async fn start(
                 let (conn, addr) = match incoming_connection {
                     Ok(incoming) => incoming,
                     Err(e) => {
-                        tracing::error!(error = %e, "Error accepting connection");
-                        carbide_instrument::emit(TlsConnectionFailed {
+                        carbide_instrument::emit(TcpAcceptFailed {
                             reason: ConnectionFailReason::TcpConnectionFailure,
+                            error: e.to_string(),
                         });
                         continue;
                     }
@@ -453,13 +477,10 @@ pub async fn start(
                                     }
                                 }
                                 Err(error) => {
-                                    tracing::error!(
-                                        %error,
-                                        peer_address = %addr,
-                                        "error accepting tls connection"
-                                    );
                                     carbide_instrument::emit(TlsConnectionFailed {
                                         reason: ConnectionFailReason::TlsConnectionFailure,
+                                        error: error.to_string(),
+                                        peer_address: addr,
                                     });
                                 }
                             }
@@ -524,31 +545,142 @@ async fn root_url() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use carbide_instrument::LabelValue;
+    use std::net::SocketAddr;
+
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
-    use super::ConnectionFailReason;
+    use super::{ConnectionFailReason, TcpAcceptFailed, TlsConnectionFailed};
 
-    /// The `reason` label values are the metric's contract: each variant
-    /// renders to the exact snake_case string the fail counter has always
-    /// reported. The failure path is never exercised by the metrics
-    /// integration test, so this is what locks those bytes.
+    const FAILURE_METRIC: &str = "carbide_api_tls_connection_fail_total";
+
+    struct FailureInput {
+        reason: &'static str,
+        emit: fn(),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FailureObservation {
+        counter_delta: f64,
+        logs: Vec<FailureLog>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FailureLog {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        reason: Option<String>,
+        error: Option<String>,
+        peer_address: Option<String>,
+    }
+
+    fn emit_tcp_accept_failure() {
+        carbide_instrument::emit(TcpAcceptFailed {
+            reason: ConnectionFailReason::TcpConnectionFailure,
+            error: "accept failed".to_string(),
+        });
+    }
+
+    fn emit_tls_connection_failure() {
+        carbide_instrument::emit(TlsConnectionFailed {
+            reason: ConnectionFailReason::TlsConnectionFailure,
+            error: "handshake failed".to_string(),
+            peer_address: "192.0.2.10:443"
+                .parse::<SocketAddr>()
+                .expect("test peer address is valid"),
+        });
+    }
+
+    fn observe_failure(input: FailureInput) -> FailureObservation {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(input.emit)
+            .into_iter()
+            .map(|log| {
+                let event_name = log.field("event_name").map(str::to_owned);
+                let metric_name = log.field("metric_name").map(str::to_owned);
+                let reason = log.field("reason").map(str::to_owned);
+                let error = log.field("error").map(str::to_owned);
+                let peer_address = log.field("peer_address").map(str::to_owned);
+                FailureLog {
+                    level: log.level,
+                    metadata_name: log.metadata_name,
+                    message: log.message,
+                    event_name,
+                    metric_name,
+                    reason,
+                    error,
+                    peer_address,
+                }
+            })
+            .collect();
+
+        FailureObservation {
+            counter_delta: metrics.counter_delta(FAILURE_METRIC, &[("reason", input.reason)]),
+            logs,
+        }
+    }
+
+    fn expected_failure(
+        event_name: &str,
+        message: &str,
+        reason: &str,
+        error: &str,
+        peer_address: Option<&str>,
+    ) -> FailureObservation {
+        FailureObservation {
+            counter_delta: 1.0,
+            logs: vec![FailureLog {
+                level: tracing::Level::ERROR,
+                metadata_name: event_name.to_string(),
+                message: message.to_string(),
+                event_name: Some(event_name.to_string()),
+                metric_name: Some(FAILURE_METRIC.to_string()),
+                reason: Some(reason.to_string()),
+                error: Some(error.to_string()),
+                peer_address: peer_address.map(str::to_owned),
+            }],
+        }
+    }
+
+    /// Each accept or handshake failure writes one ERROR record and increments
+    /// exactly one existing `reason` series.
     #[test]
-    fn connection_fail_reason_renders_expected_label_values() {
+    fn connection_failures_emit_their_metric_and_historical_log() {
         check_values(
             [
                 Check {
                     scenario: "tcp accept failure",
-                    input: ConnectionFailReason::TcpConnectionFailure,
-                    expect: "tcp_connection_failure".to_string(),
+                    input: FailureInput {
+                        reason: "tcp_connection_failure",
+                        emit: emit_tcp_accept_failure,
+                    },
+                    expect: expected_failure(
+                        "api_tcp_accept_failed",
+                        "Error accepting connection",
+                        "tcp_connection_failure",
+                        "accept failed",
+                        None,
+                    ),
                 },
                 Check {
                     scenario: "tls handshake failure",
-                    input: ConnectionFailReason::TlsConnectionFailure,
-                    expect: "tls_connection_failure".to_string(),
+                    input: FailureInput {
+                        reason: "tls_connection_failure",
+                        emit: emit_tls_connection_failure,
+                    },
+                    expect: expected_failure(
+                        "api_tls_connection_failed",
+                        "error accepting tls connection",
+                        "tls_connection_failure",
+                        "handshake failed",
+                        Some("192.0.2.10:443"),
+                    ),
                 },
             ],
-            |reason| reason.label_value().to_string(),
+            observe_failure,
         );
     }
 }

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -17,7 +17,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::net::{AddrParseError, IpAddr, Ipv6Addr};
+use std::net::{AddrParseError, IpAddr, Ipv6Addr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -259,22 +259,66 @@ enum ConnectionFailReason {
     TlsConnectionFailure,
 }
 
-/// An inbound connection failed before it could be served -- the TCP accept
-/// errored, the TLS acceptor could not be reloaded, or the TLS handshake
-/// errored. Metric-only: the `tracing::error!` beside each emit remains the log;
-/// the `reason` label distinguishes which leg failed.
+/// `TcpAcceptFailed` records a listener error before a peer connection exists.
+/// It increments the existing `tcp_connection_failure` series while keeping
+/// the per-attempt error in log-only context.
+#[derive(Event)]
+#[event(
+    event_name = "bmc_proxy_tcp_accept_failed",
+    metric_name = "carbide_bmc_proxy_tls_connection_fail_total",
+    component = "nico-bmc-proxy",
+    log = error,
+    metric = counter,
+    message = "Error accepting connection",
+    describe = "Number of failed inbound connections, by failure reason"
+)]
+struct TcpAcceptFailed {
+    #[label]
+    reason: ConnectionFailReason,
+    #[context]
+    error: String,
+}
+
+/// `TlsCertificateReloadFailed` records a failure to rebuild the acceptor from
+/// the on-disk TLS configuration. It shares the existing failure counter, but
+/// keeps the reload error out of metric labels.
+#[derive(Event)]
+#[event(
+    event_name = "bmc_proxy_tls_certificate_reload_failed",
+    metric_name = "carbide_bmc_proxy_tls_connection_fail_total",
+    component = "nico-bmc-proxy",
+    log = error,
+    metric = counter,
+    message = "Error reloading TLS certificate, will retry",
+    describe = "Number of failed inbound connections, by failure reason"
+)]
+struct TlsCertificateReloadFailed {
+    #[label]
+    reason: ConnectionFailReason,
+    #[context]
+    error: String,
+}
+
+/// `TlsConnectionFailed` records a handshake error after the listener knows
+/// the peer. It shares the failure counter with the accept and reload events,
+/// while `peer_address` and `error` remain diagnostic context.
 #[derive(Event)]
 #[event(
     event_name = "bmc_proxy_tls_connection_failed",
     metric_name = "carbide_bmc_proxy_tls_connection_fail_total",
     component = "nico-bmc-proxy",
-    log = off,
+    log = error,
     metric = counter,
+    message = "error accepting tls connection",
     describe = "Number of failed inbound connections, by failure reason"
 )]
 struct TlsConnectionFailed {
     #[label]
     reason: ConnectionFailReason,
+    #[context]
+    error: String,
+    #[context]
+    peer_address: SocketAddr,
 }
 
 struct BmcProxy {
@@ -296,9 +340,9 @@ impl BmcProxy {
             let (conn, addr) = match incoming_connection {
                 Ok(incoming) => incoming,
                 Err(e) => {
-                    tracing::error!(error = %e, "Error accepting connection");
-                    emit(TlsConnectionFailed {
+                    emit(TcpAcceptFailed {
                         reason: ConnectionFailReason::TcpConnectionFailure,
+                        error: e.to_string(),
                     });
                     continue;
                 }
@@ -311,12 +355,9 @@ impl BmcProxy {
                     match RefreshableTlsAcceptor::new(self.state.config.tls.clone()).await {
                         Ok(acceptor) => acceptor,
                         Err(e) => {
-                            tracing::error!(
-                                error = %e,
-                                "Error reloading TLS certificate, will retry",
-                            );
-                            emit(TlsConnectionFailed {
+                            emit(TlsCertificateReloadFailed {
                                 reason: ConnectionFailReason::TlsCertificateInvalid,
+                                error: e.to_string(),
                             });
                             continue;
                         }
@@ -365,13 +406,10 @@ impl BmcProxy {
                             }
                         }
                         Err(error) => {
-                            tracing::error!(
-                                %error,
-                                peer_address = %addr,
-                                "error accepting tls connection"
-                            );
                             emit(TlsConnectionFailed {
                                 reason: ConnectionFailReason::TlsConnectionFailure,
+                                error: error.to_string(),
+                                peer_address: addr,
                             });
                         }
                     }
@@ -1073,7 +1111,7 @@ mod tests {
     use std::borrow::Cow;
     use std::collections::HashMap;
     use std::convert::Infallible;
-    use std::net::{IpAddr, Ipv4Addr};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -1081,8 +1119,11 @@ mod tests {
     use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
     use bytes::Bytes;
     use carbide_authn::middleware::{AuthContext, ExternalUserInfo, Principal};
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::Outcome::{Fails, Yields};
-    use carbide_test_support::{Case, check_cases_async, scenarios, value_scenarios};
+    use carbide_test_support::{
+        Case, Check, check_cases_async, check_values, scenarios, value_scenarios,
+    };
     use carbide_utils::HostPortPair;
     use http_body_util::BodyExt;
     use mac_address::MacAddress;
@@ -1094,7 +1135,8 @@ mod tests {
     use tokio_stream::iter;
 
     use super::{
-        BmcCredentials, BmcProxyState, CredentialCache, ForwardedTarget, build_authority,
+        BmcCredentials, BmcProxyState, ConnectionFailReason, CredentialCache, ForwardedTarget,
+        TcpAcceptFailed, TlsCertificateReloadFailed, TlsConnectionFailed, build_authority,
         build_response, copy_request_headers, create_client, evict_cached_credentials,
         forwarded_header_value, get_http_client, ip_for_forwarded_target, is_hop_by_hop_header,
         method_supports_body, parse_forwarded_host_value, request_principal_ids,
@@ -1933,36 +1975,156 @@ mod tests {
         assert_eq!(body, Bytes::from_static(br#"{"value":"ok"}"#));
     }
 
-    /// The `reason` label values are the metric's contract: each variant
-    /// renders to the exact snake_case string the fail counter has always
-    /// reported. The failure path is not exercised by the metrics endpoint
-    /// tests, so this is what locks those bytes.
+    const TLS_FAILURE_METRIC: &str = "carbide_bmc_proxy_tls_connection_fail_total";
+
+    struct TlsFailureInput {
+        reason: &'static str,
+        emit: fn(),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TlsFailureObservation {
+        counter_delta: f64,
+        logs: Vec<TlsFailureLog>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TlsFailureLog {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        reason: Option<String>,
+        error: Option<String>,
+        peer_address: Option<String>,
+    }
+
+    fn emit_tcp_accept_failure() {
+        carbide_instrument::emit(TcpAcceptFailed {
+            reason: ConnectionFailReason::TcpConnectionFailure,
+            error: "accept failed".to_string(),
+        });
+    }
+
+    fn emit_tls_certificate_reload_failure() {
+        carbide_instrument::emit(TlsCertificateReloadFailed {
+            reason: ConnectionFailReason::TlsCertificateInvalid,
+            error: "certificate reload failed".to_string(),
+        });
+    }
+
+    fn emit_tls_connection_failure() {
+        carbide_instrument::emit(TlsConnectionFailed {
+            reason: ConnectionFailReason::TlsConnectionFailure,
+            error: "handshake failed".to_string(),
+            peer_address: "192.0.2.20:443"
+                .parse::<SocketAddr>()
+                .expect("test peer address is valid"),
+        });
+    }
+
+    fn observe_tls_failure(input: TlsFailureInput) -> TlsFailureObservation {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(input.emit)
+            .into_iter()
+            .map(|log| {
+                let event_name = log.field("event_name").map(str::to_owned);
+                let metric_name = log.field("metric_name").map(str::to_owned);
+                let reason = log.field("reason").map(str::to_owned);
+                let error = log.field("error").map(str::to_owned);
+                let peer_address = log.field("peer_address").map(str::to_owned);
+                TlsFailureLog {
+                    level: log.level,
+                    metadata_name: log.metadata_name,
+                    message: log.message,
+                    event_name,
+                    metric_name,
+                    reason,
+                    error,
+                    peer_address,
+                }
+            })
+            .collect();
+
+        TlsFailureObservation {
+            counter_delta: metrics.counter_delta(TLS_FAILURE_METRIC, &[("reason", input.reason)]),
+            logs,
+        }
+    }
+
+    fn expected_tls_failure(
+        event_name: &str,
+        message: &str,
+        reason: &str,
+        error: &str,
+        peer_address: Option<&str>,
+    ) -> TlsFailureObservation {
+        TlsFailureObservation {
+            counter_delta: 1.0,
+            logs: vec![TlsFailureLog {
+                level: tracing::Level::ERROR,
+                metadata_name: event_name.to_string(),
+                message: message.to_string(),
+                event_name: Some(event_name.to_string()),
+                metric_name: Some(TLS_FAILURE_METRIC.to_string()),
+                reason: Some(reason.to_string()),
+                error: Some(error.to_string()),
+                peer_address: peer_address.map(str::to_owned),
+            }],
+        }
+    }
+
+    /// Each accept, certificate reload, or handshake failure writes one ERROR
+    /// record and increments exactly one existing `reason` series.
     #[test]
-    fn connection_fail_reason_renders_expected_label_values() {
-        use carbide_instrument::LabelValue;
-        use carbide_test_support::{Check, check_values};
-
-        use super::ConnectionFailReason;
-
+    fn tls_connection_failures_emit_their_metric_and_historical_log() {
         check_values(
             [
                 Check {
                     scenario: "tcp accept failure",
-                    input: ConnectionFailReason::TcpConnectionFailure,
-                    expect: "tcp_connection_failure".to_string(),
+                    input: TlsFailureInput {
+                        reason: "tcp_connection_failure",
+                        emit: emit_tcp_accept_failure,
+                    },
+                    expect: expected_tls_failure(
+                        "bmc_proxy_tcp_accept_failed",
+                        "Error accepting connection",
+                        "tcp_connection_failure",
+                        "accept failed",
+                        None,
+                    ),
                 },
                 Check {
                     scenario: "tls certificate reload failure",
-                    input: ConnectionFailReason::TlsCertificateInvalid,
-                    expect: "tls_certificate_invalid".to_string(),
+                    input: TlsFailureInput {
+                        reason: "tls_certificate_invalid",
+                        emit: emit_tls_certificate_reload_failure,
+                    },
+                    expect: expected_tls_failure(
+                        "bmc_proxy_tls_certificate_reload_failed",
+                        "Error reloading TLS certificate, will retry",
+                        "tls_certificate_invalid",
+                        "certificate reload failed",
+                        None,
+                    ),
                 },
                 Check {
                     scenario: "tls handshake failure",
-                    input: ConnectionFailReason::TlsConnectionFailure,
-                    expect: "tls_connection_failure".to_string(),
+                    input: TlsFailureInput {
+                        reason: "tls_connection_failure",
+                        emit: emit_tls_connection_failure,
+                    },
+                    expect: expected_tls_failure(
+                        "bmc_proxy_tls_connection_failed",
+                        "error accepting tls connection",
+                        "tls_connection_failure",
+                        "handshake failed",
+                        Some("192.0.2.20:443"),
+                    ),
                 },
             ],
-            |reason| reason.label_value().to_string(),
+            observe_tls_failure,
         );
     }
 }

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -688,205 +688,251 @@ mod tests {
         MultipartUnsupported,
     }
 
-    struct FirmwareUploadCase {
-        name: &'static str,
+    struct FirmwareUploadInput {
         kind: FirmwareUploadEventKind,
         method: FirmwareUploadMethod,
-        method_label: &'static str,
         outcome: Outcome,
-        outcome_label: &'static str,
         error: &'static str,
-        expected_log: Option<ExpectedFirmwareUploadLog>,
     }
 
-    struct ExpectedFirmwareUploadLog {
-        event_name: &'static str,
+    #[derive(Debug, PartialEq)]
+    struct FirmwareUploadObservation {
+        counter_delta: f64,
+        logs: Vec<FirmwareUploadLog>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FirmwareUploadLog {
         level: tracing::Level,
-        message: &'static str,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        method: Option<String>,
+        outcome: Option<String>,
+        bmc_ip_address: Option<String>,
+        error: Option<String>,
     }
 
-    /// Every method/outcome pair moves exactly its existing series. Successes
-    /// stay silent; each failure owns the historical route-specific line and
-    /// keeps the BMC and error as log-only context.
-    #[test]
-    fn firmware_upload_outcomes_emit_their_metric_and_historical_log() {
-        let cases = [
-            FirmwareUploadCase {
-                name: "SimpleUpdate success",
-                kind: FirmwareUploadEventKind::Finished,
-                method: FirmwareUploadMethod::SimpleUpdate,
-                method_label: "simple_update",
-                outcome: Outcome::Ok,
-                outcome_label: "ok",
-                error: "",
-                expected_log: None,
-            },
-            FirmwareUploadCase {
-                name: "SimpleUpdate failure",
-                kind: FirmwareUploadEventKind::Finished,
-                method: FirmwareUploadMethod::SimpleUpdate,
-                method_label: "simple_update",
-                outcome: Outcome::Error,
-                outcome_label: "error",
-                error: "simple update failed",
-                expected_log: Some(ExpectedFirmwareUploadLog {
-                    event_name: "preingestion_firmware_upload_finished",
-                    level: tracing::Level::ERROR,
-                    message: "Simple firmware update failed",
-                }),
-            },
-            FirmwareUploadCase {
-                name: "multipart success",
-                kind: FirmwareUploadEventKind::Finished,
-                method: FirmwareUploadMethod::Multipart,
-                method_label: "multipart",
-                outcome: Outcome::Ok,
-                outcome_label: "ok",
-                error: "",
-                expected_log: None,
-            },
-            FirmwareUploadCase {
-                name: "multipart failure",
-                kind: FirmwareUploadEventKind::Finished,
-                method: FirmwareUploadMethod::Multipart,
-                method_label: "multipart",
-                outcome: Outcome::Error,
-                outcome_label: "error",
-                error: "multipart upload failed",
-                expected_log: Some(ExpectedFirmwareUploadLog {
-                    event_name: "preingestion_firmware_upload_finished",
-                    level: tracing::Level::WARN,
-                    message: "Failed to upload firmware via multipart update",
-                }),
-            },
-            FirmwareUploadCase {
-                name: "multipart unsupported",
-                kind: FirmwareUploadEventKind::MultipartUnsupported,
-                method: FirmwareUploadMethod::Multipart,
-                method_label: "multipart",
-                outcome: Outcome::Error,
-                outcome_label: "error",
-                error: "multipart is unsupported",
-                expected_log: Some(ExpectedFirmwareUploadLog {
-                    event_name: "preingestion_firmware_upload_multipart_unsupported",
-                    level: tracing::Level::WARN,
-                    message: "Multipart firmware update is not supported; trying HttpPushUri",
-                }),
-            },
-            FirmwareUploadCase {
-                name: "HttpPush success",
-                kind: FirmwareUploadEventKind::Finished,
-                method: FirmwareUploadMethod::HttpPush,
-                method_label: "http_push",
-                outcome: Outcome::Ok,
-                outcome_label: "ok",
-                error: "",
-                expected_log: None,
-            },
-            FirmwareUploadCase {
-                name: "HttpPush failure",
-                kind: FirmwareUploadEventKind::Finished,
-                method: FirmwareUploadMethod::HttpPush,
-                method_label: "http_push",
-                outcome: Outcome::Error,
-                outcome_label: "error",
-                error: "HTTP push failed",
-                expected_log: Some(ExpectedFirmwareUploadLog {
-                    event_name: "preingestion_firmware_upload_finished",
-                    level: tracing::Level::ERROR,
-                    message: "Failed to upload firmware via HttpPushUri",
-                }),
-            },
-        ];
-
-        for case in cases {
-            let metrics = MetricsCapture::start();
-            let bmc_ip_address = IpAddr::from([10, 0, 0, 5]);
-            let logs = capture_logs(|| match case.kind {
-                FirmwareUploadEventKind::Finished => emit(FirmwareUploadFinished {
-                    method: case.method,
-                    outcome: case.outcome,
+    fn observe_firmware_upload(input: FirmwareUploadInput) -> FirmwareUploadObservation {
+        let metrics = MetricsCapture::start();
+        let bmc_ip_address = IpAddr::from([10, 0, 0, 5]);
+        let method_label = input.method.label_value();
+        let outcome_label = input.outcome.label_value();
+        let logs = capture_logs(|| match input.kind {
+            FirmwareUploadEventKind::Finished => emit(FirmwareUploadFinished {
+                method: input.method,
+                outcome: input.outcome,
+                bmc_ip_address,
+                error: input.error.to_string(),
+            }),
+            FirmwareUploadEventKind::MultipartUnsupported => {
+                emit(MultipartFirmwareUploadUnsupported {
+                    method: input.method,
+                    outcome: input.outcome,
                     bmc_ip_address,
-                    error: case.error.to_string(),
-                }),
-                FirmwareUploadEventKind::MultipartUnsupported => {
-                    emit(MultipartFirmwareUploadUnsupported {
-                        method: case.method,
-                        outcome: case.outcome,
-                        bmc_ip_address,
-                        error: case.error.to_string(),
-                    });
-                }
-            });
-
-            assert_eq!(
-                metrics.counter_delta(
-                    "carbide_preingestion_firmware_upload_total",
-                    &[
-                        ("method", case.method_label),
-                        ("outcome", case.outcome_label),
-                    ],
-                ),
-                1.0,
-                "{}",
-                case.name,
-            );
-
-            match case.expected_log {
-                None => assert!(
-                    logs.is_empty(),
-                    "{}: success must remain metric-only: {logs:?}",
-                    case.name,
-                ),
-                Some(expected) => {
-                    assert_eq!(
-                        logs.len(),
-                        1,
-                        "{}: expected one failure line: {logs:?}",
-                        case.name,
-                    );
-                    let log = &logs[0];
-                    assert_eq!(log.level, expected.level, "{}", case.name);
-                    assert_eq!(log.metadata_name, expected.event_name, "{}", case.name);
-                    assert_eq!(log.message, expected.message, "{}", case.name);
-                    assert_eq!(
-                        log.field("event_name"),
-                        Some(expected.event_name),
-                        "{}",
-                        case.name,
-                    );
-                    assert_eq!(
-                        log.field("metric_name"),
-                        Some("carbide_preingestion_firmware_upload_total"),
-                        "{}",
-                        case.name,
-                    );
-                    assert_eq!(
-                        log.field("method"),
-                        Some(case.method_label),
-                        "{}",
-                        case.name,
-                    );
-                    assert_eq!(
-                        log.field("outcome"),
-                        Some(case.outcome_label),
-                        "{}",
-                        case.name,
-                    );
-                    assert_eq!(
-                        log.field("bmc_ip_address"),
-                        Some("10.0.0.5"),
-                        "{}",
-                        case.name,
-                    );
-                    assert_eq!(log.field("error"), Some(case.error), "{}", case.name);
-                }
+                    error: input.error.to_string(),
+                });
             }
+        })
+        .into_iter()
+        .map(|log| {
+            let event_name = log.field("event_name").map(str::to_owned);
+            let metric_name = log.field("metric_name").map(str::to_owned);
+            let method = log.field("method").map(str::to_owned);
+            let outcome = log.field("outcome").map(str::to_owned);
+            let bmc_ip_address = log.field("bmc_ip_address").map(str::to_owned);
+            let error = log.field("error").map(str::to_owned);
+            FirmwareUploadLog {
+                level: log.level,
+                metadata_name: log.metadata_name,
+                message: log.message,
+                event_name,
+                metric_name,
+                method,
+                outcome,
+                bmc_ip_address,
+                error,
+            }
+        })
+        .collect();
+
+        FirmwareUploadObservation {
+            counter_delta: metrics.counter_delta(
+                "carbide_preingestion_firmware_upload_total",
+                &[
+                    ("method", method_label.as_str()),
+                    ("outcome", outcome_label.as_str()),
+                ],
+            ),
+            logs,
         }
     }
 
-    /// Unsupported multipart still counts as its own error before the
-    /// HttpPush fallback records a second, independently successful attempt.
+    fn expected_firmware_upload(
+        method: FirmwareUploadMethod,
+        outcome: Outcome,
+        error: &str,
+        log: Option<(tracing::Level, &str, &str)>,
+    ) -> FirmwareUploadObservation {
+        let method = method.label_value();
+        let outcome = outcome.label_value();
+        let logs = log
+            .map(|(level, event_name, message)| FirmwareUploadLog {
+                level,
+                metadata_name: event_name.to_string(),
+                message: message.to_string(),
+                event_name: Some(event_name.to_string()),
+                metric_name: Some("carbide_preingestion_firmware_upload_total".to_string()),
+                method: Some(method.as_str().to_string()),
+                outcome: Some(outcome.as_str().to_string()),
+                bmc_ip_address: Some("10.0.0.5".to_string()),
+                error: Some(error.to_string()),
+            })
+            .into_iter()
+            .collect();
+
+        FirmwareUploadObservation {
+            counter_delta: 1.0,
+            logs,
+        }
+    }
+
+    /// Each upload attempt increments its existing `method`/`outcome` series.
+    /// Successes stay silent; failures also write the route-specific record
+    /// with `bmc_ip_address` and `error` as diagnostic context.
+    #[test]
+    fn firmware_upload_outcomes_emit_their_metric_and_historical_log() {
+        check_values(
+            [
+                Check {
+                    scenario: "SimpleUpdate success",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::Finished,
+                        method: FirmwareUploadMethod::SimpleUpdate,
+                        outcome: Outcome::Ok,
+                        error: "",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::SimpleUpdate,
+                        Outcome::Ok,
+                        "",
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "SimpleUpdate failure",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::Finished,
+                        method: FirmwareUploadMethod::SimpleUpdate,
+                        outcome: Outcome::Error,
+                        error: "simple update failed",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::SimpleUpdate,
+                        Outcome::Error,
+                        "simple update failed",
+                        Some((
+                            tracing::Level::ERROR,
+                            "preingestion_firmware_upload_finished",
+                            "Simple firmware update failed",
+                        )),
+                    ),
+                },
+                Check {
+                    scenario: "multipart success",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::Finished,
+                        method: FirmwareUploadMethod::Multipart,
+                        outcome: Outcome::Ok,
+                        error: "",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::Multipart,
+                        Outcome::Ok,
+                        "",
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "multipart failure",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::Finished,
+                        method: FirmwareUploadMethod::Multipart,
+                        outcome: Outcome::Error,
+                        error: "multipart upload failed",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::Multipart,
+                        Outcome::Error,
+                        "multipart upload failed",
+                        Some((
+                            tracing::Level::WARN,
+                            "preingestion_firmware_upload_finished",
+                            "Failed to upload firmware via multipart update",
+                        )),
+                    ),
+                },
+                Check {
+                    scenario: "multipart unsupported",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::MultipartUnsupported,
+                        method: FirmwareUploadMethod::Multipart,
+                        outcome: Outcome::Error,
+                        error: "multipart is unsupported",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::Multipart,
+                        Outcome::Error,
+                        "multipart is unsupported",
+                        Some((
+                            tracing::Level::WARN,
+                            "preingestion_firmware_upload_multipart_unsupported",
+                            "Multipart firmware update is not supported; trying HttpPushUri",
+                        )),
+                    ),
+                },
+                Check {
+                    scenario: "HttpPush success",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::Finished,
+                        method: FirmwareUploadMethod::HttpPush,
+                        outcome: Outcome::Ok,
+                        error: "",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::HttpPush,
+                        Outcome::Ok,
+                        "",
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "HttpPush failure",
+                    input: FirmwareUploadInput {
+                        kind: FirmwareUploadEventKind::Finished,
+                        method: FirmwareUploadMethod::HttpPush,
+                        outcome: Outcome::Error,
+                        error: "HTTP push failed",
+                    },
+                    expect: expected_firmware_upload(
+                        FirmwareUploadMethod::HttpPush,
+                        Outcome::Error,
+                        "HTTP push failed",
+                        Some((
+                            tracing::Level::ERROR,
+                            "preingestion_firmware_upload_finished",
+                            "Failed to upload firmware via HttpPushUri",
+                        )),
+                    ),
+                },
+            ],
+            observe_firmware_upload,
+        );
+    }
+
+    /// An unsupported multipart attempt counts as its own error before the
+    /// `HttpPush` fallback records a second, independent attempt.
     #[test]
     fn unsupported_multipart_preserves_the_http_push_fallback_sequence() {
         let metrics = MetricsCapture::start();
@@ -922,8 +968,9 @@ mod tests {
         );
     }
 
-    /// Successes are counted silently; a failure owns the WARN line with the
-    /// endpoint and the task's message as context.
+    /// `FirmwareUpgradeTaskFinished` counts every terminal task state.
+    /// Successes stay silent; failures also write the WARN record with
+    /// `address` and `error` as diagnostic context.
     #[test]
     fn firmware_upgrade_task_failures_own_the_warn_line() {
         let metrics = MetricsCapture::start();


### PR DESCRIPTION
The API and BMC proxy TLS listeners incremented their existing failure counters separately from the ERROR records that explained those failures.

Typed sibling `Event`s now pair TCP accept, certificate reload, and handshake failures with their historical records. Counter names, reason labels, messages, peer addresses, and error context remain unchanged; connection attempts and successes stay metric-only rather than adding new log volume.

The branch also moves the merged #3743 firmware-upload outcome cases into a table-driven test. Production behavior in that area is unchanged.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3728
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The API and BMC proxy failure matrices use `check_values` to verify that every reason produces one counter increment and one historical ERROR record. Since #3743 merged while this branch was open, it also converts that PR's seven firmware-upload outcome cases to `check_values`; the multipart fallback remains explicit because the ordered pair of attempts is the behavior under test.

Verified with:

- the focused `carbide-api-core` TLS failure `Event` test
- the focused `carbide-bmc-proxy` TLS failure `Event` test
- the focused `carbide-preingestion-manager` firmware-upload outcome test
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

The firmware-upload changes are test-only; production behavior in that area remains the version merged through #3743.


Closes #3728
