### PR TITLE
fix: Use states to manage reboot operation to avoid race condition.

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1778,6 +1778,14 @@ pub enum DpfState {
         #[serde(default)]
         phase_detail: Option<String>,
     },
+    /// Executing a DPF-requested power cycle. `state.version.timestamp()`
+    /// records when this step started; the handler uses it to enforce the
+    /// configured power-transition delay (`reachability_params.power_down_wait`).
+    HandleReboot {
+        op: PerformPowerOperation,
+        #[serde(default)]
+        retry_count: u32,
+    },
     /// DPU device reported ready by the DPF operator. Carbide
     /// waits for all DPUs to reach this state before proceeding.
     DeviceReady,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2260,7 +2260,7 @@ pub async fn check_restart_in_logs(
 }
 
 // Function to wait for some time in state machine.
-fn wait(basetime: &DateTime<Utc>, wait_time: Duration) -> bool {
+pub(super) fn wait(basetime: &DateTime<Utc>, wait_time: Duration) -> bool {
     let expected_time = *basetime + wait_time;
     let current_time = Utc::now();
 
@@ -2826,7 +2826,15 @@ async fn handle_dpu_reprovision(
                     "DPF reprovision state reached but DPF is not configured"
                 ))
             })?;
-            dpf::handle_dpf_state(state, dpu_snapshot, substate, ctx, dpf).await
+            dpf::handle_dpf_state(
+                state,
+                dpu_snapshot,
+                substate,
+                ctx,
+                dpf,
+                reachability_params.power_down_wait,
+            )
+            .await
         }
         ReprovisionState::InstallDpuOs { substate } => {
             handle_bfb_install_state(
@@ -4088,7 +4096,15 @@ impl DpuMachineStateHandler {
                         "DPF state reached but DPF is not configured"
                     ))
                 })?;
