### PR TITLE
refactor(mqtt,instrument): pair DSX publish metrics and logs

### DIFF
--- a/crates/api-core/src/mqtt_state_change_hook/hook.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/hook.rs
@@ -48,12 +48,10 @@ pub struct MqttStateChangeHook {
 }
 
 impl MqttStateChangeHook {
-    /// Create a new MQTT state change hook.
-    ///
-    /// Spawns a background task to process queued events.
-    /// Emits metrics:
-    /// - `forge_dsx_event_bus_publish_count`: Number of MQTT publish attempts
-    /// - `forge_dsx_event_bus_queue_depth`: Current queue depth
+    /// `MqttStateChangeHook::new` creates the bounded event queue and starts its
+    /// publisher task. Publish outcomes feed
+    /// `carbide_dsx_event_bus_publish_count_total`; queue occupancy remains in
+    /// `carbide_dsx_event_bus_queue_depth`.
     pub fn new<P: MqttPublisher>(
         client: P,
         join_set: &mut JoinSet<()>,
@@ -96,24 +94,23 @@ impl StateChangeHook<MachineId, ManagedHostState> for MqttStateChangeHook {
                 let deadline = Instant::now() + self.publish_timeout;
                 let queued = QueuedMessage {
                     topic,
+                    machine_id: event.object_id.to_string(),
                     payload,
                     deadline,
                 };
-                if let Err(e) = self.sender.try_send(queued) {
-                    tracing::warn!(
-                        error = %e,
-                        "MQTT state change event dropped (queue full)",
-                    );
-                    self.metrics.record_overflow();
+                if let Err(error) = self.sender.try_send(queued) {
+                    let error_message = error.to_string();
+                    let queued = error.into_inner();
+                    self.metrics
+                        .record_overflow(queued.topic, queued.machine_id, error_message);
                 }
             }
-            Err(e) => {
-                tracing::error!(
-                    machine_id = %event.object_id,
-                    error = %e,
-                    "Failed to serialize state change message"
+            Err(error) => {
+                self.metrics.record_state_change_serialization_error(
+                    topic,
+                    event.object_id.to_string(),
+                    error.to_string(),
                 );
-                self.metrics.record_serialization_error();
             }
         }
     }

--- a/crates/api-core/src/mqtt_state_change_hook/republisher.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/republisher.rs
@@ -67,11 +67,10 @@ pub struct ManagedHostStateRepublisherParams {
 }
 
 impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
-    /// Create a new republisher.
-    ///
-    /// Reuses the change-hook publish metrics (`carbide_dsx_event_bus_publish_count`)
-    /// under the `managed_host_republish` component so periodic publishes can be
-    /// told apart from change-driven ones on dashboards.
+    /// `ManagedHostStateRepublisher::new` reuses
+    /// `carbide_dsx_event_bus_publish_count_total`. Its
+    /// `component="managed_host_republish"` label keeps periodic sweeps
+    /// distinct from change-driven publishes on dashboards.
     pub fn new(publisher: P, params: ManagedHostStateRepublisherParams) -> Self {
         let metrics = MqttHookMetrics::without_queue_depth(PublishComponent::ManagedHostRepublish);
         Self {
@@ -293,25 +292,33 @@ async fn publish_state<P: MqttPublisher>(
         managed_host_state: state,
         timestamp,
     };
+    let topic = message.topic(topic_prefix);
+    let machine_id_context = machine_id.to_string();
 
     let payload = match message.to_json_bytes() {
         Ok(payload) => payload,
-        Err(e) => {
-            tracing::error!(
-                machine_id = %machine_id,
-                error = %e,
-                "Failed to serialize managed host state for republish"
+        Err(error) => {
+            metrics.record_republish_serialization_error(
+                topic,
+                machine_id_context,
+                error.to_string(),
             );
-            metrics.record_serialization_error();
             return;
         }
     };
 
     // Same topic layout and publish/timeout/metrics handling as the
     // change-driven hook, shared so the two paths can't drift.
-    let topic = message.topic(topic_prefix);
     let deadline = Instant::now() + publish_timeout;
-    publish_with_deadline(publisher, &topic, payload, deadline, metrics).await;
+    publish_with_deadline(
+        publisher,
+        &topic,
+        &machine_id_context,
+        payload,
+        deadline,
+        metrics,
+    )
+    .await;
 }
 
 #[cfg(test)]

--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -91,7 +91,8 @@ fn expand_label_value(input: DeriveInput) -> syn::Result<TokenStream> {
 
 /// Derives `carbide_instrument::Event` for a struct declared with an
 /// `#[event(...)]` attribute. Every field takes exactly one of `#[label]`
-/// (enum via `LabelValue`; goes to both the log line and the metric),
+/// (`LabelValue`; supplies the metric label and, when logging, the matching log
+/// field, with `name = "..."` available as a metric-only compatibility alias),
 /// `#[context]` (any `Display`; log-only), `#[context(value)]` (`bool`, `i64`,
 /// `f64`, or `String` retained as a native structured value; log-only), or
 /// `#[observation]` (the histogram value). The metric name is validated at
@@ -303,6 +304,7 @@ fn classify_field(field: &Field) -> syn::Result<FieldKind> {
         } else if attr.path().is_ident("context") {
             kinds.push(FieldKind::Context(context_mode(attr)?));
         } else if attr.path().is_ident("observation") {
+            require_bare_field_attribute(attr, "observation")?;
             kinds.push(FieldKind::Observation);
         }
     }
@@ -316,6 +318,73 @@ fn classify_field(field: &Field) -> syn::Result<FieldKind> {
         _ => Err(syn::Error::new_spanned(
             field,
             "an Event field takes only one of #[label], #[context], #[observation]",
+        )),
+    }
+}
+
+fn require_bare_field_attribute(attr: &syn::Attribute, name: &str) -> syn::Result<()> {
+    if matches!(&attr.meta, Meta::Path(_)) {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        attr,
+        format!("#[{name}] does not accept arguments; use bare #[{name}]"),
+    ))
+}
+
+/// Validate an exposed metric label key, whether it comes from the Rust field
+/// name or an explicit compatibility alias.
+fn validate_metric_label_name(value: String, span: proc_macro2::Span) -> syn::Result<String> {
+    let mut chars = value.chars();
+    let valid_first = chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic());
+    let valid_rest = chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric());
+    if !valid_first || !valid_rest {
+        return Err(syn::Error::new(
+            span,
+            "metric label names start with an ASCII letter or underscore and contain only ASCII \
+             letters, digits, and underscores",
+        ));
+    }
+    Ok(value)
+}
+
+/// `label_metric_name` resolves the metric key for one `#[label]` field. A bare
+/// attribute uses the Rust field name for both the metric and generated log;
+/// `name = "..."` changes only the metric key. That lets a frozen metric label
+/// such as `component` coexist with the `Event` log's reserved field names.
+fn label_metric_name(field: &Field) -> syn::Result<String> {
+    let ident = field.ident.as_ref().expect("named field");
+    let attr = field
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("label"))
+        .expect("label field was classified above");
+
+    match &attr.meta {
+        Meta::Path(_) => validate_metric_label_name(ident.to_string(), ident.span()),
+        Meta::List(_) => {
+            let mut name: Option<LitStr> = None;
+            attr.parse_nested_meta(|meta| {
+                if !meta.path.is_ident("name") {
+                    return Err(meta.error("unknown `label` key; expected `name`"));
+                }
+                if name.is_some() {
+                    return Err(meta.error("duplicate label `name`"));
+                }
+                name = Some(meta.value()?.parse()?);
+                Ok(())
+            })?;
+
+            let name = name.ok_or_else(|| {
+                syn::Error::new_spanned(attr, "#[label(...)] requires name = \"...\"")
+            })?;
+            validate_metric_label_name(name.value(), name.span())
+        }
+        Meta::NameValue(_) => Err(syn::Error::new_spanned(
+            attr,
+            "use #[label(name = \"...\")] to alias a metric label key",
         )),
     }
 }
@@ -540,7 +609,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         }
     };
 
