### PR TITLE
Update README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ of the bare-metal lifecycle to fast-track building next generation AI Cloud offe
 
 ## Getting Started
 
-- Go to the [NVIDIA Infra Controller overview](https://docs.nvidia.com/infra-controller/documentation/overview/what-is-nico) to get an overview of NICo architecture and capabilities.
-- Or jump to the [Quick Start Guide](https://docs.nvidia.com/infra-controller/documentation/getting-started/quick-start-guide) to start setting up your site for NICo.
+- Go to the [NVIDIA Infra Controller overview](docs/overview/what-is-nico.md) to get an overview of NICo architecture and capabilities.
+- Or jump to the [Quick Start Guide](docs/getting-started/quick-start.md) to start setting up your site for NICo.
+- The [NICo web documentation](https://docs.nvidia.com/infra-controller/documentation/home) is also available online.
 - Check out [Local Development with DevSpace](dev/deployment/devspace/README.md) to run NICo locally with mock systems.
 
 ## Bare-Metal Cluster Setup

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ of the bare-metal lifecycle to fast-track building next generation AI Cloud offe
 ## Getting Started
 
 - Go to the [NVIDIA Infra Controller overview](docs/overview/what-is-nico.md) to get an overview of NICo architecture and capabilities.
-- Or jump to the [Quick Start Guide](docs/getting-started/quick-start.md) to start setting up your site for NICo.
-- The [NICo web documentation](https://docs.nvidia.com/infra-controller/documentation/home) is also available online.
+- Or, go straight to the [Quick Start Guide](https://docs.nvidia.com/infra-controller/documentation/getting-started/quick-start-guide) to start setting up your site for NICo.
+- The [NICo web documentation](https://docs.nvidia.com/infra-controller/documentation/home) is available online.
 - Check out [Local Development with DevSpace](dev/deployment/devspace/README.md) to run NICo locally with mock systems.
 
 ## Bare-Metal Cluster Setup


### PR DESCRIPTION
## Summary

- point the README Overview link to the repository's `docs/overview/what-is-nico.md`
- point the README Quick Start link to `docs/getting-started/quick-start.md`
- retain a separate link to the published NICo web documentation

## Why

The Getting Started links should take GitHub readers directly to the documentation maintained in this repository while still making the published web documentation discoverable.

## Impact

README visitors can review the Overview and Quick Start content in the same repository and choose the web documentation when preferred.

## Validation

- confirmed both repository-relative documentation targets exist
- ran `git diff --check`
