### PR TITLE
feat: add uploading nico-flow charts

### DIFF
--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -36,6 +36,8 @@ jobs:
             valueOverrides: '["nico-rest-api.config.keycloak.enabled=true","nico-rest-api.config.keycloak.baseURL=http://keycloak:8082","nico-rest-api.config.keycloak.realm=test","nico-rest-api.config.keycloak.clientID=test"]'
           - chart: helm/rest/nico-rest-site-agent
             valueOverrides: '[]'
+          - chart: helm/charts/nico-flow
+            valueOverrides: '[]'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,6 +63,7 @@ jobs:
         chart:
           - helm/rest/nico-rest
           - helm/rest/nico-rest-site-agent
+          - helm/charts/nico-flow
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds nico-flow Helm chart to the CI/CD pipeline for publishing.

NICo Flow deployments via ArgoCD v3.4.2 were failing with an "out-of-bounds symlinks" error. ArgoCD's updated security checks reject symlinks that resolve outside the repository root, which impacted the nico-flow chart when sourced directly from the git repository. 

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

