### PR TITLE
fix(nvlink-manager): preserve tray partition GPUs when a subset of the tray's GPUs are added to a tenant partition.

### DIFF
--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -1985,6 +1985,126 @@ async fn test_logical_partition_delete_with_instance_config(pool: sqlx::PgPool) 
 }
 
 #[crate::sqlx_test]
+async fn test_subset_nvl_config_preserves_unconfigured_gpus_in_tray_partition(pool: sqlx::PgPool) {
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config),
+    )
+    .await;
+
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let NvlLogicalPartitionFixture {
+        id: logical_partition_id,
+        logical_partition: _logical_partition,
+    } = create_nvl_logical_partition(&env, "test_partition".to_string()).await;
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_1_INFO_JSON,
+        ),
+    )
+    .await;
+    let machine = mh.host().rpc_machine().await;
+    let gpus = machine
+        .status
+        .as_ref()
+        .unwrap()
+        .discovery_info
+        .as_ref()
+        .unwrap()
+        .gpus
+        .clone();
+    assert_eq!(gpus.len(), 4);
+
+    let gpu_uid = |gpu: &Gpu| {
+        let guid = &gpu.platform_info.as_ref().unwrap().fabric_guid;
+        let guid = guid
+            .strip_prefix("0x")
+            .or_else(|| guid.strip_prefix("0X"))
+            .unwrap_or(guid);
+        u64::from_str_radix(guid, 16).unwrap()
+    };
+
+    // Establish the tray default partition before allocating the instance.
+    env.run_nvl_partition_monitor_iteration().await;
+    let mut nmxc_client = env
+        .nmxc_sim
+        .create_client(libnmxc::Endpoint::new("http://localhost:4010").unwrap())
+        .await
+        .unwrap();
+    let partitions = nmxc_client
+        .get_partition_info_list(GetPartitionInfoListRequest {
+            context: None,
+            partition_id_list: vec![],
+            partition_name_list: vec![],
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .unwrap()
+        .partition_info_list;
+    let tray_partition = partitions
+        .iter()
+        .find(|partition| partition.name == "tray_partition_0")
+        .expect("tray default partition should exist before instance allocation");
+    assert_eq!(tray_partition.gpu_uid_list.len(), 4);
+
+    let nvl_config = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus[..2]
+            .iter()
+            .map(|gpu| rpc::forge::InstanceNvLinkGpuConfig {
+                device_instance: gpu.platform_info.as_ref().unwrap().module_id - 1,
+                logical_partition_id: Some(logical_partition_id),
+            })
+            .collect(),
+    };
+    create_instance_with_nvlink_config(&env, &mh, nvl_config, segment_id).await;
+
+    // Run additional passes after instance allocation to verify omitted GPUs remain accounted for
+    // after reconciliation converges.
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let partitions = nmxc_client
+        .get_partition_info_list(GetPartitionInfoListRequest {
+            context: None,
+            partition_id_list: vec![],
+            partition_name_list: vec![],
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .unwrap()
+        .partition_info_list;
+    assert_eq!(partitions.len(), 2);
+
+    let tray_partition = partitions
+        .iter()
+        .find(|partition| partition.name == "tray_partition_0")
+        .expect("tray default partition should be preserved");
+    let tenant_partition = partitions
+        .iter()
+        .find(|partition| partition.name != "tray_partition_0")
+        .expect("tenant partition should be created");
+
+    let mut expected_tenant_uids: Vec<_> = gpus[..2].iter().map(gpu_uid).collect();
+    let mut actual_tenant_uids = tenant_partition.gpu_uid_list.clone();
+    expected_tenant_uids.sort_unstable();
+    actual_tenant_uids.sort_unstable();
+    assert_eq!(actual_tenant_uids, expected_tenant_uids);
+
+    let mut expected_tray_uids: Vec<_> = gpus[2..].iter().map(gpu_uid).collect();
+    let mut actual_tray_uids = tray_partition.gpu_uid_list.clone();
+    expected_tray_uids.sort_unstable();
+    actual_tray_uids.sort_unstable();
+    assert_eq!(actual_tray_uids, expected_tray_uids);
+}
+
+#[crate::sqlx_test]
 async fn test_create_instance_gpu_in_unknown_partition(pool: sqlx::PgPool) {
     let mut config = common::api_fixtures::get_config();
     if let Some(nvlink_config) = config.nvlink_config.as_mut() {

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -335,6 +335,10 @@ fn tray_default_partition_name(slot_id: i32) -> String {
     format!("tray_partition_{slot_id}")
 }
 
+fn is_gpu_in_tray_default_partition(partition: &PartitionInfo, slot_id: i32) -> bool {
+    partition.name == tray_default_partition_name(slot_id)
+}
+
 impl PartitionProcessingContext {
     fn new(
         nmx_c_partitions: Vec<PartitionInfo>,
@@ -1681,25 +1685,29 @@ impl NvlPartitionMonitor {
                                 }
                                 None => {
                                     // TODO: should we add the partition NMX-C ID to the status obs?
-                                    if is_nmx_c_default_partition(&nmxc_partition) {
+                                    if is_nmx_c_default_partition(&nmxc_partition)
+                                        || is_gpu_in_tray_default_partition(
+                                            &nmxc_partition,
+                                            nvlink_gpu.slot_id,
+                                        )
+                                    {
                                         if instance_gpu_config.is_some() {
                                             tracing::info!(
                                                 gpu_guid = nvlink_gpu.guid,
                                                 machine_id = %instance.machine_id,
                                                 instance_id = %instance.id,
                                                 nmx_c_partition_id = partition_id,
-                                                "Removing GPU in machine and instance from default partition",
+                                                "Removing configured GPU from NMX-C holding partition",
                                             );
                                             gpu_action = GpuAction::RemoveFromUnknownPartition;
                                             gpu_ctx.partition_nmx_c_id =
                                                 nmxc_partition.partition_id.unwrap_or_default();
                                         } else {
-                                            // Do nothing if there is no config
+                                            // An omitted GPU config means this GPU should remain in its holding partition.
                                             gpu_action = GpuAction::NoOp;
                                         }
                                     } else {
-                                        // Monitor does not know about this partition, so just remove the GPU. On the next iteration
-                                        // the monitor will put the GPU in the correct partition (or leave it if the config says no partition)
+                                        // The monitor cannot safely preserve membership in an unrecognized partition.
                                         tracing::warn!(
                                             gpu_guid = nvlink_gpu.guid,
                                             nmx_c_partition_id = partition_id,
@@ -1966,8 +1974,7 @@ impl NvlPartitionMonitor {
                     }
                 };
 
-                let tray_nm = tray_default_partition_name(gpu.slot_id);
-                if nmxc_partition.name == tray_nm {
+                if is_gpu_in_tray_default_partition(nmxc_partition, gpu.slot_id) {
                     continue;
                 }
 
@@ -2587,6 +2594,36 @@ fn record_domain_health(
     }
     for (state, count) in counts {
         map.insert((domain.to_string(), state), count);
+    }
+}
+
+#[cfg(test)]
+mod partition_classification_tests {
+    use libnmxc::nmxc_model::PartitionInfo;
+
+    use super::is_gpu_in_tray_default_partition;
+
+    #[test]
+    fn tray_default_partition_match_is_slot_specific() {
+        let cases = [
+            ("tray_partition_1", 1, true),
+            ("tray_partition_1", 2, false),
+            ("tray_partition_1_extra", 1, false),
+            ("Default", 1, false),
+            ("unknown-partition", 1, false),
+        ];
+
+        for (name, slot_id, expected) in cases {
+            let partition = PartitionInfo {
+                name: name.to_string(),
+                ..Default::default()
+            };
+            assert_eq!(
+                is_gpu_in_tray_default_partition(&partition, slot_id),
+                expected,
+                "partition name {name:?}, slot {slot_id}",
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Description
When a tenant added a susbet of a tray's GPUs to a partition, the rest of the GPUs were unconditionally removed from the tray partition, because the manager treated the partition as "unknown". Fix this by checking if the GPUs should still be in the tray partition.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

