### PR TITLE
feat(bmc-proxy): count authorization denials

### DIFF
--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -54,7 +54,10 @@ use tokio_util::sync::CancellationToken;
 use tower_http::add_extension::AddExtensionLayer;
 
 use crate::config::{AuthConfig, TlsConfig};
-use crate::metrics::{MethodLabel, UpstreamRequestCompleted, UpstreamStatus};
+use crate::metrics::{
+    MethodLabel, PrincipalAllowListAuthContextMissing, PrincipalAllowListDenied,
+    RequestAclAuthContextMissing, RequestAclDenied, UpstreamRequestCompleted, UpstreamStatus,
+};
 
 const TLS_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const MAX_BODY_SIZE: usize = 8 * 1024 * 1024; // 8MiB body size limit (matches nginx ingress controller defaults)
@@ -110,7 +113,7 @@ enum ForwardedHeaderParseError {
 impl BmcProxyState {
     fn allows(&self, request: &Request<Body>) -> bool {
         let Some(auth_context) = request.extensions().get::<AuthContext<()>>() else {
-            tracing::error!("BUG: No AuthContext middleware found, all requests will be denied");
+            emit(RequestAclAuthContextMissing::new(request.method()));
             return false;
         };
 
@@ -123,12 +126,11 @@ impl BmcProxyState {
         });
 
         if !allowed {
-            tracing::info!(
-                principals = ?principal_ids,
-                path = request.uri().path(),
-                method = request.method().as_str(),
-                "Request denied by BMC proxy ACLs"
-            );
+            emit(RequestAclDenied::new(
+                request.method(),
+                format!("{principal_ids:?}"),
+                request.uri().path().to_string(),
+            ));
         }
 
         allowed
@@ -748,13 +750,19 @@ async fn authorize_proxy_request(
     request: Request<Body>,
     next: Next,
 ) -> Result<Response<Body>, StatusCode> {
+    authorize_principal_allow_list(&state, &request)?;
+    Ok(next.run(request).await)
+}
+
+fn authorize_principal_allow_list(
+    state: &BmcProxyState,
+    request: &Request<Body>,
+) -> Result<(), StatusCode> {
     let auth_context = request
         .extensions()
         .get::<AuthContext<()>>()
         .ok_or_else(|| {
-            tracing::warn!(
-                "authorize_proxy_request found a request with no AuthContext in its extensions"
-            );
+            emit(PrincipalAllowListAuthContextMissing::new(request.method()));
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
@@ -765,14 +773,14 @@ async fn authorize_proxy_request(
         .any(|principal| state.config.allowed_principals.contains(principal));
 
     if allowed {
-        Ok(next.run(request).await)
+        Ok(())
     } else {
-        tracing::info!(
-            allowed_principals = ?state.config.allowed_principals,
-            present_principals = ?present_principals,
-            path = request.uri().path(),
-            "Request denied by BMC proxy principal allow-list"
-        );
+        emit(PrincipalAllowListDenied::new(
+            request.method(),
+            format!("{:?}", state.config.allowed_principals),
+            format!("{present_principals:?}"),
+            request.uri().path().to_string(),
+        ));
         Err(StatusCode::FORBIDDEN)
     }
 }
@@ -1116,9 +1124,10 @@ mod tests {
     use std::sync::Arc;
 
     use axum::body::Body;
-    use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
+    use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode};
     use bytes::Bytes;
     use carbide_authn::middleware::{AuthContext, ExternalUserInfo, Principal};
+    use carbide_instrument::LabelValue;
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::Outcome::{Fails, Yields};
     use carbide_test_support::{
@@ -1136,11 +1145,41 @@ mod tests {
 
     use super::{
         BmcCredentials, BmcProxyState, ConnectionFailReason, CredentialCache, ForwardedTarget,
-        TcpAcceptFailed, TlsCertificateReloadFailed, TlsConnectionFailed, build_authority,
-        build_response, copy_request_headers, create_client, evict_cached_credentials,
-        forwarded_header_value, get_http_client, ip_for_forwarded_target, is_hop_by_hop_header,
-        method_supports_body, parse_forwarded_host_value, request_principal_ids,
+        TcpAcceptFailed, TlsCertificateReloadFailed, TlsConnectionFailed,
+        authorize_principal_allow_list, build_authority, build_response, copy_request_headers,
+        create_client, evict_cached_credentials, forwarded_header_value, get_http_client,
+        ip_for_forwarded_target, is_hop_by_hop_header, method_supports_body,
+        parse_forwarded_host_value, request_principal_ids,
     };
+    use crate::metrics::MethodLabel;
+
+    const TEST_CONFIG: &str = r#"
+        [tls]
+        identity_pemfile_path = ""
+        identity_keyfile_path = ""
+        root_cafile_path = ""
+        admin_root_cafile_path = ""
+
+        [auth]
+    "#;
+
+    const AUTHORIZATION_TEST_CONFIG: &str = r#"
+        allowed_principals = ["spiffe-service-id/forge-system/carbide-api"]
+
+        [tls]
+        identity_pemfile_path = ""
+        identity_keyfile_path = ""
+        root_cafile_path = ""
+        admin_root_cafile_path = ""
+
+        [auth]
+
+        [auth.acls]
+        "spiffe-service-id/forge-system/carbide-api" = ["GET /redfish/v1/**"]
+    "#;
+
+    const AUTHORIZATION_DENIED_METRIC: &str = "carbide_bmc_proxy_authorization_denied_total";
+    const AUTHORIZATION_ERROR_METRIC: &str = "carbide_bmc_proxy_authorization_errors_total";
 
     #[derive(Clone, Copy)]
     enum ForwardedHeaderCase {
@@ -1197,29 +1236,99 @@ mod tests {
         credentials: CredentialSummary,
     }
 
-    fn test_state_with_ip_cache(ip_cache: HashMap<LookupBy, IpAddr>) -> BmcProxyState {
+    fn test_state_with_config(config: &str, ip_cache: HashMap<LookupBy, IpAddr>) -> BmcProxyState {
         let client_config = ForgeClientConfig::default();
         let api_config = ApiConfig::new("https://example.com", &client_config);
 
         BmcProxyState {
-            config: Arc::new(
-                crate::Config::parse(
-                    r#"
-                        [tls]
-                        identity_pemfile_path = ""
-                        identity_keyfile_path = ""
-                        root_cafile_path = ""
-                        admin_root_cafile_path = ""
-
-                        [auth]
-                    "#,
-                )
-                .expect("test config should parse"),
-            ),
+            config: Arc::new(crate::Config::parse(config).expect("test config should parse")),
             api_client: ForgeApiClient::new(&api_config),
             credential_cache: Default::default(),
             client_cache: Default::default(),
             ip_cache: Arc::new(Mutex::new(ip_cache)),
+        }
+    }
+
+    fn test_state_with_ip_cache(ip_cache: HashMap<LookupBy, IpAddr>) -> BmcProxyState {
+        test_state_with_config(TEST_CONFIG, ip_cache)
+    }
+
+    struct AuthorizationRequestCase {
+        method: Method,
+        path: &'static str,
+        principals: Option<Vec<Principal>>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AuthorizationObservation<T> {
+        result: T,
+        denial_delta: f64,
+        error_delta: f64,
+        event_names: Vec<String>,
+    }
+
+    fn authorization_request(input: AuthorizationRequestCase) -> Request<Body> {
+        let mut request = Request::builder()
+            .method(input.method)
+            .uri(input.path)
+            .body(Body::empty())
+            .expect("authorization test request should build");
+        if let Some(principals) = input.principals {
+            request.extensions_mut().insert(AuthContext::<()> {
+                principals,
+                authorization: None,
+            });
+        }
+        request
+    }
+
+    fn authorization_event_names(logs: &[carbide_instrument::testing::CapturedLog]) -> Vec<String> {
+        logs.iter()
+            .filter_map(|log| log.field("event_name").map(str::to_owned))
+            .collect()
+    }
+
+    fn observe_request_acl(
+        state: &BmcProxyState,
+        input: AuthorizationRequestCase,
+    ) -> AuthorizationObservation<bool> {
+        let method_label = MethodLabel::from(&input.method).label_value().to_string();
+        let request = authorization_request(input);
+        let labels = [
+            ("authorization_layer", "request_acl"),
+            ("method", method_label.as_str()),
+        ];
+        let metrics = MetricsCapture::start();
+        let mut result = false;
+        let logs = capture_logs(|| result = state.allows(&request));
+
+        AuthorizationObservation {
+            result,
+            denial_delta: metrics.counter_delta(AUTHORIZATION_DENIED_METRIC, &labels),
+            error_delta: metrics.counter_delta(AUTHORIZATION_ERROR_METRIC, &labels),
+            event_names: authorization_event_names(&logs),
+        }
+    }
+
+    fn observe_principal_allow_list(
+        state: &BmcProxyState,
+        input: AuthorizationRequestCase,
+    ) -> AuthorizationObservation<Result<(), StatusCode>> {
+        let method_label = MethodLabel::from(&input.method).label_value().to_string();
+        let request = authorization_request(input);
+        let labels = [
+            ("authorization_layer", "principal_allow_list"),
+            ("method", method_label.as_str()),
+        ];
+        let metrics = MetricsCapture::start();
+        let mut result = Ok(());
+        let logs = capture_logs(|| result = authorize_principal_allow_list(state, &request));
+
+        AuthorizationObservation {
+            result,
+            denial_delta: metrics.counter_delta(AUTHORIZATION_DENIED_METRIC, &labels),
+            error_delta: metrics.counter_delta(AUTHORIZATION_ERROR_METRIC, &labels),
+            event_names: authorization_event_names(&logs),
         }
     }
 
@@ -1719,6 +1828,124 @@ mod tests {
                     "anonymous".to_string(),
                 ],
             }
+        );
+    }
+
+    /// `BmcProxyState::allows` owns the per-principal ACL boundary. An ordinary
+    /// policy rejection moves the denial counter, while a missing `AuthContext`
+    /// still rejects the request but moves only the middleware-error counter.
+    #[test]
+    fn request_acl_authorization_emits_the_matching_event() {
+        let state = test_state_with_config(AUTHORIZATION_TEST_CONFIG, HashMap::new());
+        let service_principal =
+            || Principal::SpiffeServiceIdentifier("forge-system/carbide-api".to_string());
+
+        check_values(
+            [
+                Check {
+                    scenario: "configured principal and path are allowed",
+                    input: AuthorizationRequestCase {
+                        method: Method::GET,
+                        path: "/redfish/v1/Systems/1",
+                        principals: Some(vec![service_principal()]),
+                    },
+                    expect: AuthorizationObservation {
+                        result: true,
+                        denial_delta: 0.0,
+                        error_delta: 0.0,
+                        event_names: vec![],
+                    },
+                },
+                Check {
+                    scenario: "configured principal with denied method",
+                    input: AuthorizationRequestCase {
+                        method: Method::POST,
+                        path: "/redfish/v1/Systems/1",
+                        principals: Some(vec![service_principal()]),
+                    },
+                    expect: AuthorizationObservation {
+                        result: false,
+                        denial_delta: 1.0,
+                        error_delta: 0.0,
+                        event_names: vec!["bmc_proxy_request_acl_denied".to_string()],
+                    },
+                },
+                Check {
+                    scenario: "authentication context is missing",
+                    input: AuthorizationRequestCase {
+                        method: Method::DELETE,
+                        path: "/redfish/v1/Systems/1",
+                        principals: None,
+                    },
+                    expect: AuthorizationObservation {
+                        result: false,
+                        denial_delta: 0.0,
+                        error_delta: 1.0,
+                        event_names: vec!["bmc_proxy_request_acl_auth_context_missing".to_string()],
+                    },
+                },
+            ],
+            |input| observe_request_acl(&state, input),
+        );
+    }
+
+    /// The outer allow-list returns 403 only for a real policy rejection. A
+    /// request that never passed through authentication keeps its existing 500
+    /// response and is counted as an authorization wiring error instead.
+    #[test]
+    fn principal_allow_list_authorization_emits_the_matching_event() {
+        let state = test_state_with_config(AUTHORIZATION_TEST_CONFIG, HashMap::new());
+        let service_principal =
+            || Principal::SpiffeServiceIdentifier("forge-system/carbide-api".to_string());
+
+        check_values(
+            [
+                Check {
+                    scenario: "configured principal is allowed",
+                    input: AuthorizationRequestCase {
+                        method: Method::GET,
+                        path: "/redfish/v1",
+                        principals: Some(vec![service_principal()]),
+                    },
+                    expect: AuthorizationObservation {
+                        result: Ok(()),
+                        denial_delta: 0.0,
+                        error_delta: 0.0,
+                        event_names: vec![],
+                    },
+                },
+                Check {
+                    scenario: "principal is not on the allow-list",
+                    input: AuthorizationRequestCase {
+                        method: Method::PATCH,
+                        path: "/redfish/v1",
+                        principals: Some(vec![Principal::TrustedCertificate]),
+                    },
+                    expect: AuthorizationObservation {
+                        result: Err(StatusCode::FORBIDDEN),
+                        denial_delta: 1.0,
+                        error_delta: 0.0,
+                        event_names: vec!["bmc_proxy_principal_allow_list_denied".to_string()],
+                    },
+                },
+                Check {
+                    scenario: "authentication context is missing",
+                    input: AuthorizationRequestCase {
+                        method: Method::OPTIONS,
+                        path: "/redfish/v1",
+                        principals: None,
+                    },
+                    expect: AuthorizationObservation {
+                        result: Err(StatusCode::INTERNAL_SERVER_ERROR),
+                        denial_delta: 0.0,
+                        error_delta: 1.0,
+                        event_names: vec![
+                            "bmc_proxy_principal_allow_list_auth_context_missing".to_string(),
+                        ],
+                    },
+                },
+            ],
+            |input| observe_principal_allow_list(&state, input),
         );
     }
 

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-//! The bmc-proxy metrics endpoint, and the proxy's instrumentation events:
-//! the outbound forward to a BMC records a duration histogram whose
-//! `_count` series, split by status class, is the request and outcome rate.
+//! The bmc-proxy metrics endpoint and the proxy's instrumentation events.
+//! Authorization events keep policy denials separate from missing middleware
+//! context, while each outbound BMC request records its duration and status.
 
 use std::io;
 use std::net::SocketAddr;
@@ -87,6 +87,154 @@ impl From<&Method> for MethodLabel {
             Method::PATCH => Self::Patch,
             Method::DELETE => Self::Delete,
             _ => Self::Other,
+        }
+    }
+}
+
+/// The authorization boundary that rejected a request or could not evaluate
+/// it. The outer allow-list decides which principals may use the proxy at all;
+/// the request ACL then decides which Redfish method and path they may use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum AuthorizationLayer {
+    PrincipalAllowList,
+    RequestAcl,
+}
+
+/// The request reached the per-principal ACL, but no configured rule allowed
+/// its method and path. `method_label` bounds the metric while `method` keeps
+/// the existing uppercase log field operators already search.
+#[derive(Event)]
+#[event(
+    event_name = "bmc_proxy_request_acl_denied",
+    metric_name = "carbide_bmc_proxy_authorization_denied_total",
+    component = "nico-bmc-proxy",
+    log = info,
+    metric = counter,
+    message = "Request denied by BMC proxy ACLs",
+    describe = "Number of BMC proxy requests denied by authorization layer and HTTP method"
+)]
+pub(crate) struct RequestAclDenied {
+    #[label]
+    authorization_layer: AuthorizationLayer,
+    #[label(name = "method")]
+    method_label: MethodLabel,
+    #[context]
+    principals: String,
+    #[context]
+    path: String,
+    #[context]
+    method: String,
+}
+
+impl RequestAclDenied {
+    pub(crate) fn new(method: &Method, principals: String, path: String) -> Self {
+        Self {
+            authorization_layer: AuthorizationLayer::RequestAcl,
+            method_label: method.into(),
+            principals,
+            path,
+            method: method.as_str().to_string(),
+        }
+    }
+}
+
+/// The outer principal allow-list rejected a request before it reached the
+/// per-principal ACL. Principal identities and configured policy stay on the
+/// log line; neither can create a metric series.
+#[derive(Event)]
+#[event(
+    event_name = "bmc_proxy_principal_allow_list_denied",
+    metric_name = "carbide_bmc_proxy_authorization_denied_total",
+    component = "nico-bmc-proxy",
+    log = info,
+    metric = counter,
+    message = "Request denied by BMC proxy principal allow-list",
+    describe = "Number of BMC proxy requests denied by authorization layer and HTTP method"
+)]
+pub(crate) struct PrincipalAllowListDenied {
+    #[label]
+    authorization_layer: AuthorizationLayer,
+    #[label(name = "method")]
+    method_label: MethodLabel,
+    #[context]
+    allowed_principals: String,
+    #[context]
+    present_principals: String,
+    #[context]
+    path: String,
+}
+
+impl PrincipalAllowListDenied {
+    pub(crate) fn new(
+        method: &Method,
+        allowed_principals: String,
+        present_principals: String,
+        path: String,
+    ) -> Self {
+        Self {
+            authorization_layer: AuthorizationLayer::PrincipalAllowList,
+            method_label: method.into(),
+            allowed_principals,
+            present_principals,
+            path,
+        }
+    }
+}
+
+/// The per-principal ACL could not run because authentication middleware did
+/// not attach an `AuthContext`. This is a wiring error, not a policy denial,
+/// so it has a separate metric and keeps the existing ERROR diagnostic.
+#[derive(Event)]
+#[event(
+    event_name = "bmc_proxy_request_acl_auth_context_missing",
+    metric_name = "carbide_bmc_proxy_authorization_errors_total",
+    component = "nico-bmc-proxy",
+    log = error,
+    metric = counter,
+    message = "BUG: No AuthContext middleware found, all requests will be denied",
+    describe = "Number of BMC proxy authorization errors caused by missing authentication context, by authorization layer and HTTP method"
+)]
+pub(crate) struct RequestAclAuthContextMissing {
+    #[label]
+    authorization_layer: AuthorizationLayer,
+    #[label(name = "method")]
+    method_label: MethodLabel,
+}
+
+impl RequestAclAuthContextMissing {
+    pub(crate) fn new(method: &Method) -> Self {
+        Self {
+            authorization_layer: AuthorizationLayer::RequestAcl,
+            method_label: method.into(),
+        }
+    }
+}
+
+/// The outer allow-list could not run because authentication middleware did
+/// not attach an `AuthContext`. The request remains a 500 and the diagnostic
+/// remains WARN, but the error is counted separately from a normal 403.
+#[derive(Event)]
+#[event(
+    event_name = "bmc_proxy_principal_allow_list_auth_context_missing",
+    metric_name = "carbide_bmc_proxy_authorization_errors_total",
+    component = "nico-bmc-proxy",
+    log = warn,
+    metric = counter,
+    message = "authorize_proxy_request found a request with no AuthContext in its extensions",
+    describe = "Number of BMC proxy authorization errors caused by missing authentication context, by authorization layer and HTTP method"
+)]
+pub(crate) struct PrincipalAllowListAuthContextMissing {
+    #[label]
+    authorization_layer: AuthorizationLayer,
+    #[label(name = "method")]
+    method_label: MethodLabel,
+}
+
+impl PrincipalAllowListAuthContextMissing {
+    pub(crate) fn new(method: &Method) -> Self {
+        Self {
+            authorization_layer: AuthorizationLayer::PrincipalAllowList,
+            method_label: method.into(),
         }
     }
 }
