### PR TITLE
fix(simple-sdk): deletion of the instance with SSH key does not delete SSH key group

### DIFF
--- a/rest-api/sdk/simple/instance.go
+++ b/rest-api/sdk/simple/instance.go
@@ -322,6 +322,9 @@ func (im InstanceManager) Delete(ctx context.Context, id string) *ApiError {
 				sshKeyGroupIDsToDelete = filterOutIDs(sshKeyGroupIDsToDelete, sharedIDs)
 			}
 		}
+	} else {
+		logger.Warn().Str("instanceId", id).Err(getErr).
+			Msg("failed to get Instance; skipping SSH Key Group cleanup")
 	}
 
 	_, resp, err := im.client.apiClient.InstanceAPI.DeleteInstance(ctx, im.client.apiMetadata.Organization, id).Execute()

--- a/rest-api/sdk/simple/instance.go
+++ b/rest-api/sdk/simple/instance.go
@@ -299,11 +299,145 @@ func (im InstanceManager) Update(ctx context.Context, id string, request Instanc
 	return apiInst, nil
 }
 
-// Delete deletes an Instance
+// Delete deletes an Instance.
+//
+// When the Instance was created with SSHKeys, Create auto-creates an SSH Key
+// Group named via GetInstanceSshKeyGroupName. Delete removes that group after
+// the Instance is deleted, unless another Instance still references it.
 func (im InstanceManager) Delete(ctx context.Context, id string) *ApiError {
 	ctx = WithLogger(ctx, im.client.Logger)
 	ctx = context.WithValue(ctx, standard.ContextAccessToken, im.client.Config.Token)
+	logger := LoggerFromContext(ctx)
+
+	var sshKeyGroupIDsToDelete []string
+	if instance, getErr := im.Get(ctx, id); getErr == nil {
+		sshKeyGroupIDsToDelete = collectAutoCreatedSSHKeyGroupIDs(instance)
+		if len(sshKeyGroupIDsToDelete) > 0 {
+			sharedIDs, checkErr := im.sshKeyGroupIDsUsedByOtherInstances(ctx, id, sshKeyGroupIDsToDelete)
+			if checkErr != nil {
+				logger.Warn().Str("instanceId", id).Err(checkErr).
+					Msg("failed to check SSH Key Group associations; skipping SSH Key Group cleanup")
+				sshKeyGroupIDsToDelete = nil
+			} else {
+				sshKeyGroupIDsToDelete = filterOutIDs(sshKeyGroupIDsToDelete, sharedIDs)
+			}
+		}
+	}
 
 	_, resp, err := im.client.apiClient.InstanceAPI.DeleteInstance(ctx, im.client.apiMetadata.Organization, id).Execute()
-	return HandleResponseError(resp, err)
+	if apiErr := HandleResponseError(resp, err); apiErr != nil {
+		return apiErr
+	}
+
+	skm := NewSshKeyGroupManager(im.client)
+	for _, skgID := range sshKeyGroupIDsToDelete {
+		if delErr := skm.DeleteSshKeyGroup(ctx, skgID); delErr != nil {
+			logger.Warn().Str("instanceId", id).Str("sshKeyGroupId", skgID).Err(delErr).
+				Msg("failed to delete auto-created SSH Key Group after Instance deletion")
+		}
+	}
+	return nil
+}
+
+// collectAutoCreatedSSHKeyGroupIDs returns IDs of SSH Key Groups on the Instance
+// that match the naming convention used by CreateSshKeyGroupForInstance.
+func collectAutoCreatedSSHKeyGroupIDs(instance *standard.Instance) []string {
+	if instance == nil {
+		return nil
+	}
+	expectedName := GetInstanceSshKeyGroupName(instance.GetName())
+	var ids []string
+	seen := map[string]struct{}{}
+	for _, skg := range instance.GetSshKeyGroups() {
+		id := skg.GetId()
+		if id == "" || skg.GetName() != expectedName {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// filterOutIDs returns ids with every entry present in exclude removed.
+func filterOutIDs(ids []string, exclude map[string]struct{}) []string {
+	if len(ids) == 0 || len(exclude) == 0 {
+		return ids
+	}
+	filtered := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, skip := exclude[id]; skip {
+			continue
+		}
+		filtered = append(filtered, id)
+	}
+	return filtered
+}
+
+// sshKeyGroupIDsUsedByOtherInstances returns the subset of candidateIDs that are
+// associated with at least one Instance other than excludeInstanceID on the
+// client's Site. Listing is site-scoped (not VPC-scoped) so cross-VPC sharing
+// is detected.
+func (im InstanceManager) sshKeyGroupIDsUsedByOtherInstances(ctx context.Context, excludeInstanceID string, candidateIDs []string) (map[string]struct{}, *ApiError) {
+	shared := map[string]struct{}{}
+	if len(candidateIDs) == 0 {
+		return shared, nil
+	}
+	candidates := make(map[string]struct{}, len(candidateIDs))
+	for _, id := range candidateIDs {
+		candidates[id] = struct{}{}
+	}
+
+	pageNumber := int32(1)
+	pageSize := int32(100)
+	for {
+		instances, resp, err := im.client.apiClient.InstanceAPI.GetAllInstance(ctx, im.client.apiMetadata.Organization).
+			SiteId(im.client.apiMetadata.SiteID).
+			PageNumber(pageNumber).
+			PageSize(pageSize).
+			Execute()
+		if apiErr := HandleResponseError(resp, err); apiErr != nil {
+			return nil, apiErr
+		}
+
+		for _, inst := range instances {
+			if inst.GetId() == excludeInstanceID {
+				continue
+			}
+			for _, skgID := range inst.GetSshKeyGroupIds() {
+				if _, ok := candidates[skgID]; ok {
+					shared[skgID] = struct{}{}
+				}
+			}
+			for _, skg := range inst.GetSshKeyGroups() {
+				if skgID := skg.GetId(); skgID != "" {
+					if _, ok := candidates[skgID]; ok {
+						shared[skgID] = struct{}{}
+					}
+				}
+			}
+		}
+
+		// All candidates are shared; no need to keep paging.
+		if len(shared) == len(candidates) {
+			return shared, nil
+		}
+
+		pagination, perr := standard.GetPaginationResponse(ctx, resp)
+		if perr != nil {
+			return nil, &ApiError{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to extract pagination: " + perr.Error(),
+				Data:    map[string]interface{}{"parseError": perr.Error()},
+			}
+		}
+		if len(instances) == 0 || int(pageNumber)*pagination.PageSize >= pagination.Total {
+			break
+		}
+		pageNumber++
+	}
+	return shared, nil
 }

--- a/rest-api/sdk/simple/instance_test.go
+++ b/rest-api/sdk/simple/instance_test.go
@@ -4,10 +4,17 @@
 package simple
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/sdk/standard"
 )
 
 // TestToStandardInstanceUpdateRequest verifies that nil slice/map fields in an
@@ -135,4 +142,168 @@ func TestToStandardInstanceUpdateRequest(t *testing.T) {
 		assert.Contains(t, body, "dpuExtensionServiceDeployments")
 		assert.Contains(t, body, "labels")
 	})
