### PR TITLE
Clarify NICo hardware compatibility scope

### DIFF
--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -1,8 +1,8 @@
 # Hardware Compatibility List
 
-This Hardware Compatibility List (HCL) is provided for reference purposes only. Systems listed here have been unit tested or exercised internally in limited scenarios.
-Inclusion in this list does not imply qualification, certification, or support, and does not represent a commitment to ongoing compatibility. For specific hardware support
-inquiries or technical specifications, please contact the original hardware vendor.
+The Hardware Compatibility List (HCL) identifies hardware that is currently supported and compatible from a NICo perspective. It is not an exhaustive certification or qualification of each platform. For platform certification, qualification, and detailed hardware support information, contact the hardware manufacturer.
+
+To add support for hardware that the NICo development team does not have access to, follow [Adding Support for New Hardware](development/new_hardware_support.md).
 
 ## Hosts
 


### PR DESCRIPTION
## Summary

- clarify that the HCL lists hardware currently supported and compatible from a NICo perspective
- distinguish NICo compatibility from platform certification or qualification and direct those questions to the hardware manufacturer
- link contributors to the new hardware support guide when the NICo development team does not have the hardware

## Impact

Documentation only; no runtime behavior changes.

## Validation

- compared the branch against current upstream `main`
- confirmed that only `docs/hcl.md` changed
- verified that the relative link targets `docs/development/new_hardware_support.md`
