### PR TITLE
refactor(dsx): emit queue drops, deduplications, and leak alerts

### DIFF
--- a/crates/dsx-exchange-consumer/src/health_updater.rs
+++ b/crates/dsx-exchange-consumer/src/health_updater.rs
@@ -26,12 +26,11 @@ use moka::ops::compute::Op;
 use opentelemetry::metrics::Meter;
 use tokio::sync::mpsc;
 
-use crate::ConsumerMetrics;
 use crate::api_client::{HEALTH_REPORT_SOURCE, RackHealthReportSink};
 use crate::config::CacheConfig;
 use crate::messages::{FaultValue, LeakMetadata, LeakPointType, ValueMessage};
 use crate::metrics::{
-    HealthReportPersistFailed, MessageAge, MessageDeduplicated, MessageProcessed,
+    HealthReportPersistFailed, LeakAlertDetected, MessageAge, MessageDeduplicated, MessageProcessed,
 };
 use crate::mqtt_consumer::MqttMessage;
 
@@ -39,19 +38,12 @@ use crate::mqtt_consumer::MqttMessage;
 pub struct HealthUpdater<S: RackHealthReportSink> {
     topic_prefix: String,
     api: Arc<S>,
-    metrics: ConsumerMetrics,
     metadata_cache: Cache<String, LeakMetadata>,
     value_state_cache: Cache<String, FaultValue>,
 }
 
 impl<S: RackHealthReportSink> HealthUpdater<S> {
-    pub fn new(
-        topic_prefix: String,
-        cache_config: CacheConfig,
-        api: Arc<S>,
-        metrics: ConsumerMetrics,
-        meter: Meter,
-    ) -> Self {
+    pub fn new(topic_prefix: String, cache_config: CacheConfig, api: Arc<S>, meter: Meter) -> Self {
         let metadata_cache: Cache<String, LeakMetadata> = Cache::builder()
             .time_to_live(cache_config.metadata_ttl)
             .build();
@@ -66,7 +58,6 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
         Self {
             topic_prefix,
             api,
-            metrics,
             metadata_cache,
             value_state_cache,
         }
@@ -157,7 +148,6 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
 
         let value = msg.value;
         let api = self.api.clone();
-        let metrics = self.metrics.clone();
 
         // Use and_try_compute_with for atomic check-and-update with serialized access.
         // Concurrent calls on the same key are executed serially.
@@ -167,33 +157,28 @@ impl<S: RackHealthReportSink> HealthUpdater<S> {
             .and_try_compute_with(|maybe_entry| {
                 let metadata = metadata.clone();
                 let api = api.clone();
-                let metrics = metrics.clone();
                 async move {
                     // Check for deduplication
                     if let Some(entry) = &maybe_entry
                         && *entry.value() == value
                     {
-                        emit(MessageDeduplicated);
-                        tracing::trace!(
-                            point_path = %point_path,
-                            point_type = %metadata.point_type,
-                            value = ?value,
-                            "Deduplicating unchanged value"
-                        );
+                        emit(MessageDeduplicated {
+                            point_path: point_path.to_string(),
+                            point_type: leak_type,
+                            value: format!("{value:?}"),
+                        });
                         return Ok(Op::Nop);
                     }
 
                     // Value differs or no entry - send API update
                     let send_result = if matches!(value, FaultValue::Faulting) {
-                        metrics.record_alert_detected(&metadata.point_type);
-                        tracing::info!(
-                            point_path = %point_path,
-                            rack_id = %metadata.rack_id,
-                            rack_name = %metadata.rack_name,
-                            point_type = %metadata.point_type,
-                            value = ?value,
-                            "Leak alert detected, inserting health override"
-                        );
+                        emit(LeakAlertDetected {
+                            point_type: leak_type,
+                            point_path: point_path.to_string(),
+                            rack_id: metadata.rack_id.clone(),
+                            rack_name: metadata.rack_name.clone(),
+                            value: format!("{value:?}"),
+                        });
 
                         let report = build_leak_alert_report(&metadata, leak_type);
                         api.insert_rack_health_report(&metadata.rack_id, report)
@@ -298,10 +283,6 @@ mod tests {
             metadata_ttl: Duration::from_secs(3600),
             value_state_ttl: Duration::from_secs(3600),
         }
-    }
-
-    fn test_metrics() -> ConsumerMetrics {
-        ConsumerMetrics::new(&test_meter())
     }
 
     fn test_metadata(point_type: &str, rack_id: &str) -> LeakMetadata {
@@ -458,7 +439,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -490,7 +470,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -521,7 +500,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -543,7 +521,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -569,7 +546,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -601,7 +577,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -642,7 +617,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             Arc::new(FailingSink),
-            test_metrics(),
             test_meter(),
         );
 
@@ -677,7 +651,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 
@@ -727,7 +700,6 @@ mod tests {
             TEST_PREFIX.to_string(),
             test_cache_config(),
             sink.clone(),
-            test_metrics(),
             test_meter(),
         );
 

--- a/crates/dsx-exchange-consumer/src/lib.rs
+++ b/crates/dsx-exchange-consumer/src/lib.rs
@@ -30,7 +30,6 @@ pub mod metrics;
 pub mod mqtt_consumer;
 
 pub use config::Config;
-pub use metrics::ConsumerMetrics;
 
 use crate::api_client::{ApiClientWrapper, ConsoleRackHealthSink};
 use crate::health_updater::HealthUpdater;
@@ -75,9 +74,6 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
     let join_listener =
         tokio::spawn(async move { metrics_endpoint::run_metrics_endpoint(&metrics_config).await });
 
-    // Create consumer metrics
-    let consumer_metrics = ConsumerMetrics::new(&meter);
-
     let credential_manager = carbide_secrets::create_credential_manager(
         &carbide_secrets::CredentialConfig::default(),
         meter.clone(),
@@ -104,24 +100,14 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
             api_config.client_key,
             &api_config.api_url,
         ));
-        let health_updater = HealthUpdater::new(
-            config.mqtt.topic_prefix,
-            config.cache,
-            api_client,
-            consumer_metrics,
-            meter,
-        );
+        let health_updater =
+            HealthUpdater::new(config.mqtt.topic_prefix, config.cache, api_client, meter);
         tokio::spawn(async move { health_updater.run(rx).await })
     } else {
         tracing::warn!("Carbide API disabled, using console sink");
         let api_client = Arc::new(ConsoleRackHealthSink);
-        let health_updater = HealthUpdater::new(
-            config.mqtt.topic_prefix,
-            config.cache,
-            api_client,
-            consumer_metrics,
-            meter,
-        );
+        let health_updater =
+            HealthUpdater::new(config.mqtt.topic_prefix, config.cache, api_client, meter);
         tokio::spawn(async move { health_updater.run(rx).await })
     };
 

--- a/crates/dsx-exchange-consumer/src/metrics.rs
+++ b/crates/dsx-exchange-consumer/src/metrics.rs
@@ -19,11 +19,13 @@
 
 use std::hash::Hash;
 
-use carbide_instrument::Event;
+use carbide_instrument::{Event, LabelValue};
 use moka::future::Cache;
-use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Meter};
+use opentelemetry::StringValue;
+use opentelemetry::metrics::Meter;
 use tokio::sync::mpsc;
+
+use crate::messages::LeakPointType;
 
 pub static METRICS_PREFIX: &str = "carbide_dsx_exchange_consumer";
 
@@ -94,10 +96,11 @@ where
     // The moved-in strong sender drops here, leaving only `weak_tx`.
 }
 
-// The four message counters are `carbide-instrument` events. Each declares a
-// name ending in a single `_total`: the framework strips one `_total` before
-// registering the instrument and the OpenTelemetry Prometheus exporter appends
-// its own `_total`, so `/metrics` exposes the name exactly as declared here.
+// The message counters are `carbide-instrument` events. Each declares a name
+// ending in a single `_total`: the framework strips one `_total` before
+// registering the instrument and the OpenTelemetry Prometheus exporter
+// appends its own `_total`, so `/metrics` exposes the name exactly as declared
+// here.
 
 /// An MQTT message reached a subscription handler, before any queueing.
 #[derive(Event)]
@@ -125,35 +128,119 @@ pub struct MessageReceived;
 pub struct MessageProcessed;
 
 /// The bounded internal queue was full, so an incoming message was dropped.
-///
-/// Metric-only: the `tracing::warn!` at each drop site is unchanged, so this
-/// event only moves the counter beside it.
 #[derive(Event)]
 #[event(
     event_name = "dsx_exchange_message_dropped",
     metric_name = "carbide_dsx_exchange_consumer_messages_dropped_total",
     component = "nico-dsx-exchange-consumer",
-    log = off,
+    log = warn,
     metric = counter,
+    message = dynamic,
     describe = "Number of messages dropped due to queue overflow"
 )]
-pub struct MessageDropped;
+pub struct MessageDropped {
+    /// `message_type` identifies which bounded MQTT subscription handler
+    /// rejected the message. It stays log-only so
+    /// `carbide_dsx_exchange_consumer_messages_dropped_total` remains a
+    /// zero-label metric.
+    #[context]
+    pub message_type: DroppedMessageType,
+}
+
+/// `DroppedMessageType` identifies which MQTT payload could not enter the
+/// bounded consumer queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DroppedMessageType {
+    Metadata,
+    Value,
+}
+
+impl std::fmt::Display for DroppedMessageType {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            DroppedMessageType::Metadata => "metadata",
+            DroppedMessageType::Value => "value",
+        })
+    }
+}
+
+impl carbide_instrument::DynamicMessage for MessageDropped {
+    fn message(&self) -> &'static str {
+        match self.message_type {
+            DroppedMessageType::Metadata => "Message queue full, dropping metadata message",
+            DroppedMessageType::Value => "Message queue full, dropping value message",
+        }
+    }
+}
 
 /// A value matched the state already cached for its point, so no API update
 /// was sent.