-    let mut labels: Vec<&Ident> = Vec::new();
+    let mut labels: Vec<(&Ident, String)> = Vec::new();
     let mut contexts: Vec<(&Ident, ContextMode)> = Vec::new();
     let mut observations: Vec<&Ident> = Vec::new();
     for field in fields {
@@ -548,7 +617,16 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         let field_kind = classify_field(field)?;
         validate_event_log_field(args.log, field_kind, ident)?;
         match field_kind {
-            FieldKind::Label => labels.push(ident),
+            FieldKind::Label => {
+                let metric_name = label_metric_name(field)?;
+                if labels.iter().any(|(_, name)| name == &metric_name) {
+                    return Err(syn::Error::new_spanned(
+                        field,
+                        format!("duplicate metric label name `{metric_name}`"),
+                    ));
+                }
+                labels.push((ident, metric_name));
+            }
             FieldKind::Context(mode) => contexts.push((ident, mode)),
             FieldKind::Observation => observations.push(ident),
         }
@@ -573,8 +651,12 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
 
     // The pieces of the generated impl.
     let n_labels = labels.len();
-    let label_names: Vec<String> = labels.iter().map(|i| i.to_string()).collect();
-    let context_names: Vec<String> = contexts.iter().map(|(i, _)| i.to_string()).collect();
+    let label_idents: Vec<&Ident> = labels.iter().map(|(ident, _)| *ident).collect();
+    let label_names: Vec<&str> = labels.iter().map(|(_, name)| name.as_str()).collect();
+    let context_names: Vec<String> = contexts
+        .iter()
+        .map(|(ident, _)| ident.to_string())
+        .collect();
 
     // `log = dynamic` keeps the trait's nominal LOG and routes the decision
     // through the hand-implemented `DynamicLog` -- per-instance levels (count
@@ -628,7 +710,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
     if let Some(metric_name) = metric_name {
         log_fields.push(quote! { metric_name = #metric_name });
     }
-    log_fields.extend(labels.iter().map(|ident| {
+    log_fields.extend(label_idents.iter().map(|ident| {
         quote! {
             #ident = ::carbide_instrument::LabelValue::label_value(&self.#ident).as_str()
         }
@@ -716,7 +798,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
                     #(
                         ::carbide_instrument::__private::opentelemetry::KeyValue::new(
                             #label_names,
-                            ::carbide_instrument::LabelValue::label_value(&self.#labels),
+                            ::carbide_instrument::LabelValue::label_value(&self.#label_idents),
                         ),
                     )*
                 ]
@@ -776,7 +858,7 @@ fn snake_case(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case as TestCase, check_cases};
+    use carbide_test_support::{Case as TestCase, Check, check_cases, check_values};
     use proc_macro2::Span;
     use syn::{Data, DeriveInput, Fields, Ident};
 
@@ -971,6 +1053,112 @@ mod tests {
                     Ok(_) => panic!("fixture field is context"),
                     Err(error) => Err(error.to_string()),
                 }
+            },
+        );
+    }
+
+    #[test]
+    fn label_metric_name_alias_diagnostics_are_specific() {
+        struct DiagnosticInput {
+            source: &'static str,
+            expected: &'static str,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "unknown alias key",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label(rename = "component")] publisher: Stage }"#,
+                        expected: "unknown `label` key; expected `name`",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "duplicate alias key",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label(name = "component", name = "source")] publisher: Stage }"#,
+                        expected: "duplicate label `name`",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "missing alias name",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label()] publisher: Stage }"#,
+                        expected: "requires name = \"...\"",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "invalid metric label name",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label(name = "bad-label")] publisher: Stage }"#,
+                        expected: "metric label names start with an ASCII letter",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "non-ASCII bare label name",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label] café: Stage }"#,
+                        expected: "metric label names start with an ASCII letter",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "name-value attribute syntax",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label = "component"] publisher: Stage }"#,
+                        expected: "use #[label(name = \"...\")]",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "duplicate resolved metric label name",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = info, metric = counter, message = "demo", describe = "Number of demo events")] struct Demo { #[label(name = "component")] publisher: Stage, #[label(name = "component")] source: Stage }"#,
+                        expected: "duplicate metric label name `component`",
+                    },
+                    expect: None,
+                },
+            ],
+            |DiagnosticInput { source, expected }| {
+                let error = expansion_error(source);
+                (!error.contains(expected)).then(|| format!("expected `{expected}` in `{error}`"))
+            },
+        );
+    }
+
+    #[test]
+    fn observation_attributes_reject_arguments() {
+        struct DiagnosticInput {
+            source: &'static str,
+            expected: &'static str,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "observation list arguments",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", component = "demo", message = "demo")] struct Demo { #[observation(name = "value")] value: f64 }"#,
+                        expected: "#[observation] does not accept arguments; use bare #[observation]",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "observation name-value syntax",
+                    input: DiagnosticInput {
+                        source: r#"#[event(event_name = "demo", component = "demo", message = "demo")] struct Demo { #[observation = "value"] value: f64 }"#,
+                        expected: "#[observation] does not accept arguments; use bare #[observation]",
+                    },
+                    expect: None,
+                },
+            ],
+            |DiagnosticInput { source, expected }| {
+                let error = expansion_error(source);
+                (!error.contains(expected)).then(|| format!("expected `{expected}` in `{error}`"))
             },
         );
     }

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -97,6 +97,12 @@
 //! }
 //! ```
 //!
