### PR TITLE
fix(api,redfish): format ipv6 bmc addresses at protocol boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,6 +2771,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-instrument",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-utils",
  "chrono",
  "http",

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -33,11 +33,11 @@ use model::machine_boot_interface::MachineBootInterface;
 use model::predicted_machine_interface::PredictedMachineInterface;
 use model::site_explorer::{BlueFieldOperatingMode, PreingestionState};
 use sqlx::PgConnection;
-use tokio::net::lookup_host;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_machine_id, log_request_data, log_request_data_redacted};
+use crate::handlers::utils::resolve_bmc_address;
 
 /// Resolve the boot interface an admin Redfish action should target, the same
 /// way the machine-controller resolves it.
@@ -865,20 +865,7 @@ async fn resolve_bmc_interface(
     api: &Api,
     request: &rpc::BmcEndpointRequest,
 ) -> Result<(SocketAddr, MacAddress), Status> {
-    let address = if request.ip_address.contains(':') {
-        request.ip_address.clone()
-    } else {
-        format!("{}:443", request.ip_address)
-    };
-
-    let mut addrs = lookup_host(address).await?;
-    let Some(bmc_addr) = addrs.next() else {
-        return Err(CarbideError::InvalidArgument(format!(
-            "could not resolve {}. must be hostname[:port] or IPv4[:port]",
-            request.ip_address
-        ))
-        .into());
-    };
+    let bmc_addr = resolve_bmc_address(&request.ip_address).await?;
 
     let bmc_mac_address: MacAddress;
     if let Some(mac_str) = &request.mac_address {

--- a/crates/api-core/src/handlers/redfish.rs
+++ b/crates/api-core/src/handlers/redfish.rs
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use arc_swap::ArcSwap;
 use carbide_secrets::credentials::CredentialReader;
 use carbide_utils::HostPortPair;
+use carbide_utils::redfish::{format_forwarded_host_parameter, parse_uri_host_ip};
 use chrono::{DateTime, Local};
 use db::Transaction;
 use db::redfish_actions::{
@@ -27,6 +29,7 @@ use db::redfish_actions::{
     set_applied, update_response,
 };
 use http::header::CONTENT_TYPE;
+use http::uri::Authority;
 use http::{HeaderMap, HeaderValue, Uri};
 use model::redfish::BMCResponse;
 use serde::Serialize;
@@ -233,14 +236,7 @@ pub async fn redfish_apply_action(
             }, index).await?;
         } else {
             uris.push((
-                Uri::builder()
-                    .scheme("https")
-                    .authority(machine_ip)
-                    .path_and_query(&action_request.target)
-                    .build()
-                    .map_err(|e| {
-                        CarbideError::internal(format!("invalid uri from machine_ip: {e}"))
-                    })?,
+                redfish_action_uri(&machine_ip, &action_request.target)?,
                 index,
             ));
         }
@@ -392,6 +388,75 @@ async fn handle_request(
     }
 }
 
