### PR TITLE
refactor(ib-fabric): pair UFM changes with their logs

### DIFF
--- a/crates/api-core/src/tests/ib_instance.rs
+++ b/crates/api-core/src/tests/ib_instance.rs
@@ -19,6 +19,7 @@ use std::collections::{HashMap, HashSet};
 
 use carbide_ib_fabric::config::IBFabricConfig;
 use carbide_ib_fabric::ib::{Filter, IBFabric, IBFabricManager};
+use carbide_instrument::testing::MetricsCapture;
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::machine::MachineId;
 use common::api_fixtures::ib_partition::{DEFAULT_TENANT, create_ib_partition};
@@ -48,6 +49,24 @@ async fn get_partition_status(api: &Api, ib_partition_id: IBPartitionId) -> IbPa
         .remove(0);
 
     segment.status.unwrap()
+}
+
+fn assert_successful_ufm_changes(metrics: &MetricsCapture, operation: &str, minimum: f64) {
+    let observed = metrics.counter_delta(
+        "carbide_ib_monitor_ufm_changes_applied_total",
+        &[
+            ("fabric", "default"),
+            ("operation", operation),
+            ("status", "ok"),
+        ],
+    );
+    // Event metrics share one process-global test meter. Focused Event tests
+    // pin exact counts; these checks only need to prove the instance lifecycle
+    // reached the expected UFM operation.
+    assert!(
+        observed >= minimum,
+        "expected at least {minimum} successful {operation} changes, observed {observed}"
+    );
 }
 
 #[crate::sqlx_test]
@@ -160,8 +179,11 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
     let guid_cx7 = machine_guids.get("MT2910 Family [ConnectX-7]").unwrap()[1].clone();
     let guid_cx5 = machine_guids.get("MT27800 Family [ConnectX-5]").unwrap()[0].clone();
 
+    let creation_metrics = MetricsCapture::start();
     let (tinstance, instance) =
         create_instance_with_ib_config(&env, &mh, ib_config.clone(), segment_id).await;
+    assert_successful_ufm_changes(&creation_metrics, "bind_guid_to_pkey", 2.0);
+    drop(creation_metrics);
 
     let machine = mh.host().rpc_machine().await;
     assert_eq!(&machine.state, "Assigned/Ready");
@@ -183,31 +205,6 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
             .unwrap(),
         "0"
     );
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "2".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "0".to_string()
-            )
-        ]
-    );
-
     let check_instance = tinstance.rpc_instance().await;
     assert_eq!(instance.machine_id(), mh.id);
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
@@ -260,34 +257,13 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
         "The expected amount of ports for pkey {hex_pkey} has not been registered"
     );
 
+    let deletion_metrics = MetricsCapture::start();
     tinstance.delete().await;
+    assert_successful_ufm_changes(&deletion_metrics, "unbind_guid_from_pkey", 2.0);
+    drop(deletion_metrics);
 
     // Check whether the IB ports are still bound to the partition
     verify_pkey_guids(ib_conn.clone(), &[(pkey_u16, vec![])]).await;
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "2".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "2".to_string()
-            )
-        ]
-    );
 }
 
 #[crate::sqlx_test]
@@ -765,8 +741,11 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
     let guid_cx7_2 = machine_guids.get("MT2910 Family [ConnectX-7]").unwrap()[1].clone();
     let guid_cx5_1 = machine_guids.get("MT27800 Family [ConnectX-5]").unwrap()[0].clone();
 
+    let creation_metrics = MetricsCapture::start();
     let (tinstance, instance) =
         create_instance_with_ib_config(&env, &mh, ib_config.clone(), segment_id).await;
+    assert_successful_ufm_changes(&creation_metrics, "bind_guid_to_pkey", 2.0);
+    drop(creation_metrics);
 
     let machine = mh.host().rpc_machine().await;
     assert_eq!(&machine.state, "Assigned/Ready");
@@ -788,31 +767,6 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
             .unwrap(),
         "0"
     );
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "2".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "0".to_string()
-            )
-        ]
-    );
-
     let check_instance = tinstance.rpc_instance().await;
     assert_eq!(instance.machine_id(), mh.id);
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
@@ -933,7 +887,11 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
     mh.network_configured(&env).await;
 
     // First IB partition fabric monitor iteration detects the desync and fixes it
+    let update_metrics = MetricsCapture::start();
     env.run_ib_fabric_monitor_iteration().await;
+    assert_successful_ufm_changes(&update_metrics, "bind_guid_to_pkey", 1.0);
+    assert_successful_ufm_changes(&update_metrics, "unbind_guid_from_pkey", 1.0);
+    drop(update_metrics);
     assert_eq!(
         env.test_meter
             .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
@@ -951,30 +909,6 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
             .formatted_metric("carbide_ib_monitor_machines_with_unexpected_pkeys_count")
             .unwrap(),
         "1"
-    );
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "3".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "1".to_string()
-            )
-        ]
     );
     verify_pkey_guids(
         ib_conn.clone(),
@@ -1005,31 +939,6 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
             .unwrap(),
         "0"
     );
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "3".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "1".to_string()
-            )
-        ]
-    );
-
     // Instance shows ready state again
     let instance = tinstance.rpc_instance().await;
     let instance_status = instance.status();
@@ -1069,7 +978,10 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
         panic!("ib configuration is incorrect.");
     }
 
+    let deletion_metrics = MetricsCapture::start();
     tinstance.delete().await;
