### PR TITLE
docs(instrument): explain native Event context values

### DIFF
--- a/docs/observability/instrumentation.md
+++ b/docs/observability/instrumentation.md
@@ -166,7 +166,10 @@ must be small and closed. The framework makes that structural instead of a revie
   `String` never implements it.
 - **`#[context]` fields take anything `Display`** and appear only when the Event emits a log
   line. This is where `machine_id`, addresses, and error text belong. A context field cannot
-  become a metric label.
+  become a metric label. Use **`#[context(value)]`** only for `bool`, `i64`, `f64`, or
+  `String` fields that must retain their native structured type instead of being rendered
+  through `Display`; convert other numeric widths only with a checked, lossless conversion.
+  When that cannot be guaranteed, keep the default `Display` formatting.
 - **Bounded-but-not-enumerated values** such as vendor strings or SKUs can go through a
   **manual `impl LabelValue` on a newtype** -- the deliberate, greppable escape hatch, and
   the place to justify boundedness at review. The deciding factor should be real boundedness *at the call


### PR DESCRIPTION
This is the documentation half of https://github.com/NVIDIA/infra-controller/pull/3746.

Document the narrow `#[context(value)]` form for Event context that must retain its structured tracing type. The guide names the supported native types, requires checked lossless conversion for other numeric widths, and keeps `Display` as the fallback when that guarantee is unavailable.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/3731
- Code change: https://github.com/NVIDIA/infra-controller/pull/3746
- Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Verified with:

- `cargo make format-nightly`
- `git diff --check`

The native-value and parser coverage remains with #3746.

## Additional Notes

This docs PR depends on #3746 and should merge after it so `main` does not advertise syntax before the implementation is available. The crate-level example and derive documentation remain with the code so their Rust examples are compiled against the API they describe.

Closes #3731