+/// `metadata_host` extracts the port-free host key used for BMC metadata lookup.
+///
+/// `Uri::host` retains IPv6 brackets, which are URI syntax rather than part of
+/// the address. Normalize IP literals to their bare form while leaving hostnames
+/// unchanged; a URI without a host produces an empty lookup key.
+fn metadata_host(uri: &Uri) -> String {
+    uri.host()
+        .map(|host| parse_uri_host_ip(host).map_or_else(|| host.to_string(), |ip| ip.to_string()))
+        .unwrap_or_default()
+}
+
+/// `uri_authority` combines a host and separate port into URI authority syntax.
+///
+/// IP literals can arrive bare or bracketed, so normalize them and bracket IPv6
+/// exactly once before appending the port. `Authority::try_from` rejects any
+/// remaining invalid authority syntax.
+fn uri_authority(host: &str, port: Option<u32>) -> Result<Authority, http::uri::InvalidUri> {
+    let host = match parse_uri_host_ip(host) {
+        Some(IpAddr::V4(ip)) => ip.to_string(),
+        Some(IpAddr::V6(ip)) => format!("[{ip}]"),
+        None => host.to_string(),
+    };
+
+    match port {
+        Some(port) => Authority::try_from(format!("{host}:{port}")),
+        None => Authority::try_from(host),
+    }
+}
+
+/// `client_authority` applies a proxy override to the BMC metadata authority.
+///
+/// The boolean marks that the proxy variant supplied a host. This tells
+/// `create_client` to include the original metadata IP in `Forwarded`.
+/// `HostOnly` inherits the metadata port, while `PortOnly` keeps the metadata
+/// host and leaves the boolean false.
+fn client_authority(
+    metadata_host: &str,
+    metadata_port: Option<u32>,
+    proxy_address: Option<&HostPortPair>,
+) -> Result<(Authority, bool), http::uri::InvalidUri> {
+    let (host, port, add_custom_header) = match proxy_address {
+        None => (metadata_host, metadata_port, false),
+        Some(HostPortPair::HostAndPort(host, port)) => {
+            (host.as_str(), Some(u32::from(*port)), true)
+        }
+        Some(HostPortPair::HostOnly(host)) => (host.as_str(), metadata_port, true),
+        Some(HostPortPair::PortOnly(port)) => (metadata_host, Some(u32::from(*port)), false),
+    };
+
+    uri_authority(host, port).map(|authority| (authority, add_custom_header))
+}
+
+/// `redfish_action_uri` builds the initial HTTPS URI for a Redfish action.
+///
+/// `machine_ip` is stored without URI brackets, so route it through
+/// `uri_authority` before attaching `target`. `create_client` can replace this
+/// authority later with the resolved BMC or proxy endpoint.
+fn redfish_action_uri(machine_ip: &str, target: &str) -> Result<Uri, CarbideError> {
+    let authority = uri_authority(machine_ip, None)
+        .map_err(|error| CarbideError::internal(format!("invalid uri from machine_ip: {error}")))?;
+
+    Uri::builder()
+        .scheme("https")
+        .authority(authority)
+        .path_and_query(target)
+        .build()
+        .map_err(|error| CarbideError::internal(format!("invalid uri from machine_ip: {error}")))
+}
+
 pub(crate) async fn create_client(
     uri: http::Uri,
     pool: &PgPool,
@@ -409,7 +474,7 @@ pub(crate) async fn create_client(
     let bmc_metadata_request = rpc::forge::BmcMetaDataGetRequest {
         machine_id: None,
         bmc_endpoint_request: Some(rpc::forge::BmcEndpointRequest {
-            ip_address: uri.host().map(|x| x.to_string()).unwrap_or_default(),
+            ip_address: metadata_host(&uri),
             mac_address: None,
         }),
         role: rpc::forge::UserRoles::Administrator.into(),
@@ -421,23 +486,9 @@ pub(crate) async fn create_client(
             .await?;
 
     let proxy_address = bmc_proxy.load();
-    let (host, port, add_custom_header) = match proxy_address.as_ref() {
-        // No override
-        None => (metadata.ip.clone(), metadata.port, false),
-        // Override the host and port
-        Some(HostPortPair::HostAndPort(h, p)) => (h.to_string(), Some(*p as u32), true),
-        // Only override the host
-        Some(HostPortPair::HostOnly(h)) => (h.to_string(), metadata.port, true),
-        // Only override the port
-        Some(HostPortPair::PortOnly(p)) => (metadata.ip.clone(), Some(*p as u32), false),
-    };
-    let new_authority = if let Some(port) = port {
-        http::uri::Authority::try_from(format!("{host}:{port}"))
-            .map_err(|e| CarbideError::internal(format!("creating url {e}")))?
-    } else {
-        http::uri::Authority::try_from(host)
-            .map_err(|e| CarbideError::internal(format!("creating url {e}")))?
-    };
+    let (new_authority, add_custom_header) =
+        client_authority(&metadata.ip, metadata.port, proxy_address.as_ref().as_ref())
+            .map_err(|error| CarbideError::internal(format!("creating url {error}")))?;
     let mut parts = uri.into_parts();
     parts.authority = Some(new_authority);
     let new_uri = http::Uri::from_parts(parts)
@@ -446,7 +497,7 @@ pub(crate) async fn create_client(
     if add_custom_header {
         headers.insert(
             "forwarded",
-            format!("host={orig_host}", orig_host = metadata.ip)
+            format_forwarded_host_parameter(&metadata.ip)
                 .parse()
                 .unwrap(),
         );
@@ -585,5 +636,128 @@ impl From<reqwest_middleware::Error> for RequestErrorInfo {
             status_code: e.status(),
             description: e.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use carbide_utils::HostPortPair;
+
+    use super::{client_authority, metadata_host, redfish_action_uri};
+
+    #[test]
+    fn metadata_host_is_bare_for_ip_literals() {
+        value_scenarios!(run = |raw_uri| {
+            let uri: http::Uri = raw_uri.parse().unwrap();
+            metadata_host(&uri)
+        };
+            "IPv4" {
+                "https://192.0.2.10/redfish/v1" => "192.0.2.10".to_string(),
+                "https://192.0.2.10:8443/redfish/v1" => "192.0.2.10".to_string(),
+            }
+
+            "bracketed IPv6" {
+                "https://[2001:db8::10]/redfish/v1" => "2001:db8::10".to_string(),
+                "https://[2001:db8::10]:8443/redfish/v1" => "2001:db8::10".to_string(),
+            }
+
+            "hostname" {
+                "https://bmc.example.com/redfish/v1" => "bmc.example.com".to_string(),
+                "https://bmc.example.com:8443/redfish/v1" => "bmc.example.com".to_string(),
+            }
+        );
+    }
+
+    struct ClientAuthorityCase {
+        metadata_host: &'static str,
+        metadata_port: Option<u32>,
+        proxy: Option<HostPortPair>,
+    }
+
+    #[test]
+    fn client_authority_brackets_ipv6_for_proxy_variants() {
+        value_scenarios!(run = |ClientAuthorityCase { metadata_host, metadata_port, proxy }| {
+            client_authority(metadata_host, metadata_port, proxy.as_ref())
+                .map(|(authority, forwarded)| (authority.to_string(), forwarded))
+                .unwrap()
+        };
+            "direct BMC" {
+                ClientAuthorityCase {
+                    metadata_host: "192.0.2.10",
+                    metadata_port: None,
+                    proxy: None,
+                } => ("192.0.2.10".to_string(), false),
+                ClientAuthorityCase {
+                    metadata_host: "2001:db8::10",
+                    metadata_port: None,
+                    proxy: None,
+                } => ("[2001:db8::10]".to_string(), false),
+                ClientAuthorityCase {
+                    metadata_host: "2001:db8::10",
+                    metadata_port: Some(8443),
+                    proxy: None,
+                } => ("[2001:db8::10]:8443".to_string(), false),
+                ClientAuthorityCase {
+                    metadata_host: "bmc.example.com",
+                    metadata_port: Some(8443),
+                    proxy: None,
+                } => ("bmc.example.com:8443".to_string(), false),
+            }
+
+            "proxy host and port" {
+                ClientAuthorityCase {
+                    metadata_host: "2001:db8::10",
+                    metadata_port: None,
+                    proxy: Some(HostPortPair::HostAndPort(
+                        "2001:db8::20".to_string(),
+                        9443,
+                    )),
+                } => ("[2001:db8::20]:9443".to_string(), true),
+                ClientAuthorityCase {
+                    metadata_host: "192.0.2.10",
+                    metadata_port: None,
+                    proxy: Some(HostPortPair::HostAndPort(
+                        "proxy.example.com".to_string(),
+                        9443,
+                    )),
+                } => ("proxy.example.com:9443".to_string(), true),
+            }
+
+            "proxy host only" {
+                ClientAuthorityCase {
+                    metadata_host: "2001:db8::10",
+                    metadata_port: Some(8443),
+                    proxy: Some(HostPortPair::HostOnly("[2001:db8::20]".to_string())),
+                } => ("[2001:db8::20]:8443".to_string(), true),
+            }
+
+            "proxy port only" {
+                ClientAuthorityCase {
+                    metadata_host: "2001:db8::10",
+                    metadata_port: None,
+                    proxy: Some(HostPortPair::PortOnly(9443)),
+                } => ("[2001:db8::10]:9443".to_string(), false),
+            }
+        );
+    }
+
+    #[test]
+    fn action_uri_brackets_ipv6_authorities() {
+        value_scenarios!(run = |machine_ip| {
+            redfish_action_uri(machine_ip, "/redfish/v1/Systems/1/Actions/Reset")
+                .unwrap()
+                .to_string()
+        };
+            "IPv4" {
+                "192.0.2.10" =>
+                    "https://192.0.2.10/redfish/v1/Systems/1/Actions/Reset".to_string(),
+            }
+
+            "IPv6" {
+                "2001:db8::10" =>
+                    "https://[2001:db8::10]/redfish/v1/Systems/1/Actions/Reset".to_string(),
+            }
+        );
     }
 }

--- a/crates/api-core/src/handlers/site_explorer.rs
+++ b/crates/api-core/src/handlers/site_explorer.rs
@@ -22,11 +22,11 @@ use ::rpc::forge::{self as rpc, IsBmcInManagedHostResponse};
 use carbide_site_explorer::enrich_endpoint_exploration_report;
 use config_version::ConfigVersion;
 use model::expected_entity::ExpectedEntity;
-use tokio::net::lookup_host;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
+use crate::handlers::utils::resolve_bmc_address;
 
 pub(crate) async fn find_explored_endpoint_ids(
     api: &Api,
@@ -518,20 +518,7 @@ pub(crate) async fn is_bmc_in_managed_host(
 ) -> Result<Response<IsBmcInManagedHostResponse>, tonic::Status> {
     log_request_data(&request);
     let req = request.into_inner();
-    let address = if req.ip_address.contains(':') {
-        req.ip_address.clone()
-    } else {
-        format!("{}:443", req.ip_address)
-    };
-
-    let mut addrs = lookup_host(address).await?;
-    let Some(bmc_addr) = addrs.next() else {
-        return Err(CarbideError::InvalidArgument(format!(
-            "could not resolve {}. must be hostname[:port] or IPv4[:port]",
-            req.ip_address
-        ))
-        .into());
-    };
+    let bmc_addr = resolve_bmc_address(&req.ip_address).await?;
 
     let in_managed_host =
         carbide_site_explorer::is_endpoint_in_managed_host(bmc_addr.ip(), &api.database_connection)

--- a/crates/api-core/src/handlers/utils.rs
+++ b/crates/api-core/src/handlers/utils.rs
@@ -15,10 +15,74 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
+use std::net::{IpAddr, SocketAddr};
+
+use carbide_utils::HostPortPair;
 use carbide_uuid::machine::MachineId;
+use tokio::net::lookup_host;
 
 use crate::CarbideError;
 use crate::api::log_machine_id;
+
+const DEFAULT_BMC_HTTPS_PORT: u16 = 443;
+
+/// Resolves a BMC address, applying the default HTTPS port when one is absent.
+///
+/// Bare IP literals are handled before hostname resolution so an IPv6 address's
+/// colons are never mistaken for a host/port separator. An explicit port on an
+/// IPv6 literal must use the standard `[address]:port` socket syntax.
+pub(crate) async fn resolve_bmc_address(address: &str) -> Result<SocketAddr, tonic::Status> {
+    if let Some(address) = parse_numeric_bmc_address(address) {
+        return Ok(address);
+    }
+
+    let lookup_target = bmc_lookup_target(address).map_err(tonic::Status::from)?;
+    let mut addresses = lookup_host(lookup_target.as_ref()).await?;
+
+    addresses
+        .next()
+        .ok_or_else(|| invalid_bmc_address(address, "name resolution returned no addresses").into())
+}
+
+fn parse_numeric_bmc_address(address: &str) -> Option<SocketAddr> {
+    if let Ok(address) = address.parse::<SocketAddr>() {
+        return Some(address);
+    }
+    if let Ok(address) = address.parse::<IpAddr>() {
+        return Some(SocketAddr::new(address, DEFAULT_BMC_HTTPS_PORT));
+    }
+
+    let address = address.strip_prefix('[')?.strip_suffix(']')?;
+    let address = address.parse::<IpAddr>().ok()?;
+    address
+        .is_ipv6()
+        .then(|| SocketAddr::new(address, DEFAULT_BMC_HTTPS_PORT))
+}
+
+fn bmc_lookup_target(address: &str) -> Result<Cow<'_, str>, CarbideError> {
+    if address.contains('[') || address.contains(']') {
+        return Err(invalid_bmc_address(
+            address,
+            "brackets are only valid around an IPv6 literal",
+        ));
+    }
+
+    match address
+        .parse::<HostPortPair>()
+        .map_err(|error| invalid_bmc_address(address, error))?
+    {
+        HostPortPair::HostOnly(_) => Ok(Cow::Owned(format!("{address}:{DEFAULT_BMC_HTTPS_PORT}"))),
+        HostPortPair::HostAndPort(_, _) => Ok(Cow::Borrowed(address)),
+        HostPortPair::PortOnly(_) => Err(invalid_bmc_address(address, "host is missing")),
+    }
+}
+
+fn invalid_bmc_address(address: &str, reason: impl std::fmt::Display) -> CarbideError {
+    CarbideError::InvalidArgument(format!(
+        "could not resolve BMC address {address:?}: {reason}; expected a hostname or IP address with an optional port (IPv6 with an explicit port must use [address]:port)"
+    ))
+}
 
 /// Converts a MachineID from RPC format to Model format
 /// and logs the MachineID as MachineID for the current request.
@@ -72,8 +136,79 @@ mod tests {
     use std::str::FromStr as _;
 
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
+
+    #[test]
+    fn parses_numeric_bmc_addresses_with_the_expected_port() {
+        value_scenarios!(
+            run = |address: &str| parse_numeric_bmc_address(address);
+            "default HTTPS port" {
+                "192.0.2.10" => Some("192.0.2.10:443".parse().unwrap()),
+                "2001:db8::10" => Some("[2001:db8::10]:443".parse().unwrap()),
+                "[2001:db8::10]" => Some("[2001:db8::10]:443".parse().unwrap()),
+            }
+
+            "explicit port" {
+                "192.0.2.10:8443" => Some("192.0.2.10:8443".parse().unwrap()),
+                "[2001:db8::10]:8443" => Some("[2001:db8::10]:8443".parse().unwrap()),
+            }
+
+            "hostname resolution required" {
+                "bmc.example.com" => None,
+                "bmc.example.com:8443" => None,
+            }
+        );
+    }
+
+    #[test]
+    fn hostname_lookup_targets_preserve_or_default_the_port() {
+        value_scenarios!(
+            run = |address: &str| bmc_lookup_target(address).ok().map(Cow::into_owned);
+            "default HTTPS port" {
+                "bmc.example.com" => Some("bmc.example.com:443".to_string()),
+            }
+
+            "explicit port" {
+                "bmc.example.com:8443" => Some("bmc.example.com:8443".to_string()),
+            }
+
+            "invalid host and port forms" {
+                ":8443" => None,
+                "bmc.example.com:notaport" => None,
+                "[192.0.2.10]" => None,
+                "[192.0.2.10]:8443" => None,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_hostname_forms_with_the_expected_port() {
+        for (scenario, address, expected_port) in [
+            ("hostname", "localhost", 443),
+            ("hostname and port", "localhost:8443", 8443),
+        ] {
+            let resolved = resolve_bmc_address(address)
+                .await
+                .expect("localhost should resolve");
+            assert!(resolved.ip().is_loopback(), "{scenario}");
+            assert_eq!(resolved.port(), expected_port, "{scenario}");
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_bmc_address_error_describes_accepted_forms() {
+        let error = resolve_bmc_address(":8443")
+            .await
+            .expect_err("an address without a host must be rejected");
+
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
+        assert_eq!(
+            error.message(),
+            "could not resolve BMC address \":8443\": host is missing; expected a hostname or IP address with an optional port (IPv6 with an explicit port must use [address]:port)"
+        );
+    }
 
     /// One emit writes the WARN line (machine id and error as fields) AND
     /// moves the counter, with every trigger variant rendering as its

--- a/crates/api-web/src/redfish_browser.rs
+++ b/crates/api-web/src/redfish_browser.rs
@@ -19,6 +19,7 @@
 // See https://github.com/NVIDIA/infra-controller/issues/2793
 #![allow(deprecated)]
 
+use std::net::IpAddr;
 use std::sync::Arc;
 
 use askama::Template;
@@ -27,6 +28,7 @@ use axum::extract::{Query as AxumQuery, State as AxumState};
 use axum::response::{Html, IntoResponse, Response};
 use axum_extra::extract::PrivateCookieJar;
 use carbide_api_core::{Api, NUM_REQUIRED_APPROVALS};
+use carbide_utils::redfish::parse_uri_host_ip;
 use carbide_uuid::machine::MachineId;
 use http::HeaderMap;
 use hyper::http::StatusCode;
@@ -59,6 +61,22 @@ struct Header {
 #[derive(Debug, Deserialize)]
 pub struct QueryParams {
     url: Option<String>,
+}
+
+fn bmc_base_url(uri: &http::Uri, bmc_ip: IpAddr) -> Result<String, http::uri::InvalidUri> {
+    let host = match bmc_ip {
+        IpAddr::V4(ip) => ip.to_string(),
+        IpAddr::V6(ip) => format!("[{ip}]"),
+    };
+    let authority = match uri.port_u16() {
+        Some(port) => http::uri::Authority::try_from(format!("{host}:{port}"))?,
+        None => http::uri::Authority::try_from(host)?,
+    };
+
+    Ok(format!(
+        "{}://{authority}",
+        uri.scheme_str().unwrap_or("https")
+    ))
 }
 
 /// Queries the redfish endpoint in the query parameter
@@ -106,33 +124,30 @@ pub async fn query(
         }
     };
 
-    browser.bmc_ip = match uri.host() {
-        Some(host) => host.to_string(),
+    let host = match uri.host() {
+        Some(host) => host,
         None => {
             browser.error = format!("Missing host in URL {}", browser.url);
             return (StatusCode::OK, Html(browser.render().unwrap())).into_response();
         }
     };
 
-    let bmc_ip: std::net::IpAddr = match browser.bmc_ip.parse() {
-        Ok(ip) => ip,
-        Err(_) => {
+    let bmc_ip = match parse_uri_host_ip(host) {
+        Some(ip) => ip,
+        None => {
             browser.error = format!("host in URL {} is not a valid IP", browser.url);
             return (StatusCode::OK, Html(browser.render().unwrap())).into_response();
         }
     };
+    browser.bmc_ip = bmc_ip.to_string();
 
     // This variable is used in order to allow building absolute path easier from
     // Javascript
-    browser.base_bmc_url = {
-        let scheme = match uri.scheme_str() {
-            Some(scheme) => scheme.to_string(),
-            None => "https".to_string(),
-        };
-        if let Some(port) = uri.port_u16() {
-            format!("{scheme}://{bmc_ip}:{port}")
-        } else {
-            format!("{scheme}://{bmc_ip}")
+    browser.base_bmc_url = match bmc_base_url(&uri, bmc_ip) {
+        Ok(url) => url,
+        Err(_) => {
+            browser.error = format!("Invalid URL {}", browser.url);
+            return (StatusCode::OK, Html(browser.render().unwrap())).into_response();
         }
     };
 
@@ -234,3 +249,41 @@ pub mod filters {
 }
 
 impl super::Base for RedfishBrowser {}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::{bmc_base_url, parse_uri_host_ip};
+
+    #[test]
+    fn bmc_url_parts_support_ipv4_and_ipv6() {
+        value_scenarios!(run = |raw_uri| {
+            let uri: http::Uri = raw_uri.parse().unwrap();
+            let ip = parse_uri_host_ip(uri.host().unwrap()).unwrap();
+            (ip.to_string(), bmc_base_url(&uri, ip).unwrap())
+        };
+            "IPv4" {
+                "https://192.0.2.10/redfish/v1" => (
+                    "192.0.2.10".to_string(),
+                    "https://192.0.2.10".to_string(),
+                ),
+                "http://192.0.2.10:8080/redfish/v1" => (
+                    "192.0.2.10".to_string(),
+                    "http://192.0.2.10:8080".to_string(),
+                ),
+            }
+
+            "bracketed IPv6" {
+                "https://[2001:db8::10]/redfish/v1" => (
+                    "2001:db8::10".to_string(),
+                    "https://[2001:db8::10]".to_string(),
+                ),
+                "https://[2001:db8::10]:8443/redfish/v1" => (
+                    "2001:db8::10".to_string(),
+                    "https://[2001:db8::10]:8443".to_string(),
+                ),
+            }
+        );
+    }
+}

--- a/crates/bmc-mock/src/combined_service.rs
+++ b/crates/bmc-mock/src/combined_service.rs
@@ -83,9 +83,21 @@ fn forwarded_host<B>(request: &Request<B>) -> Option<String> {
         .get(FORWARDED)
         .and_then(|v| v.to_str().ok())
         .and_then(|fh| {
-            fh.split(';')
-                .find(|substr| substr.starts_with("host="))
-                .map(|substr| substr.replace("host=", ""))
+            fh.split([',', ';'])
+                .map(str::trim)
+                .find_map(|parameter| {
+                    let (key, value) = parameter.split_once('=')?;
+                    key.trim()
+                        .eq_ignore_ascii_case("host")
+                        .then(|| value.trim())
+                })
+                .map(|host| host.trim_matches('"'))
+                .map(|host| {
+                    host.strip_prefix('[')
+                        .and_then(|host| host.strip_suffix(']'))
+                        .unwrap_or(host)
+                        .to_string()
+                })
         })
 }
 
@@ -139,25 +151,44 @@ mod tests {
 
     #[tokio::test]
     async fn routes_by_forwarded_host() {
-        let router = combined_router(Arc::new(RwLock::new(HashMap::from([(
-            "172.20.0.20".to_string(),
-            Router::new().route("/redfish/v1", get(|| async { "bmc" })),
-        )]))));
+        for (scenario, router_key, forwarded) in [
+            ("IPv4 token", "172.20.0.20", "host=172.20.0.20"),
+            (
+                "case-insensitive host parameter",
+                "172.20.0.20",
+                "Host=172.20.0.20",
+            ),
+            (
+                "quoted IPv6 host",
+                "2001:db8::20",
+                "host=\"[2001:db8::20]\"",
+            ),
+            (
+                "host in a later forwarded element",
+                "2001:db8::20",
+                "for=192.0.2.1, host=\"[2001:db8::20]\"",
+            ),
+        ] {
+            let router = combined_router(Arc::new(RwLock::new(HashMap::from([(
+                router_key.to_string(),
+                Router::new().route("/redfish/v1", get(|| async { "bmc" })),
+            )]))));
 
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .uri("/redfish/v1")
-                    .header("forwarded", "host=172.20.0.20")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/redfish/v1")
+                        .header("forwarded", forwarded)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        assert_eq!(&body[..], b"bmc");
+            assert_eq!(response.status(), StatusCode::OK, "{scenario}");
+            let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            assert_eq!(&body[..], b"bmc", "{scenario}");
+        }
     }
 
     #[tokio::test]

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
+use carbide_utils::redfish::format_forwarded_host_parameter;
 use futures::TryStreamExt;
 use http::HeaderMap;
 use http::header::{self, InvalidHeaderValue};
@@ -444,7 +445,7 @@ fn bmc_headers(addr: &BmcAddr, proxy_url: Option<&Url>) -> Result<HeaderMap, Hea
     if proxy_url.is_some() {
         headers.insert(
             header::FORWARDED,
-            format!("host={}", addr.ip)
+            format_forwarded_host_parameter(&addr.ip.to_string())
                 .parse()
                 .map_err(|e: InvalidHeaderValue| HealthError::GenericError(e.to_string()))?,
         );
@@ -701,6 +702,7 @@ mod tests {
     use std::sync::{Arc, Mutex as StdMutex};
     use std::time::Duration;
 
+    use carbide_test_support::value_scenarios;
     use mac_address::MacAddress;
     use nv_redfish::bmc_http::reqwest::ClientParams as ReqwestClientParams;
 
@@ -751,6 +753,31 @@ mod tests {
             port: Some(443),
             mac: MacAddress::from_str("00:11:22:33:44:55").unwrap(),
         }
+    }
+
+    #[test]
+    fn proxy_forwarded_header_formats_ip_literals() {
+        value_scenarios!(run = |ip: &str| {
+            let addr = BmcAddr {
+                ip: ip.parse().unwrap(),
+                port: Some(443),
+                mac: MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+            };
+            let proxy_url = Url::parse("https://proxy.example.com").unwrap();
+
+            bmc_headers(&addr, Some(&proxy_url))
+                .unwrap()
+                .get(header::FORWARDED)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
+        };
+            "Forwarded host parameter" {
+                "192.0.2.10" => "host=192.0.2.10".to_string(),
+                "2001:db8::10" => "host=\"[2001:db8::10]\"".to_string(),
+            }
+        );
     }
 
     fn reqwest() -> ReqwestClient {

--- a/crates/redfish/Cargo.toml
+++ b/crates/redfish/Cargo.toml
@@ -49,5 +49,6 @@ axum = { workspace = true }
 axum-server = { workspace = true, features = ["tls-rustls"] }
 bmc-mock = { path = "../bmc-mock" }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
 nv-redfish = { workspace = true, features = ["chassis"] }
 rustls = { workspace = true }

--- a/crates/redfish/src/libredfish/implementation.rs
+++ b/crates/redfish/src/libredfish/implementation.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::borrow::Cow;
+use std::net::Ipv6Addr;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -23,11 +25,25 @@ use async_trait::async_trait;
 use carbide_instrument::red;
 use carbide_secrets::credentials::{CredentialReader, Credentials};
 use carbide_utils::HostPortPair;
+use carbide_utils::redfish::format_forwarded_host_parameter;
 use libredfish::model::service_root::RedfishVendor;
 use libredfish::{Endpoint, Redfish};
 
 use crate::libredfish::instrumented::{InstrumentedRedfish, REDFISH_BACKEND};
 use crate::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
+
+/// Formats a host for the URL authority that `libredfish` constructs internally.
+///
+/// `libredfish::Endpoint` accepts a host and port separately, but the pinned
+/// implementation interpolates them into a URL string. Keep callers' host values
+/// bare and add IPv6 brackets only at this external serialization boundary.
+fn libredfish_endpoint_host(host: &str) -> Cow<'_, str> {
+    if host.parse::<Ipv6Addr>().is_ok() {
+        Cow::Owned(format!("[{host}]"))
+    } else {
+        Cow::Borrowed(host)
+    }
+}
 
 pub struct RedfishClientPoolImpl {
     pool: libredfish::RedfishClientPool,
@@ -97,7 +113,7 @@ impl RedfishClientPool for RedfishClientPoolImpl {
         };
 
         let endpoint = Endpoint {
-            host: host.to_string(),
+            host: libredfish_endpoint_host(host).into_owned(),
             port,
             user: username,
             password,
@@ -112,7 +128,7 @@ impl RedfishClientPool for RedfishClientPoolImpl {
             vec![(
                 http::HeaderName::from_str("forwarded")
                     .map_err(|err| RedfishClientCreationError::InvalidHeader(err.to_string()))?,
-                format!("host={original_host}"),
+                format_forwarded_host_parameter(original_host),
             )]
         } else {
             Vec::default()
@@ -160,5 +176,27 @@ impl RedfishClientPool for RedfishClientPoolImpl {
 
     fn credential_reader(&self) -> &dyn CredentialReader {
         &*self.credential_reader
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::libredfish_endpoint_host;
+
+    #[test]
+    fn endpoint_host_brackets_only_bare_ipv6_literals() {
+        value_scenarios!(run = |host| libredfish_endpoint_host(host).into_owned();
+            "unchanged hosts" {
+                "bmc.example.com" => "bmc.example.com".to_string(),
+                "192.0.2.10" => "192.0.2.10".to_string(),
+                "[2001:db8::10]" => "[2001:db8::10]".to_string(),
+            }
+
+            "bracketed IPv6 host" {
+                "2001:db8::10" => "[2001:db8::10]".to_string(),
+            }
+        );
     }
 }

--- a/crates/utils/src/redfish.rs
+++ b/crates/utils/src/redfish.rs
@@ -15,7 +15,32 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use mac_address::MacAddress;
+
+/// `parse_uri_host_ip` parses an IPv4 literal or a bare/bracketed IPv6 literal.
+///
+/// `http::Uri::host` retains IPv6 brackets, while other callers can provide
+/// bare addresses. Accept both forms here; hostnames return `None`.
+pub fn parse_uri_host_ip(host: &str) -> Option<IpAddr> {
+    host.parse().ok().or_else(|| {
+        host.strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .and_then(|host| host.parse().ok())
+    })
+}
+
+/// Formats the `host` parameter for an HTTP `Forwarded` header.
+///
+/// RFC 7239 requires an IPv6 host to use brackets inside a quoted string.
+/// Hostnames and IPv4 literals retain the existing token form.
+pub fn format_forwarded_host_parameter(host: &str) -> String {
+    match parse_uri_host_ip(host) {
+        Some(IpAddr::V6(host)) => format!("host=\"[{host}]\""),
+        _ => format!("host={host}"),
+    }
+}
 
 /// Data needed to access BMC via Redfish.
 ///
@@ -25,4 +50,41 @@ pub struct BmcAccessInfo {
     pub host: String,
     pub port: Option<u16>,
     pub mac_address: MacAddress,
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::{format_forwarded_host_parameter, parse_uri_host_ip};
+
+    #[test]
+    fn uri_host_parser_accepts_bare_and_bracketed_ip_literals() {
+        value_scenarios!(run = |host| parse_uri_host_ip(host).map(|ip| ip.to_string());
+            "IP literals" {
+                "192.0.2.10" => Some("192.0.2.10".to_string()),
+                "2001:db8::10" => Some("2001:db8::10".to_string()),
+                "[2001:db8::10]" => Some("2001:db8::10".to_string()),
+            }
+
+            "hostname" {
+                "bmc.example.com" => None,
+            }
+        );
+    }
+
+    #[test]
+    fn forwarded_host_parameter_quotes_ipv6_literals() {
+        value_scenarios!(run = format_forwarded_host_parameter;
+            "token form" {
+                "bmc.example.com" => "host=bmc.example.com".to_string(),
+                "192.0.2.10" => "host=192.0.2.10".to_string(),
+            }
+
+            "quoted IPv6 form" {
+                "2001:db8::10" => "host=\"[2001:db8::10]\"".to_string(),
+                "[2001:db8::10]" => "host=\"[2001:db8::10]\"".to_string(),
+            }
+        );
+    }
 }


### PR DESCRIPTION
A BMC IP needs three representations as it crosses NICo: a bare value for storage and resolution, a bracketed URI authority, and a quoted RFC 7239 `Forwarded` host parameter.

```text
stored / resolved address:  2001:db8::1
URI authority:             [2001:db8::1]:443
Forwarded host parameter:  host="[2001:db8::1]"
```

Several paths carried the bare address one boundary too far. Endpoint exploration treated IPv6 colons like an explicit port and skipped the default `:443`; the admin browser, Redfish actions, and `libredfish` could build ambiguous `host:port` authorities; and proxy paths serialized invalid RFC 7239 values.

This change keeps the address bare for storage and metadata lookup, then formats it at the protocol boundary that needs a URI authority or header value. `resolve_bmc_address` handles hostnames, IPv4, bare or bracketed IPv6, and explicit or default ports through one path, while shared helpers cover URI host parsing and `Forwarded` serialization for the API, browser, `libredfish`, and health proxy.

IPv4 and hostname behavior remains unchanged, including resolver error mapping. The mock proxy also accepts quoted IPv6 values and case-insensitive `host` parameter names so its routing matches the real proxy's RFC 7239 handling.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2240

Related work:

- #3008 owns the overlapping `nv_redfish` URL construction.
- #3010 owns the `bmc-proxy` upstream URI authority.
- #3012 owns IPv6 parsing and rendering in `HostPortPair`.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Focused coverage includes bare and bracketed IPv6, explicit and default ports, browser and `libredfish` URI construction, RFC 7239 header formatting, case-insensitive mock routing, and the existing IPv4 and hostname paths.

Local verification passes `cargo make format-nightly`, `cargo make clippy`, `cargo make carbide-lints`, `cargo make check-workspace-deps`, and the affected Rust tests.

## Additional Notes

`BmcAccessInfo.host` intentionally remains bare because brackets belong to a URI authority, not the stored IP value.

`crates/redfish/src/nv_redfish/mod.rs` remains in #3008, the `bmc-proxy` upstream authority remains in #3010, and `HostPortPair` remains in #3012. This PR supports #2240 without closing it while those pieces remain open.


Closes #2240