@@ -163,6 +311,132 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
+
+    const AUTHORIZATION_DENIED_METRIC: &str = "carbide_bmc_proxy_authorization_denied_total";
+    const AUTHORIZATION_ERROR_METRIC: &str = "carbide_bmc_proxy_authorization_errors_total";
+
+    struct AuthorizationEventInput {
+        authorization_layer: &'static str,
+        method: &'static str,
+        emit: fn(),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AuthorizationEventObservation {
+        denied_delta: f64,
+        error_delta: f64,
+        log: AuthorizationEventLog,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AuthorizationEventLog {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        authorization_layer: Option<String>,
+        method_label: Option<String>,
+        principals: Option<String>,
+        path: Option<String>,
+        method: Option<String>,
+        allowed_principals: Option<String>,
+        present_principals: Option<String>,
+    }
+
+    fn emit_request_acl_denied() {
+        emit(RequestAclDenied::new(
+            &Method::PATCH,
+            r#"["spiffe-service-id/nico-api", "anonymous"]"#.to_string(),
+            "/redfish/v1/Systems/1".to_string(),
+        ));
+    }
+
+    fn emit_principal_allow_list_denied() {
+        emit(PrincipalAllowListDenied::new(
+            &Method::GET,
+            r#"{"spiffe-service-id/nico-api"}"#.to_string(),
+            r#"["trusted-certificate", "anonymous"]"#.to_string(),
+            "/redfish/v1".to_string(),
+        ));
+    }
+
+    fn emit_request_acl_auth_context_missing() {
+        emit(RequestAclAuthContextMissing::new(&Method::DELETE));
+    }
+
+    fn emit_principal_allow_list_auth_context_missing() {
+        emit(PrincipalAllowListAuthContextMissing::new(&Method::OPTIONS));
+    }
+
+    fn observe_authorization_event(
+        input: AuthorizationEventInput,
+    ) -> AuthorizationEventObservation {
+        let metrics = MetricsCapture::start();
+        let mut logs = capture_logs(input.emit);
+        assert_eq!(logs.len(), 1, "an authorization Event logs exactly once");
+        let log = logs.pop().expect("the authorization Event log");
+        let field = |name: &str| log.field(name).map(str::to_owned);
+        let labels = [
+            ("authorization_layer", input.authorization_layer),
+            ("method", input.method),
+        ];
+
+        AuthorizationEventObservation {
+            denied_delta: metrics.counter_delta(AUTHORIZATION_DENIED_METRIC, &labels),
+            error_delta: metrics.counter_delta(AUTHORIZATION_ERROR_METRIC, &labels),
+            log: AuthorizationEventLog {
+                level: log.level,
+                metadata_name: log.metadata_name.clone(),
+                message: log.message.clone(),
+                event_name: field("event_name"),
+                metric_name: field("metric_name"),
+                authorization_layer: field("authorization_layer"),
+                method_label: field("method_label"),
+                principals: field("principals"),
+                path: field("path"),
+                method: field("method"),
+                allowed_principals: field("allowed_principals"),
+                present_principals: field("present_principals"),
+            },
+        }
+    }
+
+    fn expected_authorization_event(
+        level: tracing::Level,
+        event_name: &str,
+        metric_name: &str,
+        message: &str,
+        authorization_layer: &str,
+        method_label: &str,
+    ) -> AuthorizationEventObservation {
+        AuthorizationEventObservation {
+            denied_delta: if metric_name == AUTHORIZATION_DENIED_METRIC {
+                1.0
+            } else {
+                0.0
+            },
+            error_delta: if metric_name == AUTHORIZATION_ERROR_METRIC {
+                1.0
+            } else {
+                0.0
+            },
+            log: AuthorizationEventLog {
+                level,
+                metadata_name: event_name.to_string(),
+                message: message.to_string(),
+                event_name: Some(event_name.to_string()),
+                metric_name: Some(metric_name.to_string()),
+                authorization_layer: Some(authorization_layer.to_string()),
+                method_label: Some(method_label.to_string()),
+                principals: None,
+                path: None,
+                method: None,
+                allowed_principals: None,
+                present_principals: None,
+            },
+        }
+    }
 
     #[tokio::test]
     async fn start_binds_listener_and_spawns_endpoint_task() {
@@ -325,6 +599,16 @@ mod tests {
         check_values(
             [
                 Check {
+                    scenario: "principal allow-list authorization layer",
+                    input: AuthorizationLayer::PrincipalAllowList.label_value(),
+                    expect: "principal_allow_list".to_string(),
+                },
+                Check {
+                    scenario: "request ACL authorization layer",
+                    input: AuthorizationLayer::RequestAcl.label_value(),
+                    expect: "request_acl".to_string(),
+                },
+                Check {
                     scenario: "get",
                     input: MethodLabel::Get.label_value(),
                     expect: "get".to_string(),
@@ -386,6 +670,96 @@ mod tests {
                 },
             ],
             |value| value.to_string(),
+        );
+    }
+
+    /// Policy denials and missing middleware context both keep their historical
+    /// diagnostics, but they move different metric families. The shared labels
+    /// let an operator identify the boundary and method without putting any
+    /// principal or path into a time series.
+    #[test]
+    fn authorization_events_preserve_logs_and_separate_denials_from_errors() {
+        let mut request_acl_denied = expected_authorization_event(
+            tracing::Level::INFO,
+            "bmc_proxy_request_acl_denied",
+            AUTHORIZATION_DENIED_METRIC,
+            "Request denied by BMC proxy ACLs",
+            "request_acl",
+            "patch",
+        );
+        request_acl_denied.log.principals =
+            Some(r#"["spiffe-service-id/nico-api", "anonymous"]"#.to_string());
+        request_acl_denied.log.path = Some("/redfish/v1/Systems/1".to_string());
+        request_acl_denied.log.method = Some("PATCH".to_string());
+
+        let mut principal_allow_list_denied = expected_authorization_event(
+            tracing::Level::INFO,
+            "bmc_proxy_principal_allow_list_denied",
+            AUTHORIZATION_DENIED_METRIC,
+            "Request denied by BMC proxy principal allow-list",
+            "principal_allow_list",
+            "get",
+        );
+        principal_allow_list_denied.log.allowed_principals =
+            Some(r#"{"spiffe-service-id/nico-api"}"#.to_string());
+        principal_allow_list_denied.log.present_principals =
+            Some(r#"["trusted-certificate", "anonymous"]"#.to_string());
+        principal_allow_list_denied.log.path = Some("/redfish/v1".to_string());
+
+        check_values(
+            [
+                Check {
+                    scenario: "request ACL denial",
+                    input: AuthorizationEventInput {
+                        authorization_layer: "request_acl",
+                        method: "patch",
+                        emit: emit_request_acl_denied,
+                    },
+                    expect: request_acl_denied,
+                },
+                Check {
+                    scenario: "principal allow-list denial",
+                    input: AuthorizationEventInput {
+                        authorization_layer: "principal_allow_list",
+                        method: "get",
+                        emit: emit_principal_allow_list_denied,
+                    },
+                    expect: principal_allow_list_denied,
+                },
+                Check {
+                    scenario: "request ACL missing authentication context",
+                    input: AuthorizationEventInput {
+                        authorization_layer: "request_acl",
+                        method: "delete",
+                        emit: emit_request_acl_auth_context_missing,
+                    },
+                    expect: expected_authorization_event(
+                        tracing::Level::ERROR,
+                        "bmc_proxy_request_acl_auth_context_missing",
+                        AUTHORIZATION_ERROR_METRIC,
+                        "BUG: No AuthContext middleware found, all requests will be denied",
+                        "request_acl",
+                        "delete",
+                    ),
+                },
+                Check {
+                    scenario: "principal allow-list missing authentication context",
+                    input: AuthorizationEventInput {
+                        authorization_layer: "principal_allow_list",
+                        method: "other",
+                        emit: emit_principal_allow_list_auth_context_missing,
+                    },
+                    expect: expected_authorization_event(
+                        tracing::Level::WARN,
+                        "bmc_proxy_principal_allow_list_auth_context_missing",
+                        AUTHORIZATION_ERROR_METRIC,
+                        "authorize_proxy_request found a request with no AuthContext in its extensions",
+                        "principal_allow_list",
+                        "other",
+                    ),
+                },
+            ],
+            observe_authorization_event,
         );
     }
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -28,6 +28,8 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_auth_denied_total</td><td>counter</td><td>Number of Forge calls denied by the authorizer</td></tr>
 <tr><td>carbide_authn_client_cert_rejected_total</td><td>counter</td><td>Number of client certificates rejected during authentication</td></tr>
 <tr><td>carbide_available_ips_count</td><td>gauge</td><td>Number of available IPs per network segment</td></tr>
+<tr><td>carbide_bmc_proxy_authorization_denied_total</td><td>counter</td><td>Number of BMC proxy requests denied by authorization layer and HTTP method</td></tr>
+<tr><td>carbide_bmc_proxy_authorization_errors_total</td><td>counter</td><td>Number of BMC proxy authorization errors caused by missing authentication context, by authorization layer and HTTP method</td></tr>
 <tr><td>carbide_bmc_proxy_tls_connection_attempted_total</td><td>counter</td><td>Number of inbound TLS connection attempts</td></tr>
 <tr><td>carbide_bmc_proxy_tls_connection_fail_total</td><td>counter</td><td>Number of failed inbound connections, by failure reason</td></tr>
 <tr><td>carbide_bmc_proxy_tls_connection_success_total</td><td>counter</td><td>Number of successful TLS connections</td></tr>


### PR DESCRIPTION
The BMC proxy already writes the right diagnostic when either authorization boundary rejects a request, but those denials only existed in the log stream. A missing `AuthContext` is a different class of problem -- it means the middleware contract broke, not that policy rejected a caller.

So, the request ACL and principal allow-list now emit `Event`s backed by `carbide_bmc_proxy_authorization_denied_total`. The bounded `authorization_layer` and `method` labels tell us where the request stopped, while paths, principals, and configured allow-lists remain log-only context.

Missing middleware context gets its own `carbide_bmc_proxy_authorization_errors_total` counter. Authorization policy, status codes, log levels, messages, and existing diagnostic fields stay as they were.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3854

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-bmc-proxy` -- 45 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

`docs/observability/core_metrics.md` is the generated metric catalogue and is updated with both authorization metric families. This does not change which requests the proxy allows or the response status produced at either boundary.

Closes #3854
