### PR TITLE
fix(machine-controller): stop polling terminal boot-order jobs

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -3037,6 +3037,189 @@ async fn test_set_boot_order_sets_order_without_reasserting_when_device_configur
     );
 }
 
+const TEST_BOOT_ORDER_JOB_ID: &str = "JID_BOOT_ORDER_SCHEDULING";
+
+/// Runs one job state through the persisted boot-order scheduling phase and
+/// returns the resulting boot-order state.
+async fn run_wait_for_set_boot_order_job_scheduled(
+    env: &TestEnv,
+    mh: &TestManagedHost,
+    job_state: libredfish::JobState,
+    retry_count: u32,
+) -> SetBootOrderInfo {
+    env.redfish_sim.set_job_state_sequence(vec![job_state]);
+    set_host_controller_state_stuck_in(
+        env,
+        mh.host().id,
+        &ManagedHostState::HostInit {
+            machine_state: MachineState::SetBootOrder {
+                set_boot_order_info: Some(SetBootOrderInfo {
+                    set_boot_order_jid: Some(TEST_BOOT_ORDER_JOB_ID.to_string()),
+                    set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
+                    retry_count,
+                }),
+            },
+        },
+        0,
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostInit {
+        machine_state:
+            MachineState::SetBootOrder {
+                set_boot_order_info: Some(set_boot_order_info),
+            },
+    } = host.current_state()
+    else {
+        panic!(
+            "expected HostInit/SetBootOrder, got: {:?}",
+            host.current_state()
+        );
+    };
+    set_boot_order_info.clone()
+}
+
+/// A scheduled job still advances to the reboot phase with its job and retry
+/// context intact.
+#[crate::sqlx_test]
+async fn test_wait_for_set_boot_order_job_scheduled_advances_to_reboot(pool: sqlx::PgPool) {
+    const RETRY_COUNT: u32 = 2;
+
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    let set_boot_order_info = run_wait_for_set_boot_order_job_scheduled(
+        &env,
+        &mh,
+        libredfish::JobState::Scheduled,
+        RETRY_COUNT,
+    )
+    .await;
+
+    assert_eq!(
+        set_boot_order_info,
+        SetBootOrderInfo {
+            set_boot_order_jid: Some(TEST_BOOT_ORDER_JOB_ID.to_string()),
+            set_boot_order_state: SetBootOrderState::RebootHost,
+            retry_count: RETRY_COUNT,
+        }
+    );
+}
+
+/// A job that is still running remains in the scheduling wait without losing
+/// its job or retry context.
+#[crate::sqlx_test]
+async fn test_wait_for_set_boot_order_job_scheduled_keeps_waiting_for_running_job(
+    pool: sqlx::PgPool,
+) {
+    const RETRY_COUNT: u32 = 2;
+
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    let set_boot_order_info = run_wait_for_set_boot_order_job_scheduled(
+        &env,
+        &mh,
+        libredfish::JobState::Running,
+        RETRY_COUNT,
+    )
+    .await;
+
+    assert_eq!(
+        set_boot_order_info,
+        SetBootOrderInfo {
+            set_boot_order_jid: Some(TEST_BOOT_ORDER_JOB_ID.to_string()),
+            set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
+            retry_count: RETRY_COUNT,
+        }
+    );
+}
+
+/// Terminal job states observed before the boot-order reboot enter the existing
+/// job-failure recovery without losing the retry budget or diagnostic context.
+#[crate::sqlx_test]
+async fn test_wait_for_set_boot_order_job_scheduled_routes_terminal_errors_to_recovery(
+    pool: sqlx::PgPool,
+) {
+    use carbide_test_support::Outcome::Yields;
+    use carbide_test_support::{Case, check_cases_async};
+
+    const RETRY_COUNT: u32 = 2;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct FailureTransition {
+        power_state: PowerState,
+        job_id_cleared: bool,
+        retry_count: u32,
+        diagnostic_has_job_id: bool,
+        diagnostic_has_job_state: bool,
+    }
+
+    let expected = || FailureTransition {
+        power_state: PowerState::Off,
+        job_id_cleared: true,
+        retry_count: RETRY_COUNT,
+        diagnostic_has_job_id: true,
+        diagnostic_has_job_state: true,
+    };
+
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    check_cases_async(
+        [
+            Case {
+                scenario: "scheduled with errors",
+                input: libredfish::JobState::ScheduledWithErrors,
+                expect: Yields(expected()),
+            },
+            Case {
+                scenario: "completed with errors",
+                input: libredfish::JobState::CompletedWithErrors,
+                expect: Yields(expected()),
+            },
+            Case {
+                scenario: "failed",
+                input: libredfish::JobState::Failed,
+                expect: Yields(expected()),
+            },
+        ],
+        |job_state| {
+            let env = &env;
+            let mh = &mh;
+            async move {
+                let job_state_diagnostic = format!("{job_state:?}");
+                let set_boot_order_info =
+                    run_wait_for_set_boot_order_job_scheduled(env, mh, job_state, RETRY_COUNT)
+                        .await;
+                let SetBootOrderState::HandleJobFailure {
+                    failure,
+                    power_state,
+                } = &set_boot_order_info.set_boot_order_state
+                else {
+                    return Err(format!(
+                        "expected HandleJobFailure, got: {:?}",
+                        set_boot_order_info.set_boot_order_state
+                    ));
+                };
+
+                Ok(FailureTransition {
+                    power_state: *power_state,
+                    job_id_cleared: set_boot_order_info.set_boot_order_jid.is_none(),
+                    retry_count: set_boot_order_info.retry_count,
+                    diagnostic_has_job_id: failure.contains(TEST_BOOT_ORDER_JOB_ID),
+                    diagnostic_has_job_state: failure.contains(&job_state_diagnostic),
+                })
+            }
+        },
+    )
+    .await;
+}
+
 /// The reboot that applies a boot-order job can independently revert a managed
 /// BIOS setting. Final verification checks BIOS before order, routes back to
 /// the shared job-aware stages, and carries the existing convergence budget.

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11552,6 +11552,26 @@ async fn set_host_boot_order(
                     .await
                     .map_err(|e| redfish_error("get_job_state", e))?;
 
+                if job_state.is_error_state() {
+                    tracing::warn!(
+                        %job_id,
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        job_state = ?job_state,
+                        "SetBootOrder: job failed while waiting for scheduling, transitioning to HandleJobFailure",
+                    );
+
+                    return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                        set_boot_order_jid: None,
+                        set_boot_order_state: SetBootOrderState::HandleJobFailure {
+                            failure: format!(
+                                "Job {job_id} failed while waiting to be scheduled: {job_state:#?}"
+                            ),
+                            power_state: PowerState::Off,
+                        },
+                        retry_count: set_boot_order_info.retry_count,
+                    }));
+                }
+
                 if !matches!(job_state, libredfish::JobState::Scheduled) {
                     return Err(StateHandlerError::GenericError(eyre::eyre!(
                         "waiting for job {:#?} to be scheduled; current state: {job_state:#?}",


### PR DESCRIPTION
When a job ID was present, `WaitForSetBootOrderJobScheduled` treated every state besides `Scheduled` as retryable. `JobState::is_error_state()` classifies `ScheduledWithErrors`, `CompletedWithErrors`, and `Failed` as terminal, so one of those results could leave the controller polling the same persisted state instead of entering bounded recovery.

So, terminal errors now enter the existing `HandleJobFailure` path. This clears the failed job ID, preserves the retry count and job details, and lets the existing BMC reset and power recovery check the BIOS and boot order before retrying, with its bounded retry and manual-intervention behavior unchanged.

No persisted model or database migration is added.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3907

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Verified with:

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo test -p carbide-api-core test_wait_for_set_boot_order_job_scheduled --lib -- --nocapture`
- `git diff --check`

Closes #3907
