### PR TITLE
feat(dpu-remediation): count executor failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,9 @@ name = "carbide-dpu-remediation"
 version = "0.0.0"
 dependencies = [
  "carbide-dpu-agent-utils",
+ "carbide-instrument",
  "carbide-rpc",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/dpu-remediation/Cargo.toml
+++ b/crates/dpu-remediation/Cargo.toml
@@ -38,7 +38,12 @@ uuid = { workspace = true }
 
 # [local-dependencies]
 carbide-dpu-agent-utils = { path = "../dpu-agent-utils" }
+carbide-instrument = { path = "../instrument" }
+carbide-rpc = { path = "../rpc" }
 carbide-tls = { path = "../tls" }
 carbide-uuid = { path = "../uuid" }
-carbide-rpc = { path = "../rpc" }
 carbide-utils = { path = "../utils" }
+
+[dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }

--- a/crates/dpu-remediation/src/lib.rs
+++ b/crates/dpu-remediation/src/lib.rs
@@ -14,4 +14,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+mod metrics;
 pub mod remediation;

--- a/crates/dpu-remediation/src/metrics.rs
+++ b/crates/dpu-remediation/src/metrics.rs
@@ -1,0 +1,387 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Correlated logs and bounded failure counters for the remediation executor.
+//!
+//! These Events share one counter keyed by the stage that stopped an executor
+//! pass. Machine and remediation identifiers remain log context so they do not
+//! create unbounded metric series.
+
+use carbide_instrument::{Event, LabelValue};
+use carbide_uuid::dpu_remediations::RemediationId;
+use carbide_uuid::machine::MachineId;
+
+/// Where one executor pass stopped, as the bounded `failure_stage` label
+/// shared by the Events below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum RemediationExecutorFailureStage {
+    StatusDecode,
+    Apply,
+    ResponseValidation,
+    Fetch,
+    ClientCreation,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dpu_remediation_status_output_decode_failed",
+    metric_name = "carbide_dpu_remediation_executor_failures_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Unable to deserialize json into hashmap from status output file",
+    describe = "Number of DPU remediation executor failures, by failure stage."
+)]
+pub(crate) struct RemediationStatusOutputDecodeFailed {
+    #[label]
+    failure_stage: RemediationExecutorFailureStage,
+    #[context]
+    dpu_machine_id: MachineId,
+    #[context]
+    remediation_id: RemediationId,
+    #[context]
+    error: String,
+}
+
+impl RemediationStatusOutputDecodeFailed {
+    pub(crate) fn new(
+        dpu_machine_id: MachineId,
+        remediation_id: RemediationId,
+        error: String,
+    ) -> Self {
+        Self {
+            failure_stage: RemediationExecutorFailureStage::StatusDecode,
+            dpu_machine_id,
+            remediation_id,
+            error,
+        }
+    }
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dpu_remediation_apply_failed",
+    metric_name = "carbide_dpu_remediation_executor_failures_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Remediation failed",
+    describe = "Number of DPU remediation executor failures, by failure stage."
+)]
+pub(crate) struct RemediationApplyFailed {
+    #[label]
+    failure_stage: RemediationExecutorFailureStage,
+    #[context]
+    dpu_machine_id: MachineId,
+    #[context]
+    remediation_id: RemediationId,
+    #[context]
+    error: String,
+}
+
+impl RemediationApplyFailed {
+    pub(crate) fn new(
+        dpu_machine_id: MachineId,
+        remediation_id: RemediationId,
+        error: String,
+    ) -> Self {
+        Self {
+            failure_stage: RemediationExecutorFailureStage::Apply,
+            dpu_machine_id,
+            remediation_id,
+            error,
+        }
+    }
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dpu_remediation_response_invalid",
+    metric_name = "carbide_dpu_remediation_executor_failures_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "received a response with one of id or script but not both, skipping, will retry next loop",
+    describe = "Number of DPU remediation executor failures, by failure stage."
+)]
+pub(crate) struct RemediationResponseInvalid {
+    #[label]
+    failure_stage: RemediationExecutorFailureStage,
+    #[context]
+    dpu_machine_id: MachineId,
+    #[context(value)]
+    has_script: bool,
+    #[context(value)]
+    has_remediation_id: bool,
+}
+
+impl RemediationResponseInvalid {
+    pub(crate) fn new(
+        dpu_machine_id: MachineId,
+        has_script: bool,
+        has_remediation_id: bool,
+    ) -> Self {
+        Self {
+            failure_stage: RemediationExecutorFailureStage::ResponseValidation,
+            dpu_machine_id,
+            has_script,
+            has_remediation_id,
+        }
+    }
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dpu_remediation_fetch_failed",
+    metric_name = "carbide_dpu_remediation_executor_failures_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Remediation executor unable to fetch next remediation this loop, will retry next loop",
+    describe = "Number of DPU remediation executor failures, by failure stage."
+)]
+pub(crate) struct RemediationFetchFailed {
+    #[label]
+    failure_stage: RemediationExecutorFailureStage,
+    #[context]
+    dpu_machine_id: MachineId,
+    #[context]
+    error: String,
+}
+
+impl RemediationFetchFailed {
+    pub(crate) fn new(dpu_machine_id: MachineId, error: String) -> Self {
+        Self {
+            failure_stage: RemediationExecutorFailureStage::Fetch,
+            dpu_machine_id,
+            error,
+        }
+    }
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dpu_remediation_client_creation_failed",
+    metric_name = "carbide_dpu_remediation_executor_failures_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Remediation executor unable to create forge client this loop, will retry next loop",
+    describe = "Number of DPU remediation executor failures, by failure stage."
+)]
+pub(crate) struct RemediationClientCreationFailed {
+    #[label]
+    failure_stage: RemediationExecutorFailureStage,
+    #[context]
+    dpu_machine_id: MachineId,
+    #[context]
+    error: String,
+}
+
+impl RemediationClientCreationFailed {
+    pub(crate) fn new(dpu_machine_id: MachineId, error: String) -> Self {
+        Self {
+            failure_stage: RemediationExecutorFailureStage::ClientCreation,
+            dpu_machine_id,
+            error,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use carbide_instrument::emit;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    const FAILURE_METRIC: &str = "carbide_dpu_remediation_executor_failures_total";
+    const DPU_MACHINE_ID: &str = "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30";
+    const REMEDIATION_ID: &str = "00000000-0000-0000-0000-000000000000";
+
+    enum FailureCase {
+        StatusDecode,
+        Apply,
+        ResponseValidation,
+        Fetch,
+        ClientCreation,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct FailureObservation {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        failure_stage: Option<String>,
+        dpu_machine_id: Option<String>,
+        remediation_id: Option<String>,
+        error: Option<String>,
+        has_script: Option<String>,
+        has_remediation_id: Option<String>,
+        counter_delta: f64,
+    }
+
+    #[test]
+    fn executor_failures_log_and_count_by_stage() {
+        value_scenarios!(
+            run = |case| {
+                let dpu_machine_id = MachineId::from_str(DPU_MACHINE_ID).unwrap();
+                let remediation_id = RemediationId::nil();
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| match case {
+                    FailureCase::StatusDecode => {
+                        emit(RemediationStatusOutputDecodeFailed::new(
+                            dpu_machine_id,
+                            remediation_id,
+                            "expected value at line 1 column 1".to_string(),
+                        ));
+                    }
+                    FailureCase::Apply => {
+                        emit(RemediationApplyFailed::new(
+                            dpu_machine_id,
+                            remediation_id,
+                            "transport error".to_string(),
+                        ));
+                    }
+                    FailureCase::ResponseValidation => {
+                        emit(RemediationResponseInvalid::new(dpu_machine_id, true, false));
+                    }
+                    FailureCase::Fetch => {
+                        emit(RemediationFetchFailed::new(
+                            dpu_machine_id,
+                            "service unavailable".to_string(),
+                        ));
+                    }
+                    FailureCase::ClientCreation => {
+                        emit(RemediationClientCreationFailed::new(
+                            dpu_machine_id,
+                            "invalid endpoint".to_string(),
+                        ));
+                    }
+                });
+                assert_eq!(logs.len(), 1, "each failure should write one terminal record");
+                let log = logs.first().expect("failure Event did not log");
+                let failure_stage = log.field("failure_stage").map(str::to_string);
+
+                FailureObservation {
+                    level: log.level,
+                    metadata_name: log.metadata_name.clone(),
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    failure_stage: failure_stage.clone(),
+                    dpu_machine_id: log.field("dpu_machine_id").map(str::to_string),
+                    remediation_id: log.field("remediation_id").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    has_script: log.field("has_script").map(str::to_string),
+                    has_remediation_id: log
+                        .field("has_remediation_id")
+                        .map(str::to_string),
+                    counter_delta: metrics.counter_delta(
+                        FAILURE_METRIC,
+                        &[("failure_stage", failure_stage.as_deref().unwrap())],
+                    ),
+                }
+            };
+            "status output cannot be decoded" {
+                FailureCase::StatusDecode => FailureObservation {
+                    level: tracing::Level::ERROR,
+                    metadata_name: "dpu_remediation_status_output_decode_failed".to_string(),
+                    message: "Unable to deserialize json into hashmap from status output file".to_string(),
+                    event_name: Some("dpu_remediation_status_output_decode_failed".to_string()),
+                    metric_name: Some(FAILURE_METRIC.to_string()),
+                    failure_stage: Some("status_decode".to_string()),
+                    dpu_machine_id: Some(DPU_MACHINE_ID.to_string()),
+                    remediation_id: Some(REMEDIATION_ID.to_string()),
+                    error: Some("expected value at line 1 column 1".to_string()),
+                    has_script: None,
+                    has_remediation_id: None,
+                    counter_delta: 1.0,
+                },
+            }
+            "local apply or report path fails" {
+                FailureCase::Apply => FailureObservation {
+                    level: tracing::Level::ERROR,
+                    metadata_name: "dpu_remediation_apply_failed".to_string(),
+                    message: "Remediation failed".to_string(),
+                    event_name: Some("dpu_remediation_apply_failed".to_string()),
+                    metric_name: Some(FAILURE_METRIC.to_string()),
+                    failure_stage: Some("apply".to_string()),
+                    dpu_machine_id: Some(DPU_MACHINE_ID.to_string()),
+                    remediation_id: Some(REMEDIATION_ID.to_string()),
+                    error: Some("transport error".to_string()),
+                    has_script: None,
+                    has_remediation_id: None,
+                    counter_delta: 1.0,
+                },
+            }
+            "Forge response has only one required field" {
+                FailureCase::ResponseValidation => FailureObservation {
+                    level: tracing::Level::ERROR,
+                    metadata_name: "dpu_remediation_response_invalid".to_string(),
+                    message: "received a response with one of id or script but not both, skipping, will retry next loop".to_string(),
+                    event_name: Some("dpu_remediation_response_invalid".to_string()),
+                    metric_name: Some(FAILURE_METRIC.to_string()),
+                    failure_stage: Some("response_validation".to_string()),
+                    dpu_machine_id: Some(DPU_MACHINE_ID.to_string()),
+                    remediation_id: None,
+                    error: None,
+                    has_script: Some("true".to_string()),
+                    has_remediation_id: Some("false".to_string()),
+                    counter_delta: 1.0,
+                },
+            }
+            "next remediation fetch fails" {
+                FailureCase::Fetch => FailureObservation {
+                    level: tracing::Level::ERROR,
+                    metadata_name: "dpu_remediation_fetch_failed".to_string(),
+                    message: "Remediation executor unable to fetch next remediation this loop, will retry next loop".to_string(),
+                    event_name: Some("dpu_remediation_fetch_failed".to_string()),
+                    metric_name: Some(FAILURE_METRIC.to_string()),
+                    failure_stage: Some("fetch".to_string()),
+                    dpu_machine_id: Some(DPU_MACHINE_ID.to_string()),
+                    remediation_id: None,
+                    error: Some("service unavailable".to_string()),
+                    has_script: None,
+                    has_remediation_id: None,
+                    counter_delta: 1.0,
+                },
+            }
+            "Forge client cannot be created" {
+                FailureCase::ClientCreation => FailureObservation {
+                    level: tracing::Level::ERROR,
+                    metadata_name: "dpu_remediation_client_creation_failed".to_string(),
+                    message: "Remediation executor unable to create forge client this loop, will retry next loop".to_string(),
+                    event_name: Some("dpu_remediation_client_creation_failed".to_string()),
+                    metric_name: Some(FAILURE_METRIC.to_string()),
+                    failure_stage: Some("client_creation".to_string()),
+                    dpu_machine_id: Some(DPU_MACHINE_ID.to_string()),
+                    remediation_id: None,
+                    error: Some("invalid endpoint".to_string()),
+                    has_script: None,
+                    has_remediation_id: None,
+                    counter_delta: 1.0,
+                },
+            }
+        );
+    }
+}

--- a/crates/dpu-remediation/src/remediation.rs
+++ b/crates/dpu-remediation/src/remediation.rs
@@ -21,6 +21,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
+use carbide_instrument::emit;
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::dpu_remediations::RemediationId;
 use carbide_uuid::machine::MachineId;
@@ -30,6 +31,11 @@ use rpc::forge::{
     GetNextRemediationForMachineRequest, RemediationApplicationStatus, RemediationAppliedRequest,
 };
 use rpc::forge_tls_client::ForgeClientConfig;
+
+use crate::metrics::{
+    RemediationApplyFailed, RemediationClientCreationFailed, RemediationFetchFailed,
+    RemediationResponseInvalid, RemediationStatusOutputDecodeFailed,
+};
 
 const MIN_INITIAL_DELAY_TIME_SECS: u64 = 48; // 80% of 60
 const MAX_INITIAL_DELAY_TIME_SECS: u64 = 72; // 120% of 60
@@ -107,56 +113,57 @@ impl RemediationExecutor {
             .spawn()?;
         let output_fut = process.wait_with_output();
 
-        let (succeeded, results) = match tokio::time::timeout(
-            Duration::from_secs(MAX_SCRIPT_TIMEOUT_SECS),
-            output_fut,
-        )
-        .await
-        {
-            Ok(result) => match result {
-                Ok(output) => {
-                    let exit_status = output.status;
-                    let succeeded = exit_status.success();
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    let _ignored = tokio::fs::write(&stdout_path, &output.stdout).await;
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    let _ignored = tokio::fs::write(&stderr_path, &output.stderr).await;
+        let (succeeded, results) =
+            match tokio::time::timeout(Duration::from_secs(MAX_SCRIPT_TIMEOUT_SECS), output_fut)
+                .await
+            {
+                Ok(result) => match result {
+                    Ok(output) => {
+                        let exit_status = output.status;
+                        let succeeded = exit_status.success();
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        let _ignored = tokio::fs::write(&stdout_path, &output.stdout).await;
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        let _ignored = tokio::fs::write(&stderr_path, &output.stderr).await;
 
-                    tracing::debug!("Remediation stdout:\n{}", stdout);
-                    tracing::debug!("Remediation stderr:\n{}", stderr);
+                        tracing::debug!("Remediation stdout:\n{}", stdout);
+                        tracing::debug!("Remediation stderr:\n{}", stderr);
 
-                    let status_file_str = tokio::fs::read_to_string(&status_path).await?;
-                    let results = if !status_file_str.is_empty() {
-                        serde_json::from_str::<HashMap<String, String>>(&status_file_str).map_err(|err| {
-                                tracing::error!(
-                                    error = ?err,
-                                    "Unable to deserialize json into hashmap from status output file",
-                                );
-                            }).unwrap_or_default()
-                    } else {
-                        HashMap::new()
-                    };
+                        let status_file_str = tokio::fs::read_to_string(&status_path).await?;
+                        let results = if !status_file_str.is_empty() {
+                            serde_json::from_str::<HashMap<String, String>>(&status_file_str)
+                                .map_err(|error| {
+                                    emit(RemediationStatusOutputDecodeFailed::new(
+                                        self.machine_info.machine_id,
+                                        remediation_id,
+                                        format!("{error:?}"),
+                                    ));
+                                })
+                                .unwrap_or_default()
+                        } else {
+                            HashMap::new()
+                        };
 
-                    (succeeded, results)
-                }
-                Err(process_error) => {
+                        (succeeded, results)
+                    }
+                    Err(process_error) => {
+                        let results = HashMap::from([(
+                            "status".to_string(),
+                            format!("process_execution_error: {process_error}"),
+                        )]);
+
+                        (false, results)
+                    }
+                },
+                Err(_elapsed_timeout_err) => {
                     let results = HashMap::from([(
                         "status".to_string(),
-                        format!("process_execution_error: {process_error}"),
+                        "elapsed_script_timeout_error".to_string(),
                     )]);
 
                     (false, results)
                 }
-            },
-            Err(_elapsed_timeout_err) => {
-                let results = HashMap::from([(
-                    "status".to_string(),
-                    "elapsed_script_timeout_error".to_string(),
-                )]);
-
-                (false, results)
-            }
-        };
+            };
 
         let metadata = results.none_if_empty().map(|results| {
             let labels = results
@@ -227,7 +234,11 @@ impl RemediationExecutor {
                                             tracing::debug!("Remediation successfully applied.");
                                         }
                                         Err(error) => {
-                                            tracing::error!(?error, "Remediation failed",);
+                                            emit(RemediationApplyFailed::new(
+                                                self.machine_info.machine_id,
+                                                *remediation_id,
+                                                format!("{error:?}"),
+                                            ));
                                         }
                                     }
                                 }
@@ -235,28 +246,27 @@ impl RemediationExecutor {
                                     tracing::debug!("no remediation this loop, nothing to do.");
                                 }
                                 _ => {
-                                    tracing::error!(
-                                        has_script = next_remediation.remediation_script.is_some(),
-                                        has_remediation_id =
-                                            next_remediation.remediation_id.is_some(),
-                                        "received a response with one of id or script but not both, skipping, will retry next loop",
-                                    );
+                                    emit(RemediationResponseInvalid::new(
+                                        self.machine_info.machine_id,
+                                        next_remediation.remediation_script.is_some(),
+                                        next_remediation.remediation_id.is_some(),
+                                    ));
                                 }
                             }
                         }
                         Err(remediation_fetch_error) => {
-                            tracing::error!(
-                                error = ?remediation_fetch_error,
-                                "Remediation executor unable to fetch next remediation this loop, will retry next loop",
-                            );
+                            emit(RemediationFetchFailed::new(
+                                self.machine_info.machine_id,
+                                format!("{remediation_fetch_error:?}"),
+                            ));
                         }
                     }
                 }
                 Err(client_creation_error) => {
-                    tracing::error!(
-                        error = ?client_creation_error,
-                        "Remediation executor unable to create forge client this loop, will retry next loop",
-                    );
+                    emit(RemediationClientCreationFailed::new(
+                        self.machine_info.machine_id,
+                        format!("{client_creation_error:?}"),
+                    ));
                 }
             }
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -56,6 +56,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpu_agent_report_total</td><td>counter</td><td>Number of DPU-agent report-loop iterations, by loop and outcome</td></tr>
 <tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>Number of DPU agents which have reported a certain version.</td></tr>
 <tr><td>carbide_dpu_firmware_version_count</td><td>gauge</td><td>Number of DPUs which have reported a certain firmware version.</td></tr>
+<tr><td>carbide_dpu_remediation_executor_failures_total</td><td>counter</td><td>Number of DPU remediation executor failures, by failure stage.</td></tr>
 <tr><td>carbide_dpus_healthy_count</td><td>gauge</td><td>Number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>Number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
 <tr><td>carbide_dropped_v6_requests_total</td><td>counter</td><td>Number of dropped DHCPv6 requests, by reason.</td></tr>


### PR DESCRIPTION
DPU remediation now exposes executor failures as a bounded per-stage counter while retaining the existing retry diagnostics.

- Covers status decoding, local apply/report, response validation, remediation fetch, and Forge client creation failures.
- Keeps machine and remediation identifiers, error text, and response booleans in log context rather than metric labels.
- Leaves delivered script failures and timeouts on the existing result-reporting path instead of counting them as executor failures.
- Covers every `failure_stage` with table-driven log and counter assertions.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3911

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-dpu-remediation`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`
- `cargo xtask check-metric-docs`
- `cargo xtask check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

A remediation script reporting failure remains a delivered script result and does not increment the executor-failure counter by itself.