+}
+
+func TestCollectAutoCreatedSSHKeyGroupIDs(t *testing.T) {
+	t.Run("returns only groups matching instance naming convention", func(t *testing.T) {
+		instance := standard.NewInstance()
+		instance.SetName("web")
+		auto := standard.NewSshKeyGroup()
+		auto.SetId("skg-auto")
+		auto.SetName(GetInstanceSshKeyGroupName("web"))
+		manual := standard.NewSshKeyGroup()
+		manual.SetId("skg-manual")
+		manual.SetName("shared-ops-keys")
+		instance.SetSshKeyGroups([]standard.SshKeyGroup{*auto, *manual})
+
+		assert.Equal(t, []string{"skg-auto"}, collectAutoCreatedSSHKeyGroupIDs(instance))
+	})
+
+	t.Run("returns nil when instance has no matching groups", func(t *testing.T) {
+		instance := standard.NewInstance()
+		instance.SetName("web")
+		manual := standard.NewSshKeyGroup()
+		manual.SetId("skg-manual")
+		manual.SetName("shared-ops-keys")
+		instance.SetSshKeyGroups([]standard.SshKeyGroup{*manual})
+
+		assert.Nil(t, collectAutoCreatedSSHKeyGroupIDs(instance))
+	})
+
+	t.Run("returns nil for nil instance", func(t *testing.T) {
+		assert.Nil(t, collectAutoCreatedSSHKeyGroupIDs(nil))
+	})
+}
+
+func TestFilterOutIDs(t *testing.T) {
+	exclude := map[string]struct{}{"b": {}}
+	assert.Equal(t, []string{"a", "c"}, filterOutIDs([]string{"a", "b", "c"}, exclude))
+	assert.Equal(t, []string{"a"}, filterOutIDs([]string{"a"}, nil))
+	assert.Nil(t, filterOutIDs(nil, exclude))
+}
+
+func TestInstanceManagerDeleteCleansUpAutoCreatedSSHKeyGroup(t *testing.T) {
+	deletedSSHKeyGroups := []string{}
+	listedInstances := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			_, _ = io.WriteString(w, `{
+				"id":"inst-1",
+				"name":"web",
+				"sshKeyGroupIds":["skg-auto","skg-manual"],
+				"sshKeyGroups":[
+					{"id":"skg-auto","name":"web-ssh-key-group"},
+					{"id":"skg-manual","name":"shared-ops-keys"}
+				]
+			}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/org/test-org/nico/instance":
+			listedInstances = true
+			w.Header().Set("x-pagination", `{"pageNumber":1,"pageSize":100,"total":1}`)
+			_, _ = io.WriteString(w, `[{
+				"id":"inst-1",
+				"name":"web",
+				"sshKeyGroupIds":["skg-auto","skg-manual"],
+				"sshKeyGroups":[
+					{"id":"skg-auto","name":"web-ssh-key-group"},
+					{"id":"skg-manual","name":"shared-ops-keys"}
+				]
+			}]`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"message":"accepted"}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/org/test-org/nico/sshkeygroup/skg-auto":
+			deletedSSHKeyGroups = append(deletedSSHKeyGroups, "skg-auto")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"message":"accepted"}`)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/v2/org/test-org/nico/sshkeygroup/"):
+			t.Errorf("unexpected SSH Key Group delete: %s", r.URL.Path)
+			http.NotFound(w, r)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newSimpleTestClient(server.URL)
+	apiErr := NewInstanceManager(client).Delete(context.Background(), "inst-1")
+	require.Nil(t, apiErr)
+	assert.True(t, listedInstances, "expected a site-scoped instance list to check shared SSH Key Groups")
+	assert.Equal(t, []string{"skg-auto"}, deletedSSHKeyGroups)
+}
+
+func TestInstanceManagerDeleteSkipsSharedAutoCreatedSSHKeyGroup(t *testing.T) {
+	deletedSSHKeyGroups := []string{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			_, _ = io.WriteString(w, `{
+				"id":"inst-1",
+				"name":"web",
+				"sshKeyGroupIds":["skg-auto"],
+				"sshKeyGroups":[{"id":"skg-auto","name":"web-ssh-key-group"}]
+			}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/org/test-org/nico/instance":
+			w.Header().Set("x-pagination", `{"pageNumber":1,"pageSize":100,"total":2}`)
+			_, _ = io.WriteString(w, `[
+				{
+					"id":"inst-1",
+					"name":"web",
+					"sshKeyGroupIds":["skg-auto"],
+					"sshKeyGroups":[{"id":"skg-auto","name":"web-ssh-key-group"}]
+				},
+				{
+					"id":"inst-2",
+					"name":"db",
+					"sshKeyGroupIds":["skg-auto"],
+					"sshKeyGroups":[{"id":"skg-auto","name":"web-ssh-key-group"}]
+				}
+			]`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"message":"accepted"}`)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/v2/org/test-org/nico/sshkeygroup/"):
+			deletedSSHKeyGroups = append(deletedSSHKeyGroups, strings.TrimPrefix(r.URL.Path, "/v2/org/test-org/nico/sshkeygroup/"))
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"message":"accepted"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newSimpleTestClient(server.URL)
+	apiErr := NewInstanceManager(client).Delete(context.Background(), "inst-1")
+	require.Nil(t, apiErr)
+	assert.Empty(t, deletedSSHKeyGroups, "shared auto-created SSH Key Group must not be deleted")
+}
+
+func newSimpleTestClient(baseURL string) *Client {
+	apiConfig := standard.NewConfiguration()
+	apiConfig.Servers = standard.ServerConfigurations{
+		{URL: baseURL, Description: "test"},
+	}
+	apiConfig.SetAPIName("nico")
+	return &Client{
+		Config: ClientConfig{
+			BaseURL: baseURL,
+			Org:     "test-org",
+			APIName: "nico",
+			Token:   "test-token",
+			Logger:  NewNoOpLogger(),
+		},
+		apiClient: standard.NewAPIClient(apiConfig),
+		apiMetadata: ApiMetadata{
+			Organization: "test-org",
+			SiteID:       "site-1",
+			TenantID:     "tenant-1",
+		},
+		Logger: NewNoOpLogger(),
+	}
 }

--- a/rest-api/sdk/simple/instance_test.go
+++ b/rest-api/sdk/simple/instance_test.go
@@ -6,6 +6,7 @@ package simple
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -187,6 +188,7 @@ func TestFilterOutIDs(t *testing.T) {
 func TestInstanceManagerDeleteCleansUpAutoCreatedSSHKeyGroup(t *testing.T) {
 	deletedSSHKeyGroups := []string{}
 	listedInstances := false
+	requestOrder := []string{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -214,12 +216,14 @@ func TestInstanceManagerDeleteCleansUpAutoCreatedSSHKeyGroup(t *testing.T) {
 				]
 			}]`)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			requestOrder = append(requestOrder, "instance")
 			w.WriteHeader(http.StatusAccepted)
 			_, _ = io.WriteString(w, `{"message":"accepted"}`)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v2/org/test-org/nico/sshkeygroup/skg-auto":
 			deletedSSHKeyGroups = append(deletedSSHKeyGroups, "skg-auto")
-			w.WriteHeader(http.StatusAccepted)
-			_, _ = io.WriteString(w, `{"message":"accepted"}`)
+			requestOrder = append(requestOrder, "skg-auto")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"message":"cleanup failed"}`)
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/v2/org/test-org/nico/sshkeygroup/"):
 			t.Errorf("unexpected SSH Key Group delete: %s", r.URL.Path)
 			http.NotFound(w, r)
@@ -230,11 +234,17 @@ func TestInstanceManagerDeleteCleansUpAutoCreatedSSHKeyGroup(t *testing.T) {
 	}))
 	defer server.Close()
 
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
 	client := newSimpleTestClient(server.URL)