+    assert_successful_ufm_changes(&deletion_metrics, "unbind_guid_from_pkey", 2.0);
+    drop(deletion_metrics);
 
     // Check whether all partition bindings have been removed
     verify_pkey_guids(
@@ -1080,30 +992,6 @@ async fn test_update_instance_ib_config(pool: sqlx::PgPool) {
         ],
     )
     .await;
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "3".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "3".to_string()
-            )
-        ]
-    );
 }
 
 /// Tries to create an Instance using the Forge API

--- a/crates/api-core/src/tests/ib_machine.rs
+++ b/crates/api-core/src/tests/ib_machine.rs
@@ -19,6 +19,7 @@ use std::collections::{HashMap, HashSet};
 
 use carbide_ib_fabric::config::IBFabricConfig;
 use carbide_ib_fabric::ib::{GetPartitionOptions, IBFabric, IBMtu, IBRateLimit, IBServiceLevel};
+use carbide_instrument::testing::MetricsCapture;
 use carbide_uuid::machine::MachineId;
 use common::api_fixtures::create_managed_host;
 use model::ib::{DEFAULT_IB_FABRIC_NAME, IBNetwork, IBQosConf};
@@ -243,7 +244,24 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
         Some(HashSet::from_iter([guid2.clone()]))
     );
 
+    let ufm_change_metrics = MetricsCapture::start();
     env.ib_fabric_monitor.run_single_iteration().await.unwrap();
+    let successful_unbinds = ufm_change_metrics.counter_delta(
+        "carbide_ib_monitor_ufm_changes_applied_total",
+        &[
+            ("fabric", "default"),
+            ("operation", "unbind_guid_from_pkey"),
+            ("status", "ok"),
+        ],
+    );
+    // Other API tests can drive the same process-global Event concurrently.
+    // The Event-level test pins exact counts; this check proves the monitor's
+    // reconciliation path reaches the UFM change Event.
+    assert!(
+        successful_unbinds >= 3.0,
+        "expected three successful UFM unbinds, observed {successful_unbinds}"
+    );
+    drop(ufm_change_metrics);
     assert_eq!(
         env.test_meter
             .formatted_metric("carbide_ib_monitor_machine_ib_status_updates_count")
@@ -290,32 +308,6 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
             .unwrap(),
         "1"
     );
-    // Automatic reconcilation unassigns the unexpected pkey
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "3".to_string()
-            )
-        ]
-    );
-
     active_lids.clear();
     for host_machine_id in host_machines.iter().copied() {
         println!("Testing host machine {host_machine_id}");
@@ -469,30 +461,5 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
             .formatted_metric("carbide_ib_monitor_machines_with_unknown_pkeys_count")
             .unwrap(),
         "0"
-    );
-    // No additional changes means the counter metric has the same values
-    assert_eq!(
-        env.test_meter
-            .parsed_metrics("carbide_ib_monitor_ufm_changes_applied_total"),
-        vec![
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"error\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"bind_guid_to_pkey\",status=\"ok\"}".to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"error\"}"
-                    .to_string(),
-                "0".to_string()
-            ),
-            (
-                "{fabric=\"default\",operation=\"unbind_guid_from_pkey\",status=\"ok\"}"
-                    .to_string(),
-                "3".to_string()
-            )
-        ]
     );
 }

--- a/crates/api-core/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
+++ b/crates/api-core/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
@@ -1,12 +1,6 @@
 # HELP carbide_available_ips_count Number of available IPs per network segment
 # TYPE carbide_available_ips_count gauge
 carbide_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="admin"} 253
-# HELP carbide_ib_monitor_ufm_changes_applied_total Number of changes performed at UFM
-# TYPE carbide_ib_monitor_ufm_changes_applied_total counter
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
 # HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
 # TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0

--- a/crates/api-core/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
+++ b/crates/api-core/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
@@ -1,9 +1,3 @@
-# HELP carbide_ib_monitor_ufm_changes_applied_total Number of changes performed at UFM
-# TYPE carbide_ib_monitor_ufm_changes_applied_total counter
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
 # HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
 # TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0

--- a/crates/api-core/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
+++ b/crates/api-core/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
@@ -1,12 +1,6 @@
 # HELP carbide_available_ips_count Number of available IPs per network segment
 # TYPE carbide_available_ips_count gauge
 carbide_available_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 253
-# HELP carbide_ib_monitor_ufm_changes_applied_total Number of changes performed at UFM
-# TYPE carbide_ib_monitor_ufm_changes_applied_total counter
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="error"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="bind_guid_to_pkey",status="ok"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="error"} 0
-carbide_ib_monitor_ufm_changes_applied_total{fabric="default",operation="unbind_guid_from_pkey",status="ok"} 0
 # HELP carbide_machines_enqueuer_iteration_latency_milliseconds The overall time it took to enqueue state handling tasks for all carbide_machines in the system
 # TYPE carbide_machines_enqueuer_iteration_latency_milliseconds histogram
 carbide_machines_enqueuer_iteration_latency_milliseconds_bucket{le="0"} 0

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -33,8 +33,8 @@ use db::work_lock_manager::WorkLockManagerHandle;
 use db::{self, DatabaseError};
 use health_report::HealthReportApplyMode;
 use metrics::{
-    AppliedChange, FabricMetrics, IbFabricMonitorMetrics, IbMonitorIterationFinished, UfmOperation,
-    UfmOperationStatus,
+    FabricMetrics, IbFabricMonitorMetrics, IbMonitorIterationFinished, UfmGuidPkeyChangeFinished,
+    UfmOperation,
 };
 use model::ib::{IBNetwork, IBPort, IBPortMembership, IBPortState};
 use model::ib_partition::{IBPartition, IbPartitionSearchFilter, PartitionKey};
@@ -336,7 +336,6 @@ impl IbFabricMonitor {
             &tenant_partitions,
             &partition_ids_by_pkey,
             reports,
-            metrics,
         )
         .await?;
 
