### PR TITLE
backport: #3016 (BFB3.4.1 upgrade) to release/v2.0

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1082,8 +1082,7 @@ impl DpfConfig {
 }
 
 fn default_dpf_bfb_url() -> String {
-    // "https://content.mellanox.com/BlueField/BFBs/Ubuntu24.04/bf-bundle-3.2.2-125_26.02_ubuntu-24.04_64k_prod.bfb".to_string()
-    "https://nbu-nfs.gtm.nvidia.com/auto/sw_mc_soc_release/doca_dpu/doca_3.4.1/20260628.1/bfbs/pk/bf-bundle-3.4.1-7_26.04_ubuntu-24.04_prod.bfb".to_string()
+    "https://content.mellanox.com/BlueField/BFBs/Ubuntu24.04/bf-bundle-3.4.1-12_26.04_ubuntu-24.04_64k_prod.bfb".to_string()
 }
 
 fn default_dpf_deployment_name() -> String {

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1082,7 +1082,8 @@ impl DpfConfig {
 }
 
 fn default_dpf_bfb_url() -> String {
-    "https://content.mellanox.com/BlueField/BFBs/Ubuntu24.04/bf-bundle-3.2.2-125_26.02_ubuntu-24.04_64k_prod.bfb".to_string()
+    // "https://content.mellanox.com/BlueField/BFBs/Ubuntu24.04/bf-bundle-3.2.2-125_26.02_ubuntu-24.04_64k_prod.bfb".to_string()
+    "https://nbu-nfs.gtm.nvidia.com/auto/sw_mc_soc_release/doca_dpu/doca_3.4.1/20260628.1/bfbs/pk/bf-bundle-3.4.1-7_26.04_ubuntu-24.04_prod.bfb".to_string()
 }
 
 fn default_dpf_deployment_name() -> String {

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -46,9 +46,9 @@ pub const DEFAULT_CARBIDE_IMAGE_REGISTRY: &str = "nvcr.io/0837451325059433/carbi
 
 /// HBN service Definitions
 pub const DOCA_HBN_SERVICE_HELM_NAME: &str = "doca-hbn";
-pub const DOCA_HBN_SERVICE_HELM_VERSION: &str = "1.0.5";
+pub const DOCA_HBN_SERVICE_HELM_VERSION: &str = "3.4.0";
 pub const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca_hbn";
-pub const DOCA_HBN_SERVICE_IMAGE_TAG: &str = "3.2.1-doca3.2.1";
+pub const DOCA_HBN_SERVICE_IMAGE_TAG: &str = "3.4.0-doca3.4.0";
 pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 
 /// DHCP Service Definitions
@@ -60,7 +60,7 @@ pub const DHCP_SERVER_SERVICE_IMAGE_NAME: &str = "forge-dhcp-server";
 /// DTS service definitions
 /// (DTS_SERVICE_NAME lives in carbide_dpf::types so the DPF SDK can wire its dependencies.)
 pub const DTS_SERVICE_HELM_NAME: &str = "doca-telemetry";
-pub const DTS_SERVICE_HELM_VERSION: &str = "1.22.1";
+pub const DTS_SERVICE_HELM_VERSION: &str = "1.25.5";
 
 // DPU Agent Service Definitions
 pub const DPU_AGENT_SERVICE_HELM_NAME: &str = "nico-dpu-agent";

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -42,17 +42,27 @@ impl DPUFlavor {
 fn get_default_ovs_defaults() -> String {
     concat!(
         "_ovs-vsctl() {\n",
-        "   ovs-vsctl --no-wait --timeout 15 \"$@\"\n",
-        " }\n",
+            "ovs-vsctl --timeout 15 \"$@\"\n",
+        "}\n",
+
+        "# Remove default OVS configuration on the DPU and ensure no leftovers on the OVS kernel side\n",
+        "_ovs-vsctl --if-exists del-br ovsbr1\n",
+        "_ovs-vsctl --if-exists del-br ovsbr2\n",
+        "ovs-appctl --timeout 15 dpctl/del-dp system@ovs-system || true\n",
+
         "_ovs-vsctl set Open_vSwitch . other_config:doca-init=true\n",
         "_ovs-vsctl set Open_vSwitch . other_config:dpdk-max-memzones=50000\n",
         "_ovs-vsctl set Open_vSwitch . other_config:hw-offload=true\n",
         "_ovs-vsctl set Open_vSwitch . other_config:pmd-quiet-idle=true\n",
         "_ovs-vsctl set Open_vSwitch . other_config:max-idle=20000\n",
         "_ovs-vsctl set Open_vSwitch . other_config:max-revalidator=5000\n",
-        "_ovs-vsctl set Open_vSwitch . other_config:ctl-pipe-size=1024\n",
-        "_ovs-vsctl --if-exists del-br ovsbr1\n",
-        "_ovs-vsctl --if-exists del-br ovsbr2\n",
+        "_ovs-vsctl remove Open_vSwitch . other_config default-datapath-type || true\n",
+
+        "if systemctl list-unit-files openvswitch-switch.service &>/dev/null; then\n",
+            "systemctl restart openvswitch-switch\n",
+        "elif systemctl list-unit-files openvswitch.service &>/dev/null; then\n",
+            "systemctl restart openvswitch\n",
+        "fi\n",
         "_ovs-vsctl --may-exist add-br br-sfc\n",
         "_ovs-vsctl set bridge br-sfc datapath_type=netdev\n",
         "_ovs-vsctl set bridge br-sfc fail_mode=secure\n",
@@ -60,6 +70,9 @@ fn get_default_ovs_defaults() -> String {
         "_ovs-vsctl set Interface p0 type=dpdk\n",
         "_ovs-vsctl set Interface p0 mtu_request=9216\n",
         "_ovs-vsctl set Port p0 external_ids:dpf-type=physical\n",
+        "_ovs-vsctl --may-exist add-br br-hbn\n",
+        "_ovs-vsctl set bridge br-hbn datapath_type=netdev\n",
+        "_ovs-vsctl set bridge br-hbn fail_mode=secure\n",
     )
     .to_string()
 }
@@ -106,7 +119,7 @@ pub fn default_flavor(
             bfcfg_parameters: Some(bfcfg_parameters),
             config_files: Some(get_config_files(proxy)?),
             containerd_config: None,
-            grub: None,
+            grub: Some(get_default_grub()),
             host_network_interface_configs: None,
             nvconfig: Some(vec![get_default_nvconfig()]),
             ovs: Some(crate::crds::dpuflavors_generated::DpuFlavorOvs {
@@ -116,6 +129,28 @@ pub fn default_flavor(
             system_reserved_resources: None,
         },
     })
+}
+
+fn get_default_grub() -> DpuFlavorGrub {
+    DpuFlavorGrub {
+        kernel_parameters: Some(
+            vec![
+                "console=hvc0",
+                "console=ttyAMA0",
+                "earlycon=pl011,0x13010000",
+                "fixrttc",
+                "net.ifnames=0",
+                "biosdevname=0",
+                "iommu.passthrough=1",
+                "cgroup_no_v1=net_prio,net_cls",
+                "hugepagesz=2048kB",
+                "hugepages=3072",
+            ]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect(),
+        ),
+    }
 }
 
 /// Returns the base set of config files, plus an optional containerd proxy drop-in if `proxy` is set.
@@ -224,8 +259,8 @@ fn get_default_nvconfig() -> DpuFlavorNvconfig {
         "NUM_OF_VFS=16".to_string(),
         "HIDE_PORT2_PF=True".to_string(),
         "NUM_OF_PF=1".to_string(),
-        "LINK_TYPE_P1=2".to_string(),
-        "LINK_TYPE_P2=2".to_string(),
+        "LINK_TYPE_P1=ETH".to_string(),
+        "LINK_TYPE_P2=ETH".to_string(),
     ];
 
     DpuFlavorNvconfig {

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -22,7 +22,7 @@ use sha2::{Digest, Sha256};
 
 use crate::crds::dpuflavors_generated::{
     DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesOperation, DpuFlavorDpuMode,
-    DpuFlavorNvconfig, DpuFlavorNvconfigDevice, DpuFlavorSpec,
+    DpuFlavorGrub, DpuFlavorNvconfig, DpuFlavorNvconfigDevice, DpuFlavorSpec,
 };
 use crate::types::DpfProxyDetails;
 


### PR DESCRIPTION
Backport of #3016 to `release/v2.0`.

| PR | Title |
|---|---|
| #3016 | feat(dpf): BFB3.4.1 upgrade |

Includes 3 commits:
- `feat(dpf): BFB3.4.1 upgrade`
- `Update hbn and dts version`
- `Update bfb url with latest public release.`

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes