### PR TITLE
feat(power-control): route standalone vs rack-scale machines separately

### DIFF
--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -1689,10 +1689,10 @@ pub(crate) async fn component_power_control(
                 let is_rack_scale = match machine_is_rack_scale(&machines_by_id, machine_id) {
                     Ok(v) => v,
                     Err(status) => {
-                        results.push(error_result(
-                            &machine_id.to_string(),
-                            status.message().to_string(),
-                        ));
+                        // Preserve the tonic status code (NotFound for an unknown
+                        // id) in the per-machine result instead of flattening it to
+                        // InternalError.
+                        results.push(status_result(&machine_id.to_string(), status));
                         continue;
                     }
                 };
@@ -1824,16 +1824,18 @@ pub(crate) async fn component_power_control(
     }))
 }
 
-/// Fan a whole-partition dispatch failure out to one `error_result` per machine
-/// in that partition, so a failure in one partition never discards results
-/// already committed for the other partition or for the power-option updates.
+/// Fan a whole-partition dispatch failure out to one result per machine in that
+/// partition, so a failure in one partition never discards results already
+/// committed for the other partition or for the power-option updates. The tonic
+/// status code is preserved per machine (e.g. `Unavailable` for a backend that
+/// is down) rather than flattened to `InternalError`.
 fn partition_error_results(
     machine_ids: &[MachineId],
     status: &Status,
 ) -> Vec<rpc::ComponentResult> {
     machine_ids
         .iter()
-        .map(|id| error_result(&id.to_string(), status.message().to_string()))
+        .map(|id| status_result(&id.to_string(), status.clone()))
         .collect()
 }
 
@@ -3362,6 +3364,54 @@ mod tests {
         assert_eq!(r.error, "boom");
     }
 
