### PR TITLE
refactor(agent,instrument): emit DPU report outcomes with native context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ name = "carbide-instrument-macros"
 version = "0.0.0"
 dependencies = [
  "carbide-observability-schema",
+ "carbide-test-support",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -135,6 +135,7 @@ carbide-version = { path = "../version" }
 tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 ctor = { workspace = true }
 prost = { workspace = true }

--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use carbide_host_support::agent_config::MachineIdentityConfig;
-use carbide_instrument::{Outcome, emit};
+use carbide_instrument::emit;
 use eyre::eyre;
 use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
 use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
@@ -29,7 +29,7 @@ use rpc::forge::ManagedHostNetworkConfigResponse;
 use tonic::transport::Channel;
 
 use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
-use crate::instrumentation::{ReportLoop, ReportLoopCompleted};
+use crate::instrumentation::{FmdsPushFailed, FmdsPushSucceeded};
 use crate::periodic_config_fetcher::InstanceMetadata;
 
 /// FmdsUpdater abstracts over embedded vs external FMDS
@@ -59,17 +59,13 @@ impl FmdsUpdater {
             }
             FmdsUpdater::External(client) => {
                 let result = client.update_config(&instance_data, &network_config).await;
-                if let Err(err) = &result {
-                    tracing::error!(
-                        error = format!("{err:#}"),
-                        fmds_address = client.address,
-                        "Failed to send config update to external FMDS"
-                    );
+                match &result {
+                    Ok(()) => emit(FmdsPushSucceeded::new()),
+                    Err(err) => emit(FmdsPushFailed::new(
+                        format!("{err:#}"),
+                        client.address.clone(),
+                    )),
                 }
-                emit(ReportLoopCompleted {
-                    report_loop: ReportLoop::FmdsPush,
-                    outcome: Outcome::from(&result),
-                });
             }
         }
     }

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -27,41 +27,309 @@ use tower::ServiceBuilder;
 use tracing::Span;
 
 pub mod config;
+use carbide_instrument::Outcome;
 use carbide_uuid::machine::MachineId;
 pub use config::{get_dpu_agent_meter, get_prometheus_registry};
 
-/// One iteration of a DPU-agent report loop, recorded by `{report_loop,
-/// outcome}`. A pure counter: the failure detail stays on the existing
-/// call-site log, so this event never logs and carries no context of its own.
+/// `ReportLoop` labels one full agent reporting iteration rather than one
+/// outbound RPC. That boundary also counts pre-RPC build and conversion
+/// failures, plus the external FMDS push that generated-client RED metrics do
+/// not see.
 ///
-/// The loop's outbound Forge RPC is already RED-metered by the generated
-/// client, so this counter sits one level up -- it captures the whole
-/// iteration, including the pre-RPC build/connect failures and the raw FMDS
-/// push that the per-RPC metric never sees.
+/// The enum stays private so each Event constructor fixes the only valid
+/// `{report_loop, outcome}` pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+enum ReportLoop {
+    Inventory,
+    ConfigFetch,
+    FmdsPush,
+    NetworkStatus,
+}
+
+/// `InventoryReportSucceeded` records the inventory loop's successful
+/// completion and owns its DEBUG diagnostic. The other successful loops are
+/// metric-only.
 #[derive(carbide_instrument::Event)]
 #[event(