-///
-/// Metric-only: the `tracing::trace!` at the dedup site is unchanged, so this
-/// event only moves the counter beside it.
 #[derive(Event)]
 #[event(
     event_name = "dsx_exchange_message_deduplicated",
     metric_name = "carbide_dsx_exchange_consumer_dedup_skipped_total",
     component = "nico-dsx-exchange-consumer",
-    log = off,
+    log = trace,
     metric = counter,
+    message = "Deduplicating unchanged value",
     describe = "Number of messages skipped due to deduplication"
 )]
-pub struct MessageDeduplicated;
+pub struct MessageDeduplicated {
+    #[context]
+    pub point_path: String,
+    #[context]
+    pub point_type: LeakPointType,
+    #[context]
+    pub value: String,
+}
+
+/// `LeakAlertDetected` records an active BMS leak or sensor fault immediately
+/// before the consumer inserts its rack health override.
+#[derive(Event)]
+#[event(
+    event_name = "dsx_exchange_leak_alert_detected",
+    metric_name = "carbide_dsx_exchange_consumer_alerts_detected_total",
+    component = "nico-dsx-exchange-consumer",
+    log = info,
+    metric = counter,
+    message = "Leak alert detected, inserting health override",
+    describe = "Number of leak alerts detected"
+)]
+pub struct LeakAlertDetected {
+    #[label]
+    pub point_type: LeakPointType,
+    #[context]
+    pub point_path: String,
+    #[context]
+    pub rack_id: String,
+    #[context]
+    pub rack_name: String,
+    #[context]
+    pub value: String,
+}
+
+/// `leak_point_type_name` preserves the BMS's canonical CamelCase spelling for
+/// the public `point_type` metric label. `LeakPointType` is closed, but deriving
+/// `LabelValue` would render these variants as snake_case.
+fn leak_point_type_name(point_type: &LeakPointType) -> &'static str {
+    match point_type {
+        LeakPointType::LeakDetectRack => "LeakDetectRack",
+        LeakPointType::LeakSensorFaultRack => "LeakSensorFaultRack",
+        LeakPointType::LeakDetectRackTray => "LeakDetectRackTray",
+    }
+}
+
+impl std::fmt::Display for LeakPointType {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(leak_point_type_name(self))
+    }
+}
+
+impl LabelValue for LeakPointType {
+    fn label_value(&self) -> StringValue {
+        StringValue::from(leak_point_type_name(self))
+    }
+}
 
 /// How far behind the BMS event time we are when a value message reaches
 /// processing: end-to-end consumer lag (MQTT transit plus time spent queued).
