### PR TITLE
docs(metrics): catalogue DNS negative-cache counters

### DIFF
--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -43,6 +43,8 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCP replies sent, by reply message type.</td></tr>
 <tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCP packets received and decoded, by DHCP message type.</td></tr>
 <tr><td>carbide_dhcp_v6_replies_sent_total</td><td>counter</td><td>Number of DHCPv6 replies sent, by response message type.</td></tr>
+<tr><td>carbide_dns_negative_cache_hit_count_total</td><td>counter</td><td>Number of negative DNS cache hits, by response code</td></tr>
+<tr><td>carbide_dns_negative_cache_miss_count_total</td><td>counter</td><td>Number of negative DNS cache misses, by response code</td></tr>
 <tr><td>carbide_dns_queries_total</td><td>counter</td><td>Number of DNS queries received, by query type</td></tr>
 <tr><td>carbide_dns_request_duration_milliseconds</td><td>histogram</td><td>Time to process a DNS query, by query type and response code</td></tr>
 <tr><td>carbide_dns_responses_total</td><td>counter</td><td>Number of DNS responses sent, by response code</td></tr>


### PR DESCRIPTION
This is the documentation half of https://github.com/NVIDIA/infra-controller/pull/3745.

Add the negative-cache hit and miss counters to the core metrics catalogue with the names, kinds, and HELP text declared by `DnsNegativeCacheHit` and `DnsNegativeCacheMiss`. The catalogue accepts future rows, so this can land before the Event migration without weakening `check-metric-docs`.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3736
- Code change: https://github.com/NVIDIA/infra-controller/pull/3745
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Verified with:

- `cargo xtask check-metric-docs`
- `cargo make format-nightly`
- `git diff --check`

## Additional Notes

This docs PR should merge before #3745. The code PR can then update from `main` and satisfy the metric-catalogue gate without including a `docs/` change.
