### PR TITLE
test(api-model): enumerate extension-service status and readiness

### DIFF
--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -424,7 +424,8 @@ pub fn is_extension_services_ready(
 mod tests {
     use std::str::FromStr;
 
-    use chrono::Utc;
+    use carbide_test_support::value_scenarios;
+    use chrono::{TimeZone, Utc};
 
     use super::*;
     use crate::extension_service::ExtensionServiceType;
@@ -456,415 +457,661 @@ mod tests {
     }
 
     fn create_observation(
-        dpu_id: MachineId,
         config_version: ConfigVersion,
         service_version: ConfigVersion,
         status: ExtensionServiceDeploymentStatus,
+    ) -> InstanceExtensionServiceStatusObservation {
+        InstanceExtensionServiceStatusObservation {
+            config_version,
+            instance_config_version: None,
+            extension_service_statuses: vec![ExtensionServiceStatusObservation {
+                service_id: get_test_service_id(),
+                service_type: ExtensionServiceType::KubernetesPod,
+                service_name: "test-service".to_string(),
+                version: service_version,
+                removed: None,
+                overall_state: status,
+                components: vec![],
+                message: String::new(),
+            }],
+            observed_at: Utc::now(),
+        }
+    }
+
+    fn create_observations(
+        statuses: impl IntoIterator<
+            Item = (
+                MachineId,
+                ConfigVersion,
+                ConfigVersion,
+                ExtensionServiceDeploymentStatus,
+            ),
+        >,
     ) -> HashMap<MachineId, InstanceExtensionServiceStatusObservation> {
-        let mut observations = HashMap::new();
-        observations.insert(
-            dpu_id,
-            InstanceExtensionServiceStatusObservation {
-                config_version,
-                instance_config_version: None,
-                extension_service_statuses: vec![ExtensionServiceStatusObservation {
-                    service_id: get_test_service_id(),
-                    service_type: ExtensionServiceType::KubernetesPod,
-                    service_name: "test-service".to_string(),
-                    version: service_version,
-                    removed: None,
-                    overall_state: status,
-                    components: vec![],
-                    message: String::new(),
-                }],
-                observed_at: chrono::Utc::now(),
-            },
-        );
-        observations
-    }
-
-    #[test]
-    fn extension_service_status_without_observations() {
-        let service_version = ConfigVersion::initial();
-        let config = create_service_config(service_version);
-
-        let config_version = ConfigVersion::initial();
-
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[get_dpu_ids()[0]],
-            Versioned::new(&config, config_version),
-            &HashMap::new(),
-        );
-
-        // Without observations, should be unsynced with DPU status showing Unknown
-        assert_eq!(status.configs_synced, SyncState::Pending);
-        assert_eq!(status.extension_services.len(), 1);
-        assert_eq!(status.extension_services[0].version.version_nr(), 1);
-        assert_eq!(
-            status.extension_services[0].overall_status,
-            ExtensionServiceDeploymentStatus::Unknown
-        );
-        assert_eq!(status.extension_services[0].dpu_statuses.len(), 1);
-        assert_eq!(
-            status.extension_services[0].dpu_statuses[0].status,
-            ExtensionServiceDeploymentStatus::Unknown
-        );
-
-        // Readiness check: configs are not synced, so should be ConfigsPending
-        let readiness = compute_extension_services_readiness(&status);
-        assert_eq!(readiness, ExtensionServicesReadiness::ConfigsPending);
-    }
-
-    #[test]
-    fn extension_service_status_with_synced_observations() {
-        let service_version = ConfigVersion::initial();
-        let config = create_service_config(service_version);
-        let config_version = ConfigVersion::initial();
-
-        let dpu_id = get_dpu_ids()[0];
-
-        let observations = create_observation(
-            dpu_id,
-            config_version,
-            service_version,
-            ExtensionServiceDeploymentStatus::Running,
-        );
-
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[dpu_id],
-            Versioned::new(&config, config_version),
-            &observations,
-        );
-
-        assert_eq!(status.configs_synced, SyncState::Synced);
-        assert_eq!(status.extension_services.len(), 1);
-        assert_eq!(
-            status.extension_services[0].overall_status,
-            ExtensionServiceDeploymentStatus::Running
-        );
-        assert_eq!(status.extension_services[0].dpu_statuses.len(), 1);
-        assert_eq!(
-            status.extension_services[0].dpu_statuses[0].machine_id,
-            dpu_id,
-        );
-        assert_eq!(
-            status.extension_services[0].dpu_statuses[0].status,
-            ExtensionServiceDeploymentStatus::Running
-        );
-
-        // Readiness check: configs synced and all services running, should be Ready
-        let readiness = compute_extension_services_readiness(&status);
-        assert_eq!(readiness, ExtensionServicesReadiness::Ready);
-    }
-
-    #[test]
-    fn extension_service_status_with_outdated_observation() {
-        let config = create_service_config(ConfigVersion::initial());
-        let version = ConfigVersion::initial();
-        let dpu_id = get_dpu_ids()[0];
-        let observations = create_observation(
-            dpu_id,
-            ConfigVersion::initial(),
-            ConfigVersion::initial(),
-            ExtensionServiceDeploymentStatus::Running,
-        );
-
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[dpu_id],
-            Versioned::new(&config, version.increment()), // Increment config version for extension service config
-            &observations,                                // Observation has initial config version
-        );
-
-        // Should be unsynced due to version mismatch, with DPU status showing Unknown
-        assert_eq!(status.configs_synced, SyncState::Pending);
-        assert_eq!(status.extension_services.len(), 1);
-        assert_eq!(
-            status.extension_services[0].overall_status,
-            ExtensionServiceDeploymentStatus::Unknown
-        );
-        assert_eq!(status.extension_services[0].dpu_statuses.len(), 1);
-        assert_eq!(
-            status.extension_services[0].dpu_statuses[0].status,
-            ExtensionServiceDeploymentStatus::Unknown
-        );
-        assert!(
-            status.extension_services[0].dpu_statuses[0]
-                .error_message
-                .as_ref()
-                .unwrap()
-                .contains(
-                    "No status observation observed for this extension service config version yet."
+        statuses
+            .into_iter()
+            .map(|(dpu_id, config_version, service_version, status)| {
+                (
+                    dpu_id,
+                    create_observation(config_version, service_version, status),
                 )
-        );
+            })
+            .collect()
+    }
 
