### PR TITLE
fix(dpf): fix remaining BF4 DPF inventory and reboot consistency gaps

### DIFF
--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -15,19 +15,21 @@
  * limitations under the License.
  */
 
-//! Happy-path DPF integration test: DPU and host reach Ready.
+//! DPF happy-path and inventory integration tests.
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use carbide_dpf::{DpuDeploymentType, DpuPhase};
-use carbide_machine_controller::dpf::DpfOperations;
+use ::rpc::forge as rpc;
+use ::rpc::forge::forge_server::Forge;
+use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, DpuServiceVersion};
+use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use model::machine::ManagedHostState;
 use tokio::time::timeout;
+use tonic::Request;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
-
-use carbide_machine_controller::dpf::MockDpfOperations;
 
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides, get_config,
@@ -86,4 +88,143 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
         "{fresh=\"true\",state=\"ready\",substate=\"\"}".to_string(),
         "3".to_string()
     )));
+}
+
+/// Verifies DPF inventory uses the host ingestion flag and composite DPU CR name,
+/// and preserves the last complete operator inventory when a later lookup fails.
+#[crate::sqlx_test]
+async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool: sqlx::PgPool) {
+    let queried_dpu_names = Arc::new(Mutex::new(Vec::new()));
+    let fail_inventory_lookup = Arc::new(AtomicBool::new(false));
+    let mut mock = default_mock();
+    let queried_dpu_names_for_mock = queried_dpu_names.clone();
+    let fail_inventory_lookup_for_mock = fail_inventory_lookup.clone();
+    mock.expect_get_service_versions_for_dpu()
+        .returning(move |dpu_name| {
+            queried_dpu_names_for_mock
+                .lock()
+                .expect("queried DPU names lock must not be poisoned")
+                .push(dpu_name.to_string());
+            if fail_inventory_lookup_for_mock.load(Ordering::SeqCst) {
+                return Err(DpfError::InvalidState(
+                    "referenced service template is unavailable".to_string(),
+                ));
+            }
+            Ok(vec![DpuServiceVersion {
+                name: "doca-hbn".to_string(),
+                version: "operator-version".to_string(),
+                url: "nvcr.io/nvidia/doca".to_string(),
+            }])
+        });
+
+    // Ingest through DPF so only the host receives used_for_ingestion.
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
+    let mut config = get_config();
+    config.dpf = crate::cfg::file::DpfConfig {
+        enabled: true,
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: Some("http://example.com/test.bfb".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config).with_dpf_sdk(dpf_sdk),
+    )
+    .await;
+    let managed_host = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+
+    // Read both records through the public API and derive the expected CR name
+    // independently from their reported BMC MAC addresses.
+    let host = env.find_machine(managed_host.id).await.remove(0);
+    let dpu = env.find_machine(managed_host.dpu_ids[0]).await.remove(0);
+    assert!(
+        host.config
+            .as_ref()
+            .and_then(|config| config.dpf.as_ref())
+            .is_some_and(|dpf| dpf.used_for_ingestion)
+    );
+    assert!(
+        !dpu.config
+            .as_ref()
+            .and_then(|config| config.dpf.as_ref())
+            .is_some_and(|dpf| dpf.used_for_ingestion)
+    );
+    let host_node_id = host
+        .bmc_info
+        .as_ref()
+        .and_then(|bmc| bmc.mac.as_deref())
+        .expect("host BMC MAC must exist")
+        .to_ascii_lowercase()
+        .replace(':', "-");
+    let dpu_device_id = dpu
+        .bmc_info
+        .as_ref()
+        .and_then(|bmc| bmc.mac.as_deref())
+        .expect("DPU BMC MAC must exist")
+        .to_ascii_lowercase()
+        .replace(':', "-");
+    let expected_dpu_name = format!("node-{host_node_id}-device-{dpu_device_id}");
+    queried_dpu_names
+        .lock()
+        .expect("queried DPU names lock must not be poisoned")
+        .clear();
+
+    // Report an incomplete agent inventory and confirm the operator value wins.
+    let report = || {
+        Request::new(rpc::DpuAgentInventoryReport {
+            machine_id: Some(managed_host.dpu_ids[0]),
+            inventory: Some(rpc::MachineInventory {
+                components: vec![rpc::MachineInventorySoftwareComponent {
+                    name: "agent-only".to_string(),
+                    version: "incomplete".to_string(),
+                    url: String::new(),
+                }],
+            }),
+        })
+    };
+    env.api
+        .update_agent_reported_inventory(report())
+        .await
+        .expect("DPF inventory update must succeed");
+    assert_eq!(
+        *queried_dpu_names
+            .lock()
+            .expect("queried DPU names lock must not be poisoned"),
+        vec![expected_dpu_name]
+    );
+    let stored_inventory = env
+        .find_machine(managed_host.dpu_ids[0])
+        .await
+        .remove(0)
+        .inventory
+        .expect("operator inventory must be persisted");
+    assert_eq!(
+        stored_inventory.components,
+        vec![rpc::MachineInventorySoftwareComponent {
+            name: "doca-hbn".to_string(),
+            version: "operator-version".to_string(),
+            url: "nvcr.io/nvidia/doca".to_string(),
+        }]
+    );
+
+    // A later incomplete operator view must fail before replacing the complete value.
+    fail_inventory_lookup.store(true, Ordering::SeqCst);
+    env.api
+        .update_agent_reported_inventory(report())
+        .await
+        .expect_err("incomplete DPF inventory must be rejected");
+    let inventory_after_error = env
+        .find_machine(managed_host.dpu_ids[0])
+        .await
+        .remove(0)
+        .inventory
+        .expect("last complete inventory must remain persisted");
+    assert_eq!(inventory_after_error, stored_inventory);
 }

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -29,11 +29,11 @@ use carbide_redfish::libredfish::test_support::RedfishSimAction;
 use carbide_uuid::machine::MachineId;
 use db::TransactionVending;
 use libredfish::SystemPowerControl;
