### PR TITLE
refactor(pxe): pair boot failure metrics and logs

### DIFF
--- a/crates/pxe/src/metrics.rs
+++ b/crates/pxe/src/metrics.rs
@@ -97,9 +97,10 @@ pub(crate) enum OutcomeReason {
     UpstreamApiError,
 }
 
-/// A boot-path request resolved to a servable response -- the real script
-/// or an error template. Metric-only: the existing stderr lines on the
-/// failure paths stay as they are, and the rate is the signal.
+/// `PxeBootOutcome` records a boot-path result without writing a log. The
+/// quiet success and extractor paths use this type; failures that already
+/// have an `ERROR` record use the sibling Events below so one `emit()` writes
+/// the log and increments the counter.
 #[derive(Event)]
 #[event(
     event_name = "pxe_boot_outcome",
@@ -116,6 +117,52 @@ pub(crate) struct PxeBootOutcome {
     pub reason: OutcomeReason,
 }
 
+// Both failure Events write the same counter as `PxeBootOutcome`. Keep the
+// metric kind, description, and label keys identical so OpenTelemetry sees
+// one instrument while each route keeps its existing message.
+
+/// `PxeCloudInitRequestFailed` records a cloud-init request that fell back to
+/// the generic error template.
+#[derive(Event)]
+#[event(
+    event_name = "pxe_cloud_init_request_failed",
+    metric_name = "carbide_pxe_boot_outcomes_total",
+    component = "carbide-pxe",
+    log = error,
+    metric = counter,
+    message = "cloud-init request could not be served",
+    describe = "Number of PXE boot-path outcomes served, by endpoint and reason."
+)]
+pub(crate) struct PxeCloudInitRequestFailed {
+    #[label]
+    pub endpoint: BootEndpoint,
+    #[label]
+    pub reason: OutcomeReason,
+    #[context]
+    pub error: String,
+}
+
+/// `PxeCustomIpxeFetchFailed` records a custom iPXE lookup that fell back to
+/// the error script returned to the machine.
+#[derive(Event)]
+#[event(
+    event_name = "pxe_custom_ipxe_fetch_failed",
+    metric_name = "carbide_pxe_boot_outcomes_total",
+    component = "carbide-pxe",
+    log = error,
+    metric = counter,
+    message = "failed to fetch custom ipxe script",
+    describe = "Number of PXE boot-path outcomes served, by endpoint and reason."
+)]
+pub(crate) struct PxeCustomIpxeFetchFailed {
+    #[label]
+    pub endpoint: BootEndpoint,
+    #[label]
+    pub reason: OutcomeReason,
+    #[context]
+    pub error: String,
+}
+
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
@@ -123,6 +170,8 @@ mod tests {
     use carbide_test_support::{Check, check_values};
 
     use super::*;
+
+    const BOOT_OUTCOMES_METRIC: &str = "carbide_pxe_boot_outcomes_total";
 
     /// The label vocabulary is the dashboard contract: each variant renders
     /// as its snake_case name, byte for byte.
@@ -185,9 +234,8 @@ mod tests {
         );
     }
 
