### PR TITLE
feat(scout): time storage device cleanup

### DIFF
--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 
 use ::rpc::forge as rpc;
 use carbide_host_support::hardware_enumeration::discovery_ibs;
+use carbide_instrument::emit;
 use carbide_uuid::machine::MachineId;
 use regex::Regex;
 use scout::CarbideClientError;
@@ -28,6 +29,7 @@ use tracing::Instrument;
 use crate::cfg::Options;
 use crate::client::create_forge_client;
 use crate::deprovision::cmdrun;
+use crate::metrics::{ScoutStorageDeviceCleanup, StorageDeviceType};
 use crate::{CarbideClientResult, IN_QEMU_VM, platform};
 
 fn check_memory_overwrite_efi_var() -> Result<(), CarbideClientError> {
@@ -449,19 +451,18 @@ async fn all_nvme_cleanup() -> Result<(), CarbideClientError> {
                     let result = clean_this_nvme(&nvmename).await;
                     let duration = device_start.elapsed();
 
+                    emit(ScoutStorageDeviceCleanup::new(
+                        StorageDeviceType::Nvme,
+                        duration,
+                        &result,
+                    ));
                     match result {
-                        Ok(()) => {
-                            tracing::info!(?duration, "Cleanup completed successfully");
-                            Ok(())
-                        }
-                        Err(error) => {
-                            tracing::error!(?duration, %error, "Cleanup failed");
-                            Err(CleanupFailure {
-                                device,
-                                duration,
-                                error,
-                            })
-                        }
+                        Ok(()) => Ok(()),
+                        Err(error) => Err(CleanupFailure {
+                            device,
+                            duration,
+                            error,
+                        }),
                     }
                 }
                 .instrument(span),
@@ -743,19 +744,18 @@ async fn all_hdd_cleanup() -> Result<(), CarbideClientError> {
                     let result = clean_this_block_device(&devpath).await;
                     let duration = device_start.elapsed();
 
+                    emit(ScoutStorageDeviceCleanup::new(
+                        StorageDeviceType::HddSas,
+                        duration,
+                        &result,
+                    ));
                     match result {
-                        Ok(()) => {
-                            tracing::info!(?duration, "Cleanup completed successfully");
-                            Ok(())
-                        }
-                        Err(error) => {
-                            tracing::error!(?duration, %error, "Cleanup failed");
-                            Err(CleanupFailure {
-                                device,
-                                duration,
-                                error,
-                            })
-                        }
+                        Ok(()) => Ok(()),
+                        Err(error) => Err(CleanupFailure {
+                            device,
+                            duration,
+                            error,
+                        }),
                     }
                 }
                 .instrument(span),

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -21,8 +21,12 @@
 //! the records operators use to diagnose those outcomes.
 //! `ScoutStreamConnection` remains metric-only because the surrounding stream
 //! lifecycle logs already carry the endpoint and machine context.
+//! The storage cleanup Event keeps each device's terminal record together with
+//! the duration histogram operators use to compare NVMe and HDD/SAS cleanup.
 
-use carbide_instrument::{DynamicMessage, Event, LabelValue, Outcome};
+use std::time::Duration;
+
+use carbide_instrument::{DynamicLog, DynamicMessage, Event, LabelValue, LogAt, Outcome};
 use carbide_uuid::machine::MachineId;
 use rpc::forge_agent_control_response as fac;
 
@@ -133,12 +137,90 @@ pub struct ScoutStreamReconnect {
     pub machine_id: MachineId,
 }
 
+/// Which storage cleanup path scout ran for a device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum StorageDeviceType {
+    Nvme,
+    HddSas,
+}
+
+/// `ScoutStorageDeviceCleanup` records one device's terminal result. The
+/// enclosing cleanup span keeps the device path on the record, while this
+/// Event adds the bounded labels and duration sample.
+#[derive(Event)]
+#[event(
+    event_name = "scout_storage_device_cleanup",
+    metric_name = "carbide_scout_storage_device_cleanup_duration_seconds",
+    component = "nico-scout",
+    log = dynamic,
+    metric = histogram,
+    message = dynamic,
+    describe = "Duration of per-device scout storage cleanup operations, by device type and outcome."
+)]
+pub(crate) struct ScoutStorageDeviceCleanup {
+    #[label]
+    device_type: StorageDeviceType,
+    #[label]
+    outcome: Outcome,
+    #[observation]
+    took: Duration,
+    /// `duration` retains the existing Debug-formatted log field; `took`
+    /// records the same value in seconds.
+    #[context]
+    duration: String,
+    /// Failure detail; successful cleanup uses `""` because an Event keeps one
+    /// stable set of context fields.
+    #[context]
+    error: String,
+}
+
+impl ScoutStorageDeviceCleanup {
+    pub(crate) fn new<E>(
+        device_type: StorageDeviceType,
+        duration: Duration,
+        result: &Result<(), E>,
+    ) -> Self
+    where
+        E: std::fmt::Display,
+    {
+        Self {
+            device_type,
+            outcome: Outcome::from(result),
+            took: duration,
+            duration: format!("{duration:?}"),
+            error: result
+                .as_ref()
+                .err()
+                .map(ToString::to_string)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl DynamicLog for ScoutStorageDeviceCleanup {
+    fn log_at(&self) -> LogAt {
+        match self.outcome {
+            Outcome::Ok => LogAt::Level(tracing::Level::INFO),
+            Outcome::Error => LogAt::Level(tracing::Level::ERROR),
+        }
+    }
+}
+
+impl DynamicMessage for ScoutStorageDeviceCleanup {
+    fn message(&self) -> &'static str {
+        match self.outcome {
+            Outcome::Ok => "Cleanup completed successfully",
+            Outcome::Error => "Cleanup failed",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr as _;
 
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
     use super::*;
@@ -426,6 +508,205 @@ mod tests {
         assert_eq!(
             metrics.counter_delta("carbide_scout_stream_reconnects_total", &[]),
             1.0
+        );
+    }
+
+    #[test]
+    fn storage_device_cleanup_logs_and_records_duration() {
+        const METRIC_NAME: &str = "carbide_scout_storage_device_cleanup_duration_seconds";
+
+        enum CleanupCase {
+            Succeeded {
+                device_type: StorageDeviceType,
+                duration: Duration,
+            },
+            Failed {
+                device_type: StorageDeviceType,
+                duration: Duration,
+                error: &'static str,
+            },
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct LogObservation {
+            metadata_name: String,
+            level: tracing::Level,
+            message: String,
+            event_name: Option<String>,
+            metric_name: Option<String>,
+            device_type: Option<String>,
+            outcome: Option<String>,
+            duration: Option<String>,
+            duration_kind: Option<CapturedFieldKind>,
+            error: Option<String>,
+            error_kind: Option<CapturedFieldKind>,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            log_count: usize,
+            log: Option<LogObservation>,
+            histogram_count_delta: u64,
+            histogram_sum_delta: f64,
+        }
+
+        fn observe(case: CleanupCase) -> Observation {
+            let metrics = MetricsCapture::start();
+            let (device_type, duration, result) = match case {
+                CleanupCase::Succeeded {
+                    device_type,
+                    duration,
+                } => (device_type, duration, Ok(())),
+                CleanupCase::Failed {
+                    device_type,
+                    duration,
+                    error,
+                } => (device_type, duration, Err(error)),
+            };
+            let device_type_label = device_type.label_value().to_string();
+            let outcome_label = match result {
+                Ok(()) => "ok",
+                Err(_) => "error",
+            };
+            let labels = [
+                ("device_type", device_type_label.as_str()),
+                ("outcome", outcome_label),
+            ];
+            let logs = capture_logs(|| {
+                emit(ScoutStorageDeviceCleanup::new(
+                    device_type,
+                    duration,
+                    &result,
+                ));
+            });
+            let log = logs.first().map(|log| LogObservation {
+                metadata_name: log.metadata_name.clone(),
+                level: log.level,
+                message: log.message.clone(),
+                event_name: log.field("event_name").map(str::to_string),
+                metric_name: log.field("metric_name").map(str::to_string),
+                device_type: log.field("device_type").map(str::to_string),
+                outcome: log.field("outcome").map(str::to_string),
+                duration: log.field("duration").map(str::to_string),
+                duration_kind: log.field_kind("duration"),
+                error: log.field("error").map(str::to_string),
+                error_kind: log.field_kind("error"),
+            });
+
+            Observation {
+                log_count: logs.len(),
+                log,
+                histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &labels),
+                histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &labels),
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "NVMe cleanup succeeded",
+                    input: CleanupCase::Succeeded {
+                        device_type: StorageDeviceType::Nvme,
+                        duration: Duration::from_millis(250),
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            metadata_name: "scout_storage_device_cleanup".to_string(),
+                            level: tracing::Level::INFO,
+                            message: "Cleanup completed successfully".to_string(),
+                            event_name: Some("scout_storage_device_cleanup".to_string()),
+                            metric_name: Some(METRIC_NAME.to_string()),
+                            device_type: Some("nvme".to_string()),
+                            outcome: Some("ok".to_string()),
+                            duration: Some("250ms".to_string()),
+                            duration_kind: Some(CapturedFieldKind::Debug),
+                            error: Some(String::new()),
+                            error_kind: Some(CapturedFieldKind::Debug),
+                        }),
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 0.25,
+                    },
+                },
+                Check {
+                    scenario: "NVMe cleanup failed",
+                    input: CleanupCase::Failed {
+                        device_type: StorageDeviceType::Nvme,
+                        duration: Duration::from_millis(500),
+                        error: "NVMe sanitize command failed",
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            metadata_name: "scout_storage_device_cleanup".to_string(),
+                            level: tracing::Level::ERROR,
+                            message: "Cleanup failed".to_string(),
+                            event_name: Some("scout_storage_device_cleanup".to_string()),
+                            metric_name: Some(METRIC_NAME.to_string()),
+                            device_type: Some("nvme".to_string()),
+                            outcome: Some("error".to_string()),
+                            duration: Some("500ms".to_string()),
+                            duration_kind: Some(CapturedFieldKind::Debug),
+                            error: Some("NVMe sanitize command failed".to_string()),
+                            error_kind: Some(CapturedFieldKind::Debug),
+                        }),
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 0.5,
+                    },
+                },
+                Check {
+                    scenario: "HDD/SAS cleanup succeeded",
+                    input: CleanupCase::Succeeded {
+                        device_type: StorageDeviceType::HddSas,
+                        duration: Duration::from_millis(750),
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            metadata_name: "scout_storage_device_cleanup".to_string(),
+                            level: tracing::Level::INFO,
+                            message: "Cleanup completed successfully".to_string(),
+                            event_name: Some("scout_storage_device_cleanup".to_string()),
+                            metric_name: Some(METRIC_NAME.to_string()),
+                            device_type: Some("hdd_sas".to_string()),
+                            outcome: Some("ok".to_string()),
+                            duration: Some("750ms".to_string()),
+                            duration_kind: Some(CapturedFieldKind::Debug),
+                            error: Some(String::new()),
+                            error_kind: Some(CapturedFieldKind::Debug),
+                        }),
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 0.75,
+                    },
+                },
+                Check {
+                    scenario: "HDD/SAS cleanup failed",
+                    input: CleanupCase::Failed {
+                        device_type: StorageDeviceType::HddSas,
+                        duration: Duration::from_secs(1),
+                        error: "HDD security erase failed",
+                    },
+                    expect: Observation {
+                        log_count: 1,
+                        log: Some(LogObservation {
+                            metadata_name: "scout_storage_device_cleanup".to_string(),
+                            level: tracing::Level::ERROR,
+                            message: "Cleanup failed".to_string(),
+                            event_name: Some("scout_storage_device_cleanup".to_string()),
+                            metric_name: Some(METRIC_NAME.to_string()),
+                            device_type: Some("hdd_sas".to_string()),
+                            outcome: Some("error".to_string()),
+                            duration: Some("1s".to_string()),
+                            duration_kind: Some(CapturedFieldKind::Debug),
+                            error: Some("HDD security erase failed".to_string()),
+                            error_kind: Some(CapturedFieldKind::Debug),
+                        }),
+                        histogram_count_delta: 1,
+                        histogram_sum_delta: 1.0,
+                    },
+                },
+            ],
+            observe,
         );
     }
 }

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -197,6 +197,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_resourcepool_used_count</td><td>gauge</td><td>Number of currently allocated values in the resource pool</td></tr>
 <tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>Number of machines in the system that are currently running a DPU/NIC firmware update</td></tr>
 <tr><td>carbide_scout_actions_total</td><td>counter</td><td>Number of scout control-loop actions handled, by action and outcome.</td></tr>
+<tr><td>carbide_scout_storage_device_cleanup_duration_seconds</td><td>histogram</td><td>Duration of per-device scout storage cleanup operations, by device type and outcome.</td></tr>
 <tr><td>carbide_scout_stream_connections_total</td><td>counter</td><td>Number of scout stream connection attempts, by outcome.</td></tr>
 <tr><td>carbide_scout_stream_reconnects_total</td><td>counter</td><td>Number of scout stream reconnect cycles after a stream closed or errored.</td></tr>
 <tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>Number of expected machines by SKU ID and device type</td></tr>


### PR DESCRIPTION
Scout now reports per-device cleanup latency and result through one terminal Event while retaining the existing NVMe and HDD/SAS diagnostics.

- Replaces the terminal cleanup records with `ScoutStorageDeviceCleanup` while preserving their `INFO`/`ERROR` levels and messages.
- Records `carbide_scout_storage_device_cleanup_duration_seconds` by bounded `device_type` and `outcome` labels.
- Covers all four device/result combinations with table-driven log and histogram assertions.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3908

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-scout metrics::tests --bin forge-scout`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

Device paths remain on the existing cleanup spans so the histogram has only the four bounded `device_type`/`outcome` series.

Closes #3908