@@ -200,37 +287,4 @@ pub struct HealthReportPersistFailed {
     /// The API error that prevented the persist.
     #[context]
     pub error: String,
-}
-
-/// Consumer metrics that remain hand-rolled OpenTelemetry counters.
-///
-/// Only `alerts_detected` stays here: its `point_type` label is a
-/// caller-supplied string that needs a bounded mapping before it can become a
-/// framework event, which is tracked separately. The message counters are the
-/// `carbide-instrument` events above.
-///
-/// Cloning is cheap and correct: OpenTelemetry counters are internally Arc'd,
-/// so clones share the same underlying metric instances.
-#[derive(Clone)]
-pub struct ConsumerMetrics {
-    alerts_detected: Counter<u64>,
-}
-
-impl ConsumerMetrics {
-    pub fn new(meter: &Meter) -> Self {
-        Self {
-            // The Prometheus exporter appends `_total`, so the registered name
-            // omits it; that yields the single-`_total` exposed name, matching
-            // the framework counters above (not a doubled `_total_total`).
-            alerts_detected: meter
-                .u64_counter(format!("{METRICS_PREFIX}_alerts_detected"))
-                .with_description("Number of leak alerts detected")
-                .build(),
-        }
-    }
-
-    pub fn record_alert_detected(&self, point_type: &str) {
-        self.alerts_detected
-            .add(1, &[KeyValue::new("point_type", point_type.to_string())]);
-    }
 }