-    /// Each emit moves exactly its label pair's series, and none of them
-    /// builds a log line -- the event is declared `log = off` because this
-    /// binary has no tracing subscriber and its stderr lines stay untouched.
+    /// Each emit moves exactly its label pair's series. Even under the test
+    /// subscriber, `log = off` constructs no record for these quiet paths.
     #[test]
     fn boot_outcomes_count_per_label_without_logging() {
         let metrics = MetricsCapture::start();
@@ -242,6 +290,113 @@ mod tests {
             ),
             0.0,
             "an untouched label pair must not move",
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    enum FailureEvent {
+        CloudInit,
+        CustomIpxe,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FailureRecord {
+        metadata_name: String,
+        level: tracing::Level,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        endpoint: Option<String>,
+        reason: Option<String>,
+        error: Option<String>,
+        counter_delta: f64,
+    }
+
+    /// Each failure Event keeps its route's `ERROR` record and increments the
+    /// existing label pair once. This is the contract that lets the route
+    /// replace its separate `tracing::error!` and `PxeBootOutcome` calls.
+    #[test]
+    fn boot_failures_log_and_count_once() {
+        check_values(
+            [
+                Check {
+                    scenario: "cloud-init generic error",
+                    input: FailureEvent::CloudInit,
+                    expect: FailureRecord {
+                        metadata_name: "pxe_cloud_init_request_failed".to_string(),
+                        level: tracing::Level::ERROR,
+                        message: "cloud-init request could not be served".to_string(),
+                        event_name: Some("pxe_cloud_init_request_failed".to_string()),
+                        metric_name: Some(BOOT_OUTCOMES_METRIC.to_string()),
+                        endpoint: Some("cloud_init".to_string()),
+                        reason: Some("metadata_not_found".to_string()),
+                        error: Some("metadata is missing".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "custom iPXE lookup error",
+                    input: FailureEvent::CustomIpxe,
+                    expect: FailureRecord {
+                        metadata_name: "pxe_custom_ipxe_fetch_failed".to_string(),
+                        level: tracing::Level::ERROR,
+                        message: "failed to fetch custom ipxe script".to_string(),
+                        event_name: Some("pxe_custom_ipxe_fetch_failed".to_string()),
+                        metric_name: Some(BOOT_OUTCOMES_METRIC.to_string()),
+                        endpoint: Some("boot".to_string()),
+                        reason: Some("upstream_api_error".to_string()),
+                        error: Some("API unavailable".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |failure| {
+                let metrics = MetricsCapture::start();
+                let (endpoint, reason, logs) = match failure {
+                    FailureEvent::CloudInit => {
+                        let endpoint = BootEndpoint::CloudInit;
+                        let reason = OutcomeReason::MetadataNotFound;
+                        let logs = capture_logs(|| {
+                            emit(PxeCloudInitRequestFailed {
+                                endpoint,
+                                reason,
+                                error: "metadata is missing".to_string(),
+                            });
+                        });
+                        (endpoint, reason, logs)
+                    }
+                    FailureEvent::CustomIpxe => {
+                        let endpoint = BootEndpoint::Boot;
+                        let reason = OutcomeReason::UpstreamApiError;
+                        let logs = capture_logs(|| {
+                            emit(PxeCustomIpxeFetchFailed {
+                                endpoint,
+                                reason,
+                                error: "API unavailable".to_string(),
+                            });
+                        });
+                        (endpoint, reason, logs)
+                    }
+                };
+
+                assert_eq!(logs.len(), 1, "one emit must produce one log record");
+                let log = &logs[0];
+                let endpoint = endpoint.label_value();
+                let reason = reason.label_value();
+                let labels = [("endpoint", endpoint.as_str()), ("reason", reason.as_str())];
+
+                FailureRecord {
+                    metadata_name: log.metadata_name.clone(),
+                    level: log.level,
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    endpoint: log.field("endpoint").map(str::to_string),
+                    reason: log.field("reason").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    counter_delta: metrics.counter_delta(BOOT_OUTCOMES_METRIC, &labels),
+                }
+            },
         );
     }
 }

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -32,7 +32,7 @@ use rpc::forge;
 use rpc::forge::PxeDomain;
 
 use crate::common::{AppState, Machine};
-use crate::metrics::{BootEndpoint, OutcomeReason, PxeBootOutcome};
+use crate::metrics::{BootEndpoint, OutcomeReason, PxeBootOutcome, PxeCloudInitRequestFailed};
 
 const DEFAULT_NUM_OF_VFS: u32 = 16;
 const DEFAULT_HBN_BRIDGE: &str = "br-hbn";
@@ -73,10 +73,10 @@ fn log_and_generate_generic_error(
     error: String,
     reason: OutcomeReason,
 ) -> (String, HashMap<String, String>) {
-    tracing::error!(error = %error, "cloud-init request could not be served");
-    emit(PxeBootOutcome {
+    emit(PxeCloudInitRequestFailed {
         endpoint: BootEndpoint::CloudInit,
         reason,
+        error,
     });
     let mut template_data: HashMap<String, String> = HashMap::new();
     template_data.insert(

--- a/crates/pxe/src/routes/ipxe.rs
+++ b/crates/pxe/src/routes/ipxe.rs
@@ -27,7 +27,7 @@ use forge_tls::client_config::ClientCert;
 use rpc::forge_tls_client::ForgeClientConfig;
 
 use crate::common::{AppState, Machine, MachineInterface};
-use crate::metrics::{BootEndpoint, OutcomeReason, PxeBootOutcome};
+use crate::metrics::{BootEndpoint, OutcomeReason, PxeBootOutcome, PxeCustomIpxeFetchFailed};
 use crate::routes::RpcContext;
 
 pub enum PxeErrorCode {
@@ -131,17 +131,6 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
             )
             .await;
 
-            // The upstream error path still serves a script (an error
-            // template over HTTP 200), so the outcome counter is the
-            // only place the split is visible.
-            emit(PxeBootOutcome {
-                endpoint: BootEndpoint::Boot,
-                reason: match &pxe_response {
-                    Ok(_) => OutcomeReason::Ok,
-                    Err(_) => OutcomeReason::UpstreamApiError,
-                },
-            });
-
             // Use URL overrides from the API if present (for external
             // clients), falling back to global config.
             let (api_url, pxe_url, static_pxe_url) = match &pxe_response {
@@ -163,19 +152,35 @@ pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl In
                 ),
             };
 
-            let instructions = pxe_response
-                .map(|resp| resp.pxe_script)
-                .unwrap_or_else(|err| {
-                    tracing::error!(error = %err, "failed to fetch custom ipxe script");
-                    format!(
+            // Both branches return a script over HTTP 200, so the HTTP
+            // metrics cannot tell them apart. Emit at the branch that chooses
+            // the real or fallback script; that keeps each request to one
+            // `carbide_pxe_boot_outcomes_total` increment.
+            let instructions = match pxe_response {
+                Ok(resp) => {
+                    emit(PxeBootOutcome {
+                        endpoint: BootEndpoint::Boot,
+                        reason: OutcomeReason::Ok,
+                    });
+                    resp.pxe_script
+                }
+                Err(err) => {
+                    let instructions = format!(
                         r#"
 echo Failed to fetch custom_ipxe: {err} ||
 exit 101 ||
 "#
-                    )
-                })
-                .replace("[api_url]", &api_url)
-                .replace("[pxe_url]", &pxe_url);
+                    );
+                    emit(PxeCustomIpxeFetchFailed {
+                        endpoint: BootEndpoint::Boot,
+                        reason: OutcomeReason::UpstreamApiError,
+                        error: err,
+                    });
+                    instructions
+                }
+            }
+            .replace("[api_url]", &api_url)
+            .replace("[pxe_url]", &pxe_url);
 
             // Override template URLs for external clients.
             template_data.insert("pxe_url".to_string(), pxe_url);


### PR DESCRIPTION
Cloud-init and custom iPXE failures were already incrementing `carbide_pxe_boot_outcomes_total` beside an ERROR record. This gives each failure branch its own Event, so one `emit()` writes the existing log and increments its existing series. Successful custom iPXE fetches remain on the metric-only Event.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3820

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo test --locked -p carbide-pxe`

`cargo make format-nightly`

`cargo make clippy`

`cargo make carbide-lints`

`cargo make check-event-names`

`cargo make check-metric-docs`

## Additional Notes

Both failure Events share the existing counter with the same instrument definition and labels. No metric catalogue change is required.


Closes #3820
