### PR TITLE
fix: Use product_name to identify BF4 DPU.

### DIFF
--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -105,7 +105,7 @@ use model::rack_type::{
 use model::resource_pool::common::CommonPools;
 use model::resource_pool::{self};
 use model::tenant::TenantOrganizationId;
-use model::test_support::dpu::DPU_BF3_INFO_JSON;
+use model::test_support::dpu::{DPU_BF3_INFO_JSON, DPU_BF4_INFO_JSON};
 use model::test_support::{DpuConfig, HardwareInfoTemplate, ManagedHostConfig};
 use nras::{
     DeviceAttestationInfo, NrasError, ProcessedAttestationOutcome, RawAttestationOutcome,
@@ -2419,10 +2419,27 @@ pub async fn create_managed_host_with_dpf_multi(
     env: &TestEnv,
     dpu_count: usize,
 ) -> TestManagedHost {
+    create_managed_host_with_dpf_multi_hw(env, dpu_count, DPU_BF3_INFO_JSON).await
+}
+
+/// Create a managed host with a single BF4 DPU using the DPF path. The DPU's
+/// `dmi_data.product_name` identifies it as BlueField-4, which the DPU platform
+/// handler uses to skip the BF3-only vendor `machine_setup`/platform steps.
+pub async fn create_managed_host_with_dpf_bf4(env: &TestEnv) -> TestManagedHost {
+    create_managed_host_with_dpf_multi_hw(env, 1, DPU_BF4_INFO_JSON).await
+}
+
+/// Create a managed host with `dpu_count` DPUs using the DPF path, each DPU built
+/// from the given hardware-info template (BF3 vs BF4 differ by `product_name`).
+pub async fn create_managed_host_with_dpf_multi_hw(
+    env: &TestEnv,
+    dpu_count: usize,
+    hardware_info_json: &'static [u8],
+) -> TestManagedHost {
     assert!(dpu_count >= 1, "need to specify at least 1 dpu");
     let dpu_configs: Vec<DpuConfig> = (0..dpu_count)
         .map(|_| {
-            DpuConfig::with_hardware_info_template(HardwareInfoTemplate::Custom(DPU_BF3_INFO_JSON))
+            DpuConfig::with_hardware_info_template(HardwareInfoTemplate::Custom(hardware_info_json))
         })
         .collect();
     let mh_config = ManagedHostConfig::default().with_dpus(dpu_configs);

--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -33,7 +33,8 @@ use tonic::Request;
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides, get_config,
+    TestEnvOverrides, create_managed_host_with_dpf, create_managed_host_with_dpf_bf4,
+    create_test_env_with_overrides, get_config,
 };
 
 fn default_mock(deployment_type: DpuDeploymentType) -> MockDpfOperations {
@@ -112,7 +113,7 @@ async fn assert_bf4_skips_platform_configuration(pool: sqlx::PgPool, enable_secu
     .await;
     let redfish_timepoint = env.redfish_sim.timepoint();
 
-    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_bf4(&env))
         .await
         .expect("timed out during BF4 initial provisioning");
 

--- a/crates/api-model/src/hardware_info/test_data/dpu_bf4_info.json
+++ b/crates/api-model/src/hardware_info/test_data/dpu_bf4_info.json
@@ -1,0 +1,247 @@
+{
+  "cpus": [
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 0,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 1,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 2,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 3,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 4,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 5,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 6,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    },
+    {
+      "core": 0,
+      "node": 2,
+      "model": "0x1",
+      "number": 7,
+      "socket": 2,
+      "vendor": "0x41",
+      "frequency": "400.00"
+    }
+  ],
+  "machine_type": "aarch64",
+  "nvme_devices": [
+    {
+      "model": "NO_MODEL",
+      "firmware_rev": "NO_FIRMWARE_REV"
+    }
+  ],
+  "dmi_data": {
+    "board_name": "BlueField-4 SmartNIC Main Card",
+    "board_version": "1.0.0",
+    "bios_version": "4.2.0.12855",
+    "product_serial": "MT2331XZ0CGM",
+    "board_serial": "Unspecified Base Board Serial Number",
+    "chassis_serial": "Unspecified Chassis Board Serial Number",
+    "bios_date": "Aug  8 2023",
+    "product_name": "BlueField-4 SmartNIC Main Card",
+    "sys_vendor": "https://www.mellanox.com"
+  },
+  "block_devices": [
+    {
+      "model": "NO_MODEL",
+      "serial": "NO_SERIAL",
+      "revision": "NO_REVISION"
+    },
+    {
+      "model": "NO_MODEL",
+      "serial": "NO_SERIAL",
+      "revision": "NO_REVISION"
+    },
+    {
+      "model": "NO_MODEL",
+      "serial": "NO_SERIAL",
+      "revision": "NO_REVISION"
+    },
+    {
+      "model": "NO_MODEL",
+      "serial": "NO_SERIAL",
+      "revision": "NO_REVISION"
+    },
+    {
+      "model": "NO_MODEL",
+      "serial": "NO_SERIAL",
+      "revision": "NO_REVISION"
+    }
+  ],
+  "network_interfaces": [
+    {
+      "mac_address": "02:21:d6:91:84:dd",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0/mlx5_core.sf.2/net/enp3s0f0s0",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": 2147483647,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "ch:64",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0/net/en3f0pf0sf0",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": -1,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "08:c0:eb:cb:0e:8c",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0/net/p0",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": -1,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "ch:64",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.0/net/pf0hpf",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": -1,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "02:f2:ac:5c:9e:dc",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.1/mlx5_core.sf.3/net/enp3s0f1s0",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": 2147483647,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "ch:64",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.1/net/en3f1pf1sf0",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": -1,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "08:c0:eb:cb:0e:8d",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.1/net/p1",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": -1,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    },
+    {
+      "mac_address": "ch:64",
+      "pci_properties": {
+        "path": "/devices/pci0000:00/0000:00:00.0/0000:01:00.0/0000:02:00.0/0000:03:00.1/net/pf1hpf",
+        "device": "0xa2d6",
+        "vendor": "0x15b3",
+        "numa_node": -1,
+        "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+      }
+    }
+  ],
+  "dpu_info": {
+    "part_number": "900-9D3B6-00CV-A_Ax",
+    "firmware_date": "24.11.2022",
+    "product_version": "24.35.2000",
+    "firmware_version": "24.35.2000",
+    "part_description": "NVIDIA BlueField-4 B4220 P-Series FHHL DPU; 200GbE (default mode) / NDR200 IB; Dual-port QSFP112; PCIe Gen5.0 x16 with x16 PCIe extension option; 16 Arm cores; 32GB on-board DDR; integrated BMC; Crypto Enabled",
+    "factory_mac_address": "03:11:21:31:41:52 REPLACED BY TEST",
+    "switches": [
+      {
+        "name": "RNO1-M03-B17-IPMI-01",
+        "id": "mac=a1:b1:c1:00:00:01",
+        "description": "Cumulus Linux version 4.3.0 running on DELL S3048ON",
+        "local_port": "oob_net0",
+        "remote_port": "swp1",
+        "ip_address": [
+          "10.0.0.1",
+          "::1"
+        ]
+      },
+      {
+        "name": "RNO1-M03-B17-P0-01",
+        "id": "mac=a2:b2:c2:00:00:02",
+        "description": "Cumulus Linux version 4.3.0 running on DELL S3048ON",
+        "local_port": "p0",
+        "remote_port": "swp2",
+        "ip_address": [
+          "10.1.1.1",
+          "::2"
+        ]
+      },
+      {
+        "name": "RNO1-M03-B17-P1-01",
+        "id": "mac=a3:b3:c3:00:00:03",
+        "description": "Cumulus Linux version 4.3.0 running on DELL S3048ON",
+        "local_port": "p1",
+        "remote_port": "swp3",
+        "ip_address": [
+          "10.2.2.2",
+          "::3"
+        ]
+      }
+    ]
+  },
+  "gpus": []
+}

--- a/crates/api-model/src/test_support/dpu.rs
+++ b/crates/api-model/src/test_support/dpu.rs
@@ -29,6 +29,8 @@ pub const DPU_INFO_JSON: &[u8] = include_bytes!("../hardware_info/test_data/dpu_
 
 pub const DPU_BF3_INFO_JSON: &[u8] = include_bytes!("../hardware_info/test_data/dpu_bf3_info.json");
 
+pub const DPU_BF4_INFO_JSON: &[u8] = include_bytes!("../hardware_info/test_data/dpu_bf4_info.json");
+
 #[derive(Clone, Debug)]
 pub struct DpuConfig {
     pub serial: String,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3852,26 +3852,18 @@ impl DpuMachineStateHandler {
             return Ok(false);
         }
 
-        let dpf_sdk = self.dpf_sdk.as_deref().ok_or_else(|| {
-            StateHandlerError::InvalidState(
-                "DPF-managed machine reached DPU platform configuration without DPF configured"
-                    .to_string(),
-            )
-        })?;
-
-        let deployment_type = dpf_sdk
-            .deployment_type_for_dpu(dpu_snapshot)
-            .map_err(|error| {
-                StateHandlerError::InvalidState(format!(
-                    "failed to determine DPF deployment type for DPU {}: {error}",
-                    dpu_snapshot.id
-                ))
+        let product = dpu_snapshot
+            .status
+            .hardware_info
+            .as_ref()
+            .and_then(|x| x.dmi_data.as_ref())
+            .map(|x| x.product_name.to_uppercase())
+            .ok_or_else(|| StateHandlerError::MissingData {
+                object_id: dpu_snapshot.id.to_string(),
+                missing: "product_name in topology",
             })?;
 
-        Ok(matches!(
-            deployment_type,
-            carbide_dpf::DpuDeploymentType::Bf4Generic
-        ))
+        Ok(product.contains("B4") || product.contains("BLUEFIELD-4"))
     }
 
     async fn is_secure_boot_disabled(
@@ -4314,45 +4306,51 @@ impl DpuMachineStateHandler {
                     db::credential_rotation::CredentialRotationType::DpuUefi,
                 )
                 .await?;
-                if let Err(e) = ctx
+                let credentials_updated = match ctx
                     .services
                     .redfish_client_pool
                     .uefi_setup(dpu_redfish_client.as_ref(), true, dpu_uefi_credentials)
                     .await
                 {
-                    let msg = format!(
-                        "Failed to run uefi_setup call failed for DPU {}: {}",
-                        dpu_snapshot.id, e
-                    );
-                    tracing::warn!(
-                        machine_id = %dpu_snapshot.id,
-                        error = %e,
-                        "Failed to run uefi_setup for DPU",
-                    );
-                    let reboot_status = trigger_reboot_if_needed(
+                    Err(e) => {
+                        let msg = format!(
+                            "Failed to run uefi_setup call failed for DPU {}: {}",
+                            dpu_snapshot.id, e
+                        );
+                        tracing::warn!(
+                            machine_id = %dpu_snapshot.id,
+                            error = %e,
+                            "Failed to run uefi_setup for DPU",
+                        );
+                        let reboot_status = trigger_reboot_if_needed(
+                            dpu_snapshot,
+                            state,
+                            None,
+                            &self.reachability_params,
+                            ctx,
+                        )
+                        .await?;
+
+                        return Ok(StateHandlerOutcome::wait(format!(
+                            "{msg};\nWaiting for DPU {} to reboot: {reboot_status:#?}",
+                            dpu_snapshot.id
+                        )));
+                    }
+                    // BIOS does not expose a UEFI password field (e.g. BF4); skip
+                    // the restart and convergence record — nothing was staged.
+                    Ok(None) => false,
+                    // Password staged through Redfish BIOS settings; restart to commit.
+                    Ok(Some(_)) => true,
+                };
+
+                if credentials_updated {
+                    handler_restart_dpu(
                         dpu_snapshot,
-                        state,
-                        None,
-                        &self.reachability_params,
                         ctx,
+                        state.host_snapshot.config.dpf.used_for_ingestion,
                     )
                     .await?;
-
-                    return Ok(StateHandlerOutcome::wait(format!(
-                        "{msg};\nWaiting for DPU {} to reboot: {reboot_status:#?}",
-                        dpu_snapshot.id
-                    )));
                 }
-
-                // The UEFI password is staged through Redfish BIOS settings,
-                // so retain the restart even when BF4 skips platform setup and
-                // BIOS verification.
-                handler_restart_dpu(
-                    dpu_snapshot,
-                    ctx,
-                    state.host_snapshot.config.dpf.used_for_ingestion,
-                )
-                .await?;
 
                 let next_state = if dpf_managed_bf4 {
                     DpuInitState::WaitingForNetworkConfig
@@ -4361,27 +4359,30 @@ impl DpuMachineStateHandler {
                 }
                 .next_state(&state.managed_state, dpu_machine_id)?;
 
-                // The DPU's UEFI password is now the site-wide value (just set via
-                // uefi_setup above): record dpu_uefi convergence so the rotation
-                // engine tracks this DPU from ingestion onward (mirrors the
-                // backfill, which keys DPU UEFI by the DPU BMC MAC). The MAC was
-                // validated as a precondition at the top of this state. Committed
-                // with the state transition below.
-                let mut txn = ctx.services.db_pool.begin().await?;
-                db::credential_rotation::record_device_converged(
-                    &mut txn,
-                    dpu_bmc_mac,
-                    db::credential_rotation::CredentialRotationType::DpuUefi,
-                )
-                .await
-                .map_err(|e| {
-                    StateHandlerError::GenericError(eyre!(
-                        "record dpu_uefi credential rotation convergence failed: {}",
-                        e
-                    ))
-                })?;
-
-                Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
+                if credentials_updated {
+                    // The DPU's UEFI password is now the site-wide value (just set via
+                    // uefi_setup above): record dpu_uefi convergence so the rotation
+                    // engine tracks this DPU from ingestion onward (mirrors the
+                    // backfill, which keys DPU UEFI by the DPU BMC MAC). The MAC was
+                    // validated as a precondition at the top of this state. Committed
+                    // with the state transition below.
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db::credential_rotation::record_device_converged(
+                        &mut txn,
+                        dpu_bmc_mac,
+                        db::credential_rotation::CredentialRotationType::DpuUefi,
+                    )
+                    .await
+                    .map_err(|e| {
+                        StateHandlerError::GenericError(eyre!(
+                            "record dpu_uefi credential rotation convergence failed: {}",
+                            e
+                        ))
+                    })?;
+                    Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
+                } else {
+                    Ok(StateHandlerOutcome::transition(next_state))
+                }
             }
 
             DpuInitState::PollingBiosSetup => {

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -209,6 +209,18 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             (_, current_password) = match credentials {
                 Credentials::UsernamePassword { username, password } => (username, password),
             };
+
+            // DPU's change_uefi_password always returns Ok(None) on success (no async job).
+            // Return Ok(Some("")) here so callers can distinguish "updated" from the
+            // early-exit Ok(None) skip paths above. The host path below must NOT get
+            // this mapping — hosts may return Ok(None) to mean "no job to poll".
+            return client
+                .change_uefi_password(current_password.as_str(), new_password.as_str())
+                .await
+                .map_err(|err| redact_password(err, new_password.as_str()))
+                .map_err(|err| redact_password(err, current_password.as_str()))
+                .map_err(RedfishClientCreationError::RedfishError)
+                .map(|job_id| Some(job_id.unwrap_or_default()));
         } else {
             // For hosts, first try with empty current password (assuming no
             // password is set), using the site default handed in by the caller.
@@ -232,6 +244,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             }
         }
 
+        // Host fallback: second attempt using site default as current password.
         client
             .change_uefi_password(current_password.as_str(), new_password.as_str())
             .await


### PR DESCRIPTION
Use product_name to identify BF4 DPU. Also avoid dpu reboot if no BIOS operation is touched.

## Related issues
#3863 

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