--- a/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
+++ b/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
@@ -29,7 +29,7 @@ use tokio::sync::mpsc;
 use crate::DsxConsumerError;
 use crate::config::{MqttAuthMode, MqttConfig};
 use crate::messages::{LeakMetadata, ValueMessage};
-use crate::metrics::{MessageDropped, MessageReceived};
+use crate::metrics::{DroppedMessageType, MessageDropped, MessageReceived};
 
 /// Message types received from MQTT.
 #[derive(Debug, Clone)]
@@ -100,8 +100,9 @@ pub async fn connect(
                 emit(MessageReceived);
                 let msg = MqttMessage::Metadata { topic, metadata };
                 if tx.try_send(msg).is_err() {
-                    emit(MessageDropped);
-                    tracing::warn!("Message queue full, dropping metadata message");
+                    emit(MessageDropped {
+                        message_type: DroppedMessageType::Metadata,
+                    });
                 }
                 std::future::ready(())
             }
@@ -116,8 +117,9 @@ pub async fn connect(
                 emit(MessageReceived);
                 let msg = MqttMessage::Value { topic, value };
                 if tx.try_send(msg).is_err() {
-                    emit(MessageDropped);
-                    tracing::warn!("Message queue full, dropping value message");
+                    emit(MessageDropped {
+                        message_type: DroppedMessageType::Value,
+                    });
                 }
                 std::future::ready(())
             }

--- a/crates/dsx-exchange-consumer/tests/dedup_trace.rs
+++ b/crates/dsx-exchange-consumer/tests/dedup_trace.rs
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-//! Proves the reshape left the dedup site's log line byte-identical: converting
-//! the counter to a metric-only event kept the `tracing::trace!` beside it, so
-//! the dedup branch still emits exactly one "Deduplicating unchanged value"
-//! line at TRACE with its original fields.
+//! Exercises the public message loop far enough to prove
+//! `MessageDeduplicated` writes one TRACE record with the point context
+//! operators use.
 //!
 //! Its own test binary on purpose: `tracing` caches callsite interest the first
 //! time a callsite is hit, so a `capture_logs` (thread-local) subscriber only
@@ -29,18 +28,18 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use carbide_dsx_exchange_consumer::DsxConsumerError;
 use carbide_dsx_exchange_consumer::api_client::RackHealthReportSink;
 use carbide_dsx_exchange_consumer::config::CacheConfig;
 use carbide_dsx_exchange_consumer::health_updater::HealthUpdater;
 use carbide_dsx_exchange_consumer::messages::{FaultValue, LeakMetadata, ValueMessage};
 use carbide_dsx_exchange_consumer::mqtt_consumer::MqttMessage;