@@ -659,9 +658,9 @@ async fn client_for_fabric(
 }
 
 /// Applies the GUID<->pkey binding changes that the per-machine status
-/// evaluations found to be required, and records the outcome of every
-/// operation in `metrics`. Each fabric is served by a single client from
-/// `fabric_clients` for the whole batch.
+/// evaluations found to be required. Each fabric is served by a single client
+/// from `fabric_clients` for the whole batch, and every UFM call emits its
+/// counter-backed Event at the call boundary.
 ///
 /// Returns the number of successfully applied changes.
 async fn apply_guid_pkey_changes(
@@ -671,7 +670,6 @@ async fn apply_guid_pkey_changes(
     tenant_partitions: &HashMap<IBPartitionId, IBPartition>,
     partition_ids_by_pkey: &HashMap<PartitionKey, IBPartitionId>,
     reports: Vec<MachineIbStatusEvaluation>,
-    metrics: &mut IbFabricMonitorMetrics,
 ) -> IbResult<usize> {
     let mut num_changes = 0;
 
@@ -687,28 +685,19 @@ async fn apply_guid_pkey_changes(
             };
 
             let conn = client_for_fabric(fabric_manager, fabric_clients, &fabric).await?;
-            let status = match conn
+            let result = conn
                 .bind_ib_ports(partition.into(), vec![guid.clone()])
-                .await
-            {
-                Ok(()) => {
-                    num_changes += 1;
-                    UfmOperationStatus::Ok
-                }
-                Err(e) => {
-                    tracing::error!(%guid, %pkey, %fabric, error = %e, "Failed to bind GUID to pkey");
-                    UfmOperationStatus::Error
-                }
-            };
-
-            *metrics
-                .applied_changes
-                .entry(AppliedChange {
-                    fabric,
-                    operation: UfmOperation::BindGuidToPkey,
-                    status,
-                })
-                .or_default() += 1;
+                .await;
+            UfmGuidPkeyChangeFinished::emit(
+                &fabric,
+                UfmOperation::BindGuidToPkey,
+                &guid,
+                pkey,
+                &result,
+            );
+            if result.is_ok() {
+                num_changes += 1;
+            }
         }
 
         for (fabric, guid, pkey) in report.unexpected_guid_pkeys {
@@ -732,25 +721,17 @@ async fn apply_guid_pkey_changes(
             }
 
             let conn = client_for_fabric(fabric_manager, fabric_clients, &fabric).await?;
-            let status = match conn.unbind_ib_ports(pkey.into(), vec![guid.clone()]).await {
-                Ok(()) => {
-                    num_changes += 1;
-                    UfmOperationStatus::Ok
-                }
-                Err(e) => {
-                    tracing::error!(%guid, %pkey, %fabric, error = %e, "Failed to unbind GUID from pkey");
-                    UfmOperationStatus::Error
-                }
-            };
-
-            *metrics
-                .applied_changes
-                .entry(AppliedChange {
-                    fabric,
-                    operation: UfmOperation::UnbindGuidFromPkey,
-                    status,
-                })
-                .or_default() += 1;
+            let result = conn.unbind_ib_ports(pkey.into(), vec![guid.clone()]).await;
+            UfmGuidPkeyChangeFinished::emit(
+                &fabric,
+                UfmOperation::UnbindGuidFromPkey,
+                &guid,
+                pkey,
+                &result,
+            );
+            if result.is_ok() {
+                num_changes += 1;
+            }
         }
     }
 