+//! `#[label(name = "component")]` exists for a frozen metric key that cannot
+//! also be the Rust field name because Event logs reserve `component`. For a
+//! field such as `publisher: Publisher`, the metric keeps `component` while
+//! the generated log keeps `publisher`. Context and observation fields do not
+//! support this compatibility alias.
+//!
 //! The metric name is validated at compile time -- the `carbide_` prefix, the
 //! `_total` suffix for counters, a unit suffix for histograms:
 //!

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -132,6 +132,52 @@ fn native_context_retains_its_type() {
     );
 }
 
+/// `#[label(name = "...")]` preserves a frozen metric key without changing
+/// the generated log's field name. This test pins both surfaces so the
+/// compatibility alias cannot leak into the log schema.
+#[test]
+fn label_alias_changes_only_the_metric_key() {
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_label_alias_fired",
+        metric_name = "carbide_test_matrix_label_alias_total",
+        component = "matrix-test",
+        log = info,
+        metric = counter,
+        describe = "Number of aliased-label test events",
+        message = "aliased label fired"
+    )]
+    struct AliasedLabel {
+        #[label(name = "component")]
+        publisher: Stage,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(AliasedLabel {
+            publisher: Stage::Apply,
+        });
+    });
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].field("publisher"), Some("apply"));
+    assert_eq!(logs[0].field("component"), None);
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_label_alias_total",
+            &[("component", "apply")],
+        ),
+        1.0
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_label_alias_total",
+            &[("publisher", "apply")],
+        ),
+        0.0
+    );
+}
+
 /// log = off, metric = counter: the counter moves and no log line is built at
 /// all (message is not even required).
 #[test]

--- a/crates/mqtt-common/src/hook.rs
+++ b/crates/mqtt-common/src/hook.rs
@@ -30,6 +30,9 @@ use crate::metrics::MqttHookMetrics;
 /// Internal queue item containing pre-serialized MQTT message with deadline.
 pub struct QueuedMessage {
     pub topic: String,
+    /// `machine_id` travels with the queued payload so its eventual `Event` log
+    /// can identify the managed host. It never becomes a metric label.
+    pub machine_id: String,
     pub payload: Vec<u8>,
     /// Deadline by which this message must be published.
     pub deadline: Instant,
@@ -56,31 +59,31 @@ impl<T: MqttPublisher> MqttPublisher for Arc<T> {
     }
 }
 
