### PR TITLE
backport: #3769, #3779, #3781 to release/v2.0

### DIFF
--- a/crates/admin-cli/src/dpu/versions/cmd.rs
+++ b/crates/admin-cli/src/dpu/versions/cmd.rs
@@ -100,7 +100,7 @@ impl From<Machine> for DpuVersions {
             hbn_version: machine.inventory.and_then(|inv| {
                 inv.components
                     .into_iter()
-                    .find(|c| c.name == "doca-hbn" || c.name == "doca_hbn")
+                    .find(|c| c.name.contains("hbn"))
                     .map(|c| c.version)
             }),
             agent_version: machine.dpu_agent_version,

--- a/crates/admin-cli/src/dpu/versions/cmd.rs
+++ b/crates/admin-cli/src/dpu/versions/cmd.rs
@@ -100,7 +100,7 @@ impl From<Machine> for DpuVersions {
             hbn_version: machine.inventory.and_then(|inv| {
                 inv.components
                     .into_iter()
-                    .find(|c| c.name == "doca_hbn")
+                    .find(|c| c.name == "doca-hbn" || c.name == "doca_hbn")
                     .map(|c| c.version)
             }),
             agent_version: machine.dpu_agent_version,

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -22,6 +22,7 @@ use std::str::FromStr;
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::model::{RpcInto, RpcTryFrom};
 use ::rpc::{common as rpc_common, forge as rpc};
+use carbide_dpf::dpu_cr_name;
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use carbide_utils::arch::CpuArchitecture;
@@ -786,34 +787,46 @@ pub(crate) async fn update_agent_reported_inventory(
     // the DPF services directly. Read service versions from the DPF operator
     // on every inventory report so the DB stays current after upgrades.
     let mut txn = api.txn_begin().await?;
-    let dpu_machine = db::machine::find_one(
-        &mut txn,
-        &dpu_machine_id,
-        MachineSearchConfig {
-            include_dpus: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    let host_snapshot =
+        db::managed_host::load_snapshot(&mut txn, &dpu_machine_id, LoadSnapshotOptions::default())
+            .await?;
     txn.commit().await?;
 
-    if let Some(machine) = dpu_machine
-        && machine.config.dpf.used_for_ingestion
+    if let Some(snapshot) = host_snapshot
+        && snapshot.host_snapshot.config.dpf.used_for_ingestion
     {
+        let machine = snapshot
+            .dpu_snapshots
+            .iter()
+            .find(|d| d.id == dpu_machine_id)
+            .ok_or_else(|| CarbideError::NotFoundError {
+                kind: "dpu",
+                id: dpu_machine_id.to_string(),
+            })?;
+
         let dpf_sdk = api.dpf_sdk.as_ref().ok_or_else(|| {
             CarbideError::internal(format!(
-                "DPF SDK unavailable but DPU {dpu_machine_id} was ingested via DPF"
+                "dpf SDK unavailable but DPU {dpu_machine_id} was ingested via DPF"
             ))
         })?;
 
-        let device_name = machine.dpf_id().ok_or_else(|| {
-            CarbideError::InvalidArgument(format!(
-                "DPF-ingested DPU {dpu_machine_id} has no BMC MAC"
-            ))
-        })?;
+        // Both BMC MACs are needed to build the DPU CR name queried from the DPF
+        // operator. If either is not yet recorded, skip the DPF inventory update
+        // for this report rather than rejecting it; a later heartbeat retries once
+        // the MACs are known.
+        let (Some(dpu_device_id), Some(host_node_id)) =
+            (machine.dpf_id(), snapshot.host_snapshot.dpf_id())
+        else {
+            tracing::debug!(
+                machine_id = %dpu_machine_id,
+                "skipping DPF service inventory update: DPU or host BMC MAC not yet known"
+            );
+            return Ok(Response::new(()));
+        };
+        let dpu_name = dpu_cr_name(&dpu_device_id, &host_node_id);
 
         let service_versions = dpf_sdk
-            .get_service_versions_for_dpu(&device_name)
+            .get_service_versions_for_dpu(&dpu_name)
             .await
             .map_err(|e| CarbideError::internal(e.to_string()))?;
 
@@ -823,7 +836,7 @@ pub(crate) async fn update_agent_reported_inventory(
                 .map(|v| MachineInventorySoftwareComponent {
                     name: v.name,
                     version: v.version,
-                    url: String::new(),
+                    url: v.url,
                 })
                 .collect(),
         };

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -793,7 +793,7 @@ pub(crate) async fn update_agent_reported_inventory(
     txn.commit().await?;
 
     if let Some(snapshot) = host_snapshot
-        && snapshot.host_snapshot.config.dpf.used_for_ingestion
+        && snapshot.host_snapshot.dpf.used_for_ingestion
     {
         let machine = snapshot
             .dpu_snapshots

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -34,7 +34,7 @@ use db::{
 use futures_util::future::join_all;
 use itertools::Itertools;
 use model::extension_service::{ExtensionService, ExtensionServiceVersionInfo};
-use model::hardware_info::MachineInventory;
+use model::hardware_info::{MachineInventory, MachineInventorySoftwareComponent};
 use model::instance::config::extension_services::InstanceExtensionServiceConfig;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::MachineNetworkStatusObservation;
@@ -781,6 +781,64 @@ pub(crate) async fn update_agent_reported_inventory(
 
     let request = request.into_inner();
     let dpu_machine_id = convert_and_log_machine_id(request.machine_id.as_ref())?;
+
+    // For DPF-ingested DPUs the agent runs containerized and cannot enumerate
+    // the DPF services directly. Read service versions from the DPF operator
+    // on every inventory report so the DB stays current after upgrades.
+    let mut txn = api.txn_begin().await?;
+    let dpu_machine = db::machine::find_one(
+        &mut txn,
+        &dpu_machine_id,
+        MachineSearchConfig {
+            include_dpus: true,
+            ..Default::default()
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    if let Some(machine) = dpu_machine
+        && machine.config.dpf.used_for_ingestion
+    {
+        let dpf_sdk = api.dpf_sdk.as_ref().ok_or_else(|| {
+            CarbideError::internal(format!(
+                "DPF SDK unavailable but DPU {dpu_machine_id} was ingested via DPF"
+            ))
+        })?;
+
+        let device_name = machine.dpf_id().ok_or_else(|| {
+            CarbideError::InvalidArgument(format!(
+                "DPF-ingested DPU {dpu_machine_id} has no BMC MAC"
+            ))
+        })?;
+
+        let service_versions = dpf_sdk
+            .get_service_versions_for_dpu(&device_name)
+            .await
+            .map_err(|e| CarbideError::internal(e.to_string()))?;
+
+        let inventory = MachineInventory {
+            components: service_versions
+                .into_iter()
+                .map(|v| MachineInventorySoftwareComponent {
+                    name: v.name,
+                    version: v.version,
+                    url: String::new(),
+                })
+                .collect(),
+        };
+
+        let mut txn = api.txn_begin().await?;
+        db::machine::update_agent_reported_inventory(&mut txn, &dpu_machine_id, &inventory).await?;
+        txn.commit().await?;
+
+        tracing::debug!(
+            machine_id = %dpu_machine_id,
+            component_count = inventory.components.len(),
+            "updated DPF service inventory from operator",
+        );
+        return Ok(Response::new(()));
+    }
 
     if let Some(inventory) = request.inventory.as_ref() {
         let mut txn = api.txn_begin().await?;

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1757,6 +1757,14 @@ pub enum DpfState {
         #[serde(default)]
         phase_detail: Option<String>,
     },
+    /// Executing a DPF-requested power cycle. `state.version.timestamp()`
+    /// records when this step started; the handler uses it to enforce the
+    /// configured power-transition delay (`reachability_params.power_down_wait`).
+    HandleReboot {
+        op: PerformPowerOperation,
+        #[serde(default)]
+        retry_count: u32,
+    },
     /// DPU device reported ready by the DPF operator. Carbide
     /// waits for all DPUs to reach this state before proceeding.
     DeviceReady,

--- a/crates/api-web/src/dpu_versions.rs
+++ b/crates/api-web/src/dpu_versions.rs
@@ -76,7 +76,7 @@ impl From<forgerpc::Machine> for Row {
                     inventory
                         .components
                         .iter()
-                        .find(|c| c.name == "forge-dpu-agent")
+                        .find(|c| c.name == "carbide-dpu-agent" || c.name == "forge-dpu-agent")
                         .map(|c| c.version.clone())
                 })
                 .unwrap_or_default(),
@@ -102,7 +102,7 @@ impl From<forgerpc::Machine> for Row {
                 .and_then(|inv| {
                     inv.components
                         .iter()
-                        .find(|c| c.name == "doca_hbn")
+                        .find(|c| c.name == "doca-hbn" || c.name == "doca_hbn")
                         .map(|c| c.version.clone())
                 })
                 .unwrap_or_default(),

--- a/crates/api-web/src/dpu_versions.rs
+++ b/crates/api-web/src/dpu_versions.rs
@@ -102,7 +102,7 @@ impl From<forgerpc::Machine> for Row {
                 .and_then(|inv| {
                     inv.components
                         .iter()
-                        .find(|c| c.name == "doca-hbn" || c.name == "doca_hbn")
+                        .find(|c| c.name.contains("hbn"))
                         .map(|c| c.version.clone())
                 })
                 .unwrap_or_default(),

--- a/crates/api-web/src/network_status.rs
+++ b/crates/api-web/src/network_status.rs
@@ -250,7 +250,7 @@ async fn fetch_network_status(
                 inventory
                     .components
                     .iter()
-                    .find(|c| c.name == "forge-dpu-agent")
+                    .find(|c| c.name == "carbide-dpu-agent" || c.name == "forge-dpu-agent")
                     .map(|c| c.version.clone())
             })
             .unwrap_or_default();

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -79,11 +79,11 @@ pub use sdk::{
 };
 pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
-    BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DpuDeploymentType,
-    DpuDeviceInfo, DpuErrorEvent, DpuEvent, DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent,
-    DpuServiceVersion, InitDpfResourcesConfig, MaintenanceEvent, RebootRequiredEvent,
-    ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
-    ServiceInterface, ServiceNAD, ServiceNADResourceType,
+    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuErrorEvent, DpuEvent,
+    DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent, DpuServiceVersion, InitDpfResourcesConfig,
+    MaintenanceEvent, RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort,
+    ServiceConfigPortProtocol, ServiceDefinition, ServiceInterface, ServiceNAD,
+    ServiceNADResourceType,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -79,10 +79,11 @@ pub use sdk::{
 };
 pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
-    BmcPasswordProvider, ConfigPortsServiceType, DpuDeviceInfo, DpuErrorEvent, DpuEvent,
-    DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent, InitDpfResourcesConfig, MaintenanceEvent,
-    RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType,
+    BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DpuDeploymentType,
+    DpuDeviceInfo, DpuErrorEvent, DpuEvent, DpuMismatch, DpuNodeInfo, DpuPhase, DpuReadyEvent,
+    DpuServiceVersion, InitDpfResourcesConfig, MaintenanceEvent, RebootRequiredEvent,
+    ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
+    ServiceInterface, ServiceNAD, ServiceNADResourceType,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -75,12 +75,13 @@ use crate::repository::{
     K8sConfigRepository,
 };
 use crate::types::{
-    BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
-    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails, DpuDeviceInfo, DpuDeviceSummary,
-    DpuMismatch, DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
-    DpuServiceInterfaceTemplateType, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot,
-    InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
+    BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME,
+    DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails,
+    DpuDeploymentType, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch, DpuNodeInfo, DpuNodeSummary,
+    DpuPhase, DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType,
+    DpuServiceVersion, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig,
+    OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol, ServiceDefinition,
+    ServiceNADResourceType, ServiceTemplateVersion,
 };
 use crate::watcher::DpuWatcherBuilder;
 
@@ -1798,6 +1799,81 @@ impl<R: DpuServiceTemplateRepository, L> DpfSdk<R, L> {
                 }
             })
             .collect())
+    }
+}
+
+impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, L> DpfSdk<R, L> {
+    /// Resolve the installed service versions for a DPU by looking up its owning
+    /// DPUDeployment (via the `svc.dpu.nvidia.com/owned-by-dpudeployment` label on the DPU CR)
+    /// and reading each service's DPUServiceTemplate.
+    ///
+    /// Version is taken from `helmChart.values.image.tag` when set and non-empty;
+    /// otherwise falls back to `helmChart.source.version`.
+    pub async fn get_service_versions_for_dpu(
+        &self,
+        dpu_device_name: &str,
+    ) -> Result<Vec<DpuServiceVersion>, DpfError> {
+        let dpu = DpuRepository::get(&*self.repo, dpu_device_name, &self.namespace)
+            .await?
+            .ok_or_else(|| {
+                DpfError::InvalidState(format!("DPU CR not found: {dpu_device_name}"))
+            })?;
+
+        let owner_label = dpu
+            .metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
+            .ok_or_else(|| {
+                DpfError::InvalidState(format!(
+                    "DPU {dpu_device_name} is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label"
+                ))
+            })?;
+
+        let deployment_name = owner_label
+            .strip_prefix(&format!("{}_", self.namespace))
+            .unwrap_or(owner_label.as_str());
+
+        let deployment =
+            DpuDeploymentRepository::get(&*self.repo, deployment_name, &self.namespace)
+                .await?
+                .ok_or_else(|| {
+                    DpfError::InvalidState(format!(
+                        "DPUDeployment {deployment_name} not found for DPU {dpu_device_name}"
+                    ))
+                })?;
+
+        let mut versions = Vec::new();
+        for (service_name, service) in &deployment.spec.services {
+            let Some(template_name) = &service.service_template else {
+                continue;
+            };
+            let Some(template) =
+                DpuServiceTemplateRepository::get(&*self.repo, template_name, &self.namespace)
+                    .await?
+            else {
+                continue;
+            };
+
+            let version = template
+                .spec
+                .helm_chart
+                .values
+                .as_ref()
+                .and_then(|v| v.get("image"))
+                .and_then(|img| img.get("tag"))
+                .and_then(|tag| tag.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&template.spec.helm_chart.source.version)
+                .to_string();
+
+            versions.push(DpuServiceVersion {
+                name: service_name.clone(),
+                version,
+            });
+        }
+
+        Ok(versions)
     }
 }
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1807,17 +1807,21 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
     /// DPUDeployment (via the `svc.dpu.nvidia.com/owned-by-dpudeployment` label on the DPU CR)
     /// and reading each service's DPUServiceTemplate.
     ///
-    /// Version is taken from `helmChart.values.image.tag` when set and non-empty;
-    /// otherwise falls back to `helmChart.source.version`.
+    /// Each returned [`DpuServiceVersion`] is derived per field:
+    /// - `version`: `helmChart.values.image.tag` when set and non-empty, else
+    ///   `helmChart.source.version`.
+    /// - `url` + `name`: when `helmChart.values.image.repository` is set, it is
+    ///   split at its final `/` into `url` (registry/path) and `name` (image name);
+    ///   otherwise `url` is `helmChart.source.repoURL` and `name` is
+    ///   `helmChart.source.chart`. If no name can be derived, the DPUDeployment
+    ///   service name is used.
     pub async fn get_service_versions_for_dpu(
         &self,
-        dpu_device_name: &str,
+        dpu_name: &str,
     ) -> Result<Vec<DpuServiceVersion>, DpfError> {
-        let dpu = DpuRepository::get(&*self.repo, dpu_device_name, &self.namespace)
+        let dpu = DpuRepository::get(&*self.repo, dpu_name, &self.namespace)
             .await?
-            .ok_or_else(|| {
-                DpfError::InvalidState(format!("DPU CR not found: {dpu_device_name}"))
-            })?;
+            .ok_or_else(|| DpfError::InvalidState(format!("DPU CR not found: {dpu_name}")))?;
 
         let owner_label = dpu
             .metadata
@@ -1826,7 +1830,7 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
             .and_then(|l| l.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
             .ok_or_else(|| {
                 DpfError::InvalidState(format!(
-                    "DPU {dpu_device_name} is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label"
+                    "DPU {dpu_name} is missing {DPU_OWNED_BY_DEPLOYMENT_LABEL} label"
                 ))
             })?;
 
@@ -1839,7 +1843,7 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
                 .await?
                 .ok_or_else(|| {
                     DpfError::InvalidState(format!(
-                        "DPUDeployment {deployment_name} not found for DPU {dpu_device_name}"
+                        "DPUDeployment {deployment_name} not found for DPU {dpu_name}"
                     ))
                 })?;
 
@@ -1855,22 +1859,55 @@ impl<R: DpuRepository + DpuDeploymentRepository + DpuServiceTemplateRepository, 
                 continue;
             };
 
-            let version = template
+            let image_values = template
                 .spec
                 .helm_chart
                 .values
                 .as_ref()
-                .and_then(|v| v.get("image"))
+                .and_then(|v| v.get("image"));
+            let image_tag = image_values
                 .and_then(|img| img.get("tag"))
                 .and_then(|tag| tag.as_str())
-                .filter(|s| !s.is_empty())
-                .unwrap_or(&template.spec.helm_chart.source.version)
-                .to_string();
+                .filter(|s| !s.is_empty());
+            let image_repo = image_values
+                .and_then(|img| img.get("repository"))
+                .and_then(|r| r.as_str())
+                .filter(|s| !s.is_empty());
 
-            versions.push(DpuServiceVersion {
-                name: service_name.clone(),
-                version,
-            });
+            // Version is the image tag when set, otherwise the Helm chart version.
+            // These are independent of the image repository: a template that only
+            // overrides the tag must still report that tag.
+            let version = image_tag
+                .map(str::to_string)
+                .unwrap_or_else(|| template.spec.helm_chart.source.version.clone());
+
+            // url + name: split the image repository at its final '/' when present
+            // (registry/path as url, image name as name); otherwise fall back to the
+            // Helm source repo URL and chart name.
+            let (url, mut name) = if let Some(repo) = image_repo {
+                repo.rsplit_once('/')
+                    .map(|(prefix, base)| (prefix.to_string(), base.to_string()))
+                    .unwrap_or_else(|| (String::new(), repo.to_string()))
+            } else {
+                (
+                    template.spec.helm_chart.source.repo_url.clone(),
+                    template
+                        .spec
+                        .helm_chart
+                        .source
+                        .chart
+                        .clone()
+                        .unwrap_or_default(),
+                )
+            };
+
+            // Never emit a nameless component; the DPUDeployment service name is a
+            // stable identifier when neither the image basename nor chart name is set.
+            if name.is_empty() {
+                name = service_name.clone();
+            }
+
+            versions.push(DpuServiceVersion { name, version, url });
         }
 
         Ok(versions)

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -75,13 +75,12 @@ use crate::repository::{
     K8sConfigRepository,
 };
 use crate::types::{
-    BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME,
-    DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails,
-    DpuDeploymentType, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch, DpuNodeInfo, DpuNodeSummary,
-    DpuPhase, DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType,
-    DpuServiceVersion, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot, InitDpfResourcesConfig,
-    OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol, ServiceDefinition,
-    ServiceNADResourceType, ServiceTemplateVersion,
+    BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
+    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails, DpuDeviceInfo, DpuDeviceSummary,
+    DpuMismatch, DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
+    DpuServiceInterfaceTemplateType, DpuServiceVersion, DpuSummary, FMDS_SERVICE_NAME,
+    HostDpfSnapshot, InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME,
+    ServiceConfigPortProtocol, ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
 };
 use crate::watcher::DpuWatcherBuilder;
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -441,10 +441,15 @@ pub struct DpuSummary {
 /// Used by [`crate::DpfSdk::get_service_versions_for_dpu`] to populate the DPU inventory.
 #[derive(Debug, Clone)]
 pub struct DpuServiceVersion {
-    /// The `deployment_service_name` from the DPUServiceTemplate (e.g. `"doca-hbn"`).
+    /// Image case: basename after the final `/` of `helmChart.values.image.repository`.
+    /// Helm fallback: `helmChart.source.chart`.
     pub name: String,
-    /// Docker image tag if set in `helmChart.values.image.tag`, otherwise the helm chart version.
+    /// Image case: `helmChart.values.image.tag`.
+    /// Helm fallback: `helmChart.source.version`.
     pub version: String,
+    /// Image case: `helmChart.values.image.repository` up to (not including) the final `/`.
+    /// Helm fallback: `helmChart.source.repoURL`.
+    pub url: String,
 }
 
 /// Helm-chart version observed on a live `DPUServiceTemplate` CR. Used by

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -437,6 +437,16 @@ pub struct DpuSummary {
     pub status_bfb_file: Option<String>,
 }
 
+/// Service version resolved from a DPUDeployment's services and their DPUServiceTemplate CRs.
+/// Used by [`crate::DpfSdk::get_service_versions_for_dpu`] to populate the DPU inventory.
+#[derive(Debug, Clone)]
+pub struct DpuServiceVersion {
+    /// The `deployment_service_name` from the DPUServiceTemplate (e.g. `"doca-hbn"`).
+    pub name: String,
+    /// Docker image tag if set in `helmChart.values.image.tag`, otherwise the helm chart version.
+    pub version: String,
+}
+
 /// Helm-chart version observed on a live `DPUServiceTemplate` CR. Used by
 /// [`crate::DpfSdk::list_service_template_versions`] so callers (e.g. the
 /// admin CLI) can compare configured vs deployed versions.

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use carbide_dpf::types::{HostDpfSnapshot, ServiceTemplateVersion};
+use carbide_dpf::types::{DpuServiceVersion, HostDpfSnapshot, ServiceTemplateVersion};
 use carbide_dpf::{
     BmcPasswordProvider, DpfError, DpfSdk, DpuDeviceInfo, DpuNodeInfo, DpuPhase, DpuWatcher,
     KubeRepository, ResourceLabeler, node_id_from_dpu_node_cr_name,
@@ -97,6 +97,18 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// CR — used for comparing config vs deployed state.
     async fn list_service_template_versions(&self)
     -> Result<Vec<ServiceTemplateVersion>, DpfError>;
+
+    /// Get service versions for a DPU from its owning DPUDeployment.
+    ///
+    /// Looks up the DPU CR by device name, follows the
+    /// `svc.dpu.nvidia.com/owned-by-dpudeployment` label to find the owning
+    /// DPUDeployment, and resolves each service's version from its
+    /// DPUServiceTemplate. Used to populate `agent_reported_inventory` once
+    /// the DPU reaches `DpuPhase::Ready`.
+    async fn get_service_versions_for_dpu(
+        &self,
+        dpu_device_name: &str,
+    ) -> Result<Vec<DpuServiceVersion>, DpfError>;
 
     /// Return DPUs whose installed BFB or `spec.dpuFlavor` does not match
     /// the namespace's ready DPUDeployment, mapped back to carbide
@@ -503,6 +515,13 @@ impl DpfOperations for DpfSdkOps {
         &self,
     ) -> Result<Vec<ServiceTemplateVersion>, DpfError> {
         self.sdk.list_service_template_versions().await
+    }
+
+    async fn get_service_versions_for_dpu(
+        &self,
+        dpu_device_name: &str,
+    ) -> Result<Vec<DpuServiceVersion>, DpfError> {
+        self.sdk.get_service_versions_for_dpu(dpu_device_name).await
     }
 
     async fn find_outdated_dpus_dpf(&self) -> Result<Vec<OutdatedDpfDpu>, DpfError> {

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -107,7 +107,7 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
     /// the DPU reaches `DpuPhase::Ready`.
     async fn get_service_versions_for_dpu(
         &self,
-        dpu_device_name: &str,
+        dpu_name: &str,
     ) -> Result<Vec<DpuServiceVersion>, DpfError>;
 
     /// Return DPUs whose installed BFB or `spec.dpuFlavor` does not match
@@ -519,9 +519,9 @@ impl DpfOperations for DpfSdkOps {
 
     async fn get_service_versions_for_dpu(
         &self,
-        dpu_device_name: &str,
+        dpu_name: &str,
     ) -> Result<Vec<DpuServiceVersion>, DpfError> {
-        self.sdk.get_service_versions_for_dpu(dpu_device_name).await
+        self.sdk.get_service_versions_for_dpu(dpu_name).await
     }
 
     async fn find_outdated_dpus_dpf(&self) -> Result<Vec<OutdatedDpfDpu>, DpfError> {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2219,7 +2219,7 @@ pub async fn check_restart_in_logs(
 }
 
 // Function to wait for some time in state machine.
-fn wait(basetime: &DateTime<Utc>, wait_time: Duration) -> bool {
+pub(super) fn wait(basetime: &DateTime<Utc>, wait_time: Duration) -> bool {
     let expected_time = *basetime + wait_time;
     let current_time = Utc::now();
 
@@ -2784,7 +2784,15 @@ async fn handle_dpu_reprovision(
                     "DPF reprovision state reached but DPF is not configured"
                 ))
             })?;
-            dpf::handle_dpf_state(state, dpu_snapshot, substate, ctx, dpf).await
+            dpf::handle_dpf_state(
+                state,
+                dpu_snapshot,
+                substate,
+                ctx,
+                dpf,
+                reachability_params.power_down_wait,
+            )
+            .await
         }
         ReprovisionState::InstallDpuOs { substate } => {
             handle_bfb_install_state(
@@ -4229,7 +4237,15 @@ impl DpuMachineStateHandler {
                         "DPF state reached but DPF is not configured"
                     ))
                 })?;
-                dpf::handle_dpf_state(state, dpu_snapshot, dpf_state, ctx, dpf_sdk).await
+                dpf::handle_dpf_state(
+                    state,
+                    dpu_snapshot,
+                    dpf_state,
+                    ctx,
+                    dpf_sdk,
+                    self.reachability_params.power_down_wait,
+                )
+                .await
             }
             DpuInitState::WaitingForPlatformPowercycle {
                 substate: PerformPowerOperation::Off,

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -27,7 +27,8 @@ use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
 use model::machine::{
     DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
-    ManagedHostState, ManagedHostStateSnapshot, ReprovisionState, StateMachineArea,
+    ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation, ReprovisionState,
+    StateMachineArea,
 };
 use state_controller::state_handler::{
     ExternalServiceError, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
@@ -283,22 +284,33 @@ async fn handle_dpf_provisioning(
     Ok(StateHandlerOutcome::transition(next))
 }
 
-/// Power-cycle the host for a DPF reboot request. ForceOff then On across
-/// iterations; calls `reboot_complete` as soon as the On command is issued.
-async fn handle_dpf_reboot(
+/// Handle `DpfState::HandleReboot`: drive a DPF-requested power cycle using
+/// explicit per-step state rather than timestamp heuristics.
+///
+/// Transitions:
+/// - `Off`: wait for `power_state == Off` + 30 s → issue On →
+///   `HandleReboot { On, now }`
+/// - `On`:  wait for `power_state == On`  + 30 s → `reboot_complete` →
+///   `WaitingForReady`
+async fn handle_dpf_handle_reboot(
     state: &ManagedHostStateSnapshot,
-    dpu_snapshot: &Machine,
-    waiting_phase_detail: &Option<String>,
-    current_phase: &DpuPhase,
+    op: &PerformPowerOperation,
+    retry_count: u32,
     node_name: &str,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let reboot_already_requested = state
-        .host_snapshot
-        .last_reboot_requested
-        .as_ref()
-        .is_some_and(|r| r.time > state.host_snapshot.state.version.timestamp());
+    const MAX_RETRIES: u32 = 3;
+
+    if super::wait(
+        &state.host_snapshot.state.version.timestamp(),
+        power_down_wait,
+    ) {
+        return Ok(StateHandlerOutcome::wait(
+            "waiting for power transition delay".into(),
+        ));
+    }
 
     let power_state = {
         let redfish_client = ctx
@@ -308,23 +320,82 @@ async fn handle_dpf_reboot(
         host_power_state(redfish_client.as_ref()).await?
     };
 
-    if !reboot_already_requested && power_state != libredfish::PowerState::Off {
-        handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
-    } else if power_state == libredfish::PowerState::Off {
-        handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
-        dpf_sdk
-            .reboot_complete(node_name)
-            .await
-            .map_err(dpf_error)?;
+    match op {
+        PerformPowerOperation::Off => {
+            if power_state == libredfish::PowerState::Off {
+                handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::HandleReboot {
+                        op: PerformPowerOperation::On,
+                        retry_count: 0,
+                    },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else if retry_count < MAX_RETRIES {
+                tracing::warn!(
+                    host = %state.host_snapshot.id,
+                    retry_count,
+                    "Host did not power off; retrying ForceOff"
+                );
+                handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::HandleReboot {
+                        op: PerformPowerOperation::Off,
+                        retry_count: retry_count + 1,
+                    },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else {
+                tracing::error!(
+                    host = %state.host_snapshot.id,
+                    max_retries = MAX_RETRIES,
+                    "Host did not power off after max retries; manual intervention required"
+                );
+                Err(StateHandlerError::ManualInterventionRequired(
+                    "host did not power off; manual intervention required".into(),
+                ))
+            }
+        }
+        PerformPowerOperation::On => {
+            if power_state == libredfish::PowerState::On {
+                dpf_sdk
+                    .reboot_complete(node_name)
+                    .await
+                    .map_err(dpf_error)?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::WaitingForReady { phase_detail: None },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else if retry_count < MAX_RETRIES {
+                tracing::warn!(
+                    host = %state.host_snapshot.id,
+                    retry_count,
+                    "Host did not power on; retrying On"
+                );
+                handler_host_power_control(state, ctx, SystemPowerControl::On).await?;
+                let next = transition_all_dpus_to_dpf_state(
+                    DpfState::HandleReboot {
+                        op: PerformPowerOperation::On,
+                        retry_count: retry_count + 1,
+                    },
+                    state,
+                )?;
+                Ok(StateHandlerOutcome::transition(next))
+            } else {
+                tracing::error!(
+                    host = %state.host_snapshot.id,
+                    max_retries = MAX_RETRIES,
+                    "Host did not power on after max retries; manual intervention required"
+                );
+                Err(StateHandlerError::ManualInterventionRequired(
+                    "host did not power on; manual intervention required".into(),
+                ))
+            }
+        }
     }
-
-    update_phase_detail_or_wait(
-        state,
-        &dpu_snapshot.id,
-        waiting_phase_detail,
-        current_phase,
-        "Power cycling host for DPF reboot",
-    )
 }
 
 /// Handle DpfState::WaitingForReady: release hold, reboot handling,
@@ -353,16 +424,15 @@ async fn handle_dpf_waiting_for_ready(
         .await
         .map_err(dpf_error)?
     {
-        return handle_dpf_reboot(
+        handler_host_power_control(state, ctx, SystemPowerControl::ForceOff).await?;
+        let next = transition_all_dpus_to_dpf_state(
+            DpfState::HandleReboot {
+                op: PerformPowerOperation::Off,
+                retry_count: 0,
+            },
             state,
-            dpu_snapshot,
-            waiting_phase_detail,
-            &current_phase,
-            &node_name,
-            ctx,
-            dpf_sdk,
-        )
-        .await;
+        )?;
+        return Ok(StateHandlerOutcome::transition(next));
     }
 
     if current_phase == carbide_dpf::DpuPhase::Error {
@@ -477,6 +547,7 @@ pub async fn handle_dpf_state(
     dpf_state: &DpfState,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     if !dpf_sdk
@@ -510,6 +581,18 @@ pub async fn handle_dpf_state(
         DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk).await,
         DpfState::WaitingForReady { phase_detail } => {
             handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
+        }
+        DpfState::HandleReboot { op, retry_count } => {
+            handle_dpf_handle_reboot(
+                state,
+                op,
+                *retry_count,
+                &node_name,
+                ctx,
+                dpf_sdk,
+                power_down_wait,
+            )
+            .await
         }
         DpfState::DeviceReady => handle_dpf_device_ready(state),
         DpfState::Reprovisioning => {

--- a/crates/machine-controller/src/handler/helpers.rs
+++ b/crates/machine-controller/src/handler/helpers.rs
@@ -126,13 +126,14 @@ pub trait NextState {
                     all_machine_ids,
                 ),
             ReprovisionState::DpfStates { substate } => match substate {
-                DpfState::WaitingForReady { .. } | DpfState::DeviceReady => {
-                    ReprovisionState::PoweringOffHost.next_state_with_all_dpus_updated(
+                DpfState::WaitingForReady { .. }
+                | DpfState::HandleReboot { .. }
+                | DpfState::DeviceReady => ReprovisionState::PoweringOffHost
+                    .next_state_with_all_dpus_updated(
                         &state.managed_state,
                         &state.dpu_snapshots,
                         all_machine_ids,
-                    )
-                }
+                    ),
                 DpfState::Reprovisioning => ReprovisionState::DpfStates {
                     substate: DpfState::Provisioning,
                 }


### PR DESCRIPTION
Backport of three fixes from main to `release/v2.0`:

| PR | Title |
|---|---|
| #3769 | fix (dpf): Update SoftwareInventory details for the DPF ingested nodes |
| #3779 | fix: Use states to manage reboot operation to avoid race condition |
| #3781 | fix: Add URL in SoftwareInventory in UI/cli |

### Backport notes

Two v2.0 compatibility fixups were needed (not present in the original PRs):

- `BlueFieldSoftwareParams` and `DpuDeploymentType` removed from dpf import lists — these types were introduced after v2.0 by #3361 and #3084 and do not exist on this branch.
- `Machine.dpf.used_for_ingestion` used instead of `Machine.config.dpf.used_for_ingestion` — the `Machine` struct layout differs between main and v2.0.

## Related issues
#3769, #3779, #3781

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
