### PR TITLE
Fix: empty parameter error code for vpc peering endpoint 

### DIFF
--- a/rest-api/api/pkg/api/handler/vpcpeering.go
+++ b/rest-api/api/pkg/api/handler/vpcpeering.go
@@ -461,14 +461,20 @@ func (gavph GetAllVpcPeeringHandler) Handle(c echo.Context) error {
 
 	filterInput := cdbm.VpcPeeringFilterInput{}
 
+	qParams := c.QueryParams()
+
 	// Get Site ID from query param if specified and verify user has access to the Site
-	siteIDStr := c.QueryParam("siteId")
-	if siteIDStr != "" {
+	if siteIDStrs := qParams["siteId"]; len(siteIDStrs) > 0 {
+		siteIDStr := siteIDStrs[0]
 		providerSiteAuthorized := false
 		tenantSiteAuthorized := false
 
 		site, err := common.GetSiteFromIDString(ctx, nil, siteIDStr, gavph.dbSession)
 		if err != nil {
+			if errors.Is(err, common.ErrInvalidID) {
+				logger.Warn().Msg(fmt.Sprintf("invalid value in siteId query: %v", siteIDStr))
+				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("Invalid Site ID %v in query", siteIDStr), nil)
+			}
 			if errors.Is(err, cdb.ErrDoesNotExist) {
 				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Site specified in query does not exist", nil)
 			}
@@ -509,10 +515,9 @@ func (gavph GetAllVpcPeeringHandler) Handle(c echo.Context) error {
 	}
 
 	// Get isMultiTenant from query param if specified
-	isMultiTenantStr := c.QueryParam("isMultiTenant")
 	var isMultiTenant *bool
-	if isMultiTenantStr != "" {
-		isMultiTenantParam, err := strconv.ParseBool(isMultiTenantStr)
+	if isMultiTenantStrs := qParams["isMultiTenant"]; len(isMultiTenantStrs) > 0 {
+		isMultiTenantParam, err := strconv.ParseBool(isMultiTenantStrs[0])
 		if err != nil {
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Invalid value specified for `isMultiTenant` query param", nil)
 		}
@@ -520,7 +525,6 @@ func (gavph GetAllVpcPeeringHandler) Handle(c echo.Context) error {
 	}
 
 	// Get and validate includeRelation params
-	qParams := c.QueryParams()
 	qIncludeRelations, errMsg := common.GetAndValidateQueryRelations(qParams, cdbm.VpcPeeringRelatedEntities)
 	if errMsg != "" {
 		logger.Warn().Msg(errMsg)

--- a/rest-api/api/pkg/api/handler/vpcpeering_test.go
+++ b/rest-api/api/pkg/api/handler/vpcpeering_test.go
@@ -513,6 +513,13 @@ func TestGetAllVpcPeeringHandler_Handle(t *testing.T) {
 			expectedStatus: http.StatusForbidden,
 		},
 		{
+			name:           "error when siteId is invalid",
+			reqOrgName:     tnOrg1,
+			queryParams:    map[string]string{"siteId": "not-a-uuid"},
+			user:           tnu1,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			name:           "error when siteId does not exist",
 			reqOrgName:     tnOrg1,
 			queryParams:    map[string]string{"siteId": uuid.New().String()},

--- a/rest-api/api/pkg/api/handler/vpcpeering_test.go
+++ b/rest-api/api/pkg/api/handler/vpcpeering_test.go
@@ -520,6 +520,20 @@ func TestGetAllVpcPeeringHandler_Handle(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
+			name:           "error when siteId is empty",
+			reqOrgName:     tnOrg1,
+			queryParams:    map[string]string{"siteId": ""},
+			user:           tnu1,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name:           "error when isMultiTenant is empty",
+			reqOrgName:     tnOrg1,
+			queryParams:    map[string]string{"isMultiTenant": ""},
+			user:           tnu1,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
 			name:           "error when siteId does not exist",
 			reqOrgName:     tnOrg1,
 			queryParams:    map[string]string{"siteId": uuid.New().String()},


### PR DESCRIPTION
## Description
GET /v2/org/{org}/forge/vpc-peering handled empty filter values inconsistently. The newer filters (status, vpcId, peerTenantId) rejected a present-but-blank value with 400, but the older siteId and isMultiTenant silently ignored a blank value and returned an unfiltered 200.

These changes make all five filters behave the same way.

Changes:
- siteId / isMultiTenant: read the value from the parsed query-param slice instead of the single-value accessor, so an absent param still means "no filter" but a present-but-empty value is now rejected with 400.
- siteId: a malformed, non-UUID value (e.g. ?siteId=notauuid) now returns 400 instead of 500, consistent with how vpcId/peerTenantId already handle bad UUIDs.
- Test: added a test case asserting a malformed siteId returns 400.

## Related issues
[#3770](https://github.com/NVIDIA/infra-controller/issues/3770)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