-    event_name = "dpu_agent_report_loop_completed",
+    event_name = "dpu_agent_inventory_report_succeeded",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = debug,
+    metric = counter,
+    message = "Successfully updated machine inventory",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct InventoryReportSucceeded {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+}
+
+impl InventoryReportSucceeded {
+    pub(crate) fn new() -> Self {
+        Self {
+            report_loop: ReportLoop::Inventory,
+            outcome: Outcome::Ok,
+        }
+    }
+}
+
+/// `InventoryReportFailed` counts an inventory error without logging it.
+/// `machine_inventory_updater::single_run` returns the same error to the
+/// main-loop scheduler, which owns the diagnostic.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_inventory_report_failed",
     metric_name = "carbide_dpu_agent_report_total",
     component = "forge-dpu-agent",
     log = off,
     metric = counter,
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub struct ReportLoopCompleted {
+pub(crate) struct InventoryReportFailed {
     #[label]
-    pub report_loop: ReportLoop,
+    report_loop: ReportLoop,
     #[label]
-    pub outcome: carbide_instrument::Outcome,
+    outcome: Outcome,
 }
 
-/// The DPU-agent report loops that emit [`ReportLoopCompleted`]. The label
-/// field is named `report_loop` because `loop` is a keyword.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
-pub enum ReportLoop {
-    Inventory,
-    ConfigFetch,
-    FmdsPush,
-    NetworkStatus,
+impl InventoryReportFailed {
+    pub(crate) fn new() -> Self {
+        Self {
+            report_loop: ReportLoop::Inventory,
+            outcome: Outcome::Error,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_config_fetch_succeeded",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = off,
+    metric = counter,
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct ConfigFetchSucceeded {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+}
+
+impl ConfigFetchSucceeded {
+    pub(crate) fn new() -> Self {
+        Self {
+            report_loop: ReportLoop::ConfigFetch,
+            outcome: Outcome::Ok,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_config_fetch_failed",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Failed to fetch the latest configuration. Will retry",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct ConfigFetchFailed {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+    #[context]
+    error: String,
+    #[context(value)]
+    retry_interval_seconds: f64,
+}
+
+impl ConfigFetchFailed {
+    pub(crate) fn new(error: String, retry_interval_seconds: f64) -> Self {
+        Self {
+            report_loop: ReportLoop::ConfigFetch,
+            outcome: Outcome::Error,
+            error,
+            retry_interval_seconds,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_config_not_found",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = warn,
+    metric = counter,
+    message = "DPU not found",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct ConfigNotFound {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+    #[context]
+    machine_id: String,
+}
+
+impl ConfigNotFound {
+    pub(crate) fn new(machine_id: String) -> Self {
+        Self {
+            report_loop: ReportLoop::ConfigFetch,
+            outcome: Outcome::Error,
+            machine_id,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_fmds_push_succeeded",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = off,
+    metric = counter,
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct FmdsPushSucceeded {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+}
+
+impl FmdsPushSucceeded {
+    pub(crate) fn new() -> Self {
+        Self {
+            report_loop: ReportLoop::FmdsPush,
+            outcome: Outcome::Ok,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_fmds_push_failed",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Failed to send config update to external FMDS",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct FmdsPushFailed {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+    #[context]
+    error: String,
+    #[context]
+    fmds_address: String,
+}
+
+impl FmdsPushFailed {
+    pub(crate) fn new(error: String, fmds_address: String) -> Self {
+        Self {
+            report_loop: ReportLoop::FmdsPush,
+            outcome: Outcome::Error,
+            error,
+            fmds_address,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_network_status_succeeded",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = off,
+    metric = counter,
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct NetworkStatusSucceeded {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+}
+
+impl NetworkStatusSucceeded {
+    pub(crate) fn new() -> Self {
+        Self {
+            report_loop: ReportLoop::NetworkStatus,
+            outcome: Outcome::Ok,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_network_status_connection_failed",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "record_network_status: Could not connect to Forge API server. Will retry.",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct NetworkStatusConnectionFailed {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+    #[context]
+    forge_api: String,
+    #[context]
+    error: String,
+}
+
+impl NetworkStatusConnectionFailed {
+    pub(crate) fn new(forge_api: String, error: String) -> Self {
+        Self {
+            report_loop: ReportLoop::NetworkStatus,
+            outcome: Outcome::Error,
+            forge_api,
+            error,
+        }
+    }
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_network_status_rpc_failed",
+    metric_name = "carbide_dpu_agent_report_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Error while executing the record_network_status gRPC call",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+pub(crate) struct NetworkStatusRpcFailed {
+    #[label]
+    report_loop: ReportLoop,
+    #[label]
+    outcome: Outcome,
+    #[context]
+    error: String,
+}
+
+impl NetworkStatusRpcFailed {
+    pub(crate) fn new(error: String) -> Self {
+        Self {
+            report_loop: ReportLoop::NetworkStatus,
+            outcome: Outcome::Error,
+            error,
+        }
+    }
 }
 
 pub struct AgentMetricsState {
@@ -319,5 +587,295 @@ impl WithTracingLayer for Router {
             );
 
         self.layer(ServiceBuilder::new().layer(layer))
+    }
+}
+
+#[cfg(test)]
+mod report_loop_tests {
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const REPORT_METRIC: &str = "carbide_dpu_agent_report_total";
+
+    struct EventCase {
+        emit: fn(),
+        report_loop: &'static str,
+        outcome: &'static str,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct EventObservation {
+        metric_delta: f64,
+        logs: Vec<LogShape>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct LogShape {
+        metadata_name: String,
+        level: tracing::Level,
+        message: String,
+        fields: Vec<(String, String)>,
+        retry_interval_kind: Option<CapturedFieldKind>,
+    }
+
+    fn expected_log(
+        metadata_name: &str,
+        level: tracing::Level,
+        message: &str,
+        report_loop: &str,
+        outcome: &str,
+        context: &[(&str, &str)],
+        retry_interval_kind: Option<CapturedFieldKind>,
+    ) -> Vec<LogShape> {
+        let mut fields = vec![
+            ("event_name".to_string(), metadata_name.to_string()),
+            ("metric_name".to_string(), REPORT_METRIC.to_string()),
+            ("report_loop".to_string(), report_loop.to_string()),
+            ("outcome".to_string(), outcome.to_string()),
+        ];
+        fields.extend(
+            context
+                .iter()
+                .map(|(name, value)| (name.to_string(), value.to_string())),
+        );
+
+        vec![LogShape {
+            metadata_name: metadata_name.to_string(),
+            level,
+            message: message.to_string(),
+            fields,
+            retry_interval_kind,
+        }]
+    }
+
+    fn observe_event(case: EventCase) -> EventObservation {
+        let EventCase {
+            emit,
+            report_loop,
+            outcome,
+        } = case;
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(emit)
+            .into_iter()
+            .map(|log| {
+                let retry_interval_kind = log.field_kind("retry_interval_seconds");
+                LogShape {
+                    metadata_name: log.metadata_name,
+                    level: log.level,
+                    message: log.message,
+                    fields: log.fields,
+                    retry_interval_kind,
+                }
+            })
+            .collect();
+
+        EventObservation {
+            metric_delta: metrics.counter_delta(
+                REPORT_METRIC,
+                &[("report_loop", report_loop), ("outcome", outcome)],
+            ),
+            logs,
+        }
+    }
+
+    #[test]
+    fn semantic_events_preserve_the_loop_outcome_matrix_and_log_shapes() {
+        const MACHINE_ID: &str = "fm100000000000000000000000000000000000000000000000000000000000";
+
+        check_values(
+            [
+                Check {
+                    scenario: "inventory success logs at debug",
+                    input: EventCase {
+                        emit: || emit(InventoryReportSucceeded::new()),
+                        report_loop: "inventory",
+                        outcome: "ok",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "dpu_agent_inventory_report_succeeded",
+                            tracing::Level::DEBUG,
+                            "Successfully updated machine inventory",
+                            "inventory",
+                            "ok",
+                            &[],
+                            None,
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "inventory failure remains metric-only",
+                    input: EventCase {
+                        emit: || emit(InventoryReportFailed::new()),
+                        report_loop: "inventory",
+                        outcome: "error",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: Vec::new(),
+                    },
+                },
+                Check {
+                    scenario: "config fetch success remains metric-only",
+                    input: EventCase {
+                        emit: || emit(ConfigFetchSucceeded::new()),
+                        report_loop: "config_fetch",
+                        outcome: "ok",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: Vec::new(),
+                    },
+                },
+                Check {
+                    scenario: "config fetch failure retains retry context",
+                    input: EventCase {
+                        emit: || emit(ConfigFetchFailed::new("config failed".to_string(), 30.5)),
+                        report_loop: "config_fetch",
+                        outcome: "error",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "dpu_agent_config_fetch_failed",
+                            tracing::Level::ERROR,
+                            "Failed to fetch the latest configuration. Will retry",
+                            "config_fetch",
+                            "error",
+                            &[
+                                ("error", "config failed"),
+                                ("retry_interval_seconds", "30.5"),
+                            ],
+                            Some(CapturedFieldKind::F64),
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "FMDS success remains metric-only",
+                    input: EventCase {
+                        emit: || emit(FmdsPushSucceeded::new()),
+                        report_loop: "fmds_push",
+                        outcome: "ok",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: Vec::new(),
+                    },
+                },
+                Check {
+                    scenario: "FMDS failure retains address context",
+                    input: EventCase {
+                        emit: || {
+                            emit(FmdsPushFailed::new(
+                                "FMDS failed".to_string(),
+                                "http://fmds:50051".to_string(),
+                            ))
+                        },
+                        report_loop: "fmds_push",
+                        outcome: "error",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "dpu_agent_fmds_push_failed",
+                            tracing::Level::ERROR,
+                            "Failed to send config update to external FMDS",
+                            "fmds_push",
+                            "error",
+                            &[
+                                ("error", "FMDS failed"),
+                                ("fmds_address", "http://fmds:50051"),
+                            ],
+                            None,
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "network status success remains metric-only",
+                    input: EventCase {
+                        emit: || emit(NetworkStatusSucceeded::new()),
+                        report_loop: "network_status",
+                        outcome: "ok",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: Vec::new(),
+                    },
+                },
+                Check {
+                    scenario: "network status RPC failure retains error context",
+                    input: EventCase {
+                        emit: || emit(NetworkStatusRpcFailed::new("RPC failed".to_string())),
+                        report_loop: "network_status",
+                        outcome: "error",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "dpu_agent_network_status_rpc_failed",
+                            tracing::Level::ERROR,
+                            "Error while executing the record_network_status gRPC call",
+                            "network_status",
+                            "error",
+                            &[("error", "RPC failed")],
+                            None,
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "missing config retains machine context",
+                    input: EventCase {
+                        emit: || emit(ConfigNotFound::new(MACHINE_ID.to_string())),
+                        report_loop: "config_fetch",
+                        outcome: "error",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "dpu_agent_config_not_found",
+                            tracing::Level::WARN,
+                            "DPU not found",
+                            "config_fetch",
+                            "error",
+                            &[("machine_id", MACHINE_ID)],
+                            None,
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "network connection failure retains endpoint context",
+                    input: EventCase {
+                        emit: || {
+                            emit(NetworkStatusConnectionFailed::new(
+                                "https://forge:50051".to_string(),
+                                "connection refused".to_string(),
+                            ))
+                        },
+                        report_loop: "network_status",
+                        outcome: "error",
+                    },
+                    expect: EventObservation {
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "dpu_agent_network_status_connection_failed",
+                            tracing::Level::ERROR,
+                            "record_network_status: Could not connect to Forge API server. Will retry.",
+                            "network_status",
+                            "error",
+                            &[
+                                ("forge_api", "https://forge:50051"),
+                                ("error", "connection refused"),
+                            ],
+                            None,
+                        ),
+                    },
+                },
+            ],
+            observe_event,
+        );
     }
 }

--- a/crates/agent/src/instrumentation/config.rs
+++ b/crates/agent/src/instrumentation/config.rs
@@ -42,7 +42,7 @@ struct InstrumentationSingleton {
 
 impl InstrumentationSingleton {
     // Build the standard instrumentation config for dpu-agent.
-    fn try_init_for_dpu_agent() -> eyre::Result<Self> {
+    fn try_init_for_dpu_agent(set_global_meter: bool) -> eyre::Result<Self> {
         let prometheus_registry = Registry::new();
         let exporter = ExporterBuilder::default()
             .with_registry(prometheus_registry.clone())
@@ -76,7 +76,9 @@ impl InstrumentationSingleton {
         // We expect our internal users to use the interfaces inside this module,
         // but if there are other OpenTelemetry users in our dependencies, let's
         // make sure they pick up our provider.
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
+        if set_global_meter {
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
+        }
 
         Ok(InstrumentationSingleton {
             _meter_provider: meter_provider,
@@ -91,7 +93,7 @@ impl InstrumentationSingleton {
     // upgrades of the crates involved. There's a unit test below that should
     // ensure it always succeeds.
     fn init_for_dpu_agent() -> Self {
-        Self::try_init_for_dpu_agent().unwrap()
+        Self::try_init_for_dpu_agent(true).unwrap()
     }
 }
 
@@ -163,7 +165,10 @@ mod tests {
 
     #[test]
     fn test_singleton_init_function() {
-        let _s = InstrumentationSingleton::try_init_for_dpu_agent().expect(
+        // `false` keeps this construction test from replacing the process-global
+        // provider. Event instruments cache that provider on first use, and the
+        // `MetricsCapture` tests in this binary must keep reading the same one.
+        let _s = InstrumentationSingleton::try_init_for_dpu_agent(false).expect(
             "The instrumentaion singleton's initialization function must not return an error",
         );
     }

--- a/crates/agent/src/machine_inventory_updater.rs
+++ b/crates/agent/src/machine_inventory_updater.rs
@@ -19,13 +19,13 @@ use std::time::Duration;
 
 use ::rpc::forge as rpc;
 use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
-use carbide_instrument::{Outcome, emit};
+use carbide_instrument::emit;
 use carbide_uuid::machine::MachineId;
 
 use crate::command_line::AgentPlatformType;
 use crate::containerd::container;
 use crate::containerd::container::ContainerSummary;
-use crate::instrumentation::{ReportLoop, ReportLoopCompleted};
+use crate::instrumentation::{InventoryReportFailed, InventoryReportSucceeded};
 
 #[derive(Debug, Clone)]
 pub struct MachineInventoryUpdaterConfig {
@@ -110,14 +110,14 @@ pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<
     }
     .await;
 
-    // The scheduler logs a propagated error; success is quiet at debug.
+    // `single_run` returns failures to the scheduler, which logs the error.
+    // Keep `InventoryReportFailed` metric-only to avoid a duplicate diagnostic;
+    // `InventoryReportSucceeded` owns the DEBUG record.
     if result.is_ok() {
-        tracing::debug!("Successfully updated machine inventory");
+        emit(InventoryReportSucceeded::new());
+    } else {
+        emit(InventoryReportFailed::new());
     }
-    emit(ReportLoopCompleted {
-        report_loop: ReportLoop::Inventory,
-        outcome: Outcome::from(&result),
-    });
 
     result
 }

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -29,7 +29,7 @@ use ::rpc::forge::ManagedHostNetworkConfigResponse;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::{forge as rpc, forge_tls_client};
 use carbide_host_support::agent_config::AgentConfig;
-use carbide_instrument::{Outcome, emit};
+use carbide_instrument::emit;
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_rpc_utils::dhcp::{DhcpTimestamps, DhcpTimestampsFilePath};
 use carbide_systemd::systemd;
@@ -57,7 +57,8 @@ use crate::fmds_client::FmdsUpdater;
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
 use crate::instrumentation::{
-    ReportLoop, ReportLoopCompleted, create_metrics, get_dpu_agent_meter, get_prometheus_registry,
+    NetworkStatusConnectionFailed, NetworkStatusRpcFailed, NetworkStatusSucceeded, create_metrics,
+    get_dpu_agent_meter, get_prometheus_registry,
 };
 use crate::machine_inventory_updater::MachineInventoryUpdaterConfig;
 use crate::network_monitor::{self, NetworkPingerType};
@@ -1437,30 +1438,19 @@ pub async fn record_network_status(
     {
         Ok(client) => client,
         Err(err) => {
-            tracing::error!(
-                forge_api,
-                error = format!("{err:#}"),
-                "record_network_status: Could not connect to Forge API server. Will retry."
-            );
-            emit(ReportLoopCompleted {
-                report_loop: ReportLoop::NetworkStatus,
-                outcome: Outcome::Error,
-            });
+            emit(NetworkStatusConnectionFailed::new(
+                forge_api.to_string(),
+                format!("{err:#}"),
+            ));
             return;
         }
     };
     let request = tonic::Request::new(status);
     let result = client.record_dpu_network_status(request).await;
-    if let Err(err) = &result {
-        tracing::error!(
-            error = format!("{err:#}"),
-            "Error while executing the record_network_status gRPC call"
-        );
+    match &result {
+        Ok(_) => emit(NetworkStatusSucceeded::new()),
+        Err(err) => emit(NetworkStatusRpcFailed::new(format!("{err:#}"))),
     }
-    emit(ReportLoopCompleted {
-        report_loop: ReportLoop::NetworkStatus,
-        outcome: Outcome::from(&result),
-    });
 }
 
 // Get the link type, carrier status, MTU, and whatever else for our uplinks

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -22,16 +22,16 @@ use std::time::Duration;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::{Instance, forge as rpc};
 use arc_swap::ArcSwapOption;
-use carbide_instrument::{Outcome, emit};
+use carbide_instrument::emit;
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use config_version::ConfigVersion;
 use eyre::Context;
 use forge_dpu_agent_utils::utils::create_forge_client;
-use tracing::{error, trace, warn};
+use tracing::{trace, warn};
 
-use crate::instrumentation::{ReportLoop, ReportLoopCompleted};
+use crate::instrumentation::{ConfigFetchFailed, ConfigFetchSucceeded, ConfigNotFound};
 use crate::util::{get_periodic_dpu_config, get_sitename};
 
 pub struct PeriodicFetcherState {
@@ -204,50 +204,37 @@ async fn single_fetch(
     .await;
     // The outcome covers the whole fetch: a successful RPC whose instance
     // metadata fails to convert is still a failed configuration fetch.
-    let outcome = match result {
+    match result {
         Ok(resp) => {
             state.netconf.store(Some(Arc::new(resp.clone())));
 
             match instance_metadata_from_instance(resp.instance, state.sitename.clone()) {
                 Ok(Some(config)) => {
                     state.instmeta.store(Some(Arc::new(config)));
-                    Outcome::Ok
+                    emit(ConfigFetchSucceeded::new());
                 }
                 Ok(None) => {
                     state.instmeta.store(None);
-                    Outcome::Ok
+                    emit(ConfigFetchSucceeded::new());
                 }
-                Err(err) => {
-                    error!(
-                        error = %err,
-                        retry_interval_seconds = state.config.config_fetch_interval.as_secs_f64(),
-                        "Failed to fetch the latest configuration. Will retry"
-                    );
-                    Outcome::Error
-                }
+                Err(err) => emit(ConfigFetchFailed::new(
+                    err.to_string(),
+                    state.config.config_fetch_interval.as_secs_f64(),
+                )),
             }
         }
         Err(err) => match err.downcast_ref::<tonic::Status>() {
             Some(grpc_status) if grpc_status.code() == tonic::Code::NotFound => {
-                warn!(machine_id = %state.config.machine_id, "DPU not found");
                 state.netconf.store(None);
                 state.instmeta.store(None);
-                Outcome::Error
+                emit(ConfigNotFound::new(state.config.machine_id.to_string()));
             }
-            _ => {
-                error!(
-                    retry_interval_seconds = state.config.config_fetch_interval.as_secs_f64(),
-                    error = ?err,
-                    "Failed to fetch the latest configuration. Will retry"
-                );
-                Outcome::Error
-            }
+            _ => emit(ConfigFetchFailed::new(
+                format!("{err:?}"),
+                state.config.config_fetch_interval.as_secs_f64(),
+            )),
         },
-    };
-    emit(ReportLoopCompleted {
-        report_loop: ReportLoop::ConfigFetch,
-        outcome,
-    });
+    }
 
     true
 }

--- a/crates/instrument-macros/Cargo.toml
+++ b/crates/instrument-macros/Cargo.toml
@@ -36,5 +36,8 @@ syn = { workspace = true, features = [
   "proc-macro",
 ] }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -22,7 +22,7 @@
 use carbide_observability_schema::{is_event_log_reserved_field, validate_event_name};
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Field, Fields, Ident, LitStr};
+use syn::{Data, DeriveInput, Field, Fields, Ident, LitStr, Meta};
 
 /// Metric-name unit suffixes a histogram may use, with the OpenTelemetry unit
 /// string each one implies.
@@ -92,8 +92,10 @@ fn expand_label_value(input: DeriveInput) -> syn::Result<TokenStream> {
 /// Derives `carbide_instrument::Event` for a struct declared with an
 /// `#[event(...)]` attribute. Every field takes exactly one of `#[label]`
 /// (enum via `LabelValue`; goes to both the log line and the metric),
-/// `#[context]` (any `Display`; log-only), or `#[observation]` (the histogram
-/// value). The metric name is validated at compile time: `carbide_` prefix,
+/// `#[context]` (any `Display`; log-only), `#[context(value)]` (`bool`, `i64`,
+/// `f64`, or `String` retained as a native structured value; log-only), or
+/// `#[observation]` (the histogram value). The metric name is validated at
+/// compile time: `carbide_` prefix,
 /// `_total` for counters (never a doubled `_total_total`), a unit suffix for
 /// histograms. A counter's `describe` is checked too -- present and opening
 /// with "Number of ..." -- with `describe_unchecked` as the escape hatch for
@@ -259,10 +261,38 @@ fn parse_event_args(input: &DeriveInput) -> syn::Result<EventArgs> {
 }
 
 #[derive(Clone, Copy, PartialEq)]
+enum ContextMode {
+    Display,
+    Value,
+}
+
+#[derive(Clone, Copy, PartialEq)]
 enum FieldKind {
     Label,
-    Context,
+    Context(ContextMode),
     Observation,
+}
+
+fn context_mode(attr: &syn::Attribute) -> syn::Result<ContextMode> {
+    match &attr.meta {
+        Meta::Path(_) => Ok(ContextMode::Display),
+        Meta::List(_) => {
+            let mode: Ident = attr.parse_args()?;
+            if mode == "value" {
+                Ok(ContextMode::Value)
+            } else {
+                Err(syn::Error::new_spanned(
+                    mode,
+                    "unknown context mode; use #[context] for Display formatting or \
+                     #[context(value)] to preserve a native tracing value",
+                ))
+            }
+        }
+        Meta::NameValue(_) => Err(syn::Error::new_spanned(
+            attr,
+            "context is an attribute: use #[context] or #[context(value)]",
+        )),
+    }
 }
 
 fn classify_field(field: &Field) -> syn::Result<FieldKind> {
@@ -271,7 +301,7 @@ fn classify_field(field: &Field) -> syn::Result<FieldKind> {
         if attr.path().is_ident("label") {
             kinds.push(FieldKind::Label);
         } else if attr.path().is_ident("context") {
-            kinds.push(FieldKind::Context);
+            kinds.push(FieldKind::Context(context_mode(attr)?));
         } else if attr.path().is_ident("observation") {
             kinds.push(FieldKind::Observation);
         }
@@ -298,7 +328,7 @@ fn validate_event_log_field(log: LogSpec, kind: FieldKind, ident: &Ident) -> syn
         ));
     }
     if log != LogSpec::Off
-        && matches!(kind, FieldKind::Label | FieldKind::Context)
+        && matches!(kind, FieldKind::Label | FieldKind::Context(_))
         && is_event_log_reserved_field(&ident.to_string())
     {
         return Err(syn::Error::new_spanned(
@@ -511,7 +541,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
     };
 
     let mut labels: Vec<&Ident> = Vec::new();
-    let mut contexts: Vec<&Ident> = Vec::new();
+    let mut contexts: Vec<(&Ident, ContextMode)> = Vec::new();
     let mut observations: Vec<&Ident> = Vec::new();
     for field in fields {
         let ident = field.ident.as_ref().expect("named field");
@@ -519,7 +549,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         validate_event_log_field(args.log, field_kind, ident)?;
         match field_kind {
             FieldKind::Label => labels.push(ident),
-            FieldKind::Context => contexts.push(ident),
+            FieldKind::Context(mode) => contexts.push((ident, mode)),
             FieldKind::Observation => observations.push(ident),
         }
     }
@@ -544,7 +574,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
     // The pieces of the generated impl.
     let n_labels = labels.len();
     let label_names: Vec<String> = labels.iter().map(|i| i.to_string()).collect();
-    let context_names: Vec<String> = contexts.iter().map(|i| i.to_string()).collect();
+    let context_names: Vec<String> = contexts.iter().map(|(i, _)| i.to_string()).collect();
 
     // `log = dynamic` keeps the trait's nominal LOG and routes the decision
     // through the hand-implemented `DynamicLog` -- per-instance levels (count
@@ -603,11 +633,29 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
             #ident = ::carbide_instrument::LabelValue::label_value(&self.#ident).as_str()
         }
     }));
-    log_fields.extend(
+    log_fields.extend(contexts.iter().map(|(ident, mode)| match mode {
+        ContextMode::Display => quote! { #ident = %self.#ident },
+        ContextMode::Value => quote! { #ident = self.#ident },
+    }));
+
+    let context_values =
         contexts
             .iter()
-            .map(|ident| quote! { #ident = %self.#ident }),
-    );
+            .zip(&context_names)
+            .map(|((ident, mode), name)| match mode {
+                ContextMode::Display => quote! {
+                    ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                        #name,
+                        ::std::string::ToString::to_string(&self.#ident),
+                    )
+                },
+                ContextMode::Value => quote! {
+                    ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                        #name,
+                        ::std::clone::Clone::clone(&self.#ident),
+                    )
+                },
+            });
     let log_arm = |level: proc_macro2::TokenStream| {
         quote! {
             ::carbide_instrument::__private::tracing::event!(
@@ -676,12 +724,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
 
             fn context(&self) -> ::std::vec::Vec<::carbide_instrument::__private::opentelemetry::KeyValue> {
                 ::std::vec![
-                    #(
-                        ::carbide_instrument::__private::opentelemetry::KeyValue::new(
-                            #context_names,
-                            ::std::string::ToString::to_string(&self.#contexts),
-                        ),
-                    )*
+                    #(#context_values,)*
                 ]
             }
 
@@ -732,10 +775,15 @@ fn snake_case(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case as TestCase, check_cases};
     use proc_macro2::Span;
-    use syn::{DeriveInput, Ident};
+    use syn::{Data, DeriveInput, Fields, Ident};
 
-    use super::{FieldKind, LogSpec, expand_event, snake_case, validate_event_log_field};
+    use super::{
+        ContextMode, FieldKind, LogSpec, classify_field, expand_event, snake_case,
+        validate_event_log_field,
+    };
 
     fn expansion_error(source: &str) -> String {
         let input: DeriveInput = syn::parse_str(source).expect("valid derive input");
@@ -821,13 +869,17 @@ mod tests {
         for field_name in carbide_observability_schema::EVENT_LOG_RESERVED_FIELDS {
             let ident = Ident::new(field_name, Span::call_site());
             if *field_name == "message" {
-                for kind in [FieldKind::Label, FieldKind::Context, FieldKind::Observation] {
+                for kind in [
+                    FieldKind::Label,
+                    FieldKind::Context(ContextMode::Display),
+                    FieldKind::Observation,
+                ] {
                     assert!(validate_event_log_field(LogSpec::Info, kind, &ident).is_err());
                     assert!(validate_event_log_field(LogSpec::Off, kind, &ident).is_err());
                 }
                 continue;
             }
-            for kind in [FieldKind::Label, FieldKind::Context] {
+            for kind in [FieldKind::Label, FieldKind::Context(ContextMode::Display)] {
                 assert!(validate_event_log_field(LogSpec::Info, kind, &ident).is_err());
                 assert!(validate_event_log_field(LogSpec::Dynamic, kind, &ident).is_err());
                 assert!(validate_event_log_field(LogSpec::Off, kind, &ident).is_ok());
@@ -838,7 +890,89 @@ mod tests {
         }
 
         let machine_id = Ident::new("machine_id", Span::call_site());
-        assert!(validate_event_log_field(LogSpec::Info, FieldKind::Context, &machine_id).is_ok());
+        assert!(
+            validate_event_log_field(
+                LogSpec::Info,
+                FieldKind::Context(ContextMode::Display),
+                &machine_id,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn context_value_mode_is_explicit_and_validated() {
+        #[derive(Debug, PartialEq)]
+        enum ParsedContextMode {
+            Display,
+            Value,
+        }
+
+        check_cases(
+            [
+                TestCase {
+                    scenario: "bare context uses Display formatting",
+                    input: "#[context]",
+                    expect: Yields(ParsedContextMode::Display),
+                },
+                TestCase {
+                    scenario: "value context preserves its tracing type",
+                    input: "#[context(value)]",
+                    expect: Yields(ParsedContextMode::Value),
+                },
+                TestCase {
+                    scenario: "empty context arguments are rejected",
+                    input: "#[context()]",
+                    expect: Fails,
+                },
+                TestCase {
+                    scenario: "multiple context arguments are rejected",
+                    input: "#[context(value, display)]",
+                    expect: Fails,
+                },
+                TestCase {
+                    scenario: "name-value context syntax is rejected",
+                    input: "#[context = \"value\"]",
+                    expect: FailsWith(
+                        "context is an attribute: use #[context] or #[context(value)]".to_string(),
+                    ),
+                },
+                TestCase {
+                    scenario: "unknown context modes are rejected",
+                    input: "#[context(native)]",
+                    expect: FailsWith(
+                        "unknown context mode; use #[context] for Display formatting or \
+                         #[context(value)] to preserve a native tracing value"
+                            .to_string(),
+                    ),
+                },
+            ],
+            |attribute| {
+                let source = format!(
+                    r#"
+                    #[event(event_name = "demo", component = "demo", message = "demo")]
+                    struct Demo {{
+                        {attribute}
+                        elapsed_seconds: f64,
+                    }}
+                    "#,
+                );
+                let input: DeriveInput = syn::parse_str(&source).expect("valid derive input");
+                let Data::Struct(data) = input.data else {
+                    panic!("fixture is a struct");
+                };
+                let Fields::Named(fields) = data.fields else {
+                    panic!("fixture has a named field");
+                };
+
+                match classify_field(&fields.named[0]) {
+                    Ok(FieldKind::Context(ContextMode::Display)) => Ok(ParsedContextMode::Display),
+                    Ok(FieldKind::Context(ContextMode::Value)) => Ok(ParsedContextMode::Value),
+                    Ok(_) => panic!("fixture field is context"),
+                    Err(error) => Err(error.to_string()),
+                }
+            },
+        );
     }
 
     #[test]

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -80,6 +80,23 @@
 //! }
 //! ```
 //!
+//! `#[context]` formats through `Display` by default. `#[context(value)]` is
+//! the opt-in for fields whose tracing type is part of the structured-log
+//! contract; it accepts `bool`, `i64`, `f64`, or `String`:
+//!
+//! ```
+//! #[derive(carbide_instrument::Event)]
+//! #[event(
+//!     event_name = "retry_scheduled",
+//!     component = "demo",
+//!     message = "retry scheduled"
+//! )]
+//! struct RetryScheduled {
+//!     #[context(value)]
+//!     retry_interval_seconds: f64,
+//! }
+//! ```
+//!
 //! The metric name is validated at compile time -- the `carbide_` prefix, the
 //! `_total` suffix for counters, a unit suffix for histograms:
 //!

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -43,6 +43,18 @@ use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use tracing_subscriber::layer::{Context, SubscriberExt};
 
+/// `CapturedFieldKind` identifies which `tracing::field::Visit` method
+/// received a captured structured value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CapturedFieldKind {
+    String,
+    Debug,
+    Bool,
+    F64,
+    I64,
+    U64,
+}
+
 /// One captured log event: its level, message, and rendered fields.
 #[derive(Debug, Clone)]
 pub struct CapturedLog {
@@ -54,6 +66,7 @@ pub struct CapturedLog {
     pub message: String,
     /// Field name/value pairs as strings, in emission order.
     pub fields: Vec<(String, String)>,
+    field_kinds: Vec<(String, CapturedFieldKind)>,
 }
 
 impl CapturedLog {
@@ -62,6 +75,14 @@ impl CapturedLog {
         self.fields
             .iter()
             .find_map(|(field_name, value)| (field_name == name).then_some(value.as_str()))
+    }
+
+    /// `field_kind` returns the native tracing value kind of the first field
+    /// named `name`.
+    pub fn field_kind(&self, name: &str) -> Option<CapturedFieldKind> {
+        self.field_kinds
+            .iter()
+            .find_map(|(field_name, kind)| (field_name == name).then_some(*kind))
     }
 }
 
@@ -92,6 +113,7 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
         let mut visitor = CaptureVisitor {
             message: String::new(),
             fields: Vec::new(),
+            field_kinds: Vec::new(),
         };
         event.record(&mut visitor);
         self.captured
@@ -103,6 +125,7 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
                 target: event.metadata().target().to_string(),
                 message: visitor.message,
                 fields: visitor.fields,
+                field_kinds: visitor.field_kinds,
             });
     }
 }
@@ -110,12 +133,25 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
 struct CaptureVisitor {
     message: String,
     fields: Vec<(String, String)>,
+    field_kinds: Vec<(String, CapturedFieldKind)>,
+}
+
+impl CaptureVisitor {
+    fn push(
+        &mut self,
+        field: &tracing::field::Field,
+        value: impl ToString,
+        kind: CapturedFieldKind,
+    ) {
+        let name = field.name().to_string();
+        self.fields.push((name.clone(), value.to_string()));
+        self.field_kinds.push((name, kind));
+    }
 }
 
 impl tracing::field::Visit for CaptureVisitor {
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.fields
-            .push((field.name().to_string(), value.to_string()));
+        self.push(field, value, CapturedFieldKind::String);
     }
 
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
@@ -125,8 +161,24 @@ impl tracing::field::Visit for CaptureVisitor {
         if field.name() == "message" {
             self.message = rendered;
         } else {
-            self.fields.push((field.name().to_string(), rendered));
+            self.push(field, rendered, CapturedFieldKind::Debug);
         }
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.push(field, value, CapturedFieldKind::Bool);
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.push(field, value, CapturedFieldKind::F64);
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.push(field, value, CapturedFieldKind::I64);
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.push(field, value, CapturedFieldKind::U64);
     }
 }
 

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -20,8 +20,9 @@
 
 use std::time::Duration;
 
-use carbide_instrument::testing::{MetricsCapture, capture_logs};
+use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
 use carbide_instrument::{Event, LabelValue, LogAt, MetricKind, Outcome, emit};
+use carbide_test_support::value_scenarios;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
 enum Stage {
@@ -81,6 +82,53 @@ fn both_sides_from_one_emit() {
             &[("stage", "apply"), ("outcome", "error")],
         ),
         1.0
+    );
+}
+
+/// `#[context(value)]` retains each supported structured type instead of
+/// routing it through `Display` formatting.
+#[test]
+fn native_context_retains_its_type() {
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_native_context",
+        component = "matrix-test",
+        message = "native context"
+    )]
+    struct NativeContext {
+        #[context(value)]
+        ready: bool,
+        #[context(value)]
+        attempt: i64,
+        #[context(value)]
+        retry_interval_seconds: f64,
+        #[context(value)]
+        phase: String,
+    }
+
+    let logs = capture_logs(|| {
+        emit(NativeContext {
+            ready: true,
+            attempt: 3,
+            retry_interval_seconds: 30.5,
+            phase: "backoff".to_string(),
+        });
+    });
+
+    assert_eq!(logs.len(), 1);
+    value_scenarios!(run = |field| (
+        logs[0].field(field).map(str::to_string),
+        logs[0].field_kind(field),
+    );
+        "native context retains its rendered value and tracing type" {
+            "ready" => (Some("true".to_string()), Some(CapturedFieldKind::Bool)),
+            "attempt" => (Some("3".to_string()), Some(CapturedFieldKind::I64)),
+            "retry_interval_seconds" => (
+                Some("30.5".to_string()),
+                Some(CapturedFieldKind::F64),
+            ),
+            "phase" => (Some("backoff".to_string()), Some(CapturedFieldKind::String)),
+        }
     );
 }
 


### PR DESCRIPTION
`carbide_dpu_agent_report_total` already described report-loop outcomes, but their diagnostic records were assembled independently at each call site and needed different context for each loop.

Semantic sibling `Event`s now fix each valid loop/outcome pair in their constructors and preserve the existing metric series, log levels, messages, and context. A narrow `#[context(value)]` form keeps supported tracing values native without turning operational context into metric labels. Inventory failures remain metric-only because the scheduler owns their diagnostic.

Table-driven tests cover the outcome matrix, native values, parser guardrails, and metric exposition.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3731
- Documentation: https://github.com/NVIDIA/infra-controller/pull/3768
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The ten report outcomes form one named `check_values` table. Native tracing value coverage uses `value_scenarios!`, and the context-mode parser covers its valid and malformed forms through six named `check_cases` rows. Metric exposition remains covered explicitly.

Verified with:

- `cargo test -p carbide-agent --lib`
- `cargo test -p carbide-instrument-macros -p carbide-instrument`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

The broader `#[context(value)]` guide is split into #3768 and depends on this implementation. Its parser tests pin diagnostics owned by this crate while only asserting rejection for `syn`-owned wording, so a dependency copy edit does not break the suite. The pre-existing whole-response clone remains outside this instrumentation change, and the two config-fetch error records keep their historical `%err` and `?err` renderings.

Closes #3731