-use model::machine::{DpfState, DpuInitState, ManagedHostState};
+use model::machine::{DpfState, DpuInitState, ManagedHostState, PerformPowerOperation};
 use tokio::time::timeout;
 
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
+    TestEnvOverrides, TestManagedHost, create_managed_host, create_managed_host_with_dpf,
     create_test_env_with_overrides, get_config, reboot_completed,
 };
 
@@ -76,19 +76,17 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
     }
 }
 
-async fn reset_host_to_waiting_for_ready(
+/// Persists one DPU's DPF substate directly so tests can isolate a handler
+/// transition without replaying the preceding operator workflow.
+async fn reset_host_to_dpf_state(
     pool: &sqlx::PgPool,
     host_id: &MachineId,
     dpu_id: &MachineId,
+    dpf_state: DpfState,
 ) {
     let state = ManagedHostState::DPUInit {
         dpu_states: model::machine::DpuInitStates {
-            states: HashMap::from([(
-                *dpu_id,
-                DpuInitState::DpfStates {
-                    state: DpfState::WaitingForReady { phase_detail: None },
-                },
-            )]),
+            states: HashMap::from([(*dpu_id, DpuInitState::DpfStates { state: dpf_state })]),
         },
     };
     let state_json = serde_json::to_value(&state).unwrap();
@@ -110,6 +108,22 @@ async fn reset_host_to_waiting_for_ready(
     .execute(pool)
     .await
     .unwrap();
+}
+
+/// Restores WaitingForReady so tests can replay operator readiness and reboot
+/// decisions after their initial DPF ingestion has completed.
+async fn reset_host_to_waiting_for_ready(
+    pool: &sqlx::PgPool,
+    host_id: &MachineId,
+    dpu_id: &MachineId,
+) {
+    reset_host_to_dpf_state(
+        pool,
+        host_id,
+        dpu_id,
+        DpfState::WaitingForReady { phase_detail: None },
+    )
+    .await;
 }
 
 async fn get_host_state(
@@ -193,7 +207,9 @@ async fn test_waiting_for_ready_reboot_flow(pool: sqlx::PgPool) {
 
     reboot_completed(&env, mh.id).await;
 
+    // Complete On, observe DPU readiness, then cross the DeviceReady barrier.
     timeout(TEST_TIMEOUT, async {
+        env.run_machine_state_controller_iteration().await;
         env.run_machine_state_controller_iteration().await;
         env.run_machine_state_controller_iteration().await;
     })
@@ -380,6 +396,86 @@ async fn test_waiting_for_ready_idempotent_reboot(pool: sqlx::PgPool) {
     );
 }
 
+/// Verifies the On intent is persisted in a separate reconciliation before
+/// issuing power-on, preventing a crash from leaving durable state at Off.
+#[crate::sqlx_test]
+async fn test_reboot_persists_on_intent_before_power_command(pool: sqlx::PgPool) {
+    let mut mock = MockDpfOperations::new();
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::default().with_dpf_sdk(dpf_sdk),
+    )
+    .await;
+    let managed_host = create_managed_host(&env).await;
+
+    // Start with hardware Off and durable state at the completed Off phase.
+    let bmc_access_info = {
+        let mut txn = env.pool.txn_begin().await.unwrap();
+        let bmc_access_info = managed_host.host().bmc_access(&mut txn).await;
+        txn.commit().await.unwrap();
+        bmc_access_info
+    };
+    env.redfish_sim
+        .client_by_info(&bmc_access_info)
+        .await
+        .unwrap()
+        .power(SystemPowerControl::ForceOff)
+        .await
+        .unwrap();
+    reset_host_to_dpf_state(
+        &pool,
+        &managed_host.id,
+        &managed_host.dpu_ids[0],
+        DpfState::HandleReboot {
+            op: PerformPowerOperation::Off,
+            retry_count: 0,
+        },
+    )
+    .await;
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    // The first reconciliation only persists On intent and performs no power-on.
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while persisting On intent");
+    let first_actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    assert!(
+        !first_actions.contains(&RedfishSimAction::Power(SystemPowerControl::On)),
+        "On must not be issued before its intent is persisted: {first_actions:?}"
+    );
+    let host_state = get_host_state(&env, &managed_host).await;
+    let ManagedHostState::DPUInit { dpu_states } = host_state else {
+        panic!("expected DPUInit after persisting On intent");
+    };
+    assert!(matches!(
+        dpu_states.states.get(&managed_host.dpu_ids[0]),
+        Some(DpuInitState::DpfStates {
+            state: DpfState::HandleReboot {
+                op: PerformPowerOperation::On,
+                retry_count: 0,
+            },
+        })
+    ));
+
+    // The next reconciliation may now issue On from the durable On phase.
+    let second_timepoint = env.redfish_sim.timepoint();
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while issuing On command");
+    let second_actions = env.redfish_sim.actions_since(&second_timepoint).all_hosts();
+    assert!(
+        second_actions.contains(&RedfishSimAction::Power(SystemPowerControl::On)),
+        "On must be issued from the durable On phase: {second_actions:?}"
+    );
+}
+
 /// When the host is already Off and last_reboot_requested is None,
 /// the reboot handler should skip ForceOff and go straight to PowerOn.
 #[crate::sqlx_test]
@@ -470,7 +566,9 @@ async fn test_waiting_for_ready_host_already_off(pool: sqlx::PgPool) {
 
     reboot_completed(&env, mh.id).await;
 
+    // Complete On, observe DPU readiness, then cross the DeviceReady barrier.
     timeout(TEST_TIMEOUT, async {
+        env.run_machine_state_controller_iteration().await;
         env.run_machine_state_controller_iteration().await;
         env.run_machine_state_controller_iteration().await;
     })

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -2020,6 +2020,9 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
     ///   otherwise `url` is `helmChart.source.repoURL` and `name` is
     ///   `helmChart.source.chart`. If no name can be derived, the DPUDeployment
     ///   service name is used.
+    ///
+    /// Returns an error when any referenced DPUServiceTemplate is absent so
+    /// callers cannot persist a partial inventory snapshot.
     pub async fn get_service_versions_for_dpu(
         &self,
         dpu_name: &str,
@@ -2057,12 +2060,15 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
             let Some(template_name) = &service.service_template else {
                 continue;
             };
-            let Some(template) =
+            let template =
                 DpuServiceTemplateRepository::get(&*self.repo, template_name, &self.namespace)
                     .await?
-            else {
-                continue;
-            };
+                    .ok_or_else(|| {
+                        DpfError::InvalidState(format!(
+                            "DPUServiceTemplate {template_name} not found for service \
+                             {service_name} in DPUDeployment {deployment_name}"
+                        ))
+                    })?;
 
             let image_values = template
                 .spec

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-//! Tests for DPF SDK initialization object creation.
+//! Tests for DPF SDK initialization resources and lookup behavior.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -28,6 +29,7 @@ use crate::crds::bfbs_generated::BFB;
 use crate::crds::bluefieldsoftwares_generated::BlueFieldSoftware;
 use crate::crds::dpudeployments_generated::DPUDeployment;
 use crate::crds::dpuflavors_generated::DPUFlavor;
+use crate::crds::dpus_generated::{DPU, DpuStatusPhase};
 use crate::crds::dpuserviceconfigurations_generated::DPUServiceConfiguration;
 use crate::crds::dpuserviceinterfaces_generated::DPUServiceInterface;
 use crate::crds::dpuservicenads_generated::DPUServiceNAD;
@@ -35,7 +37,7 @@ use crate::crds::dpuservicetemplates_generated::DPUServiceTemplate;
 use crate::error::DpfError;
 use crate::repository::{
     BfbRepository, BlueFieldSoftwareRepository, DpfOperatorConfigRepository,
-    DpuDeploymentRepository, DpuFlavorRepository, DpuServiceConfigurationRepository,
+    DpuDeploymentRepository, DpuFlavorRepository, DpuRepository, DpuServiceConfigurationRepository,
     DpuServiceInterfaceRepository, DpuServiceNADRepository, DpuServiceTemplateRepository,
     K8sConfigRepository,
 };
@@ -60,6 +62,7 @@ struct InitializationMock {
     bfbs: Arc<DashMap<String, BFB>>,
     bluefield_softwares: Arc<DashMap<String, BlueFieldSoftware>>,
     flavors: Arc<DashMap<String, DPUFlavor>>,
+    dpus: Arc<DashMap<String, DPU>>,
     deployments: Arc<DashMap<String, DPUDeployment>>,
     service_templates: Arc<DashMap<String, DPUServiceTemplate>>,
     service_configs: Arc<DashMap<String, DPUServiceConfiguration>>,
@@ -139,6 +142,50 @@ impl DpuFlavorRepository for InitializationMock {
     async fn create(&self, f: &DPUFlavor) -> Result<DPUFlavor, DpfError> {
         self.flavors.insert(resource_key(f), f.clone());
         Ok(f.clone())
+    }
+}
+
+#[async_trait]
+impl DpuRepository for InitializationMock {
+    async fn get(&self, name: &str, ns: &str) -> Result<Option<DPU>, DpfError> {
+        Ok(self.dpus.get(&ns_key(ns, name)).map(|dpu| dpu.clone()))
+    }
+
+    async fn list(&self, ns: &str, _label_selector: Option<&str>) -> Result<Vec<DPU>, DpfError> {
+        let prefix = format!("{ns}/");
+        Ok(self
+            .dpus
+            .iter()
+            .filter(|entry| entry.key().starts_with(&prefix))
+            .map(|entry| entry.value().clone())
+            .collect())
+    }
+
+    async fn patch_status(
+        &self,
+        _name: &str,
+        _ns: &str,
+        _patch: serde_json::Value,
+    ) -> Result<(), DpfError> {
+        Ok(())
+    }
+
+    async fn delete(&self, name: &str, ns: &str) -> Result<(), DpfError> {
+        self.dpus.remove(&ns_key(ns, name));
+        Ok(())
+    }
+
+    fn watch<F, Fut>(
+        &self,
+        _ns: &str,
+        _label_selector: Option<&str>,
+        _handler: F,
+    ) -> impl Future<Output = ()> + Send + 'static
+    where
+        F: Fn(Arc<DPU>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(), DpfError>> + Send + 'static,
+    {
+        futures::future::pending()
     }
 }
 
@@ -397,4 +444,67 @@ async fn test_create_initialization_objects_bluefield_software() {
     assert!(deployment.spec.dpus.bfb.is_none());
 
     drop(sdk);
+}
+
+/// Verifies a missing referenced template fails the complete inventory lookup
+/// so callers cannot mistake an incomplete operator view for current state.
+#[tokio::test]
+async fn service_versions_fail_when_referenced_template_is_missing() {
+    let mock = InitializationMock::default();
+    let dpu_name = "node-host-device-dpu";
+    let mut dpu = super::helpers::make_dpu(
+        TEST_NS,
+        dpu_name,
+        "device-dpu",
+        "node-host",
+        DpuStatusPhase::Ready,
+    );
+    dpu.metadata.labels = Some(BTreeMap::from([(
+        "svc.dpu.nvidia.com/owned-by-dpudeployment".to_string(),
+        format!("{TEST_NS}_deployment"),
+    )]));
+    mock.dpus.insert(resource_key(&dpu), dpu);
+
+    // Resolve one service before encountering the absent template to exercise
+    // the partial-result path that must now be rejected.
+    let services = vec![
+        ServiceDefinition::new("a-present", "repo", "chart", "1.0.0"),
+        ServiceDefinition::new("z-missing", "repo", "chart", "2.0.0"),
+    ];
+    let deployment = crate::sdk::build_deployment(
+        &services,
+        "deployment",
+        &crate::sdk::DpuProvisioningSource::Bfb("bfb".to_string()),
+        "flavor",
+        TEST_NS,
+        &[],
+        BTreeMap::new(),
+        "",
+    );
+    DpuDeploymentRepository::apply(&mock, &deployment)
+        .await
+        .unwrap();
+    DpuServiceTemplateRepository::apply(
+        &mock,
+        &crate::sdk::build_service_template(&services[0], TEST_NS, ""),
+    )
+    .await
+    .unwrap();
+    let sdk = crate::sdk::DpfSdkBuilder::new(mock, TEST_NS, String::new())
+        .build_without_resources()
+        .await
+        .unwrap();
+
+    // The missing reference invalidates the whole snapshot rather than
+    // returning only the service whose template was available.
+    let error = sdk
+        .get_service_versions_for_dpu(dpu_name)
+        .await
+        .expect_err("missing referenced template must fail inventory lookup");
+    let DpfError::InvalidState(message) = error else {
+        panic!("expected invalid state, got {error}");
+    };
+    assert!(message.contains(
+        "DPUServiceTemplate z-missing not found for service z-missing in DPUDeployment deployment"
+    ));
 }

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -111,7 +111,7 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
 
     /// Get service versions for a DPU from its owning DPUDeployment.
     ///
-    /// Looks up the DPU CR by device name, follows the
+    /// Looks up the DPU CR by its full node-device resource name, follows the
     /// `svc.dpu.nvidia.com/owned-by-dpudeployment` label to find the owning
     /// DPUDeployment, and resolves each service's version from its
     /// DPUServiceTemplate. Used to populate `agent_reported_inventory` once

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -310,10 +310,10 @@ async fn handle_dpf_provisioning(
 /// explicit per-step state rather than timestamp heuristics.
 ///
 /// Transitions:
-/// - `Off`: wait for `power_state == Off` + 30 s → issue On →
-///   `HandleReboot { On, now }`
-/// - `On`:  wait for `power_state == On`  + 30 s → `reboot_complete` →
-///   `WaitingForReady`
+/// - `Off`: wait for `power_state == Off` + delay → persist
+///   `HandleReboot { On, 0 }`
+/// - `On`: issue or retry On while the host is Off; once the host is On after
+///   the delay, call `reboot_complete` and transition to `WaitingForReady`
 async fn handle_dpf_handle_reboot(
     state: &ManagedHostStateSnapshot,
     op: &PerformPowerOperation,
@@ -325,10 +325,14 @@ async fn handle_dpf_handle_reboot(
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     const MAX_RETRIES: u32 = 3;
 
-    if super::wait(
-        &state.host_snapshot.state.version.timestamp(),
-        power_down_wait,
-    ) {
+    // On with zero attempts is durable intent before the initial command, so
+    // the transition delay applies only after a power command was issued.
+    if !(matches!(op, PerformPowerOperation::On) && retry_count == 0)
+        && super::wait(
+            &state.host_snapshot.state.version.timestamp(),
+            power_down_wait,
+        )
+    {
         return Ok(StateHandlerOutcome::wait(
             "waiting for power transition delay".into(),
         ));
@@ -345,7 +349,6 @@ async fn handle_dpf_handle_reboot(
     match op {
         PerformPowerOperation::Off => {
             if power_state == libredfish::PowerState::Off {
-                handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
                 let next = transition_all_dpus_to_dpf_state(
                     DpfState::HandleReboot {
                         op: PerformPowerOperation::On,
@@ -391,12 +394,16 @@ async fn handle_dpf_handle_reboot(
                     state,
                 )?;
                 Ok(StateHandlerOutcome::transition(next))
-            } else if retry_count < MAX_RETRIES {
-                tracing::warn!(
-                    host = %state.host_snapshot.id,
-                    retry_count,
-                    "Host did not power on; retrying On"
-                );
+            } else if retry_count <= MAX_RETRIES {
+                // Zero means the On intent is durable but its initial command
+                // has not yet been issued. Later attempts are retries.
+                if retry_count > 0 {
+                    tracing::warn!(
+                        host = %state.host_snapshot.id,
+                        retry_count,
+                        "Host did not power on; retrying On"
+                    );
+                }
                 handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
                 let next = transition_all_dpus_to_dpf_state(
                     DpfState::HandleReboot {


### PR DESCRIPTION

A little clean-up based on recent findings.

Reject incomplete DPF service inventory snapshots when referenced service templates are unavailable, preserving the last-known-good database value.

Make the DPF reboot’s power-on intent durable before issuing or retrying the command, preventing persisted state from diverging from hardware after failures.

Add regression coverage for host-based DPF detection, composite DPU CR naming, inventory preservation, and reboot persistence ordering.

## Related issues


## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