-use carbide_dsx_exchange_consumer::{ConsumerMetrics, DsxConsumerError};
 use carbide_instrument::testing::capture_logs;
 use health_report::HealthReport;
 use tokio::sync::mpsc;
 
-/// Accepts every report so the first value caches and the identical second one
-/// takes the dedup branch.
+/// `OkSink` accepts every report so the first value enters the cache and an
+/// identical second value reaches the dedup branch.
 struct OkSink;
 
 #[async_trait]
@@ -81,7 +80,6 @@ fn dedup_site_keeps_its_trace_verbatim() {
                     value_state_ttl: Duration::from_secs(3600),
                 },
                 Arc::new(OkSink),
-                ConsumerMetrics::new(&meter),
                 meter.clone(),
             );
 
@@ -124,7 +122,8 @@ fn dedup_site_keeps_its_trace_verbatim() {
         .collect();
     assert_eq!(dedup.len(), 1, "expected one dedup trace; got {logs:?}");
     assert_eq!(dedup[0].level, tracing::Level::TRACE);
-    // The original trace's fields ride the line unchanged.
+    // `point_type`, `point_path`, and `value` identify the update that was
+    // skipped.
     assert!(
         dedup[0]
             .fields

--- a/crates/dsx-exchange-consumer/tests/metric_exposition.rs
+++ b/crates/dsx-exchange-consumer/tests/metric_exposition.rs
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-//! Pins the exposed names of the four message-counter events to their single
-//! `_total` form: the framework strips the declared name's `_total` before
-//! registering and the OTel Prometheus exporter appends exactly one, so
-//! `/metrics` shows one suffix, not the historical doubled `_total_total`.
+//! Exercises DSX message Events end to end: public metric names keep one
+//! `_total` suffix, and Events with logs retain their level, message, and
+//! diagnostic context.
 //!
 //! These tests live in their own binary (its own process-global registry) to
 //! keep the `counter_delta` measurements deterministic: the crate's other unit
@@ -26,71 +25,277 @@
 //! health-report persist failure below -- but from a different test process, so
 //! they cannot advance a shared counter between a test's baseline and delta.
 
+use carbide_dsx_exchange_consumer::messages::LeakPointType;
 use carbide_dsx_exchange_consumer::metrics::{
-    HealthReportPersistFailed, MessageDeduplicated, MessageDropped, MessageProcessed,
-    MessageReceived,
+    DroppedMessageType, HealthReportPersistFailed, LeakAlertDetected, MessageDeduplicated,
+    MessageDropped, MessageProcessed, MessageReceived,
 };
 use carbide_instrument::emit;
 use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+use carbide_test_support::{Check, check_values, value_scenarios};
 
-/// Emitting each event once moves exactly its counter, under the single
-/// `_total` name the OTel Prometheus exporter produces (the framework strips
-/// the declared name's `_total`, and the exporter appends exactly one). All
-/// four events are metric-only (`log = off`): the WARN at each drop site and
-/// the TRACE at the dedup site are plain `tracing` lines the reshape left
-/// untouched, so they stay at the call sites, not on the events (the dedup
-/// line is exercised in `health_updater.rs`).
+fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
+    log.fields
+        .iter()
+        .find(|(key, _)| key == name)
+        .map(|(_, value)| value.as_str())
+}
+
+#[derive(Debug, PartialEq)]
+struct LogObservation<'a> {
+    level: tracing::Level,
+    metadata_name: &'a str,
+    message: &'a str,
+    event_name: Option<&'a str>,
+    metric_name: Option<&'a str>,
+    message_type: Option<&'a str>,
+    point_path: Option<&'a str>,
+    point_type: Option<&'a str>,
+    rack_id: Option<&'a str>,
+    rack_name: Option<&'a str>,
+    value: Option<&'a str>,
+}
+
+fn observe_log(log: &CapturedLog) -> LogObservation<'_> {
+    LogObservation {
+        level: log.level,
+        metadata_name: &log.metadata_name,
+        message: &log.message,
+        event_name: field(log, "event_name"),
+        metric_name: field(log, "metric_name"),
+        message_type: field(log, "message_type"),
+        point_path: field(log, "point_path"),
+        point_type: field(log, "point_type"),
+        rack_id: field(log, "rack_id"),
+        rack_name: field(log, "rack_name"),
+        value: field(log, "value"),
+    }
+}
+
+fn expected_drop(message_type: &'static str, message: &'static str) -> LogObservation<'static> {
+    LogObservation {
+        level: tracing::Level::WARN,
+        metadata_name: "dsx_exchange_message_dropped",
+        message,
+        event_name: Some("dsx_exchange_message_dropped"),
+        metric_name: Some("carbide_dsx_exchange_consumer_messages_dropped_total"),
+        message_type: Some(message_type),
+        point_path: None,
+        point_type: None,
+        rack_id: None,
+        rack_name: None,
+        value: None,
+    }
+}
+
+fn expected_dedup() -> LogObservation<'static> {
+    LogObservation {
+        level: tracing::Level::TRACE,
+        metadata_name: "dsx_exchange_message_deduplicated",
+        message: "Deduplicating unchanged value",
+        event_name: Some("dsx_exchange_message_deduplicated"),
+        metric_name: Some("carbide_dsx_exchange_consumer_dedup_skipped_total"),
+        message_type: None,
+        point_path: Some("site/rack/point"),
+        point_type: Some("LeakDetectRack"),
+        rack_id: None,
+        rack_name: None,
+        value: Some("Faulting"),
+    }
+}
+
+fn expected_alert(point_type: &'static str) -> LogObservation<'static> {
+    LogObservation {
+        level: tracing::Level::INFO,
+        metadata_name: "dsx_exchange_leak_alert_detected",
+        message: "Leak alert detected, inserting health override",
+        event_name: Some("dsx_exchange_leak_alert_detected"),
+        metric_name: Some("carbide_dsx_exchange_consumer_alerts_detected_total"),
+        message_type: None,
+        point_path: Some("site/rack/point"),
+        point_type: Some(point_type),
+        rack_id: Some("rack-42"),
+        rack_name: Some("Rack-42"),
+        value: Some("Faulting"),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct MetricSeries {
+    name: &'static str,
+    labels: &'static [(&'static str, &'static str)],
+}
+
 #[test]
-fn message_events_expose_single_total_names_and_are_metric_only() {
+fn leak_point_type_metric_labels_keep_the_bms_names() {
+    use carbide_instrument::LabelValue;
+
+    value_scenarios!(
+        run = |point_type: LeakPointType| point_type.label_value().to_string();
+        "each leak point uses the canonical BMS metric label" {
+            LeakPointType::LeakDetectRack => "LeakDetectRack".to_string(),
+            LeakPointType::LeakSensorFaultRack => "LeakSensorFaultRack".to_string(),
+            LeakPointType::LeakDetectRackTray => "LeakDetectRackTray".to_string(),
+        }
+    );
+}
+
+/// `message_events_preserve_metrics_and_logs` pins each Event's public metric
+/// series and, when logging is enabled, its level, message, and context. The
+/// alert rows also cover every bounded BMS CamelCase `point_type` label.
+#[test]
+fn message_events_preserve_metrics_and_logs() {
+    let alert_cases = [
+        (LeakPointType::LeakDetectRack, "LeakDetectRack"),
+        (LeakPointType::LeakSensorFaultRack, "LeakSensorFaultRack"),
+        (LeakPointType::LeakDetectRackTray, "LeakDetectRackTray"),
+    ];
+
     let metrics = MetricsCapture::start();
     let logs = capture_logs(|| {
         emit(MessageReceived);
         emit(MessageProcessed);
-        emit(MessageDropped);
-        emit(MessageDeduplicated);
+        emit(MessageDropped {
+            message_type: DroppedMessageType::Metadata,
+        });
+        emit(MessageDropped {
+            message_type: DroppedMessageType::Value,
+        });
+        emit(MessageDeduplicated {
+            point_path: "site/rack/point".to_string(),
+            point_type: LeakPointType::LeakDetectRack,
+            value: "Faulting".to_string(),
+        });
+        for &(point_type, _) in &alert_cases {
+            emit(LeakAlertDetected {
+                point_type,
+                point_path: "site/rack/point".to_string(),
+                rack_id: "rack-42".to_string(),
+                rack_name: "Rack-42".to_string(),
+                value: "Faulting".to_string(),
+            });
+        }
     });
 
-    // Exposed names end in a single `_total`.
-    for name in [
-        "carbide_dsx_exchange_consumer_messages_received_total",
-        "carbide_dsx_exchange_consumer_messages_processed_total",
-        "carbide_dsx_exchange_consumer_messages_dropped_total",
-        "carbide_dsx_exchange_consumer_dedup_skipped_total",
-    ] {
-        assert_eq!(
-            metrics.counter_delta(name, &[]),
-            1.0,
-            "expected {name} to move by 1; exposition was:\n{}",
-            metrics.render()
-        );
-    }
+    check_values(
+        [
+            Check {
+                scenario: "received message increments its counter",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_messages_received_total",
+                    labels: &[],
+                },
+                expect: 1.0,
+            },
+            Check {
+                scenario: "processed message increments its counter",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_messages_processed_total",
+                    labels: &[],
+                },
+                expect: 1.0,
+            },
+            Check {
+                scenario: "both queue drop variants share the existing counter",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_messages_dropped_total",
+                    labels: &[],
+                },
+                expect: 2.0,
+            },
+            Check {
+                scenario: "deduplicated message increments its counter",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_dedup_skipped_total",
+                    labels: &[],
+                },
+                expect: 1.0,
+            },
+            Check {
+                scenario: "rack leak alert keeps its label series",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_alerts_detected_total",
+                    labels: &[("point_type", "LeakDetectRack")],
+                },
+                expect: 1.0,
+            },
+            Check {
+                scenario: "rack sensor fault keeps its label series",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_alerts_detected_total",
+                    labels: &[("point_type", "LeakSensorFaultRack")],
+                },
+                expect: 1.0,
+            },
+            Check {
+                scenario: "rack tray leak alert keeps its label series",
+                input: MetricSeries {
+                    name: "carbide_dsx_exchange_consumer_alerts_detected_total",
+                    labels: &[("point_type", "LeakDetectRackTray")],
+                },
+                expect: 1.0,
+            },
+        ],
+        |series| metrics.counter_delta(series.name, series.labels),
+    );
 
