### PR TITLE
feat(api): add IPv6 deny prefixes

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -26,7 +26,7 @@ applicable.
 | `ntp_servers` | `Vec<Ipv4Addr>` | `[]` | `networking` | Site-level NTP server IPs used for BMC time configuration and DHCP NTP Server configuration. |
 | `route_servers` | `Vec<String>` | `[]` | `networking` | Route server IPs for L2VPN Ethernet Virtual network support. |
 | `enable_route_servers` | `bool` | `false` | `networking` | Enables route server injection into DPU FRR configs for L2VPN. |
-| `deny_prefixes` | `Vec<Ipv4Network>` | `[]` | `networking` | IPv4 CIDR prefixes that tenant instances are blocked from reaching. Generates iptables DROP rules and nvue ACL policies. |
+| `deny_prefixes` | `Vec<IpNetwork>` | `[]` | `networking` | IPv4 and IPv6 CIDR prefixes that tenant instances are blocked from reaching. FNN generates family-specific NVUE ACL policies; all non-FNN virtualizers apply the IPv4 prefixes only. |
 | `site_fabric_prefixes` | `Vec<IpNetwork>` | `[]` | `networking` | IP prefixes (v4/v6) assigned for tenant use within this site. |
 | `anycast_site_prefixes` | `Vec<Ipv4Network>` | `[]` | `networking` | Aggregate IPv4 prefixes containing tenant-announced prefixes (e.g., BYOIP). **Deprecated.** Use [`routing_profiles.allowed_anycast_prefixes`](#fnnroutingprofileconfig) instead. |
 | `common_tenant_host_asn` | `Option<u32>` | — | `networking` | ASN that tenants use to peer with the DPU. If unset, any ASN is accepted. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -176,20 +176,11 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub enable_route_servers: bool,
 
-    /// List of IPv4 prefixes (in CIDR notation) that tenant instances are not allowed to talk to.
-    //
-    // TODO(chet): For now, this remains `Vec<Ipv4Network>`, because the dpu-agent consumers
-    // that process deny prefixes are IPv4-only (and I'll do it in another PR):
-    // - `crates/agent/src/acl_rules.rs` parses rules into `Ipv4Network` and generates
-    //   iptables DROP rules via `make_deny_prefix_rules(&[Ipv4Network], ...)`
-    // - nvue templates (in `nvue_startup_fnn.conf` and `nvue_startup_etv.conf`) render these
-    //   prefixes under a "p0000_deny_prefixes_ipv4" ACL policy with `type: ipv4`.
-    //
-    // Updating to support `Vec<IpNetwork>` requires the agent to generate parallel IPv6 deny
-    // rules (I think via ip6tables / `type: ipv6` ACL policy), similar to how NSG rules already
-    // handle the `ipv6: bool` split.
+    /// List of IP prefixes (in CIDR notation) that tenant instances are not allowed to reach.
+    ///
+    /// FNN supports IPv4 and IPv6 prefixes. All non-FNN virtualizers apply only IPv4 prefixes.
     #[serde(default)]
-    pub deny_prefixes: Vec<Ipv4Network>,
+    pub deny_prefixes: Vec<IpNetwork>,
 
     /// List of IP prefixes (in CIDR notation) that are assigned for tenant
     /// use within this site. Supports both IPv4 and IPv6 prefixes.
@@ -3351,6 +3342,53 @@ mod tests {
     use crate::test_support::network_segment::FIXTURE_TENANT_ORG_ID;
 
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/cfg/test_data");
+
+    #[test]
+    fn deny_prefixes_accept_both_address_families() {
+        let config: CarbideConfig = Figment::new()
+            .merge(Toml::string(
+                r#"
+                    database_url = "postgres://test"
+                    listen = "[::]:1081"
+                    asn = 1
+                    deny_prefixes = ["192.0.2.0/24", "2001:db8::/32"]
+                    anycast_site_prefixes = ["198.51.100.0/24"]
+                "#,
+            ))
+            .extract()
+            .expect("dual-stack deny prefixes must parse");
+
+        assert_eq!(
+            config.deny_prefixes,
+            vec![
+                "192.0.2.0/24".parse::<IpNetwork>().unwrap(),
+                "2001:db8::/32".parse::<IpNetwork>().unwrap(),
+            ]
+        );
+        assert_eq!(
+            config.anycast_site_prefixes,
+            vec!["198.51.100.0/24".parse::<Ipv4Network>().unwrap()]
+        );
+    }
+
+    #[test]
+    fn anycast_site_prefixes_reject_ipv6() {
+        let result = Figment::new()
+            .merge(Toml::string(
+                r#"
+                    database_url = "postgres://test"
+                    listen = "[::]:1081"
+                    asn = 1
+                    anycast_site_prefixes = ["2001:db8::/32"]
+                "#,
+            ))
+            .extract::<CarbideConfig>();
+
+        assert!(
+            result.is_err(),
+            "IPv6 anycast site prefixes must be rejected"
+        );
+    }
 
     /// Exercises the real `[certificates]` / `[certificates.dedicated_vault]`
     /// TOML contract through Figment (the production config path), rather than

--- a/crates/api-core/src/ethernet_virtualization.rs
+++ b/crates/api-core/src/ethernet_virtualization.rs
@@ -26,7 +26,7 @@ use carbide_uuid::vpc::VpcId;
 use db::vpc::{self};
 use db::vpc_peering::get_prefixes_by_vpcs;
 use db::{self, ObjectColumnFilter, network_security_group};
-use ipnetwork::{IpNetwork, Ipv4Network};
+use ipnetwork::IpNetwork;
 use model::instance::config::network::{
     InstanceInterfaceConfig, InstanceInterfaceRoutingProfile, InstanceNetworkConfig,
     InterfaceFunctionId,
@@ -48,7 +48,7 @@ use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, VpcPeeringPolicy};
 pub struct EthVirtData {
     pub asn: u32,
     pub dhcp_servers: Vec<Ipv4Addr>,
-    pub deny_prefixes: Vec<Ipv4Network>,
+    pub deny_prefixes: Vec<IpNetwork>,
     pub site_fabric_prefixes: Option<SiteFabricPrefixList>,
 }
 

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -33,6 +33,7 @@ use db::{
     network_segment,
 };
 use futures_util::future::join_all;
+use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use model::extension_service::{ExtensionService, ExtensionServiceVersionInfo};
 use model::hardware_info::{MachineInventory, MachineInventorySoftwareComponent};
@@ -67,6 +68,42 @@ fn build_consolidated_network_config(
     rpc::ManagedHostNetworkConfig {
         loopback_ip: dpu_loopback_ip.to_string(),
         quarantine_state: host_network_config.quarantine_state.clone().map(Into::into),
+    }
+}
+
+/// FNN renders family-specific deny policies, while ETV exposes only its IPv4 policy. Filter at
+/// this per-DPU boundary so a mixed site can send IPv6 to FNN without changing the IPv4-only wire
+/// contract for ETV, Flat, and older agents.
+fn deny_prefixes_for_agent(
+    prefixes: &[IpNetwork],
+    network_virtualization_type: VpcVirtualizationType,
+) -> Vec<String> {
+    let supports_ipv6 = network_virtualization_type == VpcVirtualizationType::Fnn;
+
+    prefixes
+        .iter()
+        .filter(|prefix| supports_ipv6 || prefix.is_ipv4())
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// Builds the deprecated deny field with the same address-family contract as `deny_prefixes`.
+///
+/// Mutual isolation folds site-fabric prefixes into this field, so those prefixes must pass
+/// through the per-DPU filter as well.
+fn deprecated_deny_prefixes_for_agent(
+    deny_prefixes: &[String],
+    site_fabric_prefixes: &[IpNetwork],
+    isolation_behavior: VpcIsolationBehaviorType,
+    network_virtualization_type: VpcVirtualizationType,
+) -> Vec<String> {
+    match isolation_behavior {
+        VpcIsolationBehaviorType::MutualIsolation => {
+            let site_fabric_prefixes =
+                deny_prefixes_for_agent(site_fabric_prefixes, network_virtualization_type);
+            [site_fabric_prefixes.as_slice(), deny_prefixes].concat()
+        }
+        VpcIsolationBehaviorType::Open => deny_prefixes.to_vec(),
     }
 }
 
@@ -492,29 +529,26 @@ pub(crate) async fn get_managed_host_network_config_inner(
         api.eth_data.asn
     };
 
-    let deny_prefixes: Vec<String> = api
-        .eth_data
-        .deny_prefixes
-        .iter()
-        .map(|net| net.to_string())
-        .collect();
+    let deny_prefixes =
+        deny_prefixes_for_agent(&api.eth_data.deny_prefixes, network_virtualization_type);
 
-    let site_fabric_prefixes: Vec<String> = api
+    let site_fabric_networks = api
         .eth_data
         .site_fabric_prefixes
         .as_ref()
         .map(|s| s.as_ip_slice())
-        .unwrap_or_default()
+        .unwrap_or_default();
+    let site_fabric_prefixes: Vec<String> = site_fabric_networks
         .iter()
         .map(|net| net.to_string())
         .collect();
 
-    let deprecated_deny_prefixes = match api.runtime_config.vpc_isolation_behavior {
-        VpcIsolationBehaviorType::MutualIsolation => {
-            [site_fabric_prefixes.as_slice(), deny_prefixes.as_slice()].concat()
-        }
-        VpcIsolationBehaviorType::Open => deny_prefixes.clone(),
-    };
+    let deprecated_deny_prefixes = deprecated_deny_prefixes_for_agent(
+        &deny_prefixes,
+        site_fabric_networks,
+        api.runtime_config.vpc_isolation_behavior,
+        network_virtualization_type,
+    );
 
     // Strip the source_type for the route servers that we feed back to the DPUs -- they just care
     // about the IP address. Although, maybe in the future, we might be interested in sending the
@@ -1457,6 +1491,68 @@ pub(crate) async fn get_bgp_password(
             });
         }
     })
