### PR TITLE
feat(health): emit optional Fleet node.uuid on endpoint telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "x509-parser",
 ]
 

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -89,6 +89,7 @@ nv-redfish = { workspace = true, features = [
 ] }
 rand = { workspace = true }
 url = { workspace = true, features = ["serde"] }
+uuid = { workspace = true }
 x509-parser = { workspace = true }
 
 # [local-dependencies]

--- a/crates/health/benches/collector_pipeline.rs
+++ b/crates/health/benches/collector_pipeline.rs
@@ -59,6 +59,7 @@ fn event_context() -> EventContext {
             mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
         },
         collector_type: "sensor_collector",
+        node_uuid: None,
         metadata: Some(EndpointMetadata::Machine(MachineData {
             machine_id: MACHINE_ID.parse().expect("valid machine id"),
             machine_serial: None,

--- a/crates/health/benches/processor_pipeline.rs
+++ b/crates/health/benches/processor_pipeline.rs
@@ -95,6 +95,7 @@ fn event_context() -> EventContext {
             mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
         },
         collector_type: "sensor_collector",
+        node_uuid: None,
         metadata: Some(EndpointMetadata::Machine(MachineData {
             machine_id: MACHINE_ID.parse().expect("valid machine id"),
             machine_serial: None,
@@ -273,6 +274,7 @@ fn rack_event_contexts(rack_id: &str, tray_count: usize) -> Vec<EventContext> {
                     mac: MacAddress::from_str(&mac).unwrap(),
                 },
                 collector_type: "sensor_collector",
+                node_uuid: None,
                 metadata: Some(EndpointMetadata::Machine(MachineData {
                     machine_id: MACHINE_ID.parse().expect("valid machine id"),
                     machine_serial: None,

--- a/crates/health/benches/sink_pipeline.rs
+++ b/crates/health/benches/sink_pipeline.rs
@@ -69,6 +69,7 @@ fn event_context_for_machine(machine_id: &str) -> EventContext {
             mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
         },
         collector_type: "sensor_collector",
+        node_uuid: None,
         metadata: Some(EndpointMetadata::Machine(MachineData {
             machine_id: machine_id.parse().expect("valid machine id"),
             machine_serial: None,

--- a/crates/health/example/config.bmc-mock.toml
+++ b/crates/health/example/config.bmc-mock.toml
@@ -22,6 +22,8 @@ port = 1266
 mac = "aa:bb:cc:dd:ee:ff"
 username = "admin"
 password = "secret"
+# Optional Fleet Intelligence node UUID emitted as OTLP resource attribute node.uuid
+# node_uuid = "9aee71e4-6e80-11ee-a8ac-74d4dd550187"
 rack_id = "RACK_1"
 machine = { id = "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0", serial = "MN-001", slot_number = 15, tray_index = 5, nvlink_domain_uuid = "00000000-0000-0000-0000-000000000000" }
 # switch = { id = "fsw100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0", serial = "SN-SWITCH-001", slot_number = 7, tray_index = 3 }

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -40,6 +40,8 @@ port = 443
 mac = "aa:bb:cc:dd:ee:ff"
 username = "admin"
 password = "secret"
+# Optional Fleet Intelligence node UUID (OTLP resource attribute node.uuid)
+# node_uuid = "9aee71e4-6e80-11ee-a8ac-74d4dd550187"
 machine = { id = "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0", serial = "MN-001", slot_number = 15, tray_index = 5, nvlink_domain_uuid = "00000000-0000-0000-0000-000000000000" }
 
 [[endpoint_sources.static_bmc_endpoints]]

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -606,6 +606,7 @@ impl ApiEndpointSource {
         };
         Ok(Arc::new(BmcEndpoint {
             addr,
+            node_uuid: None,
             metadata,
             rack_id,
             bmc,

--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -31,7 +31,7 @@ use super::diagnostic::{
 };
 use crate::HealthError;
 use crate::collectors::{IterationResult, PeriodicCollector};
-use crate::endpoint::{BmcEndpoint, EndpointMetadata};
+use crate::endpoint::{BmcEndpoint};
 use crate::sink::{CollectorEvent, DataSink, EventContext, LogRecord};
 
 /// Configuration for logs collector
@@ -266,10 +266,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
     }
 
     async fn collect_logs_from_services(&mut self) -> Result<(usize, usize), HealthError> {
-        let Some(EndpointMetadata::Machine(machine)) = &self.endpoint.metadata else {
-            return Ok((0, 0));
-        };
-        let machine_id = machine.machine_id.to_string();
+        let log_identity = self.endpoint.log_identity().into_owned();
 
         let Some(state) = self.state.as_mut() else {
             return Ok((0, 0));
@@ -422,7 +419,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                         body,
                         severity: severity_text,
                         attributes: vec![
-                            (Cow::Borrowed("machine_id"), machine_id.clone()),
+                            (Cow::Borrowed("node_uuid"), log_identity.clone()),
                             (Cow::Borrowed("entry_id"), entry.base.id.clone()),
                             (Cow::Borrowed("service_id"), service_id.clone()),
                         ],

--- a/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/on_change_processor.rs
@@ -375,6 +375,7 @@ mod tests {
     fn test_event_context(collector_type: &'static str) -> EventContext {
         EventContext {
             endpoint_key: "aa:bb:cc:dd:ee:ff".to_string(),
+            node_uuid: None,
             addr: BmcAddr {
                 ip: "10.0.0.1".parse().unwrap(),
                 port: None,
@@ -779,6 +780,7 @@ mod tests {
                     mac: MacAddress::from_str("AA:BB:CC:DD:EE:FF").unwrap(),
                 },
                 collector_type: ON_CHANGE_STREAM_ID_SYSTEM_EVENTS,
+                node_uuid: None,
                 metadata: Some(EndpointMetadata::Switch(SwitchData {
                     id: Some(switch_id),
                     serial: "SN-SWITCH-001".to_string(),

--- a/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
@@ -1100,6 +1100,7 @@ mod tests {
             endpoint_key: "aa:bb:cc:dd:ee:ff".to_string(),
             addr,
             collector_type: NVUE_GNMI_SAMPLE_STREAM_ID,
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         };
@@ -1167,6 +1168,7 @@ mod tests {
                     mac: MacAddress::from_str("AA:BB:CC:DD:EE:FF").unwrap(),
                 },
                 collector_type: NVUE_GNMI_SAMPLE_STREAM_ID,
+                node_uuid: None,
                 metadata: Some(EndpointMetadata::Switch(SwitchData {
                     id: Some(switch_id),
                     serial: "SN-SWITCH-001".to_string(),

--- a/crates/health/src/collectors/nvue/rest/collector.rs
+++ b/crates/health/src/collectors/nvue/rest/collector.rs
@@ -1603,6 +1603,7 @@ mod tests {
             endpoint_key: "test-switch".to_string(),
             addr: addr.clone(),
             collector_type: COLLECTOR_NAME,
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         };

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -197,6 +197,9 @@ pub struct StaticBmcEndpoint {
     pub mac: String,
     pub username: String,
     pub password: Option<String>,
+    /// Optional Fleet Intelligence node UUID emitted on endpoint telemetry.
+    #[serde(default)]
+    pub node_uuid: Option<String>,
     pub machine: Option<StaticMachineEndpoint>,
     pub power_shelf: Option<StaticPowerShelfEndpoint>,
     pub switch: Option<StaticSwitchEndpoint>,
@@ -268,6 +271,7 @@ impl Debug for StaticBmcEndpoint {
             .field("ip", &self.ip)
             .field("port", &self.port)
             .field("mac", &self.mac)
+            .field("node_uuid", &self.node_uuid)
             .field("machine", &self.machine)
             .field("power_shelf", &self.power_shelf)
             .field("switch", &self.switch)
@@ -288,6 +292,20 @@ impl StaticBmcEndpoint {
             return Err(format!(
                 "endpoint_sources.static_bmc_endpoints[{index}] must specify at most one of machine, power_shelf, or switch"
             ));
+        }
+
+        if let Some(node_uuid) = &self.node_uuid {
+            let trimmed = node_uuid.trim();
+            if trimmed.is_empty() {
+                return Err(format!(
+                    "endpoint_sources.static_bmc_endpoints[{index}].node_uuid cannot be empty"
+                ));
+            }
+            if uuid::Uuid::parse_str(trimmed).is_err() {
+                return Err(format!(
+                    "endpoint_sources.static_bmc_endpoints[{index}].node_uuid must be a UUID"
+                ));
+            }
         }
 
         if let Some(power_shelf) = &self.power_shelf

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -1209,6 +1209,7 @@ mod tests {
         );
         let endpoint = Arc::new(BmcEndpoint {
             addr,
+            node_uuid: None,
             metadata: Some(switch_metadata_with_role(
                 SwitchEndpointRole::Host,
                 true,

--- a/crates/health/src/endpoint/cluster.rs
+++ b/crates/health/src/endpoint/cluster.rs
@@ -440,6 +440,7 @@ fn build_endpoints(
         };
         endpoints.push(Arc::new(BmcEndpoint {
             addr,
+            node_uuid: None,
             metadata: None,
             rack_id: node.rack.as_deref().map(RackId::new),
             bmc,

--- a/crates/health/src/endpoint/mod.rs
+++ b/crates/health/src/endpoint/mod.rs
@@ -59,6 +59,7 @@ pub(crate) mod test_support {
         );
         BmcEndpoint {
             addr,
+            node_uuid: None,
             metadata,
             rack_id,
             bmc,

--- a/crates/health/src/endpoint/model.rs
+++ b/crates/health/src/endpoint/model.rs
@@ -33,6 +33,8 @@ use crate::bmc::{BmcClient, BoxFuture};
 #[derive(Clone)]
 pub struct BmcEndpoint {
     pub addr: BmcAddr,
+    /// Optional Fleet Intelligence node UUID for correlating OOB telemetry.
+    pub node_uuid: Option<String>,
     pub metadata: Option<EndpointMetadata>,
     pub rack_id: Option<RackId>,
     pub bmc: Arc<BmcClient>,
@@ -53,6 +55,9 @@ impl BmcEndpoint {
     }
 
     pub fn log_identity(&self) -> Cow<'_, str> {
+        if let Some(node_uuid) = self.node_uuid.as_deref() {
+            return Cow::Borrowed(node_uuid);
+        }
         match &self.metadata {
             Some(EndpointMetadata::Machine(machine)) => Cow::Owned(machine.machine_id.to_string()),
             Some(EndpointMetadata::PowerShelf(power_shelf)) => Cow::Borrowed(&power_shelf.serial),

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -192,8 +192,15 @@ impl StaticEndpointSource {
                     continue;
                 }
             };
+            let node_uuid = cfg
+                .node_uuid
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
             let endpoint = BmcEndpoint {
                 addr,
+                node_uuid,
                 metadata,
                 rack_id: cfg.rack_id.as_ref().map(|id| RackId::new(id.as_str())),
                 bmc,
@@ -288,6 +295,7 @@ mod tests {
                 mac: "00:11:22:33:44:55".to_string(),
                 username: "admin".to_string(),
                 password: Some("pass".to_string()),
+                node_uuid: None,
                 machine: None,
                 power_shelf: None,
                 switch: None,
@@ -299,6 +307,7 @@ mod tests {
                 mac: "not-a-mac".to_string(),
                 username: "admin".to_string(),
                 password: Some("pass".to_string()),
+                node_uuid: None,
                 machine: None,
                 power_shelf: None,
                 switch: None,
@@ -325,6 +334,7 @@ mod tests {
             mac: "11:22:33:44:55:66".to_string(),
             username: "cumulus".to_string(),
             password: Some("pass".to_string()),
+            node_uuid: None,
             machine: None,
             power_shelf: None,
             switch: Some(StaticSwitchEndpoint {
@@ -368,6 +378,7 @@ mod tests {
             mac: "22:33:44:55:66:77".to_string(),
             username: "admin".to_string(),
             password: Some("pass".to_string()),
+            node_uuid: None,
             machine: None,
             power_shelf: Some(StaticPowerShelfEndpoint {
                 id: Some(power_shelf_id.to_string()),
@@ -404,6 +415,7 @@ mod tests {
             mac: "11:22:33:44:55:11".to_string(),
             username: "admin".to_string(),
             password: Some("pass".to_string()),
+            node_uuid: None,
             machine: Some(StaticMachineEndpoint {
                 id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string(),
                 serial: Some("MN-001".to_string()),
@@ -449,6 +461,7 @@ mod tests {
             mac: "11:22:33:44:55:12".to_string(),
             username: "admin".to_string(),
             password: Some("pass".to_string()),
+            node_uuid: None,
             machine: Some(StaticMachineEndpoint {
                 id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string(),
                 serial: None,
@@ -482,6 +495,7 @@ mod tests {
             mac: "aa:bb:cc:dd:ee:ff".to_string(),
             username: "admin".to_string(),
             password: Some("pass".to_string()),
+            node_uuid: None,
             machine: None,
             power_shelf: None,
             switch: None,

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -85,6 +85,9 @@ fn resource_attributes(context: &EventContext) -> Vec<KeyValue> {
         }
     }
     attrs.push(kv("collector.type", context.collector_type.to_string()));
+    if let Some(node_uuid) = context.node_uuid() {
+        attrs.push(kv("node.uuid", node_uuid.to_string()));
+    }
     if let Some(machine_id) = context.machine_id() {
         attrs.push(kv("machine.id", machine_id.to_string()));
     }
@@ -343,6 +346,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }
@@ -389,6 +393,28 @@ mod tests {
     }
 
     #[test]
+    fn resource_attributes_include_node_uuid_when_present() {
+        let context = EventContext {
+            endpoint_key: "42:9e:b1:bd:9d:dd".to_string(),
+            addr: BmcAddr {
+                ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                port: Some(443),
+                mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
+            },
+            collector_type: "test",
+            node_uuid: Some("9aee71e4-6e80-11ee-a8ac-74d4dd550187".to_string()),
+            metadata: None,
+            rack_id: None,
+        };
+
+        let attrs = resource_attributes(&context);
+        assert_eq!(
+            attr_value(&attrs, "node.uuid"),
+            Some("9aee71e4-6e80-11ee-a8ac-74d4dd550187")
+        );
+    }
+
+    #[test]
     fn resource_attributes_include_machine_metadata_when_present() {
         let domain_uuid = NvLinkDomainId::nil();
         let context = EventContext {
@@ -399,6 +425,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()
@@ -437,6 +464,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()
@@ -473,6 +501,7 @@ mod tests {
                 mac: MacAddress::from_str("11:22:33:44:55:66").expect("valid mac"),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Switch(SwitchData {
                 id: Some(switch_id),
                 serial: "SN-SWITCH-001".to_string(),
@@ -510,6 +539,7 @@ mod tests {
                 mac: MacAddress::from_str("11:22:33:44:55:66").expect("valid mac"),
             },
             collector_type: "nvue_gnmi",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Switch(SwitchData {
                 id: Some(switch_id),
                 serial: "SN-SWITCH-001".to_string(),
@@ -562,6 +592,7 @@ mod tests {
                 mac: MacAddress::from_str("22:33:44:55:66:77").expect("valid mac"),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Switch(SwitchData {
                 id: Some(switch_id),
                 serial: "SN-SWITCH-BMC-001".to_string(),
@@ -611,6 +642,7 @@ mod tests {
                 mac: MacAddress::from_str("33:44:55:66:77:88").expect("valid mac"),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::PowerShelf(PowerShelfData {
                 id: Some(power_shelf_id),
                 serial: "SN-PS-001".to_string(),
@@ -735,6 +767,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         };
@@ -773,10 +806,12 @@ mod tests {
         let base_ctx = test_context();
         let rest_ctx = EventContext {
             collector_type: "nvue_rest",
+            node_uuid: None,
             ..base_ctx.clone()
         };
         let gnmi_ctx = EventContext {
             collector_type: "nvue_gnmi",
+            node_uuid: None,
             ..base_ctx
         };
         let sample = |name: &str| MetricSample {
@@ -845,6 +880,7 @@ mod tests {
                 mac: MacAddress::from_str("11:22:33:44:55:66").expect("valid mac"),
             },
             collector_type: "nvue_gnmi",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Switch(SwitchData {
                 id: Some(switch_id),
                 serial: "SN-SWITCH-001".to_string(),

--- a/crates/health/src/processor/health_report.rs
+++ b/crates/health/src/processor/health_report.rs
@@ -280,6 +280,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()

--- a/crates/health/src/processor/intrusion_events.rs
+++ b/crates/health/src/processor/intrusion_events.rs
@@ -187,6 +187,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "logs_collector",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }

--- a/crates/health/src/processor/leak_events.rs
+++ b/crates/health/src/processor/leak_events.rs
@@ -159,6 +159,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "leak_detector_collector",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }

--- a/crates/health/src/processor/mod.rs
+++ b/crates/health/src/processor/mod.rs
@@ -191,6 +191,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }

--- a/crates/health/src/processor/rack_leak.rs
+++ b/crates/health/src/processor/rack_leak.rs
@@ -150,6 +150,7 @@ mod tests {
                 mac: MacAddress::from_str(mac).expect("valid mac"),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: None,
             rack_id: Some(RackId::new(rack)),
         }
@@ -164,6 +165,7 @@ mod tests {
                 mac: MacAddress::from_str(mac).expect("valid mac"),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -46,6 +46,8 @@ pub struct EventContext {
     pub endpoint_key: String,
     pub addr: BmcAddr,
     pub collector_type: &'static str,
+    /// Optional Fleet Intelligence node UUID for correlating OOB telemetry.
+    pub node_uuid: Option<String>,
     pub metadata: Option<EndpointMetadata>,
     pub rack_id: Option<RackId>,
 }
@@ -56,6 +58,7 @@ impl EventContext {
             endpoint_key: endpoint.key(),
             addr: endpoint.addr.clone(),
             collector_type,
+            node_uuid: endpoint.node_uuid.clone(),
             metadata: endpoint.metadata.clone(),
             rack_id: endpoint.rack_id.clone(),
         }
@@ -63,6 +66,11 @@ impl EventContext {
 
     pub fn endpoint_key(&self) -> &str {
         &self.endpoint_key
+    }
+
+    /// Returns the Fleet Intelligence node UUID when configured for this endpoint.
+    pub fn node_uuid(&self) -> Option<&str> {
+        self.node_uuid.as_deref()
     }
 
     /// Returns machine metadata when this context belongs to a machine endpoint.
@@ -667,6 +675,7 @@ mod tests {
             endpoint_key: "00:11:22:33:44:55".to_string(),
             addr: addr(),
             collector_type: "unit-test",
+            node_uuid: None,
             metadata,
             rack_id: Some(RackId::new("rack-1")),
         }

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -280,6 +280,7 @@ mod tests {
                 mac: MacAddress::from_str("00:00:00:00:00:01").unwrap(),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: id,
                 machine_serial: None,

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -97,6 +97,8 @@ struct JsonLogRecord<'a> {
     endpoint: &'a str,
     collector: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
+    node_uuid: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     machine_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     machine_serial: Option<&'a str>,
@@ -118,6 +120,7 @@ impl<'a> JsonLogRecord<'a> {
         Self {
             endpoint: context.endpoint_key(),
             collector: context.collector_type,
+            node_uuid: context.node_uuid(),
             machine_id: context.machine_id().map(|id| id.to_string()),
             machine_serial: context.machine_serial(),
             driver_version: context.driver_version(),
@@ -288,6 +291,7 @@ mod tests {
                 mac: MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }

--- a/crates/health/src/sink/mod.rs
+++ b/crates/health/src/sink/mod.rs
@@ -213,6 +213,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         };
@@ -261,6 +262,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         };
@@ -362,6 +364,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()
@@ -435,6 +438,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()
@@ -491,6 +495,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()

--- a/crates/health/src/sink/otlp.rs
+++ b/crates/health/src/sink/otlp.rs
@@ -290,6 +290,7 @@ mod tests {
                 mac: MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
             },
             collector_type: "test",
+            node_uuid: None,
             metadata: None,
             rack_id: None,
         }
@@ -443,10 +444,12 @@ mod tests {
         let sink = test_sink();
         let rest_ctx = EventContext {
             collector_type: "nvue_rest",
+            node_uuid: None,
             ..test_context()
         };
         let gnmi_ctx = EventContext {
             collector_type: "nvue_gnmi",
+            node_uuid: None,
             ..test_context()
         };
         sink.handle_event(&rest_ctx, &metric_event());

--- a/crates/health/src/sink/prometheus.rs
+++ b/crates/health/src/sink/prometheus.rs
@@ -93,6 +93,9 @@ impl PrometheusSink {
             ),
         ];
 
+        if let Some(node_uuid) = context.node_uuid() {
+            labels.push((Cow::Borrowed("node_uuid"), node_uuid.to_string()));
+        }
         if let Some(machine_id) = context.machine_id() {
             labels.push((Cow::Borrowed("machine_id"), machine_id.to_string()));
         }
@@ -274,6 +277,7 @@ mod tests {
                 mac: MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(),
             },
             collector_type: "sensor_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Machine(MachineData {
                 machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
                     .parse()
@@ -320,6 +324,7 @@ mod tests {
                 mac: MacAddress::from_str("11:22:33:44:55:66").unwrap(),
             },
             collector_type: "switch_collector",
+            node_uuid: None,
             metadata: Some(EndpointMetadata::Switch(SwitchData {
                 id: Some(switch_id),
                 serial: "SN-SWITCH-001".to_string(),

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -83,6 +83,7 @@ impl DataSink for TracingSink {
                 tracing::info!(
                     endpoint = %context.endpoint_key(),
                     collector = %context.collector_type,
+                    node_uuid = context.node_uuid(),
                     machine_id = context.machine_id().map(tracing::field::display),
                     machine_serial = context.machine_serial(),
                     driver_version = context.driver_version(),


### PR DESCRIPTION
## Summary
- Adds optional `node_uuid` on static BMC endpoints for Fleet Intelligence correlation.
- Propagates the value through `BmcEndpoint` / `EventContext` and emits OTLP resource attribute `node.uuid`, plus matching Prometheus / JSONL / tracing fields.
- Relaxes periodic log collection so it no longer requires a Forge `MachineId`; it uses `log_identity()` (Fleet UUID when present).

This lets OOB-managed deployments attach Fleet node identity without Carbide API discovery or stuffing Redfish/Fleet UUIDs into Forge `machine.id`.

## Test plan
- [x] Unit test: `resource_attributes_include_node_uuid_when_present`
- [x] Local POC against real BMC + OTel/Loki stack
- [x] Confirmed Loki stream labels include `node_uuid=<fleet-uuid>` on NICo SSE logs and health reports
- [ ] CI / crate tests on PR

### POC config snippet
```toml
[[endpoint_sources.static_bmc_endpoints]]
ip = "..."
mac = "..."
username = "..."
password = "..."
node_uuid = "936672d4-bfde-1000-02bc-5cff35fbe9f2"
```

LogQL:
```logql
{service_name="nico-hardware-health", node_uuid="936672d4-bfde-1000-02bc-5cff35fbe9f2"}
```