-    // None of the historical doubled `_total_total` names appear -- this de-doubles them.
     let exposition = metrics.render();
-    for doubled in [
-        "carbide_dsx_exchange_consumer_messages_received_total_total",
-        "carbide_dsx_exchange_consumer_messages_processed_total_total",
-        "carbide_dsx_exchange_consumer_messages_dropped_total_total",
-        "carbide_dsx_exchange_consumer_dedup_skipped_total_total",
-    ] {
-        assert!(
-            !exposition.contains(doubled),
-            "doubled name {doubled} must be gone; exposition was:\n{exposition}"
-        );
-    }
+    value_scenarios!(
+        run = |name: &str| exposition.contains(name);
+        "counter names are not doubled by the exporter" {
+            "carbide_dsx_exchange_consumer_messages_received_total_total" => false,
+            "carbide_dsx_exchange_consumer_messages_processed_total_total" => false,
+            "carbide_dsx_exchange_consumer_messages_dropped_total_total" => false,
+            "carbide_dsx_exchange_consumer_dedup_skipped_total_total" => false,
+            "carbide_dsx_exchange_consumer_alerts_detected_total_total" => false,
+        }
+    );
+    assert!(exposition.contains(
+        "# HELP carbide_dsx_exchange_consumer_alerts_detected_total Number of leak alerts detected"
+    ));
 