@@ -1746,21 +1727,26 @@ mod tests {
     // ============================================================
 
     mod client_reuse {
+        use carbide_instrument::testing::MetricsCapture;
+
         use super::*;
         use crate::ib::fakes::{CountingFabricManager, make_partition};
 
         /// One fabric's worth of pending changes: three binds + two unbinds
-        /// against pkey 0x101 on "fab1".
-        fn five_pending_changes(pkey: PartitionKey) -> Vec<MachineIbStatusEvaluation> {
+        /// against pkey 0x101 on `fabric`.
+        fn five_pending_changes(
+            fabric: &str,
+            pkey: PartitionKey,
+        ) -> Vec<MachineIbStatusEvaluation> {
             vec![MachineIbStatusEvaluation {
                 missing_guid_pkeys: vec![
-                    ("fab1".to_string(), "guid-1".to_string(), pkey),
-                    ("fab1".to_string(), "guid-2".to_string(), pkey),
-                    ("fab1".to_string(), "guid-3".to_string(), pkey),
+                    (fabric.to_string(), "guid-1".to_string(), pkey),
+                    (fabric.to_string(), "guid-2".to_string(), pkey),
+                    (fabric.to_string(), "guid-3".to_string(), pkey),
                 ],
                 unexpected_guid_pkeys: vec![
-                    ("fab1".to_string(), "guid-4".to_string(), pkey),
-                    ("fab1".to_string(), "guid-5".to_string(), pkey),
+                    (fabric.to_string(), "guid-4".to_string(), pkey),
+                    (fabric.to_string(), "guid-5".to_string(), pkey),
                 ],
                 unknown_guid_pkeys: vec![],
                 down_port_guids: vec![],
@@ -1774,6 +1760,8 @@ mod tests {
         /// (one per GUID change); now the whole batch shares one.
         #[tokio::test]
         async fn applying_guid_pkey_changes_builds_one_client_per_fabric() {
+            const FABRIC: &str = "batched-change-fabric";
+
             let manager = CountingFabricManager::new();
             let pkey = PartitionKey::try_from(0x101).expect("valid pkey");
             let partition = make_partition(Some(0x101), false);
@@ -1781,11 +1769,11 @@ mod tests {
             let tenant_partitions = HashMap::from([(partition_id, partition)]);
             let partition_ids_by_pkey = HashMap::from([(pkey, partition_id)]);
             let fabrics = HashMap::from([(
-                "fab1".to_string(),
+                FABRIC.to_string(),
                 make_fabric_definition(vec![("0x100", "0x8FF")]),
             )]);
             let mut fabric_clients = HashMap::new();
-            let mut metrics = IbFabricMonitorMetrics::new();
+            let event_metrics = MetricsCapture::start();
 
             let num_changes = apply_guid_pkey_changes(
                 &manager,
@@ -1793,28 +1781,33 @@ mod tests {
                 &fabrics,
                 &tenant_partitions,
                 &partition_ids_by_pkey,
-                five_pending_changes(pkey),
-                &mut metrics,
+                five_pending_changes(FABRIC, pkey),
             )
             .await
             .expect("applying changes against stub fabric");
 
             assert_eq!(num_changes, 5, "all five changes applied");
             assert_eq!(
-                metrics.applied_changes.get(&AppliedChange {
-                    fabric: "fab1".to_string(),
-                    operation: UfmOperation::BindGuidToPkey,
-                    status: UfmOperationStatus::Ok,
-                }),
-                Some(&3),
+                event_metrics.counter_delta(
+                    "carbide_ib_monitor_ufm_changes_applied_total",
+                    &[
+                        ("fabric", FABRIC),
+                        ("operation", "bind_guid_to_pkey"),
+                        ("status", "ok"),
+                    ],
+                ),
+                3.0,
             );
             assert_eq!(
-                metrics.applied_changes.get(&AppliedChange {
-                    fabric: "fab1".to_string(),
-                    operation: UfmOperation::UnbindGuidFromPkey,
-                    status: UfmOperationStatus::Ok,
-                }),
-                Some(&2),
+                event_metrics.counter_delta(
+                    "carbide_ib_monitor_ufm_changes_applied_total",
+                    &[
+                        ("fabric", FABRIC),
+                        ("operation", "unbind_guid_from_pkey"),
+                        ("status", "ok"),
+                    ],
+                ),
+                2.0,
             );
             assert_eq!(
                 manager.build_count(),
@@ -1828,6 +1821,8 @@ mod tests {
         /// one client.
         #[tokio::test]
         async fn monitor_iteration_builds_one_client_per_fabric() {
+            const FABRIC: &str = "reused-client-fabric";
+
             let manager = CountingFabricManager::new();
             let definition = make_fabric_definition(vec![("0x100", "0x8FF")]);
             let pkey = PartitionKey::try_from(0x101).expect("valid pkey");
@@ -1835,7 +1830,7 @@ mod tests {
             let partition_id = partition.id;
             let tenant_partitions = HashMap::from([(partition_id, partition)]);
             let partition_ids_by_pkey = HashMap::from([(pkey, partition_id)]);
-            let fabrics = HashMap::from([("fab1".to_string(), definition.clone())]);
+            let fabrics = HashMap::from([(FABRIC.to_string(), definition.clone())]);
             let mut fabric_data = FabricData::default();
             let mut fabric_metrics = FabricMetrics::default();
             let mut fabric_clients = HashMap::new();
@@ -1843,14 +1838,14 @@ mod tests {
             // Data-loading phase.
             let conn = load_single_fabric_data(
                 &manager,
-                "fab1",
+                FABRIC,
                 &definition,
                 &mut fabric_data,
                 &mut fabric_metrics,
             )
             .await
             .expect("client for reachable stub fabric");
-            fabric_clients.insert("fab1".to_string(), conn);
+            fabric_clients.insert(FABRIC.to_string(), conn);
 
             assert!(fabric_data.ports_by_guid.is_some());
             assert!(fabric_data.partitions.is_some());
@@ -1861,15 +1856,13 @@ mod tests {
             );
 
             // Change-application phase reuses the data-loading client.
-            let mut metrics = IbFabricMonitorMetrics::new();
             let num_changes = apply_guid_pkey_changes(
                 &manager,
                 &mut fabric_clients,
                 &fabrics,
                 &tenant_partitions,
                 &partition_ids_by_pkey,
-                five_pending_changes(pkey),
-                &mut metrics,
+                five_pending_changes(FABRIC, pkey),
             )
             .await
             .expect("applying changes against stub fabric");

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -19,10 +19,15 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use ::carbide_utils::metrics::SharedMetricsHolder;
-use carbide_instrument::{DynamicLog, Event, LogAt};
-use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Meter};
+use carbide_instrument::{
+    DynamicLog, DynamicMessage, Event, LabelValue, LogAt, emit, initialize_counter_series,
+};
+use model::ib_partition::PartitionKey;
+use opentelemetry::metrics::Meter;
+use opentelemetry::{KeyValue, StringValue};
 use serde::Serialize;
+
+use crate::errors::IbResult;
 
 /// Metrics that are gathered in one a single `IbFabricMonitor` run
 #[derive(Clone, Debug)]
@@ -52,19 +57,6 @@ pub struct IbFabricMonitorMetrics {
     /// The amount of machines where at least one port is assigned to a pkey value
     /// that is not associated with any partition ID
     pub num_machines_with_unknown_pkeys: usize,
-    /// The amount of changes that IBFabricMonitor performed,
-    /// keyed by the type of change and outcome
-    pub applied_changes: HashMap<AppliedChange, usize>,
-}
-
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct AppliedChange {
-    /// The fabric the operation has been applied against
-    pub fabric: String,
-    /// The operation that has been performed
-    pub operation: UfmOperation,
-    /// Whether the operation succeeded or failed
-    pub status: UfmOperationStatus,
 }
 
 /// Metrics collected for a single fabric
@@ -110,7 +102,6 @@ impl IbFabricMonitorMetrics {
             num_machines_with_missing_pkeys: 0,
             num_machines_with_unexpected_pkeys: 0,
             num_machines_with_unknown_pkeys: 0,
-            applied_changes: HashMap::new(),
         }
     }
 }
@@ -147,13 +138,11 @@ impl DynamicLog for IbMonitorIterationFinished {
     }
 }
 
-/// Instruments that are used by pub struct IbFabricMonitor
-pub struct IbFabricMonitorInstruments {
-    pub ufm_changes_applied: Counter<u64>,
-}
+/// Registers the observable instruments used by `IbFabricMonitor`.
+struct IbFabricMonitorInstruments;
 
 impl IbFabricMonitorInstruments {
-    pub fn new(meter: Meter, shared_metrics: SharedMetricsHolder<IbFabricMonitorMetrics>) -> Self {
+    fn new(meter: Meter, shared_metrics: SharedMetricsHolder<IbFabricMonitorMetrics>) -> Self {
         {
             let metrics = shared_metrics.clone();
             meter
@@ -181,11 +170,6 @@ impl IbFabricMonitorInstruments {
                 })
                 .build();
         }
-
-        let ufm_changes_applied = meter
-            .u64_counter("carbide_ib_monitor_ufm_changes_applied")
-            .with_description("Number of changes performed at UFM")
-            .build();
 
         {
             let metrics = shared_metrics.clone();
@@ -448,43 +432,11 @@ impl IbFabricMonitorInstruments {
                 .build();
         }
 
-        Self {
-            ufm_changes_applied,
-        }
-    }
-
-    fn emit_counters(&self, metrics: &IbFabricMonitorMetrics) {
-        for (change, &count) in metrics.applied_changes.iter() {
-            self.ufm_changes_applied.add(
-                count as u64,
-                &[
-                    KeyValue::new("fabric", change.fabric.clone()),
-                    KeyValue::new("operation", change.operation),
-                    KeyValue::new("status", change.status),
-                ],
-            );
-        }
-    }
-
-    fn init_counters(&self, fabric_ids: &[&str]) {
-        for fabric_id in fabric_ids.iter() {
-            for status in UfmOperationStatus::values() {
-                for operation in UfmOperation::values() {
-                    self.ufm_changes_applied.add(
-                        0u64,
-                        &[
-                            KeyValue::new("fabric", fabric_id.to_string()),
-                            KeyValue::new("operation", operation),
-                            KeyValue::new("status", status),
-                        ],
-                    );
-                }
-            }
-        }
+        Self
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, LabelValue)]
 #[allow(clippy::enum_variant_names)]
 pub enum UfmOperation {
     BindGuidToPkey,
@@ -498,18 +450,7 @@ impl UfmOperation {
     }
 }
 
-impl From<UfmOperation> for opentelemetry::Value {
-    fn from(value: UfmOperation) -> Self {
-        let str_value = match value {
-            UfmOperation::BindGuidToPkey => "bind_guid_to_pkey",
-            UfmOperation::UnbindGuidFromPkey => "unbind_guid_from_pkey",
-        };
-
-        Self::from(str_value)
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, LabelValue)]
 pub enum UfmOperationStatus {
     Ok,
     Error,
@@ -522,20 +463,115 @@ impl UfmOperationStatus {
     }
 }
 
-impl From<UfmOperationStatus> for opentelemetry::Value {
-    fn from(value: UfmOperationStatus) -> Self {
-        let str_value = match value {
-            UfmOperationStatus::Ok => "ok",
-            UfmOperationStatus::Error => "error",
-        };
+/// `ConfiguredFabric` is the reviewed escape hatch for the existing `fabric`
+/// label. Values come from `IbFabricMonitor`'s startup configuration, and the
+/// same finite set is used to initialize the counter series below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfiguredFabric(String);
 
-        Self::from(str_value)
+impl LabelValue for ConfiguredFabric {
+    fn label_value(&self) -> StringValue {
+        StringValue::from(self.0.clone())
+    }
+}
+
+/// One GUID/pkey bind or unbind finished at UFM. Every call updates the
+/// existing counter; successful calls stay quiet, while failures retain the
+/// historical `ERROR` record and its operation-specific message.
+#[derive(Event)]
+#[event(
+    event_name = "ib_ufm_guid_pkey_change_finished",
+    metric_name = "carbide_ib_monitor_ufm_changes_applied_total",
+    component = "ib-fabric-monitor",
+    log = dynamic,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of changes performed at UFM"
+)]
+pub(crate) struct UfmGuidPkeyChangeFinished {
+    #[label]
+    fabric: ConfiguredFabric,
+    #[label]
+    operation: UfmOperation,
+    #[label]
+    status: UfmOperationStatus,
+    #[context]
+    guid: String,
+    #[context]
+    pkey: String,
+    #[context]
+    error: String,
+}
+
+impl UfmGuidPkeyChangeFinished {
+    pub(crate) fn emit(
+        fabric: &str,
+        operation: UfmOperation,
+        guid: &str,
+        pkey: PartitionKey,
+        result: &IbResult<()>,
+    ) {
+        emit(Self {
+            fabric: ConfiguredFabric(fabric.to_string()),
+            operation,
+            status: if result.is_ok() {
+                UfmOperationStatus::Ok
+            } else {
+                UfmOperationStatus::Error
+            },
+            guid: guid.to_string(),
+            pkey: pkey.to_string(),
+            error: result
+                .as_ref()
+                .err()
+                .map(ToString::to_string)
+                .unwrap_or_default(),
+        });
+    }
+
+    fn initialize_counter_series(fabric_ids: &[&str]) {
+        for &fabric in fabric_ids {
+            for operation in UfmOperation::values() {
+                for status in UfmOperationStatus::values() {
+                    // `initialize_counter_series` only reads labels. These
+                    // empty context values therefore never reach a log line.
+                    let event = Self {
+                        fabric: ConfiguredFabric(fabric.to_string()),
+                        operation,
+                        status,
+                        guid: String::new(),
+                        pkey: String::new(),
+                        error: String::new(),
+                    };
+                    let initialized = initialize_counter_series(&event);
+                    debug_assert!(initialized, "UFM change Event must remain a counter");
+                }
+            }
+        }
+    }
+}
+
+impl DynamicLog for UfmGuidPkeyChangeFinished {
+    fn log_at(&self) -> LogAt {
+        match self.status {
+            UfmOperationStatus::Ok => LogAt::Off,
+            UfmOperationStatus::Error => LogAt::Level(tracing::Level::ERROR),
+        }
+    }
+}
+
+impl DynamicMessage for UfmGuidPkeyChangeFinished {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            UfmOperation::BindGuidToPkey => "Failed to bind GUID to pkey",
+            UfmOperation::UnbindGuidFromPkey => "Failed to unbind GUID from pkey",
+        }
     }
 }
 
 /// Stores Metric data shared between the Fabric Monitor and the OpenTelemetry background task
 pub struct MetricHolder {
-    instruments: IbFabricMonitorInstruments,
+    _instruments: IbFabricMonitorInstruments,
     last_iteration_metrics: SharedMetricsHolder<IbFabricMonitorMetrics>,
 }
 
@@ -543,16 +579,15 @@ impl MetricHolder {
     pub fn new(meter: Meter, hold_period: Duration, fabric_ids: &[&str]) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         let instruments = IbFabricMonitorInstruments::new(meter, last_iteration_metrics.clone());
-        instruments.init_counters(fabric_ids);
+        UfmGuidPkeyChangeFinished::initialize_counter_series(fabric_ids);
         Self {
-            instruments,
+            _instruments: instruments,
             last_iteration_metrics,
         }
     }
 
     /// Updates the most recent metrics
     pub fn update_metrics(&self, metrics: IbFabricMonitorMetrics) {
-        self.instruments.emit_counters(&metrics);
         self.last_iteration_metrics.update(metrics);
     }
 }
@@ -576,17 +611,9 @@ fn truncate_error_for_metric_label(mut error: String) -> String {
 mod tests {
     use carbide_instrument::emit;
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
-    use carbide_test_support::{Check, check_values, value_scenarios};
+    use carbide_test_support::{Check, check_values};
 
     use super::*;
-
-    fn operation_metric_value(operation: UfmOperation) -> String {
-        opentelemetry::Value::from(operation).to_string()
-    }
-
-    fn status_metric_value(status: UfmOperationStatus) -> String {
-        opentelemetry::Value::from(status).to_string()
-    }
 
     #[test]
     fn ib_monitor_iteration_outcomes_pair_latency_with_failure_log() {
@@ -731,6 +758,198 @@ mod tests {
     }
 
     #[test]
+    fn ufm_guid_pkey_change_pairs_the_counter_with_failure_logs() {
+        const EXPOSED_METRIC: &str = "carbide_ib_monitor_ufm_changes_applied_total";
+        const FABRIC: &str = "event-test-fabric";
+        const GUID: &str = "guid-1";
+
+        struct ChangeCase {
+            operation: UfmOperation,
+            error: Option<&'static str>,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct LogObservation {
+            level: tracing::Level,
+            metadata_name: String,
+            message: String,
+            event_name: Option<String>,
+            metric_name: Option<String>,
+            fabric: Option<String>,
+            operation: Option<String>,
+            status: Option<String>,
+            guid: Option<String>,
+            pkey: Option<String>,
+            error: Option<String>,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            log_count: usize,
+            log: Option<LogObservation>,
+            counter_delta: f64,
+        }
+
+        let fabric_error = "failed to call IBFabricManager: simulated UFM failure";
+        check_values(
+            [
+                Check {
+                    scenario: "successful bind",
+                    input: ChangeCase {
+                        operation: UfmOperation::BindGuidToPkey,
+                        error: None,
+                    },
+                    expect: Observation {
+                        log_count: 0,
+                        log: None,
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "failed bind",
+                    input: ChangeCase {
+                        operation: UfmOperation::BindGuidToPkey,
+                        error: Some("simulated UFM failure"),
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            level: tracing::Level::ERROR,
+                            metadata_name: "ib_ufm_guid_pkey_change_finished".to_string(),
+                            message: "Failed to bind GUID to pkey".to_string(),
+                            event_name: Some("ib_ufm_guid_pkey_change_finished".to_string()),
+                            metric_name: Some(EXPOSED_METRIC.to_string()),
+                            fabric: Some(FABRIC.to_string()),
+                            operation: Some("bind_guid_to_pkey".to_string()),
+                            status: Some("error".to_string()),
+                            guid: Some(GUID.to_string()),
+                            pkey: Some("0x101".to_string()),
+                            error: Some(fabric_error.to_string()),
+                        }),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "successful unbind",
+                    input: ChangeCase {
+                        operation: UfmOperation::UnbindGuidFromPkey,
+                        error: None,
+                    },
+                    expect: Observation {
+                        log_count: 0,
+                        log: None,
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "failed unbind",
+                    input: ChangeCase {
+                        operation: UfmOperation::UnbindGuidFromPkey,
+                        error: Some("simulated UFM failure"),
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            level: tracing::Level::ERROR,
+                            metadata_name: "ib_ufm_guid_pkey_change_finished".to_string(),
+                            message: "Failed to unbind GUID from pkey".to_string(),
+                            event_name: Some("ib_ufm_guid_pkey_change_finished".to_string()),
+                            metric_name: Some(EXPOSED_METRIC.to_string()),
+                            fabric: Some(FABRIC.to_string()),
+                            operation: Some("unbind_guid_from_pkey".to_string()),
+                            status: Some("error".to_string()),
+                            guid: Some(GUID.to_string()),
+                            pkey: Some("0x101".to_string()),
+                            error: Some(fabric_error.to_string()),
+                        }),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |ChangeCase { operation, error }| {
+                let pkey = PartitionKey::try_from(0x101).expect("valid pkey");
+                let result = error.map_or(Ok(()), |error| {
+                    Err(crate::errors::IbError::IBFabricError(error.to_string()))
+                });
+                let operation_label = match operation {
+                    UfmOperation::BindGuidToPkey => "bind_guid_to_pkey",
+                    UfmOperation::UnbindGuidFromPkey => "unbind_guid_from_pkey",
+                };
+                let status_label = if result.is_ok() { "ok" } else { "error" };
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| {
+                    UfmGuidPkeyChangeFinished::emit(FABRIC, operation, GUID, pkey, &result);
+                });
+                let log = logs.first().map(|log| LogObservation {
+                    level: log.level,
+                    metadata_name: log.metadata_name.clone(),
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    fabric: log.field("fabric").map(str::to_string),
+                    operation: log.field("operation").map(str::to_string),
+                    status: log.field("status").map(str::to_string),
+                    guid: log.field("guid").map(str::to_string),
+                    pkey: log.field("pkey").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                });
+
+                Observation {
+                    log_count: logs.len(),
+                    log,
+                    counter_delta: metrics.counter_delta(
+                        EXPOSED_METRIC,
+                        &[
+                            ("fabric", FABRIC),
+                            ("operation", operation_label),
+                            ("status", status_label),
+                        ],
+                    ),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn initializes_every_ufm_change_series_without_logging() {
+        const EXPOSED_METRIC: &str = "carbide_ib_monitor_ufm_changes_applied_total";
+        const FABRIC: &str = "zero-series-fabric";
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            UfmGuidPkeyChangeFinished::initialize_counter_series(&[FABRIC]);
+        });
+
+        assert!(logs.is_empty());
+        let encoded = metrics.render();
+        assert!(
+            encoded.contains(&format!(
+                "# HELP {EXPOSED_METRIC} Number of changes performed at UFM\n"
+            )),
+            "description or exposed family changed:\n{encoded}"
+        );
+        assert!(
+            encoded.contains(&format!("# TYPE {EXPOSED_METRIC} counter\n")),
+            "expected the UFM change family to remain a counter:\n{encoded}"
+        );
+        assert!(
+            !encoded.contains("carbide_ib_monitor_ufm_changes_applied_total_total"),
+            "the counter suffix must be applied exactly once:\n{encoded}"
+        );
+        for operation in ["bind_guid_to_pkey", "unbind_guid_from_pkey"] {
+            for status in ["ok", "error"] {
+                let sample = format!(
+                    "{EXPOSED_METRIC}{{fabric=\"{FABRIC}\",operation=\"{operation}\",status=\"{status}\"}} 0"
+                );
+                assert!(
+                    encoded.lines().any(|line| line == sample),
+                    "missing initialized series {sample}:\n{encoded}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn enumerates_ufm_operations_and_statuses() {
         assert_eq!(
             UfmOperation::values().collect::<Vec<_>>(),
@@ -746,26 +965,6 @@ mod tests {
     }
 
     #[test]
-    fn converts_ufm_operations_to_metric_values() {
-        value_scenarios!(operation_metric_value:
-            "operations" {
-                UfmOperation::BindGuidToPkey => "bind_guid_to_pkey".to_string(),
-                UfmOperation::UnbindGuidFromPkey => "unbind_guid_from_pkey".to_string(),
-            }
-        );
-    }
-
-    #[test]
-    fn converts_ufm_operation_statuses_to_metric_values() {
-        value_scenarios!(status_metric_value:
-            "statuses" {
-                UfmOperationStatus::Ok => "ok".to_string(),
-                UfmOperationStatus::Error => "error".to_string(),
-            }
-        );
-    }
-
-    #[test]
     fn creates_empty_monitor_metrics() {
         let metrics = IbFabricMonitorMetrics::new();
 
@@ -777,6 +976,5 @@ mod tests {
         assert_eq!(metrics.num_machines_with_missing_pkeys, 0);
         assert_eq!(metrics.num_machines_with_unexpected_pkeys, 0);
         assert_eq!(metrics.num_machines_with_unknown_pkeys, 0);
-        assert!(metrics.applied_changes.is_empty());
     }
 }

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -363,6 +363,29 @@ pub fn emit<E: Event>(event: E) {
     }
 }
 
+/// `initialize_counter_series` exposes one Event counter label set at zero
+/// without writing the Event's log line. It uses the same cached instrument as
+/// [`emit`], so the global meter provider must already be installed before this
+/// call. Context fields are ignored; only the Event's bounded labels select the
+/// series.
+///
+/// Returns `false` without registering anything when `event` does not declare
+/// `metric = counter`.
+#[must_use = "a false result means the Event is not a counter"]
+pub fn initialize_counter_series<E: Event>(event: &E) -> bool {
+    if !matches!(E::METRIC, MetricKind::Counter) {
+        return false;
+    }
+
+    match event.__instrument() {
+        __private::CachedInstrument::Counter(counter) => {
+            counter.add(0, event.labels().as_ref());
+            true
+        }
+        __private::CachedInstrument::Histogram(_) | __private::CachedInstrument::None => false,
+    }
+}
+
 /// The success-or-failure of an operation, as a bounded label.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -21,7 +21,9 @@
 use std::time::Duration;
 
 use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
-use carbide_instrument::{Event, LabelValue, LogAt, MetricKind, Outcome, emit};
+use carbide_instrument::{
+    Event, LabelValue, LogAt, MetricKind, Outcome, emit, initialize_counter_series,
+};
 use carbide_test_support::value_scenarios;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
@@ -82,6 +84,94 @@ fn both_sides_from_one_emit() {
             &[("stage", "apply"), ("outcome", "error")],
         ),
         1.0
+    );
+}
+
+/// Counter initialization needs to expose the series without pretending the
+/// Event happened. The first real `emit` must therefore move the same series
+/// from zero to one and write exactly one log line.
+#[test]
+fn counter_series_initialization_does_not_emit_the_event() {
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_counter_initialized",
+        metric_name = "carbide_test_matrix_initialized_total",
+        component = "matrix-test",
+        log = warn,
+        metric = counter,
+        describe = "Number of initialized counter test events",
+        message = "initialized counter fired"
+    )]
+    struct InitializedCounter {
+        #[label]
+        stage: Stage,
+        #[context]
+        detail: String,
+    }
+
+    let event = InitializedCounter {
+        stage: Stage::PreFlight,
+        detail: "first real event".to_string(),
+    };
+    let metrics = MetricsCapture::start();
+    let initialization_logs = capture_logs(|| {
+        assert!(initialize_counter_series(&event));
+    });
+
+    assert!(initialization_logs.is_empty());
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_initialized_total",
+            &[("stage", "pre_flight")],
+        ),
+        0.0
+    );
+    assert!(
+        metrics
+            .render()
+            .contains("carbide_test_matrix_initialized_total{stage=\"pre_flight\"} 0")
+    );
+
+    let logs = capture_logs(|| emit(event));
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].message, "initialized counter fired");
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_initialized_total",
+            &[("stage", "pre_flight")],
+        ),
+        1.0
+    );
+}
+
+#[test]
+fn non_counter_event_cannot_initialize_a_counter_series() {
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_histogram_initialization_rejected",
+        metric_name = "carbide_test_matrix_initialization_milliseconds",
+        component = "matrix-test",
+        log = off,
+        metric = histogram,
+        describe = "Test initialization duration"
+    )]
+    struct Histogram {
+        #[observation]
+        latency: Duration,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        assert!(!initialize_counter_series(&Histogram {
+            latency: Duration::from_millis(10),
+        }));
+    });
+
+    assert!(logs.is_empty());
+    assert!(
+        !metrics
+            .render()
+            .contains("carbide_test_matrix_initialization_milliseconds")
     );
 }
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -98,6 +98,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_ib_monitor_machines_with_missing_pkeys_count</td><td>gauge</td><td>Number of machines where at least one port is not assigned to the expected pkey on UFM</td></tr>
 <tr><td>carbide_ib_monitor_machines_with_unexpected_pkeys_count</td><td>gauge</td><td>Number of machines where at least one port is assigned to an unexpected pkey on UFM</td></tr>
 <tr><td>carbide_ib_monitor_machines_with_unknown_pkeys_count</td><td>gauge</td><td>Number of machines where at least one port is assigned to a pkey value not associated with any partition ID</td></tr>
+<tr><td>carbide_ib_monitor_ufm_changes_applied_total</td><td>counter</td><td>Number of changes performed at UFM</td></tr>
 <tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>
 <tr><td>carbide_ib_partitions_iteration_latency_milliseconds</td><td>histogram</td><td>The elapsed time in the last state processor iteration to handle objects of type carbide_ib_partitions</td></tr>
 <tr><td>carbide_ib_partitions_object_tasks_enqueued_total</td><td>counter</td><td>Number of object handling tasks freshly enqueued for objects of type carbide_ib_partitions</td></tr>


### PR DESCRIPTION
Emit each UFM GUID/pkey bind and unbind through `carbide-instrument`, preserving the existing counter family and failure diagnostics. Startup zero-series now use the Event's cached counter so live and zero-valued samples share one metric instrument.

The Event keeps fabric, operation, and status as bounded labels while GUIDs, pkeys, and errors remain log-only context. API metric assertions now use scoped capture so they observe the Event-backed instrument directly.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3833

## Type of Change

- [ ] Add
- [ ] Change
- [ ] Fix
- [ ] Remove
- [x] Internal

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (explain below)

Verified with:

- `cargo test --locked -p carbide-instrument`
- `cargo test --locked -p carbide-ib-fabric --lib`
- Focused `carbide-api-core` IB machine, IB instance create/update, and network-segment metric fixture tests
- `CARGO_TARGET_DIR=/tmp/instrument-wave-ufm-target cargo make clippy`
- `CARGO_TARGET_DIR=/tmp/instrument-wave-ufm-target cargo make carbide-lints`
- `cargo make check-format-nightly`
- `cargo make check-event-names`
- `CARGO_TARGET_DIR=/tmp/instrument-wave-ufm-xtask cargo xtask check-metric-docs`

## Additional Notes

`initialize_counter_series` follows the same global meter-provider timing requirement as Event emission and intentionally does not emit a log record. The generated `docs/observability/core_metrics.md` update stays with this code change because it is produced from the metric declarations.