+}
+
+#[cfg(test)]
+mod deny_prefix_tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[test]
+    fn prefixes_follow_the_effective_virtualizer() {
+        let prefixes = ["192.0.2.0/24", "2001:db8::/32"].map(|prefix| prefix.parse().unwrap());
+        let ipv4_only = vec!["192.0.2.0/24".to_string()];
+
+        value_scenarios!(
+            run = |virtualization_type| {
+                deny_prefixes_for_agent(&prefixes, virtualization_type)
+            };
+            "dual-stack agent policy" {
+                VpcVirtualizationType::Fnn => vec![
+                    "192.0.2.0/24".to_string(),
+                    "2001:db8::/32".to_string(),
+                ],
+            }
+
+            "non-FNN wire compatibility" {
+                VpcVirtualizationType::EthernetVirtualizer => ipv4_only.clone(),
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => ipv4_only.clone(),
+                VpcVirtualizationType::Flat => ipv4_only,
+            }
+        );
+    }
+
+    #[test]
+    fn deprecated_field_filters_dual_stack_site_fabric() {
+        let deny_prefixes = vec!["198.51.100.0/24".to_string()];
+        let site_fabric_prefixes =
+            ["192.0.2.0/24", "2001:db8::/32"].map(|prefix| prefix.parse().unwrap());
+        let fnn_prefixes = vec![
+            "192.0.2.0/24".to_string(),
+            "2001:db8::/32".to_string(),
+            "198.51.100.0/24".to_string(),
+        ];
+        let ipv4_only = vec!["192.0.2.0/24".to_string(), "198.51.100.0/24".to_string()];
+
+        value_scenarios!(
+            run = |virtualization_type| deprecated_deny_prefixes_for_agent(
+                &deny_prefixes,
+                &site_fabric_prefixes,
+                VpcIsolationBehaviorType::MutualIsolation,
+                virtualization_type,
+            );
+            "dual-stack FNN compatibility field" {
+                VpcVirtualizationType::Fnn => fnn_prefixes,
+            }
+
+            "IPv4-only compatibility field" {
+                VpcVirtualizationType::EthernetVirtualizer => ipv4_only.clone(),
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => ipv4_only.clone(),
+                VpcVirtualizationType::Flat => ipv4_only,
+            }
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -21,6 +21,7 @@ use carbide_api_core::AdminUiRoutesBuilder;
 use carbide_api_core::bootstrap::{Logging, RuntimeInputs, start_runtime, start_runtime_prelude};
 use carbide_secrets::CredentialConfig;
 use eyre::WrapErr;
+use ipnetwork::IpNetwork;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -236,16 +237,21 @@ fn start_per_object_metrics_endpoint(
     Ok(per_object_metrics)
 }
 
+/// Returns whether two CIDR prefixes claim any of the same addresses.
+///
+/// Prefixes within one address family are nested or disjoint, so checking both network addresses
+/// covers either containment direction. `IpNetwork::contains` rejects cross-family addresses.
+fn prefixes_overlap(left: IpNetwork, right: IpNetwork) -> bool {
+    left.contains(right.network()) || right.contains(left.network())
+}
+
 fn validate_network_prefixes(
     carbide_config: &carbide_api_core::cfg::file::CarbideConfig,
 ) -> eyre::Result<()> {
     // Reject config that contains overlaps between deny_prefixes and site_fabric_prefixes.
-    // deny_prefixes are IPv4-only; only check against IPv4 site fabric prefixes.
     for deny_prefix in &carbide_config.deny_prefixes {
         for site_fabric_prefix in &carbide_config.site_fabric_prefixes {
-            if let ipnetwork::IpNetwork::V4(site_v4) = site_fabric_prefix
-                && deny_prefix.overlaps(*site_v4)
-            {
+            if prefixes_overlap(*deny_prefix, *site_fabric_prefix) {
                 return Err(eyre::eyre!(
                     "overlap found in deny_prefixes `{deny_prefix}` and site_fabric_prefixes \
                      `{site_fabric_prefix}`",
@@ -254,4 +260,82 @@ fn validate_network_prefixes(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    struct PrefixPair {
+        deny: &'static str,
+        site_fabric: &'static str,
+    }
+
+    #[test]
+    fn deny_site_fabric_overlap_is_address_family_aware() {
+        value_scenarios!(run = |pair: PrefixPair| {
+            prefixes_overlap(
+                pair.deny.parse().expect("valid deny prefix"),
+                pair.site_fabric.parse().expect("valid site fabric prefix"),
+            )
+        };
+            "IPv4 deny prefix contains site fabric prefix" {
+                PrefixPair {
+                    deny: "10.0.0.0/8",
+                    site_fabric: "10.20.0.0/16",
+                } => true,
+            }
+
+            "IPv4 site fabric prefix contains deny prefix" {
+                PrefixPair {
+                    deny: "10.20.0.0/16",
+                    site_fabric: "10.0.0.0/8",
+                } => true,
+            }
+
+            "IPv6 deny prefix contains site fabric prefix" {
+                PrefixPair {
+                    deny: "2001:db8::/32",
+                    site_fabric: "2001:db8:20::/48",
+                } => true,
+            }
+
+            "identical IPv6 prefixes overlap" {
+                PrefixPair {
+                    deny: "2001:db8:20::/48",
+                    site_fabric: "2001:db8:20::/48",
+                } => true,
+            }
+
+            "IPv4 prefixes are disjoint" {
+                PrefixPair {
+                    deny: "10.0.0.0/8",
+                    site_fabric: "192.0.2.0/24",
+                } => false,
+            }
+
+            "IPv6 prefixes are disjoint" {
+                PrefixPair {
+                    deny: "2001:db8::/32",
+                    site_fabric: "2001:db9::/32",
+                } => false,
+            }
+
+            "IPv4 deny and IPv6 site fabric prefixes are separate" {
+                PrefixPair {
+                    deny: "10.0.0.0/8",
+                    site_fabric: "2001:db8::/32",
+                } => false,
+            }
+
+            "IPv6 deny and IPv4 site fabric prefixes are separate" {
+                PrefixPair {
+                    deny: "2001:db8::/32",
+                    site_fabric: "10.0.0.0/8",
+                } => false,
+            }
+        );
+    }
 }


### PR DESCRIPTION
`deny_prefixes` stopped at `Ipv4Network` even though `FNN` already renders its ACL policy by address family. This moves the site config and runtime value to `IpNetwork`, so the existing `FNN` IPv6 path can receive configured prefixes.

- Filter every prefix that reaches `deny_prefixes` or `deprecated_deny_prefixes` at the per-DPU boundary. `FNN` receives both families, while `ETV` and `Flat` keep IPv4-only values, including `site_fabric_prefixes` folded into mutual isolation.
- Reject overlaps with `site_fabric_prefixes` in either containment direction while treating IPv4 and IPv6 as separate address spaces.
- Keep `anycast_site_prefixes` IPv4-only.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2405

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-api deny_site_fabric_overlap_is_address_family_aware -- --nocapture`
- `cargo test -p carbide-api-core handlers::dpu::deny_prefix_tests --lib -- --nocapture`
- `cargo test -p carbide-api-core deny_prefixes_accept_both_address_families --lib`
- `cargo test -p carbide-api-core anycast_site_prefixes_reject_ipv6 --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-licenses`
- `cargo make check-bans`
- `cargo xtask check-workspace-deps`

## Additional Notes

`site_fabric_prefixes` remains dual-stack in its dedicated wire field. Only prefixes folded into `deprecated_deny_prefixes` are filtered for the IPv4-only `ETV` and `Flat` compatibility path.

Closes #2405
