### PR TITLE
refactor(fmds): make terminal Events own their logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "carbide-dpu-fmds-shared",
  "carbide-instrument",
  "carbide-rpc",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-uuid",
  "carbide-version",

--- a/crates/fmds/Cargo.toml
+++ b/crates/fmds/Cargo.toml
@@ -78,6 +78,8 @@ tracing-subscriber = { features = [
 ], workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["client-legacy"] }

--- a/crates/fmds/src/grpc_server.rs
+++ b/crates/fmds/src/grpc_server.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use carbide_instrument::{DynamicLog, Event, LogAt, Outcome, emit};
+use carbide_instrument::{Event, Outcome, emit};
 use rpc::fmds::fmds_config_service_server::FmdsConfigService;
 use rpc::fmds::{UpdateConfigRequest, UpdateConfigResponse};
 use tonic::{Request, Response, Status};
@@ -34,15 +34,35 @@ impl FmdsGrpcServer {
     }
 }
 
-/// One inbound gRPC config-update ingest ran to completion. The event owns the
-/// failure log line -- every ingest is counted, only the failures write the
-/// WARN line (the success path keeps its own "Received config update" INFO log).
+/// `ConfigUpdateIngestSucceeded` keeps the agent address on accepted updates.
+/// Rejections use `ConfigUpdateIngested` below, which retains the existing
+/// Event identity and error-only log fields.
+#[derive(Event)]
+#[event(
+    event_name = "fmds_config_update_ingest_succeeded",
+    metric_name = "carbide_fmds_config_updates_total",
+    component = "fmds",
+    log = info,
+    metric = counter,
+    message = "Received config update from agent",
+    describe = "Number of FMDS gRPC config-update ingests, by outcome"
+)]
+struct ConfigUpdateIngestSucceeded {
+    #[label]
+    outcome: Outcome,
+    #[context(value)]
+    agent_address: String,
+}
+
+/// `ConfigUpdateIngested` retains the existing failure Event identity. Both
+/// Events feed the same `outcome` series, while each log keeps only the fields
+/// operators already receive for that result.
 #[derive(Event)]
 #[event(
     event_name = "fmds_config_update_ingested",
     metric_name = "carbide_fmds_config_updates_total",
     component = "fmds",
-    log = dynamic,
+    log = warn,
     metric = counter,
     message = "Failed to ingest config update",
     describe = "Number of FMDS gRPC config-update ingests, by outcome"
