### PR TITLE
feat(machine-identity): count token exchange failures

### DIFF
--- a/crates/api-core/src/machine_identity/token_exchange.rs
+++ b/crates/api-core/src/machine_identity/token_exchange.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use ::rpc::forge::MachineIdentityResponse;
 use base64::Engine;
+use carbide_instrument::{Event, LabelValue, emit};
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use serde::Deserialize;
 use tonic::Status;
@@ -29,6 +30,106 @@ use crate::CarbideError;
 
 const OAUTH_GRANT_TYPE_TOKEN_EXCHANGE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
 const OAUTH_TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
+const TOKEN_EXCHANGE_RESPONSE_SCHEMA_ERROR: &str =
+    "token exchange response did not match the expected schema";
+
+/// Where an RFC 8693 exchange stopped, as the bounded `failure_stage`
+/// label shared by the failure Events below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum TokenExchangeFailureStage {
+    Request,
+    ResponseBody,
+    HttpStatus,
+    ResponseJson,
+}
+
+/// The HTTP request did not reach a token-exchange response.
+#[derive(Event)]
+#[event(
+    event_name = "machine_identity_token_exchange_request_failed",
+    metric_name = "carbide_machine_identity_token_exchange_failures_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "token exchange HTTP request failed",
+    describe = "Number of machine identity token exchange failures, by failure stage"
+)]
+struct TokenExchangeRequestFailed {
+    #[label]
+    failure_stage: TokenExchangeFailureStage,
+    #[context]
+    error: String,
+    #[context]
+    token_endpoint: String,
+}
+
+/// The token endpoint answered, but its response body could not be read.
+#[derive(Event)]
+#[event(
+    event_name = "machine_identity_token_exchange_response_read_failed",
+    metric_name = "carbide_machine_identity_token_exchange_failures_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "token exchange response body read failed",
+    describe = "Number of machine identity token exchange failures, by failure stage"
+)]
+struct TokenExchangeResponseReadFailed {
+    #[label]
+    failure_stage: TokenExchangeFailureStage,
+    #[context]
+    error: String,
+    #[context]
+    token_endpoint: String,
+}
+
+/// The token endpoint returned a non-success HTTP status.
+/// Response content stays out of diagnostics because OAuth error payloads can
+/// include credentials or token-shaped values.
+#[derive(Event)]
+#[event(
+    event_name = "machine_identity_token_exchange_endpoint_rejected",
+    metric_name = "carbide_machine_identity_token_exchange_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "token exchange endpoint returned error",
+    describe = "Number of machine identity token exchange failures, by failure stage"
+)]
+struct TokenExchangeEndpointRejected {
+    #[label]
+    failure_stage: TokenExchangeFailureStage,
+    #[context]
+    http_status: String,
+    #[context]
+    response_body_length: usize,
+    #[context]
+    token_endpoint: String,
+}
+
+/// A successful HTTP response did not contain a valid token-exchange body.
+/// Neither the body nor the parser error is logged: serde errors can quote a
+/// response value, and a partially valid response can still contain a token.
+#[derive(Event)]
+#[event(
+    event_name = "machine_identity_token_exchange_response_invalid",
+    metric_name = "carbide_machine_identity_token_exchange_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "token exchange JSON parse failed",
+    describe = "Number of machine identity token exchange failures, by failure stage"
+)]
+struct TokenExchangeResponseInvalid {
+    #[label]
+    failure_stage: TokenExchangeFailureStage,
+    #[context]
+    error: String,
+    #[context]
+    response_body_length: usize,
+    #[context]
+    token_endpoint: String,
+}
 
 #[derive(Debug, Deserialize)]
 struct TokenExchangeHttpResponseBody {
@@ -109,35 +210,44 @@ pub(crate) async fn token_exchange_request(
     }
 
     let resp = req.send().await.map_err(|e| {
-        tracing::error!(
-            error = %e,
-            token_endpoint = %token_endpoint,
-            "token exchange HTTP request failed"
-        );
+        emit(TokenExchangeRequestFailed {
+            failure_stage: TokenExchangeFailureStage::Request,
+            error: e.to_string(),
+            token_endpoint: token_endpoint.to_string(),
+        });
         CarbideError::internal(format!("token exchange request failed: {e}"))
     })?;
 
     let status = resp.status();
     let bytes = resp.bytes().await.map_err(|e| {
-        tracing::error!(error = %e, "token exchange response body read failed");
+        emit(TokenExchangeResponseReadFailed {
+            failure_stage: TokenExchangeFailureStage::ResponseBody,
+            error: e.to_string(),
+            token_endpoint: token_endpoint.to_string(),
+        });
         CarbideError::internal(format!("token exchange response failed: {e}"))
     })?;
 
     if !status.is_success() {
-        let snippet = String::from_utf8_lossy(&bytes[..bytes.len().min(512)]);
-        tracing::warn!(
-            http_status = %status,
-            body_prefix = %snippet,
-            "token exchange endpoint returned error"
-        );
+        emit(TokenExchangeEndpointRejected {
+            failure_stage: TokenExchangeFailureStage::HttpStatus,
+            http_status: status.to_string(),
+            response_body_length: bytes.len(),
+            token_endpoint: token_endpoint.to_string(),
+        });
         return Err(CarbideError::InvalidArgument(format!(
             "token exchange endpoint returned HTTP {status}"
         ))
         .into());
     }
 
-    let parsed: TokenExchangeHttpResponseBody = serde_json::from_slice(&bytes).map_err(|e| {
-        tracing::warn!(error = %e, body = %String::from_utf8_lossy(&bytes[..bytes.len().min(256)]), "token exchange JSON parse failed");
+    let parsed: TokenExchangeHttpResponseBody = serde_json::from_slice(&bytes).map_err(|_| {
+        emit(TokenExchangeResponseInvalid {
+            failure_stage: TokenExchangeFailureStage::ResponseJson,
+            error: TOKEN_EXCHANGE_RESPONSE_SCHEMA_ERROR.to_string(),
+            response_body_length: bytes.len(),
+            token_endpoint: token_endpoint.to_string(),
+        });
         CarbideError::internal("token exchange response was not valid JSON".to_string())
     })?;
 
@@ -157,7 +267,15 @@ pub(crate) async fn token_exchange_request(
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases_async, check_values};
+    use tokio::io::AsyncWriteExt as _;
+
     use super::*;
+
+    const TOKEN_EXCHANGE_FAILURE_METRIC: &str =
+        "carbide_machine_identity_token_exchange_failures_total";
 
     #[test]
     fn token_exchange_body_deserializes_expires_in_as_json_number() {
@@ -208,9 +326,6 @@ mod tests {
 
     #[tokio::test]
     async fn token_exchange_request_maps_endpoint_response() {
-        use carbide_test_support::Outcome::*;
-        use carbide_test_support::{Case, check_cases_async};
-
         // What the mocked `token_endpoint` returns for one request.
         struct Reply {
             status: usize,
@@ -226,9 +341,6 @@ mod tests {
             expires_in_sec: u32,
         }
 
-        // The success row asserts the JSON parses into all four fields; the error
-        // row only asserts *that* a non-2xx fails — `Status` (the error) isn't
-        // `PartialEq`, so the closure maps it to `()` and the row uses `Fails`.
         check_cases_async(
             [
                 Case {
@@ -245,12 +357,17 @@ mod tests {
                     }),
                 },
                 Case {
-                    scenario: "non-2xx maps to an error",
+                    scenario: "omitted optional fields use RFC defaults",
                     input: Reply {
-                        status: 401,
-                        body: r#"{"error":"invalid_client"}"#,
+                        status: 200,
+                        body: r#"{"access_token":"defaulted"}"#,
                     },
-                    expect: Fails,
+                    expect: Yields(Exchanged {
+                        access_token: "defaulted".to_string(),
+                        issued_token_type: "urn:ietf:params:oauth:token-type:jwt".to_string(),
+                        token_type: "Bearer".to_string(),
+                        expires_in_sec: 0,
+                    }),
                 },
             ],
             |reply| async move {
@@ -286,6 +403,238 @@ mod tests {
             },
         )
         .await;
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FailureLog {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: String,
+        metric_name: String,
+        error_present: bool,
+        http_status: Option<String>,
+        response_body_length: Option<String>,
+        token_endpoint_present: bool,
+    }
+
+    fn observe_failure_log(logs: &[CapturedLog], failure_stage: &str) -> FailureLog {
+        let log = logs
+            .iter()
+            .find(|log| log.field("failure_stage") == Some(failure_stage))
+            .unwrap_or_else(|| panic!("missing {failure_stage} failure log in {logs:?}"));
+
+        FailureLog {
+            level: log.level,
+            metadata_name: log.metadata_name.clone(),
+            message: log.message.clone(),
+            event_name: log
+                .field("event_name")
+                .expect("Event log has event_name")
+                .to_string(),
+            metric_name: log
+                .field("metric_name")
+                .expect("metric-backed Event log has metric_name")
+                .to_string(),
+            error_present: log.field("error").is_some_and(|error| !error.is_empty()),
+            http_status: log.field("http_status").map(str::to_owned),
+            response_body_length: log.field("response_body_length").map(str::to_owned),
+            token_endpoint_present: log
+                .field("token_endpoint")
+                .is_some_and(|endpoint| !endpoint.is_empty()),
+        }
+    }
+
+    #[test]
+    fn token_exchange_failures_emit_metrics_and_structured_logs() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build");
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            runtime.block_on(async {
+                let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+                    .with(reqwest_tracing::TracingMiddleware::default())
+                    .build();
+
+                token_exchange_request(
+                    &client,
+                    "://invalid-token-endpoint",
+                    "subject.jwt",
+                    &[],
+                    None,
+                )
+                .await
+                .expect_err("an invalid URL must fail before receiving a response");
+
+                let mut server = mockito::Server::new_async().await;
+                let _rejected = server
+                    .mock("POST", "/rejected")
+                    .with_status(401)
+                    .with_body(r#"{"error":"invalid_client"}"#)
+                    .create_async()
+                    .await;
+                let _invalid_json = server
+                    .mock("POST", "/invalid-json")
+                    .with_status(200)
+                    .with_body(r#"{"expires_in":"response-secret"}"#)
+                    .create_async()
+                    .await;
+
+                for path in ["rejected", "invalid-json"] {
+                    token_exchange_request(
+                        &client,
+                        &format!("{}/{path}", server.url()),
+                        "subject.jwt",
+                        &[],
+                        None,
+                    )
+                    .await
+                    .expect_err("the mocked response must fail token exchange");
+                }
+
+                // Send a complete response header and then close before the declared body
+                // length. `reqwest` accepts the response, but `Response::bytes` sees the
+                // incomplete body and exercises the response-read failure boundary.
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                    .await
+                    .expect("raw HTTP listener should bind");
+                let endpoint = format!(
+                    "http://{}/token",
+                    listener
+                        .local_addr()
+                        .expect("raw HTTP listener should have an address")
+                );
+                let responder = tokio::spawn(async move {
+                    let (mut stream, _) = listener.accept().await.expect("request should connect");
+                    stream
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 20\r\nConnection: close\r\n\r\nshort",
+                        )
+                        .await
+                        .expect("partial response should write");
+                    stream.shutdown().await.expect("response should close");
+                });
+                token_exchange_request(&client, &endpoint, "subject.jwt", &[], None)
+                    .await
+                    .expect_err("an incomplete response body must fail token exchange");
+                responder.await.expect("raw HTTP responder should finish");
+            });
+        });
+
+        let event_logs = logs
+            .into_iter()
+            .filter(|log| log.field("metric_name") == Some(TOKEN_EXCHANGE_FAILURE_METRIC))
+            .collect::<Vec<_>>();
+        assert_eq!(event_logs.len(), 4, "one Event per failure stage");
+
+        check_values(
+            [
+                Check {
+                    scenario: "request send failure",
+                    input: "request",
+                    expect: FailureLog {
+                        level: tracing::Level::ERROR,
+                        metadata_name: "machine_identity_token_exchange_request_failed".to_string(),
+                        message: "token exchange HTTP request failed".to_string(),
+                        event_name: "machine_identity_token_exchange_request_failed".to_string(),
+                        metric_name: TOKEN_EXCHANGE_FAILURE_METRIC.to_string(),
+                        error_present: true,
+                        http_status: None,
+                        response_body_length: None,
+                        token_endpoint_present: true,
+                    },
+                },
+                Check {
+                    scenario: "response body read failure",
+                    input: "response_body",
+                    expect: FailureLog {
+                        level: tracing::Level::ERROR,
+                        metadata_name: "machine_identity_token_exchange_response_read_failed"
+                            .to_string(),
+                        message: "token exchange response body read failed".to_string(),
+                        event_name: "machine_identity_token_exchange_response_read_failed"
+                            .to_string(),
+                        metric_name: TOKEN_EXCHANGE_FAILURE_METRIC.to_string(),
+                        error_present: true,
+                        http_status: None,
+                        response_body_length: None,
+                        token_endpoint_present: true,
+                    },
+                },
+                Check {
+                    scenario: "endpoint HTTP rejection",
+                    input: "http_status",
+                    expect: FailureLog {
+                        level: tracing::Level::WARN,
+                        metadata_name: "machine_identity_token_exchange_endpoint_rejected"
+                            .to_string(),
+                        message: "token exchange endpoint returned error".to_string(),
+                        event_name: "machine_identity_token_exchange_endpoint_rejected".to_string(),
+                        metric_name: TOKEN_EXCHANGE_FAILURE_METRIC.to_string(),
+                        error_present: false,
+                        http_status: Some("401 Unauthorized".to_string()),
+                        response_body_length: Some("26".to_string()),
+                        token_endpoint_present: true,
+                    },
+                },
+                Check {
+                    scenario: "invalid response JSON",
+                    input: "response_json",
+                    expect: FailureLog {
+                        level: tracing::Level::WARN,
+                        metadata_name: "machine_identity_token_exchange_response_invalid"
+                            .to_string(),
+                        message: "token exchange JSON parse failed".to_string(),
+                        event_name: "machine_identity_token_exchange_response_invalid".to_string(),
+                        metric_name: TOKEN_EXCHANGE_FAILURE_METRIC.to_string(),
+                        error_present: true,
+                        http_status: None,
+                        response_body_length: Some("32".to_string()),
+                        token_endpoint_present: true,
+                    },
+                },
+            ],
+            |failure_stage| observe_failure_log(&event_logs, failure_stage),
+        );
+
+        for failure_stage in ["request", "response_body", "http_status", "response_json"] {
+            assert_eq!(
+                metrics.counter_delta(
+                    TOKEN_EXCHANGE_FAILURE_METRIC,
+                    &[("failure_stage", failure_stage)],
+                ),
+                1.0,
+                "failure stage {failure_stage}",
+            );
+        }
+
+        let response_json_log = event_logs
+            .iter()
+            .find(|log| log.field("failure_stage") == Some("response_json"))
+            .expect("response JSON failure log must exist");
+        assert_eq!(
+            response_json_log.field("error"),
+            Some(TOKEN_EXCHANGE_RESPONSE_SCHEMA_ERROR),
+            "response-derived values must not reach the parser diagnostic",
+        );
+
+        for log in &event_logs {
+            for sensitive_field in [
+                "subject_jwt",
+                "authorization",
+                "access_token",
+                "body",
+                "body_prefix",
+            ] {
+                assert_eq!(
+                    log.field(sensitive_field),
+                    None,
+                    "{sensitive_field} must never reach token-exchange diagnostics",
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -106,6 +106,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_ib_partitions_total</td><td>gauge</td><td>Number of carbide_ib_partitions in the system</td></tr>
 <tr><td>carbide_ipmi_commands_total</td><td>counter</td><td>Number of IPMI command executions, by command and outcome.</td></tr>
 <tr><td>carbide_log_events_total</td><td>counter</td><td>Number of log events emitted, by level and component. The always-on log-volume and error-rate signal for every binary.</td></tr>
+<tr><td>carbide_machine_identity_token_exchange_failures_total</td><td>counter</td><td>Number of machine identity token exchange failures, by failure stage</td></tr>
 <tr><td>carbide_machine_reboot_duration_seconds</td><td>histogram</td><td>Time taken for machine/host to reboot in seconds</td></tr>
 <tr><td>carbide_machine_updates_started_count</td><td>gauge</td><td>Number of machines in the system in the process of updating</td></tr>
 <tr><td>carbide_machine_validation_completed</td><td>gauge</td><td>Number of successfully completed machine validation runs</td></tr>


### PR DESCRIPTION
The machine-identity token exchange already writes a useful terminal diagnostic at each failed boundary, but there was no metric operators could trend or alert on. Request send, response read, HTTP rejection, and JSON decoding now share `carbide_machine_identity_token_exchange_failures_total`, selected by the bounded `failure_stage` label.

Each `Event` keeps the existing log level, message, and returned status mapping. `token_endpoint`, `http_status`, `response_body_length`, and error detail remain log-only context where applicable.

CodeRabbit caught two important security edges during review: OAuth response bodies can contain credentials or a partially valid access token, and serde errors can quote unexpected response values. The accepted fixes remove response-derived content from diagnostics entirely -- `subject_jwt`, `Authorization`, `access_token`, and response-body fields stay absent, while parser failures use a fixed schema message and the remaining metadata still identifies the failed boundary.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3855

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test --locked -p carbide-api-core token_exchange --lib` -- 7 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

The response-body and parser-error redaction is intentional and came from accepted CodeRabbit security findings. Request behavior and gRPC status mapping remain unchanged. `docs/observability/core_metrics.md` is the generated metric catalogue and is updated with the new counter.

Closes #3855
