### PR TITLE
refactor(ib-fabric): pair monitor latency with failure logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,6 +2133,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-health-report",
  "carbide-ib-fabric",
+ "carbide-instrument",
  "carbide-secrets",
  "carbide-test-support",
  "carbide-tls",

--- a/crates/api-core/src/tests/ib_fabric_monitor.rs
+++ b/crates/api-core/src/tests/ib_fabric_monitor.rs
@@ -16,6 +16,7 @@
  */
 
 use carbide_ib_fabric::config::IBFabricConfig;
+use carbide_instrument::testing::MetricsCapture;
 
 use crate::tests::common;
 use crate::tests::common::api_fixtures::{TestEnvOverrides, create_managed_host};
@@ -34,7 +35,18 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
     )
     .await;
 
+    let iteration_metrics = MetricsCapture::start();
     env.run_ib_fabric_monitor_iteration().await;
+    let iteration_count = iteration_metrics
+        .histogram_count_delta("carbide_ib_monitor_iteration_latency_milliseconds", &[]);
+    // Other API tests can drive the same process-global Event concurrently.
+    // The Event-level test pins exact-once behavior; this integration check
+    // only proves the real monitor path reaches the Event registry.
+    assert!(
+        iteration_count >= 1,
+        "expected the monitor pass to record latency, observed {iteration_count}"
+    );
+    drop(iteration_metrics);
     assert_eq!(
         env.test_meter
             .formatted_metric("carbide_ib_monitor_fabrics_count")
@@ -65,13 +77,6 @@ async fn test_ib_fabric_monitor(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
             .unwrap(),
         r#"{fabric="default"} 1"#
     );
-    assert_eq!(
-        env.test_meter
-            .formatted_metric("carbide_ib_monitor_iteration_latency_milliseconds_count")
-            .unwrap(),
-        r#"1"#
-    );
-
     // The fabric is configured securely
     assert_eq!(
         env.test_meter

--- a/crates/ib-fabric/Cargo.toml
+++ b/crates/ib-fabric/Cargo.toml
@@ -17,6 +17,7 @@ test-support = ["dep:config-version"]
 carbide-api-db = { path = "../api-db" }
 carbide-api-model = { path = "../api-model" }
 carbide-health-report = { path = "../health-report" }
+carbide-instrument = { path = "../instrument" }
 carbide-secrets = { path = "../secrets" }
 carbide-tls = { path = "../tls" }
 carbide-utils = { path = "../utils" }
@@ -51,6 +52,7 @@ url = { workspace = true }
 [dev-dependencies]
 # Self-dependency so the crate's own tests see the `test-support` fakes.
 carbide-ib-fabric = { path = ".", features = ["test-support"] }
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 figment = { features = ["env", "test", "toml"], workspace = true }
 tempfile = { workspace = true }

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -33,7 +33,8 @@ use db::work_lock_manager::WorkLockManagerHandle;
 use db::{self, DatabaseError};
 use health_report::HealthReportApplyMode;
 use metrics::{
-    AppliedChange, FabricMetrics, IbFabricMonitorMetrics, UfmOperation, UfmOperationStatus,
+    AppliedChange, FabricMetrics, IbFabricMonitorMetrics, IbMonitorIterationFinished, UfmOperation,
+    UfmOperationStatus,
 };
 use model::ib::{IBNetwork, IBPort, IBPortMembership, IBPortState};
 use model::ib_partition::{IBPartition, IbPartitionSearchFilter, PartitionKey};
@@ -127,18 +128,16 @@ impl IbFabricMonitor {
 
         loop {
             let mut tick = timer.tick();
-            match self.run_single_iteration().await {
-                Ok(num_changes) => {
-                    if num_changes > 0 {
-                        // If any change has been applied to the IB fabric,
-                        // the status that has been collected in the last iteration is already outdated
-                        // Therefore run again as soon as possible.
-                        tick.set_interval(Duration::from_millis(1000));
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "IB fabric monitor iteration failed");
-                }
+            // Failed passes emit `IbMonitorIterationFinished` next to their
+            // latency. This loop only adjusts cadence; logging here would
+            // duplicate the terminal diagnostic at a different level.
+            if let Ok(num_changes) = self.run_single_iteration().await
+                && num_changes > 0
+            {
+                // If any change has been applied to the IB fabric,
+                // the status that has been collected in the last iteration is already outdated
+                // Therefore run again as soon as possible.
+                tick.set_interval(Duration::from_millis(1000));
             }
 
             tokio::select! {
@@ -193,7 +192,6 @@ impl IbFabricMonitor {
                     *num_changes
                 }
                 Err(e) => {
-                    tracing::error!(error = ?e, "IB fabric monitor run failed");
                     check_ib_fabrics_span.record("otel.status_code", "error");
                     // Writing this field will set the span status to error
                     // Therefore we only write it on errors
@@ -201,6 +199,17 @@ impl IbFabricMonitor {
                     0
                 }
             };
+
+            check_ib_fabrics_span.in_scope(|| {
+                carbide_instrument::emit(IbMonitorIterationFinished {
+                    latency: metrics.recording_started_at.elapsed(),
+                    error: res
+                        .as_ref()
+                        .err()
+                        .map(|error| format!("{error:?}"))
+                        .unwrap_or_default(),
+                });
+            });
 
             // Cache all other metrics that have been captured in this iteration.
             // Those will be queried by OTEL on demand

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -19,8 +19,9 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use ::carbide_utils::metrics::SharedMetricsHolder;
+use carbide_instrument::{DynamicLog, Event, LogAt};
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::metrics::{Counter, Meter};
 use serde::Serialize;
 
 /// Metrics that are gathered in one a single `IbFabricMonitor` run
@@ -114,20 +115,45 @@ impl IbFabricMonitorMetrics {
     }
 }
 
+/// Closes a monitor pass after the work lock is acquired. Every emission
+/// records the existing label-free latency histogram; failures also retain the
+/// historical `ERROR` diagnostic.
+#[derive(Event)]
+#[event(
+    event_name = "ib_monitor_iteration_finished",
+    metric_name = "carbide_ib_monitor_iteration_latency_milliseconds",
+    component = "ib-fabric-monitor",
+    log = dynamic,
+    metric = histogram,
+    message = "IB fabric monitor run failed",
+    describe = "The time it took to perform one IB fabric monitor iteration"
+)]
+pub(crate) struct IbMonitorIterationFinished {
+    #[observation]
+    pub latency: Duration,
+    /// An empty value keeps successful passes log-silent without skipping the
+    /// latency observation.
+    #[context]
+    pub error: String,
+}
+
+impl DynamicLog for IbMonitorIterationFinished {
+    fn log_at(&self) -> LogAt {
+        if self.error.is_empty() {
+            LogAt::Off
+        } else {
+            LogAt::Level(tracing::Level::ERROR)
+        }
+    }
+}
+
 /// Instruments that are used by pub struct IbFabricMonitor
 pub struct IbFabricMonitorInstruments {
-    pub iteration_latency: Histogram<f64>,
     pub ufm_changes_applied: Counter<u64>,
 }
 
 impl IbFabricMonitorInstruments {
     pub fn new(meter: Meter, shared_metrics: SharedMetricsHolder<IbFabricMonitorMetrics>) -> Self {
-        let iteration_latency = meter
-            .f64_histogram("carbide_ib_monitor_iteration_latency")
-            .with_description("The time it took to perform one IB fabric monitor iteration")
-            .with_unit("ms")
-            .build();
-
         {
             let metrics = shared_metrics.clone();
             meter
@@ -423,17 +449,11 @@ impl IbFabricMonitorInstruments {
         }
 
         Self {
-            iteration_latency,
             ufm_changes_applied,
         }
     }
 
-    fn emit_counters_and_histograms(&self, metrics: &IbFabricMonitorMetrics) {
-        self.iteration_latency.record(
-            1000.0 * metrics.recording_started_at.elapsed().as_secs_f64(),
-            &[],
-        );
-
+    fn emit_counters(&self, metrics: &IbFabricMonitorMetrics) {
         for (change, &count) in metrics.applied_changes.iter() {
             self.ufm_changes_applied.add(
                 count as u64,
@@ -446,7 +466,7 @@ impl IbFabricMonitorInstruments {
         }
     }
 
-    fn init_counters_and_histograms(&self, fabric_ids: &[&str]) {
+    fn init_counters(&self, fabric_ids: &[&str]) {
         for fabric_id in fabric_ids.iter() {
             for status in UfmOperationStatus::values() {
                 for operation in UfmOperation::values() {
@@ -523,7 +543,7 @@ impl MetricHolder {
     pub fn new(meter: Meter, hold_period: Duration, fabric_ids: &[&str]) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         let instruments = IbFabricMonitorInstruments::new(meter, last_iteration_metrics.clone());
-        instruments.init_counters_and_histograms(fabric_ids);
+        instruments.init_counters(fabric_ids);
         Self {
             instruments,
             last_iteration_metrics,
@@ -532,8 +552,7 @@ impl MetricHolder {
 
     /// Updates the most recent metrics
     pub fn update_metrics(&self, metrics: IbFabricMonitorMetrics) {
-        // Emit the last recent latency metrics
-        self.instruments.emit_counters_and_histograms(&metrics);
+        self.instruments.emit_counters(&metrics);
         self.last_iteration_metrics.update(metrics);
     }
 }
@@ -555,7 +574,9 @@ fn truncate_error_for_metric_label(mut error: String) -> String {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::value_scenarios;
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values, value_scenarios};
 
     use super::*;
 
@@ -565,6 +586,148 @@ mod tests {
 
     fn status_metric_value(status: UfmOperationStatus) -> String {
         opentelemetry::Value::from(status).to_string()
+    }
+
+    #[test]
+    fn ib_monitor_iteration_outcomes_pair_latency_with_failure_log() {
+        const EXPOSED_METRIC: &str = "carbide_ib_monitor_iteration_latency_milliseconds";
+
+        struct IterationCase {
+            latency: Duration,
+            error: &'static str,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct LogObservation {
+            level: tracing::Level,
+            metadata_name: String,
+            message: String,
+            event_name: Option<String>,
+            metric_name: Option<String>,
+            error: Option<String>,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            log_count: usize,
+            log: Option<LogObservation>,
+            histogram_count_delta: u64,
+            histogram_sum_delta: f64,
+        }
+
+        let failure = r#"Internal { message: "simulated iteration failure" }"#;
+        check_values(
+            [
+                Check {
+                    scenario: "successful iteration",
+                    input: IterationCase {
+                        latency: Duration::from_millis(125),
+                        error: "",
+                    },
+                    expect: Observation {
+                        log_count: 0,
+                        log: None,
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 125.0,
+                    },
+                },
+                Check {
+                    scenario: "fractional milliseconds remain precise",
+                    input: IterationCase {
+                        latency: Duration::from_micros(125_500),
+                        error: "",
+                    },
+                    expect: Observation {
+                        log_count: 0,
+                        log: None,
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 125.5,
+                    },
+                },
+                Check {
+                    scenario: "failed iteration",
+                    input: IterationCase {
+                        latency: Duration::from_millis(375),
+                        error: failure,
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            level: tracing::Level::ERROR,
+                            metadata_name: "ib_monitor_iteration_finished".to_string(),
+                            message: "IB fabric monitor run failed".to_string(),
+                            event_name: Some("ib_monitor_iteration_finished".to_string()),
+                            metric_name: Some(EXPOSED_METRIC.to_string()),
+                            error: Some(failure.to_string()),
+                        }),
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 375.0,
+                    },
+                },
+            ],
+            |IterationCase { latency, error }| {
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| {
+                    emit(IbMonitorIterationFinished {
+                        latency,
+                        error: error.to_string(),
+                    });
+                });
+                let log = logs.first().map(|log| LogObservation {
+                    level: log.level,
+                    metadata_name: log.metadata_name.clone(),
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                });
+
+                Observation {
+                    log_count: logs.len(),
+                    log,
+                    histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
+                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn ib_monitor_iteration_histogram_exposition_stays_stable() {
+        const EXPOSED_METRIC: &str = "carbide_ib_monitor_iteration_latency_milliseconds";
+
+        let metrics = MetricsCapture::start();
+        emit(IbMonitorIterationFinished {
+            latency: Duration::from_millis(125),
+            error: String::new(),
+        });
+
+        let encoded = metrics.render();
+        assert!(
+            encoded.contains(&format!(
+                "# HELP {EXPOSED_METRIC} The time it took to perform one IB fabric monitor iteration\n"
+            )),
+            "description or exposed family changed:\n{encoded}"
+        );
+        assert!(
+            encoded.contains(&format!("# TYPE {EXPOSED_METRIC} histogram\n")),
+            "expected the millisecond family to remain a histogram:\n{encoded}"
+        );
+        assert!(
+            !encoded.contains("carbide_ib_monitor_iteration_latency_milliseconds_milliseconds"),
+            "the unit suffix must be applied exactly once:\n{encoded}"
+        );
+        for suffix in ["count", "sum"] {
+            let prefix = format!("{EXPOSED_METRIC}_{suffix} ");
+            let sample = encoded
+                .lines()
+                .find(|line| line.starts_with(&prefix))
+                .unwrap_or_else(|| panic!("missing {prefix} sample:\n{encoded}"));
+            assert!(
+                !sample.contains('{'),
+                "iteration latency must remain label-free: {sample}"
+            );
+        }
     }
 
     #[test]

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -92,6 +92,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>Number of remaining hosts in the NICo deployment available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>Number of hosts in the system that have their BIOS password set.</td></tr>
 <tr><td>carbide_ib_monitor_fabrics_count</td><td>gauge</td><td>Number of monitored InfiniBand fabrics</td></tr>
+<tr><td>carbide_ib_monitor_iteration_latency_milliseconds</td><td>histogram</td><td>The time it took to perform one IB fabric monitor iteration</td></tr>
 <tr><td>carbide_ib_monitor_machine_ib_status_updates_count</td><td>gauge</td><td>Number of Machines whose InfiniBand status observation was updated</td></tr>
 <tr><td>carbide_ib_monitor_machines_with_missing_pkeys_count</td><td>gauge</td><td>Number of machines where at least one port is not assigned to the expected pkey on UFM</td></tr>
 <tr><td>carbide_ib_monitor_machines_with_unexpected_pkeys_count</td><td>gauge</td><td>Number of machines where at least one port is assigned to an unexpected pkey on UFM</td></tr>


### PR DESCRIPTION
Exit code: 0
Wall time: 0.6 seconds
Output:
Each InfiniBand monitor pass recorded its latency separately from two records around the same returned error.

This closes the measured pass with one histogram-backed Event inside the iteration span. Successful iterations remain metric-only. Failed iterations retain the richer historical ERROR message and Debug-rendered error, while the duplicate outer WARN goes away. Work-lock contention still returns before the Event, and gauges plus batched UFM counters remain on their existing holder.

`carbide_ib_monitor_iteration_latency_milliseconds`, its HELP text, fractional-millisecond precision, and label-free series do not change. Table-driven Event tests and the API integration assertion cover the paired failure signal and Prometheus exposition.

## Related issues

- Supports #3790
- Part of #3169

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified with:

- `cargo test -p carbide-ib-fabric --lib`
- `cargo test -p carbide-api-core tests::ib_fabric_monitor::test_ib_fabric_monitor --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo xtask check-workspace-deps`
- `cargo make --no-workspace check-licenses`
- `cargo make --no-workspace check-bans`

## Additional Notes

`docs/observability/core_metrics.md` is generated from the Event declaration and intentionally stays with the code change.



Closes #3790