-        // Readiness check: configs not synced (version mismatch), should be ConfigsPending
-        let readiness = compute_extension_services_readiness(&status);
-        assert_eq!(readiness, ExtensionServicesReadiness::ConfigsPending);
+    struct StatusInput {
+        dpu_ids: Vec<MachineId>,
+        config: InstanceExtensionServicesConfig,
+        config_version: ConfigVersion,
+        observations: HashMap<MachineId, InstanceExtensionServiceStatusObservation>,
+    }
+
+    fn status_input(
+        dpu_ids: Vec<MachineId>,
+        service_version: ConfigVersion,
+        config_version: ConfigVersion,
+        observations: HashMap<MachineId, InstanceExtensionServiceStatusObservation>,
+    ) -> StatusInput {
+        StatusInput {
+            dpu_ids,
+            config: create_service_config(service_version),
+            config_version,
+            observations,
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct DpuStatusProjection {
+        machine_id: MachineId,
+        status: ExtensionServiceDeploymentStatus,
+        error_message: Option<String>,
+        components: Vec<ExtensionServiceComponent>,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct ServiceStatusProjection {
+        service_id: ExtensionServiceId,
+        version: u64,
+        overall_status: ExtensionServiceDeploymentStatus,
+        dpu_statuses: Vec<DpuStatusProjection>,
+        removed: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct StatusProjection {
+        configs_synced: SyncState,
+        extension_services: Vec<ServiceStatusProjection>,
+    }
+
+    fn project_status(status: InstanceExtensionServicesStatus) -> StatusProjection {
+        StatusProjection {
+            configs_synced: status.configs_synced,
+            extension_services: status
+                .extension_services
+                .into_iter()
+                .map(|service| ServiceStatusProjection {
+                    service_id: service.service_id,
+                    version: service.version.version_nr(),
+                    overall_status: service.overall_status,
+                    dpu_statuses: service
+                        .dpu_statuses
+                        .into_iter()
+                        .map(|dpu| DpuStatusProjection {
+                            machine_id: dpu.machine_id,
+                            status: dpu.status,
+                            error_message: dpu.error_message,
+                            components: dpu.components,
+                        })
+                        .collect(),
+                    removed: service.removed,
+                })
+                .collect(),
+        }
+    }
+
+    fn expected_dpu_status(
+        machine_id: MachineId,
+        status: ExtensionServiceDeploymentStatus,
+        error_message: Option<&str>,
+    ) -> DpuStatusProjection {
+        DpuStatusProjection {
+            machine_id,
+            status,
+            error_message: error_message.map(str::to_string),
+            components: vec![],
+        }
+    }
+
+    fn expected_status(
+        configs_synced: SyncState,
+        overall_status: ExtensionServiceDeploymentStatus,
+        dpu_statuses: Vec<DpuStatusProjection>,
+    ) -> StatusProjection {
+        StatusProjection {
+            extension_services: vec![ServiceStatusProjection {
+                service_id: get_test_service_id(),
+                version: 1,
+                overall_status,
+                dpu_statuses,
+                removed: None,
+            }],
+            configs_synced,
+        }
     }
 
     #[test]
-    fn extension_service_status_with_multiple_dpus_one_missing_observation() {
+    fn extension_service_status_from_config_and_observations() {
         let service_version = ConfigVersion::initial();
-        let config = create_service_config(service_version);
-
         let config_version = ConfigVersion::initial();
-
-        // Create a map with two DPUs
-        let dpu1_id = get_dpu_ids()[0];
-        let dpu2_id = get_dpu_ids()[1];
-
-        // Create observation for only one DPU
-        let observations = create_observation(
+        let [dpu1_id, dpu2_id] = get_dpu_ids().try_into().unwrap();
+        let missing_observation =
+            "No status observation observed for this extension service config version yet.";
+        let component = ExtensionServiceComponent {
+            name: "test-component".to_string(),
+            version: "1.0.0".to_string(),
+            url: "registry.example.test/test-component:1.0.0".to_string(),
+            status: "Running".to_string(),
+        };
+        let service_message = "service is running";
+        let mut synced_observation = create_observations([(
             dpu1_id,
             config_version,
             service_version,
             ExtensionServiceDeploymentStatus::Running,
-        );
-
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[dpu1_id, dpu2_id],
-            Versioned::new(&config, config_version),
-            &observations,
-        );
-
-        // Should be unsynced because one DPU is missing observation
-        assert_eq!(status.configs_synced, SyncState::Pending);
-        assert_eq!(status.extension_services.len(), 1);
-        assert_eq!(
-            status.extension_services[0].overall_status,
-            ExtensionServiceDeploymentStatus::Unknown
-        );
-        assert_eq!(status.extension_services[0].dpu_statuses.len(), 2);
-
-        // One DPU should have Running status, the other Unknown
-        let running_count = status.extension_services[0]
-            .dpu_statuses
-            .iter()
-            .filter(|s| s.status == ExtensionServiceDeploymentStatus::Running)
-            .count();
-        let unknown_count = status.extension_services[0]
-            .dpu_statuses
-            .iter()
-            .filter(|s| s.status == ExtensionServiceDeploymentStatus::Unknown)
-            .count();
-        assert_eq!(running_count, 1);
-        assert_eq!(unknown_count, 1);
-
-        // Readiness check: configs not synced (one DPU missing observation), should be ConfigsPending
-        let readiness = compute_extension_services_readiness(&status);
-        assert_eq!(readiness, ExtensionServicesReadiness::ConfigsPending);
-    }
-
-    #[test]
-    fn extension_service_status_with_all_dpus_reporting() {
-        let service_version = ConfigVersion::initial();
-        let config = create_service_config(service_version);
-        let config_version = ConfigVersion::initial();
-
-        // Create a map with two DPUs
-        let dpu1_id = get_dpu_ids()[0];
-        let dpu2_id = get_dpu_ids()[1];
-
-        // Create observations for both DPUs
-        let mut observations = HashMap::new();
-        observations.insert(
+        )]);
+        let synced_service = &mut synced_observation
+            .get_mut(&dpu1_id)
+            .unwrap()
+            .extension_service_statuses[0];
+        synced_service.message = service_message.to_string();
+        synced_service.components = vec![component.clone()];
+        let stale_service_observation = create_observations([(
             dpu1_id,
-            InstanceExtensionServiceStatusObservation {
-                config_version,
-                instance_config_version: None,
-                extension_service_statuses: vec![ExtensionServiceStatusObservation {
-                    service_id: get_test_service_id(),
-                    service_type: ExtensionServiceType::KubernetesPod,
-                    service_name: "test-service".to_string(),
-                    version: service_version,
-                    removed: None,
-                    overall_state: ExtensionServiceDeploymentStatus::Running,
-                    components: vec![],
-                    message: String::new(),
-                }],
-                observed_at: chrono::Utc::now(),
-            },
-        );
-        observations.insert(
-            dpu2_id,
-            InstanceExtensionServiceStatusObservation {
-                config_version,
-                instance_config_version: None,
-                extension_service_statuses: vec![ExtensionServiceStatusObservation {
-                    service_id: get_test_service_id(),
-                    service_type: ExtensionServiceType::KubernetesPod,
-                    service_name: "test-service".to_string(),
-                    version: service_version,
-                    removed: None,
-                    overall_state: ExtensionServiceDeploymentStatus::Running,
-                    components: vec![],
-                    message: String::new(),
-                }],
-                observed_at: chrono::Utc::now(),
-            },
-        );
-
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[dpu1_id, dpu2_id],
-            Versioned::new(&config, config_version),
-            &observations,
-        );
-
-        // Should be synced because all DPUs have observations
-        assert_eq!(status.configs_synced, SyncState::Synced);
-        assert_eq!(status.extension_services.len(), 1);
-        assert_eq!(
-            status.extension_services[0].overall_status,
-            ExtensionServiceDeploymentStatus::Running
-        );
-        assert_eq!(status.extension_services[0].dpu_statuses.len(), 2);
-
-        // Both DPUs should have Running status
-        let running_count = status.extension_services[0]
-            .dpu_statuses
-            .iter()
-            .filter(|s| s.status == ExtensionServiceDeploymentStatus::Running)
-            .count();
-        assert_eq!(running_count, 2);
-
-        // Readiness check: configs synced and all services running, should be Ready
-        let readiness = compute_extension_services_readiness(&status);
-        assert_eq!(readiness, ExtensionServicesReadiness::Ready);
-    }
-
-    #[test]
-    fn extension_service_status_scopes_to_target_dpus() {
-        let service_version = ConfigVersion::initial();
-        let config = create_service_config(service_version);
-        let config_version = ConfigVersion::initial();
-
-        let dpu1_id = get_dpu_ids()[0];
-        let dpu2_id = get_dpu_ids()[1];
-
-        let mut observations = HashMap::new();
-        observations.insert(
+            config_version,
+            service_version.increment(),
+            ExtensionServiceDeploymentStatus::Running,
+        )]);
+        let mut other_service_observation = create_observations([(
             dpu1_id,
-            InstanceExtensionServiceStatusObservation {
+            config_version,
+            service_version,
+            ExtensionServiceDeploymentStatus::Running,
+        )]);
+        other_service_observation
+            .get_mut(&dpu1_id)
+            .unwrap()
+            .extension_service_statuses[0]
+            .service_id =
+            ExtensionServiceId::from_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let missing_service =
+            format!("Status observation is found for DPU {dpu1_id} but service is not in it.");
+        let removed_at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let removed_at_text = "2026-01-01 00:00:00 UTC".to_string();
+        let second_service_version = service_version.increment();
+
+        value_scenarios!(
+            run = |StatusInput {
+                dpu_ids,
+                config,
                 config_version,
-                instance_config_version: None,
-                extension_service_statuses: vec![ExtensionServiceStatusObservation {
+                observations,
+            }| {
+                project_status(InstanceExtensionServicesStatus::from_config_and_observations(
+                    &dpu_ids,
+                    Versioned::new(&config, config_version),
+                    &observations,
+                ))
+            };
+            "without configured services" {
+                StatusInput {
+                    dpu_ids: vec![dpu1_id],
+                    config: InstanceExtensionServicesConfig {
+                        service_configs: vec![],
+                    },
+                    config_version,
+                    observations: HashMap::new(),
+                } => StatusProjection {
+                    configs_synced: SyncState::Synced,
+                    extension_services: vec![],
+                },
+            }
+
+            "with configured services but no target DPUs" {
+                StatusInput {
+                    dpu_ids: vec![],
+                    config: InstanceExtensionServicesConfig {
+                        service_configs: vec![
+                            InstanceExtensionServiceConfig {
+                                service_id: get_test_service_id(),
+                                version: second_service_version,
+                                removed: None,
+                            },
+                            InstanceExtensionServiceConfig {
+                                service_id: get_test_service_id(),
+                                version: service_version,
+                                removed: Some(removed_at),
+                            },
+                        ],
+                    },
+                    config_version,
+                    observations: HashMap::new(),
+                } => StatusProjection {
+                    configs_synced: SyncState::Pending,
+                    extension_services: vec![
+                        ServiceStatusProjection {
+                            service_id: get_test_service_id(),
+                            version: 2,
+                            overall_status: ExtensionServiceDeploymentStatus::Unknown,
+                            dpu_statuses: vec![],
+                            removed: None,
+                        },
+                        ServiceStatusProjection {
+                            service_id: get_test_service_id(),
+                            version: 1,
+                            overall_status: ExtensionServiceDeploymentStatus::Unknown,
+                            dpu_statuses: vec![],
+                            removed: Some(removed_at_text),
+                        },
+                    ],
+                },
+            }
+
+            "without observations" {
+                status_input(
+                    vec![dpu1_id],
+                    service_version,
+                    config_version,
+                    HashMap::new(),
+                ) => expected_status(
+                    SyncState::Pending,
+                    ExtensionServiceDeploymentStatus::Unknown,
+                    vec![expected_dpu_status(
+                        dpu1_id,
+                        ExtensionServiceDeploymentStatus::Unknown,
+                        Some(missing_observation),
+                    )],
+                ),
+            }
+
+            "with a synced observation" {
+                status_input(
+                    vec![dpu1_id],
+                    service_version,
+                    config_version,
+                    synced_observation,
+                ) => expected_status(
+                    SyncState::Synced,
+                    ExtensionServiceDeploymentStatus::Running,
+                    vec![DpuStatusProjection {
+                        machine_id: dpu1_id,
+                        status: ExtensionServiceDeploymentStatus::Running,
+                        error_message: Some(service_message.to_string()),
+                        components: vec![component],
+                    }],
+                ),
+            }
+
+            "when a synced observation only has a stale service version" {
+                status_input(
+                    vec![dpu1_id],
+                    service_version,
+                    config_version,
+                    stale_service_observation,
+                ) => expected_status(
+                    SyncState::Synced,
+                    ExtensionServiceDeploymentStatus::Unknown,
+                    vec![expected_dpu_status(
+                        dpu1_id,
+                        ExtensionServiceDeploymentStatus::Unknown,
+                        Some(missing_service.as_str()),
+                    )],
+                ),
+            }
+
+            "when a synced observation only has another service" {
+                status_input(
+                    vec![dpu1_id],
+                    service_version,
+                    config_version,
+                    other_service_observation,
+                ) => expected_status(
+                    SyncState::Synced,
+                    ExtensionServiceDeploymentStatus::Unknown,
+                    vec![expected_dpu_status(
+                        dpu1_id,
+                        ExtensionServiceDeploymentStatus::Unknown,
+                        Some(missing_service.as_str()),
+                    )],
+                ),
+            }
+
+            "with an outdated observation" {
+                status_input(
+                    vec![dpu1_id],
+                    service_version,
+                    config_version.increment(),
+                    create_observations([(
+                        dpu1_id,
+                        config_version,
+                        service_version,
+                        ExtensionServiceDeploymentStatus::Running,
+                    )]),
+                ) => expected_status(
+                    SyncState::Pending,
+                    ExtensionServiceDeploymentStatus::Unknown,
+                    vec![expected_dpu_status(
+                        dpu1_id,
+                        ExtensionServiceDeploymentStatus::Unknown,
+                        Some(missing_observation),
+                    )],
+                ),
+            }
+
+            "with one of two DPU observations missing" {
+                status_input(
+                    vec![dpu1_id, dpu2_id],
+                    service_version,
+                    config_version,
+                    create_observations([(
+                        dpu1_id,
+                        config_version,
+                        service_version,
+                        ExtensionServiceDeploymentStatus::Running,
+                    )]),
+                ) => expected_status(
+                    SyncState::Pending,
+                    ExtensionServiceDeploymentStatus::Unknown,
+                    vec![
+                        expected_dpu_status(
+                            dpu1_id,
+                            ExtensionServiceDeploymentStatus::Running,
+                            None,
+                        ),
+                        expected_dpu_status(
+                            dpu2_id,
+                            ExtensionServiceDeploymentStatus::Unknown,
+                            Some(missing_observation),
+                        ),
+                    ],
+                ),
+            }
+
+            "with all DPU observations present" {
+                status_input(
+                    vec![dpu1_id, dpu2_id],
+                    service_version,
+                    config_version,
+                    create_observations([
+                        (
+                            dpu1_id,
+                            config_version,
+                            service_version,
+                            ExtensionServiceDeploymentStatus::Running,
+                        ),
+                        (
+                            dpu2_id,
+                            config_version,
+                            service_version,
+                            ExtensionServiceDeploymentStatus::Running,
+                        ),
+                    ]),
+                ) => expected_status(
+                    SyncState::Synced,
+                    ExtensionServiceDeploymentStatus::Running,
+                    vec![
+                        expected_dpu_status(
+                            dpu1_id,
+                            ExtensionServiceDeploymentStatus::Running,
+                            None,
+                        ),
+                        expected_dpu_status(
+                            dpu2_id,
+                            ExtensionServiceDeploymentStatus::Running,
+                            None,
+                        ),
+                    ],
+                ),
+            }
+
+            "scoped to target DPUs" {
+                status_input(
+                    vec![dpu1_id],
+                    service_version,
+                    config_version,
+                    create_observations([
+                        (
+                            dpu1_id,
+                            config_version,
+                            service_version,
+                            ExtensionServiceDeploymentStatus::Running,
+                        ),
+                        (
+                            dpu2_id,
+                            config_version,
+                            service_version,
+                            ExtensionServiceDeploymentStatus::Pending,
+                        ),
+                    ]),
+                ) => expected_status(
+                    SyncState::Synced,
+                    ExtensionServiceDeploymentStatus::Running,
+                    vec![expected_dpu_status(
+                        dpu1_id,
+                        ExtensionServiceDeploymentStatus::Running,
+                        None,
+                    )],
+                ),
+            }
+        );
+    }
+
+    fn readiness_status(
+        configs_synced: SyncState,
+        services: impl IntoIterator<Item = (bool, ExtensionServiceDeploymentStatus)>,
+    ) -> InstanceExtensionServicesStatus {
+        InstanceExtensionServicesStatus {
+            extension_services: services
+                .into_iter()
+                .map(|(removed, overall_status)| InstanceExtensionServiceStatus {
                     service_id: get_test_service_id(),
-                    service_type: ExtensionServiceType::KubernetesPod,
-                    service_name: "test-service".to_string(),
-                    version: service_version,
-                    removed: None,
-                    overall_state: ExtensionServiceDeploymentStatus::Running,
-                    components: vec![],
-                    message: String::new(),
-                }],
-                observed_at: chrono::Utc::now(),
-            },
-        );
-        observations.insert(
-            dpu2_id,
-            InstanceExtensionServiceStatusObservation {
-                config_version,
-                instance_config_version: None,
-                extension_service_statuses: vec![ExtensionServiceStatusObservation {
-                    service_id: get_test_service_id(),
-                    service_type: ExtensionServiceType::KubernetesPod,
-                    service_name: "test-service".to_string(),
-                    version: service_version,
-                    removed: None,
-                    overall_state: ExtensionServiceDeploymentStatus::Pending,
-                    components: vec![],
-                    message: "No pod sandbox found".to_string(),
-                }],
-                observed_at: chrono::Utc::now(),
-            },
-        );
+                    version: ConfigVersion::initial(),
+                    overall_status,
+                    dpu_statuses: vec![],
+                    removed: removed.then(|| Utc::now().to_string()),
+                })
+                .collect(),
+            configs_synced,
+        }
+    }
 
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[dpu1_id],
-            Versioned::new(&config, config_version),
-            &observations,
-        );
+    #[test]
+    fn extension_service_readiness() {
+        value_scenarios!(
+            run = |status| (
+                compute_extension_services_readiness(&status),
+                is_extension_services_ready(&status),
+            );
+            "configs pending" {
+                readiness_status(
+                    SyncState::Pending,
+                    [(false, ExtensionServiceDeploymentStatus::Unknown)],
+                ) => (ExtensionServicesReadiness::ConfigsPending, false),
+            }
 
-        assert_eq!(status.configs_synced, SyncState::Synced);
-        assert_eq!(status.extension_services.len(), 1);
-        assert_eq!(
-            status.extension_services[0].overall_status,
-            ExtensionServiceDeploymentStatus::Running
-        );
-        assert_eq!(status.extension_services[0].dpu_statuses.len(), 1);
-        assert_eq!(
-            status.extension_services[0].dpu_statuses[0].machine_id,
-            dpu1_id
-        );
-        assert_eq!(
-            compute_extension_services_readiness(&status),
-            ExtensionServicesReadiness::Ready
+            "configs synced without services" {
+                readiness_status(SyncState::Synced, []) =>
+                    (ExtensionServicesReadiness::Ready, true),
+            }
+
+            "configs synced and service running" {
+                readiness_status(
+                    SyncState::Synced,
+                    [(false, ExtensionServiceDeploymentStatus::Running)],
+                ) => (ExtensionServicesReadiness::Ready, true),
+            }
+
+            "active service not running" {
+                readiness_status(
+                    SyncState::Synced,
+                    [(false, ExtensionServiceDeploymentStatus::Pending)],
+                ) => (ExtensionServicesReadiness::NotFullyRunning, false),
+            }
+
+            "removed service still terminating" {
+                readiness_status(
+                    SyncState::Synced,
+                    [(true, ExtensionServiceDeploymentStatus::Terminating)],
+                ) => (ExtensionServicesReadiness::SomeTerminating, false),
+            }
+
+            "removed service terminated" {
+                readiness_status(
+                    SyncState::Synced,
+                    [(true, ExtensionServiceDeploymentStatus::Terminated)],
+                ) => (ExtensionServicesReadiness::Ready, true),
+            }
+
+            "active failure takes precedence over removed termination" {
+                readiness_status(
+                    SyncState::Synced,
+                    [
+                        (false, ExtensionServiceDeploymentStatus::Failed),
+                        (true, ExtensionServiceDeploymentStatus::Terminating),
+                    ],
+                ) => (ExtensionServicesReadiness::NotFullyRunning, false),
+            }
         );
     }
 
     #[test]
-    fn extension_service_calculate_overall_status_all_running() {
-        let dpu_statuses = vec![
-            MachineExtensionServiceStatus {
-                machine_id: MachineId::from_str(
-                    "fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80",
-                )
-                .unwrap(),
-                status: ExtensionServiceDeploymentStatus::Running,
-                error_message: None,
-                components: vec![],
-            },
-            MachineExtensionServiceStatus {
-                machine_id: MachineId::from_str(
-                    "fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80",
-                )
-                .unwrap(),
-                status: ExtensionServiceDeploymentStatus::Running,
-                error_message: None,
-                components: vec![],
-            },
-        ];
+    fn extension_service_calculate_overall_status() {
+        value_scenarios!(
+            run = |statuses: Vec<ExtensionServiceDeploymentStatus>| {
+                let machine_id = get_dpu_ids()[0];
+                let dpu_statuses = statuses
+                    .into_iter()
+                    .map(|status| MachineExtensionServiceStatus {
+                        machine_id,
+                        status,
+                        error_message: None,
+                        components: vec![],
+                    })
+                    .collect::<Vec<_>>();
+                InstanceExtensionServicesStatus::calculate_overall_status(&dpu_statuses)
+            };
+            "all running" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Running,
+                    ExtensionServiceDeploymentStatus::Running,
+                ] => ExtensionServiceDeploymentStatus::Running,
+            }
 
-        let overall_status =
-            InstanceExtensionServicesStatus::calculate_overall_status(&dpu_statuses);
-        assert_eq!(overall_status, ExtensionServiceDeploymentStatus::Running);
+            "one failed" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Running,
+                    ExtensionServiceDeploymentStatus::Failed,
+                ] => ExtensionServiceDeploymentStatus::Error,
+            }
+
+            "error takes precedence over unknown" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Unknown,
+                    ExtensionServiceDeploymentStatus::Error,
+                ] => ExtensionServiceDeploymentStatus::Error,
+            }
+
+            "unknown takes precedence over pending" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Pending,
+                    ExtensionServiceDeploymentStatus::Unknown,
+                ] => ExtensionServiceDeploymentStatus::Unknown,
+            }
+
+            "one pending" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Running,
+                    ExtensionServiceDeploymentStatus::Pending,
+                ] => ExtensionServiceDeploymentStatus::Pending,
+            }
+
+            "pending takes precedence over terminating" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Terminating,
+                    ExtensionServiceDeploymentStatus::Pending,
+                ] => ExtensionServiceDeploymentStatus::Pending,
+            }
+
+            "one terminating" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Running,
+                    ExtensionServiceDeploymentStatus::Terminating,
+                ] => ExtensionServiceDeploymentStatus::Terminating,
+            }
+
+            "terminating takes precedence over terminated" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Terminated,
+                    ExtensionServiceDeploymentStatus::Terminating,
+                ] => ExtensionServiceDeploymentStatus::Terminating,
+            }
+
+            "all terminated" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Terminated,
+                    ExtensionServiceDeploymentStatus::Terminated,
+                ] => ExtensionServiceDeploymentStatus::Terminated,
+            }
+
+            "mixed running and terminated" {
+                vec![
+                    ExtensionServiceDeploymentStatus::Running,
+                    ExtensionServiceDeploymentStatus::Terminated,
+                ] => ExtensionServiceDeploymentStatus::Unknown,
+            }
+
+            "empty" {
+                vec![] => ExtensionServiceDeploymentStatus::Unknown,
+            }
+        );
     }
 
     #[test]
