### PR TITLE
fix(ci): align rest helm version with core helm

### DIFF
--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -151,9 +151,12 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "push_requested=$PUSH_REQUESTED" >> $GITHUB_OUTPUT
 
-          # Strict SemVer for Helm chart version, aligned with core's helm_version derivation.
-          # `git describe` output `v1.6.0-3-gabc1234` becomes `1.6.0-3.gabc1234`
+          # Helm chart version: strip leading `v`, then for non-exact-tag commits replace the
+          # last `-` with `.` to align with core helm_version (e.g. `v1.6.0-3-gabc1234` -> `1.6.0-3.gabc1234`).
           HELM_VERSION="${RAW_VERSION#v}"
+          if [[ "$RAW_VERSION" =~ -g[0-9a-f]+$ ]]; then
+            HELM_VERSION=$(echo "$HELM_VERSION" | sed 's/\(.*\)-/\1./')
+          fi
           echo "helm_version=$HELM_VERSION" >> $GITHUB_OUTPUT
 
           echo "Generated build information:"

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -78,7 +78,7 @@ jobs:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message || '' }}
           NGC_PATH_OVERRIDE: ${{ vars.NICO_TARGET_NGC_PATH }}
         run: |
-          RAW_VERSION=$(git describe --tags --first-parent --always --long)
+          RAW_VERSION=$(git describe --tags --first-parent --always)
           SEMANTIC_VERSION="${RAW_VERSION}"
 
           SHORT_SHA=$(git rev-parse --short HEAD)
@@ -153,9 +153,7 @@ jobs:
 
           # Strict SemVer for Helm chart version, aligned with core's helm_version derivation.
           # `git describe` output `v1.6.0-3-gabc1234` becomes `1.6.0-3.gabc1234`
-          # (leading `v` stripped, last `-` -> `.`).
-          HELM_VERSION_BASE="${RAW_VERSION#v}"
-          HELM_VERSION=$(echo "$HELM_VERSION_BASE" | sed 's/\(.*\)-/\1./')
+          HELM_VERSION="${RAW_VERSION#v}"
           echo "helm_version=$HELM_VERSION" >> $GITHUB_OUTPUT
 
           echo "Generated build information:"


### PR DESCRIPTION
helm charts for the core components are published as expected for helm aligning with the semvar tag in git while REST helm charts are still using the git --long tag even on actual releases. This makes it hard to easily align charts for deploymnets:

- core helm chart version: `v2.3.0-rc.1`
- rest helm chart version: `v2.3.0-rc.1-0.g09a9222d`

aligning with the git tag was added in https://github.com/NVIDIA/infra-controller/pull/3229 , this aligns the REST with the same changes. Helm chart version comparison before and after:

| context | `raw_version` | old helm ver | new helm ver |
|---|---|---|---|
| tag on main | `v2.3.0-pr` | `2.3.0-pr-0.g09a9222d` | `2.3.0-pr` |
| rc tag on release branch | `v2.3.0-rc.1` | `2.3.0-rc.1-0.g09a9222d` | `2.3.0-rc.1` |
| tag on release branch | `v2.3.5` | `2.3.5-0.g09a9222d` | `2.3.5` |
| commit on main | `v2.1.0-pr-346-g09a9222d1` | `2.1.0-pr-346.g09a9222d1` | `2.1.0-pr-346.g09a9222d1` |

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes