### PR TITLE
feat(api): persist DPU IPv6 loopback reservations

### DIFF
--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -1512,6 +1512,7 @@ mod consolidated_network_config_tests {
             // be served to the DPU agent -- the DPU's own loopback_ip
             // (passed separately) is what matters.
             loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99))),
+            loopback_ip_v6: None,
             secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 100))),
             // The host-level use_admin_network is reported in a separate
             // top-level response field, not in this consolidated struct.

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -754,6 +754,26 @@ pub(crate) async fn admin_force_delete_machine(
             .await?
         }
 
+        // The machine snapshot predates `ForceDeletion`, so a concurrent
+        // backfill can make its IPv6 field stale. The pool owner remains the
+        // authoritative reservation source during deletion.
+        if let Some(loopback_ip_v6) = db::resource_pool::find_owned_allocation(
+            &api.common_pools.ethernet.pool_loopback_ip_v6,
+            &mut txn,
+            model::resource_pool::OwnerType::Machine,
+            &dpu_machine.id.to_string(),
+        )
+        .await
+        .map_err(CarbideError::from)?
+        {
+            db::resource_pool::release(
+                &api.common_pools.ethernet.pool_loopback_ip_v6,
+                &mut txn,
+                loopback_ip_v6,
+            )
+            .await?
+        }
+
         if let Some(secondary_overlay_vtep_ip) =
             dpu_machine.network_config.secondary_overlay_vtep_ip
         {

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -307,23 +307,26 @@ pub(crate) async fn discover_machine(
             })?
         };
 
