### PR TITLE
refactor(dpa): instrument command submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,6 +1720,8 @@ dependencies = [
  "async-trait",
  "carbide-api-db",
  "carbide-api-model",
+ "carbide-instrument",
+ "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
  "chrono",

--- a/crates/dpa-manager/src/metrics.rs
+++ b/crates/dpa-manager/src/metrics.rs
@@ -120,7 +120,6 @@ impl DynamicLog for DpaMonitorIterationFinished {
 /// Instruments that are used by pub struct DpaMonitor
 #[allow(dead_code)]
 pub struct DpaMonitorInstruments {
-    pub operations_latency: Histogram<f64>,
     pub dpa_config_apply_latency: Histogram<f64>,
     pub heartbeats_sent: Counter<u64>,
     pub creates: Counter<u64>,
@@ -132,11 +131,6 @@ impl DpaMonitorInstruments {
         let dpa_config_apply_latency = meter
             .f64_histogram("carbide_dpa_monitor_dpa_config_apply_latency")
             .with_description("Time since dpa config was requested for this instance")
-            .with_unit("ms")
-            .build();
-        let operations_latency = meter
-            .f64_histogram("carbide_dpa_monitor_operations_latency")
-            .with_description("Time consumed for one operations")
             .with_unit("ms")
             .build();
         let heartbeats_sent = meter
@@ -164,7 +158,6 @@ impl DpaMonitorInstruments {
 
         Self {
             dpa_config_apply_latency,
-            operations_latency,
             heartbeats_sent,
             creates,
             deletes,

--- a/crates/dpa/Cargo.toml
+++ b/crates/dpa/Cargo.toml
@@ -24,6 +24,7 @@ authors.workspace = true
 [dependencies]
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
+carbide-instrument = { path = "../instrument", default-features = false }
 carbide-utils = { path = "../utils", default-features = false }
 carbide-uuid = { path = "../uuid", default-features = false }
 config-version = { path = "../config-version", default-features = false }
@@ -41,6 +42,8 @@ sqlx = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
 config-version = { path = "../config-version", default-features = false }
 
 mac_address = { workspace = true }

--- a/crates/dpa/src/lib.rs
+++ b/crates/dpa/src/lib.rs
@@ -19,9 +19,14 @@
 
 use std::net::Ipv4Addr;
 use std::sync::Arc;
+use std::time::Instant;
 
+use carbide_instrument::emit;
 use mqttea::client::MqtteaClient;
 
+use crate::metrics::{DpaCommandSendFailed, DpaCommandSent};
+
+mod metrics;
 pub mod rpc;
 
 pub struct DpaInfo {
@@ -65,17 +70,25 @@ pub async fn send_dpa_command(
 
     let topic = format!("dpa/command/{maddr}/SetVni");
 
-    match client.send_message(&topic, &svni).await {
+    let send_started_at = Instant::now();
+    let send_result = client.send_message(&topic, &svni).await;
+    let send_latency = send_started_at.elapsed();
+
+    match send_result {
         Ok(()) => {
-            println!("send_dpa_command revision: {revision} vni: {vni}");
+            emit(DpaCommandSent {
+                latency: send_latency,
+                revision,
+                vni: i64::from(vni),
+            });
         }
         Err(e) => {
-            tracing::error!(
-                error = ?e,
-                payload = ?svni,
-                %topic,
-                "failed to send DPA command"
-            );
+            emit(DpaCommandSendFailed {
+                latency: send_latency,
+                error: format!("{e:?}"),
+                payload: format!("{svni:?}"),
+                topic,
+            });
             return Err(eyre::eyre!("send_message error: {e}"));
         }
     }

--- a/crates/dpa/src/metrics.rs
+++ b/crates/dpa/src/metrics.rs
@@ -1,0 +1,245 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::Duration;
+
+use carbide_instrument::Event;
+
+// The accepted and failed paths keep separate records because they carry
+// different context. Both feed the same label-free histogram, so a command
+// still contributes exactly one latency sample whichever path it takes.
+/// `DpaCommandSent` means `MqtteaClient::send_message` accepted the command.
+/// That call queues the MQTT publish; it does not promise broker delivery or
+/// a later acknowledgement from the DPA.
+#[derive(Event)]
+#[event(
+    event_name = "dpa_command_sent",
+    metric_name = "carbide_dpa_monitor_operations_latency_milliseconds",
+    component = "dpa-monitor",
+    log = info,
+    metric = histogram,
+    message = "sent DPA command",
+    describe = "Time consumed for one operation"
+)]
+pub(crate) struct DpaCommandSent {
+    #[observation]
+    pub latency: Duration,
+    #[context(value)]
+    pub revision: String,
+    #[context(value)]
+    pub vni: i64,
+}
+
+/// `DpaCommandSendFailed` retains the error, payload, and topic from the
+/// existing `ERROR` record when `MqtteaClient::send_message` rejects a
+/// command.
+#[derive(Event)]
+#[event(
+    event_name = "dpa_command_send_failed",
+    metric_name = "carbide_dpa_monitor_operations_latency_milliseconds",
+    component = "dpa-monitor",
+    log = error,
+    metric = histogram,
+    message = "failed to send DPA command",
+    describe = "Time consumed for one operation"
+)]
+pub(crate) struct DpaCommandSendFailed {
+    #[observation]
+    pub latency: Duration,
+    #[context]
+    pub error: String,
+    #[context]
+    pub payload: String,
+    #[context]
+    pub topic: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    const EXPOSED_METRIC: &str = "carbide_dpa_monitor_operations_latency_milliseconds";
+
+    enum CommandCase {
+        Sent,
+        Failed,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct LogObservation {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        revision: Option<String>,
+        revision_kind: Option<CapturedFieldKind>,
+        vni: Option<String>,
+        vni_kind: Option<CapturedFieldKind>,
+        error: Option<String>,
+        error_kind: Option<CapturedFieldKind>,
+        payload: Option<String>,
+        payload_kind: Option<CapturedFieldKind>,
+        topic: Option<String>,
+        topic_kind: Option<CapturedFieldKind>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct Observation {
+        log_count: usize,
+        log: Option<LogObservation>,
+        histogram_count_delta: u64,
+        histogram_sum_delta: f64,
+    }
+
+    #[test]
+    fn dpa_command_results_pair_their_log_with_latency() {
+        value_scenarios!(
+            run = |case| {
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| match case {
+                    CommandCase::Sent => emit(DpaCommandSent {
+                        latency: Duration::from_micros(12_500),
+                        revision: "revision-42".to_string(),
+                        vni: 901,
+                    }),
+                    CommandCase::Failed => emit(DpaCommandSendFailed {
+                        latency: Duration::from_millis(375),
+                        error: "UnregisteredType(\"SetVni\")".to_string(),
+                        payload: "SetVni { metadata: Some(...) }".to_string(),
+                        topic: "dpa/command/aabbccddeeff/SetVni".to_string(),
+                    }),
+                });
+                let log = logs.first().map(|log| LogObservation {
+                    level: log.level,
+                    metadata_name: log.metadata_name.clone(),
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    revision: log.field("revision").map(str::to_string),
+                    revision_kind: log.field_kind("revision"),
+                    vni: log.field("vni").map(str::to_string),
+                    vni_kind: log.field_kind("vni"),
+                    error: log.field("error").map(str::to_string),
+                    error_kind: log.field_kind("error"),
+                    payload: log.field("payload").map(str::to_string),
+                    payload_kind: log.field_kind("payload"),
+                    topic: log.field("topic").map(str::to_string),
+                    topic_kind: log.field_kind("topic"),
+                });
+
+                Observation {
+                    log_count: logs.len(),
+                    log,
+                    histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
+                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                }
+            };
+            "MQTT queue accepted the command" {
+                CommandCase::Sent => Observation {
+                    log_count: 1,
+                    log: Some(LogObservation {
+                        level: tracing::Level::INFO,
+                        metadata_name: "dpa_command_sent".to_string(),
+                        message: "sent DPA command".to_string(),
+                        event_name: Some("dpa_command_sent".to_string()),
+                        metric_name: Some(EXPOSED_METRIC.to_string()),
+                        revision: Some("revision-42".to_string()),
+                        revision_kind: Some(CapturedFieldKind::String),
+                        vni: Some("901".to_string()),
+                        vni_kind: Some(CapturedFieldKind::I64),
+                        error: None,
+                        error_kind: None,
+                        payload: None,
+                        payload_kind: None,
+                        topic: None,
+                        topic_kind: None,
+                    }),
+                    histogram_count_delta: 1,
+                    histogram_sum_delta: 12.5,
+                },
+            }
+            "MQTT queue rejected the command" {
+                CommandCase::Failed => Observation {
+                    log_count: 1,
+                    log: Some(LogObservation {
+                        level: tracing::Level::ERROR,
+                        metadata_name: "dpa_command_send_failed".to_string(),
+                        message: "failed to send DPA command".to_string(),
+                        event_name: Some("dpa_command_send_failed".to_string()),
+                        metric_name: Some(EXPOSED_METRIC.to_string()),
+                        revision: None,
+                        revision_kind: None,
+                        vni: None,
+                        vni_kind: None,
+                        error: Some("UnregisteredType(\"SetVni\")".to_string()),
+                        error_kind: Some(CapturedFieldKind::Debug),
+                        payload: Some("SetVni { metadata: Some(...) }".to_string()),
+                        payload_kind: Some(CapturedFieldKind::Debug),
+                        topic: Some("dpa/command/aabbccddeeff/SetVni".to_string()),
+                        topic_kind: Some(CapturedFieldKind::Debug),
+                    }),
+                    histogram_count_delta: 1,
+                    histogram_sum_delta: 375.0,
+                },
+            }
+        );
+    }
+
+    /// The Event pair exposes one shared, label-free millisecond histogram for
+    /// both command results.
+    #[test]
+    fn dpa_command_histogram_exposition_stays_stable() {
+        let metrics = MetricsCapture::start();
+        emit(DpaCommandSent {
+            latency: Duration::from_millis(125),
+            revision: "revision-42".to_string(),
+            vni: 901,
+        });
+
+        let encoded = metrics.render();
+        assert!(
+            encoded.contains(&format!(
+                "# HELP {EXPOSED_METRIC} Time consumed for one operation\n"
+            )),
+            "description or exposed family changed:\n{encoded}"
+        );
+        assert!(
+            encoded.contains(&format!("# TYPE {EXPOSED_METRIC} histogram\n")),
+            "expected the millisecond family to remain a histogram:\n{encoded}"
+        );
+        assert!(
+            !encoded.contains("carbide_dpa_monitor_operations_latency_milliseconds_milliseconds"),
+            "the unit suffix must be applied exactly once:\n{encoded}"
+        );
+        for suffix in ["count", "sum"] {
+            let prefix = format!("{EXPOSED_METRIC}_{suffix} ");
+            let sample = encoded
+                .lines()
+                .find(|line| line.starts_with(&prefix))
+                .unwrap_or_else(|| panic!("missing {prefix} sample:\n{encoded}"));
+            assert!(
+                !sample.contains('{'),
+                "DPA command latency must remain label-free: {sample}"
+            );
+        }
+    }
+}

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -49,6 +49,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dns_request_duration_milliseconds</td><td>histogram</td><td>Time to process a DNS query, by query type and response code</td></tr>
 <tr><td>carbide_dns_responses_total</td><td>counter</td><td>Number of DNS responses sent, by response code</td></tr>
 <tr><td>carbide_dpa_monitor_iteration_latency_milliseconds</td><td>histogram</td><td>Time consumed for one monitor iteration</td></tr>
+<tr><td>carbide_dpa_monitor_operations_latency_milliseconds</td><td>histogram</td><td>Time consumed for one operation</td></tr>
 <tr><td>carbide_dpu_agent_report_total</td><td>counter</td><td>Number of DPU-agent report-loop iterations, by loop and outcome</td></tr>
 <tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>Number of DPU agents which have reported a certain version.</td></tr>
 <tr><td>carbide_dpu_firmware_version_count</td><td>gauge</td><td>Number of DPUs which have reported a certain firmware version.</td></tr>


### PR DESCRIPTION
Emit DPA command-submission Events around `MqtteaClient::send_message`, activating the existing operation-latency metric at the call boundary. A successful Event means the local MQTT queue accepted the command; it does not claim broker delivery or a DPA acknowledgement.

The success path replaces its stdout message with a structured Event log, while failures keep command and error details in log-only context. The metric remains label-free and keeps its existing exposed name.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3835

## Type of Change

- [ ] Add
- [ ] Change
- [ ] Fix
- [ ] Remove
- [x] Internal

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (explain below)

Verified with:

- `cargo test --locked -p carbide-dpa -p carbide-dpa-manager`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-format-nightly`
- `cargo make check-event-names`
- `CARGO_TARGET_DIR=/tmp/instrument-wave-dpa-xtask cargo xtask check-metric-docs`
- `cargo make check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

The Event is now the sole owner of the command-submission histogram; the pre-existing manual handle never recorded samples and has been removed. Since this is the metric's first emitted HELP metadata, the dormant handle's grammatical typo is corrected to “Time consumed for one operation.” The generated `docs/observability/core_metrics.md` update stays with this code change because it is produced from the metric declarations.
