### PR TITLE
patch(v2.0): Avoid machine validation result/heartbeat deadlocks

### DIFF
--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -231,8 +231,15 @@ pub(crate) async fn persist_validation_result(
                 );
             }
         };
-    let machine_validation =
-        db::machine_validation::find_by_id(&mut txn, &validation_result.validation_id).await?;
+    // Acquire the parent-run lock before record_result() touches run-item rows.
+    // Heartbeats and stale-attempt reconciliation use the same parent-run ->
+    // run-item order. Successful results also serialize with the trigger that
+    // increments the parent run's completed count.
+    let machine_validation = db::machine_validation::lock_by_id_no_key_update(
+        &mut txn,
+        &validation_result.validation_id,
+    )
+    .await?;
     if !db::machine_validation::is_active(&machine_validation) {
         tracing::info!(
             validation_id = %validation_result.validation_id,
@@ -263,8 +270,11 @@ pub(crate) async fn persist_validation_result(
 
     // Keep the durable run-item/attempt write ahead of the legacy projections.
     // A false return means this report is a replay of an already-terminal attempt.
-    let first_terminal_report =
-        db::machine_validation_execution::record_result(&mut txn, &validation_result).await?;
+    let first_terminal_report = db::machine_validation_execution::record_result_with_parent_lock(
+        &mut txn,
+        &validation_result,
+    )
+    .await?;
     if !first_terminal_report {
         tracing::info!(
             validation_id = %validation_result.validation_id,

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -239,7 +239,13 @@ pub(crate) async fn persist_validation_result(
         &mut txn,
         &validation_result.validation_id,
     )
-    .await?;
+    .await?
+    .ok_or_else(|| {
+        CarbideError::internal(format!(
+            "validation id {} was found via machine lookup but not by primary key",
+            validation_result.validation_id
+        ))
+    })?;
     if !db::machine_validation::is_active(&machine_validation) {
         tracing::info!(
             validation_id = %validation_result.validation_id,
@@ -270,11 +276,8 @@ pub(crate) async fn persist_validation_result(
 
     // Keep the durable run-item/attempt write ahead of the legacy projections.
     // A false return means this report is a replay of an already-terminal attempt.
-    let first_terminal_report = db::machine_validation_execution::record_result_with_parent_lock(
-        &mut txn,
-        &validation_result,
-    )
-    .await?;
+    let first_terminal_report =
+        db::machine_validation_execution::record_result(&mut txn, &validation_result).await?;
     if !first_terminal_report {
         tracing::info!(
             validation_id = %validation_result.validation_id,

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -310,6 +310,20 @@ async fn reconcile_stale_attempt(
         stale_attempt.attempt_id, stale_attempt.test_id, stale_attempt.validation_id
     );
 
+    // Keep the same parent-run -> run-item lock order used by result
+    // persistence and heartbeats.
+    if db::machine_validation::try_lock_by_id_no_key_update(txn, &stale_attempt.validation_id)
+        .await?
+        .is_none()
+    {
+        tracing::debug!(
+            validation_id = %stale_attempt.validation_id,
+            attempt_id = %stale_attempt.attempt_id,
+            "skipping stale machine validation attempt because run no longer exists"
+        );
+        return Ok(None);
+    }
+
     let Some(validation_id) = db::machine_validation_execution::mark_attempt_stale_if_active(
         txn,
         &stale_attempt.attempt_id,

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -321,7 +321,7 @@ async fn reconcile_stale_attempt(
             attempt_id = %stale_attempt.attempt_id,
             "skipping stale machine validation attempt because run no longer exists"
         );
-        return Ok(None);
+        return Ok(false);
     }
 
     let Some(validation_id) = db::machine_validation_execution::mark_attempt_stale_if_active(

--- a/crates/api-core/src/machine_validation/mod.rs
+++ b/crates/api-core/src/machine_validation/mod.rs
@@ -312,7 +312,7 @@ async fn reconcile_stale_attempt(
 
     // Keep the same parent-run -> run-item lock order used by result
     // persistence and heartbeats.
-    if db::machine_validation::try_lock_by_id_no_key_update(txn, &stale_attempt.validation_id)
+    if db::machine_validation::lock_by_id_no_key_update(txn, &stale_attempt.validation_id)
         .await?
         .is_none()
     {

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -347,26 +347,16 @@ pub async fn find_by_id(
     )))
 }
 
-pub async fn try_lock_by_id_no_key_update(
+pub async fn lock_by_id_no_key_update(
     txn: &mut PgConnection,
     id: &MachineValidationId,
 ) -> DatabaseResult<Option<MachineValidation>> {
-    // Raw SQL is required because FilterableQueryBuilder does not support row-lock clauses.
     let query = "SELECT * FROM machine_validation WHERE id=$1 FOR NO KEY UPDATE";
     sqlx::query_as::<_, MachineValidation>(query)
         .bind(id)
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))
-}
-
-pub async fn lock_by_id_no_key_update(
-    txn: &mut PgConnection,
-    id: &MachineValidationId,
-) -> DatabaseResult<MachineValidation> {
-    try_lock_by_id_no_key_update(txn, id)
-        .await?
-        .ok_or_else(|| DatabaseError::InvalidArgument(format!("Validation Id not found {id:?}")))
 }
 
 pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<MachineValidation>> {

--- a/crates/api-db/src/machine_validation.rs
+++ b/crates/api-db/src/machine_validation.rs
@@ -347,6 +347,28 @@ pub async fn find_by_id(
     )))
 }
 
+pub async fn try_lock_by_id_no_key_update(
+    txn: &mut PgConnection,
+    id: &MachineValidationId,
+) -> DatabaseResult<Option<MachineValidation>> {
+    // Raw SQL is required because FilterableQueryBuilder does not support row-lock clauses.
+    let query = "SELECT * FROM machine_validation WHERE id=$1 FOR NO KEY UPDATE";
+    sqlx::query_as::<_, MachineValidation>(query)
+        .bind(id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+pub async fn lock_by_id_no_key_update(
+    txn: &mut PgConnection,
+    id: &MachineValidationId,
+) -> DatabaseResult<MachineValidation> {
+    try_lock_by_id_no_key_update(txn, id)
+        .await?
+        .ok_or_else(|| DatabaseError::InvalidArgument(format!("Validation Id not found {id:?}")))
+}
+
 pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<MachineValidation>> {
     find_by(txn, ObjectColumnFilter::<IdColumn>::All).await
 }

--- a/crates/api-db/src/machine_validation_execution.rs
+++ b/crates/api-db/src/machine_validation_execution.rs
@@ -224,14 +224,6 @@ pub async fn record_result(
     Ok(first_terminal)
 }
 
-pub async fn record_result_with_parent_lock(
-    txn: &mut PgConnection,
-    result: &MachineValidationResult,
-) -> DatabaseResult<bool> {
-    crate::machine_validation::lock_by_id_no_key_update(txn, &result.validation_id).await?;
-    record_result(txn, result).await
-}
-
 pub async fn record_heartbeat(
     txn: &mut PgConnection,
     validation_id: &MachineValidationId,
@@ -1021,7 +1013,14 @@ mod tests {
         let result_pool = pool.clone();
         let mut result_task = tokio::spawn(async move {
             let mut txn = result_pool.begin().await.map_err(|err| err.to_string())?;
-            record_result_with_parent_lock(txn.as_mut(), &result)
+            crate::machine_validation::lock_by_id_no_key_update(
+                txn.as_mut(),
+                &result.validation_id,
+            )
+            .await
+            .map_err(|err| err.to_string())?
+            .ok_or_else(|| "validation disappeared before result write".to_string())?;
+            record_result(txn.as_mut(), &result)
                 .await
                 .map_err(|err| err.to_string())?;
             result_ready_tx

--- a/crates/api-db/src/machine_validation_execution.rs
+++ b/crates/api-db/src/machine_validation_execution.rs
@@ -224,6 +224,14 @@ pub async fn record_result(
     Ok(first_terminal)
 }
 
+pub async fn record_result_with_parent_lock(
+    txn: &mut PgConnection,
+    result: &MachineValidationResult,
+) -> DatabaseResult<bool> {
+    crate::machine_validation::lock_by_id_no_key_update(txn, &result.validation_id).await?;
+    record_result(txn, result).await
+}
+
 pub async fn record_heartbeat(
     txn: &mut PgConnection,
     validation_id: &MachineValidationId,
@@ -962,6 +970,169 @@ mod tests {
             .map_err(|e| DatabaseError::query(ATTEMPT_QUERY, e))?;
 
         Ok(attempt_id)
+    }
+
+    fn successful_result(
+        validation_id: MachineValidationId,
+        test_id: &str,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> MachineValidationResult {
+        MachineValidationResult {
+            validation_id,
+            name: test_id.to_string(),
+            description: "deadlock regression".to_string(),
+            stdout: "ok".to_string(),
+            stderr: String::new(),
+            command: "echo".to_string(),
+            args: "ok".to_string(),
+            context: "OnDemand".to_string(),
+            exit_code: 0,
+            start_time: now,
+            end_time: now + chrono::Duration::seconds(1),
+            test_id: Some(test_id.to_string()),
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn result_persistence_and_heartbeat_do_not_deadlock(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let now = chrono::Utc::now();
+        let test_id = "deadlock-regression";
+        let mut setup_txn = pool.begin().await?;
+        let validation_id = insert_active_validation(setup_txn.as_mut(), now).await?;
+        insert_attempt(
+            setup_txn.as_mut(),
+            &validation_id,
+            test_id,
+            0,
+            MachineValidationAttemptState::Running,
+            Some(now),
+            Some(now),
+        )
+        .await?;
+        setup_txn.commit().await?;
+
+        let result = successful_result(validation_id, test_id, now);
+        let (result_ready_tx, result_ready_rx) = tokio::sync::oneshot::channel();
+        let (heartbeat_pid_tx, heartbeat_pid_rx) = tokio::sync::oneshot::channel();
+        let (heartbeat_waiting_tx, heartbeat_waiting_rx) = tokio::sync::oneshot::channel();
+
+        let result_pool = pool.clone();
+        let mut result_task = tokio::spawn(async move {
+            let mut txn = result_pool.begin().await.map_err(|err| err.to_string())?;
+            record_result_with_parent_lock(txn.as_mut(), &result)
+                .await
+                .map_err(|err| err.to_string())?;
+            result_ready_tx
+                .send(())
+                .map_err(|_| "could not signal result write".to_string())?;
+            heartbeat_waiting_rx.await.map_err(|err| err.to_string())?;
+            crate::machine_validation_result::create(result, txn.as_mut())
+                .await
+                .map_err(|err| err.to_string())?;
+            txn.commit().await.map_err(|err| err.to_string())
+        });
+
+        let heartbeat_pool = pool.clone();
+        let mut heartbeat_task = tokio::spawn(async move {
+            result_ready_rx.await.map_err(|err| err.to_string())?;
+            let mut txn = heartbeat_pool
+                .begin()
+                .await
+                .map_err(|err| err.to_string())?;
+            let pid = sqlx::query_scalar::<_, i32>("SELECT pg_backend_pid()")
+                .fetch_one(&mut *txn)
+                .await
+                .map_err(|err| err.to_string())?;
+            heartbeat_pid_tx
+                .send(pid)
+                .map_err(|_| "could not signal heartbeat pid".to_string())?;
+            record_heartbeat(
+                txn.as_mut(),
+                &validation_id,
+                None,
+                None,
+                Some(test_id),
+                now + chrono::Duration::seconds(2),
+            )
+            .await
+            .map_err(|err| err.to_string())?;
+            txn.commit().await.map_err(|err| err.to_string())
+        });
+
+        let wait_for_heartbeat = async {
+            let heartbeat_pid = heartbeat_pid_rx
+                .await
+                .map_err(|err| std::io::Error::other(err.to_string()))?;
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    let waiting: bool = sqlx::query_scalar(
+                        "SELECT EXISTS (
+                            SELECT 1
+                            FROM pg_locks
+                            WHERE pid=$1
+                                AND NOT granted
+                        )",
+                    )
+                    .bind(heartbeat_pid)
+                    .fetch_one(&pool)
+                    .await?;
+                    if waiting {
+                        return Ok::<(), sqlx::Error>(());
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .map_err(|_| std::io::Error::other("heartbeat did not wait on result transaction"))?
+            .map_err(|err| std::io::Error::other(err.to_string()))?;
+
+            heartbeat_waiting_tx
+                .send(())
+                .map_err(|_| std::io::Error::other("could not release result transaction"))
+        }
+        .await;
+
+        if let Err(err) = wait_for_heartbeat {
+            abort_and_await_validation_tasks(&mut result_task, &mut heartbeat_task).await;
+            return Err(err.into());
+        }
+
+        let join_result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let (result_outcome, heartbeat_outcome) =
+                tokio::join!(&mut result_task, &mut heartbeat_task);
+            result_outcome
+                .map_err(|err| std::io::Error::other(err.to_string()))?
+                .map_err(std::io::Error::other)?;
+            heartbeat_outcome
+                .map_err(|err| std::io::Error::other(err.to_string()))?
+                .map_err(std::io::Error::other)?;
+            Ok::<(), std::io::Error>(())
+        })
+        .await;
+
+        match join_result {
+            Ok(result) => result?,
+            Err(_) => {
+                abort_and_await_validation_tasks(&mut result_task, &mut heartbeat_task).await;
+                return Err(std::io::Error::other("result and heartbeat deadlocked").into());
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn abort_and_await_validation_tasks(
+        result_task: &mut tokio::task::JoinHandle<Result<(), String>>,
+        heartbeat_task: &mut tokio::task::JoinHandle<Result<(), String>>,
+    ) {
+        result_task.abort();
+        heartbeat_task.abort();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let _ = tokio::join!(result_task, heartbeat_task);
+        })
+        .await;
     }
 
     #[crate::sqlx_test]

--- a/crates/api-db/src/machine_validation_execution.rs
+++ b/crates/api-db/src/machine_validation_execution.rs
@@ -986,6 +986,7 @@ mod tests {
     }
 
     #[crate::sqlx_test]
+    #[allow(txn_held_across_await)] // Intentional: this test holds locks to exercise concurrency.
     async fn result_persistence_and_heartbeat_do_not_deadlock(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
> [!IMPORTANT]
> This PR backports the machine-validation result/heartbeat deadlock fix from #3533 into `release/v2.0`.

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