-/// Publish a single pre-serialized payload to `topic`, bounded by `deadline`,
-/// recording the outcome (`ok` / `publish_error` / `timeout`) in `metrics`.
-///
-/// Shared by the queue-draining [`process_events`] task and the periodic
-/// managed-host-state republisher so the publish + timeout + metrics handling
-/// lives in one place.
+/// `publish_with_deadline` gives the queue-draining [`process_events`] task and
+/// the periodic republisher one publish/deadline path. `machine_id` follows the
+/// result into the managed-host `Event` log for correlation, but never becomes
+/// a metric label.
 pub async fn publish_with_deadline<P: MqttPublisher>(
     publisher: &P,
     topic: &str,
+    machine_id: &str,
     payload: Vec<u8>,
     deadline: Instant,
     metrics: &MqttHookMetrics,
 ) {
     match timeout_at(deadline, publisher.publish(topic, payload)).await {
         Ok(Ok(())) => {
-            tracing::debug!(topic = %topic, "Published to MQTT");
-            metrics.record_success();
+            metrics.record_managed_success(topic.to_string(), machine_id.to_string());
         }
         Ok(Err(e)) => {
-            tracing::warn!(topic = %topic, error = %e, "Failed to publish to MQTT");
-            metrics.record_publish_error();
+            metrics.record_managed_publish_error(
+                topic.to_string(),
+                machine_id.to_string(),
+                e.to_string(),
+            );
         }
         Err(Elapsed { .. }) => {
-            tracing::warn!(topic = %topic, "MQTT publish timed out");
-            metrics.record_timeout();
+            metrics.record_managed_timeout(topic.to_string(), machine_id.to_string());
         }
     }
 }
@@ -93,7 +96,15 @@ pub async fn process_events<P: MqttPublisher>(
     cancel_token: CancellationToken,
 ) {
     while let Some(Some(msg)) = cancel_token.run_until_cancelled(receiver.recv()).await {
-        publish_with_deadline(&client, &msg.topic, msg.payload, msg.deadline, &metrics).await;
+        publish_with_deadline(
+            &client,
+            &msg.topic,
+            &msg.machine_id,
+            msg.payload,
+            msg.deadline,
+            &metrics,
+        )
+        .await;
     }
     tracing::debug!("MQTT state change hook background task stopped");
 }

--- a/crates/mqtt-common/src/metrics.rs
+++ b/crates/mqtt-common/src/metrics.rs
@@ -54,35 +54,244 @@ enum PublishStatus {
     SerializationError,
 }
 
-/// A publish attempt against the DSX Exchange Event Bus, counted by publishing
-/// path and outcome.
-///
-/// The declared `metric_name` is the grandfathered exposed Prometheus series,
-/// byte-for-byte. The framework strips its trailing `_total` before registering
-/// `carbide_dsx_event_bus_publish_count`, and the OpenTelemetry Prometheus
-/// exporter appends `_total` again, reproducing the existing series without
-/// changing the underlying instrument name.
-///
-/// Metric-only (`log = off`): every emit sits beside the `tracing` line it has
-/// always had, which is left untouched -- this event moves only the counter.
-///
-/// The `component =` attribute is the framework's owning-subsystem const, used
-/// by tooling and never emitted as a label; the metric's own `component` label
-/// is the per-path discriminator field below.
+// Every `DsxEventBus*` Event below writes the frozen
+// `carbide_dsx_event_bus_publish_count_total` metric. Keep their kind and
+// description identical so the named OpenTelemetry instruments do not
+// conflict, and keep their label keys aligned so the exported series retain
+// one shape. Separate types preserve each path's log level, message, and
+// context. The Event-level `component` identifies this crate; `publisher`
+// aliases the metric's separate, frozen `component` label.
+
 #[derive(Event)]
 #[event(
-    event_name = "dsx_event_bus_publish_attempted",
+    event_name = "dsx_event_bus_publish_succeeded",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = debug,
+    metric = counter,
+    message = "Published to MQTT",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusPublishSucceeded {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    machine_id: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_bms_publish_succeeded",
     metric_name = "carbide_dsx_event_bus_publish_count_total",
     component = "nico-mqtt-common",
     log = off,
     metric = counter,
     describe = "Number of MQTT publish attempts"
 )]
