### PR TITLE
test(fmds): tolerate histogram delta rounding

### DIFF
--- a/crates/fmds/src/http_request_metrics.rs
+++ b/crates/fmds/src/http_request_metrics.rs
@@ -161,11 +161,20 @@ mod tests {
         Response,
     }
 
+    #[derive(Debug)]
+    struct ApproxLatencySum(f64);
+
+    impl PartialEq for ApproxLatencySum {
+        fn eq(&self, other: &Self) -> bool {
+            (self.0 - other.0).abs() < 1e-9
+        }
+    }
+
     #[derive(Debug, PartialEq)]
     struct EventObservation {
         request_delta: f64,
         latency_count_delta: u64,
-        latency_sum_delta: f64,
+        latency_sum_delta: ApproxLatencySum,
         logs: Vec<LogObservation>,
     }
 
@@ -206,7 +215,7 @@ mod tests {
         EventObservation {
             request_delta: metrics.counter_delta(REQUEST_METRIC, &[]),
             latency_count_delta: metrics.histogram_count_delta(LATENCY_METRIC, &[]),
-            latency_sum_delta: metrics.histogram_sum_delta(LATENCY_METRIC, &[]),
+            latency_sum_delta: ApproxLatencySum(metrics.histogram_sum_delta(LATENCY_METRIC, &[])),
             logs,
         }
     }
@@ -221,7 +230,7 @@ mod tests {
                     expect: EventObservation {
                         request_delta: 1.0,
                         latency_count_delta: 0,
-                        latency_sum_delta: 0.0,
+                        latency_sum_delta: ApproxLatencySum(0.0),
                         logs: vec![LogObservation {
                             metadata_name: "fmds_http_request_started".to_string(),
                             level: tracing::Level::INFO,
@@ -247,7 +256,7 @@ mod tests {
                     expect: EventObservation {
                         request_delta: 0.0,
                         latency_count_delta: 1,
-                        latency_sum_delta: 12.5,
+                        latency_sum_delta: ApproxLatencySum(12.5),
                         logs: vec![LogObservation {
                             metadata_name: "fmds_http_response_generated".to_string(),
                             level: tracing::Level::INFO,
@@ -268,6 +277,46 @@ mod tests {
                 },
             ],
             observe_event,
+        );
+    }
+
+    #[test]
+    fn latency_sum_comparison_uses_absolute_tolerance() {
+        struct Comparison {
+            actual: f64,
+            expected: f64,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "accepts insignificant floating-point drift",
+                    input: Comparison {
+                        actual: 12.500000000000002,
+                        expected: 12.5,
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "rejects the strict tolerance boundary",
+                    input: Comparison {
+                        actual: 1e-9,
+                        expected: 0.0,
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "rejects a meaningful difference",
+                    input: Comparison {
+                        actual: 12.500001,
+                        expected: 12.5,
+                    },
+                    expect: false,
+                },
+            ],
+            |comparison| {
+                ApproxLatencySum(comparison.actual) == ApproxLatencySum(comparison.expected)
+            },
         );
     }
 


### PR DESCRIPTION
The weird bit with the FMDS failure is that the Event itself recorded the exact `12.5` millisecond value. The test does not read that one observation back directly; it takes two snapshots from the process-global Prometheus registry and subtracts them. Since those histogram sums are cumulative `f64` values, an earlier fractional request can make `now - baseline` come back as `12.500000000000002` or `12.499999999999998`, depending on what ran first.

So yes, CI did fail here! It failed because exact equality was asking a cumulative `f64` sum to behave like an isolated value, not because `FmdsHttpResponseGenerated` recorded the wrong latency.

The fix gives only that derived sum comparison an absolute tolerance smaller than `1e-9` milliseconds. The request counter, histogram count, and structured logs continue to use exact equality. Table-driven cases accept the low-order drift, reject the strict `1e-9` boundary, and reject a meaningful `1e-6` difference.

Could we round the production value instead? We could, but that would throw away real precision without making cumulative `f64` addition exact. This keeps the tolerance where the mismatch is introduced -- in the test's snapshot subtraction -- and leaves production behavior alone.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3841

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Validated with the focused FMDS HTTP-request metrics tests, the full 35-test `carbide-fmds` suite, workspace Clippy, custom Carbide lints, nightly formatting, and `git diff --check`.