### PR TITLE
fix: avoid rounding of integers over JavaScript max in UI

### DIFF
--- a/crates/api-web/Cargo.toml
+++ b/crates/api-web/Cargo.toml
@@ -69,7 +69,7 @@ reqwest = { workspace = true, default-features = false, features = [
   "stream",
 ] }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sqlx = { workspace = true, features = [
   "runtime-tokio",
   "tls-rustls",

--- a/crates/api-web/src/filters.rs
+++ b/crates/api-web/src/filters.rs
@@ -275,6 +275,34 @@ pub fn option_fmt_or(
     })
 }
 
+/// Formats JSON for display without routing integer values through JavaScript numbers.
+///
+/// Invalid JSON is returned unchanged so this can also be used for endpoints whose
+/// response bodies are not guaranteed to be JSON.
+#[askama::filter_fn]
+pub fn pretty_json(value: impl Display, _env: &dyn askama::Values) -> ::askama::Result<String> {
+    Ok(format_json(value))
+}
+
+// separate function because askama filter functions can't be tested directly
+fn format_json(value: impl Display) -> String {
+    let input = value.to_string();
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&input) else {
+        return input;
+    };
+
+    // Some Redfish responses contain JSON encoded inside this top-level field.
+    if let Some(response_body) = json
+        .get("ResponseBody")
+        .and_then(serde_json::Value::as_str)
+        .and_then(|body| serde_json::from_str(body).ok())
+    {
+        json["ResponseBody"] = response_body;
+    }
+
+    serde_json::to_string_pretty(&json).unwrap_or(input)
+}
+
 pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, String) {
     let state_json = state_json.to_string();
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&state_json) else {
@@ -409,4 +437,47 @@ pub fn controller_state_reason_fmt(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::format_json;
+
+    #[test]
+    fn pretty_json_preserves_values_and_fallbacks() {
+        check_values(
+            [
+                Check {
+                    scenario: "smallest unsafe JavaScript integer",
+                    input: r#"{"id":9007199254740993}"#,
+                    expect: "{\n  \"id\": 9007199254740993\n}".to_string(),
+                },
+                Check {
+                    scenario: "maximum 64-bit integer",
+                    input: r#"{"gpu_uid":18446744073709551615}"#,
+                    expect: "{\n  \"gpu_uid\": 18446744073709551615\n}".to_string(),
+                },
+                Check {
+                    scenario: "nested ResponseBody JSON",
+                    input: r#"{"ResponseBody":"{\"id\":18446744073709551615}"}"#,
+                    expect: concat!(
+                        "{\n",
+                        "  \"ResponseBody\": {\n",
+                        "    \"id\": 18446744073709551615\n",
+                        "  }\n",
+                        "}"
+                    )
+                    .to_string(),
+                },
+                Check {
+                    scenario: "non-JSON response",
+                    input: "GPU not found: 18446744073709551615",
+                    expect: "GPU not found: 18446744073709551615".to_string(),
+                },
+            ],
+            format_json,
+        );
+    }
 }

--- a/crates/api-web/src/nmxc_browser.rs
+++ b/crates/api-web/src/nmxc_browser.rs
@@ -25,7 +25,7 @@ use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 use serde::Deserialize;
 
-use super::Base;
+use super::{Base, filters};
 
 #[derive(Template)]
 #[template(path = "nmxc_browser.html")]
@@ -125,3 +125,34 @@ pub async fn query(
 }
 
 impl super::Base for NmxcBrowser {}
+
+#[cfg(test)]
+mod tests {
+    use askama::Template;
+
+    use super::NmxcBrowser;
+
+    #[test]
+    fn rendered_response_preserves_large_integers_and_escapes_html() {
+        let browser = NmxcBrowser {
+            chassis_serial: "chassis".to_string(),
+            operation: "gpu_info".to_string(),
+            gpu_uid: u64::MAX.to_string(),
+            response: format!(
+                r#"{{"gpu_uid":{},"message":"<script>alert('xss')</script>"}}"#,
+                u128::MAX
+            ),
+            error: String::new(),
+            status_code: 200,
+            status_string: "OK".to_string(),
+            response_headers: Vec::new(),
+        };
+
+        let rendered = browser.render().unwrap();
+        assert!(rendered.contains("18446744073709551615"));
+        assert!(rendered.contains("340282366920938463463374607431768211455"));
+        assert!(rendered.contains("&#60;script&#62;alert("));
+        assert!(rendered.contains("&#60;/script&#62;"));
+        assert!(!rendered.contains("<script>alert('xss')</script>"));
+    }
+}

--- a/crates/api-web/src/redfish_actions.rs
+++ b/crates/api-web/src/redfish_actions.rs
@@ -211,6 +211,8 @@ pub mod filters {
     use itertools::Itertools;
     use rpc::forge::OptionalRedfishActionResult;
 
+    pub use super::super::filters::pretty_json;
+
     #[askama::filter_fn]
     pub fn date_fmt(value: &rpc::Timestamp, _env: &dyn askama::Values) -> ::askama::Result<String> {
         super::date_fmt_inner(value)

--- a/crates/api-web/src/ufm_browser.rs
+++ b/crates/api-web/src/ufm_browser.rs
@@ -25,7 +25,7 @@ use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 use serde::Deserialize;
 
-use super::Base;
+use super::{Base, filters};
 
 #[derive(Template)]
 #[template(path = "ufm_browser.html")]

--- a/crates/api-web/templates/base.html
+++ b/crates/api-web/templates/base.html
@@ -307,38 +307,8 @@
 				jsonLink.href = url.toString();
 			}
 
-			function prettifyJSONs() {
-				let elems = document.getElementsByClassName("prettyjson");
-				for (elem of elems) {
-					// No need to set whiteSpace style as it's handled by CSS now
-					try {
-						let jsObj = JSON.parse(elem.innerText);
-
-						// In some well-known member fields on the highest level,
-						// the data stored in the field is also JSON.
-						// We expand that inner data
-						const deserializeField = (obj, field) => {
-							if (obj[field] != null) {
-								try {
-									obj[field] = JSON.parse(obj[field]);
-								} catch (e) {
-								}
-							}
-						};
-
-						const unpackFields = ["ResponseBody"];
-						for (unpackField of unpackFields) {
-							deserializeField(jsObj, unpackField);
-						}
-						elem.innerText = JSON.stringify(jsObj, null,4);
-					} catch (e) {
-					}
-				}
-			}
-
 			document.addEventListener("DOMContentLoaded", function(event){
 				attachJsonLink();
-				prettifyJSONs();
 			});
 
 			// Updates the title of spans to render the localized version

--- a/crates/api-web/templates/explored_endpoint_detail.html
+++ b/crates/api-web/templates/explored_endpoint_detail.html
@@ -88,7 +88,7 @@
 			<th>Last Exploration Error</th>
 			<td class="action-cell">
 				<div style="overflow: auto;">
-					<pre><code class="prettyjson">{{ last_exploration_error }}</code></pre>
+					<pre><code>{{ last_exploration_error|pretty_json }}</code></pre>
 				</div>
 				<div style="margin-left: 1rem;">
 					<form id="clearlasterror_action" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/clear-last-error">
@@ -557,4 +557,3 @@ document.addEventListener('DOMContentLoaded', function() {
 {% endmatch %}
 
 {% endblock %}
-

--- a/crates/api-web/templates/explored_endpoints_show.html
+++ b/crates/api-web/templates/explored_endpoints_show.html
@@ -73,7 +73,7 @@
 			<td>
 				{% if ep.has_exploration_error %}
 				<div style="max-width: 400px; max-height: 100px; overflow: auto; border: 1px solid var(--border-color); border-radius: 4px; padding: 0.5rem;">
-					<pre style="margin: 0; white-space: pre-wrap; font-size: 0.8rem;"><code class="prettyjson">{{ ep.last_exploration_error }}</code></pre>
+					<pre style="margin: 0; white-space: pre-wrap; font-size: 0.8rem;"><code>{{ ep.last_exploration_error|pretty_json }}</code></pre>
 				</div>
 				<form id="clearlasterror_action" method="POST" action="/admin/explored-endpoint/{{ ep.address }}/clear-last-error">
 					<button type="submit">Clear</button>

--- a/crates/api-web/templates/health_history_table.html
+++ b/crates/api-web/templates/health_history_table.html
@@ -19,7 +19,7 @@
 				<details>
 					<summary>Expand</summary>
 					<div style="overflow: auto; max-height: 300px; border: 1px solid var(--border-color); border-radius: 8px; background-color: var(--bg-tertiary); margin-top: 0.5rem;">
-						<pre style="margin: 0; padding: 1rem; background-color: transparent; white-space: pre-wrap;"><code class="prettyjson">{{ record.health|json|safe }}</code></pre>
+						<pre style="margin: 0; padding: 1rem; background-color: transparent; white-space: pre-wrap;"><code>{{ record.health|json|pretty_json }}</code></pre>
 					</div>
 				</details>
 			</td>

--- a/crates/api-web/templates/health_reports_detail.html
+++ b/crates/api-web/templates/health_reports_detail.html
@@ -34,7 +34,7 @@
 					<details>
 						<summary>JSON Details</summary>
 						<div style="overflow: auto; max-height: 300px; border: 1px solid var(--border-color); border-radius: 8px; background-color: var(--bg-tertiary); margin-top: 0.5rem;">
-							<pre style="margin: 0; padding: 1rem; background-color: transparent; white-space: pre-wrap;"><code class="prettyjson">{{ entry|json|safe }}</code></pre>
+							<pre style="margin: 0; padding: 1rem; background-color: transparent; white-space: pre-wrap;"><code>{{ entry|json|pretty_json }}</code></pre>
 						</div>
 					</details>
 					<button id="remove-health-report-{{ entry.health_report.source }}" class="delete-button">Remove</button>

--- a/crates/api-web/templates/ipam_overlay_prefix.html
+++ b/crates/api-web/templates/ipam_overlay_prefix.html
@@ -38,7 +38,7 @@
 	{% for record in state_history %}
 		<tr>
 			<td>{{ record.version|config_version|safe }}</td>
-			<td><div style="overflow: auto;"><pre><code class="prettyjson">{{ record.state }}</code></pre></div></td>
+			<td><div style="overflow: auto;"><pre><code>{{ record.state|pretty_json }}</code></pre></div></td>
 		</tr>
 	{% endfor %}
 	</tbody>

--- a/crates/api-web/templates/lifecycle_detail.html
+++ b/crates/api-web/templates/lifecycle_detail.html
@@ -10,7 +10,7 @@
 	{% if let Some(json_state) = json_state %}
 	<tr>
 		<th>JSON State</th>
-		<td><div style="overflow: auto;"><pre><code class="prettyjson">{{ json_state }}</code></pre></div></td>
+		<td><div style="overflow: auto;"><pre><code>{{ json_state|pretty_json }}</code></pre></div></td>
 	</tr>
 	{% endif %}
 	<tr><th>State Version</th><td>{{ version|config_version|safe }}</td></tr>

--- a/crates/api-web/templates/network_segment_detail.html
+++ b/crates/api-web/templates/network_segment_detail.html
@@ -44,7 +44,7 @@
 	{% for event in history %}
 		<tr>
 			<td>{{event.version|config_version|safe}}</td>
-			<td><div style="overflow: auto;"><pre><code class="prettyjson">{{event.state}}</code></pre></div></td>
+			<td><div style="overflow: auto;"><pre><code>{{event.state|pretty_json}}</code></pre></div></td>
 		</tr>
 	{% endfor %}
 	</tbody>

--- a/crates/api-web/templates/nmxc_browser.html
+++ b/crates/api-web/templates/nmxc_browser.html
@@ -71,7 +71,7 @@ See the <a href="https://docs.nvidia.com/networking/display/nmxcv11/grpc+api+doc
 	<tr>
 		<td>
 			<div style="overflow: auto;">
-				<pre><code class="prettyjson">{{ response }}</code></pre>
+					<pre><code>{{ response|pretty_json }}</code></pre>
 			</div>
 		</td>
 	</tr>

--- a/crates/api-web/templates/redfish_actions_table.html
+++ b/crates/api-web/templates/redfish_actions_table.html
@@ -56,7 +56,7 @@
 				{% endif %}
 			{% endif %}
 		{% endif %}
-		<td><pre><code class="prettyjson">{{ request.parameters }}</code></pre></td>
+		<td><pre><code>{{ request.parameters|pretty_json }}</code></pre></td>
 		<td>{{ request.machine_ips|machine_ips_fmt|safe }}</td>
 		<td>{{ request.target }}</td>
 		<td style="text-wrap: nowrap;">{{ request.results|to_json|join("\n ")|linebreaksbr|safe }}</td>

--- a/crates/api-web/templates/state_history_table.html
+++ b/crates/api-web/templates/state_history_table.html
@@ -9,7 +9,7 @@
 	{% for record in records %}
 		<tr>
 			<td>{{record.version|config_version|safe}}</td>
-			<td><div style="overflow: auto;"><pre><code class="prettyjson">{{record.state}}</code></pre></div></td>
+			<td><div style="overflow: auto;"><pre><code>{{record.state|pretty_json}}</code></pre></div></td>
 		</tr>
 	{% endfor %}
 	</tbody>

--- a/crates/api-web/templates/ufm_browser.html
+++ b/crates/api-web/templates/ufm_browser.html
@@ -69,7 +69,7 @@ For valid Path, please refer to the <a href="https://docs.nvidia.com/networking/
 	<tr>
 		<td>
 			<div style="overflow: auto;">
-				<pre><code class="prettyjson">{{ response }}</code></pre>
+					<pre><code>{{ response|pretty_json }}</code></pre>
 			</div>
 		</td>
 	</tr>

--- a/crates/dsx-exchange-consumer/src/messages.rs
+++ b/crates/dsx-exchange-consumer/src/messages.rs
@@ -123,7 +123,7 @@ impl<'de> Deserialize<'de> for FaultValue {
             }
         }
 
-        deserializer.deserialize_any(BinaryValueVisitor)
+        deserializer.deserialize_f64(BinaryValueVisitor)
     }
 }
 


### PR DESCRIPTION
Rather than relying on a JavaScript's JSON.stringify, which can only handle numbers up to 2^53, to help format JSON for display, we now handle JSON formatting logic within Rust via a new Askama filter that uses serde_json's 'arbitrary_precision' feature.

## Related issues
internal issue

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