-    // Metric-only: the events build no log line, so the drop WARN and dedup
-    // TRACE are never doubled -- only the untouched call-site `tracing` lines
-    // remain.
-    assert!(logs.is_empty(), "events must be metric-only: {logs:?}");
+    assert_eq!(logs.len(), 6, "received and processed must remain silent");
+    check_values(
+        [
+            Check {
+                scenario: "metadata queue drop keeps its warning",
+                input: 0,
+                expect: expected_drop("metadata", "Message queue full, dropping metadata message"),
+            },
+            Check {
+                scenario: "value queue drop keeps its warning",
+                input: 1,
+                expect: expected_drop("value", "Message queue full, dropping value message"),
+            },
+            Check {
+                scenario: "deduplicated value keeps its trace context",
+                input: 2,
+                expect: expected_dedup(),
+            },
+            Check {
+                scenario: "rack leak alert keeps its diagnostic context",
+                input: 3,
+                expect: expected_alert("LeakDetectRack"),
+            },
+            Check {
+                scenario: "rack sensor fault keeps its diagnostic context",
+                input: 4,
+                expect: expected_alert("LeakSensorFaultRack"),
+            },
+            Check {
+                scenario: "rack tray leak keeps its diagnostic context",
+                input: 5,
+                expect: expected_alert("LeakDetectRackTray"),
+            },
+        ],
+        |index| observe_log(&logs[index]),
+    );
 }
 
