### PR TITLE
feat(bmc-mock): add libvirt-backed virtual media

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "lazy_static",
  "mac_address",
  "nv-redfish",
+ "quick-xml 0.39.4",
  "rand 0.10.1",
  "regex",
  "rustls",

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -45,6 +45,7 @@ mac_address = { features = ["serde"], workspace = true }
 nv-redfish = { workspace = true, features = ["bmc-http"] }
 rand = { workspace = true }
 regex = { workspace = true }
+quick-xml = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 serde = { features = ["derive"], workspace = true }
@@ -61,3 +62,6 @@ url = { workspace = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/bmc-mock/Dockerfile
+++ b/crates/bmc-mock/Dockerfile
@@ -1,0 +1,115 @@
+# syntax=docker/dockerfile:1.7
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Build from the repository root:
+#
+#   docker buildx build \
+#     --platform linux/amd64 \
+#     -f crates/bmc-mock/Dockerfile \
+#     --build-arg VERSION=0.1.0 \
+#     -t bmc-mock:latest \
+#     .
+
+ARG RUST_IMAGE=rust:1.96.0-slim-bookworm@sha256:4732ca96fd086cb9be682050c3f0176288eebaac2b80aa2bcefccfaf198e1950
+ARG RUNTIME_IMAGE=debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818
+
+FROM --platform=$BUILDPLATFORM ${RUST_IMAGE} AS builder
+
+ARG VERSION
+ARG CI_COMMIT_SHORT_SHA
+ARG TARGETARCH
+ENV VERSION=${VERSION}
+ENV CI_COMMIT_SHORT_SHA=${CI_COMMIT_SHORT_SHA}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    pkg-config \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && case "$(uname -m):${TARGETARCH}" in \
+         x86_64:amd64|aarch64:arm64) \
+           apt-get install -y --no-install-recommends gcc libc6-dev ;; \
+         aarch64:amd64) \
+           apt-get install -y --no-install-recommends \
+             gcc-x86-64-linux-gnu libc6-dev-amd64-cross ;; \
+         x86_64:arm64) \
+           apt-get install -y --no-install-recommends \
+             gcc-aarch64-linux-gnu libc6-dev-arm64-cross ;; \
+         *) echo "unsupported build/target architecture: $(uname -m)/${TARGETARCH}" >&2; exit 1 ;; \
+       esac \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN case "${TARGETARCH}" in \
+      amd64) rustup target add x86_64-unknown-linux-gnu ;; \
+      arm64) rustup target add aarch64-unknown-linux-gnu ;; \
+      *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac
+
+ENV CARGO_HOME=/cargo-home
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ENV CARGO_TARGET_DIR=/cargo-target
+ENV RUST_BACKTRACE=1
+
+WORKDIR /workspace
+COPY . .
+
+RUN --mount=type=cache,id=nico-bmc-mock-cross-cargo-home,target=/cargo-home,sharing=locked \
+    --mount=type=cache,id=nico-bmc-mock-cross-cargo-target,target=/cargo-target,sharing=locked \
+    case "${TARGETARCH}" in \
+      amd64) \
+        rust_target=x86_64-unknown-linux-gnu; \
+        if [ "$(uname -m)" != x86_64 ]; then \
+          export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc \
+                 CC_x86_64_unknown_linux_gnu=x86_64-linux-gnu-gcc; \
+        fi ;; \
+      arm64) \
+        rust_target=aarch64-unknown-linux-gnu; \
+        if [ "$(uname -m)" != aarch64 ]; then \
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+                 CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc; \
+        fi ;; \
+      *) echo "unsupported target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac && \
+    cargo build -p bmc-mock --bin bmc-mock --locked --release \
+      --target "${rust_target}" && \
+    mkdir -p /artifacts && \
+    cp "/cargo-target/${rust_target}/release/bmc-mock" /artifacts/bmc-mock
+
+FROM --platform=$TARGETPLATFORM ${RUNTIME_IMAGE}
+
+ARG VERSION
+ARG CI_COMMIT_SHORT_SHA
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${CI_COMMIT_SHORT_SHA}"
+LABEL org.opencontainers.image.title="bmc-mock"
+LABEL org.opencontainers.image.description="Redfish BMC simulator with libvirt-backed host control"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libvirt-clients \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/carbide
+
+COPY --from=builder /artifacts/bmc-mock /usr/local/bin/bmc-mock
+COPY crates/bmc-mock/tls.crt /opt/carbide/tls.crt
+COPY crates/bmc-mock/tls.key /opt/carbide/tls.key
+
+EXPOSE 1266
+
+ENTRYPOINT ["/usr/local/bin/bmc-mock"]

