### PR TITLE
fix(core): phone_home should NOT be injected in installer user-data but in target OS user-data

### DIFF
--- a/rest-api/api/pkg/api/handler/instance_test.go
+++ b/rest-api/api/pkg/api/handler/instance_test.go
@@ -55,21 +55,43 @@ func assertDeletionAcceptedResponse(t *testing.T, body []byte) {
 	assert.Equal(t, model.DeletionRequestAcceptedMessage, resp.Message)
 }
 
-func userDataHasPhoneHome(userData map[string]interface{}) bool {
-	if _, ok := userData[util.SitePhoneHomeName]; ok {
-		return true
+type phoneHomeLocation string
+
+const (
+	phoneHomeAbsent                 phoneHomeLocation = "absent"
+	phoneHomeAtRoot                 phoneHomeLocation = "root"
+	phoneHomeInAutoinstallUserData  phoneHomeLocation = "autoinstall.user-data"
+	phoneHomeAtRootAndInAutoinstall phoneHomeLocation = "root and autoinstall.user-data"
+)
+
+func phoneHomeLocationIn(userData map[string]interface{}) phoneHomeLocation {
+	_, atRoot := userData[util.SitePhoneHomeName]
+	inAutoinstall := false
+	autoinstall, ok := userData["autoinstall"].(map[string]interface{})
+	if ok {
+		targetUserData, ok := autoinstall["user-data"].(map[string]interface{})
+		if ok {
+			_, inAutoinstall = targetUserData[util.SitePhoneHomeName]
+		}
 	}
 
-	autoinstall, ok := userData["autoinstall"].(map[string]interface{})
-	if !ok {
-		return false
+	switch {
+	case atRoot && inAutoinstall:
+		return phoneHomeAtRootAndInAutoinstall
+	case atRoot:
+		return phoneHomeAtRoot
+	case inAutoinstall:
+		return phoneHomeInAutoinstallUserData
+	default:
+		return phoneHomeAbsent
 	}
-	targetUserData, ok := autoinstall["user-data"].(map[string]interface{})
-	if !ok {
-		return false
+}
+
+func expectedPhoneHomeLocation(userData map[string]interface{}) phoneHomeLocation {
+	if _, ok := userData["autoinstall"]; ok {
+		return phoneHomeInAutoinstallUserData
 	}
-	_, ok = targetUserData[util.SitePhoneHomeName]
-	return ok
+	return phoneHomeAtRoot
 }
 
 func testInstanceInitDB(t *testing.T) *cdb.Session {
@@ -3895,7 +3917,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 				err := yaml.Unmarshal([]byte(*rst.UserData), &instUserData)
 				assert.Equal(t, err, nil)
 				if *tt.args.reqData.PhoneHomeEnabled {
-					assert.True(t, userDataHasPhoneHome(instUserData))
+					assert.Equal(t, expectedPhoneHomeLocation(instUserData), phoneHomeLocationIn(instUserData))
 					if tt.args.reqData.OperatingSystemID != nil {
 						lines := strings.Split(*rst.UserData, "\n")
 						// ensure first line is always #cloud-config
@@ -3903,7 +3925,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 						assert.NotEqual(t, util.SiteCloudConfig, lines[1])
 					}
 				} else {
-					assert.False(t, userDataHasPhoneHome(instUserData))
+					assert.Equal(t, phoneHomeAbsent, phoneHomeLocationIn(instUserData))
 				}
 			} else {
 				if tt.args.reqData.OperatingSystemID != nil {
@@ -3916,7 +3938,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 						// Verify Phone home
 						err := yaml.Unmarshal([]byte(*rst.UserData), &instUserData)
 						assert.Equal(t, err, nil)
-						assert.True(t, userDataHasPhoneHome(instUserData))
+						assert.Equal(t, expectedPhoneHomeLocation(instUserData), phoneHomeLocationIn(instUserData))
 					}
 				}
 			}

--- a/rest-api/api/pkg/api/handler/instance_test.go
+++ b/rest-api/api/pkg/api/handler/instance_test.go
@@ -55,6 +55,23 @@ func assertDeletionAcceptedResponse(t *testing.T, body []byte) {
 	assert.Equal(t, model.DeletionRequestAcceptedMessage, resp.Message)
 }
 
+func userDataHasPhoneHome(userData map[string]interface{}) bool {
+	if _, ok := userData[util.SitePhoneHomeName]; ok {
+		return true
+	}
+
+	autoinstall, ok := userData["autoinstall"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	targetUserData, ok := autoinstall["user-data"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	_, ok = targetUserData[util.SitePhoneHomeName]
+	return ok
+}
+
 func testInstanceInitDB(t *testing.T) *cdb.Session {
 	dbSession := cdbu.GetTestDBSession(t, false)
 	dbSession.DB.AddQueryHook(bundebug.NewQueryHook(
@@ -3878,7 +3895,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 				err := yaml.Unmarshal([]byte(*rst.UserData), &instUserData)
 				assert.Equal(t, err, nil)
 				if *tt.args.reqData.PhoneHomeEnabled {
-					assert.Contains(t, instUserData, util.SitePhoneHomeName)
+					assert.True(t, userDataHasPhoneHome(instUserData))
 					if tt.args.reqData.OperatingSystemID != nil {
 						lines := strings.Split(*rst.UserData, "\n")
 						// ensure first line is always #cloud-config
@@ -3886,7 +3903,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 						assert.NotEqual(t, util.SiteCloudConfig, lines[1])
 					}
 				} else {
-					assert.NotContains(t, instUserData, util.SitePhoneHomeName)
+					assert.False(t, userDataHasPhoneHome(instUserData))
 				}
 			} else {
 				if tt.args.reqData.OperatingSystemID != nil {
@@ -3899,7 +3916,7 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 						// Verify Phone home
 						err := yaml.Unmarshal([]byte(*rst.UserData), &instUserData)
 						assert.Equal(t, err, nil)
-						assert.Contains(t, instUserData, util.SitePhoneHomeName)
+						assert.True(t, userDataHasPhoneHome(instUserData))
 					}
 				}
 			}

--- a/rest-api/api/pkg/api/model/util/util.go
+++ b/rest-api/api/pkg/api/model/util/util.go
@@ -121,9 +121,25 @@ func InsertPhoneHomeIntoUserData(documentRoot *yaml.Node, url string) error {
 		documentRoot.Content = []*yaml.Node{}
 	}
 
-	insertionNode, err := phoneHomeInsertionNode(documentRoot)
-	if err != nil {
-		return err
+	insertionNode := documentRoot
+	autoinstallNode := mappingValue(documentRoot, autoinstallName)
+	if autoinstallNode != nil {
+		if autoinstallNode.Kind != yaml.MappingNode {
+			return errors.New("autoinstall must be a mapping to insert phone-home")
+		}
+
+		insertionNode = mappingValue(autoinstallNode, autoinstallUserData)
+		if insertionNode == nil {
+			insertionNode = &yaml.Node{
+				Kind: yaml.MappingNode,
+				Tag:  "!!map",
+			}
+			targetUserDataKeyNode := &yaml.Node{}
+			targetUserDataKeyNode.SetString(autoinstallUserData)
+			autoinstallNode.Content = append(autoinstallNode.Content, targetUserDataKeyNode, insertionNode)
+		} else if insertionNode.Kind != yaml.MappingNode {
+			return errors.New("autoinstall user-data must be a mapping to insert phone-home")
+		}
 	}
 
 	// Remove existing phone-home blocks from both supported locations before
@@ -178,31 +194,6 @@ func mappingValue(mappingNode *yaml.Node, key string) *yaml.Node {
 	}
 
 	return nil
-}
-
-func phoneHomeInsertionNode(documentRoot *yaml.Node) (*yaml.Node, error) {
-	autoinstallNode := mappingValue(documentRoot, autoinstallName)
-	if autoinstallNode == nil {
-		return documentRoot, nil
-	}
-	if autoinstallNode.Kind != yaml.MappingNode {
-		return nil, errors.New("autoinstall must be a mapping to insert phone-home")
-	}
-
-	targetUserDataNode := mappingValue(autoinstallNode, autoinstallUserData)
-	if targetUserDataNode == nil {
-		targetUserDataNode = &yaml.Node{
-			Kind: yaml.MappingNode,
-			Tag:  "!!map",
-		}
-		targetUserDataKeyNode := &yaml.Node{}
-		targetUserDataKeyNode.SetString(autoinstallUserData)
-		autoinstallNode.Content = append(autoinstallNode.Content, targetUserDataKeyNode, targetUserDataNode)
-	} else if targetUserDataNode.Kind != yaml.MappingNode {
-		return nil, errors.New("autoinstall user-data must be a mapping to insert phone-home")
-	}
-
-	return targetUserDataNode, nil
 }
 
 // ProtobufLabelsFromAPILabels converts API labels (map[string]string) to protobuf labels ([]*corev1.Label)

--- a/rest-api/api/pkg/api/model/util/util.go
+++ b/rest-api/api/pkg/api/model/util/util.go
@@ -18,35 +18,53 @@ const (
 	SitePhoneHomePostAll = "all"
 	SitePhoneHomeUrl     = "url"
 	SiteCloudConfig      = "#cloud-config"
+	autoinstallName      = "autoinstall"
+	autoinstallUserData  = "user-data"
 )
 
-// Walks through the yaml nodes looking for a cloud-init phone-home block
+// Removes cloud-init phone-home blocks from the document root and, for
+// autoinstall configurations, from the target system's user-data.
 // If `url` is nil, then any phone-home block found will be removed.
 // If `url` is non-nil, then the phone-home block will only be removed if
-// if the URL matches the value of `url`
+// the URL matches the value of `url`.
 func RemovePhoneHomeFromUserData(documentRoot *yaml.Node, url *string) error {
-
 	if documentRoot == nil || documentRoot.Kind != yaml.MappingNode {
 		return fmt.Errorf("node must be non-nil MappingNode for user-data removal")
 	}
 
-	contentLen := len(documentRoot.Content)
+	removePhoneHomeFromMapping(documentRoot, url)
+
+	autoinstallNode := mappingValue(documentRoot, autoinstallName)
+	if autoinstallNode == nil || autoinstallNode.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	targetUserDataNode := mappingValue(autoinstallNode, autoinstallUserData)
+	if targetUserDataNode != nil && targetUserDataNode.Kind == yaml.MappingNode {
+		removePhoneHomeFromMapping(targetUserDataNode, url)
+	}
+
+	return nil
+}
+
+func removePhoneHomeFromMapping(mappingNode *yaml.Node, url *string) {
+	contentLen := len(mappingNode.Content)
 
 	// If phone-home is being disabled, then delete
 	// any phone-home data that might exist.
 	// Go through the YAML nodes and look for our target.
-	// We've previously determined that documentRoot is a
-	// valid MappingNode, so the contents wil be pairs of nodes
+	// We've previously determined that mappingNode is a
+	// valid MappingNode, so the contents will be pairs of nodes
 	// representing key/value pairs of the map.
 	//
-	// Note there are no breaks or early returns because a user
+	// Note there are no breaks or early returns from outer loop because a user
 	// could have submitted valid but nonsensical YAML with
 	// multiple phone-home blocks.
 	for i := 0; i < contentLen; i += 2 {
-		mapKeyNode := documentRoot.Content[i]
-		mapValueNode := documentRoot.Content[i+1]
+		mapKeyNode := mappingNode.Content[i]
+		mapValueNode := mappingNode.Content[i+1]
 
-		// No breaks or early-returns here because the user could have submitted
+		// No breaks or early-returns here from outer loop because the user could have submitted
 		// valid but nonsensical YAML that includes a phone-home block multiple times.
 		if mapKeyNode.Kind == yaml.ScalarNode && mapKeyNode.Value == SitePhoneHomeName {
 			// Check if the next node is a map, which will be the phone_home map itself.
@@ -58,15 +76,15 @@ func RemovePhoneHomeFromUserData(documentRoot *yaml.Node, url *string) error {
 					// (the actual map node), so +2
 					// We're working with pairs here, so the second slice-expression
 					// won't violate bounds.
-					documentRoot.Content = append(documentRoot.Content[:i], documentRoot.Content[i+2:]...)
+					mappingNode.Content = append(mappingNode.Content[:i], mappingNode.Content[i+2:]...)
 
 					// Shift the "pointer" backwards since we
-					// just modified documentRoot.Content "in-place"
+					// just modified mappingNode.Content "in-place"
 					i -= 2
 
 					// Reduce the loop limit since the
 					// list being worked on is shorter now.
-					contentLen = len(documentRoot.Content)
+					contentLen = len(mappingNode.Content)
 					continue
 				}
 
@@ -81,9 +99,10 @@ func RemovePhoneHomeFromUserData(documentRoot *yaml.Node, url *string) error {
 					phoneHomeMapValueNode := phoneHomeMapSubNodes[j+1]
 					if phoneHomeMapKeyNode.Kind == yaml.ScalarNode && phoneHomeMapKeyNode.Value == SitePhoneHomeUrl {
 						if phoneHomeMapValueNode.Value == *url {
-							documentRoot.Content = append(documentRoot.Content[:i], documentRoot.Content[i+2:]...)
+							mappingNode.Content = append(mappingNode.Content[:i], mappingNode.Content[i+2:]...)
 							i -= 2
-							contentLen = len(documentRoot.Content)
+							contentLen = len(mappingNode.Content)
+							break
 						}
 					}
 				}
@@ -91,8 +110,6 @@ func RemovePhoneHomeFromUserData(documentRoot *yaml.Node, url *string) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 func InsertPhoneHomeIntoUserData(documentRoot *yaml.Node, url string) error {
@@ -104,7 +121,13 @@ func InsertPhoneHomeIntoUserData(documentRoot *yaml.Node, url string) error {
 		documentRoot.Content = []*yaml.Node{}
 	}
 
-	// Remove any existing phone-home block found before we insert a new one.
+	insertionNode, err := phoneHomeInsertionNode(documentRoot)
+	if err != nil {
+		return err
+	}
+
+	// Remove existing phone-home blocks from both supported locations before
+	// inserting the canonical block.
 	if err := RemovePhoneHomeFromUserData(documentRoot, nil); err != nil {
 		return err
 	}
@@ -115,7 +138,7 @@ func InsertPhoneHomeIntoUserData(documentRoot *yaml.Node, url string) error {
 	phoneHomeConfigMap[SitePhoneHomePost] = SitePhoneHomePostAll
 
 	// Encode it into a new YAML node so we can
-	// add it to the root content later.
+	// add it to the selected content later.
 	phoneHomeValueNode := &yaml.Node{}
 	if err := phoneHomeValueNode.Encode(phoneHomeConfigMap); err != nil {
 		return errors.New("failed to insert phone-home into userData")
@@ -124,7 +147,7 @@ func InsertPhoneHomeIntoUserData(documentRoot *yaml.Node, url string) error {
 	phoneHomeKeyNode.SetString(SitePhoneHomeName)
 
 	// Append the node that we can marshal it back out later.
-	documentRoot.Content = append(documentRoot.Content, phoneHomeKeyNode, phoneHomeValueNode)
+	insertionNode.Content = append(insertionNode.Content, phoneHomeKeyNode, phoneHomeValueNode)
 
 	// Ensure #cloud-config is present as a head comment
 	foundCloudConfig := false
@@ -144,6 +167,42 @@ func InsertPhoneHomeIntoUserData(documentRoot *yaml.Node, url string) error {
 	}
 
 	return nil
+}
+
+func mappingValue(mappingNode *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(mappingNode.Content); i += 2 {
+		keyNode := mappingNode.Content[i]
+		if keyNode.Kind == yaml.ScalarNode && keyNode.Value == key {
+			return mappingNode.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+func phoneHomeInsertionNode(documentRoot *yaml.Node) (*yaml.Node, error) {
+	autoinstallNode := mappingValue(documentRoot, autoinstallName)
+	if autoinstallNode == nil {
+		return documentRoot, nil
+	}
+	if autoinstallNode.Kind != yaml.MappingNode {
+		return nil, errors.New("autoinstall must be a mapping to insert phone-home")
+	}
+
+	targetUserDataNode := mappingValue(autoinstallNode, autoinstallUserData)
+	if targetUserDataNode == nil {
+		targetUserDataNode = &yaml.Node{
+			Kind: yaml.MappingNode,
+			Tag:  "!!map",
+		}
+		targetUserDataKeyNode := &yaml.Node{}
+		targetUserDataKeyNode.SetString(autoinstallUserData)
+		autoinstallNode.Content = append(autoinstallNode.Content, targetUserDataKeyNode, targetUserDataNode)
+	} else if targetUserDataNode.Kind != yaml.MappingNode {
+		return nil, errors.New("autoinstall user-data must be a mapping to insert phone-home")
+	}
+
+	return targetUserDataNode, nil
 }
 
 // ProtobufLabelsFromAPILabels converts API labels (map[string]string) to protobuf labels ([]*corev1.Label)

--- a/rest-api/api/pkg/api/model/util/util_test.go
+++ b/rest-api/api/pkg/api/model/util/util_test.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestInsertPhoneHomeIntoUserData(t *testing.T) {
+	const phoneHomeURL = "http://169.254.169.254/phone-home"
+
+	tests := []struct {
+		name       string
+		userData   string
+		wantNested bool
+		wantErr    bool
+	}{
+		{
+			name:     "ordinary cloud-init inserts at document root",
+			userData: "packages:\n  - curl\n",
+		},
+		{
+			name: "autoinstall inserts into existing target user-data",
+			userData: `autoinstall:
+  version: 1
+  user-data:
+    timezone: Etc/UTC
+phone_home:
+  url: http://stale
+`,
+			wantNested: true,
+		},
+		{
+			name: "autoinstall creates target user-data",
+			userData: `autoinstall:
+  version: 1
+`,
+			wantNested: true,
+		},
+		{
+			name: "rejects non-mapping autoinstall user-data",
+			userData: `autoinstall:
+  version: 1
+  user-data: invalid
+`,
+			wantNested: true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			documentRoot := unmarshalDocumentRoot(t, tt.userData)
+
+			err := InsertPhoneHomeIntoUserData(documentRoot, phoneHomeURL)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			rootPhoneHome := mappingNodeValue(documentRoot, SitePhoneHomeName)
+			autoinstallNode := mappingNodeValue(documentRoot, "autoinstall")
+			var targetPhoneHome *yaml.Node
+			if autoinstallNode != nil {
+				targetUserDataNode := mappingNodeValue(autoinstallNode, "user-data")
+				require.NotNil(t, targetUserDataNode)
+				targetPhoneHome = mappingNodeValue(targetUserDataNode, SitePhoneHomeName)
+			}
+
+			if tt.wantNested {
+				assert.Nil(t, rootPhoneHome)
+			} else {
+				targetPhoneHome = rootPhoneHome
+			}
+			require.NotNil(t, targetPhoneHome)
+			assert.Equal(t, phoneHomeURL, mappingNodeValue(targetPhoneHome, SitePhoneHomeUrl).Value)
+			assert.Equal(t, SitePhoneHomePostAll, mappingNodeValue(targetPhoneHome, SitePhoneHomePost).Value)
+		})
+	}
+}
+
+func TestRemovePhoneHomeFromUserData(t *testing.T) {
+	const phoneHomeURL = "http://169.254.169.254/phone-home"
+
+	tests := []struct {
+		name        string
+		url         *string
+		wantRemoved bool
+	}{
+		{
+			name:        "removes all phone-home blocks from both locations",
+			wantRemoved: true,
+		},
+		{
+			name:        "removes matching phone-home blocks from both locations",
+			url:         stringPointer(phoneHomeURL),
+			wantRemoved: true,
+		},
+		{
+			name: "preserves non-matching phone-home blocks in both locations",
+			url:  stringPointer("http://different"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			documentRoot := unmarshalDocumentRoot(t, `phone_home:
+  url: http://169.254.169.254/phone-home
+autoinstall:
+  version: 1
+  user-data:
+    phone_home:
+      url: http://169.254.169.254/phone-home
+`)
+
+			require.NoError(t, RemovePhoneHomeFromUserData(documentRoot, tt.url))
+
+			rootPhoneHome := mappingNodeValue(documentRoot, SitePhoneHomeName)
+			autoinstallNode := mappingNodeValue(documentRoot, "autoinstall")
+			targetUserDataNode := mappingNodeValue(autoinstallNode, "user-data")
+			targetPhoneHome := mappingNodeValue(targetUserDataNode, SitePhoneHomeName)
+			if tt.wantRemoved {
+				assert.Nil(t, rootPhoneHome)
+				assert.Nil(t, targetPhoneHome)
+			} else {
+				assert.NotNil(t, rootPhoneHome)
+				assert.NotNil(t, targetPhoneHome)
+			}
+		})
+	}
+}
+
+func unmarshalDocumentRoot(t *testing.T, userData string) *yaml.Node {
+	t.Helper()
+
+	document := &yaml.Node{}
+	require.NoError(t, yaml.Unmarshal([]byte(userData), document))
+	require.Len(t, document.Content, 1)
+	require.Equal(t, yaml.MappingNode, document.Content[0].Kind)
+
+	return document.Content[0]
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func mappingNodeValue(mappingNode *yaml.Node, key string) *yaml.Node {
+	if mappingNode == nil || mappingNode.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i+1 < len(mappingNode.Content); i += 2 {
+		keyNode := mappingNode.Content[i]
+		if keyNode.Kind == yaml.ScalarNode && keyNode.Value == key {
+			return mappingNode.Content[i+1]
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
When using an installer to install OS on target, 'phone_home' is added to the user-data of the installer instead of the user-data for the target OS. That makes the installer to callback and instances to report Ready/BootCompleted before the OS is actually booted/reachable.

## Type of Change
- [X] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
