### PR TITLE
docs(observability): document metric label-key aliases

### DIFF
--- a/docs/observability/instrumentation.md
+++ b/docs/observability/instrumentation.md
@@ -164,6 +164,11 @@ must be small and closed. The framework makes that structural instead of a revie
 - **`#[label]` fields must implement `LabelValue`**, which is derivable **only for
   fieldless enums**. A derived label value is the variant's snake_case name.
   `String` never implements it.
+- **A frozen metric label key that collides with a reserved Event-log field** can use the
+  narrow `#[label(name = "component")] publisher: PublishComponent` compatibility form.
+  `name` changes only the Prometheus label key; the generated log uses the Rust field name
+  (`publisher`). Use a bare `#[label]` everywhere else, and do not use this to rename
+  context or observation fields.
 - **`#[context]` fields take anything `Display`** and appear only when the Event emits a log
   line. This is where `machine_id`, addresses, and error text belong. A context field cannot
   become a metric label.
@@ -309,7 +314,9 @@ inspection.
 - **Reserved Event-log fields**: `message` is always reserved. Events that can log must
   also not declare payload fields named `msg`, `level`, `location`, `component`, `span_id`,
   `event_name`, or `metric_name`. Metric-only legacy labels remain allowed because renaming
-  a Prometheus label would break its metric contract.
+  a Prometheus label would break its metric contract. When such a metric-only Event gains a
+  log, preserve the label key with `#[label(name = "component")]` on a domain-specific Rust
+  field such as `publisher`; only the metric key is aliased.
 
 ## References
 


### PR DESCRIPTION
This is the documentation half of https://github.com/NVIDIA/infra-controller/pull/3752.

Document the narrow `#[label(name = "...")]` compatibility form beside the instrumentation guide's label and reserved-field rules. It preserves a frozen Prometheus label key while generated logs keep the domain-specific Rust field name, with bare `#[label]` remaining the default.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3732
- Code change: https://github.com/NVIDIA/infra-controller/pull/3752
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Verified with:

- `cargo make format-nightly`
- `git diff --check`

The parser, rustdoc, guardrail tests, and first DSX use remain with #3752.

## Additional Notes

This docs PR depends on #3752 and should merge after it so `main` does not advertise syntax before the implementation is available. The code-local rustdoc and guardrail tests stay with the implementation.

Closes #3732