--- a/crates/bmc-mock/README.md
+++ b/crates/bmc-mock/README.md
@@ -1,0 +1,109 @@
+# bmc-mock
+
+`bmc-mock` is a standalone HTTPS Redfish simulator. Its optional libvirt mode
+maps one `bmc-mock` process or container to one libvirt domain, matching the
+real-world relationship between a Redfish endpoint and its host.
+
+## Build the libvirt image
+
+Run from the infra-controller repository root:
+
+```console
+docker buildx build \
+  --platform linux/amd64 \
+  -f crates/bmc-mock/Dockerfile \
+  --build-arg VERSION=0.1.0 \
+  -t bmc-mock:latest \
+  --load \
+  .
+```
+
+Use `--push` instead of `--load` when publishing directly to a registry.
+Omit `--platform` to build an image matching the local Docker engine's native
+architecture. The Dockerfile supports both `linux/amd64` and `linux/arm64`
+without running the Rust compiler under emulation.
+
+## Run one endpoint per virtual machine
+
+The container needs access to the libvirt daemon that owns the domain. On a
+Linux host, mount the daemon socket and configure the domain name:
+
+```console
+docker run --rm \
+  --name bmc-node-01 \
+  -p 1266:1266 \
+  -v /run/libvirt/libvirt-sock:/run/libvirt/libvirt-sock \
+  bmc-mock:latest \
+  --machine-role host \
+  --state-backend libvirt \
+  --libvirt-domain dsx-node-01 \
+  --hardware-profile generic_ami \
+  --libvirt-uri qemu:///system
+```
+
+The simulator never infers a hardware identity from a VM. Explicitly configured
+endpoints select a role, state backend, and hardware profile. The older
+`--libvirt-domain DOMAIN --hardware-profile PROFILE` form remains accepted as
+shorthand for `--machine-role host --state-backend libvirt`.
+
+| Hardware profile | DPU count |
+| --- | ---: |
+| `dell-poweredge-r750` | Variable; defaults to 0 |
+| `dell-poweredge-r760-bf4` | 1 |
+| `wiwynn-gb200-nvl` | 2 |
+| `lenovo-gb300-nvl` | 1 |
+| `nvidia-dgx-gb300` | 1 |
+| `supermicro-gb300-nvl` | 1 |
+| `nvidia-dgx-vr` | 1 |
+| `nvidia-dgx-h100` | 1 |
+| `generic-ami` | Variable; defaults to 0 |
+| `generic-supermicro` | Variable; defaults to 0 |
+| `hpe-proliant-dl380a-gen11` | Variable; defaults to 0 |
+
+Use `--dpu-count` to populate a variable-count host profile. For a fixed-count
+profile, the flag is optional and is validated if supplied.
+
+Multiple containers on a bridge network can all listen on their internal port
+1266 and use their container or service names as distinct BMC endpoints. Only
+published host ports need to be unique.
+
+Clients must discover the ComputerSystem instead of assuming a system ID:
+
+```console
+curl --insecure https://localhost:1266/redfish/v1/Systems
+```
+
+Do not assume the first member is the host. Some profiles expose both an HGX
+baseboard and a controllable host. Fetch the members and select the resource
+that contains `PowerState` for power, boot override, BIOS, and VirtualMedia
+requests.
+
+The default libvirt device targets are `sdb` for `Cd` and `sdc` for `ConfigCd`.
+Confirm those targets are unused with `virsh domblklist DOMAIN --details` before
+inserting media. HTTP or HTTPS ISO URLs must be reachable from the host running
+the QEMU process. File paths must exist in that host's filesystem.
+
+## Run a separate DPU endpoint
+
+A DPU is independently addressable hardware, so expose it through its own
+`bmc-mock` process rather than adding its ComputerSystem to the host BMC
+endpoint. This example exposes the second DPU from a Wiwynn GB200 host and uses
+the in-process state machine because no DPU VM exists:
+
+```console
+bmc-mock \
+  --port 8102 \
+  --machine-role dpu \
+  --state-backend internal \
+  --hardware-profile wiwynn_gb200_nvl \
+  --dpu-index 1 \
+  --instance-index 1
+```
+
+Start the host and all of its DPU endpoints with the same `--hardware-profile`,
+`--dpu-count`, and `--instance-index`. Their generated DPU serial numbers and
+MAC addresses will then agree. `--state-backend libvirt --libvirt-domain NAME`
+can be used for a DPU endpoint when a separate DPU VM exists.
+
+The internal backend maintains power state entirely within the process. It does
+not affect the host VM and intentionally does not expose libvirt virtual media.

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -17,7 +17,33 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use clap::Parser;
+use bmc_mock::HostHardwareType;
+use clap::{Parser, ValueEnum};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum MachineRole {
+    Host,
+    Dpu,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum StateBackend {
+    Internal,
+    Libvirt,
+}
+
+fn parse_hardware_profile(value: &str) -> Result<HostHardwareType, String> {
+    let hardware_type = serde_json::from_value(serde_json::Value::String(value.to_string()))
+        .map_err(|_| format!("unknown hardware profile: {value}"))?;
+    match hardware_type {
+        HostHardwareType::LiteOnPowerShelf
+        | HostHardwareType::DeltaPowerShelf
+        | HostHardwareType::NvidiaSwitchNd5200Ld => {
+            Err(format!("hardware profile is not a host or DPU: {value}"))
+        }
+        hardware_type => Ok(hardware_type),
+    }
+}
 
 #[derive(Clone, Parser, Debug)]
 pub struct IpRouterPair {
@@ -61,8 +87,129 @@ pub struct Args {
 
     #[clap(long, help = "Start an IPMI/SOL simulator for the generated BMC mock")]
     pub enable_ipmi_simulation: bool,
+
+    #[clap(long, help = "Back the generated BMC with the named libvirt domain")]
+    pub libvirt_domain: Option<String>,
+
+    #[clap(
+        long,
+        value_parser = parse_hardware_profile,
+        help = "Redfish hardware profile for an explicitly configured host or DPU, using its existing snake_case name"
+    )]
+    pub hardware_profile: Option<HostHardwareType>,
+
+    #[clap(long, value_enum, help = "Expose a host BMC or one DPU BMC")]
+    pub machine_role: Option<MachineRole>,
+
+    #[clap(
+        long,
+        value_enum,
+        help = "Use an in-process power-state simulator or a libvirt domain"
+    )]
+    pub state_backend: Option<StateBackend>,
+
+    #[clap(
+        long,
+        requires = "hardware_profile",
+        help = "DPU count for a variable-count profile, or an assertion for a fixed-count profile"
+    )]
+    pub dpu_count: Option<u8>,
+
+    #[clap(
+        long,
+        requires = "hardware_profile",
+        help = "Zero-based DPU index when --machine-role=dpu"
+    )]
+    pub dpu_index: Option<usize>,
+
+    #[clap(
+        long,
+        default_value_t = 0,
+        help = "Stable instance number used to make generated identities unique"
+    )]
+    pub instance_index: u8,
+
+    #[clap(long, default_value = "qemu:///system", requires = "libvirt_domain")]
+    pub libvirt_uri: String,
+
+    #[clap(long, default_value = "virsh", requires = "libvirt_domain")]
+    pub virsh_path: PathBuf,
 }
 
 pub fn parse_args() -> Args {
     Args::parse()
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::error::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn parses_supported_hardware_profiles() {
+        let cases = [
+            ("dell_poweredge_r750", HostHardwareType::DellPowerEdgeR750),
+            (
+                "dell_poweredge_r760_bf4",
+                HostHardwareType::DellPowerEdgeR760Bf4,
+            ),
+            ("wiwynn_gb200_nvl", HostHardwareType::WiwynnGB200Nvl),
+            ("lenovo_gb300_nvl", HostHardwareType::LenovoGB300Nvl),
+            ("nvidia_dgx_gb300", HostHardwareType::NvidiaDgxGb300),
+            ("supermicro_gb300_nvl", HostHardwareType::SupermicroGb300Nvl),
+            ("nvidia_dgx_vr", HostHardwareType::NvidiaDgxVr),
+            ("nvidia_dgx_h100", HostHardwareType::NvidiaDgxH100),
+            ("generic_ami", HostHardwareType::GenericAmi),
+            ("generic_supermicro", HostHardwareType::GenericSupermicro),
+            (
+                "hpe_proliant_dl380a_gen11",
+                HostHardwareType::HpeProliantDl380aGen11,
+            ),
+        ];
+
+        for (value, expected) in cases {
+            let args = Args::try_parse_from(["bmc-mock", "--hardware-profile", value]).unwrap();
+            assert_eq!(args.hardware_profile, Some(expected), "profile {value}");
+        }
+    }
+
+    #[test]
+    fn parses_explicit_dpu_with_internal_state() {
+        let args = Args::try_parse_from([
+            "bmc-mock",
+            "--machine-role",
+            "dpu",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "wiwynn_gb200_nvl",
+            "--dpu-index",
+            "1",
+            "--instance-index",
+            "3",
+        ])
+        .unwrap();
+
+        assert_eq!(args.machine_role, Some(MachineRole::Dpu));
+        assert_eq!(args.state_backend, Some(StateBackend::Internal));
+        assert_eq!(args.dpu_index, Some(1));
+        assert_eq!(args.instance_index, 3);
+    }
+
+    #[test]
+    fn rejects_non_host_hardware_profile() {
+        let error = Args::try_parse_from(["bmc-mock", "--hardware-profile", "liteon_power_shelf"])
+            .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_alternate_hardware_profile_name() {
+        let error =
+            Args::try_parse_from(["bmc-mock", "--hardware-profile", "generic-ami"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+    }
 }

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -22,6 +22,8 @@ use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
 pub mod ipmi;
 pub mod ipmi_sim;
+pub mod libvirt;
+pub mod simulated;
 
 mod auth_router;
 mod bmc_state;
@@ -46,9 +48,10 @@ pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,
 };
 pub use mock_machine_router::{
-    BmcCommand, SetSystemPowerError, SetSystemPowerResult, machine_router,
+    BmcCommand, MachineRouterOptions, SetSystemPowerError, SetSystemPowerResult, machine_router,
     machine_router_with_injection_store,
 };
+pub use redfish::virtual_media::DeviceConfig as VirtualMediaDeviceConfig;
 
 pub const DUMMY_FACTORY_USERNAME: &str = "root";
 pub const DUMMY_FACTORY_PASSWORD: &str = "factory_password";

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -1,0 +1,730 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::{Arc, Mutex, OnceLock, Weak};
+
+use quick_xml::events::{BytesEnd, BytesStart, Event};
+use quick_xml::{Reader, Writer};
+use url::Url;
+
+use crate::redfish::computer_system::{SingleSystemState, SystemState};
+use crate::{BmcState, Callbacks, MockPowerState, SetSystemPowerError, SystemPowerControl};
+
+#[derive(Debug, thiserror::Error)]
+enum VirtualMediaError {
+    #[error("invalid virtual media request: {0}")]
+    BadRequest(String),
+    #[error("virtual media command failed: {0}")]
+    Command(String),
+}
+
+type VirtualMediaResult = Result<(), VirtualMediaError>;
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub virsh_path: PathBuf,
+    pub uri: String,
+    pub domain: String,
+    pub virtual_media_targets: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+pub struct LibvirtCallbacks {
+    config: Config,
+    restore_boot_after_power_on: Mutex<bool>,
+    system_state: OnceLock<Weak<SystemState>>,
+    applied_state: Mutex<AppliedState>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct AppliedState {
+    boot_source_override: serde_json::Value,
+    virtual_media: BTreeMap<String, serde_json::Value>,
+}
+
+impl LibvirtCallbacks {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config,
+            restore_boot_after_power_on: Mutex::new(false),
+            system_state: OnceLock::new(),
+            applied_state: Mutex::new(AppliedState::default()),
+        }
+    }
+
+    pub fn bind_state(&self, state: &BmcState) -> Result<(), &'static str> {
+        let controlled_system = state
+            .system_state
+            .controlled_system()
+            .ok_or("libvirt backend has no controlled ComputerSystem")?;
+        self.system_state
+            .set(Arc::downgrade(&state.system_state))
+            .map_err(|_| "libvirt backend state is already bound")?;
+        *self.applied_state.lock().unwrap() = AppliedState::from(controlled_system);
+        Ok(())
+    }
+
+    fn virsh_output(&self, arguments: &[&str]) -> Result<Output, String> {
+        Command::new(&self.config.virsh_path)
+            .arg("--connect")
+            .arg(&self.config.uri)
+            .args(arguments)
+            .output()
+            .map_err(|error| {
+                format!(
+                    "could not execute {}: {error}",
+                    self.config.virsh_path.display()
+                )
+            })
+    }
+
+    fn virsh(&self, arguments: &[&str]) -> Result<Output, String> {
+        let output = self.virsh_output(arguments)?;
+        if output.status.success() {
+            return Ok(output);
+        }
+        Err(format!(
+            "{} exited with {}: {}",
+            self.config.virsh_path.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+
+    fn domain_command(&self, command: &str) -> Result<(), SetSystemPowerError> {
+        self.virsh(&[command, &self.config.domain])
+            .map(drop)
+            .map_err(SetSystemPowerError::CommandSendError)
+    }
+
+    fn start(&self) -> Result<(), SetSystemPowerError> {
+        self.domain_command("start")?;
+        let restore_boot = {
+            let mut restore_boot_after_power_on = self.restore_boot_after_power_on.lock().unwrap();
+            std::mem::take(&mut *restore_boot_after_power_on)
+        };
+        if restore_boot {
+            self.set_boot_devices(&["hd"])?;
+        }
+        Ok(())
+    }
+
+    fn set_boot_devices(&self, devices: &[&str]) -> Result<(), SetSystemPowerError> {
+        let output = self
+            .virsh(&["dumpxml", "--inactive", &self.config.domain])
+            .map_err(SetSystemPowerError::CommandSendError)?;
+        let xml = String::from_utf8(output.stdout).map_err(|error| {
+            SetSystemPowerError::CommandSendError(format!(
+                "virsh dumpxml returned invalid UTF-8: {error}"
+            ))
+        })?;
+        let xml =
+            set_boot_order_xml(&xml, devices).map_err(SetSystemPowerError::CommandSendError)?;
+        let mut file = tempfile::NamedTempFile::new().map_err(|error| {
+            SetSystemPowerError::CommandSendError(format!(
+                "could not create temporary domain XML: {error}"
+            ))
+        })?;
+        file.write_all(xml.as_bytes()).map_err(|error| {
+            SetSystemPowerError::CommandSendError(format!(
+                "could not write temporary domain XML: {error}"
+            ))
+        })?;
+        self.virsh(&["define", file.path().to_string_lossy().as_ref()])
+            .map(drop)
+            .map_err(SetSystemPowerError::CommandSendError)
+    }
+
+    fn target_for_device(&self, device_id: &str) -> Result<&str, VirtualMediaError> {
+        self.config
+            .virtual_media_targets
+            .get(device_id)
+            .map(String::as_str)
+            .ok_or_else(|| {
+                VirtualMediaError::BadRequest(format!(
+                    "virtual media device {device_id} has no libvirt target"
+                ))
+            })
+    }
+
+    fn target_is_attached(&self, target: &str) -> Result<bool, VirtualMediaError> {
+        let output = self
+            .virsh(&["domblklist", "--details", &self.config.domain])
+            .map_err(VirtualMediaError::Command)?;
+        let output = String::from_utf8(output.stdout).map_err(|error| {
+            VirtualMediaError::Command(format!("virsh domblklist returned invalid UTF-8: {error}"))
+        })?;
+        Ok(output.lines().any(|line| {
+            line.split_whitespace()
+                .nth(2)
+                .is_some_and(|value| value == target)
+        }))
+    }
+
+    fn detach_target(&self, target: &str) -> VirtualMediaResult {
+        if !self.target_is_attached(target)? {
+            return Ok(());
+        }
+        self.virsh(&["detach-disk", &self.config.domain, target, "--persistent"])
+            .map(drop)
+            .map_err(VirtualMediaError::Command)
+    }
+
+    fn set_boot_source_override(
+        &self,
+        boot_source_override: &serde_json::Value,
+    ) -> Result<(), SetSystemPowerError> {
+        let enabled = boot_source_override
+            .get("BootSourceOverrideEnabled")
+            .and_then(serde_json::Value::as_str);
+        let target = boot_source_override
+            .get("BootSourceOverrideTarget")
+            .and_then(serde_json::Value::as_str);
+        let devices = match (enabled, target) {
+            (Some("Disabled"), _) | (_, Some("None")) => &["hd"][..],
+            (_, Some("Cd")) => &["cdrom", "hd"][..],
+            (_, Some("Hdd")) => &["hd"][..],
+            (_, Some("Pxe" | "UefiHttp")) => &["network", "hd"][..],
+            (_, Some(target)) => {
+                return Err(SetSystemPowerError::BadRequest(format!(
+                    "unsupported boot source override target: {target}"
+                )));
+            }
+            (_, None) => return Ok(()),
+        };
+        self.set_boot_devices(devices)?;
+        *self.restore_boot_after_power_on.lock().unwrap() =
+            enabled == Some("Once") && target != Some("Hdd");
+        Ok(())
+    }
+
+    fn insert_virtual_media(
+        &self,
+        device_id: &str,
+        image: &str,
+        write_protected: bool,
+    ) -> VirtualMediaResult {
+        let target = self.target_for_device(device_id)?;
+        self.detach_target(target)?;
+        let xml = virtual_media_xml(device_id, target, image, write_protected)?;
+        let mut file = tempfile::NamedTempFile::new().map_err(|error| {
+            VirtualMediaError::Command(format!("could not create temporary device XML: {error}"))
+        })?;
+        file.write_all(xml.as_bytes()).map_err(|error| {
+            VirtualMediaError::Command(format!("could not write temporary device XML: {error}"))
+        })?;
+        self.virsh(&[
+            "attach-device",
+            &self.config.domain,
+            file.path().to_string_lossy().as_ref(),
+            "--persistent",
+        ])
+        .map(drop)
+        .map_err(VirtualMediaError::Command)
+    }
+
+    fn eject_virtual_media(&self, device_id: &str) -> VirtualMediaResult {
+        let target = self.target_for_device(device_id)?;
+        self.detach_target(target)
+    }
+
+    fn apply_virtual_media(&self, state: &serde_json::Value) -> VirtualMediaResult {
+        let device_id = state
+            .get("Id")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                VirtualMediaError::BadRequest("virtual media state has no Id".to_string())
+            })?;
+        let inserted = state
+            .get("Inserted")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if !inserted {
+            return self.eject_virtual_media(device_id);
+        }
+        let image = state
+            .get("Image")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                VirtualMediaError::BadRequest(format!(
+                    "inserted virtual media device {device_id} has no Image"
+                ))
+            })?;
+        let write_protected = state
+            .get("WriteProtected")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(true);
+        self.insert_virtual_media(device_id, image, write_protected)
+    }
+
+    fn reconcile_state(&self, desired: AppliedState) -> Result<(), String> {
+        let mut applied = self.applied_state.lock().unwrap();
+        if desired.boot_source_override != applied.boot_source_override {
+            self.set_boot_source_override(&desired.boot_source_override)
+                .map_err(|error| error.to_string())?;
+            applied.boot_source_override = desired.boot_source_override;
+        }
+        for (device_id, desired_device) in desired.virtual_media {
+            if applied.virtual_media.get(&device_id) == Some(&desired_device) {
+                continue;
+            }
+            self.apply_virtual_media(&desired_device)
+                .map_err(|error| error.to_string())?;
+            applied.virtual_media.insert(device_id, desired_device);
+        }
+        Ok(())
+    }
+}
+
+impl From<&SingleSystemState> for AppliedState {
+    fn from(system: &SingleSystemState) -> Self {
+        let virtual_media = system
+            .virtual_media()
+            .into_iter()
+            .flat_map(|virtual_media| virtual_media.desired_state())
+            .filter_map(|state| {
+                let device_id = state
+                    .get("Id")
+                    .and_then(serde_json::Value::as_str)?
+                    .to_string();
+                Some((device_id, state))
+            })
+            .collect();
+        Self {
+            boot_source_override: system.boot_source_override(),
+            virtual_media,
+        }
+    }
+}
+
+impl Callbacks for LibvirtCallbacks {
+    fn get_power_state(&self) -> MockPowerState {
+        match self.virsh(&["domstate", &self.config.domain]) {
+            Ok(output) => match String::from_utf8_lossy(&output.stdout).trim() {
+                "running" | "idle" | "blocked" | "paused" | "in shutdown" | "pmsuspended" => {
+                    MockPowerState::On
+                }
+                _ => MockPowerState::Off,
+            },
+            Err(error) => {
+                tracing::warn!(
+                    domain = %self.config.domain,
+                    error,
+                    "could not read libvirt domain power state",
+                );
+                MockPowerState::Off
+            }
+        }
+    }
+
+    fn send_power_command(
+        &self,
+        reset_type: SystemPowerControl,
+    ) -> Result<(), SetSystemPowerError> {
+        use SystemPowerControl::*;
+        match reset_type {
+            On | ForceOn => self.start(),
+            GracefulShutdown => self.domain_command("shutdown"),
+            ForceOff => self.domain_command("destroy"),
+            GracefulRestart => self.domain_command("reboot"),
+            ForceRestart => self.domain_command("reset"),
+            PowerCycle => {
+                self.domain_command("destroy")?;
+                self.start()
+            }
+            Pause => self.domain_command("suspend"),
+            Resume => self.domain_command("resume"),
+            Nmi => self.domain_command("inject-nmi"),
+            PushPowerButton | Suspend => Err(SetSystemPowerError::BadRequest(format!(
+                "libvirt backend does not support {reset_type:?}"
+            ))),
+        }
+    }
+
+    fn state_refresh_indication(&self) {
+        let Some(system_state) = self.system_state.get().and_then(Weak::upgrade) else {
+            tracing::error!(
+                domain = %self.config.domain,
+                "libvirt backend is not bound to BMC mock state",
+            );
+            return;
+        };
+        let Some(controlled_system) = system_state.controlled_system() else {
+            tracing::error!(
+                domain = %self.config.domain,
+                "BMC mock state has no controlled ComputerSystem",
+            );
+            return;
+        };
+        if let Err(error) = self.reconcile_state(AppliedState::from(controlled_system)) {
+            tracing::error!(
+                domain = %self.config.domain,
+                error = %error,
+                "could not reconcile libvirt domain with BMC mock state",
+            );
+        }
+    }
+}
+
+fn set_boot_order_xml(xml: &str, devices: &[&str]) -> Result<String, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+    let mut writer = Writer::new(Vec::new());
+    let mut inside_os = false;
+    loop {
+        let event = reader
+            .read_event()
+            .map_err(|error| format!("could not parse libvirt domain XML: {error}"))?;
+        match event {
+            Event::Start(start) if start.name().as_ref() == b"os" => {
+                inside_os = true;
+                writer.write_event(Event::Start(start.into_owned()))
+            }
+            Event::Empty(empty) if inside_os && empty.name().as_ref() == b"boot" => Ok(()),
+            Event::End(end) if end.name().as_ref() == b"os" => {
+                let result: std::io::Result<()> = (|| {
+                    for device in devices {
+                        let mut boot = BytesStart::new("boot");
+                        boot.push_attribute(("dev", *device));
+                        writer.write_event(Event::Empty(boot))?;
+                    }
+                    inside_os = false;
+                    writer.write_event(Event::End(BytesEnd::new("os")))
+                })();
+                result
+            }
+            Event::Eof => break,
+            event => writer.write_event(event.into_owned()),
+        }
+        .map_err(|error| format!("could not write libvirt domain XML: {error}"))?;
+    }
+    String::from_utf8(writer.into_inner())
+        .map_err(|error| format!("generated libvirt domain XML is invalid UTF-8: {error}"))
+}
+
+enum MediaSource {
+    File(PathBuf),
+    Network {
+        protocol: String,
+        host: String,
+        port: u16,
+        path: String,
+    },
+}
+
+impl MediaSource {
+    fn parse(image: &str) -> Result<Self, VirtualMediaError> {
+        let Ok(url) = Url::parse(image) else {
+            return Ok(Self::File(PathBuf::from(image)));
+        };
+        match url.scheme() {
+            "file" => url
+                .to_file_path()
+                .map(Self::File)
+                .map_err(|()| VirtualMediaError::BadRequest(format!("invalid file URL: {image}"))),
+            "http" | "https" => {
+                if url.username() != "" || url.password().is_some() || url.query().is_some() {
+                    return Err(VirtualMediaError::BadRequest(
+                        "virtual media URLs must not contain credentials or a query".to_string(),
+                    ));
+                }
+                let host = url.host_str().ok_or_else(|| {
+                    VirtualMediaError::BadRequest(format!("virtual media URL has no host: {image}"))
+                })?;
+                Ok(Self::Network {
+                    protocol: url.scheme().to_string(),
+                    host: host.to_string(),
+                    port: url
+                        .port_or_known_default()
+                        .expect("HTTP(S) has a default port"),
+                    path: url.path().to_string(),
+                })
+            }
+            scheme => Err(VirtualMediaError::BadRequest(format!(
+                "unsupported virtual media URL scheme: {scheme}"
+            ))),
+        }
+    }
+}
+
+fn virtual_media_xml(
+    device_id: &str,
+    target: &str,
+    image: &str,
+    write_protected: bool,
+) -> Result<String, VirtualMediaError> {
+    let mut writer = Writer::new(Vec::new());
+    let mut disk = BytesStart::new("disk");
+    let source = MediaSource::parse(image)?;
+    disk.push_attribute((
+        "type",
+        match &source {
+            MediaSource::File(_) => "file",
+            MediaSource::Network { .. } => "network",
+        },
+    ));
+    disk.push_attribute(("device", "cdrom"));
+    writer.write_event(Event::Start(disk)).unwrap();
+
+    let mut driver = BytesStart::new("driver");
+    driver.push_attribute(("name", "qemu"));
+    driver.push_attribute(("type", "raw"));
+    writer.write_event(Event::Empty(driver)).unwrap();
+
+    match source {
+        MediaSource::File(path) => {
+            let mut source = BytesStart::new("source");
+            let path = path.to_string_lossy();
+            source.push_attribute(("file", path.as_ref()));
+            writer.write_event(Event::Empty(source)).unwrap();
+        }
+        MediaSource::Network {
+            protocol,
+            host,
+            port,
+            path,
+        } => {
+            let mut source = BytesStart::new("source");
+            source.push_attribute(("protocol", protocol.as_str()));
+            source.push_attribute(("name", path.as_str()));
+            writer.write_event(Event::Start(source)).unwrap();
+            let mut host_element = BytesStart::new("host");
+            let port = port.to_string();
+            host_element.push_attribute(("name", host.as_str()));
+            host_element.push_attribute(("port", port.as_str()));
+            writer.write_event(Event::Empty(host_element)).unwrap();
+            writer
+                .write_event(Event::End(BytesEnd::new("source")))
+                .unwrap();
+        }
+    }
+
+    let mut target_element = BytesStart::new("target");
+    target_element.push_attribute(("dev", target));
+    target_element.push_attribute(("bus", "sata"));
+    writer.write_event(Event::Empty(target_element)).unwrap();
+    if write_protected {
+        writer
+            .write_event(Event::Empty(BytesStart::new("readonly")))
+            .unwrap();
+    }
+    let mut alias = BytesStart::new("alias");
+    let alias_name = format!("ua-bmc-mock-vmedia-{device_id}");
+    alias.push_attribute(("name", alias_name.as_str()));
+    writer.write_event(Event::Empty(alias)).unwrap();
+    writer
+        .write_event(Event::End(BytesEnd::new("disk")))
+        .unwrap();
+
+    String::from_utf8(writer.into_inner()).map_err(|error| {
+        VirtualMediaError::Command(format!("generated device XML is invalid UTF-8: {error}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::fs;
+    use std::sync::Arc;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use serde_json::json;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_support::host_info;
+    use crate::{HostHardwareType, MachineRouterOptions, VirtualMediaDeviceConfig, machine_router};
+
+    async fn request(
+        router: &Router,
+        method: Method,
+        uri: &str,
+        body: serde_json::Value,
+    ) -> StatusCode {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        response.status()
+    }
+
+    #[test]
+    fn replaces_domain_boot_order() {
+        let xml = "<domain><os><type>hvm</type><boot dev='hd'/></os><devices/></domain>";
+        let actual = set_boot_order_xml(xml, &["cdrom", "hd"]).unwrap();
+
+        assert!(actual.contains("<type>hvm</type>"));
+        assert!(actual.contains("<boot dev=\"cdrom\"/><boot dev=\"hd\"/>"));
+        assert!(!actual.contains("<boot dev='hd'/>"));
+    }
+
+    #[test]
+    fn builds_http_virtual_media_device() {
+        let actual =
+            virtual_media_xml("Cd", "sdb", "http://127.0.0.1:8080/installer.iso", true).unwrap();
+
+        assert!(actual.contains("<disk type=\"network\" device=\"cdrom\">"));
+        assert!(actual.contains("<source protocol=\"http\" name=\"/installer.iso\">"));
+        assert!(actual.contains("<host name=\"127.0.0.1\" port=\"8080\"/>"));
+        assert!(actual.contains("<target dev=\"sdb\" bus=\"sata\"/>"));
+        assert!(actual.contains("<readonly/>"));
+    }
+
+    #[test]
+    fn builds_file_virtual_media_device() {
+        let actual = virtual_media_xml("ConfigCd", "sdc", "/tmp/config.iso", false).unwrap();
+
+        assert!(actual.contains("<disk type=\"file\" device=\"cdrom\">"));
+        assert!(actual.contains("<source file=\"/tmp/config.iso\"/>"));
+        assert!(actual.contains("<target dev=\"sdc\" bus=\"sata\"/>"));
+        assert!(!actual.contains("<readonly/>"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn state_refresh_drives_the_configured_domain() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let log_path = directory.path().join("virsh.log");
+        let defined_xml_path = directory.path().join("defined.xml");
+        let attached_xml_path = directory.path().join("attached.xml");
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> '{}'
+case "$3" in
+  domstate) printf 'shut off\n' ;;
+  dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
+  domblklist) printf 'Type Device Target Source\nnetwork cdrom sdb http://example/old.iso\n' ;;
+  define) cp "$4" '{}' ;;
+  attach-device) cp "$5" '{}' ;;
+esac
+"#,
+            log_path.display(),
+            defined_xml_path.display(),
+            attached_xml_path.display(),
+        );
+        fs::write(&virsh_path, script).unwrap();
+        let mut permissions = fs::metadata(&virsh_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&virsh_path, permissions).unwrap();
+
+        let callbacks = Arc::new(LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "dsx-node".to_string(),
+            virtual_media_targets: BTreeMap::from([("Cd".to_string(), "sdb".to_string())]),
+        }));
+        let (router, state) = machine_router(
+            &host_info(HostHardwareType::DellPowerEdgeR750),
+            callbacks.clone(),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions {
+                virtual_media_devices: Some(vec![VirtualMediaDeviceConfig {
+                    id: Cow::Borrowed("Cd"),
+                    name: Cow::Borrowed("Operating System Virtual CD"),
+                    media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
+                }]),
+            },
+        );
+        callbacks.bind_state(&state).unwrap();
+        let system = "/redfish/v1/Systems/System.Embedded.1";
+
+        let status = request(
+            &router,
+            Method::PATCH,
+            system,
+            json!({
+                "Boot": {
+                    "BootSourceOverrideEnabled": "Once",
+                    "BootSourceOverrideTarget": "Cd",
+                }
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/Actions/ComputerSystem.Reset"),
+            json!({"ResetType": "On"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/VirtualMedia/Cd/Actions/VirtualMedia.InsertMedia"),
+            json!({
+                "Image": "http://127.0.0.1:8080/installer.iso",
+                "WriteProtected": true,
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/VirtualMedia/Cd/Actions/VirtualMedia.EjectMedia"),
+            json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let status = request(
+            &router,
+            Method::PATCH,
+            system,
+            json!({
+                "Boot": {
+                    "BootSourceOverrideMode": "UEFI",
+                    "BootSourceOverrideEnabled": "Disabled",
+                    "BootSourceOverrideTarget": "None",
+                }
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("--connect qemu:///system dumpxml --inactive dsx-node"));
+        assert!(log.contains("--connect qemu:///system start dsx-node"));
+        assert!(log.contains("--connect qemu:///system detach-disk dsx-node sdb --persistent"));
+        assert!(log.contains("--connect qemu:///system attach-device dsx-node"));
+        let attached_xml = fs::read_to_string(attached_xml_path).unwrap();
+        assert!(attached_xml.contains("protocol=\"http\""));
+        assert!(attached_xml.contains("dev=\"sdb\""));
+        let defined_xml = fs::read_to_string(defined_xml_path).unwrap();
+        assert!(defined_xml.contains("<boot dev=\"hd\"/>"));
+        assert!(!defined_xml.contains("<boot dev=\"cdrom\"/>"));
+    }
+}

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -17,7 +17,8 @@
 mod command_line;
 mod tar_router;
 
-use std::collections::HashMap;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::process::Command;
@@ -30,9 +31,10 @@ use bmc_mock::mac_address_pool::{
 };
 use bmc_mock::{
     BmcCommand, BmcState, Callbacks, DpuMachineInfo, DpuSettings, HostHardwareType,
-    HostMachineInfo, ListenerOrAddress, MachineInfo, MockPowerState, SetSystemPowerError,
-    SystemPowerControl,
+    HostMachineInfo, ListenerOrAddress, MachineInfo, MachineRouterOptions, MockPowerState,
+    SetSystemPowerError, SystemPowerControl, VirtualMediaDeviceConfig,
 };
+use command_line::{MachineRole, StateBackend};
 use mac_address::MacAddress;
 use tar_router::TarGzOption;
 use tokio::sync::{RwLock, mpsc};
@@ -76,6 +78,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "--enable-ipmi-simulation cannot be combined with archive-backed routers".into(),
         );
     }
+    let has_generated_options = args.libvirt_domain.is_some()
+        || args.hardware_profile.is_some()
+        || args.machine_role.is_some()
+        || args.state_backend.is_some()
+        || args.dpu_count.is_some()
+        || args.dpu_index.is_some()
+        || args.instance_index != 0;
+    if has_generated_options && (args.targz.is_some() || args.ip_router.is_some()) {
+        return Err(
+            "generated-machine options cannot be combined with archive-backed routers".into(),
+        );
+    }
+    let generated_config = generated_mock_config(&args)?;
     if let Some(ip_routers) = args.ip_router {
         for ip_router in ip_routers {
             info!(
@@ -102,8 +117,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             None,
         )
     } else {
-        info!("Using default BMC mock");
-        let (router, state) = default_host_mock();
+        info!(
+            hardware_type = %generated_config.hardware_type,
+            role = ?generated_config.machine_role,
+            backend = ?generated_config.state_backend,
+            "Using generated BMC mock",
+        );
+        let (router, state) = generated_mock(generated_config);
         (router, Some(state))
     };
 
@@ -195,34 +215,214 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
     command_tx
 }
 
-fn default_host_mock() -> (Router, BmcState) {
-    let command_channel = spawn_qemu_reboot_handler();
-    let callbacks = Arc::new(ChannelCallbacks::new(command_channel));
+#[derive(Debug)]
+struct GeneratedMockConfig {
+    machine_role: MachineRole,
+    state_backend: StateBackend,
+    hardware_type: HostHardwareType,
+    dpu_count: u8,
+    dpu_index: usize,
+    instance_index: u8,
+    libvirt_config: Option<bmc_mock::libvirt::Config>,
+    use_channel_callbacks: bool,
+}
+
+fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfig, String> {
+    let explicit_mode = args.machine_role.is_some() || args.state_backend.is_some();
+    let libvirt_shorthand_mode =
+        args.libvirt_domain.is_some() && args.hardware_profile.is_some() && !explicit_mode;
+    let default_generated_mode = args.libvirt_domain.is_none()
+        && args.hardware_profile.is_none()
+        && !explicit_mode
+        && args.dpu_count.is_none()
+        && args.dpu_index.is_none()
+        && args.instance_index == 0;
+
+    if default_generated_mode {
+        return Ok(GeneratedMockConfig {
+            machine_role: MachineRole::Host,
+            state_backend: StateBackend::Internal,
+            hardware_type: HostHardwareType::WiwynnGB200Nvl,
+            dpu_count: 2,
+            dpu_index: 0,
+            instance_index: 0,
+            libvirt_config: None,
+            use_channel_callbacks: true,
+        });
+    }
+
+    if !explicit_mode && !libvirt_shorthand_mode {
+        return Err(
+            "explicit generated machines require --hardware-profile, --machine-role, and --state-backend"
+                .to_string(),
+        );
+    }
+
+    let machine_role = if libvirt_shorthand_mode {
+        MachineRole::Host
+    } else {
+        args.machine_role.ok_or_else(|| {
+            "--machine-role is required when explicitly configuring a generated machine".to_string()
+        })?
+    };
+    let state_backend = if libvirt_shorthand_mode {
+        StateBackend::Libvirt
+    } else {
+        args.state_backend.ok_or_else(|| {
+            "--state-backend is required when explicitly configuring a generated machine"
+                .to_string()
+        })?
+    };
+    let hardware_type = args.hardware_profile.ok_or_else(|| {
+        "--hardware-profile is required when explicitly configuring a generated machine".to_string()
+    })?;
+
+    let dpu_count = match (hardware_type.fixed_number_of_dpu(), args.dpu_count) {
+        (Some(fixed), Some(requested)) if fixed != requested => {
+            return Err(format!(
+                "hardware profile {hardware_type} requires {fixed} DPU(s), not {requested}"
+            ));
+        }
+        (Some(fixed), _) => fixed,
+        (None, requested) => requested.unwrap_or(0),
+    };
+    let dpu_index = args.dpu_index.unwrap_or(0);
+    match machine_role {
+        MachineRole::Host if args.dpu_index.is_some() => {
+            return Err("--dpu-index is valid only with --machine-role=dpu".to_string());
+        }
+        MachineRole::Dpu if dpu_index >= usize::from(dpu_count) => {
+            return Err(format!(
+                "DPU index {dpu_index} is outside hardware profile {hardware_type}'s {dpu_count} DPU(s)"
+            ));
+        }
+        _ => {}
+    }
+
+    let libvirt_config = match (state_backend, &args.libvirt_domain) {
+        (StateBackend::Libvirt, Some(domain)) => Some(bmc_mock::libvirt::Config {
+            virsh_path: args.virsh_path.clone(),
+            uri: args.libvirt_uri.clone(),
+            domain: domain.clone(),
+            virtual_media_targets: BTreeMap::from([
+                ("Cd".to_string(), "sdb".to_string()),
+                ("ConfigCd".to_string(), "sdc".to_string()),
+            ]),
+        }),
+        (StateBackend::Libvirt, None) => {
+            return Err("--state-backend=libvirt requires --libvirt-domain".to_string());
+        }
+        (StateBackend::Internal, Some(_)) => {
+            return Err("--libvirt-domain requires --state-backend=libvirt".to_string());
+        }
+        (StateBackend::Internal, None) => None,
+    };
+
+    Ok(GeneratedMockConfig {
+        machine_role,
+        state_backend,
+        hardware_type,
+        dpu_count,
+        dpu_index,
+        instance_index: args.instance_index,
+        libvirt_config,
+        use_channel_callbacks: false,
+    })
+}
+
+fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
+    let libvirt_callbacks = config
+        .libvirt_config
+        .map(bmc_mock::libvirt::LibvirtCallbacks::new)
+        .map(Arc::new);
+    let callbacks: Arc<dyn Callbacks> = if config.use_channel_callbacks {
+        let command_channel = spawn_qemu_reboot_handler();
+        Arc::new(ChannelCallbacks::new(command_channel))
+    } else if let Some(callbacks) = &libvirt_callbacks {
+        callbacks.clone()
+    } else {
+        Arc::new(bmc_mock::simulated::SimulatedCallbacks::new())
+    };
+    let machine_info = generated_machine_info(
+        config.machine_role,
+        config.hardware_type,
+        config.dpu_count,
+        config.dpu_index,
+        config.instance_index,
+    );
+    let result = if config.machine_role == MachineRole::Host
+        && config.state_backend == StateBackend::Libvirt
+    {
+        bmc_mock::machine_router(
+            &machine_info,
+            callbacks,
+            String::default(),
+            false,
+            MachineRouterOptions {
+                virtual_media_devices: Some(vec![
+                    VirtualMediaDeviceConfig {
+                        id: Cow::Borrowed("Cd"),
+                        name: Cow::Borrowed("Operating System Virtual CD"),
+                        media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
+                    },
+                    VirtualMediaDeviceConfig {
+                        id: Cow::Borrowed("ConfigCd"),
+                        name: Cow::Borrowed("Configuration Virtual CD"),
+                        media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
+                    },
+                ]),
+            },
+        )
+    } else {
+        bmc_mock::machine_router(
+            &machine_info,
+            callbacks,
+            String::default(),
+            false,
+            MachineRouterOptions::default(),
+        )
+    };
+    if let Some(callbacks) = libvirt_callbacks {
+        callbacks
+            .bind_state(&result.1)
+            .expect("libvirt backend must bind to generated BMC state");
+    }
+    result
+}
+
+fn generated_machine_info(
+    machine_role: MachineRole,
+    hardware_type: HostHardwareType,
+    dpu_count: u8,
+    dpu_index: usize,
+    instance_index: u8,
+) -> MachineInfo {
     let mut pool = MacAddressPool::new(MacAddressConfig {
         pool: Some(
-            MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16)
+            MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, instance_index, 0, 0]), 16)
                 .expect("Must be constructed with these parameters"),
         ),
         ranges: Some(
-            MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16, 8)
+            MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, instance_index, 0, 0]), 16, 8)
                 .expect("Must be constructed with these parameters"),
         ),
     });
 
