### PR TITLE
fix(helm-prereqs): stop managing MetalLB CRDs via helm on re-sync

### DIFF
--- a/helm-prereqs/operators/values/metallb.yaml
+++ b/helm-prereqs/operators/values/metallb.yaml
@@ -33,3 +33,11 @@ prometheus:
       additionalLabels: {}
   prometheusRule:
     enabled: false
+
+# CRD management disabled: setup.sh applies the rendered CRDs itself
+# (server-side, idempotently) on EVERY run, before the helmfile sync. Helm
+# must not manage them because MetalLB's cert rotator takes SSA ownership of
+# the conversion-webhook caBundle after install, so a helm-managed CRD
+# upgrade conflicts on every re-sync.
+crds:
+  enabled: false

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -293,6 +293,32 @@ helmfile sync -l name=postgres-operator
 _SETUP_PHASE="[1c] MetalLB"
 echo "=== [1c] MetalLB ==="
 
+# CRDs are applied directly (server-side), not helm-managed: MetalLB's cert
+# rotator takes SSA ownership of the CRD conversion-webhook caBundle after
+# install, so a helm-managed CRD upgrade conflicts on every re-sync (see
+# operators/values/metallb.yaml crds.enabled=false). --force-conflicts keeps
+# this idempotent against the rotator's field ownership.
+echo "Applying MetalLB CRDs (server-side)..."
+# Single source of truth for the chart version is the metallb release in
+# helmfile.yaml — read it from there so this bootstrap and the helm release
+# cannot drift when the version is bumped.
+METALLB_CHART_VERSION="$(awk '/chart: metallb\/metallb/{found=1} found && /^[[:space:]]*version:/{gsub(/"/,"",$2); print $2; exit}' helmfile.yaml)"
+if [[ -z "${METALLB_CHART_VERSION}" ]]; then
+    echo "ERROR: could not read the metallb chart version from helmfile.yaml" >&2
+    exit 1
+fi
+# The awk filter emits only CustomResourceDefinition documents, splitting on
+# '---' separator lines itself (POSIX awk/mawk/BusyBox treat a multi-character
+# RS as its first character only, so RS="\n---\n" is not portable). helm's
+# stderr is left attached so a repo/render failure says what actually broke
+# instead of surfacing as a confusing kubectl parse error downstream.
+helm template metallb metallb/metallb --version "${METALLB_CHART_VERSION}" -n metallb-system --include-crds \
+    | awk '
+        /^---[[:space:]]*$/ { if (doc ~ /kind: CustomResourceDefinition/) printf "%s---\n", doc; doc = ""; next }
+        { doc = doc $0 "\n" }
+        END { if (doc ~ /kind: CustomResourceDefinition/) printf "%s", doc }' \
+    | kubectl apply --server-side --force-conflicts -f -
+
 helmfile sync -l name=metallb
 
 echo "Waiting for MetalLB controller to be ready..."


### PR DESCRIPTION
`setup.sh` cannot currently be re-run against an existing cluster: phase [1c] fails every time with a server-side-apply conflict on the MetalLB CRDs. After the first install, MetalLB's cert rotator takes SSA field ownership of the CRD conversion-webhook `caBundle` (field manager "MetalLB"), so the next `helmfile sync -l name=metallb` — which setup.sh runs unconditionally — conflicts on `bgppeers.metallb.io` `.spec.conversion.webhook.clientConfig.caBundle` and aborts the whole setup. Since setup.sh is documented as idempotent and re-running it is the standard way to resume after any later-phase failure, this makes every recovery path a manual MetalLB surgery. Force-transferring ownership back to helm doesn't stick — the rotator re-claims the field on its next rotation, so it's a losing race rather than a one-time migration.

The fix takes CRD lifecycle away from helm entirely:

- `operators/values/metallb.yaml` sets `crds.enabled: false`, so the release manifest no longer contains the CRDs and helm never fights the rotator again.
- setup.sh phase [1c] applies the chart's rendered CRDs directly (`kubectl apply --server-side --force-conflicts`) before the helmfile sync, keeping fresh installs working and staying idempotent against the rotator's field ownership on re-runs.

One migration note for **existing** clusters: the first upgrade that applies `crds.enabled=false` removes the CRDs from the release manifest, and helm deletes objects that leave the manifest — the setup.sh CRD-apply step runs before the sync, so the CRDs are immediately re-applied on the next run, but that first transition upgrade should be followed by a re-run (or a one-time manual `kubectl apply` of the rendered CRDs) to restore them. Fresh installs are unaffected.

Verified on a live 3-node dev cluster: fresh install (CRDs applied, pools created, VIPs allocated) and repeated `setup.sh -y` re-runs, which previously failed 100% of the time in phase [1c] and now pass.

## Related issues
Hit while validating #3323 end-to-end (every setup.sh resume on the test cluster failed in phase [1c]).

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
The `helm template` for the CRDs relies on the metallb repo already being registered; setup.sh phases [1b]/[1c] run helmfile (which adds all repos) in every invocation, and the CRD apply step sits inside phase [1c] after those repo adds, so no ordering change is needed.