+	client.Logger = &logger
 	apiErr := NewInstanceManager(client).Delete(context.Background(), "inst-1")
 	require.Nil(t, apiErr)
 	assert.True(t, listedInstances, "expected a site-scoped instance list to check shared SSH Key Groups")
 	assert.Equal(t, []string{"skg-auto"}, deletedSSHKeyGroups)
+	assert.Equal(t, []string{"instance", "skg-auto"}, requestOrder)
+	assert.Contains(t, logs.String(), `"level":"warn"`)
+	assert.Contains(t, logs.String(), `"sshKeyGroupId":"skg-auto"`)
 }
 
 func TestInstanceManagerDeleteSkipsSharedAutoCreatedSSHKeyGroup(t *testing.T) {
@@ -309,10 +319,14 @@ func TestInstanceManagerDeleteWarnsWhenInstanceLookupFails(t *testing.T) {
 
 	apiErr := NewInstanceManager(client).Delete(context.Background(), "inst-1")
 	require.Nil(t, apiErr)
-	assert.Contains(t, logs.String(), `"level":"warn"`)
-	assert.Contains(t, logs.String(), `"instanceId":"inst-1"`)
-	assert.Contains(t, logs.String(), `"error":`)
-	assert.Contains(t, logs.String(), `"message":"failed to get Instance; skipping SSH Key Group cleanup"`)
+
+	var logEntry map[string]interface{}
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &logEntry))
+	assert.Equal(t, "warn", logEntry["level"])
+	assert.Equal(t, "inst-1", logEntry["instanceId"])
+	assert.Contains(t, logEntry["error"], "Code: 500")
+	assert.Contains(t, logEntry["error"], "lookup failed")
+	assert.Equal(t, "failed to get Instance; skipping SSH Key Group cleanup", logEntry["message"])
 }
 
 func newSimpleTestClient(baseURL string) *Client {

--- a/rest-api/sdk/simple/instance_test.go
+++ b/rest-api/sdk/simple/instance_test.go
@@ -4,6 +4,7 @@
 package simple
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -282,6 +284,35 @@ func TestInstanceManagerDeleteSkipsSharedAutoCreatedSSHKeyGroup(t *testing.T) {
 	apiErr := NewInstanceManager(client).Delete(context.Background(), "inst-1")
 	require.Nil(t, apiErr)
 	assert.Empty(t, deletedSSHKeyGroups, "shared auto-created SSH Key Group must not be deleted")
+}
+
+func TestInstanceManagerDeleteWarnsWhenInstanceLookupFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			http.Error(w, `{"message":"lookup failed"}`, http.StatusInternalServerError)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v2/org/test-org/nico/instance/inst-1":
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"message":"accepted"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	client := newSimpleTestClient(server.URL)
+	client.Logger = &logger
+
+	apiErr := NewInstanceManager(client).Delete(context.Background(), "inst-1")
+	require.Nil(t, apiErr)
+	assert.Contains(t, logs.String(), `"level":"warn"`)
+	assert.Contains(t, logs.String(), `"instanceId":"inst-1"`)
+	assert.Contains(t, logs.String(), `"error":`)
+	assert.Contains(t, logs.String(), `"message":"failed to get Instance; skipping SSH Key Group cleanup"`)
 }
 
 func newSimpleTestClient(baseURL string) *Client {


### PR DESCRIPTION
Create with SSHKeys auto-creates a group named {instance}-ssh-key-group, but Delete only removed the instance.
Backend instance delete drops associations only (correct for manually managed groups).
This PR makes a best effort at identifying auto-created groups and deleting them if they are not shared.

Fix in rest-api/sdk/simple/instance.go:
- Load the instance before delete
- Identify auto-created groups (naming convention)
- Skip any still attached to another instance on the site
- Delete the instance, then delete unshared auto-created groups (best-effort; failures are logged)

Validated with go test ./sdk/simple/.

## Type of Change
- [X] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated

## Related issue:
https://github.com/NVIDIA/infra-controller/issues/3849