-        if db_machine.network_config.loopback_ip.is_none() {
-            let loopback_ip = db::machine::allocate_loopback_ip(
-                &api.common_pools,
-                &mut txn,
-                &stable_machine_id.to_string(),
-            )
-            .await?;
+        // Collect every missing address into one `network_config` write. Each
+        // write bumps the whole machine group, so writing one field at a time
+        // leaves the later call with a stale `network_config_version`.
+        let (mut network_config, network_config_version) = db_machine.network_config.clone().take();
+        let owner_id = stable_machine_id.to_string();
+        let mut network_config_changed = false;
 
-            let mut network_config = db_machine.network_config.value.clone();
+        if network_config.loopback_ip.is_none() {
+            let loopback_ip =
+                db::machine::allocate_loopback_ip(&api.common_pools, &mut txn, &owner_id).await?;
             network_config.loopback_ip = Some(loopback_ip);
-            db::machine::try_update_network_config(
-                &mut txn,
-                &stable_machine_id,
-                db_machine.network_config.version,
-                &network_config,
-            )
-            .await?;
+            network_config_changed = true;
+        }
+
+        if network_config.loopback_ip_v6.is_none()
+            && let Some(loopback_ip_v6) =
+                db::machine::allocate_loopback_ip_v6(&api.common_pools, &mut txn, &owner_id).await?
+        {
+            network_config.loopback_ip_v6 = Some(loopback_ip_v6);
+            network_config_changed = true;
         }
 
         if api
@@ -332,27 +335,30 @@ pub(crate) async fn discover_machine(
             .as_ref()
             .map(|vc| vc.secondary_overlay_support)
             .unwrap_or_default()
-            && db_machine
-                .network_config
-                .secondary_overlay_vtep_ip
-                .is_none()
+            && network_config.secondary_overlay_vtep_ip.is_none()
         {
-            let secondary_vtep_ip = db::machine::allocate_secondary_vtep_ip(
-                &api.common_pools,
-                &mut txn,
-                &stable_machine_id.to_string(),
-            )
-            .await?;
-
-            let mut network_config = db_machine.network_config.value.clone();
+            let secondary_vtep_ip =
+                db::machine::allocate_secondary_vtep_ip(&api.common_pools, &mut txn, &owner_id)
+                    .await?;
             network_config.secondary_overlay_vtep_ip = Some(secondary_vtep_ip);
-            db::machine::try_update_network_config(
+            network_config_changed = true;
+        }
+
+        if network_config_changed
+            && !db::machine::try_update_network_config(
                 &mut txn,
                 &stable_machine_id,
-                db_machine.network_config.version,
+                network_config_version,
                 &network_config,
             )
-            .await?;
+            .await?
+        {
+            // The version error also rolls back the allocations above.
+            return Err(CarbideError::ConcurrentModificationError(
+                "machine",
+                network_config_version.to_string(),
+            )
+            .into());
         }
 
         db_machine.id

--- a/crates/api-core/src/handlers/resource_pool.rs
+++ b/crates/api-core/src/handlers/resource_pool.rs
@@ -43,10 +43,21 @@ pub(crate) async fn grow(
             .map_err(|e: toml::de::Error| CarbideError::InvalidArgument(e.to_string()))?;
         pools.insert(name, d);
     }
+    let reconcile_dpu_loopbacks = pools.contains_key(model::resource_pool::common::LOOPBACK_IP_V6);
     use db::resource_pool::DefineResourcePoolError as DE;
     match db::resource_pool::define_all_from(&mut txn, &pools).await {
         Ok(()) => {
             txn.commit().await?;
+            if reconcile_dpu_loopbacks {
+                // The backfill opens one transaction per DPU, so publish the
+                // new pool rows before it starts reconciliation.
+                db::machine::update_dpu_loopback_ips_v6(
+                    &api.database_connection,
+                    &api.common_pools,
+                )
+                .await
+                .map_err(CarbideError::from)?;
+            }
             Ok(Response::new(rpc::GrowResourcePoolResponse {}))
         }
         Err(DE::InvalidArgument(msg)) => Err(CarbideError::InvalidArgument(msg).into()),

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -66,7 +66,7 @@ use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_vpc_prefix_controller::context::VpcPrefixStateHandlerServices;
 use carbide_vpc_prefix_controller::handler::VpcPrefixStateHandler;
 use carbide_vpc_prefix_controller::io::VpcPrefixStateControllerIO;
-use db::machine::update_dpu_asns;
+use db::machine::{update_dpu_asns, update_dpu_loopback_ips_v6};
 use db::resource_pool::DefineResourcePoolError;
 use db::{Transaction, work_lock_manager};
 use eyre::WrapErr;
@@ -1030,6 +1030,13 @@ async fn initialize_and_start_controllers<'a>(
         carbide_config.initial_dpu_agent_upgrade_policy,
     )
     .await?;
+
+    if let Err(error) = update_dpu_loopback_ips_v6(db_pool, common_pools).await {
+        tracing::error!(
+            error = %error,
+            "Failed to update IPv6 loopback IPs for DPUs",
+        );
+    }
 
     if let Err(e) = update_dpu_asns(db_pool, common_pools).await {
         tracing::warn!(

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -44,6 +44,7 @@ use model::hardware_info::TpmEkCertificate;
 use model::ib::DEFAULT_IB_FABRIC_NAME;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{InstanceState, ManagedHostState};
+use model::resource_pool::{ResourcePoolDef, ResourcePoolType};
 use model::site_explorer::ExploredManagedHost;
 use sqlx::{PgConnection, Row};
 use tonic::Request;
@@ -70,6 +71,30 @@ async fn get_partition_status(api: &Api, ib_partition_id: IBPartitionId) -> IbPa
 #[crate::sqlx_test]
 async fn test_admin_force_delete_dpu_only(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
+    let mut txn = env.pool.begin().await.unwrap();
+    db::resource_pool::define(
+        &mut txn,
+        model::resource_pool::common::LOOPBACK_IP_V6,
+        &ResourcePoolDef {
+            pool_type: ResourcePoolType::Ipv6,
+            prefix: Some("2001:db8::/125".to_string()),
+            ranges: vec![],
+            delegate_prefix_len: None,
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let initial_loopback_v6_pool_stats = db::resource_pool::stats(
+        txn.as_mut(),
+        env.common_pools.ethernet.pool_loopback_ip_v6.name(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
     let host_config = env.managed_host_config();
     let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
 
@@ -82,6 +107,17 @@ async fn test_admin_force_delete_dpu_only(pool: sqlx::PgPool) {
     .await
     .unwrap()
     .unwrap();
+    assert!(dpu_machine.network_config.loopback_ip_v6.is_some());
+    let allocated_loopback_v6_pool_stats = db::resource_pool::stats(
+        txn.as_mut(),
+        env.common_pools.ethernet.pool_loopback_ip_v6.name(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        allocated_loopback_v6_pool_stats.used,
+        initial_loopback_v6_pool_stats.used + 1
+    );
     assert!(
         !db::state_history::find_by_object_ids(
             &mut txn,
@@ -99,12 +135,32 @@ async fn test_admin_force_delete_dpu_only(pool: sqlx::PgPool) {
             .is_empty()
     );
 
+    // Model the stale snapshot race directly: the reservation still belongs
+    // to this DPU even when its persisted network config no longer names it.
+    sqlx::query(
+        "UPDATE machines
+         SET network_config = jsonb_set(
+             network_config,
+             '{loopback_ip_v6}',
+             'null'::jsonb
+         )
+         WHERE id = $1",
+    )
+    .bind(dpu_machine_id)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    let network_config = db::machine::get_network_config(txn.as_mut(), &dpu_machine_id)
+        .await
+        .unwrap();
+    assert_eq!(network_config.value.loopback_ip_v6, None);
+
     let host = db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine_id)
         .await
         .unwrap()
         .unwrap();
 
-    txn.rollback().await.unwrap();
+    txn.commit().await.unwrap();
 
     let response = force_delete(&env, &dpu_machine_id).await;
     validate_delete_response(&response, Some(&host.id), &dpu_machine_id);
@@ -117,6 +173,18 @@ async fn test_admin_force_delete_dpu_only(pool: sqlx::PgPool) {
 
     // Validate that the DPU is gone
     validate_machine_deletion(&env, &dpu_machine_id, None).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let released_loopback_v6_pool_stats = db::resource_pool::stats(
+        txn.as_mut(),
+        env.common_pools.ethernet.pool_loopback_ip_v6.name(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        released_loopback_v6_pool_stats,
+        initial_loopback_v6_pool_stats
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -32,6 +32,7 @@ use mac_address::MacAddress;
 use model::hardware_info::{HardwareInfo, TpmEkCertificate};
 use model::machine::machine_id::from_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
+use model::resource_pool::{ResourcePoolDef, ResourcePoolType};
 use rpc::forge::forge_server::Forge;
 use tonic::{Code, Request};
 
@@ -303,6 +304,20 @@ async fn test_discover_dpu_by_source_ip(
         TestEnvOverrides::with_config(secure_discovery_config()),
     )
     .await;
+    let mut txn = env.pool.begin().await?;
+    db::resource_pool::define(
+        &mut txn,
+        model::resource_pool::common::LOOPBACK_IP_V6,
+        &ResourcePoolDef {
+            pool_type: ResourcePoolType::Ipv6,
+            prefix: Some("2001:db8::/125".to_string()),
+            ranges: vec![],
+            delegate_prefix_len: None,
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
     let host_config = env.managed_host_config();
     let dpu = host_config.get_and_assert_single_dpu();
 
@@ -342,10 +357,26 @@ async fn test_discover_dpu_by_source_ip(
 
     let response = env.api.discover_machine(req).await.unwrap().into_inner();
 
-    assert!(response.machine_id.is_some());
     assert_eq!(
         response.machine_interface_id,
         dhcp_response.machine_interface_id
+    );
+    let dpu_machine_id = response.machine_id.expect("DPU should be created");
+    let mut txn = env.pool.begin().await?;
+    let dpu_machine = db::machine::find_one(
+        txn.as_mut(),
+        &dpu_machine_id,
+        MachineSearchConfig::default(),
+    )
+    .await?
+    .expect("DPU should exist");
+    assert!(dpu_machine.network_config.loopback_ip.is_some());
+    assert!(dpu_machine.network_config.loopback_ip_v6.is_some());
+    assert!(
+        dpu_machine
+            .network_config
+            .secondary_overlay_vtep_ip
+            .is_some()
     );
 
     Ok(())

--- a/crates/api-core/src/tests/resource_pool.rs
+++ b/crates/api-core/src/tests/resource_pool.rs
@@ -20,8 +20,10 @@ use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use carbide_uuid::machine::MachineId;
 use common::api_fixtures::create_test_env;
-use model::resource_pool::common::VPC_VNI;
+use model::machine::ManagedHostState;
+use model::resource_pool::common::{LOOPBACK_IP_V6, VPC_VNI};
 use model::resource_pool::{
     OwnerType, ResourcePool, ResourcePoolError, ResourcePoolStats as St, ValueType,
 };
@@ -99,6 +101,83 @@ prefix = "172.0.1.0/24"
             non_auto_assign_free: 0,
             non_auto_assign_used: 0
         }
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_grow_ipv6_loopback_pool_backfills_existing_dpus(
+    db_pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env = create_test_env(db_pool.clone()).await;
+    let dpu_machine_ids = [
+        MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?,
+        MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")?,
+    ];
+
+    // These rows predate the optional pool. Growing `lo-ip-v6` at runtime must
+    // reconcile them without waiting for another API restart or discovery.
+    let mut txn = db_pool.begin().await?;
+    for machine_id in &dpu_machine_ids {
+        db::machine::create(
+            txn.as_mut(),
+            None,
+            machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+    }
+    txn.commit().await?;
+
+    let toml = r#"
+[lo-ip-v6]
+type = "ipv6"
+prefix = "2001:db8:2389::/126"
+"#;
+    let grow = || rpc::forge::GrowResourcePoolRequest {
+        text: toml.to_string(),
+    };
+    env.api
+        .admin_grow_resource_pool(tonic::Request::new(grow()))
+        .await?;
+
+    let mut assigned = HashSet::new();
+    let mut versions = Vec::new();
+    let mut txn = db_pool.begin().await?;
+    for machine_id in &dpu_machine_ids {
+        let config = db::machine::get_network_config(txn.as_mut(), machine_id).await?;
+        assigned.insert(
+            config
+                .value
+                .loopback_ip_v6
+                .expect("runtime pool growth should backfill every existing DPU"),
+        );
+        versions.push(config.version);
+    }
+    txn.commit().await?;
+    assert_eq!(assigned.len(), dpu_machine_ids.len());
+
+    let stats_after_backfill = db::resource_pool::stats(&db_pool, LOOPBACK_IP_V6).await?;
+    assert_eq!(stats_after_backfill.used, dpu_machine_ids.len());
+
+    // Replaying the additive grow request also replays reconciliation. Both the
+    // persisted addresses and their group versions must remain unchanged.
+    env.api
+        .admin_grow_resource_pool(tonic::Request::new(grow()))
+        .await?;
+    let mut txn = db_pool.begin().await?;
+    for (machine_id, version) in dpu_machine_ids.iter().zip(versions) {
+        let config = db::machine::get_network_config(txn.as_mut(), machine_id).await?;
+        assert!(assigned.contains(&config.value.loopback_ip_v6.unwrap()));
+        assert_eq!(config.version, version);
+    }
+    txn.commit().await?;
+    assert_eq!(
+        db::resource_pool::stats(&db_pool, LOOPBACK_IP_V6).await?,
+        stats_after_backfill
     );
 
     Ok(())

--- a/crates/api-db/migrations/20260722120000_preserve_machine_ipv6_loopback.sql
+++ b/crates/api-db/migrations/20260722120000_preserve_machine_ipv6_loopback.sql
@@ -1,0 +1,26 @@
+-- A pre-#2389 API pod replaces the complete network_config document without
+-- fields it does not know. Preserve the IPv6 loopback across mixed-version
+-- upgrades and rollbacks, while still allowing current writers to clear it
+-- with an explicit JSON null. This guard can be retired once every supported
+-- API version preserves loopback_ip_v6.
+CREATE FUNCTION preserve_machine_ipv6_loopback()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF OLD.network_config ? 'loopback_ip_v6'
+       AND NOT NEW.network_config ? 'loopback_ip_v6' THEN
+        NEW.network_config := jsonb_set(
+            NEW.network_config,
+            '{loopback_ip_v6}',
+            OLD.network_config -> 'loopback_ip_v6',
+            true
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER preserve_machine_ipv6_loopback
+BEFORE UPDATE OF network_config ON machines
+FOR EACH ROW
+EXECUTE FUNCTION preserve_machine_ipv6_loopback();

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -18,7 +18,7 @@
 //! Machine - represents a database-backed Machine object
 
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -57,7 +57,7 @@ use model::machine_interface_address::MachineInterfaceAssociation;
 use model::metadata::Metadata;
 use model::resource_pool;
 use model::resource_pool::ResourcePoolError;
-use model::resource_pool::common::CommonPools;
+use model::resource_pool::common::{CommonPools, LOOPBACK_IP_V6};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, PgConnection, Pool, Postgres, Row};
@@ -1333,6 +1333,39 @@ pub async fn try_update_network_config(
     expected_version: ConfigVersion,
     new_state: &ManagedHostNetworkConfig,
 ) -> Result<bool, DatabaseError> {
+    try_update_network_config_inner(txn, machine_id, expected_version, new_state, false).await
+}
+
+async fn try_update_network_config_unless_force_deleting(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    expected_version: ConfigVersion,
+    new_state: &ManagedHostNetworkConfig,
+) -> Result<bool, DatabaseError> {
+    try_update_network_config_inner(txn, machine_id, expected_version, new_state, true).await
+}
+
+async fn is_force_deleting_or_deleted(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+) -> Result<bool, DatabaseError> {
+    let query = "SELECT controller_state = $2::jsonb FROM machines WHERE id = $1";
+    let is_force_deleting: Option<bool> = sqlx::query_scalar(query)
+        .bind(machine_id)
+        .bind(sqlx::types::Json(&ManagedHostState::ForceDeletion))
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?;
+    Ok(is_force_deleting.unwrap_or(true))
+}
+
+async fn try_update_network_config_inner(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    expected_version: ConfigVersion,
+    new_state: &ManagedHostNetworkConfig,
+    reject_force_deletion: bool,
+) -> Result<bool, DatabaseError> {
     let next_version = expected_version.increment();
 
     // First, do our usual "optimistic" lock update on the target row, which
@@ -1340,12 +1373,15 @@ pub async fn try_update_network_config(
     // the row currently being at `expected_version`).
     let target_query = "UPDATE machines SET network_config_version=$1, network_config=$2::json
             WHERE id=$3 AND network_config_version=$4
+              AND (NOT $5 OR controller_state != $6::jsonb)
             RETURNING id";
     let target_result: Result<MachineId, _> = sqlx::query_as(target_query)
         .bind(next_version)
         .bind(sqlx::types::Json(new_state))
         .bind(machine_id)
         .bind(expected_version)
+        .bind(reject_force_deletion)
+        .bind(sqlx::types::Json(&ManagedHostState::ForceDeletion))
         .fetch_one(&mut *txn)
         .await;
 
@@ -1563,7 +1599,20 @@ pub async fn create(
     let version = ConfigVersion::initial();
 
     let network_config_version = ConfigVersion::initial();
-    let network_config = ManagedHostNetworkConfig::default();
+    let loopback_ip_v6 = if stable_machine_id.machine_type() == MachineType::Dpu {
+        match common_pools {
+            Some(common_pools) => {
+                allocate_loopback_ip_v6(common_pools, txn, &stable_machine_id_string).await?
+            }
+            None => None,
+        }
+    } else {
+        None
+    };
+    let network_config = ManagedHostNetworkConfig {
+        loopback_ip_v6,
+        ..Default::default()
+    };
     let asn: Option<i64> = if stable_machine_id.machine_type() == MachineType::Dpu {
         if let Some(common_pools) = common_pools {
             match crate::resource_pool::allocate(
@@ -2321,6 +2370,70 @@ pub async fn allocate_loopback_ip(
     }
 }
 
+/// Allocates one IPv6 underlay loopback when `lo-ip-v6` is configured.
+/// `None` preserves IPv4-only sites where the optional pool is absent;
+/// exhaustion remains an error so a configured site cannot silently leave a
+/// DPU without its reserved address.
+pub async fn allocate_loopback_ip_v6(
+    common_pools: &CommonPools,
+    txn: &mut PgConnection,
+    owner_id: &str,
+) -> Result<Option<Ipv6Addr>, DatabaseError> {
+    let pool = &common_pools.ethernet.pool_loopback_ip_v6;
+    if !crate::resource_pool::pool_has_rows(txn, pool.name()).await? {
+        return Ok(None);
+    }
+
+    if let Some(value) = crate::resource_pool::find_owned_allocation(
+        pool,
+        txn,
+        resource_pool::OwnerType::Machine,
+        owner_id,
+    )
+    .await?
+    {
+        return Ok(Some(value));
+    }
+
+    match crate::resource_pool::allocate(
+        pool,
+        txn,
+        resource_pool::OwnerType::Machine,
+        owner_id,
+        None,
+    )
+    .await
+    {
+        Ok(value) => Ok(Some(value)),
+        Err(
+            error @ crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
+                ResourcePoolError::Empty,
+            ),
+        ) => {
+            crate::resource_pool::emit_allocation_failure(
+                pool.value_type,
+                owner_id,
+                false,
+                LOOPBACK_IP_V6,
+                &error,
+            );
+            Err(DatabaseError::ResourceExhausted(format!(
+                "pool {LOOPBACK_IP_V6}"
+            )))
+        }
+        Err(error) => {
+            crate::resource_pool::emit_allocation_failure(
+                pool.value_type,
+                owner_id,
+                false,
+                LOOPBACK_IP_V6,
+                &error,
+            );
+            Err(error.into())
+        }
+    }
+}
+
 /// Allocate a value from the loopback IP resource pool.
 ///
 /// If the pool exists but is empty or has en error, return that.
@@ -2569,6 +2682,120 @@ pub async fn update_dpu_asns(
     }
 
     txn.commit().await?;
+
+    Ok(())
+}
+
+/// Fills the optional IPv6 loopback for DPUs created before `lo-ip-v6` was
+/// configured. Each DPU is reloaded immediately before its write because an
+/// update to one member bumps every sibling's `network_config_version` and
+/// invalidates versions loaded earlier in the pass.
+pub async fn update_dpu_loopback_ips_v6(
+    db_pool: &Pool<Postgres>,
+    common_pools: &CommonPools,
+) -> Result<(), DatabaseError> {
+    const MAX_CAS_ATTEMPTS: usize = 3;
+
+    let mut txn = Transaction::begin(db_pool).await?;
+    let pool = &common_pools.ethernet.pool_loopback_ip_v6;
+    if !crate::resource_pool::pool_has_rows(txn.as_pgconn(), pool.name()).await? {
+        txn.commit().await?;
+        return Ok(());
+    }
+
+    let query = "SELECT id FROM machines
+        WHERE starts_with(id, $1)
+          AND network_config->>'loopback_ip_v6' IS NULL
+        ORDER BY id";
+    let dpu_machine_ids: Vec<MachineId> = sqlx::query_as(query)
+        .bind(MachineType::Dpu.id_prefix())
+        .fetch_all(txn.as_pgconn())
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?;
+    txn.commit().await?;
+
+    if !dpu_machine_ids.is_empty() {
+        tracing::info!(
+            dpu_count = dpu_machine_ids.len(),
+            "Updating missing IPv6 loopback IPs for DPUs"
+        );
+    }
+
+    let mut first_conflicting_version = None;
+
+    for dpu_machine_id in dpu_machine_ids {
+        let mut last_conflicting_version = None;
+
+        for _ in 0..MAX_CAS_ATTEMPTS {
+            let mut txn = Transaction::begin(db_pool).await?;
+            let (mut network_config, network_config_version) =
+                match get_network_config(txn.as_pgconn(), &dpu_machine_id).await {
+                    Ok(network_config) => network_config.take(),
+                    Err(error) if error.is_not_found() => {
+                        // Force deletion can remove a DPU after the initial ID
+                        // scan. It no longer needs a reservation.
+                        txn.commit().await?;
+                        last_conflicting_version = None;
+                        break;
+                    }
+                    Err(error) => return Err(error),
+                };
+            if network_config.loopback_ip_v6.is_some() {
+                txn.commit().await?;
+                last_conflicting_version = None;
+                break;
+            }
+
+            let loopback_ip_v6 = allocate_loopback_ip_v6(
+                common_pools,
+                txn.as_pgconn(),
+                &dpu_machine_id.to_string(),
+            )
+            .await?
+            .ok_or_else(|| {
+                DatabaseError::FailedPrecondition(format!(
+                    "resource pool {LOOPBACK_IP_V6} disappeared during DPU IPv6 loopback backfill"
+                ))
+            })?;
+            network_config.loopback_ip_v6 = Some(loopback_ip_v6);
+
+            if try_update_network_config_unless_force_deleting(
+                txn.as_pgconn(),
+                &dpu_machine_id,
+                network_config_version,
+                &network_config,
+            )
+            .await?
+            {
+                txn.commit().await?;
+                last_conflicting_version = None;
+                break;
+            }
+
+            let force_deleting_or_deleted =
+                is_force_deleting_or_deleted(txn.as_pgconn(), &dpu_machine_id).await?;
+            txn.rollback().await?;
+            if force_deleting_or_deleted {
+                last_conflicting_version = None;
+                break;
+            }
+            last_conflicting_version = Some(network_config_version);
+        }
+
+        if let Some(version) = last_conflicting_version {
+            // One busy DPU should not postpone every row after it in the scan.
+            // Remember the first conflict, continue the pass, and report it
+            // once the remaining DPUs have had their own chance to reconcile.
+            first_conflicting_version.get_or_insert(version);
+        }
+    }
+
+    if let Some(version) = first_conflicting_version {
+        return Err(DatabaseError::ConcurrentModificationError(
+            "machine",
+            version.to_string(),
+        ));
+    }
 
     Ok(())
 }
@@ -2902,8 +3129,8 @@ pub fn count_healthy_unhealthy_host_machines(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-    use std::net::IpAddr;
+    use std::collections::{HashMap, HashSet};
+    use std::net::{IpAddr, Ipv6Addr};
     use std::str::FromStr;
     use std::sync::{Arc, Mutex};
 
@@ -2918,8 +3145,9 @@ mod test {
     use model::machine::topology::{DiscoveryData, TopologyData};
     use model::resource_pool::common::{
         CommonPools, DPA_VNI, EXTERNAL_VPC_VNI, EthernetPools, FNN_ASN, IbPools, LOOPBACK_IP,
-        SECONDARY_VTEP_IP, VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
+        LOOPBACK_IP_V6, SECONDARY_VTEP_IP, VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
     };
+    use model::resource_pool::define::{Range, ResourcePoolDef, ResourcePoolType};
     use model::resource_pool::{ResourcePool, ValueType};
     use tokio::sync::oneshot;
 
@@ -2930,6 +3158,10 @@ mod test {
                 pool_loopback_ip: Arc::new(ResourcePool::new(
                     LOOPBACK_IP.to_string(),
                     ValueType::Ipv4,
+                )),
+                pool_loopback_ip_v6: Arc::new(ResourcePool::new(
+                    LOOPBACK_IP_V6.to_string(),
+                    ValueType::Ipv6,
                 )),
                 pool_vlan_id: Arc::new(ResourcePool::new(VLANID.to_string(), ValueType::Integer)),
                 pool_vni: Arc::new(ResourcePool::new(VNI.to_string(), ValueType::Integer)),
@@ -3013,6 +3245,75 @@ mod test {
         );
 
         Ok(())
+    }
+
+    fn integer_pool() -> ResourcePoolDef {
+        ResourcePoolDef {
+            ranges: vec![Range {
+                start: "1".to_string(),
+                end: "16".to_string(),
+                auto_assign: true,
+            }],
+            prefix: None,
+            pool_type: ResourcePoolType::Integer,
+            delegate_prefix_len: None,
+        }
+    }
+
+    fn address_pool(pool_type: ResourcePoolType, prefix: &str) -> ResourcePoolDef {
+        ResourcePoolDef {
+            ranges: Vec::new(),
+            prefix: Some(prefix.to_string()),
+            pool_type,
+            delegate_prefix_len: None,
+        }
+    }
+
+    async fn common_pools(
+        pool: &sqlx::PgPool,
+        loopback_ip_v6_prefix: Option<&str>,
+    ) -> Result<Arc<CommonPools>, Box<dyn std::error::Error>> {
+        let mut definitions = HashMap::from([
+            (
+                LOOPBACK_IP.to_string(),
+                address_pool(ResourcePoolType::Ipv4, "192.0.2.0/29"),
+            ),
+            (VLANID.to_string(), integer_pool()),
+            (VNI.to_string(), integer_pool()),
+            (VPC_VNI.to_string(), integer_pool()),
+        ]);
+        if let Some(prefix) = loopback_ip_v6_prefix {
+            definitions.insert(
+                LOOPBACK_IP_V6.to_string(),
+                address_pool(ResourcePoolType::Ipv6, prefix),
+            );
+        }
+
+        let mut txn = pool.begin().await?;
+        crate::resource_pool::define_all_from(txn.as_mut(), &definitions).await?;
+        txn.commit().await?;
+
+        Ok(crate::resource_pool::create_common_pools(pool.clone(), HashSet::new()).await?)
+    }
+
+    async fn wait_until_blocked_on(pool: &sqlx::PgPool, relation: &str) {
+        for _ in 0..600 {
+            let waiting: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM pg_stat_activity
+                 WHERE datname = current_database()
+                   AND wait_event_type = 'Lock'
+                   AND query ILIKE '%' || $1 || '%'",
+            )
+            .bind(relation)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+            if waiting > 0 {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        panic!("query never blocked on {relation}");
     }
 
     /// The machine snapshot reports the BMC IP from the *live* `machine_interface_addresses`
@@ -3147,6 +3448,470 @@ mod test {
             .unwrap()
             .unwrap();
         assert!(host.config.firmware_autoupdate.is_none());
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn ipv6_loopback_pool_absence_preserves_ipv4_only_creation(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, None).await?;
+        let dpu_machine_id =
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?;
+
+        let mut txn = pool.begin().await?;
+        assert_eq!(
+            super::allocate_loopback_ip_v6(
+                &common_pools,
+                txn.as_mut(),
+                &dpu_machine_id.to_string(),
+            )
+            .await?,
+            None
+        );
+
+        let dpu = super::create(
+            txn.as_mut(),
+            Some(&common_pools),
+            &dpu_machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        assert_eq!(dpu.network_config.loopback_ip_v6, None);
+
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn configured_ipv6_loopback_reservation_is_reused_and_exhausts_for_another_owner(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, Some("2001:db8:1::1/128")).await?;
+        let first_dpu_id =
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?;
+        let second_dpu_id =
+            MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")?;
+
+        let mut txn = pool.begin().await?;
+        let first_dpu = super::create(
+            txn.as_mut(),
+            Some(&common_pools),
+            &first_dpu_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        assert_eq!(
+            first_dpu.network_config.loopback_ip_v6,
+            Some("2001:db8:1::1".parse::<Ipv6Addr>()?)
+        );
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        let reused =
+            super::allocate_loopback_ip_v6(&common_pools, txn.as_mut(), &first_dpu_id.to_string())
+                .await?;
+        assert_eq!(reused, first_dpu.network_config.loopback_ip_v6);
+        let stats_after_reuse = crate::resource_pool::stats(txn.as_mut(), LOOPBACK_IP_V6).await?;
+        assert_eq!(stats_after_reuse.used, 1);
+        assert_eq!(stats_after_reuse.free, 0);
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        let error = super::create(
+            txn.as_mut(),
+            Some(&common_pools),
+            &second_dpu_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await
+        .expect_err("a configured but exhausted IPv6 loopback pool must fail DPU creation");
+        assert!(matches!(error, crate::DatabaseError::ResourceExhausted(_)));
+        txn.rollback().await?;
+
+        let stats = crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?;
+        assert_eq!(stats.used, 1);
+        assert_eq!(stats.free, 0);
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn ipv6_loopback_survives_legacy_updates_and_reuses_its_reservation(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, Some("2001:db8:4::1/128")).await?;
+        let dpu_machine_id =
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?;
+
+        let mut txn = pool.begin().await?;
+        let dpu = super::create(
+            txn.as_mut(),
+            Some(&common_pools),
+            &dpu_machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        let allocated = dpu
+            .network_config
+            .loopback_ip_v6
+            .expect("the configured pool should reserve an IPv6 loopback");
+        txn.commit().await?;
+
+        // An older API replaces the complete document without the field it
+        // does not know. The trigger restores that field while retaining its
+        // changes to fields it does know.
+        let legacy_network_config = serde_json::json!({
+            "loopback_ip": null,
+            "secondary_overlay_vtep_ip": null,
+            "use_admin_network": false,
+            "quarantine_state": null,
+            "use_admin_network_changed": null
+        });
+        let update_query = "UPDATE machines SET network_config = $1 WHERE id = $2";
+        let mut txn = pool.begin().await?;
+        sqlx::query(update_query)
+            .bind(sqlx::types::Json(&legacy_network_config))
+            .bind(dpu_machine_id)
+            .execute(txn.as_mut())
+            .await?;
+        let after_legacy_update = super::get_network_config(txn.as_mut(), &dpu_machine_id).await?;
+        assert_eq!(after_legacy_update.value.loopback_ip_v6, Some(allocated));
+        assert_eq!(after_legacy_update.value.use_admin_network, Some(false));
+        let stats_after_legacy_update =
+            crate::resource_pool::stats(txn.as_mut(), LOOPBACK_IP_V6).await?;
+        assert_eq!(stats_after_legacy_update.used, 1);
+        assert_eq!(stats_after_legacy_update.free, 0);
+        txn.commit().await?;
+
+        let current_network_config = serde_json::json!({
+            "loopback_ip": null,
+            "loopback_ip_v6": null,
+            "secondary_overlay_vtep_ip": null,
+            "use_admin_network": false,
+            "quarantine_state": null,
+            "use_admin_network_changed": null
+        });
+        let mut txn = pool.begin().await?;
+        sqlx::query(update_query)
+            .bind(sqlx::types::Json(&current_network_config))
+            .bind(dpu_machine_id)
+            .execute(txn.as_mut())
+            .await?;
+        let after_explicit_clear = super::get_network_config(txn.as_mut(), &dpu_machine_id).await?;
+        assert_eq!(after_explicit_clear.value.loopback_ip_v6, None);
+
+        let reused = super::allocate_loopback_ip_v6(
+            &common_pools,
+            txn.as_mut(),
+            &dpu_machine_id.to_string(),
+        )
+        .await?;
+        assert_eq!(reused, Some(allocated));
+        let stats_after_reuse = crate::resource_pool::stats(txn.as_mut(), LOOPBACK_IP_V6).await?;
+        assert_eq!(stats_after_reuse.used, 1);
+        assert_eq!(stats_after_reuse.free, 0);
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn ipv6_loopback_backfill_reloads_each_dpu_and_is_idempotent(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, Some("2001:db8:2::/125")).await?;
+        let host_machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")?;
+        let dpu_machine_ids = [
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?,
+            MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")?,
+        ];
+
+        // These rows model DPUs that predate `loopback_ip_v6`, so create them
+        // without common pools and then connect both to the same host group.
+        let mut txn = pool.begin().await?;
+        super::create(
+            txn.as_mut(),
+            None,
+            &host_machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        for dpu_machine_id in &dpu_machine_ids {
+            super::create(
+                txn.as_mut(),
+                None,
+                dpu_machine_id,
+                ManagedHostState::Ready,
+                None,
+                2,
+            )
+            .await?;
+        }
+
+        let network_segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('ipv6-loopback-backfill', 'V1-T0') RETURNING id",
+        )
+        .fetch_one(txn.as_mut())
+        .await?;
+        for (index, dpu_machine_id) in dpu_machine_ids.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO machine_interfaces
+                    (machine_id, attached_dpu_machine_id, association_type,
+                     segment_id, mac_address, primary_interface, hostname)
+                 VALUES ($1, $2, 'Machine', $3, $4::macaddr, $5, $6)",
+            )
+            .bind(host_machine_id)
+            .bind(dpu_machine_id)
+            .bind(network_segment_id)
+            .bind(format!("02:00:00:00:10:{index:02x}"))
+            .bind(index == 0)
+            .bind(format!("backfill-dpu-{index}"))
+            .execute(txn.as_mut())
+            .await?;
+        }
+        txn.commit().await?;
+
+        super::update_dpu_loopback_ips_v6(&pool, &common_pools).await?;
+
+        let mut txn = pool.begin().await?;
+        let host_config = super::get_network_config(txn.as_mut(), &host_machine_id).await?;
+        let first_dpu_config = super::get_network_config(txn.as_mut(), &dpu_machine_ids[0]).await?;
+        let second_dpu_config =
+            super::get_network_config(txn.as_mut(), &dpu_machine_ids[1]).await?;
+        let allocated = [
+            first_dpu_config
+                .value
+                .loopback_ip_v6
+                .expect("first DPU should be backfilled"),
+            second_dpu_config
+                .value
+                .loopback_ip_v6
+                .expect("second DPU should be backfilled"),
+        ];
+        assert_ne!(allocated[0], allocated[1]);
+        assert_eq!(host_config.value.loopback_ip_v6, None);
+        assert_eq!(host_config.version, first_dpu_config.version);
+        assert_eq!(first_dpu_config.version, second_dpu_config.version);
+        let version_after_backfill = host_config.version;
+        txn.commit().await?;
+
+        let stats_after_backfill = crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?;
+        assert_eq!(stats_after_backfill.used, 2);
+
+        // A second startup pass must preserve both reservations and avoid a
+        // version bump: `None` is the only row state the backfill owns.
+        super::update_dpu_loopback_ips_v6(&pool, &common_pools).await?;
+        let stats_after_rerun = crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?;
+        assert_eq!(stats_after_rerun, stats_after_backfill);
+
+        let mut txn = pool.begin().await?;
+        let host_config = super::get_network_config(txn.as_mut(), &host_machine_id).await?;
+        let first_dpu_config = super::get_network_config(txn.as_mut(), &dpu_machine_ids[0]).await?;
+        let second_dpu_config =
+            super::get_network_config(txn.as_mut(), &dpu_machine_ids[1]).await?;
+        assert_eq!(host_config.version, version_after_backfill);
+        assert_eq!(
+            [
+                first_dpu_config.value.loopback_ip_v6.unwrap(),
+                second_dpu_config.value.loopback_ip_v6.unwrap(),
+            ],
+            allocated
+        );
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn ipv6_loopback_backfill_skips_force_deleting_dpus(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, Some("2001:db8:5::/125")).await?;
+        let dpu_machine_id =
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?;
+
+        let mut txn = pool.begin().await?;
+        super::create(
+            txn.as_mut(),
+            None,
+            &dpu_machine_id,
+            ManagedHostState::ForceDeletion,
+            None,
+            2,
+        )
+        .await?;
+        txn.commit().await?;
+
+        super::update_dpu_loopback_ips_v6(&pool, &common_pools).await?;
+
+        let network_config = super::get_network_config(&pool, &dpu_machine_id).await?;
+        assert_eq!(network_config.value.loopback_ip_v6, None);
+        let stats = crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?;
+        assert_eq!(stats.used, 0);
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    #[allow(txn_held_across_await)] // Intentional: this test holds a row lock to force a CAS retry.
+    async fn ipv6_loopback_backfill_retries_after_network_config_conflict(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, Some("2001:db8:6::1/128")).await?;
+        let dpu_machine_id =
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?;
+
+        let mut txn = pool.begin().await?;
+        super::create(
+            txn.as_mut(),
+            None,
+            &dpu_machine_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        )
+        .await?;
+        let reserved = super::allocate_loopback_ip_v6(
+            &common_pools,
+            txn.as_mut(),
+            &dpu_machine_id.to_string(),
+        )
+        .await?
+        .expect("configured pool should reserve an IPv6 loopback");
+        txn.commit().await?;
+
+        // Hold the existing reservation after the backfill reads its machine
+        // version. This gives another writer a deterministic window to bump
+        // that version before the first compare-and-swap reaches the row.
+        let mut reservation_lock = pool.begin().await?;
+        sqlx::query(
+            "SELECT value FROM resource_pool
+             WHERE name = $1 AND value = $2
+             FOR UPDATE",
+        )
+        .bind(LOOPBACK_IP_V6)
+        .bind(reserved.to_string())
+        .fetch_one(reservation_lock.as_mut())
+        .await?;
+
+        let backfill_pool = pool.clone();
+        let backfill_common_pools = Arc::clone(&common_pools);
+        let backfill = tokio::spawn(async move {
+            super::update_dpu_loopback_ips_v6(&backfill_pool, &backfill_common_pools).await
+        });
+        wait_until_blocked_on(&pool, "resource_pool").await;
+
+        let mut txn = pool.begin().await?;
+        let (mut network_config, version) =
+            super::get_network_config(txn.as_mut(), &dpu_machine_id)
+                .await?
+                .take();
+        network_config.use_admin_network = Some(false);
+        assert!(
+            super::try_update_network_config(
+                txn.as_mut(),
+                &dpu_machine_id,
+                version,
+                &network_config,
+            )
+            .await?
+        );
+        txn.commit().await?;
+        reservation_lock.commit().await?;
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), backfill)
+            .await??
+            .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)?;
+
+        let network_config = super::get_network_config(&pool, &dpu_machine_id).await?;
+        assert_eq!(network_config.value.loopback_ip_v6, Some(reserved));
+        let stats = crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?;
+        assert_eq!(stats.used, 1);
+        assert_eq!(stats.free, 0);
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn ipv6_loopback_backfill_preserves_completed_rows_when_pool_exhausts(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let common_pools = common_pools(&pool, Some("2001:db8:3::1/128")).await?;
+        let dpu_machine_ids = [
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")?,
+            MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")?,
+        ];
+
+        // Passing no common pools recreates rows from before the IPv6 pool was
+        // configured without consuming its only address during insertion.
+        let mut txn = pool.begin().await?;
+        for dpu_machine_id in &dpu_machine_ids {
+            super::create(
+                txn.as_mut(),
+                None,
+                dpu_machine_id,
+                ManagedHostState::Ready,
+                None,
+                2,
+            )
+            .await?;
+        }
+        txn.commit().await?;
+
+        let error = super::update_dpu_loopback_ips_v6(&pool, &common_pools)
+            .await
+            .expect_err("one address cannot backfill two DPUs");
+        assert!(matches!(error, crate::DatabaseError::ResourceExhausted(_)));
+
+        let mut txn = pool.begin().await?;
+        let configs_after_first_pass = [
+            super::get_network_config(txn.as_mut(), &dpu_machine_ids[0])
+                .await?
+                .value,
+            super::get_network_config(txn.as_mut(), &dpu_machine_ids[1])
+                .await?
+                .value,
+        ];
+        assert_eq!(
+            configs_after_first_pass
+                .iter()
+                .filter(|config| config.loopback_ip_v6.is_some())
+                .count(),
+            1
+        );
+        txn.commit().await?;
+        let stats_after_first_pass = crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?;
+        assert_eq!(stats_after_first_pass.used, 1);
+        assert_eq!(stats_after_first_pass.free, 0);
+
+        let error = super::update_dpu_loopback_ips_v6(&pool, &common_pools)
+            .await
+            .expect_err("the remaining DPU must continue to report exhaustion");
+        assert!(matches!(error, crate::DatabaseError::ResourceExhausted(_)));
+
+        let mut txn = pool.begin().await?;
+        let configs_after_second_pass = [
+            super::get_network_config(txn.as_mut(), &dpu_machine_ids[0])
+                .await?
+                .value,
+            super::get_network_config(txn.as_mut(), &dpu_machine_ids[1])
+                .await?
+                .value,
+        ];
+        txn.commit().await?;
+        assert_eq!(configs_after_second_pass, configs_after_first_pass);
+        assert_eq!(
+            crate::resource_pool::stats(&pool, LOOPBACK_IP_V6).await?,
+            stats_after_first_pass
+        );
         Ok(())
     }
 }

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -25,7 +25,7 @@ use ipnetwork::Ipv6Network;
 use model::resource_pool;
 use model::resource_pool::common::{
     CommonPools, DPA_VNI, EXTERNAL_VPC_VNI, EthernetPools, FNN_ASN, IbPools, LOOPBACK_IP,
-    SECONDARY_VTEP_IP, VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
+    LOOPBACK_IP_V6, SECONDARY_VTEP_IP, VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
 };
 use model::resource_pool::define::{ResourcePoolDef, ResourcePoolType};
 use model::resource_pool::{
@@ -374,6 +374,63 @@ RETURNING allocate.value
     Ok(out)
 }
 
+/// Returns the value already reserved by one owner in this pool.
+///
+/// A duplicate reservation is treated as corrupted pool state. Callers cannot
+/// safely choose one value while leaving the other assigned to the same owner.
+pub async fn find_owned_allocation<T>(
+    pool: &ResourcePool<T>,
+    txn: &mut PgConnection,
+    owner_type: OwnerType,
+    owner_id: &str,
+) -> Result<Option<T>, ResourcePoolDatabaseError>
+where
+    T: ToString + FromStr + Send + Sync + 'static,
+    <T as FromStr>::Err: std::error::Error,
+{
+    let allocated_state = ResourcePoolEntryState::Allocated {
+        owner: owner_id.to_string(),
+        owner_type: owner_type.to_string(),
+    };
+    let query = "SELECT value FROM resource_pool
+        WHERE name = $1 AND state = $2
+        ORDER BY value
+        LIMIT 2
+        FOR UPDATE";
+    let values: Vec<String> = sqlx::query_scalar(query)
+        .bind(pool.name())
+        .bind(sqlx::types::Json(&allocated_state))
+        .fetch_all(&mut *txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?;
+
+    if values.len() > 1 {
+        return Err(DatabaseError::FailedPrecondition(format!(
+            "resource pool `{}` has multiple values allocated to {} `{owner_id}`",
+            pool.name(),
+            owner_type
+        ))
+        .into());
+    }
+
+    values
+        .into_iter()
+        .next()
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|error: <T as FromStr>::Err| ResourcePoolError::Parse {
+                    e: error.to_string(),
+                    v: value,
+                    pool_name: pool.name.clone(),
+                    owner_type: owner_type.to_string(),
+                    owner_id: owner_id.to_string(),
+                })
+        })
+        .transpose()
+        .map_err(Into::into)
+}
+
 /// Return a resource to the pool
 pub async fn release<T>(
     pool: &ResourcePool<T>,
@@ -531,7 +588,7 @@ pub async fn all(txn: &mut PgConnection) -> Result<Vec<ResourcePoolSnapshot>, Da
                 FROM resource_pool WHERE value_type = 'integer' GROUP BY name
             ) snapshot";
 
-    let query_ipv4 = "
+    let query_ip_address = "
             SELECT
                 name,
                 min,
@@ -549,10 +606,10 @@ pub async fn all(txn: &mut PgConnection) -> Result<Vec<ResourcePoolSnapshot>, Da
                     count(*) FILTER (WHERE state != '{\"state\": \"free\"}' AND auto_assign) AS auto_assign_used,
                     count(*) FILTER (WHERE state = '{\"state\": \"free\"}' AND NOT auto_assign) AS non_auto_assign_free,
                     count(*) FILTER (WHERE state != '{\"state\": \"free\"}' AND NOT auto_assign) AS non_auto_assign_used
-                FROM resource_pool WHERE value_type = 'ipv4' GROUP BY name
+                FROM resource_pool WHERE value_type IN ('ipv4', 'ipv6') GROUP BY name
             ) snapshot";
 
-    for query in [query_int, query_ipv4] {
+    for query in [query_int, query_ip_address] {
         let mut rows: Vec<ResourcePoolSnapshot> = sqlx::query_as(query)
             .fetch_all(&mut *txn)
             .await
@@ -1316,6 +1373,11 @@ pub async fn create_common_pools(
     let pool_loopback_ip: Arc<ResourcePool<IpAddr>> =
         Arc::new(ResourcePool::new(LOOPBACK_IP.to_string(), ValueType::Ipv4));
     pool_names.push(pool_loopback_ip.name().to_string());
+    let pool_loopback_ip_v6: Arc<ResourcePool<Ipv6Addr>> = Arc::new(ResourcePool::new(
+        LOOPBACK_IP_V6.to_string(),
+        ValueType::Ipv6,
+    ));
+    optional_pool_names.push(pool_loopback_ip_v6.name().to_string());
     let pool_vlan_id: Arc<ResourcePool<i16>> =
         Arc::new(ResourcePool::new(VLANID.to_string(), ValueType::Integer));
     pool_names.push(pool_vlan_id.name().to_string());
@@ -1408,6 +1470,7 @@ pub async fn create_common_pools(
     Ok(Arc::new(CommonPools {
         ethernet: EthernetPools {
             pool_loopback_ip,
+            pool_loopback_ip_v6,
             pool_vlan_id,
             pool_vni,
             pool_vpc_vni,
@@ -2112,6 +2175,51 @@ mod tests {
         Ok(())
     }
 
+    #[crate::sqlx_test]
+    async fn find_owned_allocation_returns_typed_value_and_rejects_duplicates(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use model::resource_pool::define::{ResourcePoolDef, ResourcePoolType};
+
+        let mut txn = pool.begin().await?;
+        define(
+            &mut txn,
+            "test-owned-ipv6-pool",
+            &ResourcePoolDef {
+                prefix: Some("2001:db8::/126".to_string()),
+                ranges: Vec::new(),
+                pool_type: ResourcePoolType::Ipv6,
+                delegate_prefix_len: None,
+            },
+        )
+        .await?;
+        let pool_handle =
+            ResourcePool::<Ipv6Addr>::new("test-owned-ipv6-pool".to_string(), ValueType::Ipv6);
+
+        assert_eq!(
+            find_owned_allocation(&pool_handle, &mut txn, OwnerType::Machine, "owner-1",).await?,
+            None
+        );
+        let first = allocate(&pool_handle, &mut txn, OwnerType::Machine, "owner-1", None).await?;
+        assert_eq!(
+            find_owned_allocation(&pool_handle, &mut txn, OwnerType::Machine, "owner-1",).await?,
+            Some(first)
+        );
+
+        allocate(&pool_handle, &mut txn, OwnerType::Machine, "owner-1", None).await?;
+        let error = find_owned_allocation(&pool_handle, &mut txn, OwnerType::Machine, "owner-1")
+            .await
+            .expect_err("duplicate reservations for one owner must be rejected");
+        assert!(matches!(
+            error,
+            ResourcePoolDatabaseError::Database(ref boxed)
+                if matches!(boxed.as_ref(), DatabaseError::FailedPrecondition(_))
+        ));
+
+        txn.rollback().await?;
+        Ok(())
+    }
+
     /// Requesting a specific value that the pool cannot hand out — while the
     /// pool still has free non-auto-assign entries — must map to
     /// `FailedPrecondition`, distinct from the `Empty` (exhausted) case. The
@@ -2328,6 +2436,17 @@ mod tests {
         // /120 == 256 usable IPv6 addresses.
         let pool_stats = stats(txn.as_mut(), "test-ipv6-pool").await?;
         assert_eq!(pool_stats.free, 256);
+
+        // `admin-cli resource-pool list` reads `all()`, so the IPv6 pool must
+        // appear alongside the older integer and IPv4 pool types.
+        let snapshots = all(txn.as_mut()).await?;
+        let snapshot = snapshots
+            .iter()
+            .find(|snapshot| snapshot.name == "test-ipv6-pool")
+            .expect("IPv6 pool should be listed");
+        assert_eq!(snapshot.min, "fd00:abcd::");
+        assert_eq!(snapshot.max, "fd00:abcd::ff");
+        assert_eq!(snapshot.stats.free, 256);
 
         // Allocate an address.
         let pool_handle =

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -17,7 +17,7 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 use carbide_uuid::domain::DomainId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
@@ -980,6 +980,12 @@ impl Machine {
 
     pub fn loopback_ip(&self) -> Option<IpAddr> {
         self.network_config.loopback_ip
+    }
+
+    /// Returns the DPU's reserved FNN IPv6 loopback when its optional pool is
+    /// configured.
+    pub fn loopback_ip_v6(&self) -> Option<Ipv6Addr> {
+        self.network_config.loopback_ip_v6
     }
 
     /// Returns all associated DPU Machine IDs if this is Host Machine

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Duration, Utc};
@@ -146,6 +146,9 @@ impl MachineNetworkStatusObservation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ManagedHostNetworkConfig {
     pub loopback_ip: Option<IpAddr>,
+    /// IPv6 loopback reserved for the FNN underlay. `None` keeps the existing
+    /// IPv4-only behavior for sites without `lo-ip-v6`.
+    pub loopback_ip_v6: Option<Ipv6Addr>,
     pub secondary_overlay_vtep_ip: Option<IpAddr>,
     /// This is a host-level field of the "consolidated" network
     /// config served to all [DPU] agents within host machine group.
@@ -190,6 +193,7 @@ impl Default for ManagedHostNetworkConfig {
     fn default() -> Self {
         ManagedHostNetworkConfig {
             loopback_ip: None,
+            loopback_ip_v6: None,
             secondary_overlay_vtep_ip: None,
             use_admin_network: Some(true),
             quarantine_state: None,
@@ -296,12 +300,14 @@ mod tests {
             "ipv4 round-trip" {
                 ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
                     use_admin_network: Some(true),
                     quarantine_state: None,
                     use_admin_network_changed: None,
                 } => Yields(ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
                     use_admin_network: Some(true),
                     quarantine_state: None,
@@ -309,11 +315,12 @@ mod tests {
                 }),
             }
 
-            "ipv6 round-trip" {
+            "generic IPv6 addresses round-trip" {
                 ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
                         0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
                     ))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
                         0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
                     ))),
@@ -324,9 +331,32 @@ mod tests {
                     loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
                         0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
                     ))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
                         0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
                     ))),
+                    use_admin_network: Some(false),
+                    quarantine_state: None,
+                    use_admin_network_changed: None,
+                }),
+            }
+
+            "dedicated IPv6 loopback round-trip" {
+                ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: Some(Ipv6Addr::new(
+                        0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                    )),
+                    secondary_overlay_vtep_ip: None,
+                    use_admin_network: Some(false),
+                    quarantine_state: None,
+                    use_admin_network_changed: None,
+                } => Yields(ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: Some(Ipv6Addr::new(
+                        0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                    )),
+                    secondary_overlay_vtep_ip: None,
                     use_admin_network: Some(false),
                     quarantine_state: None,
                     use_admin_network_changed: None,
@@ -335,15 +365,15 @@ mod tests {
         );
     }
 
-    // Deserialize raw JSON (as it would already exist in the database) into the
-    // IpAddr-typed config, projecting to the (loopback_ip, secondary_overlay_vtep_ip)
-    // pair the original tests asserted. Covers legacy IPv4 JSON and IPv6 JSON.
+    // `loopback_ip_v6` is optional in persisted machine JSON, so rows written
+    // before this field existed keep loading it as `None`. Once populated, the
+    // `Ipv6Addr` type rejects an IPv4 value before it can reach FNN rendering.
     #[test]
     fn test_managed_host_network_config_deserialize_json() {
         scenarios!(
             run = |json| {
                 serde_json::from_str::<ManagedHostNetworkConfig>(json)
-                    .map(|c| (c.loopback_ip, c.secondary_overlay_vtep_ip))
+                    .map(|c| (c.loopback_ip, c.secondary_overlay_vtep_ip, c.loopback_ip_v6))
                     .map_err(drop)
             };
             "legacy ipv4 json" {
@@ -352,22 +382,42 @@ mod tests {
                             "secondary_overlay_vtep_ip": "172.16.0.5",
                             "use_admin_network": true,
                             "quarantine_state": null
-                        }"# => Yields((
+                }"# => Yields((
                     Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
                     Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                    None,
                 )),
             }
 
-            "ipv6 json" {
+            "generic IPv6 address json" {
                 r#"{
                             "loopback_ip": "2001:db8::1",
                             "secondary_overlay_vtep_ip": null,
                             "use_admin_network": true,
                             "quarantine_state": null
-                        }"# => Yields((
+                }"# => Yields((
                     Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
                     None,
+                    None,
                 )),
+            }
+
+            "dedicated IPv6 loopback json" {
+                r#"{
+                            "loopback_ip": "10.0.0.1",
+                            "loopback_ip_v6": "2001:db8::1",
+                            "secondary_overlay_vtep_ip": null,
+                            "use_admin_network": true,
+                            "quarantine_state": null
+                        }"# => Yields((
+                    Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    None,
+                    Some(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                )),
+            }
+
+            "IPv4 rejected for dedicated IPv6 loopback" {
+                r#"{"loopback_ip_v6": "192.0.2.1"}"# => Fails,
             }
         );
     }
@@ -380,6 +430,7 @@ mod tests {
     fn test_managed_host_network_config_ipv4_json_format_unchanged() {
         let config = ManagedHostNetworkConfig {
             loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            loopback_ip_v6: None,
             secondary_overlay_vtep_ip: None,
             use_admin_network: Some(true),
             quarantine_state: None,
@@ -398,6 +449,8 @@ mod tests {
     #[test]
     fn test_managed_host_network_config_default() {
         let default = ManagedHostNetworkConfig::default();
+        assert_eq!(default.loopback_ip_v6, None);
+
         value_scenarios!(
             run = |ip| ip;
             "loopback_ip defaults to None" {
@@ -624,6 +677,7 @@ mod tests {
                             }
                         }"# => Yields(ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: None,
                     use_admin_network: Some(false),
                     quarantine_state: Some(ManagedHostQuarantineState {
@@ -637,6 +691,7 @@ mod tests {
             "empty object defaults all optional fields" {
                 "{}" => Yields(ManagedHostNetworkConfig {
                     loopback_ip: None,
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: None,
                     use_admin_network: None,
                     quarantine_state: None,
@@ -685,6 +740,7 @@ mod tests {
             "quarantine state round-trips" {
                 ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: None,
                     use_admin_network: Some(true),
                     quarantine_state: Some(ManagedHostQuarantineState {
@@ -694,6 +750,7 @@ mod tests {
                     use_admin_network_changed: None,
                 } => Yields(ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    loopback_ip_v6: None,
                     secondary_overlay_vtep_ip: None,
                     use_admin_network: Some(true),
                     quarantine_state: Some(ManagedHostQuarantineState {

--- a/crates/api-model/src/resource_pool/common.rs
+++ b/crates/api-model/src/resource_pool/common.rs
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::oneshot;
 
 use crate::resource_pool::{ResourcePool, ResourcePoolStats};
 
-/// DPU VPC loopback IP pool
-/// Must match a pool defined in dev/resource_pools.toml
+/// IPv4 DPU loopback IP pool.
 pub const LOOPBACK_IP: &str = "lo-ip";
+/// IPv6 DPU loopback IP pool used by the FNN underlay.
+pub const LOOPBACK_IP_V6: &str = "lo-ip-v6";
 /// VNI pool. FabricNetworkConfiguration
 /// Must match a pool defined in dev/resource_pools.toml
 pub const VNI: &str = "vni";
@@ -71,6 +72,7 @@ pub struct CommonPools {
 #[derive(Debug)]
 pub struct EthernetPools {
     pub pool_loopback_ip: Arc<ResourcePool<IpAddr>>,
+    pub pool_loopback_ip_v6: Arc<ResourcePool<Ipv6Addr>>,
     pub pool_vlan_id: Arc<ResourcePool<i16>>,
     pub pool_vni: Arc<ResourcePool<i32>>,
     pub pool_vpc_vni: Arc<ResourcePool<i32>>,

--- a/crates/api-model/src/test_support/machine_snapshot.rs
+++ b/crates/api-model/src/test_support/machine_snapshot.rs
@@ -384,6 +384,7 @@ pub fn machine_snapshot_pg_json(machine_id: MachineId) -> MachineSnapshotPgJson 
         network_config_version: config_version(3).version_string(),
         network_config: ManagedHostNetworkConfig {
             loopback_ip: Some(IpAddr::from([172, 20, 0, 42])),
+            loopback_ip_v6: None,
             secondary_overlay_vtep_ip: None,
             use_admin_network: Some(false),
             quarantine_state: None,

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -738,9 +738,10 @@ impl MachineCreator {
     // configures it appropriately, returning the new `Machine`.
     // If the DPU already exists in the machines table, this is a no-op and returns `None`.
     //
-    // The DPU's `network_config` is intentionally NOT written here -- the caller writes it after
-    // `attach_dpu_to_host` has wired the host link in `machine_interfaces`, so that
-    // `try_update_network_config`'s group sync observes both rows as siblings and keeps their
+    // `db::machine::create` can persist pool-backed defaults on the new row.
+    // The full `network_config` reconciliation and version bump wait until
+    // `attach_dpu_to_host` wires the host link in `machine_interfaces`; only
+    // then can `try_update_network_config` observe both siblings and keep their
     // versions equal.
     async fn create_dpu(
         &self,
@@ -973,6 +974,15 @@ impl MachineCreator {
             network_config.loopback_ip = Some(loopback_ip);
         }
 
+        if network_config.loopback_ip_v6.is_none() {
+            network_config.loopback_ip_v6 = db::machine::allocate_loopback_ip_v6(
+                &self.common_pools,
+                txn,
+                &dpu_machine.id.to_string(),
+            )
+            .await?;
+        }
+
         if self.config.allocate_secondary_vtep_ip
             && network_config.secondary_overlay_vtep_ip.is_none()
         {
@@ -985,8 +995,17 @@ impl MachineCreator {
             network_config.secondary_overlay_vtep_ip = Some(secondary_vtep_ip);
         }
 
-        db::machine::try_update_network_config(txn, &dpu_machine.id, version, &network_config)
-            .await?;
+        // A stale version must fail the whole transaction so any addresses
+        // allocated above return to their pools.
+        if !db::machine::try_update_network_config(txn, &dpu_machine.id, version, &network_config)
+            .await?
+        {
+            return Err(db::DatabaseError::ConcurrentModificationError(
+                "machine",
+                version.to_string(),
+            )
+            .into());
+        }
 
         Ok(())
     }

--- a/crates/site-explorer/tests/integration/machine_creator.rs
+++ b/crates/site-explorer/tests/integration/machine_creator.rs
@@ -603,6 +603,7 @@ async fn test_machine_creator_creates_multi_dpu_managed_host(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let resource_pools = ResourcePoolBuilder::default()
+        .with_loopback_ip_v6("2001:db8::/125")
         .with_secondary_vtep_ip("172.21.0.0/29")
         .build();
     let test_harness = TestHarness::builder(pool.clone())
@@ -625,6 +626,12 @@ async fn test_machine_creator_creates_multi_dpu_managed_host(
     let initial_loopback_pool_stats = db::resource_pool::stats(
         &mut *txn,
         env.api().common_pools().ethernet.pool_loopback_ip.name(),
+    )
+    .await?;
+
+    let initial_loopback_v6_pool_stats = db::resource_pool::stats(
+        &mut *txn,
+        env.api().common_pools().ethernet.pool_loopback_ip_v6.name(),
     )
     .await?;
 
@@ -714,6 +721,7 @@ async fn test_machine_creator_creates_multi_dpu_managed_host(
         txn.commit().await?;
 
         let expected_loopback_ip = dpu_machine.network_config.loopback_ip.unwrap().to_string();
+        assert!(dpu_machine.network_config.loopback_ip_v6.is_some());
         let expected_secondary_overlay_vtep_ip = dpu_machine
             .network_config
             .secondary_overlay_vtep_ip
@@ -762,6 +770,24 @@ async fn test_machine_creator_creates_multi_dpu_managed_host(
         assert_eq!(&hm.id, host_machine_id.as_ref().unwrap());
         dpu_machines.push(dpu_machine);
     }
+
+    let mut txn = env.pool.begin().await?;
+    assert_eq!(
+        db::resource_pool::stats(
+            &mut *txn,
+            env.api().common_pools().ethernet.pool_loopback_ip_v6.name()
+        )
+        .await?,
+        ResourcePoolStats {
+            used: expected_loopback_count,
+            free: initial_loopback_v6_pool_stats.free - expected_loopback_count,
+            auto_assign_free: initial_loopback_v6_pool_stats.free - expected_loopback_count,
+            auto_assign_used: expected_loopback_count,
+            non_auto_assign_free: 0,
+            non_auto_assign_used: 0
+        }
+    );
+    txn.commit().await?;
 
     // And make sure resource pool stats agree with how many
     // secondary vteps should have been assigned.

--- a/crates/test-harness/src/resource_pool.rs
+++ b/crates/test-harness/src/resource_pool.rs
@@ -25,16 +25,24 @@ use model::resource_pool::{ResourcePoolDef, ResourcePoolType};
 
 #[derive(Default)]
 pub struct ResourcePoolBuilder {
+    loopback_ip_v6: Option<IpNetwork>,
     secondary_vtep_ip: Option<IpNetwork>,
     vlan_id_ranges: Option<Vec<(u32, u32)>>,
     vni_ranges: Option<Vec<(u32, u32)>>,
 }
 
 impl ResourcePoolBuilder {
+    pub fn with_loopback_ip_v6(self, addr: &str) -> Self {
+        Self {
+            loopback_ip_v6: Some(
+                addr.parse()
+                    .expect("correct IP address / mask must be provided"),
+            ),
+            ..self
+        }
+    }
+
     pub fn with_secondary_vtep_ip(self, addr: &str) -> Self {
-        // This "allow" should be removed when more options will be
-        // added to the builder.
-        #[allow(clippy::needless_update)]
         Self {
             secondary_vtep_ip: Some(
                 addr.parse()
@@ -104,6 +112,17 @@ impl ResourcePoolBuilder {
         ]
         .into_iter()
         .map(Some)
+        .chain(iter::once(self.loopback_ip_v6.map(|network| {
+            (
+                resource_pool::common::LOOPBACK_IP_V6.to_string(),
+                ResourcePoolDef {
+                    pool_type: ResourcePoolType::Ipv6,
+                    prefix: Some(network.to_string()),
+                    ranges: vec![],
+                    delegate_prefix_len: None,
+                },
+            )
+        })))
         .chain(iter::once(self.secondary_vtep_ip.map(|network| {
             (
                 SECONDARY_VTEP_IP.to_string(),


### PR DESCRIPTION
As it stood, the IPv6 underlay work had nowhere durable to keep one loopback address per DPU. #2390 needs that value before it can render the IPv6 underlay, but there was no pool-backed `ManagedHostNetworkConfig.loopback_ip_v6` to provide one.

So, this adds the optional `lo-ip-v6` pool and reserves one typed `Ipv6Addr` per DPU. New DPU rows allocate it in `db::machine::create`; existing rows get a bounded backfill during startup or `AdminGrowResourcePool`; discovery and `MachineCreator` fill any remaining gap; and `admin_force_delete_machine` returns the reservation to the pool.

Mixed-version deployments need a little extra care here: an older API pod replaces the complete `network_config` document without fields it doesn't know. The targeted `preserve_machine_ipv6_loopback` trigger restores only an omitted `loopback_ip_v6`, while an explicit `null` from a current writer can still clear it. Backfill reuses the DPU's existing reservation, retries compare-and-swap conflicts, and refuses to write once `ForceDeletion` wins; deletion asks the pool for the owner's current reservation instead of trusting its earlier machine snapshot.

While collecting the missing address fields into one compare-and-swap write, this also fixes an existing secondary-VTEP leak: discovery could reserve `secondary_overlay_vtep_ip`, make a second write with the now-stale `network_config_version`, ignore the `false` return, and commit the reservation without persisting it. A failed compare-and-swap now fails the transaction, which returns every new address to its pool.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2389

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The new coverage walks typed serialization, IPv6 pool listing, reservation reuse and exhaustion, mixed-version writes, startup/runtime backfill, compare-and-swap retries, force-deletion races, discovery, cleanup, and multi-DPU `MachineCreator` creation.

```text
cargo make format-nightly
cargo make check-format-nightly
cargo make clippy
cargo make carbide-lints
cargo test -p carbide-api-model managed_host_network_config --lib -- --nocapture
cargo test -p carbide-api-db test_ipv6_pool_define_allocate_release --lib -- --nocapture
cargo test -p carbide-api-db ipv6_loopback --lib -- --nocapture
cargo test -p carbide-api-db find_owned_allocation_returns_typed_value_and_rejects_duplicates --lib -- --nocapture
cargo test -p carbide-api-core test_grow_ipv6_loopback_pool_backfills_existing_dpus --lib -- --nocapture
cargo test -p carbide-api-core test_discover_dpu_by_source_ip --lib -- --nocapture
cargo test -p carbide-api-core test_admin_force_delete_dpu_only --lib -- --nocapture
cargo test -p carbide-site-explorer --test integration test_machine_creator_creates_multi_dpu_managed_host
```

Tests added!

## Additional Notes

This intentionally does **NOT** enable IPv6 FNN rendering by itself. `lo-ip-v6` is optional, so sites without it keep their IPv4-only behavior; #2390 is the step that plumbs the persisted value into the underlay.

Deploy this change before configuring `lo-ip-v6` or rolling out #2390, so every API pod knows how to preserve the field before it can be written.

The grow-time backfill sees committed DPU rows. A creation transaction that crosses the first `lo-ip-v6` grow can land just after that scan; replaying the additive grow or restarting the API reruns the idempotent pass.

`AdminGrowResourcePool` commits the additive pool change before it starts per-DPU reconciliation. If reconciliation reports exhaustion or a persistent compare-and-swap conflict, the grow itself is already durable and the request can be replayed safely after correcting the pool or contention.

Startup uses the same per-DPU pass but logs a failure and continues, so one exhausted or busy DPU does not take the API offline while completed reservations remain persisted.

Closes #2389
