### PR TITLE
fix(api-model): avoid panic parsing build versions with a "-dirty" suffix

### DIFF
--- a/crates/api-model/src/machine/upgrade_policy.rs
+++ b/crates/api-model/src/machine/upgrade_policy.rs
@@ -117,6 +117,8 @@ pub struct BuildVersion<'a> {
     hotfix: usize,
     commits: usize,
     git_hash: &'a str,
+    /// True if (git) appended a "-dirty" suffix.
+    is_dirty: bool,
 }
 
 impl BuildVersion<'_> {
@@ -154,6 +156,9 @@ impl fmt::Display for BuildVersion<'_> {
         if !self.git_hash.is_empty() {
             write!(f, "-{}", self.git_hash)?;
         }
+        if self.is_dirty {
+            write!(f, "-dirty")?;
+        }
         Ok(())
     }
 }
@@ -162,6 +167,11 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
     type Error = eyre::Report;
 
     fn try_from(s: &'_ str) -> Result<BuildVersion<'_>, Self::Error> {
+        let (s, is_dirty) = match s.strip_suffix("-dirty") {
+            Some(stripped) => (stripped, true),
+            None => (s, false),
+        };
+
         if s.is_empty() {
             eyre::bail!("build version is empty");
         }
@@ -188,6 +198,7 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
                 hotfix: 0,
                 commits: 0,
                 git_hash: "",
+                is_dirty,
             }),
             // Tag only with a release-candidate part
             // v2023.09-rc1 or v0.0.4-rc1
@@ -197,6 +208,7 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
                 hotfix: 0,
                 commits: 0,
                 git_hash: "",
+                is_dirty,
             }),
             // Version tag with commits OR new style version-rc-hotfix
             // v2023.08-92-g1b48e8b6 OR v2024.05.02-rc3-0
@@ -209,6 +221,7 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
                         hotfix: 0,
                         commits: parts[1].parse().unwrap(),
                         git_hash: parts[2],
+                        is_dirty,
                     })
                 } else {
                     // v2024.05.02-rc3-0 or v0.0.4-rc4-0
@@ -218,6 +231,7 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
                         hotfix: parts[2].parse().unwrap(),
                         commits: 0,
                         git_hash: "",
+                        is_dirty,
                     })
                 }
             }
@@ -229,6 +243,7 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
                 hotfix: 0,
                 commits: parts[2].parse().unwrap(),
                 git_hash: parts[3],
+                is_dirty,
             }),
             // version, rc, hotfix, commits and hash
             // v2024.05.02-rc4-0-27-gc3ce4d5d or v0.0.4-rc4-0-27-gc3ce4d5d
@@ -238,6 +253,7 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
                 hotfix: parts[2].parse().unwrap(),
                 commits: parts[3].parse().unwrap(),
                 git_hash: parts[4],
+                is_dirty,
             }),
             n => {
                 eyre::bail!("invalid build version. has {n} dash-separated parts")
@@ -247,6 +263,9 @@ impl<'a> TryFrom<&'a str> for BuildVersion<'a> {
 }
 
 impl Ord for BuildVersion<'_> {
+    // Ordering is by version/rc/hotfix/commits only; `git_hash` and `is_dirty`
+    // are intentionally ignored (neither affects which build is "newer"). Note
+    // the derived `Eq` is structural and does consider them.
     fn cmp(&self, other: &Self) -> Ordering {
         // If one is date-based and one is semver, semver is always newer
         // (represents migration from date-based to semver versioning)
@@ -302,6 +321,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 92,
                     git_hash: "g1b48e8b6",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -313,6 +333,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 27,
                     git_hash: "gc3ce4d5d",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -324,6 +345,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 0,
                     git_hash: "",
+                    is_dirty: false,
                 }),
             },
             // Semver versions
@@ -336,6 +358,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 0,
                     git_hash: "g2a3c98cac",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -347,6 +370,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 0,
                     git_hash: "",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -358,6 +382,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 0,
                     git_hash: "",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -369,6 +394,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 0,
                     git_hash: "",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -380,6 +406,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 27,
                     git_hash: "gc3ce4d5d",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -391,6 +418,7 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 0,
                     git_hash: "",
+                    is_dirty: false,
                 }),
             },
             Case {
@@ -402,6 +430,19 @@ fn test_parse_version() {
                     hotfix: 0,
                     commits: 27,
                     git_hash: "gc3ce4d5d",
+                    is_dirty: false,
+                }),
+            },
+            Case {
+                scenario: "semver with rc, commits, hash and -dirty suffix",
+                input: "v2.0.0-rc.2-9-g0401aad9f-dirty",
+                expect: Yields(BuildVersion {
+                    version: "2.0.0",
+                    rc: "rc.2",
+                    hotfix: 0,
+                    commits: 9,
+                    git_hash: "g0401aad9f",
+                    is_dirty: true,
                 }),
             },
             Case {
@@ -413,6 +454,7 @@ fn test_parse_version() {
                     hotfix: 2,
                     commits: 0,
                     git_hash: "",
+                    is_dirty: false,
                 }),
             },
             Case {


### PR DESCRIPTION
## Bug description
The NICo API panicked at runtime

```
thread 'tokio-rt-worker' (7) panicked at crates/api-model/src/machine/upgrade_policy.rs:239:43:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }
stack backtrace:
```

The root cause is a combination of:
- default [VERSION constructor](https://github.com/NVIDIA/infra-controller/blob/main/Makefile#L88) which uses the following command that includes the `--dirty` key: `VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)`
- `BuildVersion` parser which can't parse the default-generated version string like: `v2.0.0-rc.2-9-g0401aad9f-dirty`

## Proposed solution

Strip the `-dirty` suffix before parsing BuildVersion if present.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)



