### PR TITLE
fix(machine-controller): report DPU restart outcome accurately

### DIFF
--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -9921,7 +9921,7 @@ fn handler_restart_dpu(
         tracing::info!(
             dpu_machine_id = %machine.id,
             %trigger_location,
-            "Attempting DPU restart"
+            "attempting DPU restart"
         );
 
         if let Err(error) = restart_dpu(machine, ctx.services, dpf_used_for_ingestion).await {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -9917,18 +9917,37 @@ fn handler_restart_dpu(
     dpf_used_for_ingestion: bool,
 ) -> impl Future<Output = Result<(), StateHandlerError>> {
     let trigger_location = std::panic::Location::caller();
-    tracing::info!(
-        dpu_machine_id = %machine.id,
-        %trigger_location,
-        "DPU restart triggered"
-    );
-    ctx.pending_db_writes
-        .push(MachineWriteOp::UpdateRebootRequestedTime {
-            machine_id: machine.id,
-            mode: model::machine::MachineLastRebootRequestedMode::Reboot,
-            time: Utc::now(),
-        });
-    restart_dpu(machine, ctx.services, dpf_used_for_ingestion)
+    async move {
+        tracing::info!(
+            dpu_machine_id = %machine.id,
+            %trigger_location,
+            "Attempting DPU restart"
+        );
+
+        if let Err(error) = restart_dpu(machine, ctx.services, dpf_used_for_ingestion).await {
+            tracing::error!(
+                dpu_machine_id = %machine.id,
+                %trigger_location,
+                error = %error,
+                "DPU restart failed"
+            );
+            return Err(error);
+        }
+
+        ctx.pending_db_writes
+            .push(MachineWriteOp::UpdateRebootRequestedTime {
+                machine_id: machine.id,
+                mode: model::machine::MachineLastRebootRequestedMode::Reboot,
+                time: Utc::now(),
+            });
+        tracing::info!(
+            dpu_machine_id = %machine.id,
+            %trigger_location,
+            "DPU restart triggered"
+        );
+
+        Ok(())
+    }
 }
 
 pub async fn host_power_state(
@@ -10585,13 +10604,10 @@ async fn restart_dpu(
             });
     }
 
-    if let Err(e) = dpu_redfish_client
+    dpu_redfish_client
         .power(SystemPowerControl::ForceRestart)
         .await
-    {
-        tracing::error!(error = %e, "Failed to reboot a DPU");
-        return Err(redfish_error("reboot dpu", e));
-    }
+        .map_err(|error| redfish_error("reboot dpu", error))?;
 
     Ok(())
 }


### PR DESCRIPTION
DPU restart handling logged success and queued the reboot-request timestamp before the Redfish restart completed. When the restart failed, logs could falsely imply success, and the lower-level failure log did not identify the affected DPU.

This change:

- Logs the restart attempt before calling Redfish.
- Logs failures with both `dpu_machine_id` and the returned error.
- Records the reboot-request timestamp and logs success only after the restart succeeds.
- Removes the redundant lower-level failure log while preserving the original error.

This gives operators an accurate restart outcome and identifies the failed DPU without changing any API or configuration.

## Related issues

Fixes #3713

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
- [x] Existing unit tests run:
  - `cargo test -p carbide-machine-controller --lib`
  - 56 passed, 0 failed, 0 ignored, 0 measured, 0 filtered out
- [x] Formatting verified:
  - `cargo fmt --all -- --check`

## Additional Notes

No API, configuration, or database-schema changes.
