### PR TITLE
feat: Add opt-in DSX Exchange DevSpace profile

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -4586,6 +4586,10 @@ mod tests {
             jail.set_env("CARBIDE_API_ASN", 777);
             jail.set_env("CARBIDE_API_AUTH", "{permissive_mode=true}");
             jail.set_env(
+                "CARBIDE_API_DSX_EXCHANGE_EVENT_BUS",
+                r#"{enabled=true,mqtt_endpoint="dsx-exchange",mqtt_broker_port=1883,auth={auth_mode="none"},periodic_state_republish={interval="10s"}}"#,
+            );
+            jail.set_env(
                 "CARBIDE_API_TLS",
                 "{identity_pemfile_path=/patched/path/to/cert}",
             );
@@ -4615,6 +4619,15 @@ mod tests {
             );
             assert_eq!(config.tls.as_ref().unwrap().root_cafile_path, "/path/to/ca");
             assert!(config.auth.as_ref().unwrap().permissive_mode);
+            let dsx_exchange = config.dsx_exchange_event_bus.as_ref().unwrap();
+            assert!(dsx_exchange.enabled);
+            assert_eq!(dsx_exchange.mqtt_endpoint, "dsx-exchange");
+            assert_eq!(dsx_exchange.mqtt_broker_port, 1883);
+            assert_eq!(dsx_exchange.auth.auth_mode, MqttAuthMode::None);
+            assert_eq!(
+                dsx_exchange.periodic_state_republish.interval,
+                std::time::Duration::from_secs(10)
+            );
             assert_eq!(
                 config
                     .auth

--- a/dev/deployment/devspace/README.md
+++ b/dev/deployment/devspace/README.md
@@ -122,6 +122,21 @@ devspace deploy --skip-build -n nico-system
 devspace deploy --force-build
 ```
 
+To deploy a local DSX Exchange-compatible event bus and enable NICo's managed
+host state publisher, opt in with the `dsx-exchange` profile:
+
+```bash
+devspace deploy --profile dsx-exchange
+```
+
+This profile adds a single-node, unauthenticated NATS MQTT service alongside
+NICo in the local development namespace and publishes managed host state to
+`NICO/v1/machine/<machine-id>/state`. It also republishes current state every
+10 seconds so a local subscriber can observe messages after the initial state
+transitions. The event bus and publisher remain disabled when the profile is
+not selected. The profile does not enable the separate inbound
+`nico-dsx-exchange-consumer`.
+
 The post-deploy setup uses temporary port-forwards to register the site and verifies that machines from Core are visible through the REST API. To keep the REST API and Keycloak available on localhost after `devspace deploy` exits, run these in separate terminals:
 
 ```bash

--- a/dev/deployment/devspace/setup-rest-integration.sh
+++ b/dev/deployment/devspace/setup-rest-integration.sh
@@ -42,7 +42,7 @@ require_bin base64
 mkdir -p "${WORK_DIR}"
 
 kubectl rollout status deployment/nico-api -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
-kubectl rollout status deployment/machine-a-tron -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
+kubectl rollout status deployment/nico-machine-a-tron -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-api -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-cert-manager -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-cloud-worker -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
@@ -128,7 +128,7 @@ inventory_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 machine_status="$(kubectl exec deployment/nico-api -n "${CORE_NAMESPACE}" -- \
   curl --fail --insecure --silent --max-time 5 \
-  https://machine-a-tron-bmc-mock:1266/machines/status 2>/dev/null || true)"
+  https://nico-machine-a-tron-bmc-mock:1266/machines/status 2>/dev/null || true)"
 expected_host_count="$(jq -r \
   'if (.machines | type) == "array" then .machines | length else 0 end' \
   <<<"${machine_status}" 2>/dev/null || printf '0')"

--- a/dev/deployment/devspace/setup-rest-integration.sh
+++ b/dev/deployment/devspace/setup-rest-integration.sh
@@ -179,7 +179,9 @@ for attempt in {1..90}; do
   fi
 
   core_hosts="$(kubectl exec deployment/nico-api -n "${CORE_NAMESPACE}" -- \
-    /opt/carbide/nico-admin-cli -f json machine show --hosts 2>/dev/null || true)"
+    /opt/carbide/nico-admin-cli \
+    --api-url "https://nico-api.${CORE_NAMESPACE}.svc.cluster.local:1079" \
+    -f json machine show --hosts 2>/dev/null || true)"
   core_host_count="$(jq -r \
     'if (.machines | type) == "array" then .machines | length else 0 end' \
     <<<"${core_hosts}" 2>/dev/null || printf '0')"

--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -9,8 +9,6 @@ nico-api:
     requests:
       cpu: "1"
       memory: "1Gi"
-  legacyAlias:
-    enabled: false
   webAuth:
     mode: "none"
   siteConfig:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -320,6 +320,54 @@ hooks:
         dev/deployment/devspace/setup-rest-integration.sh
 
 profiles:
+  - name: dsx-exchange
+    patches:
+      - op: add
+        path: deployments.dsx-exchange
+        value:
+          namespace: ${LOCAL_DEV_NAMESPACE}
+          helm:
+            chart:
+              name: nats
+              version: "2.12.6"
+              repo: https://nats-io.github.io/k8s/helm/charts/
+            values:
+              fullnameOverride: dsx-exchange
+              config:
+                cluster:
+                  enabled: false
+                jetstream:
+                  enabled: true
+                  fileStore:
+                    enabled: true
+                    maxSize: 256Mi
+                    pvc:
+                      enabled: false
+                  memoryStore:
+                    enabled: true
+                    maxSize: 64Mi
+                mqtt:
+                  enabled: true
+                  port: 1883
+                  merge:
+                    stream_replicas: 1
+                    consumer_memory_storage: true
+              container:
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 64Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+              natsBox:
+                enabled: false
+              podDisruptionBudget:
+                enabled: false
+      - op: add
+        path: deployments.carbide-local.helm.values.nico-api
+        value:
+          dsxExchangeEventBusConfig: '{enabled=true,mqtt_endpoint="dsx-exchange",mqtt_broker_port=1883,auth={auth_mode="none"},periodic_state_republish={interval="10s"}}'
   - name: core-only
     patches:
       - op: remove

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -155,6 +155,10 @@ spec:
               value: {{ .Values.env.RUST_BACKTRACE | quote }}
             - name: RUST_LIB_BACKTRACE
               value: {{ .Values.env.RUST_LIB_BACKTRACE | quote }}
+            {{- with .Values.dsxExchangeEventBusConfig }}
+            - name: CARBIDE_API_DSX_EXCHANGE_EVENT_BUS
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/helm/charts/nico-api/tests/dsx_exchange_event_bus_test.yaml
+++ b/helm/charts/nico-api/tests/dsx_exchange_event_bus_test.yaml
@@ -1,0 +1,28 @@
+suite: DSX Exchange Event Bus deployment configuration
+templates:
+  - deployment.yaml
+tests:
+  - it: does not inject the event bus configuration by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CARBIDE_API_DSX_EXCHANGE_EVENT_BUS
+
+  - it: injects the event bus configuration without replacing extra environment variables
+    set:
+      dsxExchangeEventBusConfig: '{enabled=true,mqtt_endpoint="dsx-exchange",mqtt_broker_port=1883}'
+      extraEnv:
+        - name: DISABLE_TLS_ENFORCEMENT
+          value: "1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CARBIDE_API_DSX_EXCHANGE_EVENT_BUS
+            value: '{enabled=true,mqtt_endpoint="dsx-exchange",mqtt_broker_port=1883}'
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_TLS_ENFORCEMENT
+            value: "1"

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -153,6 +153,9 @@ env:
   RUST_BACKTRACE: "full"
   RUST_LIB_BACKTRACE: "0"
 
+## Optional Figment dictionary for CARBIDE_API_DSX_EXCHANGE_EVENT_BUS.
+dsxExchangeEventBusConfig: ""
+
 extraEnv: []
 
 ## Authentication for the /admin WebUI. CARBIDE_WEB_AUTH_TYPE in extraEnv


### PR DESCRIPTION
Adds an opt-in DSX Exchange DevSpace profile that deploys a local NATS MQTT service alongside NICo and passes the event-bus configuration to nico-api. The default DevSpace and Helm paths remain disabled unless the profile is selected. It also corrects the post-deploy integration checks to use the current Machine-a-Tron resource names and the local nico-api endpoint so a clean deployment can complete verification.

## Related issues

None.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Verified at `1f59be25338f57cb78a737ef0f01a9e83bf0cf5d` in an isolated local Kind cluster. The default render omitted DSX Exchange, the opt-in profile deployed NATS with MQTT, both Core hosts reached Ready and synced into a current REST inventory, and a subscriber received a managed-host `ready` state. Full reproduction steps are in the manual-testing comment.
