### PR TITLE
fix (dpf): Update SoftwareInventory details for the DPF ingested nodes.

### DIFF
--- a/crates/admin-cli/src/dpu/versions/cmd.rs
+++ b/crates/admin-cli/src/dpu/versions/cmd.rs
@@ -101,7 +101,7 @@ impl From<Machine> for DpuVersions {
             hbn_version: machine.inventory.and_then(|inv| {
                 inv.components
                     .into_iter()
-                    .find(|c| c.name == "doca_hbn")
+                    .find(|c| c.name == "doca-hbn" || c.name == "doca_hbn")
                     .map(|c| c.version)
             }),
             agent_version: machine.dpu_agent_version,

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -34,7 +34,7 @@ use db::{
 use futures_util::future::join_all;
 use itertools::Itertools;
 use model::extension_service::{ExtensionService, ExtensionServiceVersionInfo};
-use model::hardware_info::MachineInventory;
+use model::hardware_info::{MachineInventory, MachineInventorySoftwareComponent};
 use model::instance::config::extension_services::InstanceExtensionServiceConfig;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::MachineNetworkStatusObservation;
@@ -814,6 +814,64 @@ pub(crate) async fn update_agent_reported_inventory(
 
     let request = request.into_inner();
     let dpu_machine_id = convert_and_log_machine_id(request.machine_id.as_ref())?;
+
+    // For DPF-ingested DPUs the agent runs containerized and cannot enumerate
+    // the DPF services directly. Read service versions from the DPF operator
+    // on every inventory report so the DB stays current after upgrades.
+    let mut txn = api.txn_begin().await?;
+    let dpu_machine = db::machine::find_one(
+        &mut txn,
+        &dpu_machine_id,
+        MachineSearchConfig {
+            include_dpus: true,
+            ..Default::default()
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    if let Some(machine) = dpu_machine
+        && machine.config.dpf.used_for_ingestion
+    {
+        let dpf_sdk = api.dpf_sdk.as_ref().ok_or_else(|| {
+            CarbideError::internal(format!(
+                "DPF SDK unavailable but DPU {dpu_machine_id} was ingested via DPF"
+            ))
+        })?;
+
+        let device_name = machine.dpf_id().ok_or_else(|| {
+            CarbideError::InvalidArgument(format!(
+                "DPF-ingested DPU {dpu_machine_id} has no BMC MAC"
+            ))
+        })?;
+
+        let service_versions = dpf_sdk
+            .get_service_versions_for_dpu(&device_name)
+            .await
+            .map_err(|e| CarbideError::internal(e.to_string()))?;
+
+        let inventory = MachineInventory {
+            components: service_versions
+                .into_iter()
+                .map(|v| MachineInventorySoftwareComponent {
+                    name: v.name,
+                    version: v.version,
+                    url: String::new(),
+                })
+                .collect(),
+        };
+
+        let mut txn = api.txn_begin().await?;
+        db::machine::update_agent_reported_inventory(&mut txn, &dpu_machine_id, &inventory).await?;
+        txn.commit().await?;
+
+        tracing::debug!(
+            machine_id = %dpu_machine_id,
+            component_count = inventory.components.len(),
+            "updated DPF service inventory from operator",
+        );
+        return Ok(Response::new(()));
+    }
 
     if let Some(inventory) = request.inventory.as_ref() {
         let mut txn = api.txn_begin().await?;

--- a/crates/api-web/src/dpu_versions.rs
+++ b/crates/api-web/src/dpu_versions.rs
@@ -80,7 +80,7 @@ impl From<forgerpc::Machine> for Row {
                     inventory
                         .components
                         .iter()
-                        .find(|c| c.name == "forge-dpu-agent")
+                        .find(|c| c.name == "carbide-dpu-agent" || c.name == "forge-dpu-agent")
                         .map(|c| c.version.clone())
                 })
                 .unwrap_or_default(),
@@ -106,7 +106,7 @@ impl From<forgerpc::Machine> for Row {
                 .and_then(|inv| {
                     inv.components
                         .iter()
-                        .find(|c| c.name == "doca_hbn")
+                        .find(|c| c.name == "doca-hbn" || c.name == "doca_hbn")
                         .map(|c| c.version.clone())
                 })
                 .unwrap_or_default(),

--- a/crates/api-web/src/network_status.rs
+++ b/crates/api-web/src/network_status.rs
@@ -254,7 +254,7 @@ async fn fetch_network_status(
                 inventory
                     .components
                     .iter()
-                    .find(|c| c.name == "forge-dpu-agent")
+                    .find(|c| c.name == "carbide-dpu-agent" || c.name == "forge-dpu-agent")
                     .map(|c| c.version.clone())
             })
             .unwrap_or_default();

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -81,9 +81,9 @@ pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
     BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DpuDeploymentType,
     DpuDeviceInfo, DpuErrorEvent, DpuEvent, DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent,
-    InitDpfResourcesConfig, MaintenanceEvent, RebootRequiredEvent, ServiceChainSwitch,
-    ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition, ServiceInterface, ServiceNAD,
-    ServiceNADResourceType,
+    DpuServiceVersion, InitDpfResourcesConfig, MaintenanceEvent, RebootRequiredEvent,
+    ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
+    ServiceInterface, ServiceNAD, ServiceNADResourceType,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -81,9 +81,10 @@ use crate::types::{
     BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME,
     DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails,
     DpuDeploymentType, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch, DpuNodeInfo, DpuNodeSummary,
-    DpuPhase, DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType, DpuSummary,
-    FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME,
-    ServiceConfigPortProtocol, ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
+    DpuPhase, DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType,
+    DpuServiceVersion, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig,
+    OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol, ServiceDefinition,
+    ServiceNADResourceType, ServiceTemplateVersion,
 };
 use crate::watcher::DpuWatcherBuilder;
 
@@ -2003,6 +2004,81 @@ impl<R: DpuServiceTemplateRepository, L> DpfSdk<R, L> {
                 }
             })
             .collect())
+    }
+}
+
+impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, L> DpfSdk<R, L> {
+    /// Resolve the installed service versions for a DPU by looking up its owning
+    /// DPUDeployment (via the `svc.dpu.nvidia.com/owned-by-dpudeployment` label on the DPU CR)
+    /// and reading each service's DPUServiceTemplate.
+    ///
+    /// Version is taken from `helmChart.values.image.tag` when set and non-empty;
+    /// otherwise falls back to `helmChart.source.version`.
+    pub async fn get_service_versions_for_dpu(
+        &self,
+        dpu_device_name: &str,
+    ) -> Result<Vec<DpuServiceVersion>, DpfError> {
+        let dpu = DpuRepository::get(&*self.repo, dpu_device_name, &self.namespace)
+            .await?
+            .ok_or_else(|| {
+                DpfError::InvalidState(format!("DPU CR not found: {dpu_device_name}"))
+            })?;
+
+        let owner_label = dpu
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
+            .ok_or_else(|| {
+                DpfError::InvalidState(format!(
+                    "DPU {dpu_device_name} is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label"
+                ))
+            })?;
+
+        let deployment_name = owner_label
+            .strip_prefix(&format!("{}_", self.namespace))
+            .unwrap_or(owner_label.as_str());
+
+        let deployment =
+            DpuDeploymentRepository::get(&*self.repo, deployment_name, &self.namespace)
+                .await?
+                .ok_or_else(|| {
+                    DpfError::InvalidState(format!(
+                        "DPUDeployment {deployment_name} not found for DPU {dpu_device_name}"
+                    ))
+                })?;
+
+        let mut versions = Vec::new();
+        for (service_name, service) in &deployment.spec.services {
+            let Some(template_name) = &service.service_template else {
+                continue;
+            };
+            let Some(template) =
+                DpuServiceTemplateRepository::get(&*self.repo, template_name, &self.namespace)
+                    .await?
+            else {
+                continue;
+            };
+
+            let version = template
+                .spec
+                .helm_chart
+                .values
+                .as_ref()
+                .and_then(|v| v.get("image"))
+                .and_then(|img| img.get("tag"))
+                .and_then(|tag| tag.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&template.spec.helm_chart.source.version)
+                .to_string();
+
+            versions.push(DpuServiceVersion {
+                name: service_name.clone(),
+                version,
+            });
+        }
+
+        Ok(versions)
     }
 }
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -473,6 +473,16 @@ pub struct DpuSummary {
     pub status_bfb_file: Option<String>,
 }
 