-                dpf::handle_dpf_state(state, dpu_snapshot, dpf_state, ctx, dpf_sdk).await
+                dpf::handle_dpf_state(
+                    state,
+                    dpu_snapshot,
+                    dpf_state,
+                    ctx,
+                    dpf_sdk,
+                    self.reachability_params.power_down_wait,
+                )
+                .await
             }
             DpuInitState::WaitingForPlatformPowercycle {
                 substate: PerformPowerOperation::Off,

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -27,7 +27,8 @@ use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
 use model::machine::{
     DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
-    ManagedHostState, ManagedHostStateSnapshot, ReprovisionState, StateMachineArea,
+    ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation, ReprovisionState,
+    StateMachineArea,
 };
 use state_controller::state_handler::{
     ExternalServiceError, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
@@ -305,23 +306,33 @@ async fn handle_dpf_provisioning(
     Ok(StateHandlerOutcome::transition(next))
 }
 
-/// Power-cycle the host for a DPF reboot request. ForceOff then On across
-/// iterations; calls `reboot_complete` as soon as the On command is issued.
-async fn handle_dpf_reboot(
+/// Handle `DpfState::HandleReboot`: drive a DPF-requested power cycle using
+/// explicit per-step state rather than timestamp heuristics.
+///
+/// Transitions:
+/// - `Off`: wait for `power_state == Off` + 30 s → issue On →
+///   `HandleReboot { On, now }`
+/// - `On`:  wait for `power_state == On`  + 30 s → `reboot_complete` →
+///   `WaitingForReady`
+async fn handle_dpf_handle_reboot(
     state: &ManagedHostStateSnapshot,
-    dpu_snapshot: &Machine,
-    waiting_phase_detail: &Option<String>,
-    current_phase: &DpuPhase,
+    op: &PerformPowerOperation,
+    retry_count: u32,
     node_name: &str,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let reboot_already_requested = state
-        .host_snapshot
-        .status
-        .last_reboot_requested
-        .as_ref()
-        .is_some_and(|r| r.time > state.host_snapshot.state.version.timestamp());
+    const MAX_RETRIES: u32 = 3;
+
+    if super::wait(
+        &state.host_snapshot.state.version.timestamp(),
+        power_down_wait,
+    ) {
+        return Ok(StateHandlerOutcome::wait(
+            "waiting for power transition delay".into(),
+        ));
+    }
 
     let power_state = {
         let redfish_client = ctx
@@ -331,23 +342,82 @@ async fn handle_dpf_reboot(
         host_power_state(redfish_client.as_ref()).await?
     };
 
-    if !reboot_already_requested && power_state != libredfish::PowerState::Off {
-        handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
-    } else if power_state == libredfish::PowerState::Off {
-        handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
-        dpf_sdk
-            .reboot_complete(node_name)
-            .await
-            .map_err(dpf_error)?;
+    match op {
+        PerformPowerOperation::Off => {
+            if power_state == libredfish::PowerState::Off {
+                handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::HandleReboot {
+                        op: PerformPowerOperation::On,
+                        retry_count: 0,
+                    },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else if retry_count < MAX_RETRIES {
+                tracing::warn!(
+                    host = %state.host_snapshot.id,
+                    retry_count,
+                    "Host did not power off; retrying ForceOff"
+                );
+                handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::HandleReboot {
+                        op: PerformPowerOperation::Off,
+                        retry_count: retry_count + 1,
+                    },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else {
+                tracing::error!(
+                    host = %state.host_snapshot.id,
+                    max_retries = MAX_RETRIES,
+                    "Host did not power off after max retries; manual intervention required"
+                );
+                Err(StateHandlerError::ManualInterventionRequired(
+                    "host did not power off; manual intervention required".into(),
+                ))
+            }
+        }
+        PerformPowerOperation::On => {
+            if power_state == libredfish::PowerState::On {
+                dpf_sdk
+                    .reboot_complete(node_name)
+                    .await
+                    .map_err(dpf_error)?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::WaitingForReady { phase_detail: None },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else if retry_count < MAX_RETRIES {
+                tracing::warn!(
+                    host = %state.host_snapshot.id,
+                    retry_count,
+                    "Host did not power on; retrying On"
+                );
+                handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::HandleReboot {
+                        op: PerformPowerOperation::On,
+                        retry_count: retry_count + 1,
+                    },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else {
+                tracing::error!(
+                    host = %state.host_snapshot.id,
+                    max_retries = MAX_RETRIES,
+                    "Host did not power on after max retries; manual intervention required"
+                );
+                Err(StateHandlerError::ManualInterventionRequired(
+                    "host did not power on; manual intervention required".into(),
+                ))
+            }
+        }
     }
-
-    update_phase_detail_or_wait(
-        state,
-        &dpu_snapshot.id,
-        waiting_phase_detail,
-        current_phase,
-        "Power cycling host for DPF reboot",
-    )
 }
 
 /// Handle DpfState::WaitingForReady: release hold, reboot handling,
@@ -376,16 +446,15 @@ async fn handle_dpf_waiting_for_ready(
         .await
         .map_err(dpf_error)?
     {
-        return handle_dpf_reboot(
+        handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
+        let next = transition_all_dpus_to_dpf_state(
+            DpfState::HandleReboot {
+                op: PerformPowerOperation::Off,
+                retry_count: 0,
+            },
             state,
-            dpu_snapshot,
-            waiting_phase_detail,
-            &current_phase,
-            &node_name,
-            ctx,
-            dpf_sdk,
-        )
-        .await;
+        )?;
+        return Ok(StateHandlerOutcome::transition(next));
     }
 
     if current_phase == carbide_dpf::DpuPhase::Error {
@@ -500,6 +569,7 @@ pub async fn handle_dpf_state(
     dpf_state: &DpfState,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let deployment_type = dpf_sdk
@@ -536,6 +606,18 @@ pub async fn handle_dpf_state(
         DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk).await,
         DpfState::WaitingForReady { phase_detail } => {
             handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
+        }
+        DpfState::HandleReboot { op, retry_count } => {
+            handle_dpf_handle_reboot(
+                state,
+                op,
+                *retry_count,
+                &node_name,
+                ctx,
+                dpf_sdk,
+                power_down_wait,
+            )
+            .await
         }
         DpfState::DeviceReady => handle_dpf_device_ready(state),
         DpfState::Reprovisioning => {

--- a/crates/machine-controller/src/handler/helpers.rs
+++ b/crates/machine-controller/src/handler/helpers.rs
@@ -126,13 +126,14 @@ pub trait NextState {
                     all_machine_ids,
                 ),
             ReprovisionState::DpfStates { substate } => match substate {
-                DpfState::WaitingForReady { .. } | DpfState::DeviceReady => {
-                    ReprovisionState::PoweringOffHost.next_state_with_all_dpus_updated(
+                DpfState::WaitingForReady { .. }
+                | DpfState::HandleReboot { .. }
+                | DpfState::DeviceReady => ReprovisionState::PoweringOffHost
+                    .next_state_with_all_dpus_updated(
                         &state.managed_state,
                         &state.dpu_snapshots,
                         all_machine_ids,
-                    )
-                }
+                    ),
                 DpfState::Reprovisioning => ReprovisionState::DpfStates {
                     substate: DpfState::Provisioning,
                 }


### PR DESCRIPTION
Three fixes to the DPF-requested power cycle:
 
1. No delay between power commands and status check:
ForceOff and On were issued and their result checked in the same tick, giving the BMC no time to act. A delay (reachability_params.power_down_wait, consistent with ReprovisionState::PowerDown) is now enforced after each command before reading back the power state. 
    
2. No retry when power state does not change:
If the host failed to respond to ForceOff or On, the handler would wait indefinitely with no recovery. The handler now retries the command up to 3 times before stopping and waiting for manual intervention.
    
3. Only the current DPU's state was advanced on power off/on:
A host power cycle affects all DPUs simultaneously, but the handler was calling set_one_dpu_dpf_state instead of    transition_all_dpus_to_dpf_state. With multiple DPUs, the second DPU would enter the same reboot branch independently and issue another ForceOff/On cycle against the host, causing repeated unintended reboots. All DPUs now advance together when a host power transition completes.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