-    let hw_type = HostHardwareType::WiwynnGB200Nvl;
-    let ndpu = hw_type.fixed_number_of_dpu().unwrap_or(1);
     let mac_range = pool
         .allocate_range_config()
         .expect("MAC address pool should be allocated");
-    let machine_info = MachineInfo::Host(HostMachineInfo::new(
-        HostHardwareType::WiwynnGB200Nvl,
-        (0..ndpu)
-            .map(|_| DpuMachineInfo::new(hw_type, &mut pool, DpuSettings::default()))
-            .collect(),
-        &mut pool,
-        mac_range,
-    ));
-    bmc_mock::machine_router(&machine_info, callbacks, String::default(), false)
+    let dpus = (0..dpu_count)
+        .map(|_| DpuMachineInfo::new(hardware_type, &mut pool, DpuSettings::default()))
+        .collect::<Vec<_>>();
+    match machine_role {
+        MachineRole::Host => MachineInfo::Host(HostMachineInfo::new(
+            hardware_type,
+            dpus,
+            &mut pool,
+            mac_range,
+        )),
+        MachineRole::Dpu => MachineInfo::Dpu(dpus[dpu_index].clone()),
+    }
 }
 
 #[derive(Debug)]
@@ -257,5 +457,97 @@ impl Callbacks for ChannelCallbacks {
         let _ = self
             .command_channel
             .send(BmcCommand::StateRefreshIndication);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    fn config(arguments: &[&str]) -> Result<GeneratedMockConfig, String> {
+        let args = command_line::Args::try_parse_from(arguments).unwrap();
+        generated_mock_config(&args)
+    }
+
+    #[test]
+    fn default_generated_mode_uses_channel_callbacks() {
+        let config = config(&["bmc-mock"]).unwrap();
+        assert_eq!(config.machine_role, MachineRole::Host);
+        assert_eq!(config.state_backend, StateBackend::Internal);
+        assert!(matches!(
+            config.hardware_type,
+            HostHardwareType::WiwynnGB200Nvl
+        ));
+        assert!(config.use_channel_callbacks);
+    }
+
+    #[test]
+    fn preserves_the_existing_libvirt_shorthand() {
+        let config = config(&[
+            "bmc-mock",
+            "--libvirt-domain",
+            "host-01",
+            "--hardware-profile",
+            "dell_poweredge_r750",
+        ])
+        .unwrap();
+        assert_eq!(config.machine_role, MachineRole::Host);
+        assert_eq!(config.state_backend, StateBackend::Libvirt);
+        assert!(!config.use_channel_callbacks);
+    }
+
+    #[test]
+    fn validates_dpu_count_and_index() {
+        let cases = [
+            [
+                "bmc-mock",
+                "--machine-role",
+                "dpu",
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                "wiwynn_gb200_nvl",
+                "--dpu-count",
+                "1",
+                "--dpu-index",
+                "0",
+            ],
+            [
+                "bmc-mock",
+                "--machine-role",
+                "dpu",
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                "wiwynn_gb200_nvl",
+                "--dpu-count",
+                "2",
+                "--dpu-index",
+                "2",
+            ],
+        ];
+
+        for arguments in cases {
+            assert!(config(&arguments).is_err(), "arguments {arguments:?}");
+        }
+    }
+
+    #[test]
+    fn host_and_dpu_endpoints_share_deterministic_dpu_identity() {
+        let host =
+            generated_machine_info(MachineRole::Host, HostHardwareType::WiwynnGB200Nvl, 2, 0, 3);
+        let dpu =
+            generated_machine_info(MachineRole::Dpu, HostHardwareType::WiwynnGB200Nvl, 2, 1, 3);
+        let MachineInfo::Host(host) = host else {
+            panic!("expected host machine info");
+        };
+        let MachineInfo::Dpu(dpu) = dpu else {
+            panic!("expected DPU machine info");
+        };
+
+        assert_eq!(host.dpus[1].serial, dpu.serial);
+        assert_eq!(host.dpus[1].bmc_mac_address, dpu.bmc_mac_address);
     }
 }

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -24,9 +24,14 @@ use crate::bmc_state::BmcState;
 use crate::injection::InjectionStore;
 use crate::redfish::manager::ManagerState;
 use crate::{
-    Callbacks, HostHardwareType, MachineInfo, SystemPowerControl, auth_router, middleware_router,
-    redfish,
+    Callbacks, HostHardwareType, MachineInfo, SystemPowerControl, VirtualMediaDeviceConfig,
+    auth_router, middleware_router, redfish,
 };
