### PR TITLE
feat: support per-model BMC factory default credentials for DPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "askama_escape",
  "base64",
  "bmc-mock",
+ "bmc-vendor",
  "carbide-api-core",
  "carbide-api-db",
  "carbide-api-test-helper",
@@ -1437,6 +1438,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "bmc-mock",
+ "bmc-vendor",
  "carbide-api",
  "carbide-api-db",
  "carbide-instrument",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "axum-server",
+ "bmc-vendor",
  "bytes",
  "chrono",
  "clap",

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
@@ -22,8 +22,14 @@ use rpc::{CredentialType, forge as forgerpc};
 #[command(after_long_help = "\
 EXAMPLES:
 
-Add the factory-default DPU BMC credential:
-    $ nico-admin-cli credential add-dpu-factory-default --username admin --password mypassword
+Add the factory-default DPU BMC credential for all unrecognized models (backward-compatible default):
+    $ nico-admin-cli credential add-dpu-factory-default --username root --password mypassword
+
+Add a model-specific factory-default for BlueField-3 DPUs:
+    $ nico-admin-cli credential add-dpu-factory-default --model bf3 --username root --password mypassword
+
+Add a model-specific factory-default for BlueField-4 DPUs:
+    $ nico-admin-cli credential add-dpu-factory-default --model bf4 --username root --password mynewpassword
 
 ")]
 pub struct Args {
@@ -31,6 +37,12 @@ pub struct Args {
     pub username: String,
     #[clap(long, required(true), help = "DPU manufacturer default password")]
     pub password: String,
+    #[clap(
+        long,
+        default_value = "unknown",
+        help = "DPU model: bf2, bf3, bf4, or unknown (catch-all / backward-compatible default)"
+    )]
+    pub model: bmc_vendor::DpuModel,
 }
 
 impl From<Args> for forgerpc::CredentialCreationRequest {
@@ -40,7 +52,7 @@ impl From<Args> for forgerpc::CredentialCreationRequest {
             username: Some(args.username),
             password: args.password,
             mac_address: None,
-            vendor: None,
+            vendor: Some(args.model.to_string()),
         }
     }
 }

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
@@ -29,7 +29,7 @@ Add a model-specific factory-default for BlueField-3 DPUs:
     $ nico-admin-cli credential add-dpu-factory-default --model bf3 --username root --password mypassword
 
 Add a model-specific factory-default for BlueField-4 DPUs:
