### PR TITLE
fix(machine-controller,dpf): stop manipulating rshim and host privilege settings for BF4

### DIFF
--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -25,6 +25,7 @@ use ::rpc::forge as rpc;
 use ::rpc::forge::forge_server::Forge;
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, DpuServiceVersion};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
+use carbide_redfish::libredfish::test_support::{RedfishSimAction, RedfishSimPlatformAction};
 use model::machine::ManagedHostState;
 use tokio::time::timeout;
 use tonic::Request;
@@ -35,7 +36,7 @@ use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides, get_config,
 };
 
-fn default_mock() -> MockDpfOperations {
+fn default_mock(deployment_type: DpuDeploymentType) -> MockDpfOperations {
     let mut mock = MockDpfOperations::new();
     mock.expect_register_dpu_device().returning(|_| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
@@ -44,17 +45,14 @@ fn default_mock() -> MockDpfOperations {
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
     mock.expect_deployment_type_for_dpu()
-        .returning(|_| Ok(DpuDeploymentType::Bf3));
+        .returning(move |_| Ok(deployment_type));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock
 }
 
-#[crate::sqlx_test]
-async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
-    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(default_mock());
-
-    let mut config = get_config();
-    config.dpf = crate::cfg::file::DpfConfig {
+/// DPF configuration shared by happy-path integration tests.
+fn dpf_config() -> crate::cfg::file::DpfConfig {
+    crate::cfg::file::DpfConfig {
         enabled: true,
         deployments: crate::cfg::file::DpfDeploymentsConfig {
             bf3: crate::cfg::file::DpfDeploymentConfig {
@@ -64,7 +62,15 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
             ..Default::default()
         },
         ..Default::default()
-    };
+    }
+}
+
+#[crate::sqlx_test]
+async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(default_mock(DpuDeploymentType::Bf3));
+
+    let mut config = get_config();
+    config.dpf = dpf_config();
 
     let env = create_test_env_with_overrides(
         pool,
@@ -90,13 +96,96 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
     )));
 }
 
+/// Provision a BF4 through DPF and verify that NICo performs only the
+/// credential portion of post-ready platform handling.
+async fn assert_bf4_skips_platform_configuration(pool: sqlx::PgPool, enable_secure_boot: bool) {
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(default_mock(DpuDeploymentType::Bf4Generic));
+
+    let mut config = get_config();
+    config.dpf = dpf_config();
+    config.dpu_config.dpu_enable_secure_boot = enable_secure_boot;
+
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config).with_dpf_sdk(dpf_sdk),
+    )
+    .await;
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during BF4 initial provisioning");
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    let dpu = mh.dpu().db_machine(&mut txn).await;
+
+    assert!(host.config.dpf.used_for_ingestion);
+    assert!(matches!(dpu.current_state(), ManagedHostState::Ready));
+
+    let dpu_bmc_ip = dpu
+        .status
+        .bmc_info
+        .ip
+        .expect("DPU BMC IP must be present")
+        .to_string();
+
+    // BF4 must not receive the opaque vendor machine_setup call.
+    let dpu_redfish_actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .for_host(&dpu_bmc_ip);
+    assert!(
+        dpu_redfish_actions
+            .iter()
+            .all(|action| !matches!(action, RedfishSimAction::MachineSetup { .. })),
+        "BF4 received machine_setup: {dpu_redfish_actions:?}"
+    );
+
+    let platform_actions = env.redfish_sim.platform_actions();
+
+    // Credential replacement remains NICo-owned until DPF supports it.
+    assert_eq!(
+        platform_actions
+            .iter()
+            .filter(|action| matches!(action, RedfishSimPlatformAction::UefiSetup { dpu: true }))
+            .count(),
+        1,
+        "BF4 DPU UEFI credential was not replaced exactly once: {platform_actions:?}"
+    );
+
+    // No BF4 platform mutation or BIOS verification may run after DPF reports Ready.
+    assert!(
+        platform_actions.iter().all(|action| !matches!(
+            action,
+            RedfishSimPlatformAction::SetHostRshim { host }
+                | RedfishSimPlatformAction::SetHostPrivilegeLevel { host }
+                | RedfishSimPlatformAction::IsBiosSetup { host }
+                if host == &dpu_bmc_ip
+        )),
+        "BF4 received post-ready platform configuration: {platform_actions:?}"
+    );
+}
+
+/// BF4 skips `machine_setup` when the legacy non-secure-boot branch is selected.
+#[crate::sqlx_test]
+async fn test_bf4_dpf_skips_machine_setup(pool: sqlx::PgPool) {
+    assert_bf4_skips_platform_configuration(pool, false).await;
+}
+
+/// BF4 skips the RShim and host-privilege mutations when secure boot is enabled.
+#[crate::sqlx_test]
+async fn test_bf4_dpf_skips_secure_boot_platform_setup(pool: sqlx::PgPool) {
+    assert_bf4_skips_platform_configuration(pool, true).await;
+}
+
 /// Verifies DPF inventory uses the host ingestion flag and composite DPU CR name,
 /// and preserves the last complete operator inventory when a later lookup fails.
 #[crate::sqlx_test]
 async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool: sqlx::PgPool) {
     let queried_dpu_names = Arc::new(Mutex::new(Vec::new()));
     let fail_inventory_lookup = Arc::new(AtomicBool::new(false));
-    let mut mock = default_mock();
+    let mut mock = default_mock(DpuDeploymentType::Bf3);
     let queried_dpu_names_for_mock = queried_dpu_names.clone();
     let fail_inventory_lookup_for_mock = fail_inventory_lookup.clone();
     mock.expect_get_service_versions_for_dpu()
@@ -120,17 +209,7 @@ async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool
     // Ingest through DPF so only the host receives used_for_ingestion.
     let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
     let mut config = get_config();
-    config.dpf = crate::cfg::file::DpfConfig {
-        enabled: true,
-        deployments: crate::cfg::file::DpfDeploymentsConfig {
-            bf3: crate::cfg::file::DpfDeploymentConfig {
-                bfb_url: Some("http://example.com/test.bfb".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    };
+    config.dpf = dpf_config();
     let env = create_test_env_with_overrides(
         pool,
         TestEnvOverrides::with_config(config).with_dpf_sdk(dpf_sdk),

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3818,6 +3818,41 @@ impl DpuMachineStateHandler {
         }
     }
 
+    /// Whether DPF owns platform configuration for this BF4 DPU.
+    ///
+    /// The persisted ingestion marker prevents an enabled-but-unused DPF
+    /// configuration from changing the legacy provisioning path.
+    fn is_dpf_managed_bf4(
+        &self,
+        state: &ManagedHostStateSnapshot,
+        dpu_snapshot: &Machine,
+    ) -> Result<bool, StateHandlerError> {
+        if !state.host_snapshot.config.dpf.used_for_ingestion {
+            return Ok(false);
+        }
+
+        let dpf_sdk = self.dpf_sdk.as_deref().ok_or_else(|| {
+            StateHandlerError::InvalidState(
+                "DPF-managed machine reached DPU platform configuration without DPF configured"
+                    .to_string(),
+            )
+        })?;
+
+        let deployment_type = dpf_sdk
+            .deployment_type_for_dpu(dpu_snapshot)
+            .map_err(|error| {
+                StateHandlerError::InvalidState(format!(
+                    "failed to determine DPF deployment type for DPU {}: {error}",
+                    dpu_snapshot.id
+                ))
+            })?;
+
+        Ok(matches!(
+            deployment_type,
+            carbide_dpf::DpuDeploymentType::Bf4Generic
+        ))
+    }
+
     async fn is_secure_boot_disabled(
         &self,
         // passing in dpu_machine_id only for testing
@@ -4162,6 +4197,8 @@ impl DpuMachineStateHandler {
                     }
                 })?;
 
+                let dpf_managed_bf4 = self.is_dpf_managed_bf4(state, dpu_snapshot)?;
+
                 let dpu_redfish_client = match ctx
                     .services
                     .create_redfish_client_from_machine(dpu_snapshot)
@@ -4204,45 +4241,50 @@ impl DpuMachineStateHandler {
                     return Ok(outcome);
                 }
 
-                let boot_interface = None; // libredfish will choose the DPU
-                if self.enable_secure_boot {
-                    dpu_redfish_client
-                        .set_host_rshim(EnabledDisabled::Disabled)
-                        .await
-                        .map_err(|e| redfish_error("set_host_rshim", e))?;
-                    dpu_redfish_client
-                        .set_host_privilege_level(HostPrivilegeLevel::Restricted)
-                        .await
-                        .map_err(|e| redfish_error("set_host_privilege_level", e))?;
-                } else if let Err(e) = call_machine_setup_and_handle_no_dpu_error(
-                    dpu_redfish_client.as_ref(),
-                    boot_interface,
-                    state.host_snapshot.associated_dpu_machine_ids().len(),
-                    &ctx.services.site_config,
-                )
-                .await
-                {
-                    // TODO(chet): I don't know if this is still a thing, but I'm pretty sure
-                    // it hasn't been fixed/addressed yet, and it appears to be logged all over
-                    // the place now.
-                    let msg = format!(
-                        "redfish machine_setup failed for DPU {}, potentially due to known race condition between UEFI POST and BMC. issuing a force-restart. err: {}",
-                        dpu_snapshot.id, e
-                    );
-                    tracing::warn!(msg);
-                    let reboot_status = trigger_reboot_if_needed(
-                        dpu_snapshot,
-                        state,
-                        None,
-                        &self.reachability_params,
-                        ctx,
+                // DPF owns BF4 platform configuration. NICo still owns the
+                // UEFI credential change performed below until DPF credential
+                // management is available.
+                if !dpf_managed_bf4 {
+                    let boot_interface = None; // libredfish will choose the DPU
+                    if self.enable_secure_boot {
+                        dpu_redfish_client
+                            .set_host_rshim(EnabledDisabled::Disabled)
+                            .await
+                            .map_err(|e| redfish_error("set_host_rshim", e))?;
+                        dpu_redfish_client
+                            .set_host_privilege_level(HostPrivilegeLevel::Restricted)
+                            .await
+                            .map_err(|e| redfish_error("set_host_privilege_level", e))?;
+                    } else if let Err(e) = call_machine_setup_and_handle_no_dpu_error(
+                        dpu_redfish_client.as_ref(),
+                        boot_interface,
+                        state.host_snapshot.associated_dpu_machine_ids().len(),
+                        &ctx.services.site_config,
                     )
-                    .await?;
+                    .await
+                    {
+                        // TODO(chet): I don't know if this is still a thing, but I'm pretty sure
+                        // it hasn't been fixed/addressed yet, and it appears to be logged all over
+                        // the place now.
+                        let msg = format!(
+                            "redfish machine_setup failed for DPU {}, potentially due to known race condition between UEFI POST and BMC. issuing a force-restart. err: {}",
+                            dpu_snapshot.id, e
+                        );
+                        tracing::warn!(msg);
+                        let reboot_status = trigger_reboot_if_needed(
+                            dpu_snapshot,
+                            state,
+                            None,
+                            &self.reachability_params,
+                            ctx,
+                        )
+                        .await?;
 
-                    return Ok(StateHandlerOutcome::wait(format!(
-                        "{msg};\nWaiting for DPU {} to reboot: {reboot_status:#?}",
-                        dpu_snapshot.id
-                    )));
+                        return Ok(StateHandlerOutcome::wait(format!(
+                            "{msg};\nWaiting for DPU {} to reboot: {reboot_status:#?}",
+                            dpu_snapshot.id
+                        )));
+                    }
                 }
 
                 let dpu_uefi_credentials = resolve_site_uefi_credentials(
@@ -4281,8 +4323,9 @@ impl DpuMachineStateHandler {
                     )));
                 }
 
-                // We need to reboot the DPU after configuring the BIOS settings appropriately
-                // so that they are applied
+                // The UEFI password is staged through Redfish BIOS settings,
+                // so retain the restart even when BF4 skips platform setup and
+                // BIOS verification.
                 handler_restart_dpu(
                     dpu_snapshot,
                     ctx,
@@ -4290,8 +4333,12 @@ impl DpuMachineStateHandler {
                 )
                 .await?;
 
-                let next_state = DpuInitState::PollingBiosSetup
-                    .next_state(&state.managed_state, dpu_machine_id)?;
+                let next_state = if dpf_managed_bf4 {
+                    DpuInitState::WaitingForNetworkConfig
+                } else {
+                    DpuInitState::PollingBiosSetup
+                }
+                .next_state(&state.managed_state, dpu_machine_id)?;
 
                 // The DPU's UEFI password is now the site-wide value (just set via
                 // uefi_setup above): record dpu_uefi convergence so the rotation
@@ -4319,6 +4366,16 @@ impl DpuMachineStateHandler {
             DpuInitState::PollingBiosSetup => {
                 let next_state = DpuInitState::WaitingForNetworkConfig
                     .next_state(&state.managed_state, dpu_machine_id)?;
+
+                // Handle BF4 machines already persisted in this state when the
+                // controller is upgraded: do not issue even one more BIOS query.
+                if self.is_dpf_managed_bf4(state, dpu_snapshot)? {
+                    tracing::info!(
+                        dpu_machine_id = %dpu_snapshot.id,
+                        "Skipping BIOS setup verification for DPF-managed BF4"
+                    );
+                    return Ok(StateHandlerOutcome::transition(next_state));
+                }
 
                 let dpu_redfish_client = match ctx
                     .services

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -79,6 +79,7 @@ struct RedfishSimState {
     /// When set, overrides the `Manufacturer` returned by `get_chassis`, so
     /// tests can drive `probe_bmc_vendor`'s Lite-On/Delta chassis fallback.
     chassis_manufacturer: Option<String>,
+    platform_actions: Vec<RedfishSimPlatformAction>,
 }
 
 /// Snapshot of a single `RedfishClientPool::create_client` invocation.
@@ -174,6 +175,11 @@ impl RedfishSim {
             .values()
             .map(|host| host.lockdown)
             .collect()
+    }
+
+    /// Return calls related to platform configuration and UEFI credentials.
+    pub fn platform_actions(&self) -> Vec<RedfishSimPlatformAction> {
+        self.state.lock().unwrap().platform_actions.clone()
     }
 
     /// Build a simulator with optional SPDM / firmware-integration test flags.
@@ -313,6 +319,15 @@ pub struct RedfishSimTimepoint {
     pos: HashMap<String, usize>,
 }
 
+/// Platform-configuration calls recorded separately from power actions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RedfishSimPlatformAction {
+    SetHostRshim { host: String },
+    SetHostPrivilegeLevel { host: String },
+    IsBiosSetup { host: String },
+    UefiSetup { dpu: bool },
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum RedfishSimAction {
     Power(libredfish::SystemPowerControl),
@@ -352,6 +367,11 @@ impl RedfishSimActions {
             .values()
             .flat_map(|actions| actions.iter().cloned())
             .collect()
+    }
+
+    /// Return Redfish actions issued to one simulated endpoint.
+    pub fn for_host(&self, host: &str) -> Vec<RedfishSimAction> {
+        self.host_actions.get(host).cloned().unwrap_or_default()
     }
 }
 
@@ -1483,7 +1503,14 @@ impl Redfish for RedfishSimClient {
         &'a self,
         _enabled: EnabledDisabled,
     ) -> libredfish::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { Ok(()) })
+        Box::pin(async move {
+            self.state.lock().unwrap().platform_actions.push(
+                RedfishSimPlatformAction::SetHostRshim {
+                    host: self._host.clone(),
+                },
+            );
+            Ok(())
+        })
     }
 
     fn get_host_rshim<'a>(
@@ -1540,9 +1567,17 @@ impl Redfish for RedfishSimClient {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _: Option<libredfish::BootInterfaceRef<'a>>,
+        _boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
     ) -> libredfish::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { Ok(self.state.lock().unwrap().is_bios_setup.unwrap_or(true)) })
+        Box::pin(async move {
+            let mut state = self.state.lock().unwrap();
+            state
+                .platform_actions
+                .push(RedfishSimPlatformAction::IsBiosSetup {
+                    host: self._host.clone(),
+                });
+            Ok(state.is_bios_setup.unwrap_or(true))
+        })
     }
 
     fn get_secure_boot_certificate<'a>(
@@ -1926,7 +1961,14 @@ impl Redfish for RedfishSimClient {
         &'a self,
         _level: HostPrivilegeLevel,
     ) -> libredfish::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { Ok(()) })
+        Box::pin(async move {
+            self.state.lock().unwrap().platform_actions.push(
+                RedfishSimPlatformAction::SetHostPrivilegeLevel {
+                    host: self._host.clone(),
+                },
+            );
+            Ok(())
+        })
     }
 
     fn set_utc_timezone<'a>(&'a self) -> libredfish::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -2005,9 +2047,14 @@ impl RedfishClientPool for RedfishSim {
     async fn uefi_setup(
         &self,
         _client: &dyn Redfish,
-        _dpu: bool,
+        dpu: bool,
         _sitewide_uefi_credentials: carbide_secrets::credentials::Credentials,
     ) -> Result<Option<String>, RedfishClientCreationError> {
+        self.state
+            .lock()
+            .unwrap()
+            .platform_actions
+            .push(RedfishSimPlatformAction::UefiSetup { dpu });
         Ok(None)
     }
 }


### PR DESCRIPTION
BF4 provisioning through DPF already owns the DPU’s platform and BIOS configuration. Continuing to run NICo’s legacy post-ready setup can conflict with DPF and invokes operations that BF4 does not currently support.

NICo must still replace the factory DPU UEFI password for now because DPF credential management is not yet integrated/available.

This PR separates credential ownership from platform configuration to let NICo retain the credential change and required restart, while leaving BF4 BIOS and security setup to DPF.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3862

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Closes https://github.com/NVIDIA/infra-controller/issues/3862

