### PR TITLE
feat(dhcp-server): count timestamp-file failures

### DIFF
--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -17,6 +17,7 @@
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 
+use carbide_instrument::emit;
 use carbide_rpc_utils::dhcp::{
     DhcpConfig as ModelDhcpConfig, DhcpTimestamps, DhcpTimestampsFilePath,
     HostConfig as ModelHostConfig, InterfaceInfo as ModelInterfaceInfo,
@@ -37,6 +38,7 @@ use proto::{
 };
 
 use crate::errors::DhcpError;
+use crate::metrics::DhcpTimestampFileReadFailed;
 
 // ── Public control channel types ─────────────────────────────────────────────
 
@@ -215,7 +217,10 @@ impl DhcpServerControl for DhcpServerControlService {
     ) -> Result<Response<GetDhcpTimestampsResponse>, Status> {
         let mut ts = DhcpTimestamps::new(DhcpTimestampsFilePath::Hbn);
         if let Err(e) = ts.read() {
-            tracing::warn!(error = %e, "Failed to read DHCP timestamps file");
+            emit(DhcpTimestampFileReadFailed::new(
+                DhcpTimestampsFilePath::Hbn.path_str().to_string(),
+                e.to_string(),
+            ));
         }
         let entries = ts
             .into_iter()

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -42,7 +42,10 @@ use forge_tls::client_config::ClientCert;
 use forge_tls::default::{default_client_cert, default_client_key, default_root_ca};
 use grpc_server::{ControlRequest, run_grpc_server};
 use lru::LruCache;
-use metrics::{DhcpPacketDropped, DhcpReplySent, DropReason};
+use metrics::{
+    DhcpPacketDropped, DhcpReplySent, DhcpTimestampFileInitializationFailed,
+    DhcpTimestampFileWriteFailed, DropReason,
+};
 use metrics_endpoint::{MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint};
 use modes::DhcpMode;
 use modes::controller::Controller;
@@ -78,11 +81,13 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
     };
 
     let dhcp_timestamps = Arc::new(Mutex::new({
-        let d = DhcpTimestamps::new(if let ServerMode::Dpu = args.mode {
+        let dhcp_timestamps_path = if let ServerMode::Dpu = args.mode {
             DhcpTimestampsFilePath::HbnTmp
         } else {
             DhcpTimestampsFilePath::NotSet
-        });
+        };
+        let dhcp_timestamps_path_context = dhcp_timestamps_path.path_str().to_string();
+        let d = DhcpTimestamps::new(dhcp_timestamps_path);
 
         // It looks like we can only expect the file to be present
         // if something has successfully DHCP'ed, after write() has been
@@ -91,7 +96,10 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         // and pollute the logs. We could have read() skip NotFound errors, but that
         // could be misleading in other scenarios.  Let's just "init" the file.
         if let Err(e) = d.write() {
-            tracing::error!(error = %e, "Failed to init DHCP timestamps file");
+            emit(DhcpTimestampFileInitializationFailed::new(
+                dhcp_timestamps_path_context,
+                e.to_string(),
+            ));
             return;
         }
         d
@@ -734,11 +742,11 @@ async fn process(
         let mut dhcp_timestamps = dhcp_timestamps.lock().await;
         dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
         if let Err(e) = dhcp_timestamps.write() {
-            tracing::error!(
-                dhcp_timestamps_path = DhcpTimestampsFilePath::HbnTmp.path_str(),
-                error = %e,
-                "Failed to write DHCP timestamps file"
-            );
+            emit(DhcpTimestampFileWriteFailed::new(
+                DhcpTimestampsFilePath::HbnTmp.path_str().to_string(),
+                host_config.host_interface_id.to_string(),
+                e.to_string(),
+            ));
         }
     }
 }

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -20,6 +20,8 @@
 //! while the per-packet log lines stay reachable at DEBUG for forensics. A
 //! drop is the operational error, so its event also writes the ERROR line --
 //! one declaration moves the counter and logs the reason together.
+//! Timestamp-file failures share a counter by operation while their paths,
+//! host interface, and errors remain log-only diagnostics.
 
 use carbide_instrument::{Event, LabelValue};
 use dhcproto::v4::MessageType;
@@ -116,6 +118,15 @@ impl From<&DhcpError> for DropReason {
     }
 }
 
+/// The timestamp-file operation that failed. These are the only three file
+/// operations performed by the DHCP server, so the metric remains bounded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum TimestampFileOperation {
+    Initialize,
+    Write,
+    Read,
+}
+
 /// A DHCP packet was decoded from the wire, whatever becomes of it next.
 #[derive(Event)]
 #[event(
@@ -169,6 +180,106 @@ pub struct DhcpReplySent {
     pub message_type: MessageTypeLabel,
 }
 
+/// The startup write could not initialize the timestamp file. This server
+/// generation does not start after the failure.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_timestamp_file_initialization_failed",
+    metric_name = "carbide_dhcp_timestamp_file_failures_total",
+    component = "nico-dhcp",
+    log = error,
+    metric = counter,
+    message = "Failed to init DHCP timestamps file",
+    describe = "Number of DHCP timestamp file failures, by operation"
+)]
+pub(crate) struct DhcpTimestampFileInitializationFailed {
+    #[label]
+    operation: TimestampFileOperation,
+    #[context]
+    dhcp_timestamps_path: String,
+    #[context]
+    error: String,
+}
+
+impl DhcpTimestampFileInitializationFailed {
+    pub(crate) fn new(dhcp_timestamps_path: String, error: String) -> Self {
+        Self {
+            operation: TimestampFileOperation::Initialize,
+            dhcp_timestamps_path,
+            error,
+        }
+    }
+}
+
+/// Updating the in-memory timestamp succeeded, but persisting the file failed.
+/// Packet processing continues because the timestamp write is best effort.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_timestamp_file_write_failed",
+    metric_name = "carbide_dhcp_timestamp_file_failures_total",
+    component = "nico-dhcp",
+    log = error,
+    metric = counter,
+    message = "Failed to write DHCP timestamps file",
+    describe = "Number of DHCP timestamp file failures, by operation"
+)]
+pub(crate) struct DhcpTimestampFileWriteFailed {
+    #[label]
+    operation: TimestampFileOperation,
+    #[context]
+    dhcp_timestamps_path: String,
+    #[context]
+    host_interface_id: String,
+    #[context]
+    error: String,
+}
+
+impl DhcpTimestampFileWriteFailed {
+    pub(crate) fn new(
+        dhcp_timestamps_path: String,
+        host_interface_id: String,
+        error: String,
+    ) -> Self {
+        Self {
+            operation: TimestampFileOperation::Write,
+            dhcp_timestamps_path,
+            host_interface_id,
+            error,
+        }
+    }
+}
+
+/// The control RPC could not read the timestamp file. It still returns an
+/// empty list so callers keep treating an unreadable file as no requests yet.
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_timestamp_file_read_failed",
+    metric_name = "carbide_dhcp_timestamp_file_failures_total",
+    component = "nico-dhcp",
+    log = warn,
+    metric = counter,
+    message = "Failed to read DHCP timestamps file",
+    describe = "Number of DHCP timestamp file failures, by operation"
+)]
+pub(crate) struct DhcpTimestampFileReadFailed {
+    #[label]
+    operation: TimestampFileOperation,
+    #[context]
+    dhcp_timestamps_path: String,
+    #[context]
+    error: String,
+}
+
+impl DhcpTimestampFileReadFailed {
+    pub(crate) fn new(dhcp_timestamps_path: String, error: String) -> Self {
+        Self {
+            operation: TimestampFileOperation::Read,
+            dhcp_timestamps_path,
+            error,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;
@@ -180,6 +291,173 @@ mod tests {
     use dhcproto::v4::relay::RelayCode;
 
     use super::*;
+
+    const TIMESTAMP_FILE_FAILURE_METRIC: &str = "carbide_dhcp_timestamp_file_failures_total";
+
+    struct TimestampFileFailureInput {
+        emit: fn(),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TimestampFileFailureObservation {
+        initialize_delta: f64,
+        write_delta: f64,
+        read_delta: f64,
+        log: TimestampFileFailureLog,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct TimestampFileFailureLog {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        operation: Option<String>,
+        dhcp_timestamps_path: Option<String>,
+        host_interface_id: Option<String>,
+        error: Option<String>,
+    }
+
+    fn emit_timestamp_initialization_failure() {
+        emit(DhcpTimestampFileInitializationFailed::new(
+            "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp".to_string(),
+            "permission denied".to_string(),
+        ));
+    }
+
+    fn emit_timestamp_write_failure() {
+        emit(DhcpTimestampFileWriteFailed::new(
+            "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp".to_string(),
+            "60cef902-9779-4666-8362-c9bb4b37185f".to_string(),
+            "read-only file system".to_string(),
+        ));
+    }
+
+    fn emit_timestamp_read_failure() {
+        emit(DhcpTimestampFileReadFailed::new(
+            "/var/support/forge-dhcp/logs/dhcp_timestamps.json".to_string(),
+            "file not found".to_string(),
+        ));
+    }
+
+    fn observe_timestamp_file_failure(
+        input: TimestampFileFailureInput,
+    ) -> TimestampFileFailureObservation {
+        let metrics = MetricsCapture::start();
+        let mut logs = capture_logs(input.emit);
+        assert_eq!(logs.len(), 1, "a timestamp-file failure logs once");
+        let log = logs.pop().expect("the timestamp-file failure log");
+        let field = |name: &str| log.field(name).map(str::to_owned);
+
+        TimestampFileFailureObservation {
+            initialize_delta: metrics.counter_delta(
+                TIMESTAMP_FILE_FAILURE_METRIC,
+                &[("operation", "initialize")],
+            ),
+            write_delta: metrics
+                .counter_delta(TIMESTAMP_FILE_FAILURE_METRIC, &[("operation", "write")]),
+            read_delta: metrics
+                .counter_delta(TIMESTAMP_FILE_FAILURE_METRIC, &[("operation", "read")]),
+            log: TimestampFileFailureLog {
+                level: log.level,
+                metadata_name: log.metadata_name.clone(),
+                message: log.message.clone(),
+                event_name: field("event_name"),
+                metric_name: field("metric_name"),
+                operation: field("operation"),
+                dhcp_timestamps_path: field("dhcp_timestamps_path"),
+                host_interface_id: field("host_interface_id"),
+                error: field("error"),
+            },
+        }
+    }
+
+    fn expected_timestamp_file_failure(
+        operation: &str,
+        level: tracing::Level,
+        event_name: &str,
+        message: &str,
+        dhcp_timestamps_path: &str,
+        host_interface_id: Option<&str>,
+        error: &str,
+    ) -> TimestampFileFailureObservation {
+        TimestampFileFailureObservation {
+            initialize_delta: if operation == "initialize" { 1.0 } else { 0.0 },
+            write_delta: if operation == "write" { 1.0 } else { 0.0 },
+            read_delta: if operation == "read" { 1.0 } else { 0.0 },
+            log: TimestampFileFailureLog {
+                level,
+                metadata_name: event_name.to_string(),
+                message: message.to_string(),
+                event_name: Some(event_name.to_string()),
+                metric_name: Some(TIMESTAMP_FILE_FAILURE_METRIC.to_string()),
+                operation: Some(operation.to_string()),
+                dhcp_timestamps_path: Some(dhcp_timestamps_path.to_string()),
+                host_interface_id: host_interface_id.map(str::to_owned),
+                error: Some(error.to_string()),
+            },
+        }
+    }
+
+    /// Every timestamp-file failure keeps its historical diagnostic while the
+    /// operation label selects exactly one series in the shared counter.
+    #[test]
+    fn timestamp_file_failures_log_and_count_by_operation() {
+        // No other test in this binary triggers a timestamp-file failure. The
+        // exact process-global counter deltas below rely on that isolation;
+        // keep any future call-site failure test under the same log capture.
+        check_values(
+            [
+                Check {
+                    scenario: "initialization failure",
+                    input: TimestampFileFailureInput {
+                        emit: emit_timestamp_initialization_failure,
+                    },
+                    expect: expected_timestamp_file_failure(
+                        "initialize",
+                        tracing::Level::ERROR,
+                        "dhcp_timestamp_file_initialization_failed",
+                        "Failed to init DHCP timestamps file",
+                        "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp",
+                        None,
+                        "permission denied",
+                    ),
+                },
+                Check {
+                    scenario: "post-reply write failure",
+                    input: TimestampFileFailureInput {
+                        emit: emit_timestamp_write_failure,
+                    },
+                    expect: expected_timestamp_file_failure(
+                        "write",
+                        tracing::Level::ERROR,
+                        "dhcp_timestamp_file_write_failed",
+                        "Failed to write DHCP timestamps file",
+                        "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp",
+                        Some("60cef902-9779-4666-8362-c9bb4b37185f"),
+                        "read-only file system",
+                    ),
+                },
+                Check {
+                    scenario: "read failure",
+                    input: TimestampFileFailureInput {
+                        emit: emit_timestamp_read_failure,
+                    },
+                    expect: expected_timestamp_file_failure(
+                        "read",
+                        tracing::Level::WARN,
+                        "dhcp_timestamp_file_read_failed",
+                        "Failed to read DHCP timestamps file",
+                        "/var/support/forge-dhcp/logs/dhcp_timestamps.json",
+                        None,
+                        "file not found",
+                    ),
+                },
+            ],
+            observe_timestamp_file_failure,
+        );
+    }
 
     #[test]
     fn message_type_label_maps_the_rfc2131_set_and_buckets_the_rest() {

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -42,6 +42,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dhcp_dropped_requests_total</td><td>counter</td><td>Number of DHCP packets dropped without a reply, by drop reason.</td></tr>
 <tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCP replies sent, by reply message type.</td></tr>
 <tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCP packets received and decoded, by DHCP message type.</td></tr>
+<tr><td>carbide_dhcp_timestamp_file_failures_total</td><td>counter</td><td>Number of DHCP timestamp file failures, by operation</td></tr>
 <tr><td>carbide_dhcp_v6_replies_sent_total</td><td>counter</td><td>Number of DHCPv6 replies sent, by response message type.</td></tr>
 <tr><td>carbide_dns_negative_cache_hit_count_total</td><td>counter</td><td>Number of negative DNS cache hits, by response code</td></tr>
 <tr><td>carbide_dns_negative_cache_miss_count_total</td><td>counter</td><td>Number of negative DNS cache misses, by response code</td></tr>


### PR DESCRIPTION
DHCP timestamp-file failures already make three different decisions: initialization stops that server generation, a post-reply write failure lets packet handling continue, and a control-service read failure returns an empty list. Each path wrote its diagnostic, but there was no counter showing which file operation was failing.

So, initialization, write, and read failures now emit `Event`s backed by `carbide_dhcp_timestamp_file_failures_total`. Only the bounded `operation` becomes a metric label; the timestamp path, `host_interface_id`, and error remain log-only context.

The existing levels, messages, and control flow stay exactly the same, which lets us add the signal without changing how DHCP behaves when the file is unavailable.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3856

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-dhcp-server timestamp_file` -- 1 passed
- `cargo test -p carbide-dhcp-server` -- 28 passed
- `cargo clippy -p carbide-dhcp-server --all-targets -- -D warnings`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

Agent-side timestamp fetching and DHCP socket-lifecycle failures remain outside this PR because they cross different process and operational boundaries. `docs/observability/core_metrics.md` is the generated metric catalogue and is updated with the timestamp-file counter.

Closes #3856