+    #[test]
+    fn status_result_maps_tonic_codes_and_defaults_to_internal_error() {
+        use super::status_result;
+
+        let cases = [
+            (
+                Status::not_found("missing"),
+                rpc::ComponentManagerStatusCode::NotFound,
+            ),
+            (
+                Status::invalid_argument("bad"),
+                rpc::ComponentManagerStatusCode::InvalidArgument,
+            ),
+            (
+                Status::failed_precondition("precondition"),
+                rpc::ComponentManagerStatusCode::InvalidArgument,
+            ),
+            (
+                Status::already_exists("dup"),
+                rpc::ComponentManagerStatusCode::AlreadyExists,
+            ),
+            (
+                Status::unavailable("down"),
+                rpc::ComponentManagerStatusCode::Unavailable,
+            ),
+            // Codes without an explicit arm collapse to InternalError.
+            (
+                Status::internal("boom"),
+                rpc::ComponentManagerStatusCode::InternalError,
+            ),
+            (
+                Status::permission_denied("nope"),
+                rpc::ComponentManagerStatusCode::InternalError,
+            ),
+        ];
+
+        for (status, expected) in cases {
+            let message = status.message().to_string();
+            let r = status_result("machine-1", status);
+            assert_eq!(r.component_id, "machine-1");
+            assert_eq!(
+                r.status, expected as i32,
+                "unexpected mapping for {message:?}"
+            );
+            assert_eq!(r.error, message);
+        }
+    }
+
     fn test_switch_id() -> SwitchId {
         use carbide_uuid::switch::{SwitchIdSource, SwitchType};
         SwitchId::new(SwitchIdSource::Tpm, [0u8; 32], SwitchType::NvLink)
@@ -3667,9 +3717,10 @@ mod tests {
         assert_eq!(results.len(), ids.len());
         for (result, id) in results.iter().zip(ids) {
             assert_eq!(result.component_id, id.to_string());
+            // The dispatch status code is preserved per machine, not flattened.
             assert_eq!(
                 result.status,
-                rpc::ComponentManagerStatusCode::InternalError as i32
+                rpc::ComponentManagerStatusCode::Unavailable as i32
             );
             assert!(result.error.contains("backend down"));
         }

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -30,7 +30,10 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use component_manager::component_manager::{ComponentManager, SwitchMaintenanceRequestResult};
-use component_manager::compute_tray_manager::{ComputeTrayEndpoint, ComputeTrayVendor};
+use component_manager::compute_tray_manager::{
+    ComputeTrayEndpoint, ComputeTrayManager, ComputeTrayVendor,
+};
+use component_manager::core_compute_manager::CoreComputeTrayManager;
 use component_manager::error::ComponentManagerError;
 use component_manager::nv_switch_manager::SwitchEndpoint;
 use component_manager::power_shelf_manager::{PowerShelfEndpoint, PowerShelfVendor};
@@ -1633,112 +1636,110 @@ pub(crate) async fn component_power_control(
             }
         }
         rpc::component_power_control_request::Target::MachineIds(list) => {
-            if cm.compute_tray_use_state_controller && !bypass_state_controller {
-                let results = queue_machine_power_control_via_state_controller(
+            // Divide the requested machines the same way compute firmware
+            // updates do: rack-scale (MNNVL) systems vs standalone servers. Only
+            // rack-scale systems have a compute-tray backend (RMS) and a
+            // state-controller maintenance flow; standalone servers are always
+            // driven synchronously through NICo-core's Redfish stack, because
+            // RMS cannot power-control them.
+            let (rack_scale_ids, standalone_ids) =
+                partition_compute_machines_by_rack_scale(api, &list.machine_ids).await?;
+
+            // Update the power-manager desired state for every requested machine
+            // up front, before splitting. The state controller does not do this
+            // today, so the handler owns it regardless of which dispatch path
+            // (rack vs standalone) a machine ultimately takes.
+            //
+            // The health override exists only to satisfy `update_power_option`'s
+            // precondition for powering a host off (it requires an
+            // `internal_maintenance` / `suppress_external_alerting` alert). The
+            // Redfish dispatch does not need it, so it brackets just the
+            // power-manager change. Durable alert suppression for an
+            // intentionally-off host comes from `desired_power_state` itself.
+            let desired_state = desired_power_state(action) as i32;
+            let mut results: Vec<rpc::ComponentResult> = Vec::new();
+            for &machine_id in &list.machine_ids {
+                let override_inserted = power_control_health_override(api, machine_id, true).await;
+
+                let power_req = rpc::PowerOptionUpdateRequest {
+                    machine_id: Some(machine_id),
+                    power_state: desired_state,
+                };
+                match crate::handlers::power_options::update_power_option(
                     api,
-                    cm,
-                    &list.machine_ids,
+                    Request::new(power_req),
+                )
+                .await
+                {
+                    Ok(_) => {}
+                    Err(e)
+                        if e.code() == Code::InvalidArgument
+                            && e.message().contains("already set as") =>
+                    {
+                        tracing::debug!(
+                            %machine_id,
+                            desired_state,
+                            "power option already in desired state, skipping"
+                        );
+                    }
+                    Err(e) => {
+                        results.push(error_result(
+                            &machine_id.to_string(),
+                            format!("failed to update power option: {e}"),
+                        ));
+                    }
+                }
+
+                if override_inserted {
+                    power_control_health_override(api, machine_id, false).await;
+                }
+            }
+
+            let mut ips: Vec<IpAddr> = Vec::new();
+
+            // Rack-scale systems: the state-controller maintenance flow when
+            // enabled, otherwise a synchronous dispatch through the configured
+            // backend (RMS).
+            if !rack_scale_ids.is_empty() {
+                if cm.compute_tray_use_state_controller && !bypass_state_controller {
+                    let sc_results = queue_machine_power_control_via_state_controller(
+                        api,
+                        cm,
+                        &rack_scale_ids,
+                        action,
+                    )
+                    .await?;
+                    results.extend(sc_results);
+                } else {
+                    let (rack_results, rack_ips) = dispatch_compute_tray_power_control(
+                        api,
+                        cm.compute_tray.as_ref(),
+                        &rack_scale_ids,
+                        action,
+                    )
+                    .await?;
+                    results.extend(rack_results);
+                    ips.extend(rack_ips);
+                }
+            }
+
+            // Standalone servers: always synchronous, always NICo-core's Redfish
+            // stack (never the state machine, which has no non-rack path), so
+            // power control works even when the configured backend is RMS.
+            if !standalone_ids.is_empty() {
+                let core_backend = CoreComputeTrayManager::new(api.redfish_pool.clone());
+                let (standalone_results, standalone_ips) = dispatch_compute_tray_power_control(
+                    api,
+                    &core_backend,
+                    &standalone_ids,
                     action,
                 )
                 .await?;
-                let ips = Vec::new();
-                (results, ips)
-            } else {
-                let resolved = resolve_compute_tray_endpoints(api, &list.machine_ids).await?;
-
-                let mut results: Vec<_> = resolved
-                    .unresolved
-                    .iter()
-                    .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
-                    .collect();
-
-                let resolved_machine_ids: Vec<_> = resolved
-                    .resolved
-                    .endpoints
-                    .iter()
-                    .filter_map(|ep| resolved.resolved.ip_to_machine_id.get(&ep.bmc_ip).copied())
-                    .collect();
-
-                // Insert health overrides and update power-manager desired state
-                // before issuing Redfish commands.
-                let desired_state = desired_power_state(action) as i32;
-                let mut overrides_inserted = Vec::new();
-                for &machine_id in &resolved_machine_ids {
-                    let inserted = power_control_health_override(api, machine_id, true).await;
-                    if inserted {
-                        overrides_inserted.push(machine_id);
-                    }
-
-                    let power_req = rpc::PowerOptionUpdateRequest {
-                        machine_id: Some(machine_id),
-                        power_state: desired_state,
-                    };
-                    match crate::handlers::power_options::update_power_option(
-                        api,
-                        Request::new(power_req),
-                    )
-                    .await
-                    {
-                        Ok(_) => {}
-                        Err(e)
-                            if e.code() == Code::InvalidArgument
-                                && e.message().contains("already set as") =>
-                        {
-                            tracing::debug!(
-                                %machine_id,
-                                desired_state,
-                                "power option already in desired state, skipping"
-                            );
-                        }
-                        Err(e) => {
-                            results.push(error_result(
-                                &machine_id.to_string(),
-                                format!("failed to update power option: {e}"),
-                            ));
-                        }
-                    }
-                }
-
-                tracing::info!(
-                    backend = cm.compute_tray.name(),
-                    compute_tray_count = resolved.resolved.endpoints.len(),
-                    ?action,
-                    "power control for compute trays"
-                );
-                let backend_results = cm
-                    .compute_tray
-                    .power_control(&resolved.resolved.endpoints, action)
-                    .await
-                    .map_err(component_manager_error_to_status)?;
-
-                // Clear health overrides after Redfish dispatch.
-                for machine_id in &overrides_inserted {
-                    power_control_health_override(api, *machine_id, false).await;
-                }
-
-                let ips: Vec<IpAddr> = resolved
-                    .resolved
-                    .endpoints
-                    .iter()
-                    .map(|ep| ep.bmc_ip)
-                    .collect();
-
-                results.extend(backend_results.into_iter().map(|r| {
-                    let id = resolved
-                        .resolved
-                        .ip_to_machine_id
-                        .get(&r.bmc_ip)
-                        .map(|id| id.to_string())
-                        .unwrap_or_else(|| r.bmc_ip.to_string());
-                    if r.success {
-                        success_result(&id)
-                    } else {
-                        error_result(&id, r.error.unwrap_or_default())
-                    }
-                }));
-
-                (results, ips)
+                results.extend(standalone_results);
+                ips.extend(standalone_ips);
             }
+
+            (results, ips)
         }
     };
 
@@ -1751,6 +1752,62 @@ pub(crate) async fn component_power_control(
     Ok(Response::new(rpc::ComponentPowerControlResponse {
         results,
     }))
+}
+
+/// Resolve BMC endpoints for `machine_ids`, issue power control through
+/// `backend`, and return per-machine results (keyed by machine id via the
+/// resolved `ip_to_machine_id` map) alongside the BMC IPs that were dispatched
+/// to, so the caller can request site re-exploration for them.
+///
+/// Shared by the rack-scale synchronous path (configured backend, e.g. RMS) and
+/// the standalone path (always NICo-core's Redfish backend).
+async fn dispatch_compute_tray_power_control(
+    api: &Api,
+    backend: &dyn ComputeTrayManager,
+    machine_ids: &[MachineId],
+    action: PowerAction,
+) -> Result<(Vec<rpc::ComponentResult>, Vec<IpAddr>), Status> {
+    let resolved = resolve_compute_tray_endpoints(api, machine_ids).await?;
+
+    let mut results: Vec<rpc::ComponentResult> = resolved
+        .unresolved
+        .iter()
+        .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
+        .collect();
+
+    tracing::info!(
+        backend = backend.name(),
+        compute_tray_count = resolved.resolved.endpoints.len(),
+        ?action,
+        "power control for compute trays"
+    );
+    let backend_results = backend
+        .power_control(&resolved.resolved.endpoints, action)
+        .await
+        .map_err(component_manager_error_to_status)?;
+
+    let ips: Vec<IpAddr> = resolved
+        .resolved
+        .endpoints
+        .iter()
+        .map(|ep| ep.bmc_ip)
+        .collect();
+
+    results.extend(backend_results.into_iter().map(|r| {
+        let id = resolved
+            .resolved
+            .ip_to_machine_id
+            .get(&r.bmc_ip)
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| r.bmc_ip.to_string());
+        if r.success {
+            success_result(&id)
+        } else {
+            error_result(&id, r.error.unwrap_or_default())
+        }
+    }));
+
+    Ok((results, ips))
 }
 
 pub(crate) async fn component_configure_switch_certificate(

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -728,6 +728,28 @@ async fn partition_compute_machines_by_rack_scale(
     api: &Api,
     machine_ids: &[MachineId],
 ) -> Result<(Vec<MachineId>, Vec<MachineId>), Status> {
+    let machines_by_id = load_machines_by_id(api, machine_ids).await?;
+
+    let mut rack_scale = Vec::new();
+    let mut standalone = Vec::new();
+    for &machine_id in machine_ids {
+        if machine_is_rack_scale(&machines_by_id, machine_id)? {
+            rack_scale.push(machine_id);
+        } else {
+            standalone.push(machine_id);
+        }
+    }
+
+    Ok((rack_scale, standalone))
+}
+
+/// Load the requested machines keyed by id. A DB lookup failure is a hard
+/// error, since nothing can be classified without it; ids that don't exist are
+/// simply absent from the returned map, left for the caller to handle.
+async fn load_machines_by_id(
+    api: &Api,
+    machine_ids: &[MachineId],
+) -> Result<HashMap<MachineId, Machine>, Status> {
     let machines = db::machine::find(
         api.db_reader().as_mut(),
         db::ObjectFilter::List(machine_ids),
@@ -735,25 +757,24 @@ async fn partition_compute_machines_by_rack_scale(
     )
     .await
     .map_err(|e| Status::internal(format!("failed to look up machines: {e}")))?;
-    let machines_by_id: HashMap<_, _> = machines
+    Ok(machines
         .into_iter()
         .map(|machine| (machine.id, machine))
-        .collect();
+        .collect())
+}
 
-    let mut rack_scale = Vec::new();
-    let mut standalone = Vec::new();
-    for machine_id in machine_ids {
-        let machine = machines_by_id
-            .get(machine_id)
-            .ok_or_else(|| Status::not_found(format!("machine {machine_id} not found")))?;
-        if is_rack_scale_server(machine) {
-            rack_scale.push(*machine_id);
-        } else {
-            standalone.push(*machine_id);
-        }
-    }
-
-    Ok((rack_scale, standalone))
+/// Classify a single already-loaded machine as rack-scale (`true`) or
+/// standalone (`false`), returning `Err(Status::not_found)` if the id is not in
+/// the map. Callers decide whether an unknown id aborts the batch or is
+/// collected as a per-machine error.
+fn machine_is_rack_scale(
+    machines_by_id: &HashMap<MachineId, Machine>,
+    machine_id: MachineId,
+) -> Result<bool, Status> {
+    let machine = machines_by_id
+        .get(&machine_id)
+        .ok_or_else(|| Status::not_found(format!("machine {machine_id} not found")))?;
+    Ok(is_rack_scale_server(machine))
 }
 
 /// Initiate a firmware upgrade for standalone (non rack-scale) servers
@@ -1642,13 +1663,16 @@ pub(crate) async fn component_power_control(
             // state-controller maintenance flow; standalone servers are always
             // driven synchronously through NICo-core's Redfish stack, because
             // RMS cannot power-control them.
-            let (rack_scale_ids, standalone_ids) =
-                partition_compute_machines_by_rack_scale(api, &list.machine_ids).await?;
-
-            // Update the power-manager desired state for every requested machine
-            // up front, before splitting. The state controller does not do this
-            // today, so the handler owns it regardless of which dispatch path
-            // (rack vs standalone) a machine ultimately takes.
+            //
+            // Classify each machine and persist its power-manager desired state
+            // in a single pass. A machine joins `rack_scale_ids`/`standalone_ids`
+            // only after both steps succeed, so unknown ids and power-option
+            // failures are reported per-machine and never dispatched (no
+            // duplicate result, no actuation without a recorded intent).
+            //
+            // The state controller does not update the power manager today, so
+            // the handler owns it regardless of which dispatch path (rack vs
+            // standalone) a machine ultimately takes.
             //
             // The health override exists only to satisfy `update_power_option`'s
             // precondition for powering a host off (it requires an
@@ -1656,22 +1680,36 @@ pub(crate) async fn component_power_control(
             // Redfish dispatch does not need it, so it brackets just the
             // power-manager change. Durable alert suppression for an
             // intentionally-off host comes from `desired_power_state` itself.
+            let machines_by_id = load_machines_by_id(api, &list.machine_ids).await?;
             let desired_state = desired_power_state(action) as i32;
             let mut results: Vec<rpc::ComponentResult> = Vec::new();
+            let (mut rack_scale_ids, mut standalone_ids) = (Vec::new(), Vec::new());
             for &machine_id in &list.machine_ids {
+                // Unknown ids are reported per-machine and never dispatched.
+                let is_rack_scale = match machine_is_rack_scale(&machines_by_id, machine_id) {
+                    Ok(v) => v,
+                    Err(status) => {
+                        results.push(error_result(
+                            &machine_id.to_string(),
+                            status.message().to_string(),
+                        ));
+                        continue;
+                    }
+                };
+
                 let override_inserted = power_control_health_override(api, machine_id, true).await;
 
                 let power_req = rpc::PowerOptionUpdateRequest {
                     machine_id: Some(machine_id),
                     power_state: desired_state,
                 };
-                match crate::handlers::power_options::update_power_option(
+                let power_option_ok = match crate::handlers::power_options::update_power_option(
                     api,
                     Request::new(power_req),
                 )
                 .await
                 {
-                    Ok(_) => {}
+                    Ok(_) => true,
                     Err(e)
                         if e.code() == Code::InvalidArgument
                             && e.message().contains("already set as") =>
@@ -1681,17 +1719,30 @@ pub(crate) async fn component_power_control(
                             desired_state,
                             "power option already in desired state, skipping"
                         );
+                        true
                     }
                     Err(e) => {
                         results.push(error_result(
                             &machine_id.to_string(),
                             format!("failed to update power option: {e}"),
                         ));
+                        false
                     }
-                }
+                };
 
                 if override_inserted {
                     power_control_health_override(api, machine_id, false).await;
+                }
+
+                // Only machines whose desired state was recorded proceed to
+                // dispatch, so a power-option failure never actuates hardware
+                // without a matching intent.
+                if power_option_ok {
+                    if is_rack_scale {
+                        rack_scale_ids.push(machine_id);
+                    } else {
+                        standalone_ids.push(machine_id);
+                    }
                 }
             }
 
@@ -1702,24 +1753,36 @@ pub(crate) async fn component_power_control(
             // backend (RMS).
             if !rack_scale_ids.is_empty() {
                 if cm.compute_tray_use_state_controller && !bypass_state_controller {
-                    let sc_results = queue_machine_power_control_via_state_controller(
+                    match queue_machine_power_control_via_state_controller(
                         api,
                         cm,
                         &rack_scale_ids,
                         action,
                     )
-                    .await?;
-                    results.extend(sc_results);
+                    .await
+                    {
+                        Ok(sc_results) => results.extend(sc_results),
+                        Err(status) => {
+                            results.extend(partition_error_results(&rack_scale_ids, &status))
+                        }
+                    }
                 } else {
-                    let (rack_results, rack_ips) = dispatch_compute_tray_power_control(
+                    match dispatch_compute_tray_power_control(
                         api,
                         cm.compute_tray.as_ref(),
                         &rack_scale_ids,
                         action,
                     )
-                    .await?;
-                    results.extend(rack_results);
-                    ips.extend(rack_ips);
+                    .await
+                    {
+                        Ok((rack_results, rack_ips)) => {
+                            results.extend(rack_results);
+                            ips.extend(rack_ips);
+                        }
+                        Err(status) => {
+                            results.extend(partition_error_results(&rack_scale_ids, &status))
+                        }
+                    }
                 }
             }
 
@@ -1728,15 +1791,22 @@ pub(crate) async fn component_power_control(
             // power control works even when the configured backend is RMS.
             if !standalone_ids.is_empty() {
                 let core_backend = CoreComputeTrayManager::new(api.redfish_pool.clone());
-                let (standalone_results, standalone_ips) = dispatch_compute_tray_power_control(
+                match dispatch_compute_tray_power_control(
                     api,
                     &core_backend,
                     &standalone_ids,
                     action,
                 )
-                .await?;
-                results.extend(standalone_results);
-                ips.extend(standalone_ips);
+                .await
+                {
+                    Ok((standalone_results, standalone_ips)) => {
+                        results.extend(standalone_results);
+                        ips.extend(standalone_ips);
+                    }
+                    Err(status) => {
+                        results.extend(partition_error_results(&standalone_ids, &status))
+                    }
+                }
             }
 
             (results, ips)
@@ -1752,6 +1822,19 @@ pub(crate) async fn component_power_control(
     Ok(Response::new(rpc::ComponentPowerControlResponse {
         results,
     }))
+}
+
+/// Fan a whole-partition dispatch failure out to one `error_result` per machine
+/// in that partition, so a failure in one partition never discards results
+/// already committed for the other partition or for the power-option updates.
+fn partition_error_results(
+    machine_ids: &[MachineId],
+    status: &Status,
+) -> Vec<rpc::ComponentResult> {
+    machine_ids
+        .iter()
+        .map(|id| error_result(&id.to_string(), status.message().to_string()))
+        .collect()
 }
 
 /// Resolve BMC endpoints for `machine_ids`, issue power control through
@@ -3503,5 +3586,92 @@ mod tests {
                 .as_ref()
                 .is_some_and(|result| result.error.contains("machine not found"))
         );
+    }
+
+    // ---- compute power-control (MachineIds) decision logic ----
+
+    use model::hardware_info::{Gpu, GpuPlatformInfo, HardwareInfo};
+    use model::test_support::machine_snapshot::{dpu_machine_id, host_machine, host_machine_id};
+
+    /// A GPU carrying NVLink platform metadata and an MNNVL family name — what
+    /// `is_mnnvl_capable` keys off of to flag a rack-scale (GB200) server.
+    fn mnnvl_gpu() -> Gpu {
+        Gpu {
+            name: "NVIDIA GB200".to_string(),
+            serial: String::new(),
+            driver_version: String::new(),
+            vbios_version: String::new(),
+            inforom_version: String::new(),
+            total_memory: String::new(),
+            frequency: String::new(),
+            pci_bus_id: String::new(),
+            platform_info: Some(GpuPlatformInfo {
+                chassis_serial: "CHASSIS-1".to_string(),
+                slot_number: 1,
+                tray_index: 1,
+                host_id: 1,
+                module_id: 1,
+                fabric_guid: String::new(),
+            }),
+        }
+    }
+
+    fn machine_with_hardware(hardware_info: Option<HardwareInfo>) -> Machine {
+        let mut machine = host_machine();
+        machine.status.hardware_info = hardware_info;
+        machine
+    }
+
+    /// Rack-scale: at least one MNNVL-capable GPU.
+    fn rack_scale_machine() -> Machine {
+        machine_with_hardware(Some(HardwareInfo {
+            gpus: vec![mnnvl_gpu()],
+            ..Default::default()
+        }))
+    }
+
+    /// Standalone: no MNNVL-capable GPU.
+    fn standalone_machine() -> Machine {
+        machine_with_hardware(Some(HardwareInfo::default()))
+    }
+
+    #[test]
+    fn machine_is_rack_scale_classifies_rack_standalone_and_unknown() {
+        let id = host_machine_id();
+
+        let rack_map = HashMap::from([(id, rack_scale_machine())]);
+        assert!(
+            machine_is_rack_scale(&rack_map, id).unwrap(),
+            "MNNVL hardware should classify as rack-scale"
+        );
+
+        let standalone_map = HashMap::from([(id, standalone_machine())]);
+        assert!(
+            !machine_is_rack_scale(&standalone_map, id).unwrap(),
+            "non-MNNVL hardware should classify as standalone"
+        );
+
+        // Unknown id (absent from the map) is a per-machine NotFound carrying the id.
+        let err = machine_is_rack_scale(&HashMap::new(), id).unwrap_err();
+        assert_eq!(err.code(), Code::NotFound);
+        assert!(err.message().contains(&id.to_string()));
+    }
+
+    #[test]
+    fn partition_error_results_reports_one_error_per_machine() {
+        let ids = [host_machine_id(), dpu_machine_id(0)];
+        let status = Status::unavailable("backend down");
+
+        let results = partition_error_results(&ids, &status);
+
+        assert_eq!(results.len(), ids.len());
+        for (result, id) in results.iter().zip(ids) {
+            assert_eq!(result.component_id, id.to_string());
+            assert_eq!(
+                result.status,
+                rpc::ComponentManagerStatusCode::InternalError as i32
+            );
+            assert!(result.error.contains("backend down"));
+        }
     }
 }

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2362,7 +2362,19 @@ impl StateHandler for MachineStateHandler {
             continue_state_machine,
             msg,
         } = match mh_snapshot.host_snapshot.state.value {
-            ManagedHostState::Ready if self.power_options_config.enabled => {
+            // A pending maintenance request takes precedence over power-manager
+            // handling: `handle_power` can return `continue_state_machine = false`
+            // (e.g. desired state Off), which would keep `attempt_state_transition`
+            // -- and therefore `maintenance_transition_if_requested` -- from ever
+            // running, starving the queued operation. Skipping power handling here
+            // lets the request reach the Maintenance transition.
+            ManagedHostState::Ready
+                if self.power_options_config.enabled
+                    && mh_snapshot
+                        .host_snapshot
+                        .machine_maintenance_requested
+                        .is_none() =>
+            {
                 power::handle_power(mh_snapshot, ctx, &self.power_options_config).await?
             }
             _ => PowerHandlingOutcome::new(None, true, None),

--- a/crates/machine-controller/tests/integration/maintenance.rs
+++ b/crates/machine-controller/tests/integration/maintenance.rs
@@ -48,13 +48,13 @@ enum BackendOutcome {
 }
 
 #[derive(Debug)]
-struct ReconciliationComputeTrayManager {
+pub(crate) struct ReconciliationComputeTrayManager {
     outcome: Mutex<BackendOutcome>,
     actions: Mutex<Vec<PowerAction>>,
 }
 
 impl ReconciliationComputeTrayManager {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             outcome: Mutex::new(BackendOutcome::Success),
             actions: Mutex::new(Vec::new()),
@@ -161,7 +161,9 @@ fn expected_action(operation: MachineMaintenanceOperation) -> PowerAction {
     }
 }
 
-fn component_manager(compute_tray: Arc<dyn ComputeTrayManager>) -> Arc<ComponentManager> {
+pub(crate) fn component_manager(
+    compute_tray: Arc<dyn ComputeTrayManager>,
+) -> Arc<ComponentManager> {
     Arc::new(ComponentManager::new(
         Arc::new(MockNvSwitchManager::default()),
         Arc::new(MockPowerShelfManager),
@@ -172,7 +174,7 @@ fn component_manager(compute_tray: Arc<dyn ComputeTrayManager>) -> Arc<Component
     ))
 }
 
-fn valid_credential_manager() -> Arc<dyn CredentialManager> {
+pub(crate) fn valid_credential_manager() -> Arc<dyn CredentialManager> {
     Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
         username: "root".into(),
         password: "password".into(),

--- a/crates/machine-controller/tests/integration/power_management.rs
+++ b/crates/machine-controller/tests/integration/power_management.rs
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use carbide_redfish::libredfish::RedfishClientPool as _;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use carbide_utils::redfish::BmcAccessInfo;
-use model::machine::ManagedHostState;
+use model::machine::{MachineMaintenanceOperation, ManagedHostState};
 use model::power_manager::PowerState;
 use model::test_support::ManagedHostConfig;
 use rpc::forge::{
@@ -36,16 +38,23 @@ struct TestContext {
 
 impl TestContext {
     async fn init(pool: PgPool) -> Self {
-        let env = Env::builder(pool)
-            .configure_runtime(|config| {
-                let zero = chrono::Duration::zero();
-                config.power_manager_options.enabled = true;
-                config.power_manager_options.next_try_duration_on_success = zero;
-                config.power_manager_options.next_try_duration_on_failure = zero;
-                config.power_manager_options.wait_duration_until_host_reboot = zero;
-            })
+        Self::from_env(power_manager_env_builder(pool).build().await).await
+    }
+
+    /// Like [`init`], but wires a component manager backed by an always-succeeding
+    /// compute-tray backend (plus valid BMC credentials) so maintenance power
+    /// operations can run to completion and return the host to Ready.
+    async fn init_with_success_backend(pool: PgPool) -> Self {
+        let backend = Arc::new(crate::maintenance::ReconciliationComputeTrayManager::new());
+        let env = power_manager_env_builder(pool)
+            .with_component_manager(crate::maintenance::component_manager(backend))
+            .with_credential_manager(crate::maintenance::valid_credential_manager())
             .build()
             .await;
+        Self::from_env(env).await
+    }
+
+    async fn from_env(env: Env) -> Self {
         let domain = env.test_harness.test_domain().await;
         let network_controller = env.test_harness.network_controller();
         let underlay_segment = network_controller.create_underlay_segment(&domain).await;
@@ -61,6 +70,16 @@ impl TestContext {
         mh.advance_state(ManagedHostState::Ready).await;
         Self { env, mh }
     }
+}
+
+fn power_manager_env_builder(pool: PgPool) -> crate::env::EnvBuilder {
+    Env::builder(pool).configure_runtime(|config| {
+        let zero = chrono::Duration::zero();
+        config.power_manager_options.enabled = true;
+        config.power_manager_options.next_try_duration_on_success = zero;
+        config.power_manager_options.next_try_duration_on_failure = zero;
+        config.power_manager_options.wait_duration_until_host_reboot = zero;
+    })
 }
 
 trait TestManagedHostPowerExt {
@@ -267,6 +286,99 @@ async fn desired_off_persists_observed_off_state(
     assert_eq!(power_options[0].last_fetched_power_state, PowerState::Off);
     assert!(power_options[0].last_fetched_updated_at > updated_at_before_poll);
     txn.rollback().await?;
+
+    Ok(())
+}
+
+/// A queued machine-maintenance PowerOff (what the compute-tray state-controller
+/// path posts when `compute_tray_use_state_controller = true`) must still reach
+/// the Maintenance transition when the power manager is enabled and the host's
+/// desired state is Off. Without the maintenance-takes-precedence guard,
+/// `handle_power` returns `continue_state_machine = false` for desired Off and
+/// `maintenance_transition_if_requested` is never reached, leaving the host
+/// parked in Ready with the request unconsumed.
+#[sqlx_test]
+async fn queued_power_off_runs_when_power_manager_gates_desired_off(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let TestContext { mut env, mh } = TestContext::init_with_success_backend(pool).await;
+
+    // Enable maintenance (the health override) so desired = Off is accepted, then
+    // set desired = Off. This is precisely the gating condition for handle_power.
+    env.test_harness
+        .api()
+        .set_maintenance(Request::new(MaintenanceRequest {
+            operation: MaintenanceOperation::Enable as i32,
+            host_id: Some(mh.host.id),
+            reference: Some("testing".to_string()),
+        }))
+        .await?;
+    env.test_harness
+        .api()
+        .update_power_option(Request::new(PowerOptionUpdateRequest {
+            machine_id: Some(mh.host.id),
+            power_state: rpc::forge::PowerState::Off as i32,
+        }))
+        .await?;
+    // Mirror the component manager, which removes the override immediately after
+    // the power-option write: at reconcile time only desired = Off persists, so
+    // the gate is driven purely by the power-manager desired state.
+    env.test_harness
+        .api()
+        .set_maintenance(Request::new(MaintenanceRequest {
+            operation: MaintenanceOperation::Disable as i32,
+            host_id: Some(mh.host.id),
+            reference: Some("testing".to_string()),
+        }))
+        .await?;
+
+    let mut txn = env.test_harness.db_txn().await;
+    let power_options = db::power_options::get_all(&mut txn).await?;
+    assert_eq!(power_options[0].desired_power_state, PowerState::Off);
+    txn.rollback().await?;
+
+    // Queue the PowerOff maintenance request, as the state-controller power path does.
+    let mut txn = env.test_harness.db_txn().await;
+    db::machine::set_machine_maintenance_requested(
+        &mut txn,
+        mh.host.id,
+        "component-manager",
+        MachineMaintenanceOperation::PowerOff,
+    )
+    .await?;
+    txn.commit().await?;
+
+    // First iteration must promote the request to Maintenance rather than parking
+    // in Ready behind the desired-Off power-manager gate.
+    env.run_single_iteration().await;
+
+    let machine = mh.host.machine().await;
+    assert!(
+        matches!(
+            machine.state.value,
+            ManagedHostState::Maintenance {
+                operation: MachineMaintenanceOperation::PowerOff
+            }
+        ),
+        "expected Maintenance(PowerOff) after one iteration, got {:?}",
+        machine.state.value,
+    );
+
+    // Second iteration reconciles the PowerOff against the (succeeding) backend,
+    // clears the request, and returns the host to Ready -- confirming the queued
+    // operation runs to completion, not just that it entered Maintenance.
+    env.run_single_iteration().await;
+
+    let machine = mh.host.machine().await;
+    assert!(
+        matches!(machine.state.value, ManagedHostState::Ready),
+        "expected Ready after the PowerOff completes, got {:?}",
+        machine.state.value,
+    );
+    assert!(
+        machine.machine_maintenance_requested.is_none(),
+        "maintenance request should be cleared once the operation completes",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Compute-tray power control called cm.compute_tray.power_control for all machines regardless of type. On an RMS-backed deployment this fails for standalone (non-rack-scale) servers, since RMS cannot resolve them.

Partition requested machines the same way compute firmware updates do (is_mnnvl_capable):

- Standalone servers: always dispatched synchronously through NICo-core's Redfish stack (CoreComputeTrayManager over api.redfish_pool), never the state machine, which has no non-rack path.
- Rack-scale servers: state-controller maintenance flow when enabled, else a synchronous dispatch through the configured backend (RMS).

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