-    $ nico-admin-cli credential add-dpu-factory-default --model bf4 --username root --password mynewpassword
+    $ nico-admin-cli credential add-dpu-factory-default --model bf4 --username admin --password mynewpassword
 
 ")]
 pub struct Args {

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -199,10 +199,15 @@ pub(crate) async fn create_credential(
             let Some(username) = req.username else {
                 return Err(CarbideError::InvalidArgument("missing username".to_string()).into());
             };
+            let model: bmc_vendor::DpuModel = req
+                .vendor
+                .as_deref()
+                .map(bmc_vendor::DpuModel::from)
+                .unwrap_or_default();
             api.credential_manager
                 .set_credentials(
                     &CredentialKey::DpuRedfish {
-                        credential_type: CredentialType::DpuHardwareDefault,
+                        credential_type: CredentialType::DpuHardwareDefault { model },
                     },
                     &Credentials::UsernamePassword { username, password },
                 )

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -199,11 +199,26 @@ pub(crate) async fn create_credential(
             let Some(username) = req.username else {
                 return Err(CarbideError::InvalidArgument("missing username".to_string()).into());
             };
-            let model: bmc_vendor::DpuModel = req
-                .vendor
-                .as_deref()
-                .map(bmc_vendor::DpuModel::from)
-                .unwrap_or_default();
+            // Reuse the proto `vendor` field to carry the DPU model. Absent/empty
+            // means the catch-all default (backward compatible). `DpuModel::from`
+            // maps anything unrecognized to `Unknown`, so only accept that when the
+            // caller explicitly asked for the catch-all -- otherwise it's a typo and
+            // we reject it rather than silently writing to the legacy `root` path.
+            let model: bmc_vendor::DpuModel = match req.vendor.as_deref() {
+                None | Some("") => bmc_vendor::DpuModel::Unknown,
+                Some(vendor) => {
+                    let model = bmc_vendor::DpuModel::from(vendor);
+                    if model == bmc_vendor::DpuModel::Unknown
+                        && !vendor.eq_ignore_ascii_case("unknown")
+                    {
+                        return Err(CarbideError::InvalidArgument(format!(
+                            "unrecognized DPU model {vendor:?}; expected one of bf2, bf3, bf4, unknown"
+                        ))
+                        .into());
+                    }
+                    model
+                }
+            };
             api.credential_manager
                 .set_credentials(
                     &CredentialKey::DpuRedfish {

--- a/crates/api-integration-tests/Cargo.toml
+++ b/crates/api-integration-tests/Cargo.toml
@@ -34,6 +34,7 @@ carbide-secrets = { path = "../secrets" }
 carbide-api-core = { path = "../api-core", default-features = false }
 carbide-api-db = { path = "../api-db", default-features = false }
 bmc-mock = { path = "../bmc-mock" }
+bmc-vendor = { path = "../bmc-vendor" }
 # DO NOT PUT DEPENDENCIES OTHER THAN LOCAL DEPS HERE, THEY SHOULD ALL HAVE 'path =' IN THEM.
 
 #these are alphabetized

--- a/crates/api-integration-tests/tests/secrets_import.rs
+++ b/crates/api-integration-tests/tests/secrets_import.rs
@@ -21,6 +21,7 @@
 
 use std::str::FromStr;
 
+use bmc_vendor::DpuModel;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialReader, CredentialType, CredentialWriter,
     Credentials, MqttCredentialType, NicLockdownIkm,
@@ -79,7 +80,9 @@ fn generate_test_secrets(min_count: usize) -> Vec<(CredentialKey, Credentials)> 
         ),
         (
             CredentialKey::DpuRedfish {
-                credential_type: CredentialType::DpuHardwareDefault,
+                credential_type: CredentialType::DpuHardwareDefault {
+                    model: DpuModel::Unknown,
+                },
             },
             cred("dpu-redfish-hw", "pass"),
         ),
@@ -97,7 +100,9 @@ fn generate_test_secrets(min_count: usize) -> Vec<(CredentialKey, Credentials)> 
         ),
         (
             CredentialKey::DpuUefi {
-                credential_type: CredentialType::DpuHardwareDefault,
+                credential_type: CredentialType::DpuHardwareDefault {
+                    model: DpuModel::Unknown,
+                },
             },
             cred("dpu-uefi-hw", "pass"),
         ),

--- a/crates/api-test-helper/Cargo.toml
+++ b/crates/api-test-helper/Cargo.toml
@@ -31,6 +31,7 @@ carbide-instrument = { path = "../instrument" }
 # [local-dependencies]
 async-trait = { workspace = true }
 bmc-mock = { path = "../bmc-mock" }
+bmc-vendor = { path = "../bmc-vendor" }
 carbide-api = { path = "../api", default-features = false }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-version = { path = "../version" }

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, path};
 
+use bmc_vendor;
 use carbide_secrets::credentials::{
     CredentialKey, CredentialType, CredentialWriter, Credentials, NicLockdownIkm,
 };
@@ -330,7 +331,9 @@ pub async fn populate_initial_vault_secrets(
     credential_manager
         .set_credentials(
             &CredentialKey::DpuUefi {
-                credential_type: CredentialType::DpuHardwareDefault,
+                credential_type: CredentialType::DpuHardwareDefault {
+                    model: bmc_vendor::DpuModel::Unknown,
+                },
             },
             &Credentials::UsernamePassword {
                 username: "root".to_string(),

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{env, path};
 
-use bmc_vendor;
 use carbide_secrets::credentials::{
     CredentialKey, CredentialType, CredentialWriter, Credentials, NicLockdownIkm,
 };

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -23,6 +23,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
+bmc-vendor = { path = "../bmc-vendor" }
 arc-swap = { workspace = true }
 axum = { workspace = true }
 axum-extra = { features = ["typed-header"], workspace = true }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -22,10 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use crate::redfish::update_service::UpdateServiceConfig;
-use crate::{
-    DUMMY_FACTORY_DPU_PASSWORD, DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostHardwareType,
-    hw, redfish,
-};
+use crate::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostHardwareType, hw, redfish};
 
 /// Represents static information we know ahead of time about a host or DPU (independent of any
 /// state we get from carbide like IP addresses or machine ID's.) Intended to be immutable and
@@ -201,6 +198,16 @@ impl DpuMachineInfo {
             HostHardwareType::DellPowerEdgeR760Bf4 | HostHardwareType::NvidiaDgxVr => {
                 DpuType::Bluefield4
             }
+        }
+    }
+
+    /// The [`bmc_vendor::DpuModel`] this DPU emulates, so the mock can share
+    /// per-model logic (e.g. factory-default credentials) with the rest of the
+    /// stack rather than duplicating it against the local [`DpuType`].
+    fn dpu_model(&self) -> bmc_vendor::DpuModel {
+        match self.dpu_type() {
+            DpuType::Bluefield3 => bmc_vendor::DpuModel::BlueField3,
+            DpuType::Bluefield4 => bmc_vendor::DpuModel::BlueField4,
         }
     }
 
@@ -1032,11 +1039,12 @@ impl MachineInfo {
     pub fn factory_default_account(&self) -> redfish::account_service::Account {
         match self {
             MachineInfo::Host(h) => h.factory_default_account(),
-            MachineInfo::Dpu(_) => redfish::account_service::Account::administrator(
-                "root",
-                DUMMY_FACTORY_USERNAME,
-                DUMMY_FACTORY_DPU_PASSWORD,
-            ),
+            MachineInfo::Dpu(d) => {
+                // Read the per-model default from the shared source of truth so the
+                // mock and site-explorer's fallback cannot drift.
+                let (username, password) = d.dpu_model().default_factory_credentials();
+                redfish::account_service::Account::administrator(username, username, password)
+            }
         }
     }
 }

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -88,8 +88,11 @@ impl From<&str> for BMCVendor {
     serde::Deserialize,
 )]
 pub enum DpuModel {
+    #[value(name = "bf2")]
     BlueField2,
+    #[value(name = "bf3")]
     BlueField3,
+    #[value(name = "bf4")]
     BlueField4,
     #[serde(other)]
     #[default]

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -135,6 +135,21 @@ impl DpuModel {
             DpuModel::Unknown
         }
     }
+
+    /// Publicly-documented factory-default BMC credentials `(username, password)`
+    /// for this DPU generation.
+    ///
+    /// This is the single source of truth shared by site-explorer's last-resort
+    /// credential fallback (used when no vault entry is configured) and the BMC
+    /// mock's factory-default account, so the two cannot drift. BlueField-4 ships
+    /// with a distinct default account (`admin`); earlier generations and
+    /// unrecognized models use the legacy `root` default.
+    pub fn default_factory_credentials(&self) -> (&'static str, &'static str) {
+        match self {
+            DpuModel::BlueField4 => ("admin", "0penBmc"),
+            DpuModel::BlueField2 | DpuModel::BlueField3 | DpuModel::Unknown => ("root", "0penBmc"),
+        }
+    }
 }
 
 impl BMCVendor {

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -69,6 +69,74 @@ impl From<&str> for BMCVendor {
     }
 }
 
+/// DPU generation / model identifier used to key per-model factory default credentials.
+///
+/// The `Display` impl produces the lowercase vault path segment ("bf3", "bf4", ...).
+/// `Unknown` maps to "unknown" for new vault paths; existing deployments keep their
+/// legacy entry at `machines/all_dpus/factory_default/bmc-metadata-items/root`, which
+/// the credential key encoding maps `Unknown` to for backward compatibility.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Hash,
+    Eq,
+    PartialEq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum DpuModel {
+    BlueField2,
+    BlueField3,
+    BlueField4,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+impl fmt::Display for DpuModel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            DpuModel::BlueField2 => "bf2",
+            DpuModel::BlueField3 => "bf3",
+            DpuModel::BlueField4 => "bf4",
+            DpuModel::Unknown => "unknown",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl From<&str> for DpuModel {
+    fn from(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "bf2" => DpuModel::BlueField2,
+            "bf3" => DpuModel::BlueField3,
+            "bf4" => DpuModel::BlueField4,
+            _ => DpuModel::Unknown,
+        }
+    }
+}
+
+impl DpuModel {
+    /// Identify the DPU generation from the Redfish service root `Product` field,
+    /// which BlueField BMCs set to a human-readable model string (e.g. "BlueField-3 DPU").
+    /// Returns `Unknown` for unrecognized strings so callers can fall back gracefully.
+    pub fn from_service_root_product(product: &str) -> Self {
+        let lower = product.to_lowercase();
+        if lower.contains("bluefield-2") || lower.contains("bluefield 2") {
+            DpuModel::BlueField2
+        } else if lower.contains("bluefield-3") || lower.contains("bluefield 3") {
+            DpuModel::BlueField3
+        } else if lower.contains("bluefield-4") || lower.contains("bluefield 4") {
+            DpuModel::BlueField4
+        } else {
+            DpuModel::Unknown
+        }
+    }
+}
+
 impl BMCVendor {
     /// From the string libudev returns querying the dmi subsystem
     pub fn from_udev_dmi(s: &str) -> BMCVendor {

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 pub use auth::RedfishAuth;
+use bmc_vendor;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
 use carbide_utils::HostPortPair;
 use carbide_utils::redfish::BmcAccessInfo;
@@ -196,7 +197,9 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             let credentials = self
                 .credential_reader()
                 .get_credentials(&CredentialKey::DpuUefi {
-                    credential_type: CredentialType::DpuHardwareDefault,
+                    credential_type: CredentialType::DpuHardwareDefault {
+                        model: bmc_vendor::DpuModel::Unknown,
+                    },
                 })
                 .await?
                 .unwrap_or(Credentials::UsernamePassword {

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -31,7 +31,6 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 pub use auth::RedfishAuth;
-use bmc_vendor;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
 use carbide_utils::HostPortPair;
 use carbide_utils::redfish::BmcAccessInfo;

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -278,7 +278,7 @@ impl<R: CredentialReader, W: CredentialWriter> CredentialManager
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[allow(clippy::enum_variant_names)]
 pub enum CredentialType {
-    DpuHardwareDefault,
+    DpuHardwareDefault { model: bmc_vendor::DpuModel },
     HostHardwareDefault { vendor: bmc_vendor::BMCVendor },
     SiteDefault,
 }
@@ -521,6 +521,17 @@ impl CredentialPrefix {
     }
 }
 
+/// Returns the vault path segment for a `DpuModel`. `Unknown` maps to `"root"` to
+/// preserve backward compatibility with the pre-per-model vault entry.
+fn dpu_model_vault_segment(model: bmc_vendor::DpuModel) -> &'static str {
+    match model {
+        bmc_vendor::DpuModel::BlueField2 => "bf2",
+        bmc_vendor::DpuModel::BlueField3 => "bf3",
+        bmc_vendor::DpuModel::BlueField4 => "bf4",
+        bmc_vendor::DpuModel::Unknown => "root",
+    }
+}
+
 impl CredentialKey {
     /// Resolve the site-wide host UEFI credential key for `version`, the
     /// table-driven "current site-wide host UEFI credential" lookup: a caller
@@ -595,8 +606,11 @@ impl CredentialKey {
                 Cow::from(format!("machines/{machine_id}/dpu-hbn"))
             }
             CredentialKey::DpuRedfish { credential_type } => match credential_type {
-                CredentialType::DpuHardwareDefault => {
-                    Cow::from("machines/all_dpus/factory_default/bmc-metadata-items/root")
+                CredentialType::DpuHardwareDefault { model } => {
+                    let segment = dpu_model_vault_segment(*model);
+                    Cow::from(format!(
+                        "machines/all_dpus/factory_default/bmc-metadata-items/{segment}"
+                    ))
                 }
                 CredentialType::SiteDefault => {
                     Cow::from("machines/all_dpus/site_default/bmc-metadata-items/root")
@@ -614,7 +628,7 @@ impl CredentialKey {
                 CredentialType::SiteDefault => {
                     Cow::from("machines/all_hosts/site_default/bmc-metadata-items/root")
                 }
-                CredentialType::DpuHardwareDefault => {
+                CredentialType::DpuHardwareDefault { .. } => {
                     unreachable!(
                         "HostRedfish / DpuHardwareDefault is an invalid credential combination"
                     );
@@ -622,7 +636,7 @@ impl CredentialKey {
             },
             CredentialKey::UfmAuth { fabric } => Cow::from(format!("ufm/{fabric}/auth")),
             CredentialKey::DpuUefi { credential_type } => match credential_type {
-                CredentialType::DpuHardwareDefault => {
+                CredentialType::DpuHardwareDefault { .. } => {
                     Cow::from("machines/all_dpus/factory_default/uefi-metadata-items/auth")
                 }
                 CredentialType::SiteDefault => {
@@ -971,10 +985,24 @@ mod tests {
                     expect: PathChecks::all_hold(),
                 },
                 Check {
-                    scenario: "dpu redfish hardware default",
+                    scenario: "dpu redfish hardware default (unknown/root)",
                     input: Row {
                         key: CredentialKey::DpuRedfish {
-                            credential_type: CredentialType::DpuHardwareDefault,
+                            credential_type: CredentialType::DpuHardwareDefault {
+                                model: bmc_vendor::DpuModel::Unknown,
+                            },
+                        },
+                        expected_prefix: "machines/all_dpus/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
+                    scenario: "dpu redfish hardware default (bf3)",
+                    input: Row {
+                        key: CredentialKey::DpuRedfish {
+                            credential_type: CredentialType::DpuHardwareDefault {
+                                model: bmc_vendor::DpuModel::BlueField3,
+                            },
                         },
                         expected_prefix: "machines/all_dpus/",
                     },
@@ -1026,7 +1054,9 @@ mod tests {
                     scenario: "dpu uefi hardware default",
                     input: Row {
                         key: CredentialKey::DpuUefi {
-                            credential_type: CredentialType::DpuHardwareDefault,
+                            credential_type: CredentialType::DpuHardwareDefault {
+                                model: bmc_vendor::DpuModel::Unknown,
+                            },
                         },
                         expected_prefix: "machines/all_dpus/",
                     },

--- a/crates/secrets/src/local_credentials/mod.rs
+++ b/crates/secrets/src/local_credentials/mod.rs
@@ -70,7 +70,12 @@ pub struct MachineIdentityConfig {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CredentialSnapshot {
+    /// Legacy single DPU BMC factory default (catch-all when no per-model entry exists).
+    /// Kept for backward compatibility; prefer `dpu_redfish_factory_default_by_model`.
     pub dpu_redfish_factory_default: Option<UsernamePassword>,
+    /// Per-model DPU BMC factory defaults, keyed by [`bmc_vendor::DpuModel`].
+    /// Takes precedence over `dpu_redfish_factory_default` when present.
+    pub dpu_redfish_factory_default_by_model: HashMap<bmc_vendor::DpuModel, UsernamePassword>,
     pub dpu_redfish_site_default: Option<UsernamePassword>,
     pub host_redfish_factory_default_by_vendor: HashMap<bmc_vendor::BMCVendor, UsernamePassword>,
     pub host_redfish_site_default: Option<UsernamePassword>,
@@ -88,9 +93,12 @@ impl CredentialSnapshot {
     pub fn get_credentials(&self, key: &CredentialKey) -> Option<Credentials> {
         match key {
             CredentialKey::DpuRedfish { credential_type } => match credential_type {
-                CredentialType::DpuHardwareDefault => {
-                    self.dpu_redfish_factory_default.clone().map(Into::into)
-                }
+                CredentialType::DpuHardwareDefault { model } => self
+                    .dpu_redfish_factory_default_by_model
+                    .get(model)
+                    .cloned()
+                    .or_else(|| self.dpu_redfish_factory_default.clone())
+                    .map(Into::into),
                 CredentialType::SiteDefault => {
                     self.dpu_redfish_site_default.clone().map(Into::into)
                 }
@@ -105,13 +113,13 @@ impl CredentialSnapshot {
                 CredentialType::SiteDefault => {
                     self.host_redfish_site_default.clone().map(Into::into)
                 }
-                CredentialType::DpuHardwareDefault => None,
+                CredentialType::DpuHardwareDefault { .. } => None,
             },
             CredentialKey::UfmAuth { fabric } => {
                 self.ufm_auth_by_fabric.get(fabric).cloned().map(Into::into)
             }
             CredentialKey::DpuUefi { credential_type } => match credential_type {
-                CredentialType::DpuHardwareDefault => {
+                CredentialType::DpuHardwareDefault { .. } => {
                     self.dpu_uefi_factory_default.clone().map(Into::into)
                 }
                 CredentialType::SiteDefault => self.dpu_uefi_site_default.clone().map(Into::into),
@@ -178,6 +186,9 @@ mod tests {
         let mut host_vendors = HashMap::new();
         host_vendors.insert(bmc_vendor::BMCVendor::Dell, up("dell-u", "dell-p"));
 
+        let mut dpu_models = HashMap::new();
+        dpu_models.insert(bmc_vendor::DpuModel::BlueField3, up("bf3-u", "bf3-p"));
+
         let mut ufm = HashMap::new();
         ufm.insert("fabric-1".to_string(), up("ufm-u", "ufm-p"));
 
@@ -186,6 +197,7 @@ mod tests {
 
         CredentialSnapshot {
             dpu_redfish_factory_default: Some(up("drf-u", "drf-p")),
+            dpu_redfish_factory_default_by_model: dpu_models,
             dpu_redfish_site_default: Some(up("drs-u", "drs-p")),
             host_redfish_factory_default_by_vendor: host_vendors,
             host_redfish_site_default: Some(up("hrs-u", "hrs-p")),
@@ -212,8 +224,23 @@ mod tests {
         let snap = populated_snapshot();
         value_scenarios!(run = |key| snap.get_credentials(&key);
             "dpu redfish" {
+                // per-model entry takes precedence
                 CredentialKey::DpuRedfish {
-                    credential_type: CredentialType::DpuHardwareDefault,
+                    credential_type: CredentialType::DpuHardwareDefault {
+                        model: bmc_vendor::DpuModel::BlueField3,
+                    },
+                } => Some(cred("bf3-u", "bf3-p")),
+                // unknown model falls back to legacy dpu_redfish_factory_default
+                CredentialKey::DpuRedfish {
+                    credential_type: CredentialType::DpuHardwareDefault {
+                        model: bmc_vendor::DpuModel::Unknown,
+                    },
+                } => Some(cred("drf-u", "drf-p")),
+                // unconfigured model also falls back to legacy field
+                CredentialKey::DpuRedfish {
+                    credential_type: CredentialType::DpuHardwareDefault {
+                        model: bmc_vendor::DpuModel::BlueField4,
+                    },
                 } => Some(cred("drf-u", "drf-p")),
                 CredentialKey::DpuRedfish {
                     credential_type: CredentialType::SiteDefault,
@@ -247,7 +274,9 @@ mod tests {
 
             "dpu uefi" {
                 CredentialKey::DpuUefi {
-                    credential_type: CredentialType::DpuHardwareDefault,
+                    credential_type: CredentialType::DpuHardwareDefault {
+                        model: bmc_vendor::DpuModel::Unknown,
+                    },
                 } => Some(cred("duf-u", "duf-p")),
                 CredentialKey::DpuUefi {
                     credential_type: CredentialType::SiteDefault,
@@ -289,7 +318,9 @@ mod tests {
                     },
                 } => None,
                 CredentialKey::HostRedfish {
-                    credential_type: CredentialType::DpuHardwareDefault,
+                    credential_type: CredentialType::DpuHardwareDefault {
+                        model: bmc_vendor::DpuModel::Unknown,
+                    },
                 } => None,
             }
         );

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -19,6 +19,7 @@ test-support = []
 
 [dependencies]
 bmc-explorer = { path = "../bmc-explorer" }
+bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
 carbide-firmware = { path = "../firmware" }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -176,9 +176,11 @@ impl BmcEndpointExplorer {
         })
     }
 
-    fn get_default_hardware_dpu_bmc_root_credentials(&self) -> BmcCredentialsData<'static> {
+    async fn get_dpu_factory_default_credentials(&self, bmc_ip_address: SocketAddr) -> Credentials {
+        let model = self.redfish_client.get_dpu_model_hint(bmc_ip_address).await;
         self.credential_client
-            .get_default_hardware_dpu_bmc_root_credentials()
+            .get_dpu_factory_default_credentials(model)
+            .await
     }
 
     pub async fn get_bmc_root_credentials(
@@ -799,6 +801,19 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     "Site explorer could not find a BMC root credential entry in vault - this is expected if the BMC has never been seen before.",
                 );
 
+                // When no expected entity is present and the vendor is a DPU, look up the
+                // per-model factory default from vault (or fall back to the hardcoded default).
+                // Declared before `bmc_cred_data` so it outlives the borrow.
+                let dpu_factory_creds = if expected.is_none() && vendor == RedfishVendor::NvidiaDpu
+                {
+                    Some(
+                        self.get_dpu_factory_default_credentials(bmc_ip_address)
+                            .await,
+                    )
+                } else {
+                    None
+                };
+
                 let bmc_cred_data = match expected {
                     Some(v) => {
                         tracing::info!(
@@ -811,14 +826,19 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     }
                     None => {
                         tracing::info!(%bmc_ip_address, %bmc_mac_address, %vendor, "No expected machine found, could be a BlueField");
-                        // We dont know if this machine is a DPU at this point
-                        // Check the vendor to see if it could be a DPU (the DPU's vendor is NVIDIA)
                         match vendor {
                             RedfishVendor::NvidiaDpu => {
-                                // This machine is a DPU.
-                                // Try the DPU hardware default password to handle the DPU case
-                                // This password will not work for a Viking host and we will return an error
-                                self.get_default_hardware_dpu_bmc_root_credentials()
+                                // This machine is a DPU. Use the per-model factory default credential
+                                // (looked up above from vault, with hardcoded fallback).
+                                let Credentials::UsernamePassword {
+                                    ref username,
+                                    ref password,
+                                } = *dpu_factory_creds.as_ref().unwrap();
+                                BmcCredentialsData {
+                                    username,
+                                    password,
+                                    retain_credentials: false,
+                                }
                             }
                             _ => {
                                 return Err(EndpointExplorationError::MissingCredentials {

--- a/crates/site-explorer/src/credentials.rs
+++ b/crates/site-explorer/src/credentials.rs
@@ -17,7 +17,6 @@
 
 use std::sync::Arc;
 
-use bmc_vendor;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
     REQUIRED_SITE_DEFAULT_CREDENTIAL_KEYS,
@@ -151,7 +150,7 @@ impl CredentialClient {
     /// 1. Model-specific vault entry (`machines/all_dpus/factory_default/bmc-metadata-items/{model}`)
     /// 2. Catch-all vault entry (`machines/all_dpus/factory_default/bmc-metadata-items/root`,
     ///    i.e. `DpuModel::Unknown`) — skipped when `model` is already `Unknown`
-    /// 3. Hardcoded default `root`/`0penBmc`
+    /// 3. Model's publicly-documented factory default (`DpuModel::default_factory_credentials`)
     ///
     /// Never fails: vault misses are silently swallowed and the hardcoded fallback is returned.
     pub async fn get_dpu_factory_default_credentials(
@@ -176,9 +175,10 @@ impl CredentialClient {
             }
         }
 
+        let (username, password) = model.default_factory_credentials();
         Credentials::UsernamePassword {
-            username: "root".to_string(),
-            password: "0penBmc".to_string(),
+            username: username.to_string(),
+            password: password.to_string(),
         }
     }
 

--- a/crates/site-explorer/src/credentials.rs
+++ b/crates/site-explorer/src/credentials.rs
@@ -17,12 +17,12 @@
 
 use std::sync::Arc;
 
+use bmc_vendor;
 use carbide_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialManager, Credentials,
+    BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
     REQUIRED_SITE_DEFAULT_CREDENTIAL_KEYS,
 };
 use mac_address::MacAddress;
-use model::expected_entity::BmcCredentialsData;
 use model::site_explorer::EndpointExplorationError;
 
 use super::metrics::SiteExplorationMetrics;
@@ -145,11 +145,40 @@ impl CredentialClient {
         self.get_credentials(&key).await
     }
 
-    pub fn get_default_hardware_dpu_bmc_root_credentials(&self) -> BmcCredentialsData<'static> {
-        BmcCredentialsData {
-            username: "root",
-            password: "0penBmc",
-            retain_credentials: false,
+    /// Returns the factory-default BMC credentials for a DPU of the given model.
+    ///
+    /// Lookup order:
+    /// 1. Model-specific vault entry (`machines/all_dpus/factory_default/bmc-metadata-items/{model}`)
+    /// 2. Catch-all vault entry (`machines/all_dpus/factory_default/bmc-metadata-items/root`,
+    ///    i.e. `DpuModel::Unknown`) — skipped when `model` is already `Unknown`
+    /// 3. Hardcoded default `root`/`0penBmc`
+    ///
+    /// Never fails: vault misses are silently swallowed and the hardcoded fallback is returned.
+    pub async fn get_dpu_factory_default_credentials(
+        &self,
+        model: bmc_vendor::DpuModel,
+    ) -> Credentials {
+        let model_key = CredentialKey::DpuRedfish {
+            credential_type: CredentialType::DpuHardwareDefault { model },
+        };
+        if let Ok(creds) = self.get_credentials(&model_key).await {
+            return creds;
+        }
+
+        if model != bmc_vendor::DpuModel::Unknown {
+            let unknown_key = CredentialKey::DpuRedfish {
+                credential_type: CredentialType::DpuHardwareDefault {
+                    model: bmc_vendor::DpuModel::Unknown,
+                },
+            };
+            if let Ok(creds) = self.get_credentials(&unknown_key).await {
+                return creds;
+            }
+        }
+
+        Credentials::UsernamePassword {
+            username: "root".to_string(),
+            password: "0penBmc".to_string(),
         }
     }
 

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -156,6 +156,28 @@ impl RedfishClient {
         }
     }
 
+    /// Probe the DPU model from the unauthenticated Redfish service root `Product` field.
+    ///
+    /// BlueField BMCs populate `ServiceRoot.Product` with a human-readable model string
+    /// (e.g. `"BlueField-3 DPU"`). This makes a single anonymous `/redfish/v1` call and
+    /// parses that field. Returns `DpuModel::Unknown` on any error or unrecognized string
+    /// so callers can fall back to the catch-all factory credential.
+    pub async fn get_dpu_model_hint(&self, bmc_ip_address: SocketAddr) -> ::bmc_vendor::DpuModel {
+        let client = match self.create_anon_redfish_client(bmc_ip_address).await {
+            Ok(c) => c,
+            Err(_) => return ::bmc_vendor::DpuModel::Unknown,
+        };
+        let service_root = match client.get_service_root().await {
+            Ok(s) => s,
+            Err(_) => return ::bmc_vendor::DpuModel::Unknown,
+        };
+        service_root
+            .product
+            .as_deref()
+            .map(::bmc_vendor::DpuModel::from_service_root_product)
+            .unwrap_or_default()
+    }
+
     pub async fn validate_bmc_credentials(
         &self,
         bmc_ip_address: SocketAddr,

--- a/dev/deployment/devspace/setup-rest-integration.sh
+++ b/dev/deployment/devspace/setup-rest-integration.sh
@@ -42,7 +42,7 @@ require_bin base64
 mkdir -p "${WORK_DIR}"
 
 kubectl rollout status deployment/nico-api -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
-kubectl rollout status deployment/machine-a-tron -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
+kubectl rollout status deployment/nico-machine-a-tron -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-api -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-cert-manager -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-cloud-worker -n "${REST_NAMESPACE}" --timeout=300s >/dev/null

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-add-dpu-factory-default.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-add-dpu-factory-default.md
@@ -10,7 +10,7 @@ factory default BMC user/pass for the DPUs
 ## SYNOPSIS
 
 **nico-admin-cli credential add-dpu-factory-default** \<**--username**\>
-\<**--password**\> \[**--extended**\] \[**--sort-by**\]
+\<**--password**\> \[**--model**\] \[**--extended**\] \[**--sort-by**\]
 \[**-h**\|**--help**\]
 
 ## DESCRIPTION
@@ -24,6 +24,21 @@ Default username: root, ADMIN, etc
 
 **--password** *\<PASSWORD\>*  
 DPU manufacturer default password
+
+**--model** *\<MODEL\>* \[default: unknown\]  
+DPU model: bf2, bf3, bf4, or unknown (catch-all / backward-compatible
+default)\
+
+\
+*Possible values:*
+
+- bf2
+
+- bf3
+
+- bf4
+
+- unknown
 
 **--extended**  
 Extended result output.
@@ -48,7 +63,9 @@ Print help (see a summary with -h)
 ## Examples
 
 ```sh
-nico-admin-cli credential add-dpu-factory-default --username admin --password mypassword
+nico-admin-cli credential add-dpu-factory-default --username root --password mypassword
+nico-admin-cli credential add-dpu-factory-default --model bf3 --username root --password mypassword
+nico-admin-cli credential add-dpu-factory-default --model bf4 --username admin --password mynewpassword
 ```
 
 ---

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -78,17 +78,18 @@ vault:
         UsernamePassword:
           username: "root"
           password: "0penBmc"
-    ## Per-model DPU BMC factory defaults (BlueField-3/4 ship with "admin"/"0penBmc").
-    - path: "machines/all_dpus/factory_default/bmc-metadata-items/bf3"
-      data:
-        UsernamePassword:
-          username: "admin"
-          password: "0penBmc"
-    - path: "machines/all_dpus/factory_default/bmc-metadata-items/bf4"
-      data:
-        UsernamePassword:
-          username: "admin"
-          password: "0penBmc"
+    ## Per-model DPU BMC factory-default OVERRIDES (optional).
+    ##
+    ## Not seeded by default: site-explorer already falls back to each model's
+    ## publicly-documented factory default in code (DpuModel::default_factory_credentials
+    ## — BlueField-4 = admin/0penBmc, earlier generations = root/0penBmc, matching the
+    ## "root" catch-all above). Only add a per-model entry here to override that default
+    ## for a site whose DPUs ship with a non-standard factory password.
+    # - path: "machines/all_dpus/factory_default/bmc-metadata-items/bf4"
+    #   data:
+    #     UsernamePassword:
+    #       username: "admin"
+    #       password: ""          # SITE SECRET: this site's BF4 factory password
     - path: "machines/all_dpus/factory_default/uefi-metadata-items/auth"
       data:
         UsernamePassword:

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -71,10 +71,23 @@ vault:
   ## (forged/terraform/v2/modules/vault) writes via vault_kv_secret_v2.
   ## Set kvSeeds: [] to disable seeding.
   kvSeeds:
+    ## Legacy catch-all DPU BMC factory default (DpuModel::Unknown → path segment "root").
+    ## Used when no model-specific entry is configured or the DPU model cannot be identified.
     - path: "machines/all_dpus/factory_default/bmc-metadata-items/root"
       data:
         UsernamePassword:
           username: "root"
+          password: "0penBmc"
+    ## Per-model DPU BMC factory defaults (BlueField-3/4 ship with "admin"/"0penBmc").
+    - path: "machines/all_dpus/factory_default/bmc-metadata-items/bf3"
+      data:
+        UsernamePassword:
+          username: "admin"
+          password: "0penBmc"
+    - path: "machines/all_dpus/factory_default/bmc-metadata-items/bf4"
+      data:
+        UsernamePassword:
+          username: "admin"
           password: "0penBmc"
     - path: "machines/all_dpus/factory_default/uefi-metadata-items/auth"
       data:


### PR DESCRIPTION
Newer BlueField generations (BF4) ship with different factory default BMC credentials than BF3/legacy hardware. Sites that mix DPU generations need per-model credential configuration rather than a single catch-all. This consolidates with the existing per-vendor pattern already used for host hardware.

A new `DpuModel` enum is threaded through the credential stack: on each DPU provisioning cycle, an unauthenticated `GET /redfish/v1` probe reads the `Product` field to identify the model, then the credential lookup follows a fallback chain: model-specific vault entry → catch-all `root` vault entry → the model's publicly-documented factory default. That last step is `DpuModel::default_factory_credentials()` (BlueField-4 = `admin`/`0penBmc`, earlier generations and unknown = `root`/`0penBmc`) — a single source of truth shared by both site-explorer's fallback and the BMC mock, so they cannot drift. The existing `root` vault path segment is preserved for `DpuModel::Unknown`, so no vault migration is required for existing deployments.

Closes #2858

## Related issues

#2858 — feat: Support for per-model BMC factory_default credentials

## Type of Change

- [x] **Add** - New feature or capability

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

**Manual end-to-end validation (machine-a-tron, local devspace):** On a freshly bootstrapped cluster with a vault containing **zero DPU factory-default seeds**, a `dell_poweredge_r760_bf4` mock host and its BlueField-4 DPUs authenticate purely via the new `default_factory_credentials()` fallback — the BF4 host BMC explores successfully (`vendor=Dell`) and the host reaches `MachineUp`/`Dpu Agent`, which is unreachable without a working BMC credential. This proves the per-model fallback works with no manual seeding. The `bmc-mock` change (BF4 → `admin`/`0penBmc`) reads the same shared source as the credential fallback.

## Additional Notes

- **Pre-existing, out of scope:** the `dell_poweredge_r760_bf4` host does not reach full `Ready` in machine-a-tron — its DPUs hit a DHCP-relay / `discover_machine` authorization gap (`"machine discovery is not authorized for the selected interface"`). This is a limitation of the pre-existing BF4 mock *scaffolding* (#2902), reproducible on a clean env and independent of this PR (which touches no DHCP/discovery code). Local dev config remains on the working `wiwynn_gb200_nvl` (BF3) host.
- The `admin-cli` docs (`docs/manuals/nico-admin-cli/`) need regenerating with `cargo make gen-cli-docs` (requires `pandoc`) to pick up the `--model` flag on `credential add-dpu-factory-default`.