+
+#[derive(Debug, Default)]
+pub struct MachineRouterOptions {
+    pub virtual_media_devices: Option<Vec<VirtualMediaDeviceConfig>>,
+}
 
 #[derive(Debug)]
 pub enum BmcCommand {
@@ -66,13 +71,15 @@ pub fn machine_router(
     callbacks: Arc<dyn Callbacks>,
     mat_host_id: String,
     redfish_auth: bool,
+    options: MachineRouterOptions,
 ) -> (Router, BmcState) {
-    machine_router_with_injection_store(
+    machine_router_inner(
         machine_info,
         callbacks,
         mat_host_id,
         redfish_auth,
         Arc::new(InjectionStore::new()),
+        options,
     )
 }
 
@@ -83,6 +90,24 @@ pub fn machine_router_with_injection_store(
     mat_host_id: String,
     redfish_auth: bool,
     injection: Arc<InjectionStore>,
+) -> (Router, BmcState) {
+    machine_router_inner(
+        machine_info,
+        callbacks,
+        mat_host_id,
+        redfish_auth,
+        injection,
+        MachineRouterOptions::default(),
+    )
+}
+
+fn machine_router_inner(
+    machine_info: &MachineInfo,
+    callbacks: Arc<dyn Callbacks>,
+    mat_host_id: String,
+    redfish_auth: bool,
+    injection: Arc<InjectionStore>,
+    options: MachineRouterOptions,
 ) -> (Router, BmcState) {
     let system_config = machine_info.system_config(callbacks.clone());
     let chassis_config = machine_info.chassis_config();
@@ -103,6 +128,7 @@ pub fn machine_router_with_injection_store(
         .add_routes(crate::redfish::account_service::add_routes)
         .add_routes(crate::redfish::session_service::add_routes)
         .add_routes(|routes| crate::redfish::computer_system::add_routes(routes, bmc_vendor))
+        .add_routes(crate::redfish::virtual_media::add_routes)
         .add_routes(crate::ipmi::add_routes);
     let router = match machine_info {
         MachineInfo::Dpu(_) => {
@@ -115,6 +141,7 @@ pub fn machine_router_with_injection_store(
     let manager = Arc::new(ManagerState::new(&machine_info.manager_config()));
     let system_state = Arc::new(crate::redfish::computer_system::SystemState::from_config(
         system_config,
+        &options,
     ));
     let chassis_state = Arc::new(crate::redfish::chassis::ChassisState::from_config(
         chassis_config,

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -30,8 +30,8 @@ use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch, json_patch};
 use crate::redfish::Builder;
 use crate::{
-    BootOptionKind, Callbacks, LogServices, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError,
-    http, redfish,
+    BootOptionKind, Callbacks, LogServices, MachineRouterOptions, MockPowerState,
+    POWER_CYCLE_DELAY, SetSystemPowerError, http, redfish,
 };
 
 pub fn collection() -> redfish::Collection<'static> {
@@ -172,6 +172,7 @@ pub struct BootSourceOverride {
 
 pub struct SingleSystemState {
     config: SingleSystemConfig,
+    virtual_media: Option<redfish::virtual_media::VirtualMediaState>,
     boot_order_override: Mutex<Option<Vec<String>>>,
     boot_source_override: Mutex<BootSourceOverride>,
     secure_boot_enabled: Arc<AtomicBool>,
@@ -198,8 +199,8 @@ pub enum Oem {
 }
 
 impl SystemState {
-    pub fn from_config(config: Config) -> Self {
-        Self::from_configs(config.systems)
+    pub fn from_config(config: Config, options: &MachineRouterOptions) -> Self {
+        Self::from_configs(config.systems, options.virtual_media_devices.clone())
     }
 
     pub fn systems(&self) -> &[SingleSystemState] {
@@ -212,9 +213,30 @@ impl SystemState {
             .find(|system| system.config.id.as_ref() == system_id)
     }
 
-    fn from_configs(configs: Vec<SingleSystemConfig>) -> Self {
-        let systems = configs.into_iter().map(SingleSystemState::new).collect();
+    fn from_configs(
+        configs: Vec<SingleSystemConfig>,
+        virtual_media_devices: Option<Vec<redfish::virtual_media::DeviceConfig>>,
+    ) -> Self {
+        let mut virtual_media =
+            virtual_media_devices.map(redfish::virtual_media::VirtualMediaState::new);
+        let systems = configs
+            .into_iter()
+            .map(|config| {
+                let virtual_media = if config.callbacks.is_some() {
+                    virtual_media.take()
+                } else {
+                    None
+                };
+                SingleSystemState::new(config, virtual_media)
+            })
+            .collect();
         Self { systems }
+    }
+
+    pub(crate) fn controlled_system(&self) -> Option<&SingleSystemState> {
+        self.systems
+            .iter()
+            .find(|system| system.config.callbacks.is_some())
     }
 
     pub fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
@@ -229,9 +251,13 @@ impl SystemState {
 }
 
 impl SingleSystemState {
-    fn new(config: SingleSystemConfig) -> Self {
+    fn new(
+        config: SingleSystemConfig,
+        virtual_media: Option<redfish::virtual_media::VirtualMediaState>,
+    ) -> Self {
         Self {
             config,
+            virtual_media,
             boot_order_override: Mutex::new(None),
             boot_source_override: Mutex::new(BootSourceOverride::default()),
             secure_boot_enabled: Arc::new(AtomicBool::new(false)),
@@ -268,6 +294,58 @@ impl SingleSystemState {
 
     fn boot_order_override(&self) -> Option<Vec<String>> {
         self.boot_order_override.lock().unwrap().clone()
+    }
+
+    pub(crate) fn virtual_media(&self) -> Option<&redfish::virtual_media::VirtualMediaState> {
+        self.virtual_media.as_ref()
+    }
+
+    pub(crate) fn boot_source_override(&self) -> serde_json::Value {
+        let boot_source_override = self.boot_source_override.lock().unwrap();
+        let mut value = serde_json::Map::new();
+        if let Some(mode) = &boot_source_override.mode {
+            value.insert(
+                "BootSourceOverrideMode".to_string(),
+                serde_json::Value::String(mode.clone()),
+            );
+        }
+        if let Some(enabled) = &boot_source_override.enabled {
+            value.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                serde_json::Value::String(enabled.clone()),
+            );
+        }
+        if let Some(target) = &boot_source_override.target {
+            value.insert(
+                "BootSourceOverrideTarget".to_string(),
+                serde_json::Value::String(target.clone()),
+            );
+        }
+        serde_json::Value::Object(value)
+    }
+
+    fn apply_boot_source_override(&self, boot: &serde_json::Value) {
+        let has_override = [
+            "BootSourceOverrideMode",
+            "BootSourceOverrideEnabled",
+            "BootSourceOverrideTarget",
+        ]
+        .iter()
+        .any(|field| boot.get(field).is_some());
+        if !has_override {
+            return;
+        }
+
+        let mut boot_source_override = self.boot_source_override.lock().unwrap();
+        if let Some(value) = boot.get("BootSourceOverrideMode") {
+            boot_source_override.mode = value.as_str().map(ToString::to_string);
+        }
+        if let Some(value) = boot.get("BootSourceOverrideEnabled") {
+            boot_source_override.enabled = value.as_str().map(ToString::to_string);
+        }
+        if let Some(value) = boot.get("BootSourceOverrideTarget") {
+            boot_source_override.target = value.as_str().map(ToString::to_string);
+        }
     }
 
     fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
@@ -358,6 +436,18 @@ async fn get_system(State(state): State<BmcState>, Path(system_id): Path<String>
                     .collect::<Vec<_>>(),
             );
         }
+    }
+
+    let boot_source_override = system_state.boot_source_override();
+    if boot_source_override
+        .as_object()
+        .is_some_and(|value| !value.is_empty())
+    {
+        b = b.boot_source_override(boot_source_override);
+    }
+
+    if system_state.virtual_media().is_some() {
+        b = b.virtual_media(&redfish::virtual_media::collection(&system_id));
     }
 
     b = match config.oem {
@@ -492,27 +582,7 @@ async fn patch_settings(
                 }
             }
         }
-        boot.get("BootSourceOverrideMode").inspect(|v| {
-            if let Some(v) = v.as_str() {
-                system_state.boot_source_override.lock().unwrap().mode = Some(v.to_string())
-            } else {
-                system_state.boot_source_override.lock().unwrap().mode = None
-            }
-        });
-        boot.get("BootSourceOverrideEnabled").inspect(|v| {
-            if let Some(v) = v.as_str() {
-                system_state.boot_source_override.lock().unwrap().enabled = Some(v.to_string())
-            } else {
-                system_state.boot_source_override.lock().unwrap().enabled = None
-            }
-        });
-        boot.get("BootSourceOverrideTarget").inspect(|v| {
-            if let Some(v) = v.as_str() {
-                system_state.boot_source_override.lock().unwrap().target = Some(v.to_string())
-            } else {
-                system_state.boot_source_override.lock().unwrap().target = None
-            }
-        });
+        system_state.apply_boot_source_override(boot);
     }
     json!({}).into_ok_response()
 }
@@ -525,8 +595,8 @@ async fn patch_system(
     let Some(system_state) = state.system_state.find(&system_id) else {
         return http::not_found();
     };
-    if let Some(new_boot_order) = patch_system
-        .get("Boot")
+    let boot = patch_system.get("Boot");
+    let response = if let Some(new_boot_order) = boot
         .and_then(|obj| obj.get("BootOrder"))
         .and_then(serde_json::Value::as_array)
         .map(|arr| {
@@ -534,13 +604,12 @@ async fn patch_system(
                 .filter_map(serde_json::Value::as_str)
                 .map(ToString::to_string)
                 .collect()
-        })
-    {
+        }) {
         match system_state.config.boot_order_mode {
             BootOrderMode::OrderedCollection => {
                 system_state.set_boot_order_override(new_boot_order);
                 if matches!(&state.oem_state, redfish::oem::State::DellIdrac(_)) {
-                    redfish::oem::dell::idrac::create_job_with_location(state)
+                    redfish::oem::dell::idrac::create_job_with_location(state.clone())
                 } else {
                     json!({}).into_ok_response()
                 }
@@ -554,7 +623,11 @@ async fn patch_system(
         }
     } else {
         json!({}).into_ok_response()
+    };
+    if let Some(boot) = boot {
+        system_state.apply_boot_source_override(boot);
     }
+    response
 }
 
 async fn post_reset_system(
@@ -921,6 +994,14 @@ impl SystemBuilder {
 
     pub fn boot_options(self, boot_options: &redfish::Collection<'_>) -> Self {
         self.apply_patch(json!({"Boot": boot_options.nav_property("BootOptions")}))
+    }
+
+    pub fn boot_source_override(self, value: serde_json::Value) -> Self {
+        self.apply_patch(json!({"Boot": value}))
+    }
+
+    pub fn virtual_media(self, value: &redfish::Collection<'_>) -> Self {
+        self.apply_patch(value.nav_property("VirtualMedia"))
     }
 
     pub fn secure_boot(self, secure_boot: &redfish::Resource<'_>) -> Self {

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -277,6 +277,7 @@ mod tests {
             callbacks,
             String::default(),
             false,
+            MachineRouterOptions::default(),
         )
         .0
     }

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -48,6 +48,7 @@ pub mod task_service;
 pub mod telemetry_service;
 pub mod thermal_subsystem;
 pub mod update_service;
+pub mod virtual_media;
 
 pub mod expander_router;
 

--- a/crates/bmc-mock/src/redfish/telemetry_service.rs
+++ b/crates/bmc-mock/src/redfish/telemetry_service.rs
@@ -150,7 +150,8 @@ mod tests {
     use crate::test_support::axum_http_client::AxumRouterHttpClient;
     use crate::test_support::{NoopCallbacks, TEST_MAC_POOL};
     use crate::{
-        DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo, MachineInfo, machine_router,
+        DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo, MachineInfo,
+        MachineRouterOptions, machine_router,
     };
 
     fn test_host_mock() -> Router {
@@ -172,6 +173,7 @@ mod tests {
             Arc::new(NoopCallbacks),
             "test-host-id".to_string(),
             false,
+            MachineRouterOptions::default(),
         )
         .0
     }

--- a/crates/bmc-mock/src/redfish/virtual_media.rs
+++ b/crates/bmc-mock/src/redfish/virtual_media.rs
@@ -1,0 +1,487 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::sync::Mutex;
+
+use axum::Router;
+use axum::extract::{Json, Path, State};
+use axum::response::Response;
+use axum::routing::{get, post};
+use serde_json::json;
+
+use crate::bmc_state::BmcState;
+use crate::json::{JsonExt, JsonPatch};
+use crate::{http, redfish};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeviceConfig {
+    pub id: Cow<'static, str>,
+    pub name: Cow<'static, str>,
+    pub media_types: Vec<Cow<'static, str>>,
+}
+
+#[derive(Default)]
+struct Media {
+    image: Option<String>,
+    inserted: bool,
+    write_protected: bool,
+}
+
+struct DeviceState {
+    config: DeviceConfig,
+    media: Mutex<Media>,
+}
+
+pub struct VirtualMediaState {
+    devices: Vec<DeviceState>,
+}
+
+impl VirtualMediaState {
+    pub fn new(devices: Vec<DeviceConfig>) -> Self {
+        Self {
+            devices: devices
+                .into_iter()
+                .map(|config| DeviceState {
+                    config,
+                    media: Mutex::new(Media {
+                        write_protected: true,
+                        ..Default::default()
+                    }),
+                })
+                .collect(),
+        }
+    }
+
+    fn find_device(&self, device_id: &str) -> Option<&DeviceState> {
+        self.devices
+            .iter()
+            .find(|device| device.config.id == device_id)
+    }
+
+    pub(crate) fn desired_state(&self) -> Vec<serde_json::Value> {
+        self.devices.iter().map(DeviceState::state_json).collect()
+    }
+}
+
+pub fn collection(system_id: &str) -> redfish::Collection<'static> {
+    redfish::Collection {
+        odata_id: Cow::Owned(format!(
+            "{}/VirtualMedia",
+            redfish::computer_system::resource(system_id).odata_id
+        )),
+        odata_type: Cow::Borrowed("#VirtualMediaCollection.VirtualMediaCollection"),
+        name: Cow::Borrowed("Virtual Media Collection"),
+    }
+}
+
+pub fn resource<'a>(system_id: &str, device_id: &'a str) -> redfish::Resource<'a> {
+    redfish::Resource {
+        odata_id: Cow::Owned(format!("{}/{device_id}", collection(system_id).odata_id)),
+        odata_type: Cow::Borrowed("#VirtualMedia.v1_3_2.VirtualMedia"),
+        id: Cow::Borrowed(device_id),
+        name: Cow::Borrowed("Virtual Media"),
+    }
+}
+
+fn insert_media_target(system_id: &str, device_id: &str) -> String {
+    format!(
+        "{}/Actions/VirtualMedia.InsertMedia",
+        resource(system_id, device_id).odata_id
+    )
+}
+
+fn eject_media_target(system_id: &str, device_id: &str) -> String {
+    format!(
+        "{}/Actions/VirtualMedia.EjectMedia",
+        resource(system_id, device_id).odata_id
+    )
+}
+
+pub fn add_routes(router: Router<BmcState>) -> Router<BmcState> {
+    const SYSTEM_ID: &str = "{system_id}";
+    const DEVICE_ID: &str = "{device_id}";
+    router
+        .route(&collection(SYSTEM_ID).odata_id, get(get_collection))
+        .route(&resource(SYSTEM_ID, DEVICE_ID).odata_id, get(get_device))
+        .route(
+            &insert_media_target(SYSTEM_ID, DEVICE_ID),
+            post(insert_media),
+        )
+        .route(&eject_media_target(SYSTEM_ID, DEVICE_ID), post(eject_media))
+}
+
+async fn get_collection(State(state): State<BmcState>, Path(system_id): Path<String>) -> Response {
+    let Some(virtual_media) = state
+        .system_state
+        .find(&system_id)
+        .and_then(|system| system.virtual_media())
+    else {
+        return http::not_found();
+    };
+    let members = virtual_media
+        .devices
+        .iter()
+        .map(|device| resource(&system_id, &device.config.id).entity_ref())
+        .collect::<Vec<_>>();
+    collection(&system_id)
+        .with_members(&members)
+        .into_ok_response()
+}
+
+async fn get_device(
+    State(state): State<BmcState>,
+    Path((system_id, device_id)): Path<(String, String)>,
+) -> Response {
+    let Some(device) = state
+        .system_state
+        .find(&system_id)
+        .and_then(|system| system.virtual_media())
+        .and_then(|virtual_media| virtual_media.find_device(&device_id))
+    else {
+        return http::not_found();
+    };
+    device.to_json(&system_id).into_ok_response()
+}
+
+async fn insert_media(
+    State(state): State<BmcState>,
+    Path((system_id, device_id)): Path<(String, String)>,
+    Json(request): Json<serde_json::Value>,
+) -> Response {
+    let Some(device) = state
+        .system_state
+        .find(&system_id)
+        .and_then(|system| system.virtual_media())
+        .and_then(|virtual_media| virtual_media.find_device(&device_id))
+    else {
+        return http::not_found();
+    };
+    let Some(image) = request.get("Image").and_then(serde_json::Value::as_str) else {
+        return http::bad_request("Image must be a string");
+    };
+    if image.is_empty() {
+        return http::bad_request("Image must not be empty");
+    }
+    match request.get("Inserted") {
+        Some(serde_json::Value::Bool(false)) => {
+            return http::bad_request("Inserted must not be false for InsertMedia");
+        }
+        Some(serde_json::Value::Bool(true)) | None => {}
+        Some(_) => return http::bad_request("Inserted must be a boolean"),
+    }
+    let write_protected = match request.get("WriteProtected") {
+        Some(serde_json::Value::Bool(value)) => *value,
+        None => true,
+        Some(_) => return http::bad_request("WriteProtected must be a boolean"),
+    };
+    *device.media.lock().expect("mutex poisoned") = Media {
+        image: Some(image.to_string()),
+        inserted: true,
+        write_protected,
+    };
+    http::ok_no_content()
+}
+
+async fn eject_media(
+    State(state): State<BmcState>,
+    Path((system_id, device_id)): Path<(String, String)>,
+) -> Response {
+    let Some(device) = state
+        .system_state
+        .find(&system_id)
+        .and_then(|system| system.virtual_media())
+        .and_then(|virtual_media| virtual_media.find_device(&device_id))
+    else {
+        return http::not_found();
+    };
+    *device.media.lock().expect("mutex poisoned") = Media {
+        write_protected: true,
+        ..Default::default()
+    };
+    http::ok_no_content()
+}
+
+impl DeviceState {
+    fn state_json(&self) -> serde_json::Value {
+        let media = self.media.lock().expect("mutex poisoned");
+        json!({
+            "Id": self.config.id,
+            "Image": media.image,
+            "Inserted": media.inserted,
+            "WriteProtected": media.write_protected,
+        })
+    }
+
+    fn to_json(&self, system_id: &str) -> serde_json::Value {
+        let resource = resource(system_id, &self.config.id);
+        resource.json_patch().patch(self.state_json()).patch(json!({
+            "Name": self.config.name,
+            "MediaTypes": self.config.media_types,
+            "ConnectedVia": "URI",
+            "Actions": {
+                "#VirtualMedia.InsertMedia": {
+                    "target": insert_media_target(system_id, &self.config.id),
+                },
+                "#VirtualMedia.EjectMedia": {
+                    "target": eject_media_target(system_id, &self.config.id),
+                },
+            },
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_support::host_info;
+    use crate::{
+        Callbacks, HostHardwareType, MachineRouterOptions, MockPowerState, SetSystemPowerError,
+        SystemPowerControl, machine_router,
+    };
+
+    #[derive(Debug, Default)]
+    struct RecordingCallbacks {
+        refresh_count: AtomicUsize,
+    }
+
+    impl Callbacks for RecordingCallbacks {
+        fn get_power_state(&self) -> MockPowerState {
+            MockPowerState::Off
+        }
+
+        fn send_power_command(
+            &self,
+            _reset_type: SystemPowerControl,
+        ) -> Result<(), SetSystemPowerError> {
+            Ok(())
+        }
+
+        fn state_refresh_indication(&self) {
+            self.refresh_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn test_router() -> (Router, Arc<RecordingCallbacks>) {
+        test_router_for(HostHardwareType::DellPowerEdgeR750)
+    }
+
+    fn test_router_for(hardware_type: HostHardwareType) -> (Router, Arc<RecordingCallbacks>) {
+        let callbacks = Arc::new(RecordingCallbacks::default());
+        let router = machine_router(
+            &host_info(hardware_type),
+            callbacks.clone(),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions {
+                virtual_media_devices: Some(vec![
+                    DeviceConfig {
+                        id: "Cd".into(),
+                        name: "Operating System Virtual CD".into(),
+                        media_types: vec!["CD".into(), "DVD".into()],
+                    },
+                    DeviceConfig {
+                        id: "ConfigCd".into(),
+                        name: "Configuration Virtual CD".into(),
+                        media_types: vec!["CD".into(), "DVD".into()],
+                    },
+                ]),
+            },
+        )
+        .0;
+        (router, callbacks)
+    }
+
+    #[tokio::test]
+    async fn attaches_virtual_media_to_the_controlled_system_not_the_first_member() {
+        let (router, _) = test_router_for(HostHardwareType::NvidiaDgxGb300);
+        let hgx = "/redfish/v1/Systems/HGX_Baseboard_0";
+        let host = "/redfish/v1/Systems/System_0";
+
+        let (status, body) = request(&router, Method::GET, hgx, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.unwrap().get("VirtualMedia").is_none());
+
+        let (status, body) = request(&router, Method::GET, host, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap()["VirtualMedia"]["@odata.id"],
+            format!("{host}/VirtualMedia")
+        );
+    }
+
+    async fn request(
+        router: &Router,
+        method: Method,
+        uri: &str,
+        body: Option<serde_json::Value>,
+    ) -> (StatusCode, Option<serde_json::Value>) {
+        let mut request = Request::builder().method(method).uri(uri);
+        let body = if let Some(body) = body {
+            request = request.header("content-type", "application/json");
+            Body::from(body.to_string())
+        } else {
+            Body::empty()
+        };
+        let response = router
+            .clone()
+            .oneshot(request.body(body).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body = (!body.is_empty()).then(|| serde_json::from_slice(&body).unwrap());
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn exposes_and_controls_two_independent_virtual_media_devices() {
+        let (router, callbacks) = test_router();
+        let system = "/redfish/v1/Systems/System.Embedded.1";
+
+        let (status, body) = request(&router, Method::GET, system, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.unwrap()["VirtualMedia"]["@odata.id"],
+            format!("{system}/VirtualMedia")
+        );
+
+        let insert = |image: &str| {
+            json!({
+                "Image": image,
+                "Inserted": true,
+                "WriteProtected": true,
+            })
+        };
+        let (status, _) = request(
+            &router,
+            Method::POST,
+            &format!("{system}/VirtualMedia/Cd/Actions/VirtualMedia.InsertMedia"),
+            Some(insert("http://127.0.0.1:8080/installer.iso")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (status, _) = request(
+            &router,
+            Method::POST,
+            &format!("{system}/VirtualMedia/ConfigCd/Actions/VirtualMedia.InsertMedia"),
+            Some(insert("http://127.0.0.1:8080/config.iso")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, body) = request(
+            &router,
+            Method::GET,
+            &format!("{system}/VirtualMedia/Cd"),
+            None,
+        )
+        .await;
+        let body = body.unwrap();
+        assert_eq!(body["Inserted"], true);
+        assert_eq!(body["Image"], "http://127.0.0.1:8080/installer.iso");
+
+        let (status, _) = request(
+            &router,
+            Method::POST,
+            &format!("{system}/VirtualMedia/ConfigCd/Actions/VirtualMedia.EjectMedia"),
+            Some(json!({})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        let (_, body) = request(
+            &router,
+            Method::GET,
+            &format!("{system}/VirtualMedia/Cd"),
+            None,
+        )
+        .await;
+        assert_eq!(body.unwrap()["Inserted"], true);
+        let (_, body) = request(
+            &router,
+            Method::GET,
+            &format!("{system}/VirtualMedia/ConfigCd"),
+            None,
+        )
+        .await;
+        assert_eq!(body.unwrap()["Inserted"], false);
+
+        assert_eq!(callbacks.refresh_count.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn applies_cd_boot_override_on_the_computer_system_resource() {
+        let (router, callbacks) = test_router();
+        let system = "/redfish/v1/Systems/System.Embedded.1";
+
+        let (status, _) = request(
+            &router,
+            Method::PATCH,
+            system,
+            Some(json!({
+                "Boot": {
+                    "BootSourceOverrideTarget": "Cd",
+                    "BootSourceOverrideMode": "UEFI",
+                    "BootSourceOverrideEnabled": "Once",
+                }
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(callbacks.refresh_count.load(Ordering::Relaxed), 1);
+
+        let (_, body) = request(&router, Method::GET, system, None).await;
+        let body = body.unwrap();
+        assert_eq!(body["Boot"]["BootSourceOverrideMode"], "UEFI");
+        assert_eq!(body["Boot"]["BootSourceOverrideEnabled"], "Once");
+        assert_eq!(body["Boot"]["BootSourceOverrideTarget"], "Cd");
+    }
+
+    #[tokio::test]
+    async fn preserves_unrecognized_boot_override_values() {
+        let (router, callbacks) = test_router();
+        let system = "/redfish/v1/Systems/System.Embedded.1";
+
+        let (status, _) = request(
+            &router,
+            Method::PATCH,
+            system,
+            Some(json!({
+                "Boot": {
+                    "BootSourceOverrideTarget": "VendorSpecific",
+                }
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(callbacks.refresh_count.load(Ordering::Relaxed), 1);
+
+        let (_, body) = request(&router, Method::GET, system, None).await;
+        assert_eq!(
+            body.unwrap()["Boot"]["BootSourceOverrideTarget"],
+            "VendorSpecific"
+        );
+    }
+}

--- a/crates/bmc-mock/src/simulated.rs
+++ b/crates/bmc-mock/src/simulated.rs
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Mutex;
+
+use tokio::time::Instant;
+
+use crate::{
+    Callbacks, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SystemPowerControl,
+};
+
+/// Stateful callbacks for a generated BMC that is not connected to a real or
+/// virtual machine. This is useful for modeling independently addressable
+/// devices such as a DPU BMC.
+#[derive(Debug, Default)]
+pub struct SimulatedCallbacks {
+    power_state: Mutex<MockPowerState>,
+}
+
+impl SimulatedCallbacks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Callbacks for SimulatedCallbacks {
+    fn get_power_state(&self) -> MockPowerState {
+        let mut state = self.power_state.lock().unwrap();
+        if matches!(
+            *state,
+            MockPowerState::PowerCycling { since } if since.elapsed() >= POWER_CYCLE_DELAY
+        ) {
+            *state = MockPowerState::On;
+        }
+        *state
+    }
+
+    fn send_power_command(
+        &self,
+        reset_type: SystemPowerControl,
+    ) -> Result<(), SetSystemPowerError> {
+        use SystemPowerControl::*;
+
+        let new_state = match reset_type {
+            On | ForceOn | GracefulRestart | ForceRestart | PushPowerButton | Pause | Resume => {
+                MockPowerState::On
+            }
+            GracefulShutdown | ForceOff | Nmi | Suspend => MockPowerState::Off,
+            PowerCycle => MockPowerState::PowerCycling {
+                since: Instant::now(),
+            },
+        };
+        *self.power_state.lock().unwrap() = new_state;
+        Ok(())
+    }
+
+    fn state_refresh_indication(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn changes_power_state_without_an_external_machine() {
+        let callbacks = SimulatedCallbacks::new();
+        assert!(matches!(callbacks.get_power_state(), MockPowerState::On));
+
+        callbacks
+            .set_power_state(SystemPowerControl::ForceOff)
+            .unwrap();
+        assert!(matches!(callbacks.get_power_state(), MockPowerState::Off));
+
+        callbacks.set_power_state(SystemPowerControl::On).unwrap();
+        assert!(matches!(callbacks.get_power_state(), MockPowerState::On));
+    }
+
+    #[test]
+    fn completes_a_power_cycle_after_the_delay() {
+        let callbacks = SimulatedCallbacks::new();
+        callbacks
+            .set_power_state(SystemPowerControl::PowerCycle)
+            .unwrap();
+        assert!(matches!(
+            callbacks.get_power_state(),
+            MockPowerState::PowerCycling { .. }
+        ));
+
+        *callbacks.power_state.lock().unwrap() = MockPowerState::PowerCycling {
+            since: Instant::now() - POWER_CYCLE_DELAY,
+        };
+        assert!(matches!(callbacks.get_power_state(), MockPowerState::On));
+    }
+}

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -29,7 +29,7 @@ use crate::mac_address_pool::{
 use crate::machine_info::DpuSettings;
 use crate::{
     BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
-    MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
+    MachineRouterOptions, MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
 };
 
 pub mod axum_http_client;
@@ -97,11 +97,12 @@ pub async fn bmc_for_machine(machine_info: MachineInfo) -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         machine_id.to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
 
-fn host_info(hw_type: HostHardwareType) -> MachineInfo {
+pub(crate) fn host_info(hw_type: HostHardwareType) -> MachineInfo {
     let ndpu = hw_type.fixed_number_of_dpu().unwrap_or(0);
     let mut pool = TEST_MAC_POOL.lock().unwrap();
     let ranges_config = pool.allocate_range_config().unwrap();
@@ -121,6 +122,7 @@ pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -131,6 +133,7 @@ pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -141,6 +144,7 @@ pub async fn dgx_gb300_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -156,6 +160,7 @@ pub async fn nvidia_dgx_vr_host_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -166,6 +171,7 @@ pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -176,6 +182,7 @@ pub async fn generic_supermicro_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -186,6 +193,7 @@ pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -196,6 +204,7 @@ pub async fn delta_powershelf_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -213,6 +222,7 @@ pub async fn delta_powershelf_bmc_with_psu_power(states: Vec<bool>) -> TestBmcHa
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -223,6 +233,7 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -233,6 +244,7 @@ pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -251,6 +263,7 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -262,6 +275,7 @@ pub async fn dell_poweredge_r760_bluefield4_bmc(dpu: DpuMachineInfo) -> TestBmcH
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -280,6 +294,7 @@ pub async fn nvidia_dgx_vr_bluefield4_dpu_bmc(settings: DpuSettings) -> TestBmcH
         Arc::new(NoopCallbacks),
         "test-dpu-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -290,6 +305,7 @@ pub async fn hpe_proliant_dl380a_gen11_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -300,6 +316,7 @@ pub async fn generic_ami_bmc() -> TestBmcHandle {
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
+        MachineRouterOptions::default(),
     ))
     .await
 }
@@ -360,6 +377,7 @@ mod test {
                 Arc::new(NoopCallbacks),
                 "test-host-id".to_string(),
                 false,
+                MachineRouterOptions::default(),
             )
             .0,
         );


### PR DESCRIPTION
Adds a consumable libvirt-backed mode to `bmc-mock` for VM-based development and test environments. This allows Redfish clients to exercise host power, boot override, and virtual-media workflows against a simulated BMC that controls a configured libvirt domain.

Previously, the standalone generated mock provided Redfish resources but did not provide a complete per-VM backend for these workflows.

This change:

- Adds selectable internal and libvirt state backends.
- Maps Redfish power operations to the configured libvirt domain.
- Adds Redfish VirtualMedia resources for inserting and ejecting file-backed or HTTP(S) media.
- Supports explicit host and DPU endpoints with deterministic identities.
- Preserves the existing generated mode, archive-backed routers, and library callers.

## Related issues

None.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

The existing standalone invocation and archive-backed behavior remain supported.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `cargo test -p bmc-mock --locked`
- `cargo fmt --all -- --check`
- `cargo clippy -p bmc-mock --all-targets --all-features -- -D warnings`

## Additional Notes

- No image-publishing CI is added by this PR. The Dockerfile is provided for downstream consumers to build and publish the artifact.
- The standalone server retains its existing unauthenticated Redfish behavior. Libvirt mode grants power and media control over the configured domain and is intended only for trusted development and test networks.
- Each process or container represents one Redfish endpoint and maps to one configured libvirt domain.