@@ -50,19 +70,14 @@ impl FmdsGrpcServer {
 struct ConfigUpdateIngested {
     #[label]
     outcome: Outcome,
-    /// The rejection's error text; empty on success (the line only renders on
-    /// failure).
     #[context]
     error: String,
 }
 
-impl DynamicLog for ConfigUpdateIngested {
-    fn log_at(&self) -> LogAt {
-        match self.outcome {
-            Outcome::Error => LogAt::Level(tracing::Level::WARN),
-            Outcome::Ok => LogAt::Off,
-        }
-    }
+#[derive(Debug)]
+struct AppliedConfigUpdate {
+    response: Response<UpdateConfigResponse>,
+    agent_address: String,
 }
 
 #[tonic::async_trait]
@@ -71,16 +86,22 @@ impl FmdsConfigService for FmdsGrpcServer {
         &self,
         request: Request<UpdateConfigRequest>,
     ) -> Result<Response<UpdateConfigResponse>, Status> {
-        let result = self.apply_config_update(request);
-        emit(ConfigUpdateIngested {
-            outcome: Outcome::from(&result),
-            error: result
-                .as_ref()
-                .err()
-                .map(|status| status.to_string())
-                .unwrap_or_default(),
-        });
-        result
+        match self.apply_config_update(request) {
+            Ok(applied) => {
+                emit(ConfigUpdateIngestSucceeded {
+                    outcome: Outcome::Ok,
+                    agent_address: applied.agent_address,
+                });
+                Ok(applied.response)
+            }
+            Err(status) => {
+                emit(ConfigUpdateIngested {
+                    outcome: Outcome::Error,
+                    error: status.to_string(),
+                });
+                Err(status)
+            }
+        }
     }
 }
 
@@ -88,7 +109,7 @@ impl FmdsGrpcServer {
     fn apply_config_update(
         &self,
         request: Request<UpdateConfigRequest>,
-    ) -> Result<Response<UpdateConfigResponse>, Status> {
+    ) -> Result<AppliedConfigUpdate, Status> {
         let agent_address = request
             .remote_addr()
             .map(|addr| addr.to_string())
@@ -143,14 +164,17 @@ impl FmdsGrpcServer {
                 .map_err(Status::invalid_argument)?;
         }
 
-        tracing::info!(agent_address, "Received config update from agent");
-
-        Ok(Response::new(UpdateConfigResponse {}))
+        Ok(AppliedConfigUpdate {
+            response: Response::new(UpdateConfigResponse {}),
+            agent_address,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
     use rpc::fmds::{FmdsConfigUpdate, FmdsMachineIdentityConfig, IbDevice, IbInstance};
 
@@ -178,8 +202,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_update_config_omitted_machine_identity_preserves_serving() {
+    #[test]
+    fn test_update_config_omitted_machine_identity_preserves_serving() {
         let state = make_test_state();
         let server = FmdsGrpcServer::new(state.clone());
 
@@ -194,10 +218,9 @@ mod tests {
         });
 
         server
-            .update_config(Request::new(UpdateConfigRequest {
+            .apply_config_update(Request::new(UpdateConfigRequest {
                 config_update: Some(first),
             }))
-            .await
             .unwrap();
 
         let ptr_after_first = Arc::as_ptr(&state.machine_identity.load_full());
@@ -207,10 +230,9 @@ mod tests {
         second.machine_identity = None;
 
         server
-            .update_config(Request::new(UpdateConfigRequest {
+            .apply_config_update(Request::new(UpdateConfigRequest {
                 config_update: Some(second),
             }))
-            .await
             .unwrap();
 
         assert_eq!(
@@ -222,8 +244,8 @@ mod tests {
         assert_eq!(config.address, "10.0.0.2");
     }
 
-    #[tokio::test]
-    async fn test_update_config_stores_data() {
+    #[test]
+    fn test_update_config_stores_data() {
         let state = make_test_state();
         let server = FmdsGrpcServer::new(state.clone());
 
@@ -231,7 +253,7 @@ mod tests {
             config_update: Some(make_test_update()),
         });
 
-        let response = server.update_config(request).await;
+        let response = server.apply_config_update(request);
         assert!(response.is_ok());
 
         let config = state.config.load_full().unwrap();
@@ -241,8 +263,8 @@ mod tests {
         assert_eq!(config.asn, 65000);
     }
 
-    #[tokio::test]
-    async fn test_update_config_missing_config_update() {
+    #[test]
+    fn test_update_config_missing_config_update() {
         let state = make_test_state();
         let server = FmdsGrpcServer::new(state);
 
@@ -250,13 +272,13 @@ mod tests {
             config_update: None,
         });
 
-        let response = server.update_config(request).await;
+        let response = server.apply_config_update(request);
         assert!(response.is_err());
         assert_eq!(response.unwrap_err().code(), tonic::Code::InvalidArgument);
     }
 
-    #[tokio::test]
-    async fn test_update_config_with_ib_devices() {
+    #[test]
+    fn test_update_config_with_ib_devices() {
         let state = make_test_state();
         let server = FmdsGrpcServer::new(state.clone());
 
@@ -281,7 +303,7 @@ mod tests {
             config_update: Some(update),
         });
 
-        server.update_config(request).await.unwrap();
+        server.apply_config_update(request).unwrap();
 
         let config = state.config.load_full().unwrap();
         let devices = config.ib_devices.as_ref().unwrap();
@@ -294,8 +316,8 @@ mod tests {
         assert!(devices[0].instances[1].ib_partition_id.is_none());
     }
 
-    #[tokio::test]
-    async fn test_update_config_empty_ib_devices_becomes_none() {
+    #[test]
+    fn test_update_config_empty_ib_devices_becomes_none() {
         let state = make_test_state();
         let server = FmdsGrpcServer::new(state.clone());
 
@@ -303,9 +325,158 @@ mod tests {
             config_update: Some(make_test_update()),
         });
 
-        server.update_config(request).await.unwrap();
+        server.apply_config_update(request).unwrap();
 
         let config = state.config.load_full().unwrap();
         assert!(config.ib_devices.is_none());
+    }
+
+    enum TerminalCase {
+        Accepted,
+        MissingUpdate,
+    }
+
+    impl TerminalCase {
+        fn metric_label(&self) -> &'static str {
+            match self {
+                Self::Accepted => "ok",
+                Self::MissingUpdate => "error",
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TerminalObservation {
+        status: Option<tonic::Code>,
+        metric_delta: f64,
+        logs: Vec<LogObservation>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct LogObservation {
+        metadata_name: String,
+        level: tracing::Level,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        outcome: Option<String>,
+        agent_address: Option<String>,
+        agent_address_kind: Option<CapturedFieldKind>,
+        error: Option<String>,
+        error_kind: Option<CapturedFieldKind>,
+    }
+
+    fn expected_log(
+        metadata_name: &str,
+        level: tracing::Level,
+        message: &str,
+        outcome: &str,
+        agent_address: Option<&str>,
+        error: Option<&str>,
+    ) -> Vec<LogObservation> {
+        vec![LogObservation {
+            metadata_name: metadata_name.to_string(),
+            level,
+            message: message.to_string(),
+            event_name: Some(metadata_name.to_string()),
+            metric_name: Some("carbide_fmds_config_updates_total".to_string()),
+            outcome: Some(outcome.to_string()),
+            agent_address: agent_address.map(str::to_string),
+            agent_address_kind: agent_address.map(|_| CapturedFieldKind::String),
+            error: error.map(str::to_string),
+            error_kind: error.map(|_| CapturedFieldKind::Debug),
+        }]
+    }
+
+    fn observe_terminal_call(case: TerminalCase) -> TerminalObservation {
+        let outcome = case.metric_label();
+        let request = Request::new(UpdateConfigRequest {
+            config_update: match case {
+                TerminalCase::Accepted => Some(make_test_update()),
+                TerminalCase::MissingUpdate => None,
+            },
+        });
+        let server = FmdsGrpcServer::new(make_test_state());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let metrics = MetricsCapture::start();
+        let mut result = None;
+        let logs = capture_logs(|| {
+            result = Some(runtime.block_on(server.update_config(request)));
+        })
+        .into_iter()
+        .map(|log| {
+            let event_name = log.field("event_name").map(str::to_string);
+            let metric_name = log.field("metric_name").map(str::to_string);
+            let outcome = log.field("outcome").map(str::to_string);
+            let agent_address = log.field("agent_address").map(str::to_string);
+            let agent_address_kind = log.field_kind("agent_address");
+            let error = log.field("error").map(str::to_string);
+            let error_kind = log.field_kind("error");
+            LogObservation {
+                metadata_name: log.metadata_name,
+                level: log.level,
+                message: log.message,
+                event_name,
+                metric_name,
+                outcome,
+                agent_address,
+                agent_address_kind,
+                error,
+                error_kind,
+            }
+        })
+        .collect();
+
+        TerminalObservation {
+            status: result.unwrap().err().map(|status| status.code()),
+            metric_delta: metrics
+                .counter_delta("carbide_fmds_config_updates_total", &[("outcome", outcome)]),
+            logs,
+        }
+    }
+
+    #[test]
+    fn update_config_emits_one_terminal_event_per_call() {
+        let missing_update = Status::invalid_argument("missing config_update").to_string();
+        check_values(
+            [
+                Check {
+                    scenario: "accepted updates keep the agent address field",
+                    input: TerminalCase::Accepted,
+                    expect: TerminalObservation {
+                        status: None,
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "fmds_config_update_ingest_succeeded",
+                            tracing::Level::INFO,
+                            "Received config update from agent",
+                            "ok",
+                            Some("unknown"),
+                            None,
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "rejected updates keep the status error field",
+                    input: TerminalCase::MissingUpdate,
+                    expect: TerminalObservation {
+                        status: Some(tonic::Code::InvalidArgument),
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "fmds_config_update_ingested",
+                            tracing::Level::WARN,
+                            "Failed to ingest config update",
+                            "error",
+                            None,
+                            Some(&missing_update),
+                        ),
+                    },
+                },
+            ],
+            observe_terminal_call,
+        );
     }
 }

--- a/crates/fmds/src/phone_home.rs
+++ b/crates/fmds/src/phone_home.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt, emit};
+use carbide_instrument::{Event, LabelValue, emit};
 use eyre::eyre;
 use forge_dpu_agent_utils::utils::create_forge_client;
 use rpc::forge::InstancePhoneHomeLastContactRequest;
@@ -37,15 +37,38 @@ enum PhoneHomeOutcome {
     Error,
 }
 
-/// One phone-home operation ran to completion. The event owns the failure log
-/// line -- every attempt is counted, only the failures write the WARN line
-/// (the success path keeps its own "Successfully phoned home" INFO log).
+/// `PhoneHomeSucceeded` writes the existing success record with the configured
+/// machine ID and the timestamp returned by Forge. `PhoneHomeCompleted` below
+/// retains the existing Event identity for failures, and both increment the
+/// same metric.
+#[derive(Event)]
+#[event(
+    event_name = "fmds_phone_home_succeeded",
+    metric_name = "carbide_fmds_phone_home_total",
+    component = "fmds",
+    log = info,
+    metric = counter,
+    message = "Successfully phoned home",
+    describe = "Number of FMDS tenant phone-home operations, by outcome"
+)]
+struct PhoneHomeSucceeded {
+    #[label]
+    outcome: PhoneHomeOutcome,
+    #[context]
+    machine_id: String,
+    #[context]
+    timestamp: String,
+}
+
+/// `PhoneHomeCompleted` retains the existing failure Event identity. Keeping
+/// success and failure as separate types lets each log expose only the fields
+/// it actually has while both increment the same `outcome` series.
 #[derive(Event)]
 #[event(
     event_name = "fmds_phone_home_completed",
     metric_name = "carbide_fmds_phone_home_total",
     component = "fmds",
-    log = dynamic,
+    log = warn,
     metric = counter,
     message = "Phone home failed",
     describe = "Number of FMDS tenant phone-home operations, by outcome"
@@ -53,20 +76,8 @@ enum PhoneHomeOutcome {
 struct PhoneHomeCompleted {
     #[label]
     outcome: PhoneHomeOutcome,
-    /// The failure's error chain; empty on success.
     #[context]
     error: String,
-}
-
-impl DynamicLog for PhoneHomeCompleted {
-    fn log_at(&self) -> LogAt {
-        match self.outcome {
-            PhoneHomeOutcome::Ok => LogAt::Off,
-            PhoneHomeOutcome::RateLimited
-            | PhoneHomeOutcome::InstanceNotFound
-            | PhoneHomeOutcome::Error => LogAt::Level(tracing::Level::WARN),
-        }
-    }
 }
 
 /// A phone-home failure tagged with the bounded outcome for the metric label,
@@ -96,16 +107,38 @@ impl From<tonic::Status> for PhoneHomeError {
 }
 
 pub async fn phone_home(state: &Arc<FmdsState>) -> Result<(), eyre::Error> {
-    let result = attempt_phone_home(state).await;
-    let (outcome, error) = match &result {
-        Ok(()) => (PhoneHomeOutcome::Ok, String::new()),
-        Err(err) => (err.outcome, format!("{:#}", err.source)),
-    };
-    emit(PhoneHomeCompleted { outcome, error });
-    result.map_err(|err| err.source)
+    complete_phone_home(attempt_phone_home(state).await)
 }
 
-async fn attempt_phone_home(state: &Arc<FmdsState>) -> Result<(), PhoneHomeError> {
+struct PhoneHomeSuccess {
+    machine_id: String,
+    timestamp: String,
+}
+
+fn complete_phone_home(
+    result: Result<PhoneHomeSuccess, PhoneHomeError>,
+) -> Result<(), eyre::Error> {
+    match result {
+        Ok(success) => {
+            emit(PhoneHomeSucceeded {
+                outcome: PhoneHomeOutcome::Ok,
+                machine_id: success.machine_id,
+                timestamp: success.timestamp,
+            });
+            Ok(())
+        }
+        Err(failure) => {
+            let PhoneHomeError { outcome, source } = failure;
+            emit(PhoneHomeCompleted {
+                outcome,
+                error: format!("{source:#}"),
+            });
+            Err(source)
+        }
+    }
+}
+
+async fn attempt_phone_home(state: &Arc<FmdsState>) -> Result<PhoneHomeSuccess, PhoneHomeError> {
     state
         .outbound_governor
         .clone()
@@ -152,11 +185,229 @@ async fn attempt_phone_home(state: &Arc<FmdsState>) -> Result<(), PhoneHomeError
         .timestamp
         .ok_or_else(|| eyre!("timestamp is empty in response"))?;
 
-    tracing::info!(
-        %machine_id,
-        %timestamp,
-        "Successfully phoned home",
-    );
+    Ok(PhoneHomeSuccess {
+        machine_id: machine_id.to_string(),
+        timestamp: timestamp.to_string(),
+    })
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const PHONE_HOME_METRIC: &str = "carbide_fmds_phone_home_total";
+    const MACHINE_ID: &str = "fm100ht6n80e7do39u8gmt7cvhm89pb32st9ngevgdolu542l1nfa4an0rg";
+    const TIMESTAMP: &str = "2026-07-21T18:42:00Z";
+
+    enum CompletionCase {
+        Success,
+        Failure {
+            outcome: PhoneHomeOutcome,
+            error: &'static str,
+        },
+    }
+
+    impl CompletionCase {
+        fn metric_label(&self) -> &'static str {
+            match self {
+                Self::Success => "ok",
+                Self::Failure { outcome, .. } => match outcome {
+                    PhoneHomeOutcome::Ok => "ok",
+                    PhoneHomeOutcome::RateLimited => "rate_limited",
+                    PhoneHomeOutcome::InstanceNotFound => "instance_not_found",
+                    PhoneHomeOutcome::Error => "error",
+                },
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct CompletionObservation {
+        returned_error: Option<String>,
+        metric_delta: f64,
+        logs: Vec<LogObservation>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct LogObservation {
+        metadata_name: String,
+        level: tracing::Level,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        outcome: Option<String>,
+        machine_id: Option<String>,
+        machine_id_kind: Option<CapturedFieldKind>,
+        timestamp: Option<String>,
+        timestamp_kind: Option<CapturedFieldKind>,
+        error: Option<String>,
+        error_kind: Option<CapturedFieldKind>,
+    }
+
+    fn expected_log(
+        metadata_name: &str,
+        level: tracing::Level,
+        message: &str,
+        outcome: &str,
+        machine_id: Option<&str>,
+        timestamp: Option<&str>,
+        error: Option<&str>,
+    ) -> Vec<LogObservation> {
+        vec![LogObservation {
+            metadata_name: metadata_name.to_string(),
+            level,
+            message: message.to_string(),
+            event_name: Some(metadata_name.to_string()),
+            metric_name: Some(PHONE_HOME_METRIC.to_string()),
+            outcome: Some(outcome.to_string()),
+            machine_id: machine_id.map(str::to_string),
+            machine_id_kind: machine_id.map(|_| CapturedFieldKind::Debug),
+            timestamp: timestamp.map(str::to_string),
+            timestamp_kind: timestamp.map(|_| CapturedFieldKind::Debug),
+            error: error.map(str::to_string),
+            error_kind: error.map(|_| CapturedFieldKind::Debug),
+        }]
+    }
+
+    fn observe_completion(case: CompletionCase) -> CompletionObservation {
+        let outcome = case.metric_label();
+        let result = match case {
+            CompletionCase::Success => Ok(PhoneHomeSuccess {
+                machine_id: MACHINE_ID.to_string(),
+                timestamp: TIMESTAMP.to_string(),
+            }),
+            CompletionCase::Failure { outcome, error } => Err(PhoneHomeError {
+                outcome,
+                source: eyre!("{error}"),
+            }),
+        };
+
+        let metrics = MetricsCapture::start();
+        let mut completion = None;
+        let logs = capture_logs(|| {
+            completion = Some(complete_phone_home(result));
+        })
+        .into_iter()
+        .map(|log| {
+            let event_name = log.field("event_name").map(str::to_string);
+            let metric_name = log.field("metric_name").map(str::to_string);
+            let outcome = log.field("outcome").map(str::to_string);
+            let machine_id = log.field("machine_id").map(str::to_string);
+            let machine_id_kind = log.field_kind("machine_id");
+            let timestamp = log.field("timestamp").map(str::to_string);
+            let timestamp_kind = log.field_kind("timestamp");
+            let error = log.field("error").map(str::to_string);
+            let error_kind = log.field_kind("error");
+            LogObservation {
+                metadata_name: log.metadata_name,
+                level: log.level,
+                message: log.message,
+                event_name,
+                metric_name,
+                outcome,
+                machine_id,
+                machine_id_kind,
+                timestamp,
+                timestamp_kind,
+                error,
+                error_kind,
+            }
+        })
+        .collect();
+
+        CompletionObservation {
+            returned_error: completion.unwrap().err().map(|error| error.to_string()),
+            metric_delta: metrics.counter_delta(PHONE_HOME_METRIC, &[("outcome", outcome)]),
+            logs,
+        }
+    }
+
+    #[test]
+    fn terminal_events_log_and_count_each_phone_home_result() {
+        check_values(
+            [
+                Check {
+                    scenario: "success keeps its machine and timestamp fields",
+                    input: CompletionCase::Success,
+                    expect: CompletionObservation {
+                        returned_error: None,
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "fmds_phone_home_succeeded",
+                            tracing::Level::INFO,
+                            "Successfully phoned home",
+                            "ok",
+                            Some(MACHINE_ID),
+                            Some(TIMESTAMP),
+                            None,
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "rate limiting keeps its warning and error field",
+                    input: CompletionCase::Failure {
+                        outcome: PhoneHomeOutcome::RateLimited,
+                        error: "rate limit exceeded",
+                    },
+                    expect: CompletionObservation {
+                        returned_error: Some("rate limit exceeded".to_string()),
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "fmds_phone_home_completed",
+                            tracing::Level::WARN,
+                            "Phone home failed",
+                            "rate_limited",
+                            None,
+                            None,
+                            Some("rate limit exceeded"),
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "a missing instance keeps its bounded metric label",
+                    input: CompletionCase::Failure {
+                        outcome: PhoneHomeOutcome::InstanceNotFound,
+                        error: "instance not found",
+                    },
+                    expect: CompletionObservation {
+                        returned_error: Some("instance not found".to_string()),
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "fmds_phone_home_completed",
+                            tracing::Level::WARN,
+                            "Phone home failed",
+                            "instance_not_found",
+                            None,
+                            None,
+                            Some("instance not found"),
+                        ),
+                    },
+                },
+                Check {
+                    scenario: "other failures use the generic error label",
+                    input: CompletionCase::Failure {
+                        outcome: PhoneHomeOutcome::Error,
+                        error: "forge unavailable",
+                    },
+                    expect: CompletionObservation {
+                        returned_error: Some("forge unavailable".to_string()),
+                        metric_delta: 1.0,
+                        logs: expected_log(
+                            "fmds_phone_home_completed",
+                            tracing::Level::WARN,
+                            "Phone home failed",
+                            "error",
+                            None,
+                            None,
+                            Some("forge unavailable"),
+                        ),
+                    },
+                },
+            ],
+            observe_completion,
+        );
+    }
 }


### PR DESCRIPTION
FMDS phone-home and config-ingestion handlers already counted every completed operation, then wrote their terminal logs separately. This gives successful and failed paths their own Events while keeping the existing metric names, descriptions, labels, log levels, messages, and fields. The public handlers emit once after their inner operation returns the context needed by the matching log.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3822

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo test --locked -p carbide-fmds`

`cargo make format-nightly`

`cargo make clippy`

`cargo make carbide-lints`

`cargo make check-event-names`

`cargo make check-metric-docs`

## Additional Notes

The existing failure Event identities remain unchanged. Successful paths use sibling Events because the success and failure logs expose different context fields.


Closes #3822