-/// A persist failure writes the WARN line carrying the rack id and error, and
-/// moves `carbide_dsx_exchange_consumer_health_report_persist_failures_total` once --
-/// the "log it AND count it" the safety-relevant drop needs. Isolated here
-/// because `health_updater`'s failure-path unit tests emit this same event
-/// without a `MetricsCapture`; from a shared process they could advance the
-/// zero-label counter between this test's baseline and delta.
+/// `HealthReportPersistFailed` exposes the failed rack and moves its zero-label
+/// counter from the same `emit`. Keep this check in its own integration-test
+/// process: unit tests emit the same Event without `MetricsCapture`, so a
+/// shared registry would make the counter delta depend on test order.
 #[test]
 fn health_report_persist_failed_logs_warn_and_counts() {
     let metrics = MetricsCapture::start();
@@ -104,12 +309,6 @@ fn health_report_persist_failed_logs_warn_and_counts() {
     assert_eq!(logs.len(), 1);
     assert_eq!(logs[0].level, tracing::Level::WARN);
     assert_eq!(logs[0].message, "Failed to persist rack health report");
-    fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
-        log.fields
-            .iter()
-            .find(|(key, _)| key == name)
-            .map(|(_, value)| value.as_str())
-    }
     assert_eq!(field(&logs[0], "rack_id"), Some("rack-42"));
     assert_eq!(
         field(&logs[0], "error"),

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -53,6 +53,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>Number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
 <tr><td>carbide_dropped_v6_requests_total</td><td>counter</td><td>Number of dropped DHCPv6 requests, by reason.</td></tr>
 <tr><td>carbide_dsx_event_bus_publish_count_total</td><td>counter</td><td>Number of MQTT publish attempts</td></tr>
+<tr><td>carbide_dsx_exchange_consumer_alerts_detected_total</td><td>counter</td><td>Number of leak alerts detected</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_dedup_skipped_total</td><td>counter</td><td>Number of messages skipped due to deduplication</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_health_report_persist_failures_total</td><td>counter</td><td>Number of rack health report persist failures against the Carbide API</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_message_age_seconds</td><td>histogram</td><td>Age of consumed BMS value messages at processing time (consumer lag), in seconds</td></tr>


### PR DESCRIPTION
The DSX exchange consumer counted queue drops, deduplications, and leak alerts separately from the records that explained them. Leak alerts also retained the consumer's final hand-built counter.

Typed `Event`s now own each existing counter and diagnostic together. Drop and deduplication counters remain zero-label, leak alerts preserve the BMS CamelCase `LeakPointType` values, and rack/point detail stays log-only. The empty metrics holder left behind is removed.

Metric/log exposition and the bounded label mappings are covered with table-driven tests.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3733
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The metric series, log fields, exporter names, and canonical leak-point labels are covered by named `check_values` and `value_scenarios!` rows. Stateful deduplication and health-report persistence remain explicit tests.

Verified with:

- `cargo test -p carbide-dsx-exchange-consumer`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

`LeakPointType` keeps a manual `LabelValue` mapping because the existing metric contract uses the BMS CamelCase spellings. Deriving that mapping would silently change them to snake_case.

The generated `docs/observability/core_metrics.md` row stays with this implementation because it is validated as part of the Event contract and is excluded from technical-writer review.

Closes #3733
