### PR TITLE
fix(api-core): scope transaction lint exemptions

### DIFF
--- a/crates/api-core/src/handlers/astra.rs
+++ b/crates/api-core/src/handlers/astra.rs
@@ -181,6 +181,10 @@ pub(crate) async fn get_astra_config(
         }
     }
 
+    txn.commit()
+        .await
+        .map_err(|e| CarbideError::internal(format!("failed to commit astra config read: {e}")))?;
+
     Ok(Some(AstraConfig { astra_attachments }))
 }
 

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -21,7 +21,7 @@ use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
 use ::rpc::model::machine::ManagedHostStateSnapshotRpc;
 use carbide_redfish::libredfish::RedfishAuth;
-use carbide_secrets::credentials::{BmcCredentialType, CredentialKey};
+use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
 use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
 use model::hardware_info::MachineNvLinkInfo;
@@ -34,6 +34,29 @@ use crate::CarbideError;
 use crate::api::{Api, log_machine_id, log_request_data};
 use crate::auth::AuthContext;
 use crate::handlers::utils::convert_and_log_machine_id;
+
+// TODO(#2991, @spydaNVIDIA): avoid holding this transaction while the
+// credential reader may perform a remote Vault request. Keep the allowance on
+// this small helper rather than the full force-delete handler.
+#[allow(txn_held_across_await)]
+async fn resolve_host_uefi_clear_credentials(
+    api: &Api,
+    bmc_mac_address: mac_address::MacAddress,
+) -> Option<Credentials> {
+    match api.txn_begin().await {
+        Ok(mut txn) => {
+            let credentials = crate::handlers::uefi::host_uefi_clear_credentials(
+                &mut txn,
+                api.redfish_pool.credential_reader(),
+                bmc_mac_address,
+            )
+            .await;
+            let _ = txn.commit().await;
+            credentials.ok()
+        }
+        Err(_) => None,
+    }
+}
 
 pub(crate) async fn find_machine_ids(
     api: &Api,
@@ -527,20 +550,8 @@ pub(crate) async fn admin_force_delete_machine(
                             // authenticate the clear (table-driven). Best effort: if it
                             // cannot be resolved, skip the clear rather than aborting the
                             // force-delete.
-                            let clear_credentials = match api.txn_begin().await {
-                                Ok(mut txn) => {
-                                    let credentials =
-                                        crate::handlers::uefi::host_uefi_clear_credentials(
-                                            &mut txn,
-                                            api.redfish_pool.credential_reader(),
-                                            bmc_mac_address,
-                                        )
-                                        .await;
-                                    let _ = txn.commit().await;
-                                    credentials.ok()
-                                }
-                                Err(_) => None,
-                            };
+                            let clear_credentials =
+                                resolve_host_uefi_clear_credentials(api, bmc_mac_address).await;
                             if let Some(clear_credentials) = clear_credentials {
                                 match api
                                     .redfish_pool

--- a/crates/api-core/src/handlers/uefi.rs
+++ b/crates/api-core/src/handlers/uefi.rs
@@ -110,6 +110,9 @@ async fn read_uefi_credentials(
 /// Resolve the site-wide host UEFI credential to *set* on a device: the secret
 /// at the current `host_uefi` target version (table-driven; v0 = the legacy
 /// unversioned site-default).
+// TODO(#2991, @spydaNVIDIA): do not hold the database connection while the
+// credential reader may perform a remote Vault request.
+#[allow(txn_held_across_await)]
 pub(crate) async fn host_uefi_set_credentials(
     conn: &mut sqlx::PgConnection,
     reader: &dyn CredentialReader,
@@ -123,6 +126,9 @@ pub(crate) async fn host_uefi_set_credentials(
 /// Resolve the host UEFI credential a device currently carries, to authenticate
 /// a *clear* against its existing password (the device's converged version; see
 /// [`host_uefi_device_version`]).
+// TODO(#2991, @spydaNVIDIA): do not hold the database connection while the
+// credential reader may perform a remote Vault request.
+#[allow(txn_held_across_await)]
 pub(crate) async fn host_uefi_clear_credentials(
     conn: &mut sqlx::PgConnection,
     reader: &dyn CredentialReader,

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -488,6 +488,11 @@ async fn allocate_prefix_candidate_once(
 ///
 /// Every unsuccessful attempt explicitly rolls back its savepoint before the
 /// caller advances or retries, releasing any lock acquired only by that attempt.
+// Custom-lint exception for #3456 (@bcavnvidia): the lint treats the outer
+// `PgConnection` as a transaction held across every await. All awaits here are
+// database work performed through an inner savepoint, which is explicitly
+// committed or rolled back before returning.
+#[allow(txn_held_across_await)]
 async fn attempt_prefix_candidate(
     txn: &mut PgConnection,
     vpc_id: VpcId,

--- a/crates/api-core/src/lib.rs
+++ b/crates/api-core/src/lib.rs
@@ -24,11 +24,10 @@
 //! UI lives in the separate `carbide-api-web` crate.
 
 // It's too cumbersome for tests to adhere to these, which are less important in testing anyway.
-// The `test_support` module also compiles when a dependent enables the `test-support` feature, so
-// the allow must cover that build too; otherwise the custom txn lints fire on shared test helpers
-// under `--all-features`.
-#![cfg_attr(any(test, feature = "test-support"), allow(txn_held_across_await))]
-#![cfg_attr(any(test, feature = "test-support"), allow(txn_without_commit))]
+// Keep this exemption limited to test builds so enabling `test-support` under `--all-features`
+// does not hide violations in production modules.
+#![cfg_attr(test, allow(txn_held_across_await))]
+#![cfg_attr(test, allow(txn_without_commit))]
 
 // NOTE on pub vs non-pub mods:
 //
@@ -75,6 +74,9 @@ mod setup;
 mod storage;
 
 #[cfg(any(test, feature = "test-support"))]
+// Dependents compile these fixtures through the `test-support` feature, outside a `cfg(test)`
+// build, so scope their custom-lint exemption to this module.
+#[allow(txn_held_across_await, txn_without_commit)]
 pub mod test_support;
 
 #[cfg(test)]

--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -517,6 +517,13 @@ fn build_kms_backend(
 /// where they are stranded. Site-explorer credential rotation is the writer
 /// to worry about; keep it disabled until the whole fleet runs a consistent
 /// config.
+// Custom-lint exception for #2665 (@chet): this function intentionally keeps a
+// dedicated detached connection alive across awaits because the Vault import
+// lock is session-scoped and releases when that connection closes. The custom
+// lint also classifies bare `PgConnection`s as transactions, but no transaction
+// is open here: Vault reads and Postgres writes use separate pool connections so
+// the importer cannot block itself on pool capacity.
+#[allow(txn_held_across_await)]
 async fn import_vault_secrets_once(
     db_pool: &PgPool,
     secrets_config: &SecretsConfig,

--- a/crates/api-core/src/secrets/re_wrap.rs
+++ b/crates/api-core/src/secrets/re_wrap.rs
@@ -60,6 +60,13 @@ struct PendingReWrap {
 /// Historical journal entries are re-wrapped too: they must stay
 /// decryptable, and re-wrapping them is what lets an old KEK be retired
 /// completely.
+// Custom-lint exception for #2665 (@chet): this function intentionally keeps a
+// dedicated detached connection alive across awaits because the re-wrap lock is
+// session-scoped and releases when that connection closes. The custom lint
+// classifies bare `PgConnection`s as transactions, but no transaction is open on
+// this connection; batch reads, KMS work, and batch-write transactions use
+// separate pool connections.
+#[allow(txn_held_across_await)]
 pub async fn re_wrap_stale(
     pool: &PgPool,
     kms: &dyn KmsBackend,


### PR DESCRIPTION
Restore custom transaction-lint coverage for production api-core code. The API crate split in #2054 unintentionally made the test-support exemption crate-wide, while carbide-lints runs with --all-features; as a result, enabling test-support suppressed transaction warnings in production modules.

Changes:
- Restrict the crate-wide transaction-lint exemptions to cfg(test) builds.
- Scope the test-support exemptions to the test-support module itself.
- Explicitly commit the read transaction left open by the Astra configuration path from #2904 (@srinivasadmurthy).
- Add narrow, documented follow-ups for findings outside this PR’s scope:
    - UEFI credential lookup from #2991 (@spydaNVIDIA).
    - Automatic-prefix savepoint handling from #3456 (@bcavnvidia).
    - Vault import and secret re-wrap session locks from #2665 (@chet).

The UEFI and force-delete behavior is intentionally preserved. The prefix and secrets allowances document cases where the custom lint cannot distinguish database-only savepoint work or detached session-lock connections from transactions.

## Related issues

#2054
#2904
#2991
#3456
#2665

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