-struct DsxEventBusPublish {
-    #[label]
-    component: PublishComponent,
+struct DsxEventBusBmsPublishSucceeded {
+    #[label(name = "component")]
+    publisher: PublishComponent,
     #[label]
     status: PublishStatus,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_publish_failed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "Failed to publish to MQTT",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusPublishFailed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    machine_id: String,
+    #[context]
+    error: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_bms_publish_failed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "Failed to publish BMS DSX message",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusBmsPublishFailed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    error: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_publish_timed_out",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "MQTT publish timed out",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusPublishTimedOut {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    machine_id: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_bms_publish_timed_out",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "BMS DSX publish timed out",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusBmsPublishTimedOut {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_publish_queue_overflowed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "MQTT state change event dropped (queue full)",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusPublishQueueOverflowed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    machine_id: String,
+    #[context]
+    error: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_state_change_serialization_failed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = error,
+    metric = counter,
+    message = "Failed to serialize state change message",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusStateChangeSerializationFailed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    machine_id: String,
+    #[context]
+    error: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_republish_serialization_failed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = error,
+    metric = counter,
+    message = "Failed to serialize managed host state for republish",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusRepublishSerializationFailed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    machine_id: String,
+    #[context]
+    error: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_bms_metadata_parse_failed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "Failed to parse BMS metadata",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusBmsMetadataParseFailed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    error: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dsx_event_bus_bms_publication_serialization_failed",
+    metric_name = "carbide_dsx_event_bus_publish_count_total",
+    component = "nico-mqtt-common",
+    log = warn,
+    metric = counter,
+    message = "Failed to serialize BMS DSX publication",
+    describe = "Number of MQTT publish attempts"
+)]
+struct DsxEventBusBmsPublicationSerializationFailed {
+    #[label(name = "component")]
+    publisher: PublishComponent,
+    #[label]
+    status: PublishStatus,
+    #[context]
+    topic: String,
+    #[context]
+    error: String,
 }
 
 /// Metrics for the MQTT state change hook.
@@ -132,81 +341,181 @@ impl MqttHookMetrics {
         Self { component }
     }
 
-    /// Count one publish attempt for this component with the given outcome.
-    fn record(&self, status: PublishStatus) {
-        carbide_instrument::emit(DsxEventBusPublish {
-            component: self.component,
-            status,
+    /// `record_managed_success` advances the publish counter and retains the
+    /// change hook's `DEBUG` record. `topic` and `machine_id` stay log-only.
+    pub fn record_managed_success(&self, topic: String, machine_id: String) {
+        carbide_instrument::emit(DsxEventBusPublishSucceeded {
+            publisher: self.component,
+            status: PublishStatus::Ok,
+            topic,
+            machine_id,
         });
     }
 
-    /// Record a successful publish.
-    pub fn record_success(&self) {
-        self.record(PublishStatus::Ok);
+    /// `record_bms_success` advances the counter without adding a success log;
+    /// the BMS publisher has no success record to preserve.
+    pub fn record_bms_success(&self) {
+        carbide_instrument::emit(DsxEventBusBmsPublishSucceeded {
+            publisher: self.component,
+            status: PublishStatus::Ok,
+        });
     }
 
-    /// Record that an event was dropped due to queue overflow.
-    pub fn record_overflow(&self) {
-        self.record(PublishStatus::Overflow);
+    /// `record_overflow` keeps a full-queue drop's counter and `WARN` record
+    /// together, with per-message detail left off the metric labels.
+    pub fn record_overflow(&self, topic: String, machine_id: String, error: String) {
+        carbide_instrument::emit(DsxEventBusPublishQueueOverflowed {
+            publisher: self.component,
+            status: PublishStatus::Overflow,
+            topic,
+            machine_id,
+            error,
+        });
     }
 
-    /// Record a publish timeout.
-    pub fn record_timeout(&self) {
-        self.record(PublishStatus::Timeout);
+    /// `record_managed_timeout` pairs the managed-host timeout counter with its
+    /// `WARN` record and log-only correlation fields.
+    pub fn record_managed_timeout(&self, topic: String, machine_id: String) {
+        carbide_instrument::emit(DsxEventBusPublishTimedOut {
+            publisher: self.component,
+            status: PublishStatus::Timeout,
+            topic,
+            machine_id,
+        });
     }
 
-    /// Record an MQTT publish error.
-    pub fn record_publish_error(&self) {
-        self.record(PublishStatus::PublishError);
+    /// `record_bms_timeout` pairs the BMS timeout counter with its `WARN`
+    /// record.
+    pub fn record_bms_timeout(&self, topic: String) {
+        carbide_instrument::emit(DsxEventBusBmsPublishTimedOut {
+            publisher: self.component,
+            status: PublishStatus::Timeout,
+            topic,
+        });
     }
 
-    /// Record a serialization failure.
-    pub fn record_serialization_error(&self) {
-        self.record(PublishStatus::SerializationError);
+    /// `record_managed_publish_error` pairs a broker failure's counter with its
+    /// `WARN` record and log-only error context.
+    pub fn record_managed_publish_error(&self, topic: String, machine_id: String, error: String) {
+        carbide_instrument::emit(DsxEventBusPublishFailed {
+            publisher: self.component,
+            status: PublishStatus::PublishError,
+            topic,
+            machine_id,
+            error,
+        });
+    }
+
+    /// `record_bms_publish_error` pairs a BMS broker failure's counter with its
+    /// `WARN` record and log-only error context.
+    pub fn record_bms_publish_error(&self, topic: String, error: String) {
+        carbide_instrument::emit(DsxEventBusBmsPublishFailed {
+            publisher: self.component,
+            status: PublishStatus::PublishError,
+            topic,
+            error,
+        });
+    }
+
+    /// `record_state_change_serialization_error` pairs a change-driven
+    /// serialization failure's counter with its `ERROR` record.
+    pub fn record_state_change_serialization_error(
+        &self,
+        topic: String,
+        machine_id: String,
+        error: String,
+    ) {
+        carbide_instrument::emit(DsxEventBusStateChangeSerializationFailed {
+            publisher: self.component,
+            status: PublishStatus::SerializationError,
+            topic,
+            machine_id,
+            error,
+        });
+    }
+
+    /// `record_republish_serialization_error` pairs the periodic republisher's
+    /// counter with its distinct `ERROR` record and `publisher` label.
+    pub fn record_republish_serialization_error(
+        &self,
+        topic: String,
+        machine_id: String,
+        error: String,
+    ) {
+        carbide_instrument::emit(DsxEventBusRepublishSerializationFailed {
+            publisher: self.component,
+            status: PublishStatus::SerializationError,
+            topic,
+            machine_id,
+            error,
+        });
+    }
+
+    /// `record_bms_metadata_parse_error` retains the BMS parser's `WARN`
+    /// record.
+    /// The frozen counter groups this with serialization failures under
+    /// `status="serialization_error"`.
+    pub fn record_bms_metadata_parse_error(&self, topic: String, error: String) {
+        carbide_instrument::emit(DsxEventBusBmsMetadataParseFailed {
+            publisher: self.component,
+            status: PublishStatus::SerializationError,
+            topic,
+            error,
+        });
+    }
+
+    /// `record_bms_publication_serialization_error` retains the BMS encoder's
+    /// `WARN` record under the same frozen `serialization_error` status.
+    pub fn record_bms_publication_serialization_error(&self, topic: String, error: String) {
+        carbide_instrument::emit(DsxEventBusBmsPublicationSerializationFailed {
+            publisher: self.component,
+            status: PublishStatus::SerializationError,
+            topic,
+            error,
+        });
     }
 }
 
 #[cfg(test)]
 mod tests {
     use carbide_instrument::LabelValue;
-    use carbide_instrument::testing::MetricsCapture;
-    use carbide_test_support::{Check, check_values};
+    use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+    use carbide_test_support::value_scenarios;
 
-    use super::{DsxEventBusPublish, PublishComponent, PublishStatus};
+    use super::{MqttHookMetrics, PublishComponent, PublishStatus};
+
+    const PUBLISH_METRIC: &str = "carbide_dsx_event_bus_publish_count_total";
+
+    fn assert_event_log(
+        log: &CapturedLog,
+        event_name: &str,
+        level: tracing::Level,
+        message: &str,
+        publisher: &str,
+        status: &str,
+    ) {
+        assert_eq!(log.metadata_name, event_name);
+        assert_eq!(log.level, level);
+        assert_eq!(log.message, message);
+        assert_eq!(log.field("event_name"), Some(event_name));
+        assert_eq!(log.field("metric_name"), Some(PUBLISH_METRIC));
+        assert_eq!(log.field("publisher"), Some(publisher));
+        assert_eq!(log.field("component"), None);
+        assert_eq!(log.field("status"), Some(status));
+    }
 
     /// The `status` label values are the metric's contract: each variant renders
     /// to the exact string the publish counter has always reported.
     #[test]
     fn publish_status_renders_expected_label_values() {
-        check_values(
-            [
-                Check {
-                    scenario: "success",
-                    input: PublishStatus::Ok,
-                    expect: "ok".to_string(),
-                },
-                Check {
-                    scenario: "queue overflow",
-                    input: PublishStatus::Overflow,
-                    expect: "overflow".to_string(),
-                },
-                Check {
-                    scenario: "publish timeout",
-                    input: PublishStatus::Timeout,
-                    expect: "timeout".to_string(),
-                },
-                Check {
-                    scenario: "publish error",
-                    input: PublishStatus::PublishError,
-                    expect: "publish_error".to_string(),
-                },
-                Check {
-                    scenario: "serialization error",
-                    input: PublishStatus::SerializationError,
-                    expect: "serialization_error".to_string(),
-                },
-            ],
-            |status| status.label_value().to_string(),
+        value_scenarios!(run = |status| status.label_value().to_string();
+            "publish status label contract" {
+                PublishStatus::Ok => "ok".to_string(),
+                PublishStatus::Overflow => "overflow".to_string(),
+                PublishStatus::Timeout => "timeout".to_string(),
+                PublishStatus::PublishError => "publish_error".to_string(),
+                PublishStatus::SerializationError => "serialization_error".to_string(),
+            }
         );
     }
 
@@ -215,47 +524,226 @@ mod tests {
     /// have always reported.
     #[test]
     fn publish_component_renders_expected_label_values() {
-        check_values(
-            [
-                Check {
-                    scenario: "bms publisher",
-                    input: PublishComponent::Bms,
-                    expect: "bms".to_string(),
-                },
-                Check {
-                    scenario: "change-driven managed host hook",
-                    input: PublishComponent::ManagedHost,
-                    expect: "managed_host".to_string(),
-                },
-                Check {
-                    scenario: "periodic managed host republisher",
-                    input: PublishComponent::ManagedHostRepublish,
-                    expect: "managed_host_republish".to_string(),
-                },
-            ],
-            |component| component.label_value().to_string(),
+        value_scenarios!(run = |component| component.label_value().to_string();
+            "publish component label contract" {
+                PublishComponent::Bms => "bms".to_string(),
+                PublishComponent::ManagedHost => "managed_host".to_string(),
+                PublishComponent::ManagedHostRepublish => "managed_host_republish".to_string(),
+            }
         );
     }
 
-    /// The exposed series is the metric's contract. Emitting the event moves
-    /// `carbide_dsx_event_bus_publish_count_total` -- byte-for-byte what the
-    /// hand-rolled counter exported before the framework conversion, under the
-    /// same `component` and `status` labels.
     #[test]
-    fn publish_event_exposes_grandfathered_count_series() {
+    fn managed_publish_outcomes_log_and_count() {
         let metrics = MetricsCapture::start();
-
-        carbide_instrument::emit(DsxEventBusPublish {
-            component: PublishComponent::ManagedHost,
-            status: PublishStatus::PublishError,
+        let hook = MqttHookMetrics::without_queue_depth(PublishComponent::ManagedHost);
+        let logs = capture_logs(|| {
+            hook.record_managed_success(
+                "NICO/v1/machine/host-1/state".to_string(),
+                "host-1".to_string(),
+            );
+            hook.record_overflow(
+                "NICO/v1/machine/host-2/state".to_string(),
+                "host-2".to_string(),
+                "no available capacity".to_string(),
+            );
+            hook.record_managed_timeout(
+                "NICO/v1/machine/host-3/state".to_string(),
+                "host-3".to_string(),
+            );
+            hook.record_managed_publish_error(
+                "NICO/v1/machine/host-4/state".to_string(),
+                "host-4".to_string(),
+                "broker unavailable".to_string(),
+            );
+            hook.record_state_change_serialization_error(
+                "NICO/v1/machine/host-5/state".to_string(),
+                "host-5".to_string(),
+                "invalid map key".to_string(),
+            );
         });
+
+        assert_eq!(logs.len(), 5);
+        assert_event_log(
+            &logs[0],
+            "dsx_event_bus_publish_succeeded",
+            tracing::Level::DEBUG,
+            "Published to MQTT",
+            "managed_host",
+            "ok",
+        );
+        assert_event_log(
+            &logs[1],
+            "dsx_event_bus_publish_queue_overflowed",
+            tracing::Level::WARN,
+            "MQTT state change event dropped (queue full)",
+            "managed_host",
+            "overflow",
+        );
+        assert_event_log(
+            &logs[2],
+            "dsx_event_bus_publish_timed_out",
+            tracing::Level::WARN,
+            "MQTT publish timed out",
+            "managed_host",
+            "timeout",
+        );
+        assert_event_log(
+            &logs[3],
+            "dsx_event_bus_publish_failed",
+            tracing::Level::WARN,
+            "Failed to publish to MQTT",
+            "managed_host",
+            "publish_error",
+        );
+        assert_event_log(
+            &logs[4],
+            "dsx_event_bus_state_change_serialization_failed",
+            tracing::Level::ERROR,
+            "Failed to serialize state change message",
+            "managed_host",
+            "serialization_error",
+        );
+
+        for (index, host) in (1..=5).map(|index| (index - 1, format!("host-{index}"))) {
+            assert_eq!(logs[index].field("machine_id"), Some(host.as_str()));
+            let topic = format!("NICO/v1/machine/{host}/state");
+            assert_eq!(logs[index].field("topic"), Some(topic.as_str()));
+        }
+        assert_eq!(logs[1].field("error"), Some("no available capacity"));
+        assert_eq!(logs[3].field("error"), Some("broker unavailable"));
+        assert_eq!(logs[4].field("error"), Some("invalid map key"));
+
+        value_scenarios!(run = |status| {
+            metrics.counter_delta(
+                PUBLISH_METRIC,
+                &[("component", "managed_host"), ("status", status)],
+            )
+        };
+            "each managed publish outcome increments its counter" {
+                "ok" => 1.0,
+                "overflow" => 1.0,
+                "timeout" => 1.0,
+                "publish_error" => 1.0,
+                "serialization_error" => 1.0,
+            }
+        );
+    }
+
+    #[test]
+    fn republish_serialization_failure_logs_and_counts() {
+        let metrics = MetricsCapture::start();
+        let hook = MqttHookMetrics::without_queue_depth(PublishComponent::ManagedHostRepublish);
+        let logs = capture_logs(|| {
+            hook.record_republish_serialization_error(
+                "NICO/v1/machine/host-6/state".to_string(),
+                "host-6".to_string(),
+                "invalid state".to_string(),
+            );
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_event_log(
+            &logs[0],
+            "dsx_event_bus_republish_serialization_failed",
+            tracing::Level::ERROR,
+            "Failed to serialize managed host state for republish",
+            "managed_host_republish",
+            "serialization_error",
+        );
+        assert_eq!(logs[0].field("topic"), Some("NICO/v1/machine/host-6/state"));
+        assert_eq!(logs[0].field("machine_id"), Some("host-6"));
+        assert_eq!(logs[0].field("error"), Some("invalid state"));
 
         assert_eq!(
             metrics.counter_delta(
-                "carbide_dsx_event_bus_publish_count_total",
-                &[("component", "managed_host"), ("status", "publish_error")],
+                PUBLISH_METRIC,
+                &[
+                    ("component", "managed_host_republish"),
+                    ("status", "serialization_error"),
+                ],
             ),
             1.0,
         );
+    }
+
+    #[test]
+    fn bms_publish_siblings_preserve_logs_and_accumulate() {
+        let metrics = MetricsCapture::start();
+        let hook = MqttHookMetrics::without_queue_depth(PublishComponent::Bms);
+        let logs = capture_logs(|| {
+            hook.record_bms_success();
+            hook.record_bms_publish_error(
+                "BMS/v1/PUB/Data/rack-1".to_string(),
+                "connection lost".to_string(),
+            );
+            hook.record_bms_timeout("BMS/v1/PUB/Data/rack-2".to_string());
+            hook.record_bms_metadata_parse_error(
+                "BMS/v1/PUB/Metadata/rack-3".to_string(),
+                "missing pointType".to_string(),
+            );
+            hook.record_bms_publication_serialization_error(
+                "BMS/v1/PUB/Data/rack-4".to_string(),
+                "non-finite value".to_string(),
+            );
+        });
+
+        // `record_bms_success` is the metric-only sibling. The remaining calls
+        // preserve the four `WARN` records operators already receive.
+        assert_eq!(logs.len(), 4);
+        assert_event_log(
+            &logs[0],
+            "dsx_event_bus_bms_publish_failed",
+            tracing::Level::WARN,
+            "Failed to publish BMS DSX message",
+            "bms",
+            "publish_error",
+        );
+        assert_event_log(
+            &logs[1],
+            "dsx_event_bus_bms_publish_timed_out",
+            tracing::Level::WARN,
+            "BMS DSX publish timed out",
+            "bms",
+            "timeout",
+        );
+        assert_event_log(
+            &logs[2],
+            "dsx_event_bus_bms_metadata_parse_failed",
+            tracing::Level::WARN,
+            "Failed to parse BMS metadata",
+            "bms",
+            "serialization_error",
+        );
+        assert_event_log(
+            &logs[3],
+            "dsx_event_bus_bms_publication_serialization_failed",
+            tracing::Level::WARN,
+            "Failed to serialize BMS DSX publication",
+            "bms",
+            "serialization_error",
+        );
+        assert_eq!(logs[0].field("topic"), Some("BMS/v1/PUB/Data/rack-1"));
+        assert_eq!(logs[1].field("topic"), Some("BMS/v1/PUB/Data/rack-2"));
+        assert_eq!(logs[2].field("topic"), Some("BMS/v1/PUB/Metadata/rack-3"));
+        assert_eq!(logs[3].field("topic"), Some("BMS/v1/PUB/Data/rack-4"));
+        assert_eq!(logs[0].field("error"), Some("connection lost"));
+        assert_eq!(logs[2].field("error"), Some("missing pointType"));
+        assert_eq!(logs[3].field("error"), Some("non-finite value"));
+
+        for (status, expected) in [
+            ("ok", 1.0),
+            ("publish_error", 1.0),
+            ("timeout", 1.0),
+            // Metadata parsing and publication encoding are distinct Events,
+            // but both feed this frozen `component`/`status` series.
+            ("serialization_error", 2.0),
+        ] {
+            assert_eq!(
+                metrics.counter_delta(PUBLISH_METRIC, &[("component", "bms"), ("status", status)],),
+                expected,
+                "status {status}",
+            );
+        }
     }
 }

--- a/crates/rack/src/bms_client.rs
+++ b/crates/rack/src/bms_client.rs
@@ -190,8 +190,7 @@ async fn run_worker<P: MqttPublisher>(
                         }
                         Ok(None) => Vec::new(),
                         Err(error) => {
-                            tracing::warn!(topic = %topic, %error, "Failed to parse BMS metadata");
-                            metrics.record_serialization_error();
+                            metrics.record_bms_metadata_parse_error(topic, error.to_string());
                             Vec::new()
                         }
                     },
@@ -216,22 +215,22 @@ async fn publish_all<P: MqttPublisher>(
         let payload = match publication.payload_json() {
             Ok(payload) => payload,
             Err(error) => {
-                tracing::warn!(topic = %publication.topic, %error, "Failed to serialize BMS DSX publication");
-                metrics.record_serialization_error();
+                metrics.record_bms_publication_serialization_error(
+                    publication.topic,
+                    error.to_string(),
+                );
                 continue;
             }
         };
 
         let deadline = Instant::now() + publish_timeout;
         match timeout_at(deadline, publisher.publish(&publication.topic, payload)).await {
-            Ok(Ok(())) => metrics.record_success(),
+            Ok(Ok(())) => metrics.record_bms_success(),
             Ok(Err(error)) => {
-                tracing::warn!(topic = %publication.topic, %error, "Failed to publish BMS DSX message");
-                metrics.record_publish_error();
+                metrics.record_bms_publish_error(publication.topic, error.to_string());
             }
             Err(_) => {
-                tracing::warn!(topic = %publication.topic, "BMS DSX publish timed out");
-                metrics.record_timeout();
+                metrics.record_bms_timeout(publication.topic);
             }
         }
     }


### PR DESCRIPTION
The API state-change hook, managed-host republisher, and rack BMS worker counted DSX publish outcomes separately from their matching diagnostics.

Typed sibling `Event`s now pair those signals while preserving the frozen `{component,status}` series and each publisher's historical log behavior. Operational detail remains log-only. The narrow `#[label(name = "component")]` alias keeps the existing metric key without colliding with the Event log's reserved `component` identity, and field-attribute diagnostics reject unsupported metadata instead of silently ignoring it.

Table-driven tests cover the outcome matrix and alias guardrails.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3732
- Documentation: https://github.com/NVIDIA/infra-controller/pull/3767
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The bounded component/status mappings and publish-outcome metric/log matrix use `value_scenarios!`; the proc-macro diagnostics use named `check_values` rows. Stateful queue, republisher, and rack BMS behavior remains covered by their existing focused tests.

Verified with:

- `cargo test -p carbide-instrument-macros -p carbide-instrument -p carbide-mqtt-common`
- `cargo test -p carbide-api-core mqtt_state_change_hook --lib`
- `cargo test -p carbide-rack bms_client --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

The `#[label(name = "component")]` guardrail tests and code-local rustdoc stay with the implementation. The broader instrumentation-guide update is split into #3767 and depends on this PR.

This PR and #3746 both extend Event field-attribute parsing. Merge reconciliation must retain #3746's `#[context(value)]` mode and this PR's bare-only `#[observation]` validation; metric-key aliases remain exclusive to `#[label(name = "...")]`.
