### PR TITLE
fix: hw-health discovery missing error logs

### DIFF
--- a/crates/health/src/collectors/discovery.rs
+++ b/crates/health/src/collectors/discovery.rs
@@ -173,19 +173,22 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
         let discovered: Vec<_> = stream::iter(processors)
             .map(|processor| async move {
                 let processor = Arc::new(processor);
-                let env = processor
-                    .environment_sensor_links()
-                    .await
-                    .unwrap_or_default();
-                let metric = processor.metrics_sensor_links().await.unwrap_or_default();
-                let sensors: Vec<_> = env.into_iter().chain(metric).collect();
-                (processor, sensors)
+                let env = processor.environment_sensor_links().await;
+                let metric = processor.metrics_sensor_links().await;
+                (processor, env, metric)
             })
             .buffer_unordered(self.discovery_concurrency)
             .collect()
             .await;
 
-        for (entity, sensors) in discovered {
+        for (entity, env, metric) in discovered {
+            let env = self
+                .record_failure(env, "get processor environment sensors", fetch_failures)
+                .unwrap_or_default();
+            let metric = self
+                .record_failure(metric, "get processor metric sensors", fetch_failures)
+                .unwrap_or_default();
+            let sensors: Vec<_> = env.into_iter().chain(metric).collect();
             for sensor in &sensors {
                 sensor_ids.insert(sensor.odata_id().to_string());
             }
@@ -216,7 +219,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
         let discovered: Vec<_> = stream::iter(memory_modules)
             .map(|memory| async move {
                 let memory = Arc::new(memory);
-                let sensors = memory.environment_sensor_links().await.unwrap_or_default();
+                let sensors = memory.environment_sensor_links().await;
                 (memory, sensors)
             })
             .buffer_unordered(self.discovery_concurrency)
@@ -224,6 +227,9 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             .await;
 
         for (entity, sensors) in discovered {
+            let sensors = self
+                .record_failure(sensors, "get memory environment sensors", fetch_failures)
+                .unwrap_or_default();
             for sensor in &sensors {
                 sensor_ids.insert(sensor.odata_id().to_string());
             }
@@ -261,7 +267,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             let discovered: Vec<_> = stream::iter(drives)
                 .map(|drive| async move {
                     let drive = Arc::new(drive);
-                    let sensors = drive.environment_sensor_links().await.unwrap_or_default();
+                    let sensors = drive.environment_sensor_links().await;
                     (drive, sensors)
                 })
                 .buffer_unordered(self.discovery_concurrency)
@@ -269,6 +275,9 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                 .await;
 
             for (entity, sensors) in discovered {
+                let sensors = self
+                    .record_failure(sensors, "get drive environment sensors", fetch_failures)
+                    .unwrap_or_default();
                 for sensor in &sensors {
                     sensor_ids.insert(sensor.odata_id().to_string());
                 }
@@ -300,7 +309,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
         let discovered: Vec<_> = stream::iter(power_supplies)
             .map(|ps| async move {
                 let ps = Arc::new(ps);
-                let sensors = ps.metrics_sensor_links().await.unwrap_or_default();
+                let sensors = ps.metrics_sensor_links().await;
                 (ps, sensors)
             })
             .buffer_unordered(self.discovery_concurrency)
@@ -308,6 +317,9 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             .await;
 
         for (entity, sensors) in discovered {
+            let sensors = self
+                .record_failure(sensors, "get power supply metric sensors", fetch_failures)
+                .unwrap_or_default();
             for sensor in &sensors {
                 sensor_ids.insert(sensor.odata_id().to_string());
             }


### PR DESCRIPTION
HW Health service moved some of the async closure and swalled dicovery fetch errors with `unwrap_or_default`.

This fix moves result out of closure so it can be properly logged.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3986

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

