### PR TITLE
docs(metrics): catalogue the DSX leak-alert counter

### DIFF
--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -53,6 +53,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>Number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
 <tr><td>carbide_dropped_v6_requests_total</td><td>counter</td><td>Number of dropped DHCPv6 requests, by reason.</td></tr>
 <tr><td>carbide_dsx_event_bus_publish_count_total</td><td>counter</td><td>Number of MQTT publish attempts</td></tr>
+<tr><td>carbide_dsx_exchange_consumer_alerts_detected_total</td><td>counter</td><td>Number of leak alerts detected</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_dedup_skipped_total</td><td>counter</td><td>Number of messages skipped due to deduplication</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_health_report_persist_failures_total</td><td>counter</td><td>Number of rack health report persist failures against the Carbide API</td></tr>
 <tr><td>carbide_dsx_exchange_consumer_message_age_seconds</td><td>histogram</td><td>Age of consumed BMS value messages at processing time (consumer lag), in seconds</td></tr>


### PR DESCRIPTION
This is the documentation half of https://github.com/NVIDIA/infra-controller/pull/3742.

Add `carbide_dsx_exchange_consumer_alerts_detected_total` to the core metrics catalogue with the counter kind and HELP text declared by `LeakAlertDetected`. The catalogue accepts future rows, so this can land before the Event migration without weakening `check-metric-docs`.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3733
- Code change: https://github.com/NVIDIA/infra-controller/pull/3742
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Verified with:

- `cargo xtask check-metric-docs`
- `cargo make format-nightly`
- `git diff --check`

## Additional Notes

This docs PR should merge before #3742. The code PR can then update from `main` and satisfy the metric-catalogue gate without including a `docs/` change.
