### PR TITLE
fix(core): remove identity from /meta-data index

### DIFF
--- a/crates/agent/src/instance_metadata_endpoint.rs
+++ b/crates/agent/src/instance_metadata_endpoint.rs
@@ -391,7 +391,6 @@ async fn get_metadata_params(
             MACHINE_ID_CATEGORY,
             INSTANCE_ID_CATEGORY,
             ASN_CATEGORY,
-            machine_identity::META_DATA_IDENTITY_CATEGORY,
         ]
         .join("\n"),
     )
@@ -735,7 +734,6 @@ mod tests {
             MACHINE_ID_CATEGORY,
             INSTANCE_ID_CATEGORY,
             ASN_CATEGORY,
-            machine_identity::META_DATA_IDENTITY_CATEGORY,
         ]
         .join("\n");
 

--- a/crates/fmds/src/rest_server.rs
+++ b/crates/fmds/src/rest_server.rs
@@ -185,7 +185,6 @@ async fn get_metadata_params(State(_state): State<Arc<FmdsState>>) -> (StatusCod
             MACHINE_ID_CATEGORY,
             INSTANCE_ID_CATEGORY,
             ASN_CATEGORY,
-            machine_identity::META_DATA_IDENTITY_CATEGORY,
         ]
         .join("\n"),
     )
@@ -533,30 +532,39 @@ mod tests {
     }
 
     // Test metadata listing.
+    //
+    // `identity` must not appear in the plain /meta-data/ index: cloud-init's EC2
+    // IMDS crawler GETs every advertised key without a Metadata header, and the
+    // identity handler returns 400 without that header — which aborts the crawl.
+    // The /meta-data/identity route remains for clients that send Metadata: true.
     #[tokio::test]
     async fn test_get_metadata_listing() {
         let state = make_test_state();
         state.update_config(make_test_config());
         let (server, port) = setup_server(state).await;
 
-        let expected = [
-            "hostname",
-            "sitename",
-            "machine-id",
-            "instance-id",
-            "asn",
-            machine_identity::META_DATA_IDENTITY_CATEGORY,
-        ]
-        .join("\n");
+        let expected = ["hostname", "sitename", "machine-id", "instance-id", "asn"].join("\n");
 
         let (status, body) = get_request(port, "meta-data").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, expected);
+        assert!(
+            !body
+                .lines()
+                .any(|line| line == machine_identity::META_DATA_IDENTITY_CATEGORY),
+            "identity must not be listed in /meta-data/ (cloud-init EC2 crawl)"
+        );
 
         // Also check with trailing slash (cloud-init compat).
         let (status, body) = get_request(port, "meta-data/").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, expected);
+        assert!(
+            !body
+                .lines()
+                .any(|line| line == machine_identity::META_DATA_IDENTITY_CATEGORY),
+            "identity must not be listed in /meta-data/ (cloud-init EC2 crawl)"
+        );
 
         server.abort();
     }


### PR DESCRIPTION
Scope (not universal): only images whose cloud-init uses the EC2/IMDS datasource that crawls /meta-data/.

Root cause: get_metadata_params (crates/fmds/src/rest_server.rs:179-191) advertises identity, but serve_meta_data_identity (crates/dpu-fmds-shared/src/machine_identity.rs:525-531) returns 400 without a Metadata: true header. cloud-init crawls with plain GETs; a 400 on any advertised key is fatal (404 is tolerated) → empty metadata → KeyError: 'instance-id' (DataSourceEc2.py:242) → datasource rejected → DataSourceNone → no phone-home.

Fix: remove identity from the /meta-data/ index (keep the route for Metadata: true clients). Also add a regression test that the plain /meta-data/ index excludes identity.

## Type of Change
- [X] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