-    fn extension_service_calculate_overall_status_one_failed() {
-        let dpu_statuses = vec![
-            MachineExtensionServiceStatus {
-                machine_id: MachineId::from_str(
-                    "fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80",
-                )
-                .unwrap(),
-                status: ExtensionServiceDeploymentStatus::Running,
-                error_message: None,
-                components: vec![],
-            },
-            MachineExtensionServiceStatus {
-                machine_id: MachineId::from_str(
-                    "fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0",
-                )
-                .unwrap(),
-                status: ExtensionServiceDeploymentStatus::Failed,
-                error_message: Some("Test error".to_string()),
-                components: vec![],
-            },
-        ];
+    fn extension_service_observations_from_dpu_snapshots() {
+        let config_version = ConfigVersion::initial();
+        let observation = create_observation(
+            config_version,
+            ConfigVersion::initial(),
+            ExtensionServiceDeploymentStatus::Running,
+        );
+        let mut observed_dpu = crate::test_support::machine_snapshot::dpu_machine(0);
+        observed_dpu
+            .network_status_observation
+            .as_mut()
+            .unwrap()
+            .extension_service_observation = Some(observation.clone());
+        let observed_dpu_id = observed_dpu.id;
 
-        let overall_status =
-            InstanceExtensionServicesStatus::calculate_overall_status(&dpu_statuses);
-        // If any DPU reports Failed, the overall status is Error
-        assert_eq!(overall_status, ExtensionServiceDeploymentStatus::Error);
-    }
+        value_scenarios!(
+            run = |dpu_snapshots: Vec<Machine>| {
+                InstanceExtensionServiceStatusObservation::aggregate_instance_observation(
+                    &dpu_snapshots,
+                )
+            };
+            "without snapshots" {
+                vec![] => HashMap::new(),
+            }
 
-    #[test]
-    fn extension_service_calculate_overall_status_empty() {
-        let dpu_statuses = vec![];
-        let overall_status =
-            InstanceExtensionServicesStatus::calculate_overall_status(&dpu_statuses);
-        assert_eq!(overall_status, ExtensionServiceDeploymentStatus::Unknown);
+            "snapshot without an extension-service observation" {
+                vec![crate::test_support::machine_snapshot::dpu_machine(1)] => HashMap::new(),
+            }
+
+            "mixed snapshots" {
+                vec![
+                    observed_dpu,
+                    crate::test_support::machine_snapshot::dpu_machine(1),
+                ] => HashMap::from([(observed_dpu_id, observation)]),
+            }
+        );
     }
 
     fn create_observation_two_versions(
@@ -909,9 +1156,38 @@ mod tests {
         observations
     }
 
+    fn machine_statuses(
+        statuses: impl IntoIterator<Item = (MachineId, ExtensionServiceDeploymentStatus)>,
+    ) -> Vec<MachineExtensionServiceStatus> {
+        statuses
+            .into_iter()
+            .map(|(machine_id, status)| MachineExtensionServiceStatus {
+                machine_id,
+                status,
+                error_message: None,
+                components: vec![],
+            })
+            .collect()
+    }
+
+    fn service_status(
+        version: ConfigVersion,
+        removed: bool,
+        overall_status: ExtensionServiceDeploymentStatus,
+        dpu_statuses: Vec<MachineExtensionServiceStatus>,
+    ) -> InstanceExtensionServiceStatus {
+        InstanceExtensionServiceStatus {
+            service_id: get_test_service_id(),
+            version,
+            overall_status,
+            dpu_statuses,
+            removed: removed.then(|| "removed".to_string()),
+        }
+    }
+
     #[test]
     fn extension_service_get_terminated_service_keys() {
-        let dpu_id = get_dpu_ids()[0];
+        let [dpu1_id, dpu2_id] = get_dpu_ids().try_into().unwrap();
 
         let init_version = ConfigVersion::initial();
         let second_version = init_version.increment();
@@ -931,7 +1207,7 @@ mod tests {
         };
         let config_version = ConfigVersion::initial();
         let observations = create_observation_two_versions(
-            dpu_id,
+            dpu1_id,
             config_version,
             second_version,
             ExtensionServiceDeploymentStatus::Running,
@@ -939,15 +1215,79 @@ mod tests {
             ExtensionServiceDeploymentStatus::Terminated,
         );
 
-        let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &[dpu_id],
+        let aggregated_status = InstanceExtensionServicesStatus::from_config_and_observations(
+            &[dpu1_id],
             Versioned::new(&config, config_version),
             &observations,
         );
 
-        let keys = status.get_terminated_service_keys();
-        assert_eq!(keys.len(), 1);
-        assert_eq!(keys[0].0, get_test_service_id());
-        assert_eq!(keys[0].1, init_version);
+        value_scenarios!(
+            run = |status: InstanceExtensionServicesStatus| {
+                status.get_terminated_service_keys()
+            };
+            "removed version terminated on every DPU" {
+                aggregated_status => vec![(get_test_service_id(), init_version)],
+            }
+
+            "active version" {
+                InstanceExtensionServicesStatus {
+                    extension_services: vec![service_status(
+                        init_version,
+                        false,
+                        ExtensionServiceDeploymentStatus::Terminated,
+                        machine_statuses([(
+                            dpu1_id,
+                            ExtensionServiceDeploymentStatus::Terminated,
+                        )]),
+                    )],
+                    configs_synced: SyncState::Synced,
+                } => vec![],
+            }
+
+            "removed version not terminated overall" {
+                InstanceExtensionServicesStatus {
+                    extension_services: vec![service_status(
+                        init_version,
+                        true,
+                        ExtensionServiceDeploymentStatus::Terminating,
+                        machine_statuses([(
+                            dpu1_id,
+                            ExtensionServiceDeploymentStatus::Terminated,
+                        )]),
+                    )],
+                    configs_synced: SyncState::Synced,
+                } => vec![],
+            }
+
+            "removed version without DPU statuses" {
+                InstanceExtensionServicesStatus {
+                    extension_services: vec![service_status(
+                        init_version,
+                        true,
+                        ExtensionServiceDeploymentStatus::Terminated,
+                        vec![],
+                    )],
+                    configs_synced: SyncState::Synced,
+                } => vec![],
+            }
+
+            "removed version with one DPU not terminated" {
+                InstanceExtensionServicesStatus {
+                    extension_services: vec![service_status(
+                        init_version,
+                        true,
+                        ExtensionServiceDeploymentStatus::Terminated,
+                        machine_statuses([
+                            (
+                                dpu1_id,
+                                ExtensionServiceDeploymentStatus::Terminated,
+                            ),
+                            (dpu2_id, ExtensionServiceDeploymentStatus::Running),
+                        ]),
+                    )],
+                    configs_synced: SyncState::Synced,
+                } => vec![],
+            }
+        );
     }
 }

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -205,10 +205,15 @@ mod tests {
 
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Check, scenarios, value_scenarios};
+    use carbide_uuid::extension_service::ExtensionServiceId;
     use chrono::TimeZone;
     use config_version::ConfigVersion;
 
     use super::*;
+    use crate::extension_service::ExtensionServiceType;
+    use crate::instance::status::extension_service::{
+        ExtensionServiceDeploymentStatus, ExtensionServiceStatusObservation,
+    };
     use crate::test_support::machine_snapshot::config_version;
 
     // A stable MachineId for status observations; `any_observed_version_changed`
@@ -255,13 +260,23 @@ mod tests {
     }
 
     fn extension_observation(
-        config_version: ConfigVersion,
+        observation_config_version: ConfigVersion,
         instance_config_version: Option<ConfigVersion>,
     ) -> InstanceExtensionServiceStatusObservation {
         InstanceExtensionServiceStatusObservation {
-            config_version,
+            config_version: observation_config_version,
             instance_config_version,
-            extension_service_statuses: Vec::new(),
+            extension_service_statuses: vec![ExtensionServiceStatusObservation {
+                service_id: ExtensionServiceId::from_str("00000000-0000-0000-0000-000000000000")
+                    .unwrap(),
+                service_type: ExtensionServiceType::KubernetesPod,
+                service_name: "test-service".to_string(),
+                version: config_version(1),
+                removed: None,
+                overall_state: ExtensionServiceDeploymentStatus::Running,
+                components: vec![],
+                message: String::new(),
+            }],
             observed_at: observed_at(),
         }
     }
@@ -570,6 +585,21 @@ mod tests {
                 (
                     network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
                     network_status(Some(v1), None, Some(extension_observation(v1, Some(v2)))),
+                ) => true,
+            }
+
+            "extension observation service version differs -> changed" {
+                (
+                    network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                    network_status(
+                        Some(v1),
+                        None,
+                        Some({
+                            let mut observation = extension_observation(v1, None);
+                            observation.extension_service_statuses[0].version = v2;
+                            observation
+                        }),
+                    ),
                 ) => true,
             }
         );


### PR DESCRIPTION
Extension-service status tests had grown as separate examples that repeated setup and asserted different subsets of the same result. Important boundaries remained unexercised, including empty configurations, zero-DPU configurations, observation matching, snapshot collection, and several deployment-state precedence pairs.

This consolidates those checks into labeled `value_scenarios!` tables with complete, independent projections. It keeps version-change behavior in its existing owner test and removes the older overlapping tests instead of layering new coverage beside them.

## Related issues

Supports #3960.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Coverage was measured from the same base at original, conversion-only, and expanded checkpoints:

- The relevant production slice stayed at 138/191 lines (72.25%) through conversion, then reached 191/191 (100%) after the missing cases were added.
- The complete target file moved from 553/612 lines (90.36%) to 866/866 (100%).
- Package coverage moved from 12,478/18,561 lines (67.23%) to 13,163/18,837 (69.88%), with 409 fewer uncovered lines. Some of that package-level increase comes from executing the full machine fixture used by the snapshot-aggregation table; the production-slice figure is the direct measure for this change.

Validation:

- `cargo +1.96.0 test --locked -p carbide-api-model extension_service --lib`
- `cargo +1.96.0 test --locked -p carbide-api-model machine::network::tests::test_any_observed_version_changed --lib`
- Full `carbide-api-model` coverage run: 373 tests passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Local CodeRabbit review: no findings
- Local Claude review: no required changes

Closes #3960