+/// Service version resolved from a DPUDeployment's services and their DPUServiceTemplate CRs.
+/// Used by [`crate::DpfSdk::get_service_versions_for_dpu`] to populate the DPU inventory.
+#[derive(Debug, Clone)]
+pub struct DpuServiceVersion {
+    /// The `deployment_service_name` from the DPUServiceTemplate (e.g. `"doca-hbn"`).
+    pub name: String,
+    /// Docker image tag if set in `helmChart.values.image.tag`, otherwise the helm chart version.
+    pub version: String,
+}
+
 /// Helm-chart version observed on a live `DPUServiceTemplate` CR. Used by
 /// [`crate::DpfSdk::list_service_template_versions`] so callers (e.g. the
 /// admin CLI) can compare configured vs deployed versions.

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use carbide_dpf::types::{HostDpfSnapshot, ServiceTemplateVersion};
+use carbide_dpf::types::{DpuServiceVersion, HostDpfSnapshot, ServiceTemplateVersion};
 use carbide_dpf::{
     BmcPasswordProvider, DpfError, DpfSdk, DpuDeploymentType, DpuDeviceInfo, DpuNodeInfo, DpuPhase,
     DpuWatcher, KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
@@ -108,6 +108,18 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// CR — used for comparing config vs deployed state.
     async fn list_service_template_versions(&self)
     -> Result<Vec<ServiceTemplateVersion>, DpfError>;
+
+    /// Get service versions for a DPU from its owning DPUDeployment.
+    ///
+    /// Looks up the DPU CR by device name, follows the
+    /// `svc.dpu.nvidia.com/owned-by-dpudeployment` label to find the owning
+    /// DPUDeployment, and resolves each service's version from its
+    /// DPUServiceTemplate. Used to populate `agent_reported_inventory` once
+    /// the DPU reaches `DpuPhase::Ready`.
+    async fn get_service_versions_for_dpu(
+        &self,
+        dpu_device_name: &str,
+    ) -> Result<Vec<DpuServiceVersion>, DpfError>;
 
     /// Return DPUs whose installed BFB or `spec.dpuFlavor` does not match
     /// the namespace's ready DPUDeployment, mapped back to carbide
@@ -578,6 +590,13 @@ impl DpfOperations for DpfSdkOps {
         &self,
     ) -> Result<Vec<ServiceTemplateVersion>, DpfError> {
         self.sdk.list_service_template_versions().await
+    }
+
+    async fn get_service_versions_for_dpu(
+        &self,
+        dpu_device_name: &str,
+    ) -> Result<Vec<DpuServiceVersion>, DpfError> {
+        self.sdk.get_service_versions_for_dpu(dpu_device_name).await
     }
 
     async fn find_outdated_dpus_dpf(&self) -> Result<Vec<OutdatedDpfDpu>, DpfError> {


### PR DESCRIPTION
In DPF mode the agent runs containerized and cannot enumerate the services managed by the DPF operator, so agent_reported_inventory was always empty for DPF-ingested DPUs. Service versions (HBN, DTS, DHCP, etc.) were therefore never surfaced in the UI or admin CLI.

Fix this by intercepting the agent's hourly inventory report on the API server side: when a DPU was ingested via DPF, read the currently deployed service versions directly from the DPF operator (DPUDeployment → DPUServiceTemplate CRs) and store those in the DB instead of the agent's reported data. This keeps displayed versions accurate after upgrades without any changes to the agent.
  
## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes