### PR TITLE
docs(v2.0): add release notes for NTP subchart, REST DB consolidation, and NVSwitch cred rotation

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -205,7 +205,11 @@ envConfig:
 
 MetalLB provides LoadBalancer IPs for NICo Core services (nico-api, DHCP, DNS, PXE, SSH console). Without it, those services stay in `<pending>` state and the site is unreachable.
 
-> **NTP note:** NICo does not run a standalone NTP service. Instead, NTP server addresses are provided to managed hosts via DHCP option 42--configured in the `nico-dhcp` chart Kea hook parameters (`nico-ntpserver`). Point this to your enterprise NTP servers.
+<Note>
+NICo includes a built-in NTP service (`nico-ntp`). This is a 3-replica chrony StatefulSet where each replica gets its own MetalLB VIP.
+
+To use the service, set `nico-ntp.externalService.enabled: true`, assign three VIPs from your internal pool via `nico-ntp.externalService.perPodAnnotations`, and set `nico-dhcp.config.kea.hookParameters.ntpServer` to a comma-separated list of those same VIPs so DPUs receive them over DHCP. Enterprise NTP server IPs in `siteConfig.ntp_servers` continue to be used for BMC pre-ingestion time sync independently of `nico-ntp`.
+</Note>
 
 Edit `helm-prereqs/values/metallb-config.yaml`--this file ships pre-populated with example values. Replace all values labeled `# EXAMPLE` with your site-specific configuration before running `setup.sh`.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,59 @@
 
 This document contains release notes for the NVIDIA Infra Controller (NICo) project.
 
+## Infra Controller v2.0
+
+### New Features
+
+#### NTP Service (`nico-ntp`)
+
+NICo now ships a built-in NTP service. The `nico-ntp` subchart deploys a 3-replica [chrony](https://chrony-project.org/) StatefulSet, each replica exposed on its own MetalLB LoadBalancer VIP so DPUs have a stable, site-local clock source. The Kea DHCP hook advertises these VIPs to DPUs as DHCP option 42 NTP servers.
+
+To enable, configure three VIPs in `helm-prereqs/values/nico-core.yaml`:
+
+```yaml
+nico-ntp:
+  externalService:
+    enabled: true
+    perPodAnnotations:
+      - metallb.universe.tf/loadBalancerIPs: "<ntp-vip-0>"
+      - metallb.universe.tf/loadBalancerIPs: "<ntp-vip-1>"
+      - metallb.universe.tf/loadBalancerIPs: "<ntp-vip-2>"
+```
+
+Set `nico-dhcp.config.kea.hookParameters.ntpServer` to the same three VIPs (comma-separated). If you previously configured enterprise NTP servers in `siteConfig.ntp_servers`, those continue to be used for BMC pre-ingestion time sync and can coexist with `nico-ntp`.
+
+Upstream NTP peers default to `time{1-4}.google.com`. Override via `nico-ntp.ntp.upstreamServers` for air-gapped or enterprise-NTP environments.
+
+#### NVSwitch Credential Rotation
+
+The Vault policy for the `nico-vault-policy` role now includes full access to the `switch_nvos` credential path, enabling automated NVSwitch NVOS credential rotation. The following Vault paths are now granted:
+
+- `secret/data/switch_nvos/*` — create, read, patch, list, update, delete
+- `secret/metadata/switch_nvos/*` — list, read, delete
+- `secret/destroy/switch_nvos/*` — update (KV v2 destroys secret versions via update)
+
+No operator action is required; the policy is applied automatically by `setup.sh` on install or upgrade.
+
+### Upgrade Notes
+
+#### REST Database Consolidation (`v0.x` → `v2.0`)
+
+The NICo REST API database has been moved from its own standalone PostgreSQL instance to the shared Zalando-managed `nico-pg-cluster`. The standalone REST database is no longer deployed.
+
+**What changes:**
+
+- A new `nico_rest` database and `nico-rest.nico` user are provisioned on `nico-pg-cluster` (gated on `rest.enabled: true`, which is the default).
+- Database credentials are now synced via External Secrets Operator (ESO) as the `nico-rest-pg-creds` Secret in the `nico-rest` namespace (previously `db-creds`).
+- The `nico-rest-db` Helm chart's `waitForPostgres` init container now connects to `nico-pg-cluster` instead of a separate postgres instance.
+
+**Upgrade path from v0.x:**
+
+1. Back up the REST database from the old standalone PostgreSQL pod before upgrading.
+2. Run `setup.sh` as normal — it will provision the `nico_rest` database on `nico-pg-cluster` and apply the ESO secret sync automatically.
+3. Migrate data from the backup into the new `nico_rest` database on `nico-pg-cluster` if preserving existing REST state is required.
+4. Confirm the `nico-rest-pg-creds` Secret exists in the `nico-rest` namespace before starting the `nico-rest-db` migration job.
+
 ## Infra Controller v0.8
 
 ### Highlights

--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -261,7 +261,7 @@ spec:
                 capabilities = ["read", "list", "delete"]
               }
               path "{{ .Values.vault.kvMount }}/destroy/switch_nvos/*" {
-                capabilities = ["delete"]
+                capabilities = ["update"]
               }
               POLICY
 


### PR DESCRIPTION
Cherry-pick of #3631 (\`71d602f58\`) onto \`release/v2.0\`, following the same process as #3340.

Adds the v2.0 release notes section covering:
- \`nico-ntp\` chrony NTP subchart with per-pod MetalLB VIPs
- REST database consolidation onto shared \`nico-pg-cluster\` with upgrade path from v0.x
- NVSwitch NVOS credential rotation via corrected Vault policy (\`update\` on KV v2 destroy path)

Also updates the quick-start NTP note to reflect the bundled \`nico-ntp\` subchart (conflict with the v2.0 branch's old note resolved by taking the new text).

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs only)